### PR TITLE
Remove legacy meta data from orders

### DIFF
--- a/includes/class-wc-privacy-erasers.php
+++ b/includes/class-wc-privacy-erasers.php
@@ -271,7 +271,7 @@ class WC_Privacy_Erasers {
 				 * Expose a way to control the anonymized value of a prop via 3rd party code.
 				 *
 				 * @since 3.4.0
-				 * @param bool     $anonymized_data Value of this prop after anonymization.
+				 * @param string   $anon_value Value of this prop after anonymization.
 				 * @param string   $prop Name of the prop being removed.
 				 * @param string   $value Current value of the data.
 				 * @param string   $data_type Type of data.
@@ -307,8 +307,8 @@ class WC_Privacy_Erasers {
 				 * Expose a way to control the anonymized value of a value via 3rd party code.
 				 *
 				 * @since 3.4.0
-				 * @param bool     $anonymized_data Value of this data after anonymization.
-				 * @param string   $prop Meta key being removed.
+				 * @param string   $anon_value Value of this data after anonymization.
+				 * @param string   $prop meta_key key being removed.
 				 * @param string   $value Current value of the data.
 				 * @param string   $data_type Type of data.
 				 * @param WC_Order $order An order object.
@@ -316,9 +316,9 @@ class WC_Privacy_Erasers {
 				$anon_value = apply_filters( 'woocommerce_privacy_remove_order_personal_data_meta_value', $anon_value, $meta_key, $value, $data_type, $order );
 
 				if ( $anon_value ) {
-					$order->delete_meta_data( $meta_key );
-				} else {
 					$order->update_meta_data( $meta_key, $anon_value );
+				} else {
+					$order->delete_meta_data( $meta_key );
 				}
 			}
 		}

--- a/includes/class-wc-privacy-erasers.php
+++ b/includes/class-wc-privacy-erasers.php
@@ -285,6 +285,20 @@ class WC_Privacy_Erasers {
 			}
 		}
 
+		// Remove meta data.
+		$meta_to_remove = apply_filters( 'woocommerce_privacy_remove_order_personal_data_meta', array(
+			'Payer first name'     => 'text',
+			'Payer last name'      => 'text',
+			'Payer PayPal address' => 'email',
+			'Transaction ID'       => 'numeric_id',
+		) );
+
+		if ( ! empty( $meta_to_remove ) && is_array( $meta_to_remove ) ) {
+			foreach ( $meta_to_remove as $meta_key => $data_type ) {
+				$order->delete_meta_data( $meta_key );
+			}
+		}
+
 		// Set all new props and persist the new data to the database.
 		$order->set_props( $anonymized_data );
 		$order->update_meta_data( '_anonymized', 'yes' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I've included the types for future proofing but this just deletes meta :)

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20119

### How to test the changes in this Pull Request:

1. Add custom field to an order called Payer last name
2. Remove order data via the bulk actions on order screen
3. Check data is removed.