### PR TITLE
Improve external product string parsing

### DIFF
--- a/includes/class-wc-product-external.php
+++ b/includes/class-wc-product-external.php
@@ -49,7 +49,7 @@ class WC_Product_External extends WC_Product {
 	 * @return string
 	 */
 	public function get_product_url( $context = 'view' ) {
-		return esc_url( $this->get_prop( 'product_url', $context ) );
+		return esc_url_raw( $this->get_prop( 'product_url', $context ) );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class WC_Product_External extends WC_Product {
 	 * @param string $product_url Product URL.
 	 */
 	public function set_product_url( $product_url ) {
-		$this->set_prop( 'product_url', $product_url );
+		$this->set_prop( 'product_url', htmlspecialchars_decode( $product_url ) );
 	}
 
 	/**

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -655,15 +655,22 @@ function wc_product_class( $class = '', $product_id = null ) {
  * Outputs hidden form inputs for each query string variable.
  *
  * @since 3.0.0
- * @param array  $values Name value pairs.
- * @param array  $exclude Keys to exclude.
- * @param string $current_key Current key we are outputting.
- * @param bool   $return Whether to return.
+ * @param string|array $values Name value pairs, or a URL to parse.
+ * @param array        $exclude Keys to exclude.
+ * @param string       $current_key Current key we are outputting.
+ * @param bool         $return Whether to return.
  * @return string
  */
 function wc_query_string_form_fields( $values = null, $exclude = array(), $current_key = '', $return = false ) {
 	if ( is_null( $values ) ) {
 		$values = $_GET; // WPCS: input var ok, CSRF ok.
+	} elseif ( is_string( $values ) ) {
+		$url_parts = wp_parse_url( $values );
+		$values    = array();
+
+		if ( ! empty( $url_parts['query'] ) ) {
+			parse_str( $url_parts['query'], $values );
+		}
 	}
 	$html = '';
 

--- a/templates/single-product/add-to-cart/external.php
+++ b/templates/single-product/add-to-cart/external.php
@@ -17,13 +17,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$product_url_parts = wp_parse_url( $product_url );
-$query_string      = array();
-
-if ( ! empty( $product_url_parts['query'] ) ) {
-	parse_str( $product_url_parts['query'], $query_string );
-}
-
 do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 <form class="cart" action="<?php echo esc_url( $product_url ); ?>" method="get">
@@ -31,7 +24,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 	<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $button_text ); ?></button>
 
-	<?php wc_query_string_form_fields( $query_string ); ?>
+	<?php wc_query_string_form_fields( $product_url ); ?>
 
 	<?php do_action( 'woocommerce_after_add_to_cart_button' ); ?>
 </form>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

URLs with ampersands were not being decoded properly meaning some query string params were not added to the form.

Closes #20133

### How to test the changes in this Pull Request:

1. Create external product
2. URL http://classic.avantlink.com/click.php?p=246895&pw=210371&pt=3&pri=595424&tt=df
3. Test frontend single add to cart buttons
