### PR TITLE
Use GET in external product form

### DIFF
--- a/templates/single-product/add-to-cart/external.php
+++ b/templates/single-product/add-to-cart/external.php
@@ -17,12 +17,21 @@
 
 defined( 'ABSPATH' ) || exit;
 
+$product_url_parts = wp_parse_url( $product_url );
+$query_string      = array();
+
+if ( ! empty( $product_url_parts['query'] ) ) {
+	parse_str( $product_url_parts['query'], $query_string );
+}
+
 do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
-<form class="cart" action="<?php echo esc_url( $product_url ); ?>" method="post">
+<form class="cart" action="<?php echo esc_url( $product_url ); ?>" method="get">
 	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
-	<button type="submit" name="add-to-cart" class="single_add_to_cart_button button alt"><?php echo esc_html( $button_text ); ?></button>
+	<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $button_text ); ?></button>
+
+	<?php wc_query_string_form_fields( $query_string ); ?>
 
 	<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 </form>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Uses GET instead of POST in new external product form.

To support query string, this parses the product URL and adds to the form.

Closes #20133

### How to test the changes in this Pull Request:

See #20133 