### PR TITLE
Product import from file on server

### DIFF
--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -279,7 +279,7 @@ class WC_Product_CSV_Importer_Controller {
 		);
 
 		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification -- Nonce already verified in WC_Product_CSV_Importer_Controller::upload_form_handler()
-		$file_url = isset( $_POST['file_url'] ) ? esc_url_raw( wp_unslash( $_POST['file_url'] ) ) : '';
+		$file_url = isset( $_POST['file_url'] ) ? wc_clean( wp_unslash( $_POST['file_url'] ) ) : '';
 
 		if ( empty( $file_url ) ) {
 			if ( ! isset( $_FILES['import'] ) ) {
@@ -329,13 +329,6 @@ class WC_Product_CSV_Importer_Controller {
 			}
 
 			return ABSPATH . $file_url;
-		} elseif ( file_exists( $file_url ) ) {
-			$filetype = wp_check_filetype( $file_url, $valid_filetypes );
-			if ( ! in_array( $filetype['type'], $valid_filetypes, true ) ) {
-				return new WP_Error( 'woocommerce_product_csv_importer_upload_file_invalid', __( 'Invalid file type. The importer supports CSV and TXT file formats.', 'woocommerce' ) );
-			}
-
-			return $file_url;
 		}
 		// phpcs:enable
 

--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -329,6 +329,13 @@ class WC_Product_CSV_Importer_Controller {
 			}
 
 			return ABSPATH . $file_url;
+		} elseif ( file_exists( $file_url ) ) {
+			$filetype = wp_check_filetype( $file_url, $valid_filetypes );
+			if ( ! in_array( $filetype['type'], $valid_filetypes, true ) ) {
+				return new WP_Error( 'woocommerce_product_csv_importer_upload_file_invalid', __( 'Invalid file type. The importer supports CSV and TXT file formats.', 'woocommerce' ) );
+			}
+
+			return $file_url;
 		}
 		// phpcs:enable
 

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -23,6 +23,7 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 
 		$bootstrap = WC_Unit_Tests_Bootstrap::instance();
 		require_once $bootstrap->plugin_dir . '/includes/import/class-wc-product-csv-importer.php';
+		require_once $bootstrap->plugin_dir . '/includes/admin/importers/class-wc-product-csv-importer-controller.php';
 	}
 
 	/**
@@ -106,20 +107,11 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	 *
 	 * @return void
 	 */
-	public function test_server_file_import() {
-		$args = array(
-			'mapping'          => $this->get_csv_mapped_items(),
-			'parse'            => true,
-			'prevent_timeouts' => false,
-		);
-		// Move file to a server location.
+	public function test_server_file() {
 		copy( $this->csv_file, ABSPATH . '/sample.csv' );
-		$importer = new WC_Product_CSV_Importer( ABSPATH . '/sample.csv', $args );
-		$results  = $importer->import();
-		$this->assertEquals( 7, count( $results['imported'] ) );
-		$this->assertEquals( 0, count( $results['failed'] ) );
-		$this->assertEquals( 0, count( $results['updated'] ) );
-		$this->assertEquals( 0, count( $results['skipped'] ) );
+		$_POST['file_url'] = ABSPATH . '/sample.csv';
+		$import_controller = new WC_Product_CSV_Importer_Controller();
+		$this->assertEquals( ABSPATH . '/sample.csv', $import_controller->handle_upload() );
 	}
 
 	/**

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -102,6 +102,27 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test importing file located on another location on server.
+	 *
+	 * @return void
+	 */
+	public function test_server_file_import() {
+		$args = array(
+			'mapping'          => $this->get_csv_mapped_items(),
+			'parse'            => true,
+			'prevent_timeouts' => false,
+		);
+		// Move file to a server location.
+		copy( $this->csv_file, ABSPATH . '/sample.csv' );
+		$importer = new WC_Product_CSV_Importer( ABSPATH . '/sample.csv', $args );
+		$results  = $importer->import();
+		$this->assertEquals( 7, count( $results['imported'] ) );
+		$this->assertEquals( 0, count( $results['failed'] ) );
+		$this->assertEquals( 0, count( $results['updated'] ) );
+		$this->assertEquals( 0, count( $results['skipped'] ) );
+	}
+
+	/**
 	 * Test get_raw_keys.
 	 * @since 3.1.0
 	 */

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -109,9 +109,9 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	 */
 	public function test_server_file() {
 		copy( $this->csv_file, ABSPATH . '/sample.csv' );
-		$_POST['file_url'] = ABSPATH . '/sample.csv';
+		$_POST['file_url'] = 'sample.csv';
 		$import_controller = new WC_Product_CSV_Importer_Controller();
-		$this->assertEquals( ABSPATH . '/sample.csv', $import_controller->handle_upload() );
+		$this->assertEquals( ABSPATH . 'sample.csv', $import_controller->handle_upload() );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes the issue where files already located on the server could not be used for importing products due to a conflict with uploads and ABSPATH.

Closes #20186.

### How to test the changes in this Pull Request:

1. Put a product import CSV file directly on your server.
2. Use the product importer and under advanced option specify the path to the file on the server
3. Make sure the file is read and no error are thrown about the file not found

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Product CSV import from files located on server.
