### PR TITLE
"payment tokens" terminology

### DIFF
--- a/includes/class-wc-privacy-exporters.php
+++ b/includes/class-wc-privacy-exporters.php
@@ -352,7 +352,7 @@ class WC_Privacy_Exporters {
 	}
 
 	/**
-	 * Finds and exports customer tokens by email address.
+	 * Finds and exports payment tokens by email address for a customer.
 	 *
 	 * @since 3.4.0
 	 * @param string $email_address The user email address.

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -42,13 +42,13 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		$this->add_exporter( 'woocommerce-customer-data', __( 'Customer Data', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'customer_data_exporter' ) );
 		$this->add_exporter( 'woocommerce-customer-orders', __( 'Customer Orders', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'order_data_exporter' ) );
 		$this->add_exporter( 'woocommerce-customer-downloads', __( 'Customer Downloads', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'download_data_exporter' ) );
-		$this->add_exporter( 'woocommerce-customer-tokens', __( 'Customer Tokens', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'customer_tokens_exporter' ) );
+		$this->add_exporter( 'woocommerce-customer-tokens', __( 'Customer Payment Tokens', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'customer_tokens_exporter' ) );
 
 		// This hook registers WooCommerce data erasers.
 		$this->add_eraser( 'woocommerce-customer-data', __( 'Customer Data', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'customer_data_eraser' ) );
 		$this->add_eraser( 'woocommerce-customer-orders', __( 'Customer Orders', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'order_data_eraser' ) );
 		$this->add_eraser( 'woocommerce-customer-downloads', __( 'Customer Downloads', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'download_data_eraser' ) );
-		$this->add_eraser( 'woocommerce-customer-tokens', __( 'Customer Tokens', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'customer_tokens_eraser' ) );
+		$this->add_eraser( 'woocommerce-customer-tokens', __( 'Customer Payment Tokens', 'woocommerce' ), array( 'WC_Privacy_Erasers', 'customer_tokens_eraser' ) );
 
 		// Cleanup orders daily - this is a callback on a daily cron event.
 		add_action( 'woocommerce_cleanup_personal_data', array( $this, 'queue_cleanup_personal_data' ) );


### PR DESCRIPTION
Updates "customer tokens" wording to "payment tokens".

Closes #20183

Does not touch function names to avoid deprecation.