### PR TITLE
Recalc taxes if address changes in API

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -532,7 +532,7 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 			} else {
 				// If items have changed, recalculate order totals.
 				if ( isset( $request['billing'] ) || isset( $request['shipping'] ) || isset( $request['line_items'] ) || isset( $request['shipping_lines'] ) || isset( $request['fee_lines'] ) || isset( $request['coupon_lines'] ) ) {
-					$object->calculate_totals();
+					$object->calculate_totals( true );
 				}
 			}
 

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -576,7 +576,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 
 			// If items have changed, recalculate order totals.
 			if ( isset( $request['billing'] ) || isset( $request['shipping'] ) || isset( $request['line_items'] ) || isset( $request['shipping_lines'] ) || isset( $request['fee_lines'] ) || isset( $request['coupon_lines'] ) ) {
-				$order->calculate_totals();
+				$order->calculate_totals( true );
 			}
 
 			return $order->get_id();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When the address changes, taxes may need recalculating. This makes taxes recalc via the API when something changes.

Closes #20135.