### PR TITLE
Moving programming logic from single-product/add-to-cart/external.php

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1552,9 +1552,18 @@ if ( ! function_exists( 'woocommerce_external_add_to_cart' ) ) {
 			return;
 		}
 
+		$product_url       = $product->add_to_cart_url();
+		$product_url_parts = wp_parse_url( $product_url );
+		$query_string      = array();
+
+		if ( ! empty( $product_url_parts['query'] ) ) {
+			parse_str( $product_url_parts['query'], $query_string );
+		}
+
 		wc_get_template( 'single-product/add-to-cart/external.php', array(
-			'product_url' => $product->add_to_cart_url(),
-			'button_text' => $product->single_add_to_cart_text(),
+			'product_url'  => $product_url,
+			'button_text'  => $product->single_add_to_cart_text(),
+			'query_string' => $query_string,
 		) );
 	}
 }

--- a/templates/single-product/add-to-cart/external.php
+++ b/templates/single-product/add-to-cart/external.php
@@ -17,13 +17,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$product_url_parts = wp_parse_url( $product_url );
-$query_string      = array();
-
-if ( ! empty( $product_url_parts['query'] ) ) {
-	parse_str( $product_url_parts['query'], $query_string );
-}
-
 do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 <form class="cart" action="<?php echo esc_url( $product_url ); ?>" method="get">


### PR DESCRIPTION
Related to #20138

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

To many code in the template that is not HTML, so moving to `woocommerce_external_add_to_cart()` function.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?