### PR TITLE
Checkout preview in customizer

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -274,7 +274,7 @@ class WC_AJAX {
 
 		wc_maybe_define_constant( 'WOOCOMMERCE_CHECKOUT', true );
 
-		if ( WC()->cart->is_empty() ) {
+		if ( WC()->cart->is_empty() && ! is_customize_preview() ) {
 			self::update_order_review_expired();
 		}
 

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -21,7 +21,6 @@ class WC_Shop_Customizer {
 		add_action( 'customize_controls_print_styles', array( $this, 'add_styles' ) );
 		add_action( 'customize_controls_print_scripts', array( $this, 'add_scripts' ), 30 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'add_frontend_scripts' ) );
-		add_action( 'woocommerce_cart_loaded_from_session', array( $this, 'populate_cart' ) );
 	}
 
 	/**
@@ -53,31 +52,6 @@ class WC_Shop_Customizer {
 
 		$css = '.woocommerce-store-notice, p.demo_store { display: block !important; }';
 		wp_add_inline_style( 'customize-preview', $css );
-	}
-
-	/**
-	 * Make sure the cart has something inside when we're customizing.
-	 *
-	 * @return void
-	 */
-	public function populate_cart() {
-		if ( ! is_customize_preview() ) {
-			return;
-		}
-		if ( WC()->cart->is_empty() ) {
-			$dummy_product = new WC_Product();
-			$dummy_product->set_name( 'Sample' );
-			$dummy_product->set_price( 0 );
-			$dummy_product->set_status( 'publish' );
-			$cart_contents['customize-preview'] = array(
-				'data'         => $dummy_product,
-				'product_id'   => 0,
-				'variation_id' => 0,
-				'data_hash'    => false,
-				'quantity'     => 1,
-			);
-			WC()->cart->set_cart_contents( $cart_contents );
-		}
 	}
 
 	/**

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -222,7 +222,7 @@ class WC_Shortcode_Checkout {
 		wc_print_notices();
 
 		// Check cart has contents.
-		if ( WC()->cart->is_empty() ) {
+		if ( WC()->cart->is_empty() && ! is_customize_preview() ) {
 			return;
 		}
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -22,7 +22,7 @@ function wc_template_redirect() {
 		wp_safe_redirect( get_post_type_archive_link( 'product' ) );
 		exit;
 
-	} elseif ( is_page( wc_get_page_id( 'checkout' ) ) && wc_get_page_id( 'checkout' ) !== wc_get_page_id( 'cart' ) && WC()->cart->is_empty() && empty( $wp->query_vars['order-pay'] ) && ! isset( $wp->query_vars['order-received'] ) ) {
+	} elseif ( is_page( wc_get_page_id( 'checkout' ) ) && wc_get_page_id( 'checkout' ) !== wc_get_page_id( 'cart' ) && WC()->cart->is_empty() && empty( $wp->query_vars['order-pay'] ) && ! isset( $wp->query_vars['order-received'] ) && ! is_customize_preview() ) {
 
 		// When on the checkout with an empty cart, redirect to cart page.
 		wc_add_notice( __( 'Checkout is not available whilst your cart is empty.', 'woocommerce' ), 'notice' );
@@ -717,7 +717,8 @@ function wc_privacy_policy_page_id() {
  * @return bool
  */
 function wc_terms_and_conditions_checkbox_enabled() {
-	$page = get_post( wc_terms_and_conditions_page_id() );
+	$page_id = wc_terms_and_conditions_page_id();
+	$page    = $page_id ? get_post( $page_id ) : false;
 	return $page && wc_get_terms_and_conditions_checkbox_text();
 }
 


### PR DESCRIPTION
Enables preview in the customizer without the use of a dummy product.

Closes #20157

### How to test the changes in this Pull Request:

1. Empty cart
2. Open customizer 
3. Go to checkout customization tab
4. Ensure checkout shows 