### PR TITLE
Fix WC_Coupon constructor with Coupon object

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -83,14 +83,24 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	public function __construct( $data = '' ) {
 		parent::__construct( $data );
 
+		// If we already have a coupon object, read it again.
+		if ( $data instanceof WC_Coupon ) {
+			$this->set_id( absint( $data->get_id() ) );
+			$this->read_object_from_database();
+			return;
+		}
+
+		// This filter allows custom coupon objects to be created on the fly.
 		$coupon = apply_filters( 'woocommerce_get_shop_coupon_data', false, $data );
+
 		if ( $coupon ) {
 			$this->read_manual_coupon( $data, $coupon );
 			return;
-		} elseif ( is_int( $data ) && $data > 0 ) {
+		}
+
+		// Try to load coupon using ID or code.
+		if ( is_int( $data ) && 'shop_coupon' === get_post_type( $data ) ) {
 			$this->set_id( $data );
-		} elseif ( $data instanceof self ) {
-			$this->set_id( absint( $data->get_id() ) );
 		} elseif ( ! empty( $data ) ) {
 			$id = wc_get_coupon_id_by_code( $data );
 			// Need to support numeric strings for backwards compatibility.
@@ -104,12 +114,21 @@ class WC_Coupon extends WC_Legacy_Coupon {
 			$this->set_object_read( true );
 		}
 
+		$this->read_object_from_database();
+	}
+
+	/**
+	 * If the object has an ID, read using the data store.
+	 *
+	 * @since 3.4.1
+	 */
+	protected function read_object_from_database() {
 		$this->data_store = WC_Data_Store::load( 'coupon' );
+
 		if ( $this->get_id() > 0 ) {
 			$this->data_store->read( $this );
 		}
 	}
-
 	/**
 	 * Checks the coupon type.
 	 *

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -83,19 +83,16 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	public function __construct( $data = '' ) {
 		parent::__construct( $data );
 
-		if ( $data instanceof WC_Coupon ) {
-			$this->set_id( absint( $data->get_id() ) );
-		}
-
 		$coupon = apply_filters( 'woocommerce_get_shop_coupon_data', false, $data );
 		if ( $coupon ) {
 			$this->read_manual_coupon( $data, $coupon );
 			return;
-		} elseif ( is_int( $data ) && 'shop_coupon' === get_post_type( $data ) ) {
+		} elseif ( is_int( $data ) && $data > 0 ) {
 			$this->set_id( $data );
+		} elseif ( $data instanceof self ) {
+			$this->set_id( absint( $data->get_id() ) );
 		} elseif ( ! empty( $data ) ) {
 			$id = wc_get_coupon_id_by_code( $data );
-
 			// Need to support numeric strings for backwards compatibility.
 			if ( ! $id && 'shop_coupon' === get_post_type( $data ) ) {
 				$this->set_id( $data );

--- a/tests/unit-tests/coupon/coupon.php
+++ b/tests/unit-tests/coupon/coupon.php
@@ -44,6 +44,10 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		// Required for backwards compatibility, but will try and initialize coupon by code if possible first.
 		$test_coupon = new WC_Coupon( (string) $coupon_2->get_id() );
 		$this->assertEquals( $coupon_2->get_id(), $test_coupon->get_id() );
+
+		// Test getting a coupon by coupon object
+		$test_coupon = new WC_Coupon( $coupon_1 );
+		$this->assertEquals( $test_coupon->get_id(), $coupon_1->get_id() );
 	}
 
 	/**

--- a/tests/unit-tests/coupon/data-store.php
+++ b/tests/unit-tests/coupon/data-store.php
@@ -41,6 +41,13 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 		$this->assertNotEquals( 0, $coupon_id );
 		$coupon->delete( true );
 		$this->assertEquals( 0, $coupon->get_id() );
+		// Test loading a deleted coupon exception.
+		try {
+			$coupon = new WC_Coupon( $coupon_id );
+		} catch ( Exception $e ) {
+			$this->assertEquals( 'Invalid coupon.', $e->getMessage() );
+		}
+
 	}
 
 	/**

--- a/tests/unit-tests/coupon/data-store.php
+++ b/tests/unit-tests/coupon/data-store.php
@@ -40,7 +40,6 @@ class WC_Tests_Coupon_Data_Store extends WC_Unit_Test_Case {
 		$coupon_id = $coupon->get_id();
 		$this->assertNotEquals( 0, $coupon_id );
 		$coupon->delete( true );
-		$coupon = new WC_Coupon( $coupon_id );
 		$this->assertEquals( 0, $coupon->get_id() );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Refactor the WC_Coupon constructor so that when initiating with a coupon object it returns the actual coupon object.

Closes #20192  .

### How to test the changes in this Pull Request:

1. Load an existing coupon via WC_Coupon into a variable
2. Use that object in the variable to initiate a new WC_Coupon
3. Call get_id() and get_code() on the new object and it should be the same as the original object you loaded.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - WC_Coupon constructor with WC_Coupon object.
