### PR TITLE
Prevent autofocus on checkout

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -618,7 +618,6 @@ class WC_Countries {
 				'required'     => true,
 				'class'        => array( 'form-row-first' ),
 				'autocomplete' => 'given-name',
-				'autofocus'    => true,
 				'priority'     => 10,
 			),
 			'last_name'  => array(

--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -179,19 +179,14 @@ class WC_Payment_Gateways {
 			return;
 		}
 
-		if ( is_user_logged_in() ) {
-			$default_token = WC_Payment_Tokens::get_customer_default_token( get_current_user_id() );
-			if ( ! is_null( $default_token ) ) {
-				$default_token_gateway = $default_token->get_gateway_id();
-			}
-		}
-
-		$current = ( isset( $default_token_gateway ) ? $default_token_gateway : WC()->session->get( 'chosen_payment_method' ) );
+		$current_gateway = false;
+		$current         = WC()->session->get( 'chosen_payment_method' );
 
 		if ( $current && isset( $gateways[ $current ] ) ) {
 			$current_gateway = $gateways[ $current ];
+		}
 
-		} else {
+		if ( ! $current_gateway ) {
 			$current_gateway = current( $gateways );
 		}
 

--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -179,14 +179,19 @@ class WC_Payment_Gateways {
 			return;
 		}
 
-		$current_gateway = false;
-		$current         = WC()->session->get( 'chosen_payment_method' );
+		if ( is_user_logged_in() ) {
+			$default_token = WC_Payment_Tokens::get_customer_default_token( get_current_user_id() );
+			if ( ! is_null( $default_token ) ) {
+				$default_token_gateway = $default_token->get_gateway_id();
+			}
+		}
+
+		$current = ( isset( $default_token_gateway ) ? $default_token_gateway : WC()->session->get( 'chosen_payment_method' ) );
 
 		if ( $current && isset( $gateways[ $current ] ) ) {
 			$current_gateway = $gateways[ $current ];
-		}
 
-		if ( ! $current_gateway ) {
+		} else {
 			$current_gateway = current( $gateways );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prevents autofocus/page scroll on checkout. It does not seem to keep in focus anyway due to validation.

Closes #20110

### How to test the changes in this Pull Request:

1. Add a bunch of content to your checkout page above the form so it's below the fold
2. Go to the checkout page
3. Page should not scroll to the form after this patch
