### PR TITLE
Export legacy paypal meta data in exporter

### DIFF
--- a/includes/class-wc-privacy-exporters.php
+++ b/includes/class-wc-privacy-exporters.php
@@ -284,6 +284,27 @@ class WC_Privacy_Exporters {
 			}
 		}
 
+		// Export meta data.
+		$meta_to_export = apply_filters( 'woocommerce_privacy_export_order_personal_data_meta', array(
+			'Payer first name'     => __( 'Payer first name', 'woocommerce' ),
+			'Payer last name'      => __( 'Payer last name', 'woocommerce' ),
+			'Payer PayPal address' => __( 'Payer PayPal address', 'woocommerce' ),
+			'Transaction ID'       => __( 'Transaction ID', 'woocommerce' ),
+		) );
+
+		if ( ! empty( $meta_to_export ) && is_array( $meta_to_export ) ) {
+			foreach ( $meta_to_export as $meta_key => $name ) {
+				$value = apply_filters( 'woocommerce_privacy_export_order_personal_data_meta_value', $order->get_meta( $meta_key ), $meta_key, $order );
+
+				if ( $value ) {
+					$personal_data[] = array(
+						'name'  => $name,
+						'value' => $value,
+					);
+				}
+			}
+		}
+
 		/**
 		 * Allow extensions to register their own personal data for this order for the export.
 		 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds legacy PayPal meta to order export.

Closes #20184

### How to test the changes in this Pull Request:

1. Add some legacy meta to an order (see list in #20184)
2. Tools > Export personal data, export orders for the user who placed the order
3. Check export lists the meta where set