### PR TITLE
Included REST API feature plugin endpoints and changes

### DIFF
--- a/includes/api/class-wc-rest-data-continents-controller.php
+++ b/includes/api/class-wc-rest-data-continents-controller.php
@@ -1,0 +1,357 @@
+<?php
+/**
+ * REST API Data continents controller.
+ *
+ * Handles requests to the /data/continents endpoint.
+ *
+ * @package WooCommerce/API
+ * @since   3.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Data continents controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Data_Continents_Controller extends WC_REST_Data_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'data/continents';
+
+	/**
+	 * Register routes.
+	 *
+	 * @since 3.5.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base, array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base . '/(?P<location>[\w-]+)', array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'continent' => array(
+							'description' => __( '2 character continent code.', 'woocommerce' ),
+							'type'        => 'string',
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Return the list of countries and states for a given continent.
+	 *
+	 * @since  3.5.0
+	 * @param  string          $continent_code Continent code.
+	 * @param  WP_REST_Request $request        Request data.
+	 * @return array|mixed Response data, ready for insertion into collection data.
+	 */
+	public function get_continent( $continent_code = false, $request ) {
+		$continents  = WC()->countries->get_continents();
+		$countries   = WC()->countries->get_countries();
+		$states      = WC()->countries->get_states();
+		$locale_info = include WC()->plugin_path() . '/i18n/locale-info.php';
+		$data        = array();
+
+		if ( ! array_key_exists( $continent_code, $continents ) ) {
+			return false;
+		}
+
+		$continent_list = $continents[ $continent_code ];
+
+		$continent = array(
+			'code' => $continent_code,
+			'name' => $continent_list['name'],
+		);
+
+		$local_countries = array();
+		foreach ( $continent_list['countries'] as $country_code ) {
+			if ( isset( $countries[ $country_code ] ) ) {
+				$country = array(
+					'code' => $country_code,
+					'name' => $countries[ $country_code ],
+				);
+
+				// If we have detailed locale information include that in the response.
+				if ( array_key_exists( $country_code, $locale_info ) ) {
+					// Defensive programming against unexpected changes in locale-info.php.
+					$country_data = wp_parse_args(
+						$locale_info[ $country_code ], array(
+							'currency_code'  => 'USD',
+							'currency_pos'   => 'left',
+							'decimal_sep'    => '.',
+							'dimension_unit' => 'in',
+							'num_decimals'   => 2,
+							'thousand_sep'   => ',',
+							'weight_unit'    => 'lbs',
+						)
+					);
+
+					$country = array_merge( $country, $country_data );
+				}
+
+				$local_states = array();
+				if ( isset( $states[ $country_code ] ) ) {
+					foreach ( $states[ $country_code ] as $state_code => $state_name ) {
+						$local_states[] = array(
+							'code' => $state_code,
+							'name' => $state_name,
+						);
+					}
+				}
+				$country['states'] = $local_states;
+
+				// Allow only desired keys (e.g. filter out tax rates).
+				$allowed = array(
+					'code',
+					'currency_code',
+					'currency_pos',
+					'decimal_sep',
+					'dimension_unit',
+					'name',
+					'num_decimals',
+					'states',
+					'thousand_sep',
+					'weight_unit',
+				);
+				$country = array_intersect_key( $country, array_flip( $allowed ) );
+
+				$local_countries[] = $country;
+			}
+		}
+
+		$continent['countries'] = $local_countries;
+		return $continent;
+	}
+
+	/**
+	 * Return the list of states for all continents.
+	 *
+	 * @since  3.5.0
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$continents = WC()->countries->get_continents();
+		$data       = array();
+
+		foreach ( array_keys( $continents ) as $continent_code ) {
+			$continent = $this->get_continent( $continent_code, $request );
+			$response  = $this->prepare_item_for_response( $continent, $request );
+			$data[]    = $this->prepare_response_for_collection( $response );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Return the list of locations for a given continent.
+	 *
+	 * @since  3.5.0
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$data = $this->get_continent( strtoupper( $request['location'] ), $request );
+		if ( empty( $data ) ) {
+			return new WP_Error( 'woocommerce_rest_data_invalid_location', __( 'There are no locations matching these parameters.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+		return $this->prepare_item_for_response( $data, $request );
+	}
+
+	/**
+	 * Prepare the data object for response.
+	 *
+	 * @since  3.5.0
+	 * @param object          $item Data object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$data     = $this->add_additional_fields_to_object( $item, $request );
+		$data     = $this->filter_response_by_context( $data, 'view' );
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $item ) );
+
+		/**
+		 * Filter the location list returned from the API.
+		 *
+		 * Allows modification of the loction data right before it is returned.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param array            $item     The original list of continent(s), countries, and states.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_data_continent', $response, $item, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param object $item Data object.
+	 * @return array Links for the given continent.
+	 */
+	protected function prepare_links( $item ) {
+		$continent_code = strtolower( $item['code'] );
+		$links          = array(
+			'self'       => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $continent_code ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+		return $links;
+	}
+
+	/**
+	 * Get the location schema, conforming to JSON Schema.
+	 *
+	 * @since  3.5.0
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'data_continents',
+			'type'       => 'object',
+			'properties' => array(
+				'code'      => array(
+					'type'        => 'string',
+					'description' => __( '2 character continent code.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'name'      => array(
+					'type'        => 'string',
+					'description' => __( 'Full name of continent.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'countries' => array(
+					'type'        => 'array',
+					'description' => __( 'List of countries on this continent.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'context'    => array( 'view' ),
+						'readonly'   => true,
+						'properties' => array(
+							'code'           => array(
+								'type'        => 'string',
+								'description' => __( 'ISO3166 alpha-2 country code.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'currency_code'  => array(
+								'type'        => 'string',
+								'description' => __( 'Default ISO4127 alpha-3 currency code for the country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'currency_pos'   => array(
+								'type'        => 'string',
+								'description' => __( 'Currency symbol position for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'decimal_sep'    => array(
+								'type'        => 'string',
+								'description' => __( 'Decimal separator for displayed prices for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'dimension_unit' => array(
+								'type'        => 'string',
+								'description' => __( 'The unit lengths are defined in for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'name'           => array(
+								'type'        => 'string',
+								'description' => __( 'Full name of country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'num_decimals'   => array(
+								'type'        => 'integer',
+								'description' => __( 'Number of decimal points shown in displayed prices for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'states'         => array(
+								'type'        => 'array',
+								'description' => __( 'List of states in this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+								'items'       => array(
+									'type'       => 'object',
+									'context'    => array( 'view' ),
+									'readonly'   => true,
+									'properties' => array(
+										'code' => array(
+											'type'        => 'string',
+											'description' => __( 'State code.', 'woocommerce' ),
+											'context'     => array( 'view' ),
+											'readonly'    => true,
+										),
+										'name' => array(
+											'type'        => 'string',
+											'description' => __( 'Full name of state.', 'woocommerce' ),
+											'context'     => array( 'view' ),
+											'readonly'    => true,
+										),
+									),
+								),
+							),
+							'thousand_sep'   => array(
+								'type'        => 'string',
+								'description' => __( 'Thousands separator for displayed prices in this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'weight_unit'    => array(
+								'type'        => 'string',
+								'description' => __( 'The unit weights are defined in for this country.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/includes/api/class-wc-rest-data-controller.php
+++ b/includes/api/class-wc-rest-data-controller.php
@@ -1,0 +1,188 @@
+<?php
+/**
+ * REST API Data controller.
+ *
+ * Handles requests to the /data endpoint.
+ *
+ * @package WooCommerce/API
+ * @since   3.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Data controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Data_Controller extends WC_REST_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'data';
+
+	/**
+	 * Register routes.
+	 *
+	 * @since 3.5.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base, array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check whether a given request has permission to read site data.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check whether a given request has permission to read site settings.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'read' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Return the list of data resources.
+	 *
+	 * @since  3.5.0
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$data      = array();
+		$resources = array(
+			array(
+				'slug'        => 'continents',
+				'description' => __( 'List of supported continents, countries, and states.', 'woocommerce' ),
+			),
+			array(
+				'slug'        => 'countries',
+				'description' => __( 'List of supported states in a given country.', 'woocommerce' ),
+			),
+			array(
+				'slug'        => 'counts',
+				'description' => __( 'Information about the amount of various objects on this site.', 'woocommerce' ),
+			),
+			array(
+				'slug'        => 'currencies',
+				'description' => __( 'List of supported currencies.', 'woocommerce' ),
+			),
+		);
+
+		foreach ( $resources as $resource ) {
+			$item   = $this->prepare_item_for_response( (object) $resource, $request );
+			$data[] = $this->prepare_response_for_collection( $item );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Prepare a data resource object for serialization.
+	 *
+	 * @param stdClass        $resource Resource data.
+	 * @param WP_REST_Request $request  Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $resource, $request ) {
+		$data = array(
+			'slug'        => $resource->slug,
+			'description' => $resource->description,
+		);
+
+		$data = $this->add_additional_fields_to_object( $data, $request );
+		$data = $this->filter_response_by_context( $data, 'view' );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $resource ) );
+
+		return $response;
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param object $item Data object.
+	 * @return array Links for the given country.
+	 */
+	protected function prepare_links( $item ) {
+		$links = array(
+			'self'       => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $item->slug ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+
+		return $links;
+	}
+
+	/**
+	 * Get the data index schema, conforming to JSON Schema.
+	 *
+	 * @since  3.5.0
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'data_index',
+			'type'       => 'object',
+			'properties' => array(
+				'slug'        => array(
+					'description' => __( 'Data resource ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'description' => array(
+					'description' => __( 'Data resource description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/includes/api/class-wc-rest-data-countries-controller.php
+++ b/includes/api/class-wc-rest-data-countries-controller.php
@@ -1,0 +1,240 @@
+<?php
+/**
+ * REST API Data countries controller.
+ *
+ * Handles requests to the /data/countries endpoint.
+ *
+ * @package WooCommerce/API
+ * @since   3.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Data countries controller class.
+ *
+ * @package WooCommerce/API
+ * @extends WC_REST_Controller
+ */
+class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'data/countries';
+
+	/**
+	 * Register routes.
+	 *
+	 * @since 3.5.0
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base, array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base . '/(?P<location>[\w-]+)', array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => array(
+						'location' => array(
+							'description' => __( 'ISO3166 alpha-2 country code.', 'woocommerce' ),
+							'type'        => 'string',
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Get a list of countries and states.
+	 *
+	 * @param  string          $country_code Country code.
+	 * @param  WP_REST_Request $request      Request data.
+	 * @return array|mixed Response data, ready for insertion into collection data.
+	 */
+	public function get_country( $country_code = false, $request ) {
+		$countries = WC()->countries->get_countries();
+		$states    = WC()->countries->get_states();
+		$data      = array();
+
+		if ( ! array_key_exists( $country_code, $countries ) ) {
+			return false;
+		}
+
+		$country = array(
+			'code' => $country_code,
+			'name' => $countries[ $country_code ],
+		);
+
+		$local_states = array();
+		if ( isset( $states[ $country_code ] ) ) {
+			foreach ( $states[ $country_code ] as $state_code => $state_name ) {
+				$local_states[] = array(
+					'code' => $state_code,
+					'name' => $state_name,
+				);
+			}
+		}
+		$country['states'] = $local_states;
+		return $country;
+	}
+
+	/**
+	 * Return the list of states for all countries.
+	 *
+	 * @since  3.5.0
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$countries = WC()->countries->get_countries();
+		$data      = array();
+
+		foreach ( array_keys( $countries ) as $country_code ) {
+			$country  = $this->get_country( $country_code, $request );
+			$response = $this->prepare_item_for_response( $country, $request );
+			$data[]   = $this->prepare_response_for_collection( $response );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Return the list of states for a given country.
+	 *
+	 * @since  3.5.0
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$data = $this->get_country( strtoupper( $request['location'] ), $request );
+		if ( empty( $data ) ) {
+			return new WP_Error( 'woocommerce_rest_data_invalid_location', __( 'There are no locations matching these parameters.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+		return $this->prepare_item_for_response( $data, $request );
+	}
+
+	/**
+	 * Prepare the data object for response.
+	 *
+	 * @since  3.5.0
+	 * @param object          $item Data object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$data     = $this->add_additional_fields_to_object( $item, $request );
+		$data     = $this->filter_response_by_context( $data, 'view' );
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $item ) );
+
+		/**
+		 * Filter the states list for a country returned from the API.
+		 *
+		 * Allows modification of the loction data right before it is returned.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param array            $data     The original country's states list.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_data_country', $response, $item, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param object $item Data object.
+	 * @return array Links for the given country.
+	 */
+	protected function prepare_links( $item ) {
+		$country_code = strtolower( $item['code'] );
+		$links        = array(
+			'self'       => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $country_code ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+
+		return $links;
+	}
+
+
+	/**
+	 * Get the location schema, conforming to JSON Schema.
+	 *
+	 * @since  3.5.0
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'data_countries',
+			'type'       => 'object',
+			'properties' => array(
+				'code'   => array(
+					'type'        => 'string',
+					'description' => __( 'ISO3166 alpha-2 country code.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'name'   => array(
+					'type'        => 'string',
+					'description' => __( 'Full name of country.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'states' => array(
+					'type'        => 'array',
+					'description' => __( 'List of states in this country.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'context'    => array( 'view' ),
+						'readonly'   => true,
+						'properties' => array(
+							'code' => array(
+								'type'        => 'string',
+								'description' => __( 'State code.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'type'        => 'string',
+								'description' => __( 'Full name of state.', 'woocommerce' ),
+								'context'     => array( 'view' ),
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/includes/api/class-wc-rest-data-currencies-controller.php
+++ b/includes/api/class-wc-rest-data-currencies-controller.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * REST API Data currencies controller.
+ *
+ * Handles requests to the /data/currencies endpoint.
+ *
+ * @package WooCommerce/API
+ * @since   3.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * REST API Data Currencies controller class.
+ *
+ * @package WooCommerce/API
+ */
+class WC_REST_Data_Currencies_Controller extends WC_REST_Data_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc/v3';
+
+	/**
+	 * Route base.
+	 *
+	 * @var string
+	 */
+	protected $rest_base = 'data/currencies';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base, array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base . '/current', array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_current_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+		register_rest_route(
+			$this->namespace, '/' . $this->rest_base . '/(?P<currency>[\w-]{3})', array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'location' => array(
+							'description' => __( 'ISO4217 currency code.', 'woocommerce' ),
+							'type'        => 'string',
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Get currency information.
+	 *
+	 * @param  string          $code    Currency code.
+	 * @param  WP_REST_Request $request Request data.
+	 * @return array|mixed Response data, ready for insertion into collection data.
+	 */
+	public function get_currency( $code = false, $request ) {
+		$currencies = get_woocommerce_currencies();
+		$data       = array();
+
+		if ( ! array_key_exists( $code, $currencies ) ) {
+			return false;
+		}
+
+		$currency = array(
+			'code'   => $code,
+			'name'   => $currencies[ $code ],
+			'symbol' => get_woocommerce_currency_symbol( $code ),
+		);
+
+		return $currency;
+	}
+
+	/**
+	 * Return the list of currencies.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$currencies = get_woocommerce_currencies();
+		foreach ( array_keys( $currencies ) as $code ) {
+			$currency = $this->get_currency( $code, $request );
+			$response = $this->prepare_item_for_response( $currency, $request );
+			$data[]   = $this->prepare_response_for_collection( $response );
+		}
+
+		return rest_ensure_response( $data );
+	}
+
+	/**
+	 * Return information for a specific currency.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_item( $request ) {
+		$data = $this->get_currency( strtoupper( $request['currency'] ), $request );
+		if ( empty( $data ) ) {
+			return new WP_Error( 'woocommerce_rest_data_invalid_currency', __( 'There are no currencies matching these parameters.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+		return $this->prepare_item_for_response( $data, $request );
+	}
+
+	/**
+	 * Return information for the current site currency.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_current_item( $request ) {
+		$currency = get_option( 'woocommerce_currency' );
+		return $this->prepare_item_for_response( $this->get_currency( $currency, $request ), $request );
+	}
+
+	/**
+	 * Prepare the data object for response.
+	 *
+	 * @param object          $item Data object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$data     = $this->add_additional_fields_to_object( $item, $request );
+		$data     = $this->filter_response_by_context( $data, 'view' );
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $item ) );
+
+		/**
+		 * Filter currency returned from the API.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param array            $item     Currency data.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_data_currency', $response, $item, $request );
+	}
+
+	/**
+	 * Prepare links for the request.
+	 *
+	 * @param object $item Data object.
+	 * @return array Links for the given currency.
+	 */
+	protected function prepare_links( $item ) {
+		$code  = strtoupper( $item['code'] );
+		$links = array(
+			'self'       => array(
+				'href' => rest_url( sprintf( '/%s/%s/%s', $this->namespace, $this->rest_base, $code ) ),
+			),
+			'collection' => array(
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+			),
+		);
+
+		return $links;
+	}
+
+
+	/**
+	 * Get the currency schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'data_currencies',
+			'type'       => 'object',
+			'properties' => array(
+				'code'   => array(
+					'type'        => 'string',
+					'description' => __( 'ISO4217 currency code.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'name'   => array(
+					'type'        => 'string',
+					'description' => __( 'Full name of currency.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+				'symbol' => array(
+					'type'        => 'string',
+					'description' => __( 'Currency symbol.', 'woocommerce' ),
+					'context'     => array( 'view' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/includes/api/class-wc-rest-order-notes-controller.php
+++ b/includes/api/class-wc-rest-order-notes-controller.php
@@ -24,4 +24,108 @@ class WC_REST_Order_Notes_Controller extends WC_REST_Order_Notes_V2_Controller {
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Prepare a single order note output for response.
+	 *
+	 * @param WP_Comment      $note    Order note object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response $response Response data.
+	 */
+	public function prepare_item_for_response( $note, $request ) {
+		$data = array(
+			'id'               => (int) $note->comment_ID,
+			'author'           => __( 'WooCommerce', 'woocommerce' ) === $note->comment_author ? 'system' : $note->comment_author,
+			'date_created'     => wc_rest_prepare_date_response( $note->comment_date ),
+			'date_created_gmt' => wc_rest_prepare_date_response( $note->comment_date_gmt ),
+			'note'             => $note->comment_content,
+			'customer_note'    => (bool) get_comment_meta( $note->comment_ID, 'is_customer_note', true ),
+		);
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $note ) );
+
+		/**
+		 * Filter order note object returned from the REST API.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param WP_Comment       $note     Order note object used to create response.
+		 * @param WP_REST_Request  $request  Request object.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_order_note', $response, $note, $request );
+	}
+
+	/**
+	 * Create a single order note.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function create_item( $request ) {
+		if ( ! empty( $request['id'] ) ) {
+			/* translators: %s: post type */
+			return new WP_Error( "woocommerce_rest_{$this->post_type}_exists", sprintf( __( 'Cannot create existing %s.', 'woocommerce' ), $this->post_type ), array( 'status' => 400 ) );
+		}
+
+		$order = wc_get_order( (int) $request['order_id'] );
+
+		if ( ! $order || $this->post_type !== $order->get_type() ) {
+			return new WP_Error( 'woocommerce_rest_order_invalid_id', __( 'Invalid order ID.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		// Create the note.
+		$note_id = $order->add_order_note( $request['note'], $request['customer_note'], $request['added_by_user'] );
+
+		if ( ! $note_id ) {
+			return new WP_Error( 'woocommerce_api_cannot_create_order_note', __( 'Cannot create order note, please try again.', 'woocommerce' ), array( 'status' => 500 ) );
+		}
+
+		$note = get_comment( $note_id );
+		$this->update_additional_fields_for_object( $note, $request );
+
+		/**
+		 * Fires after a order note is created or updated via the REST API.
+		 *
+		 * @param WP_Comment      $note      New order note object.
+		 * @param WP_REST_Request $request   Request object.
+		 * @param boolean         $creating  True when creating item, false when updating.
+		 */
+		do_action( 'woocommerce_rest_insert_order_note', $note, $request, true );
+
+		$request->set_param( 'context', 'edit' );
+		$response = $this->prepare_item_for_response( $note, $request );
+		$response = rest_ensure_response( $response );
+		$response->set_status( 201 );
+		$response->header( 'Location', rest_url( sprintf( '/%s/%s/%d', $this->namespace, str_replace( '(?P<order_id>[\d]+)', $order->get_id(), $this->rest_base ), $note_id ) ) );
+
+		return $response;
+	}
+
+	/**
+	 * Get the Order Notes schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema                                = parent::get_item_schema();
+		$schema['properties']['author']        = array(
+			'description' => __( 'Order note author.', 'woocommerce' ),
+			'type'        => 'string',
+			'readonly'    => true,
+			'context'     => array( 'view', 'edit' ),
+		);
+		$schema['properties']['added_by_user'] = array(
+			'description' => __( 'If true, this note will be attributed to the current user. If false, the note will be attributed to the system.', 'woocommerce' ),
+			'type'        => 'boolean',
+			'default'     => false,
+			'context'     => array( 'edit' ),
+		);
+		return $schema;
+	}
 }

--- a/includes/api/class-wc-rest-order-refunds-controller.php
+++ b/includes/api/class-wc-rest-order-refunds-controller.php
@@ -24,4 +24,63 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Prepares one object for create or update operation.
+	 *
+	 * @since  3.0.0
+	 * @param  WP_REST_Request $request Request object.
+	 * @param  bool            $creating If is creating a new object.
+	 * @return WP_Error|WC_Data The prepared item, or WP_Error object on failure.
+	 */
+	protected function prepare_object_for_database( $request, $creating = false ) {
+		$order = wc_get_order( (int) $request['order_id'] );
+
+		if ( ! $order ) {
+			return new WP_Error( 'woocommerce_rest_invalid_order_id', __( 'Invalid order ID.', 'woocommerce' ), 404 );
+		}
+
+		if ( 0 > $request['amount'] ) {
+			return new WP_Error( 'woocommerce_rest_invalid_order_refund', __( 'Refund amount must be greater than zero.', 'woocommerce' ), 400 );
+		}
+
+		// Create the refund.
+		$refund = wc_create_refund(
+			array(
+				'order_id'       => $order->get_id(),
+				'amount'         => $request['amount'],
+				'reason'         => empty( $request['reason'] ) ? null : $request['reason'],
+				'line_items'     => empty( $request['line_items'] ) ? array() : $request['line_items'],
+				'refund_payment' => is_bool( $request['api_refund'] ) ? $request['api_refund'] : true,
+				'restock_items'  => true,
+			)
+		);
+
+		if ( is_wp_error( $refund ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_create_order_refund', $refund->get_error_message(), 500 );
+		}
+
+		if ( ! $refund ) {
+			return new WP_Error( 'woocommerce_rest_cannot_create_order_refund', __( 'Cannot create order refund, please try again.', 'woocommerce' ), 500 );
+		}
+
+		if ( ! empty( $request['meta_data'] ) && is_array( $request['meta_data'] ) ) {
+			foreach ( $request['meta_data'] as $meta ) {
+				$refund->update_meta_data( $meta['key'], $meta['value'], isset( $meta['id'] ) ? $meta['id'] : '' );
+			}
+			$refund->save_meta_data();
+		}
+
+		/**
+		 * Filters an object before it is inserted via the REST API.
+		 *
+		 * The dynamic portion of the hook name, `$this->post_type`,
+		 * refers to the object type slug.
+		 *
+		 * @param WC_Data         $coupon   Object object.
+		 * @param WP_REST_Request $request  Request object.
+		 * @param bool            $creating If is creating a new object.
+		 */
+		return apply_filters( "woocommerce_rest_pre_insert_{$this->post_type}_object", $refund, $request, $creating );
+	}
 }

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -24,4 +24,52 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Prepare objects query.
+	 *
+	 * @since  3.0.0
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return array
+	 */
+	protected function prepare_objects_query( $request ) {
+		// This is needed to get around an array to string notice in WC_REST_Orders_Controller::prepare_objects_query.
+		$statuses = $request['status'];
+		unset( $request['status'] );
+		$args = parent::prepare_objects_query( $request );
+
+		$args['post_status'] = array();
+		foreach ( $statuses as $status ) {
+			if ( 'any' === $status ) {
+				// Set status to "any" and short-circuit out.
+				$args['post_status'] = 'any';
+				break;
+			}
+			$args['post_status'][] = 'wc-' . $status;
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params = parent::get_collection_params();
+
+		$params['status'] = array(
+			'default'           => 'any',
+			'description'       => __( 'Limit result set to orders assigned a specific status.', 'woocommerce' ),
+			'type'              => 'array',
+			'items'             => array(
+				'type' => 'string',
+				'enum' => array_merge( array( 'any' ), $this->get_order_statuses() ),
+			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		return $params;
+	}
 }

--- a/includes/api/class-wc-rest-payment-gateways-controller.php
+++ b/includes/api/class-wc-rest-payment-gateways-controller.php
@@ -24,4 +24,203 @@ class WC_REST_Payment_Gateways_Controller extends WC_REST_Payment_Gateways_V2_Co
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Prepare a payment gateway for response.
+	 *
+	 * @param  WC_Payment_Gateway $gateway    Payment gateway object.
+	 * @param  WP_REST_Request    $request    Request object.
+	 * @return WP_REST_Response   $response   Response data.
+	 */
+	public function prepare_item_for_response( $gateway, $request ) {
+		$order = (array) get_option( 'woocommerce_gateway_order' );
+		$item  = array(
+			'id'                 => $gateway->id,
+			'title'              => $gateway->title,
+			'description'        => $gateway->description,
+			'order'              => isset( $order[ $gateway->id ] ) ? $order[ $gateway->id ] : '',
+			'enabled'            => ( 'yes' === $gateway->enabled ),
+			'method_title'       => $gateway->get_method_title(),
+			'method_description' => $gateway->get_method_description(),
+			'method_supports'    => $gateway->supports,
+			'settings'           => $this->get_settings( $gateway ),
+		);
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $item, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $gateway, $request ) );
+
+		/**
+		 * Filter payment gateway objects returned from the REST API.
+		 *
+		 * @param WP_REST_Response   $response The response object.
+		 * @param WC_Payment_Gateway $gateway  Payment gateway object.
+		 * @param WP_REST_Request    $request  Request object.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_payment_gateway', $response, $gateway, $request );
+	}
+
+	/**
+	 * Return settings associated with this payment gateway.
+	 *
+	 * @param WC_Payment_Gateway $gateway Gateway instance.
+	 *
+	 * @return array
+	 */
+	public function get_settings( $gateway ) {
+		$settings = array();
+		$gateway->init_form_fields();
+		foreach ( $gateway->form_fields as $id => $field ) {
+			// Make sure we at least have a title and type.
+			if ( empty( $field['title'] ) || empty( $field['type'] ) ) {
+				continue;
+			}
+
+			// Ignore 'enabled' and 'description' which get included elsewhere.
+			if ( in_array( $id, array( 'enabled', 'description' ), true ) ) {
+				continue;
+			}
+
+			$data = array(
+				'id'          => $id,
+				'label'       => empty( $field['label'] ) ? $field['title'] : $field['label'],
+				'description' => empty( $field['description'] ) ? '' : $field['description'],
+				'type'        => $field['type'],
+				'value'       => empty( $gateway->settings[ $id ] ) ? '' : $gateway->settings[ $id ],
+				'default'     => empty( $field['default'] ) ? '' : $field['default'],
+				'tip'         => empty( $field['description'] ) ? '' : $field['description'],
+				'placeholder' => empty( $field['placeholder'] ) ? '' : $field['placeholder'],
+			);
+			if ( ! empty( $field['options'] ) ) {
+				$data['options'] = $field['options'];
+			}
+			$settings[ $id ] = $data;
+		}
+		return $settings;
+	}
+
+	/**
+	 * Get the payment gateway schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'payment_gateway',
+			'type'       => 'object',
+			'properties' => array(
+				'id'                 => array(
+					'description' => __( 'Payment gateway ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'title'              => array(
+					'description' => __( 'Payment gateway title on checkout.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'description'        => array(
+					'description' => __( 'Payment gateway description on checkout.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'order'              => array(
+					'description' => __( 'Payment gateway sort order.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'absint',
+					),
+				),
+				'enabled'            => array(
+					'description' => __( 'Payment gateway enabled status.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'method_title'       => array(
+					'description' => __( 'Payment gateway method title.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'method_description' => array(
+					'description' => __( 'Payment gateway method description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'method_supports'    => array(
+					'description' => __( 'Supported features for this payment gateway.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type' => 'string',
+					),
+				),
+				'settings'           => array(
+					'description' => __( 'Payment gateway settings.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'id'          => array(
+							'description' => __( 'A unique identifier for the setting.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'label'       => array(
+							'description' => __( 'A human readable label for the setting used in interfaces.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'description' => array(
+							'description' => __( 'A human readable description for the setting used in interfaces.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'type'        => array(
+							'description' => __( 'Type of setting.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'enum'        => array( 'text', 'email', 'number', 'color', 'password', 'textarea', 'select', 'multiselect', 'radio', 'image_width', 'checkbox' ),
+							'readonly'    => true,
+						),
+						'value'       => array(
+							'description' => __( 'Setting value.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'default'     => array(
+							'description' => __( 'Default value for the setting.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'tip'         => array(
+							'description' => __( 'Additional help text shown to the user about the setting.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'placeholder' => array(
+							'description' => __( 'Placeholder text to be displayed in text inputs.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
 }

--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -24,4 +24,716 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Prepare a single variation output for response.
+	 *
+	 * @param  WC_Data         $object  Object data.
+	 * @param  WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_object_for_response( $object, $request ) {
+		$data = array(
+			'id'                    => $object->get_id(),
+			'date_created'          => wc_rest_prepare_date_response( $object->get_date_created(), false ),
+			'date_created_gmt'      => wc_rest_prepare_date_response( $object->get_date_created() ),
+			'date_modified'         => wc_rest_prepare_date_response( $object->get_date_modified(), false ),
+			'date_modified_gmt'     => wc_rest_prepare_date_response( $object->get_date_modified() ),
+			'description'           => wc_format_content( $object->get_description() ),
+			'permalink'             => $object->get_permalink(),
+			'sku'                   => $object->get_sku(),
+			'price'                 => $object->get_price(),
+			'regular_price'         => $object->get_regular_price(),
+			'sale_price'            => $object->get_sale_price(),
+			'date_on_sale_from'     => wc_rest_prepare_date_response( $object->get_date_on_sale_from(), false ),
+			'date_on_sale_from_gmt' => wc_rest_prepare_date_response( $object->get_date_on_sale_from() ),
+			'date_on_sale_to'       => wc_rest_prepare_date_response( $object->get_date_on_sale_to(), false ),
+			'date_on_sale_to_gmt'   => wc_rest_prepare_date_response( $object->get_date_on_sale_to() ),
+			'on_sale'               => $object->is_on_sale(),
+			'status'                => $object->get_status(),
+			'purchasable'           => $object->is_purchasable(),
+			'virtual'               => $object->is_virtual(),
+			'downloadable'          => $object->is_downloadable(),
+			'downloads'             => $this->get_downloads( $object ),
+			'download_limit'        => '' !== $object->get_download_limit() ? (int) $object->get_download_limit() : -1,
+			'download_expiry'       => '' !== $object->get_download_expiry() ? (int) $object->get_download_expiry() : -1,
+			'tax_status'            => $object->get_tax_status(),
+			'tax_class'             => $object->get_tax_class(),
+			'manage_stock'          => $object->managing_stock(),
+			'stock_quantity'        => $object->get_stock_quantity(),
+			'in_stock'              => $object->is_in_stock(),
+			'backorders'            => $object->get_backorders(),
+			'backorders_allowed'    => $object->backorders_allowed(),
+			'backordered'           => $object->is_on_backorder(),
+			'weight'                => $object->get_weight(),
+			'dimensions'            => array(
+				'length' => $object->get_length(),
+				'width'  => $object->get_width(),
+				'height' => $object->get_height(),
+			),
+			'shipping_class'        => $object->get_shipping_class(),
+			'shipping_class_id'     => $object->get_shipping_class_id(),
+			'image'                 => $this->get_image( $object ),
+			'attributes'            => $this->get_attributes( $object ),
+			'menu_order'            => $object->get_menu_order(),
+			'meta_data'             => $object->get_meta_data(),
+		);
+
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data     = $this->add_additional_fields_to_object( $data, $request );
+		$data     = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $object, $request ) );
+
+		/**
+		 * Filter the data for a response.
+		 *
+		 * The dynamic portion of the hook name, $this->post_type,
+		 * refers to object type being prepared for the response.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param WC_Data          $object   Object data.
+		 * @param WP_REST_Request  $request  Request object.
+		 */
+		return apply_filters( "woocommerce_rest_prepare_{$this->post_type}_object", $response, $object, $request );
+	}
+
+	/**
+	 * Prepare a single variation for create or update.
+	 *
+	 * @param  WP_REST_Request $request Request object.
+	 * @param  bool            $creating If is creating a new object.
+	 * @return WP_Error|WC_Data
+	 */
+	protected function prepare_object_for_database( $request, $creating = false ) {
+		if ( isset( $request['id'] ) ) {
+			$variation = wc_get_product( absint( $request['id'] ) );
+		} else {
+			$variation = new WC_Product_Variation();
+		}
+
+		$variation->set_parent_id( absint( $request['product_id'] ) );
+
+		// Status.
+		if ( isset( $request['status'] ) ) {
+			$variation->set_status( get_post_status_object( $request['status'] ) ? $request['status'] : 'draft' );
+		}
+
+		// SKU.
+		if ( isset( $request['sku'] ) ) {
+			$variation->set_sku( wc_clean( $request['sku'] ) );
+		}
+
+		// Thumbnail.
+		if ( isset( $request['image'] ) ) {
+			if ( is_array( $request['image'] ) ) {
+				$variation = $this->set_variation_image( $variation, $request['image'] );
+			} else {
+				$variation->set_image_id( '' );
+			}
+		}
+
+		// Virtual variation.
+		if ( isset( $request['virtual'] ) ) {
+			$variation->set_virtual( $request['virtual'] );
+		}
+
+		// Downloadable variation.
+		if ( isset( $request['downloadable'] ) ) {
+			$variation->set_downloadable( $request['downloadable'] );
+		}
+
+		// Downloads.
+		if ( $variation->get_downloadable() ) {
+			// Downloadable files.
+			if ( isset( $request['downloads'] ) && is_array( $request['downloads'] ) ) {
+				$variation = $this->save_downloadable_files( $variation, $request['downloads'] );
+			}
+
+			// Download limit.
+			if ( isset( $request['download_limit'] ) ) {
+				$variation->set_download_limit( $request['download_limit'] );
+			}
+
+			// Download expiry.
+			if ( isset( $request['download_expiry'] ) ) {
+				$variation->set_download_expiry( $request['download_expiry'] );
+			}
+		}
+
+		// Shipping data.
+		$variation = $this->save_product_shipping_data( $variation, $request );
+
+		// Stock handling.
+		if ( isset( $request['manage_stock'] ) ) {
+			$variation->set_manage_stock( $request['manage_stock'] );
+		}
+
+		if ( isset( $request['in_stock'] ) ) {
+			$variation->set_stock_status( true === $request['in_stock'] ? 'instock' : 'outofstock' );
+		}
+
+		if ( isset( $request['backorders'] ) ) {
+			$variation->set_backorders( $request['backorders'] );
+		}
+
+		if ( $variation->get_manage_stock() ) {
+			if ( isset( $request['stock_quantity'] ) ) {
+				$variation->set_stock_quantity( $request['stock_quantity'] );
+			} elseif ( isset( $request['inventory_delta'] ) ) {
+				$stock_quantity  = wc_stock_amount( $variation->get_stock_quantity() );
+				$stock_quantity += wc_stock_amount( $request['inventory_delta'] );
+				$variation->set_stock_quantity( $stock_quantity );
+			}
+		} else {
+			$variation->set_backorders( 'no' );
+			$variation->set_stock_quantity( '' );
+		}
+
+		// Regular Price.
+		if ( isset( $request['regular_price'] ) ) {
+			$variation->set_regular_price( $request['regular_price'] );
+		}
+
+		// Sale Price.
+		if ( isset( $request['sale_price'] ) ) {
+			$variation->set_sale_price( $request['sale_price'] );
+		}
+
+		if ( isset( $request['date_on_sale_from'] ) ) {
+			$variation->set_date_on_sale_from( $request['date_on_sale_from'] );
+		}
+
+		if ( isset( $request['date_on_sale_from_gmt'] ) ) {
+			$variation->set_date_on_sale_from( $request['date_on_sale_from_gmt'] ? strtotime( $request['date_on_sale_from_gmt'] ) : null );
+		}
+
+		if ( isset( $request['date_on_sale_to'] ) ) {
+			$variation->set_date_on_sale_to( $request['date_on_sale_to'] );
+		}
+
+		if ( isset( $request['date_on_sale_to_gmt'] ) ) {
+			$variation->set_date_on_sale_to( $request['date_on_sale_to_gmt'] ? strtotime( $request['date_on_sale_to_gmt'] ) : null );
+		}
+
+		// Tax class.
+		if ( isset( $request['tax_class'] ) ) {
+			$variation->set_tax_class( $request['tax_class'] );
+		}
+
+		// Description.
+		if ( isset( $request['description'] ) ) {
+			$variation->set_description( wp_kses_post( $request['description'] ) );
+		}
+
+		// Update taxonomies.
+		if ( isset( $request['attributes'] ) ) {
+			$attributes        = array();
+			$parent            = wc_get_product( $variation->get_parent_id() );
+			$parent_attributes = $parent->get_attributes();
+
+			foreach ( $request['attributes'] as $attribute ) {
+				$attribute_id   = 0;
+				$attribute_name = '';
+
+				// Check ID for global attributes or name for product attributes.
+				if ( ! empty( $attribute['id'] ) ) {
+					$attribute_id   = absint( $attribute['id'] );
+					$attribute_name = wc_attribute_taxonomy_name_by_id( $attribute_id );
+				} elseif ( ! empty( $attribute['name'] ) ) {
+					$attribute_name = sanitize_title( $attribute['name'] );
+				}
+
+				if ( ! $attribute_id && ! $attribute_name ) {
+					continue;
+				}
+
+				if ( ! isset( $parent_attributes[ $attribute_name ] ) || ! $parent_attributes[ $attribute_name ]->get_variation() ) {
+					continue;
+				}
+
+				$attribute_key   = sanitize_title( $parent_attributes[ $attribute_name ]->get_name() );
+				$attribute_value = isset( $attribute['option'] ) ? wc_clean( stripslashes( $attribute['option'] ) ) : '';
+
+				if ( $parent_attributes[ $attribute_name ]->is_taxonomy() ) {
+					// If dealing with a taxonomy, we need to get the slug from the name posted to the API.
+					$term = get_term_by( 'name', $attribute_value, $attribute_name );
+
+					if ( $term && ! is_wp_error( $term ) ) {
+						$attribute_value = $term->slug;
+					} else {
+						$attribute_value = sanitize_title( $attribute_value );
+					}
+				}
+
+				$attributes[ $attribute_key ] = $attribute_value;
+			}
+
+			$variation->set_attributes( $attributes );
+		}
+
+		// Menu order.
+		if ( $request['menu_order'] ) {
+			$variation->set_menu_order( $request['menu_order'] );
+		}
+
+		// Meta data.
+		if ( is_array( $request['meta_data'] ) ) {
+			foreach ( $request['meta_data'] as $meta ) {
+				$variation->update_meta_data( $meta['key'], $meta['value'], isset( $meta['id'] ) ? $meta['id'] : '' );
+			}
+		}
+
+		/**
+		 * Filters an object before it is inserted via the REST API.
+		 *
+		 * The dynamic portion of the hook name, `$this->post_type`,
+		 * refers to the object type slug.
+		 *
+		 * @param WC_Data         $variation Object object.
+		 * @param WP_REST_Request $request   Request object.
+		 * @param bool            $creating  If is creating a new object.
+		 */
+		return apply_filters( "woocommerce_rest_pre_insert_{$this->post_type}_object", $variation, $request, $creating );
+	}
+
+	/**
+	 * Get the image for a product variation.
+	 *
+	 * @param WC_Product_Variation $variation Variation data.
+	 * @return array
+	 */
+	protected function get_image( $variation ) {
+		if ( ! has_post_thumbnail( $variation->get_id() ) ) {
+			return;
+		}
+
+		$attachment_id   = $variation->get_image_id();
+		$attachment_post = get_post( $attachment_id );
+		if ( is_null( $attachment_post ) ) {
+			return;
+		}
+
+		$attachment = wp_get_attachment_image_src( $attachment_id, 'full' );
+		if ( ! is_array( $attachment ) ) {
+			return;
+		}
+
+		if ( ! isset( $image ) ) {
+			return array(
+				'id'                => (int) $attachment_id,
+				'date_created'      => wc_rest_prepare_date_response( $attachment_post->post_date, false ),
+				'date_created_gmt'  => wc_rest_prepare_date_response( strtotime( $attachment_post->post_date_gmt ) ),
+				'date_modified'     => wc_rest_prepare_date_response( $attachment_post->post_modified, false ),
+				'date_modified_gmt' => wc_rest_prepare_date_response( strtotime( $attachment_post->post_modified_gmt ) ),
+				'src'               => current( $attachment ),
+				'name'              => get_the_title( $attachment_id ),
+				'alt'               => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+			);
+		}
+	}
+
+	/**
+	 * Set variation image.
+	 *
+	 * @throws WC_REST_Exception REST API exceptions.
+	 * @param  WC_Product_Variation $variation Variation instance.
+	 * @param  array                $image    Image data.
+	 * @return WC_Product_Variation
+	 */
+	protected function set_variation_image( $variation, $image ) {
+		$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
+
+		if ( 0 === $attachment_id && isset( $image['src'] ) ) {
+			$upload = wc_rest_upload_image_from_url( esc_url_raw( $image['src'] ) );
+
+			if ( is_wp_error( $upload ) ) {
+				if ( ! apply_filters( 'woocommerce_rest_suppress_image_upload_error', false, $upload, $variation->get_id(), array( $image ) ) ) {
+					throw new WC_REST_Exception( 'woocommerce_variation_image_upload_error', $upload->get_error_message(), 400 );
+				}
+			}
+
+			$attachment_id = wc_rest_set_uploaded_image_as_attachment( $upload, $variation->get_id() );
+		}
+
+		if ( ! wp_attachment_is_image( $attachment_id ) ) {
+			/* translators: %s: attachment ID */
+			throw new WC_REST_Exception( 'woocommerce_variation_invalid_image_id', sprintf( __( '#%s is an invalid image ID.', 'woocommerce' ), $attachment_id ), 400 );
+		}
+
+		$variation->set_image_id( $attachment_id );
+
+		// Set the image alt if present.
+		if ( ! empty( $image['alt'] ) ) {
+			update_post_meta( $attachment_id, '_wp_attachment_image_alt', wc_clean( $image['alt'] ) );
+		}
+
+		// Set the image name if present.
+		if ( ! empty( $image['name'] ) ) {
+			wp_update_post(
+				array(
+					'ID'         => $attachment_id,
+					'post_title' => $image['name'],
+				)
+			);
+		}
+
+		return $variation;
+	}
+
+	/**
+	 * Get the Variation's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$weight_unit    = get_option( 'woocommerce_weight_unit' );
+		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$schema         = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->post_type,
+			'type'       => 'object',
+			'properties' => array(
+				'id'                    => array(
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created'          => array(
+					'description' => __( "The date the variation was created, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_modified'         => array(
+					'description' => __( "The date the variation was last modified, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'description'           => array(
+					'description' => __( 'Variation description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'permalink'             => array(
+					'description' => __( 'Variation URL.', 'woocommerce' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'sku'                   => array(
+					'description' => __( 'Unique identifier.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'price'                 => array(
+					'description' => __( 'Current variation price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'regular_price'         => array(
+					'description' => __( 'Variation regular price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'sale_price'            => array(
+					'description' => __( 'Variation sale price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_from'     => array(
+					'description' => __( "Start date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_from_gmt' => array(
+					'description' => __( 'Start date of sale price, as GMT.', 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_to'       => array(
+					'description' => __( "End date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_to_gmt'   => array(
+					'description' => __( "End date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'on_sale'               => array(
+					'description' => __( 'Shows if the variation is on sale.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'status'                => array(
+					'description' => __( 'Variation status.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'publish',
+					'enum'        => array_keys( get_post_statuses() ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'purchasable'           => array(
+					'description' => __( 'Shows if the variation can be bought.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'virtual'               => array(
+					'description' => __( 'If the variation is virtual.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'downloadable'          => array(
+					'description' => __( 'If the variation is downloadable.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'downloads'             => array(
+					'description' => __( 'List of downloadable files.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'   => array(
+								'description' => __( 'File MD5 hash.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'description' => __( 'File name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'file' => array(
+								'description' => __( 'File URL.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'download_limit'        => array(
+					'description' => __( 'Number of times downloadable files can be downloaded after purchase.', 'woocommerce' ),
+					'type'        => 'integer',
+					'default'     => -1,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'download_expiry'       => array(
+					'description' => __( 'Number of days until access to downloadable files expires.', 'woocommerce' ),
+					'type'        => 'integer',
+					'default'     => -1,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'tax_status'            => array(
+					'description' => __( 'Tax status.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'taxable',
+					'enum'        => array( 'taxable', 'shipping', 'none' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'tax_class'             => array(
+					'description' => __( 'Tax class.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'manage_stock'          => array(
+					'description' => __( 'Stock management at variation level.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'stock_quantity'        => array(
+					'description' => __( 'Stock quantity.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'in_stock'              => array(
+					'description' => __( 'Controls whether or not the variation is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => true,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'backorders'            => array(
+					'description' => __( 'If managing stock, this controls if backorders are allowed.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'no',
+					'enum'        => array( 'no', 'notify', 'yes' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'backorders_allowed'    => array(
+					'description' => __( 'Shows if backorders are allowed.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'backordered'           => array(
+					'description' => __( 'Shows if the variation is on backordered.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'weight'                => array(
+					/* translators: %s: weight unit */
+					'description' => sprintf( __( 'Variation weight (%s).', 'woocommerce' ), $weight_unit ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'dimensions'            => array(
+					'description' => __( 'Variation dimensions.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'length' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Variation length (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'width'  => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Variation width (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'height' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Variation height (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'shipping_class'        => array(
+					'description' => __( 'Shipping class slug.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'shipping_class_id'     => array(
+					'description' => __( 'Shipping class ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'image'                 => array(
+					'description' => __( 'Variation image data.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'id'                => array(
+							'description' => __( 'Image ID.', 'woocommerce' ),
+							'type'        => 'integer',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'date_created'      => array(
+							'description' => __( "The date the image was created, in the site's timezone.", 'woocommerce' ),
+							'type'        => 'date-time',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'date_created_gmt'  => array(
+							'description' => __( 'The date the image was created, as GMT.', 'woocommerce' ),
+							'type'        => 'date-time',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'date_modified'     => array(
+							'description' => __( "The date the image was last modified, in the site's timezone.", 'woocommerce' ),
+							'type'        => 'date-time',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'date_modified_gmt' => array(
+							'description' => __( 'The date the image was last modified, as GMT.', 'woocommerce' ),
+							'type'        => 'date-time',
+							'context'     => array( 'view', 'edit' ),
+							'readonly'    => true,
+						),
+						'src'               => array(
+							'description' => __( 'Image URL.', 'woocommerce' ),
+							'type'        => 'string',
+							'format'      => 'uri',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'name'              => array(
+							'description' => __( 'Image name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'alt'               => array(
+							'description' => __( 'Image alternative text.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'attributes'            => array(
+					'description' => __( 'List of attributes.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'     => array(
+								'description' => __( 'Attribute ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name'   => array(
+								'description' => __( 'Attribute name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'option' => array(
+								'description' => __( 'Selected attribute term name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'menu_order'            => array(
+					'description' => __( 'Menu order, used to custom sort products.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'meta_data'             => array(
+					'description' => __( 'Meta data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'    => array(
+								'description' => __( 'Meta ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'key'   => array(
+								'description' => __( 'Meta key.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'value' => array(
+								'description' => __( 'Meta value.', 'woocommerce' ),
+								'type'        => 'mixed',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+			),
+		);
+		return $this->add_additional_fields_schema( $schema );
+	}
 }

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -24,4 +24,767 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Get the images for a product or product variation.
+	 *
+	 * @param WC_Product|WC_Product_Variation $product Product instance.
+	 * @return array
+	 */
+	protected function get_images( $product ) {
+		$images         = array();
+		$attachment_ids = array();
+
+		// Add featured image.
+		if ( has_post_thumbnail( $product->get_id() ) ) {
+			$attachment_ids[] = $product->get_image_id();
+		}
+
+		// Add gallery images.
+		$attachment_ids = array_merge( $attachment_ids, $product->get_gallery_image_ids() );
+
+		// Build image data.
+		foreach ( $attachment_ids as $attachment_id ) {
+			$attachment_post = get_post( $attachment_id );
+			if ( is_null( $attachment_post ) ) {
+				continue;
+			}
+
+			$attachment = wp_get_attachment_image_src( $attachment_id, 'full' );
+			if ( ! is_array( $attachment ) ) {
+				continue;
+			}
+
+			$images[] = array(
+				'id'                => (int) $attachment_id,
+				'date_created'      => wc_rest_prepare_date_response( $attachment_post->post_date, false ),
+				'date_created_gmt'  => wc_rest_prepare_date_response( strtotime( $attachment_post->post_date_gmt ) ),
+				'date_modified'     => wc_rest_prepare_date_response( $attachment_post->post_modified, false ),
+				'date_modified_gmt' => wc_rest_prepare_date_response( strtotime( $attachment_post->post_modified_gmt ) ),
+				'src'               => current( $attachment ),
+				'name'              => get_the_title( $attachment_id ),
+				'alt'               => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+			);
+		}
+
+		return $images;
+	}
+
+	/**
+	 * Make extra product orderby features supported by WooCommerce available to the WC API.
+	 * This includes 'price', 'popularity', and 'rating'.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return array
+	 */
+	protected function prepare_objects_query( $request ) {
+		$args = parent::prepare_objects_query( $request );
+
+		$orderby = $request->get_param( 'orderby' );
+		$order   = $request->get_param( 'order' );
+
+		$ordering_args   = WC()->query->get_catalog_ordering_args( $orderby, $order );
+		$args['orderby'] = $ordering_args['orderby'];
+		$args['order']   = $ordering_args['order'];
+		if ( $ordering_args['meta_key'] ) {
+			$args['meta_key'] = $ordering_args['meta_key']; // WPCS: slow query ok.
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Set product images.
+	 *
+	 * @throws WC_REST_Exception REST API exceptions.
+	 * @param WC_Product $product Product instance.
+	 * @param array      $images  Images data.
+	 * @return WC_Product
+	 */
+	protected function set_product_images( $product, $images ) {
+		if ( is_array( $images ) ) {
+			$gallery = array();
+
+			foreach ( $images as $index => $image ) {
+				$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
+
+				if ( 0 === $attachment_id && isset( $image['src'] ) ) {
+					$upload = wc_rest_upload_image_from_url( esc_url_raw( $image['src'] ) );
+
+					if ( is_wp_error( $upload ) ) {
+						if ( ! apply_filters( 'woocommerce_rest_suppress_image_upload_error', false, $upload, $product->get_id(), $images ) ) {
+							throw new WC_REST_Exception( 'woocommerce_product_image_upload_error', $upload->get_error_message(), 400 );
+						} else {
+							continue;
+						}
+					}
+
+					$attachment_id = wc_rest_set_uploaded_image_as_attachment( $upload, $product->get_id() );
+				}
+
+				if ( ! wp_attachment_is_image( $attachment_id ) ) {
+					/* translators: %s: image ID */
+					throw new WC_REST_Exception( 'woocommerce_product_invalid_image_id', sprintf( __( '#%s is an invalid image ID.', 'woocommerce' ), $attachment_id ), 400 );
+				}
+
+				$featured_image = $product->get_image_id();
+
+				if ( 0 === $index ) {
+					$product->set_image_id( $attachment_id );
+				} else {
+					$gallery[] = $attachment_id;
+				}
+
+				// Set the image alt if present.
+				if ( ! empty( $image['alt'] ) ) {
+					update_post_meta( $attachment_id, '_wp_attachment_image_alt', wc_clean( $image['alt'] ) );
+				}
+
+				// Set the image name if present.
+				if ( ! empty( $image['name'] ) ) {
+					wp_update_post(
+						array(
+							'ID'         => $attachment_id,
+							'post_title' => $image['name'],
+						)
+					);
+				}
+			}
+
+			$product->set_gallery_image_ids( $gallery );
+		} else {
+			$product->set_image_id( '' );
+			$product->set_gallery_image_ids( array() );
+		}
+
+		return $product;
+	}
+
+	/**
+	 * Add new options for 'orderby' to the collection params.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                    = parent::get_collection_params();
+		$params['orderby']['enum'] = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating' ) );
+		return $params;
+	}
+
+	/**
+	 * Get the Product's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$weight_unit    = get_option( 'woocommerce_weight_unit' );
+		$dimension_unit = get_option( 'woocommerce_dimension_unit' );
+		$schema         = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => $this->post_type,
+			'type'       => 'object',
+			'properties' => array(
+				'id'                    => array(
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'name'                  => array(
+					'description' => __( 'Product name.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'slug'                  => array(
+					'description' => __( 'Product slug.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'permalink'             => array(
+					'description' => __( 'Product URL.', 'woocommerce' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created'          => array(
+					'description' => __( "The date the product was created, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created_gmt'      => array(
+					'description' => __( 'The date the product was created, as GMT.', 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_modified'         => array(
+					'description' => __( "The date the product was last modified, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_modified_gmt'     => array(
+					'description' => __( 'The date the product was last modified, as GMT.', 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'type'                  => array(
+					'description' => __( 'Product type.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'simple',
+					'enum'        => array_keys( wc_get_product_types() ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'status'                => array(
+					'description' => __( 'Product status (post status).', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'publish',
+					'enum'        => array_keys( get_post_statuses() ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'featured'              => array(
+					'description' => __( 'Featured product.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'catalog_visibility'    => array(
+					'description' => __( 'Catalog visibility.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'visible',
+					'enum'        => array( 'visible', 'catalog', 'search', 'hidden' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'description'           => array(
+					'description' => __( 'Product description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'short_description'     => array(
+					'description' => __( 'Product short description.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'sku'                   => array(
+					'description' => __( 'Unique identifier.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'price'                 => array(
+					'description' => __( 'Current product price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'regular_price'         => array(
+					'description' => __( 'Product regular price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'sale_price'            => array(
+					'description' => __( 'Product sale price.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_from'     => array(
+					'description' => __( "Start date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_from_gmt' => array(
+					'description' => __( 'Start date of sale price, as GMT.', 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_to'       => array(
+					'description' => __( "End date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'date_on_sale_to_gmt'   => array(
+					'description' => __( "End date of sale price, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'price_html'            => array(
+					'description' => __( 'Price formatted in HTML.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'on_sale'               => array(
+					'description' => __( 'Shows if the product is on sale.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'purchasable'           => array(
+					'description' => __( 'Shows if the product can be bought.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'total_sales'           => array(
+					'description' => __( 'Amount of sales.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'virtual'               => array(
+					'description' => __( 'If the product is virtual.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'downloadable'          => array(
+					'description' => __( 'If the product is downloadable.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'downloads'             => array(
+					'description' => __( 'List of downloadable files.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'   => array(
+								'description' => __( 'File MD5 hash.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'name' => array(
+								'description' => __( 'File name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'file' => array(
+								'description' => __( 'File URL.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'download_limit'        => array(
+					'description' => __( 'Number of times downloadable files can be downloaded after purchase.', 'woocommerce' ),
+					'type'        => 'integer',
+					'default'     => -1,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'download_expiry'       => array(
+					'description' => __( 'Number of days until access to downloadable files expires.', 'woocommerce' ),
+					'type'        => 'integer',
+					'default'     => -1,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'external_url'          => array(
+					'description' => __( 'Product external URL. Only for external products.', 'woocommerce' ),
+					'type'        => 'string',
+					'format'      => 'uri',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'button_text'           => array(
+					'description' => __( 'Product external button text. Only for external products.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'tax_status'            => array(
+					'description' => __( 'Tax status.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'taxable',
+					'enum'        => array( 'taxable', 'shipping', 'none' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'tax_class'             => array(
+					'description' => __( 'Tax class.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'manage_stock'          => array(
+					'description' => __( 'Stock management at product level.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'stock_quantity'        => array(
+					'description' => __( 'Stock quantity.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'in_stock'              => array(
+					'description' => __( 'Controls whether or not the product is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => true,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'backorders'            => array(
+					'description' => __( 'If managing stock, this controls if backorders are allowed.', 'woocommerce' ),
+					'type'        => 'string',
+					'default'     => 'no',
+					'enum'        => array( 'no', 'notify', 'yes' ),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'backorders_allowed'    => array(
+					'description' => __( 'Shows if backorders are allowed.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'backordered'           => array(
+					'description' => __( 'Shows if the product is on backordered.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'sold_individually'     => array(
+					'description' => __( 'Allow one item to be bought in a single order.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'weight'                => array(
+					/* translators: %s: weight unit */
+					'description' => sprintf( __( 'Product weight (%s).', 'woocommerce' ), $weight_unit ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'dimensions'            => array(
+					'description' => __( 'Product dimensions.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'length' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Product length (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'width'  => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Product width (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'height' => array(
+							/* translators: %s: dimension unit */
+							'description' => sprintf( __( 'Product height (%s).', 'woocommerce' ), $dimension_unit ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'shipping_required'     => array(
+					'description' => __( 'Shows if the product need to be shipped.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'shipping_taxable'      => array(
+					'description' => __( 'Shows whether or not the product shipping is taxable.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'shipping_class'        => array(
+					'description' => __( 'Shipping class slug.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'shipping_class_id'     => array(
+					'description' => __( 'Shipping class ID.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'reviews_allowed'       => array(
+					'description' => __( 'Allow reviews.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => true,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'average_rating'        => array(
+					'description' => __( 'Reviews average rating.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'rating_count'          => array(
+					'description' => __( 'Amount of reviews that the product have.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'related_ids'           => array(
+					'description' => __( 'List of related products IDs.', 'woocommerce' ),
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'integer',
+					),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'upsell_ids'            => array(
+					'description' => __( 'List of up-sell products IDs.', 'woocommerce' ),
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'integer',
+					),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'cross_sell_ids'        => array(
+					'description' => __( 'List of cross-sell products IDs.', 'woocommerce' ),
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'integer',
+					),
+					'context'     => array( 'view', 'edit' ),
+				),
+				'parent_id'             => array(
+					'description' => __( 'Product parent ID.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'purchase_note'         => array(
+					'description' => __( 'Optional note to send the customer after purchase.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'categories'            => array(
+					'description' => __( 'List of categories.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'   => array(
+								'description' => __( 'Category ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Category name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'slug' => array(
+								'description' => __( 'Category slug.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+				'tags'                  => array(
+					'description' => __( 'List of tags.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'   => array(
+								'description' => __( 'Tag ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name' => array(
+								'description' => __( 'Tag name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'slug' => array(
+								'description' => __( 'Tag slug.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+						),
+					),
+				),
+				'images'                => array(
+					'description' => __( 'List of images.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'                => array(
+								'description' => __( 'Image ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'date_created'      => array(
+								'description' => __( "The date the image was created, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_created_gmt'  => array(
+								'description' => __( 'The date the image was created, as GMT.', 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_modified'     => array(
+								'description' => __( "The date the image was last modified, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_modified_gmt' => array(
+								'description' => __( 'The date the image was last modified, as GMT.', 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'src'               => array(
+								'description' => __( 'Image URL.', 'woocommerce' ),
+								'type'        => 'string',
+								'format'      => 'uri',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name'              => array(
+								'description' => __( 'Image name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'alt'               => array(
+								'description' => __( 'Image alternative text.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'attributes'            => array(
+					'description' => __( 'List of attributes.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'        => array(
+								'description' => __( 'Attribute ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name'      => array(
+								'description' => __( 'Attribute name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'position'  => array(
+								'description' => __( 'Attribute position.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'visible'   => array(
+								'description' => __( "Define if the attribute is visible on the \"Additional information\" tab in the product's page.", 'woocommerce' ),
+								'type'        => 'boolean',
+								'default'     => false,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'variation' => array(
+								'description' => __( 'Define if the attribute can be used as variation.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'default'     => false,
+								'context'     => array( 'view', 'edit' ),
+							),
+							'options'   => array(
+								'description' => __( 'List of available term names of the attribute.', 'woocommerce' ),
+								'type'        => 'array',
+								'items'       => array(
+									'type' => 'string',
+								),
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'default_attributes'    => array(
+					'description' => __( 'Defaults variation attributes.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'     => array(
+								'description' => __( 'Attribute ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'name'   => array(
+								'description' => __( 'Attribute name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'option' => array(
+								'description' => __( 'Selected attribute term name.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+				'variations'            => array(
+					'description' => __( 'List of variations IDs.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type' => 'integer',
+					),
+					'readonly'    => true,
+				),
+				'grouped_products'      => array(
+					'description' => __( 'List of grouped products ID.', 'woocommerce' ),
+					'type'        => 'array',
+					'items'       => array(
+						'type' => 'integer',
+					),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'menu_order'            => array(
+					'description' => __( 'Menu order, used to custom sort products.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'meta_data'             => array(
+					'description' => __( 'Meta data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'    => array(
+								'description' => __( 'Meta ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'key'   => array(
+								'description' => __( 'Meta key.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'value' => array(
+								'description' => __( 'Meta value.', 'woocommerce' ),
+								'type'        => 'mixed',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+			),
+		);
+		return $this->add_additional_fields_schema( $schema );
+	}
 }

--- a/includes/api/class-wc-rest-setting-options-controller.php
+++ b/includes/api/class-wc-rest-setting-options-controller.php
@@ -24,4 +24,227 @@ class WC_REST_Setting_Options_Controller extends WC_REST_Setting_Options_V2_Cont
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Get setting data.
+	 *
+	 * @param string $group_id Group ID.
+	 * @param string $setting_id Setting ID.
+	 * @return stdClass|WP_Error
+	 */
+	public function get_setting( $group_id, $setting_id ) {
+		$setting = parent::get_setting( $group_id, $setting_id );
+		if ( is_wp_error( $setting ) ) {
+			return $setting;
+		}
+		$setting['group_id'] = $group_id;
+		return $setting;
+	}
+
+	/**
+	 * Callback for allowed keys for each setting response.
+	 *
+	 * @param  string $key Key to check.
+	 * @return boolean
+	 */
+	public function allowed_setting_keys( $key ) {
+		return in_array(
+			$key, array(
+				'id',
+				'group_id',
+				'label',
+				'description',
+				'default',
+				'tip',
+				'placeholder',
+				'type',
+				'options',
+				'value',
+				'option_key',
+			), true
+		);
+	}
+
+	/**
+	 * Get all settings in a group.
+	 *
+	 * @param string $group_id Group ID.
+	 * @return array|WP_Error
+	 */
+	public function get_group_settings( $group_id ) {
+		if ( empty( $group_id ) ) {
+			return new WP_Error( 'rest_setting_setting_group_invalid', __( 'Invalid setting group.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		$settings = apply_filters( 'woocommerce_settings-' . $group_id, array() ); // phpcs:ignore WordPress.NamingConventions.ValidHookName.UseUnderscores
+
+		if ( empty( $settings ) ) {
+			return new WP_Error( 'rest_setting_setting_group_invalid', __( 'Invalid setting group.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		$filtered_settings = array();
+		foreach ( $settings as $setting ) {
+			$option_key = $setting['option_key'];
+			$setting    = $this->filter_setting( $setting );
+			$default    = isset( $setting['default'] ) ? $setting['default'] : '';
+			// Get the option value.
+			if ( is_array( $option_key ) ) {
+				$option           = get_option( $option_key[0] );
+				$setting['value'] = isset( $option[ $option_key[1] ] ) ? $option[ $option_key[1] ] : $default;
+			} else {
+				$admin_setting_value = WC_Admin_Settings::get_option( $option_key, $default );
+				$setting['value']    = $admin_setting_value;
+			}
+
+			if ( 'multi_select_countries' === $setting['type'] ) {
+				$setting['options'] = WC()->countries->get_countries();
+				$setting['type']    = 'multiselect';
+			} elseif ( 'single_select_country' === $setting['type'] ) {
+				$setting['type']    = 'select';
+				$setting['options'] = $this->get_countries_and_states();
+			} elseif ( 'single_select_page' === $setting['type'] ) {
+				$pages   = get_pages(
+					array(
+						'sort_column'  => 'menu_order',
+						'sort_order'   => 'ASC',
+						'hierarchical' => 0,
+					)
+				);
+				$options = array();
+				foreach ( $pages as $page ) {
+					$options[ $page->ID ] = ! empty( $page->post_title ) ? $page->post_title : '#' . $page->ID;
+				}
+				$setting['type']    = 'select';
+				$setting['options'] = $options;
+			}
+
+			$filtered_settings[] = $setting;
+		}
+
+		return $filtered_settings;
+	}
+
+	/**
+	 * Returns a list of countries and states for use in the base location setting.
+	 *
+	 * @since  3.0.7
+	 * @return array Array of states and countries.
+	 */
+	private function get_countries_and_states() {
+		$countries = WC()->countries->get_countries();
+		if ( ! $countries ) {
+			return array();
+		}
+		$output = array();
+		foreach ( $countries as $key => $value ) {
+			$states = WC()->countries->get_states( $key );
+
+			if ( $states ) {
+				foreach ( $states as $state_key => $state_value ) {
+					$output[ $key . ':' . $state_key ] = $value . ' - ' . $state_value;
+				}
+			} else {
+				$output[ $key ] = $value;
+			}
+		}
+		return $output;
+	}
+
+	/**
+	 * Get the settings schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'setting',
+			'type'       => 'object',
+			'properties' => array(
+				'id'          => array(
+					'description' => __( 'A unique identifier for the setting.', 'woocommerce' ),
+					'type'        => 'string',
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_title',
+					),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'group_id'    => array(
+					'description' => __( 'An identifier for the group this setting belongs to.', 'woocommerce' ),
+					'type'        => 'string',
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_title',
+					),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'label'       => array(
+					'description' => __( 'A human readable label for the setting used in interfaces.', 'woocommerce' ),
+					'type'        => 'string',
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'description' => array(
+					'description' => __( 'A human readable description for the setting used in interfaces.', 'woocommerce' ),
+					'type'        => 'string',
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'value'       => array(
+					'description' => __( 'Setting value.', 'woocommerce' ),
+					'type'        => 'mixed',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'default'     => array(
+					'description' => __( 'Default value for the setting.', 'woocommerce' ),
+					'type'        => 'mixed',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'tip'         => array(
+					'description' => __( 'Additional help text shown to the user about the setting.', 'woocommerce' ),
+					'type'        => 'string',
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'placeholder' => array(
+					'description' => __( 'Placeholder text to be displayed in text inputs.', 'woocommerce' ),
+					'type'        => 'string',
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'type'        => array(
+					'description' => __( 'Type of setting.', 'woocommerce' ),
+					'type'        => 'string',
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+					'context'     => array( 'view', 'edit' ),
+					'enum'        => array( 'text', 'email', 'number', 'color', 'password', 'textarea', 'select', 'multiselect', 'radio', 'image_width', 'checkbox' ),
+					'readonly'    => true,
+				),
+				'options'     => array(
+					'description' => __( 'Array of options (key value pairs) for inputs such as select, multiselect, and radio buttons.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
 }

--- a/includes/api/class-wc-rest-settings-controller.php
+++ b/includes/api/class-wc-rest-settings-controller.php
@@ -24,4 +24,46 @@ class WC_REST_Settings_Controller extends WC_REST_Settings_V2_Controller {
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Register routes.
+	 */
+	public function register_routes() {
+		parent::register_routes();
+		register_rest_route( $this->namespace, '/' . $this->rest_base . '/batch', array(
+			array(
+				'methods'             => WP_REST_Server::EDITABLE,
+				'callback'            => array( $this, 'batch_items' ),
+				'permission_callback' => array( $this, 'update_items_permissions_check' ),
+			),
+			'schema' => array( $this, 'get_public_batch_schema' ),
+		) );
+	}
+
+	/**
+	 * Makes sure the current user has access to WRITE the settings APIs.
+	 *
+	 * @param WP_REST_Request $request Full data about the request.
+	 * @return WP_Error|bool
+	 */
+	public function update_items_permissions_check( $request ) {
+		if ( ! wc_rest_check_manager_permissions( 'settings', 'edit' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_edit', __( 'Sorry, you cannot edit this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Update a setting.
+	 *
+	 * @param  WP_REST_Request $request Request data.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function update_item( $request ) {
+		$options_controller = new WC_REST_Dev_Setting_Options_Controller();
+		$response           = $options_controller->update_item( $request );
+
+		return $response;
+	}
 }

--- a/includes/api/v2/class-wc-rest-order-refunds-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-order-refunds-v2-controller.php
@@ -455,7 +455,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 							),
 							'tax_class'    => array(
 								'description' => __( 'Tax class of product.', 'woocommerce' ),
-								'type'        => 'integer',
+								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
@@ -549,7 +549,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 							),
 							'price'        => array(
 								'description' => __( 'Product price.', 'woocommerce' ),
-								'type'        => 'string',
+								'type'        => 'number',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -228,6 +228,10 @@ class WC_API extends WC_Legacy_API {
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-system-status-tools-controller.php';
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-shipping-methods-controller.php';
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-payment-gateways-controller.php';
+		include_once dirname( __FILE__ ) . '/api/includes/api/class-wc-rest-data-continents-controller.php';
+		include_once dirname( __FILE__ ) . '/api/includes/api/class-wc-rest-data-controller.php';
+		include_once dirname( __FILE__ ) . '/api/includes/api/class-wc-rest-data-countries-controller.php';
+		include_once dirname( __FILE__ ) . '/api/includes/api/class-wc-rest-data-currencies-controller.php';
 	}
 
 	/**


### PR DESCRIPTION
Just copied all changes and new endpoints from https://github.com/woocommerce/wc-api-dev

Note that the follow endpoints has been removed:

- `products/reviews` - Removed because it was not consistent enough with the current `products/<id>/reviews`, I want to refactor it, changing the whole endpoint to return all reviews by default and allow filter results by `product_id`, `customer_id` and so on.
- `data/counts` - Removed since we already return counts in the headers of `orders` and `products` requests, and if we refactor `product/reviews` endpoint we should have the same on headers too. Anyway this endpoint is generating a sort of "stats" so we probably should include into the new `reports` or `stats` endpoint (we need to decide about the name).

cc @mikejolley @justinshreve @ryelle @allendav 