### PR TITLE
Add an action hook after printing the cart item name

### DIFF
--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -81,6 +81,8 @@ do_action( 'woocommerce_before_cart' ); ?>
 							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $_product->get_name() ), $cart_item, $cart_item_key ) );
 						}
 
+						do_action( 'woocommerce_after_cart_item_name', $cart_item, $cart_item_key );
+
 						// Meta data.
 						echo wc_get_formatted_cart_item_data( $cart_item ); // PHPCS: XSS ok.
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Trigger an action hook after printing the cart item name in the cart template. In the past, we were using the `woocommerce_cart_item_name` filter to attach some custom HTML. Since 3.4, that value is now escaped and so our HTML is no longer included. This action hook will allow us to print that HTML ourselves. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
