### PR TITLE
Wait for address fields to update in e2e checkout test

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -736,10 +736,6 @@ class WC_Checkout {
 		$this->validate_posted_data( $data, $errors );
 		$this->check_cart_items();
 
-		if ( empty( $data['woocommerce_checkout_update_totals'] ) && empty( $data['terms'] ) && ! empty( $_POST['terms-field'] ) ) { // WPCS: input var ok, CSRF ok.
-			$errors->add( 'terms', __( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce' ) );
-		}
-
 		if ( WC()->cart->needs_shipping() ) {
 			$shipping_country = WC()->customer->get_shipping_country();
 

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -736,6 +736,10 @@ class WC_Checkout {
 		$this->validate_posted_data( $data, $errors );
 		$this->check_cart_items();
 
+		if ( empty( $data['woocommerce_checkout_update_totals'] ) && empty( $data['terms'] ) && ! empty( $_POST['terms-field'] ) ) { // WPCS: input var ok, CSRF ok.
+			$errors->add( 'terms', __( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce' ) );
+		}
+
 		if ( WC()->cart->needs_shipping() ) {
 			$shipping_country = WC()->customer->get_shipping_country();
 

--- a/tests/e2e-tests/checkout-page.js
+++ b/tests/e2e-tests/checkout-page.js
@@ -138,6 +138,7 @@ test.describe( 'Checkout Page', function() {
 		billingDetails.setCity( 'San Francisco' );
 		billingDetails.selectState( 'cali', 'California' );
 		billingDetails.setZip( '94107' );
+		Helper.waitTillUIBlockNotPresent( driver );
 		checkoutPage.selectPaymentMethod( 'Cash on delivery' );
 		checkoutPage.placeOrder();
 		Helper.waitTillUIBlockNotPresent( driver );


### PR DESCRIPTION
Could help avoid timeout issues, or race conditions due to totals being updated after address input.