### PR TITLE
Avoid double input field

### DIFF
--- a/assets/js/frontend/geolocation.js
+++ b/assets/js/frontend/geolocation.js
@@ -56,8 +56,9 @@ jQuery( function( $ ) {
 		$( 'form' ).each( function() {
 			var $this  = $( this );
 			var method = $this.attr( 'method' );
+			var hasField = $this.find('input[name="v"]').length > 0;
 
-			if ( method && 'get' === method.toLowerCase() ) {
+			if ( method && 'get' === method.toLowerCase() && !hasField ) {
 				$this.append( '<input type="hidden" name="v" value="' + wc_geolocation_params.hash + '" />' );
 			} else {
 				var href = $this.attr( 'action' );


### PR DESCRIPTION
When geolocalization is active and a form uses the GET method, the script adds an hidden field for the geolocalization hash v, without checking if it already exists. But wc_query_string_form_fields adds it already, if the parameter was present in the called url.

![code](https://user-images.githubusercontent.com/25102786/40254728-d31d4c8a-5ae4-11e8-8463-ce181cf0f8fe.jpeg)

