### PR TITLE
Data erasers; target shop_order only and allow filtering

### DIFF
--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -165,11 +165,12 @@ class WC_Privacy extends WC_Abstract_Privacy {
 			return 0;
 		}
 
-		return self::trash_orders_query( array(
+		return self::trash_orders_query( apply_filters( 'woocommerce_trash_pending_orders_query_args', array(
 			'date_created' => '<' . strtotime( '-' . $option['number'] . ' ' . $option['unit'] ),
 			'limit'        => $limit, // Batches of 20.
 			'status'       => 'wc-pending',
-		) );
+			'type'         => 'shop_order',
+		) ) );
 	}
 
 	/**
@@ -186,11 +187,12 @@ class WC_Privacy extends WC_Abstract_Privacy {
 			return 0;
 		}
 
-		return self::trash_orders_query( array(
+		return self::trash_orders_query( apply_filters( 'woocommerce_trash_failed_orders_query_args', array(
 			'date_created' => '<' . strtotime( '-' . $option['number'] . ' ' . $option['unit'] ),
 			'limit'        => $limit, // Batches of 20.
 			'status'       => 'wc-failed',
-		) );
+			'type'         => 'shop_order',
+		) ) );
 	}
 
 	/**
@@ -207,11 +209,12 @@ class WC_Privacy extends WC_Abstract_Privacy {
 			return 0;
 		}
 
-		return self::trash_orders_query( array(
+		return self::trash_orders_query( apply_filters( 'woocommerce_trash_cancelled_orders_query_args', array(
 			'date_created' => '<' . strtotime( '-' . $option['number'] . ' ' . $option['unit'] ),
 			'limit'        => $limit, // Batches of 20.
 			'status'       => 'wc-cancelled',
-		) );
+			'type'         => 'shop_order',
+		) ) );
 	}
 
 	/**
@@ -249,12 +252,13 @@ class WC_Privacy extends WC_Abstract_Privacy {
 			return 0;
 		}
 
-		return self::anonymize_orders_query( array(
+		return self::anonymize_orders_query( apply_filters( 'woocommerce_anonymize_completed_orders_query_args', array(
 			'date_created' => '<' . strtotime( '-' . $option['number'] . ' ' . $option['unit'] ),
 			'limit'        => $limit, // Batches of 20.
 			'status'       => 'wc-completed',
 			'anonymized'   => false,
-		) );
+			'type'         => 'shop_order',
+		) ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates our data erasers to only target shop_orders, not other order types, as well as adding filtering should the default queries need adjustment. 

This is instead of #20106 which removed the limit in the query and could lead to performance problems.

@james-allan Happy with this?

Closes #20105