### PR TITLE
When shipping methods supports settings and instance-settings saving …

### DIFF
--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -532,7 +532,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 */
 	public function process_admin_options() {
 		if ( $this->instance_id ) {
-			if ( isset( $_GET['instance_id'] ) && $this->instance_id == $_GET['instance_id']  ) {
+			if ( isset( $_GET['instance_id'] ) && $this->instance_id == $_GET['instance_id'] ) {
 				$this->init_instance_settings();
 
 				$post_data = $this->get_post_data();

--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -532,21 +532,24 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 */
 	public function process_admin_options() {
 		if ( $this->instance_id ) {
-			$this->init_instance_settings();
+			if ( isset( $_GET['instance_id'] ) && $this->instance_id == $_GET['instance_id']  ) {
+				$this->init_instance_settings();
 
-			$post_data = $this->get_post_data();
+				$post_data = $this->get_post_data();
 
-			foreach ( $this->get_instance_form_fields() as $key => $field ) {
-				if ( 'title' !== $this->get_field_type( $field ) ) {
-					try {
-						$this->instance_settings[ $key ] = $this->get_field_value( $key, $field, $post_data );
-					} catch ( Exception $e ) {
-						$this->add_error( $e->getMessage() );
+				foreach ( $this->get_instance_form_fields() as $key => $field ) {
+					if ( 'title' !== $this->get_field_type( $field ) ) {
+						try {
+							$this->instance_settings[ $key ] = $this->get_field_value( $key, $field, $post_data );
+						} catch ( Exception $e ) {
+							$this->add_error( $e->getMessage() );
+						}
 					}
 				}
-			}
 
-			return update_option( $this->get_instance_option_key(), apply_filters( 'woocommerce_shipping_' . $this->id . '_instance_settings_values', $this->instance_settings, $this ) );
+				return update_option( $this->get_instance_option_key(), apply_filters( 'woocommerce_shipping_' . $this->id . '_instance_settings_values', $this->instance_settings, $this ) );
+			}
+			return false;
 		} else {
 			return parent::process_admin_options();
 		}


### PR DESCRIPTION
…settings resetting all instance settings.

Steps to reproduce:
1. Install and activate this plugin: https://wordpress.org/plugins/flexible-shipping-ups/
2. Go to Woocommerce Settings -> Shipping -> Shipping zones and add UPS shipping method in any zone.
3. Go to UPS settings in zone and check any chekbox. Save chenges
4. Go to Shipping -> UPS and save settings
5. Check UPS settings in shipping zones - all checkboxes are unchecked - serrings are reseted.

