### PR TITLE
Tweak file includes

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -12,6 +12,7 @@
 defined( 'ABSPATH' ) || exit;
 
 require_once WC_ABSPATH . 'includes/legacy/class-wc-legacy-cart.php';
+require_once WC_ABSPATH . 'includes/class-wc-cart-fees.php';
 require_once WC_ABSPATH . 'includes/class-wc-cart-session.php';
 
 /**

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -8,6 +8,10 @@
 
 defined( 'ABSPATH' ) || exit;
 
+if ( ! class_exists( 'WC_Privacy_Background_Process', false ) ) {
+	include_once dirname( __FILE__ ) . '/class-wc-privacy-background-process.php';
+}
+
 /**
  * WC_Privacy Class.
  */

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -328,7 +328,9 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/customizer/class-wc-shop-customizer.php';
 		include_once WC_ABSPATH . 'includes/class-wc-regenerate-images.php';
 		include_once WC_ABSPATH . 'includes/class-wc-privacy.php';
-		include_once WC_ABSPATH . 'includes/class-wc-privacy-background-process.php';
+		include_once WC_ABSPATH . 'includes/class-wc-structured-data.php';
+		include_once WC_ABSPATH . 'includes/class-wc-shortcodes.php';
+		include_once WC_ABSPATH . 'includes/class-wc-logger.php';
 
 		/**
 		 * Data stores - used to store and retrieve CRUD object data from the database.
@@ -437,9 +439,7 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-tax.php';
 		include_once WC_ABSPATH . 'includes/class-wc-shipping-zones.php';
 		include_once WC_ABSPATH . 'includes/class-wc-customer.php';
-		include_once WC_ABSPATH . 'includes/class-wc-shortcodes.php';
 		include_once WC_ABSPATH . 'includes/class-wc-embed.php';
-		include_once WC_ABSPATH . 'includes/class-wc-structured-data.php';
 		include_once WC_ABSPATH . 'includes/class-wc-session-handler.php';
 	}
 


### PR DESCRIPTION
I disabled our autoloader to see what would happen and found some examples of included files which are being included after they are used. Moving them means they are included before the autoloaded needs to search - search make it slightly more efficient and less prone to failure.

Nothing to test; just ensure tests pass.