### PR TITLE
Don't force default token gateway active by default

### DIFF
--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -179,19 +179,14 @@ class WC_Payment_Gateways {
 			return;
 		}
 
-		if ( is_user_logged_in() ) {
-			$default_token = WC_Payment_Tokens::get_customer_default_token( get_current_user_id() );
-			if ( ! is_null( $default_token ) ) {
-				$default_token_gateway = $default_token->get_gateway_id();
-			}
-		}
-
-		$current = ( isset( $default_token_gateway ) ? $default_token_gateway : WC()->session->get( 'chosen_payment_method' ) );
+		$current_gateway = false;
+		$current         = WC()->session->get( 'chosen_payment_method' );
 
 		if ( $current && isset( $gateways[ $current ] ) ) {
 			$current_gateway = $gateways[ $current ];
+		}
 
-		} else {
+		if ( ! $current_gateway ) {
 			$current_gateway = current( $gateways );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This code was forcing token gateways to be selected regardless of session so I've removed it. If it's needed, it should be done when the session is first created for logged in users, but I don't know if there is a benefit to doing so.

Closes #20054