### PR TITLE
WC_Abstract_Privacy allow to specify filters' priority

### DIFF
--- a/includes/abstracts/abstract-wc-privacy.php
+++ b/includes/abstracts/abstract-wc-privacy.php
@@ -40,12 +40,28 @@ abstract class WC_Abstract_Privacy {
 	protected $erasers = array();
 
 	/**
+	 * This is a priority for the wp_privacy_personal_data_exporters filter
+	 *
+	 * @var int
+	 */
+	protected $export_priority;
+
+	/**
+	 * This is a priority for the wp_privacy_personal_data_erasers filter
+	 *
+	 * @var int
+	 */
+	protected $erase_priority;
+
+	/**
 	 * Constructor
 	 *
 	 * @param string $name Plugin identifier.
 	 */
-	public function __construct( $name = '' ) {
+	public function __construct( $name = '', $export_priority = 5, $erase_priority = 10 ) {
 		$this->name = $name;
+		$this->export_priority = $export_priority;
+		$this->erase_priority = $erase_priority;
 		$this->init();
 	}
 
@@ -55,8 +71,8 @@ abstract class WC_Abstract_Privacy {
 	protected function init() {
 		add_action( 'admin_init', array( $this, 'add_privacy_message' ) );
 		// We set priority to 5 to help WooCommerce's findings appear before those from extensions in exported items.
-		add_filter( 'wp_privacy_personal_data_exporters', array( $this, 'register_exporters' ), 5 );
-		add_filter( 'wp_privacy_personal_data_erasers', array( $this, 'register_erasers' ) );
+		add_filter( 'wp_privacy_personal_data_exporters', array( $this, 'register_exporters' ), $this->export_priority );
+		add_filter( 'wp_privacy_personal_data_erasers', array( $this, 'register_erasers' ), $this->erase_priority );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
With the way `wp_privacy_personal_data_exporters` filter works, the data that is exported by higher priority filter will end up below the lower priority. [See here](https://github.com/Automattic/woocommerce-services/pull/1392#issuecomment-390184877).

Also, unless a priority is specified in `wp_privacy_personal_data_erasers` the WooCommerce privacy eraser will get to the order data first, and then extensions that use `WC_Abstract_Privacy` and the email address to find orders will not be able to erase anything. [See here for an example implementation](https://github.com/Automattic/woocommerce-services/pull/1408/files#diff-8af355cb16c3286cf0f0863a97a3f079R118).

This PR allows the extensions using `WC_Abstract_Privacy` to specify the priority with which they attach to the data exporters and erasers filters. [See here for an example](https://github.com/Automattic/woocommerce-services/pull/1408/files#diff-8af355cb16c3286cf0f0863a97a3f079R14).

### How to test the changes in this Pull Request:

1. Everything should work as before when priorities are not specified in the constructor
2. Tweaking the priorities changes the order of export/erasure
