### PR TITLE
Allow HTML when using `wc_attribute_label()`

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<h3>
 		<a href="#" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
 		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'woocommerce' ); ?>"></div>
-		<strong class="attribute_name"><?php echo esc_html( wc_attribute_label( $attribute->get_name() ) ); ?></strong>
+		<strong class="attribute_name"><?php echo wc_attribute_label( $attribute->get_name() ); ?></strong>
 	</h3>
 	<div class="woocommerce_attribute_data wc-metabox-content">
 		<table cellpadding="0" cellspacing="0">
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<label><?php esc_html_e( 'Name', 'woocommerce' ); ?>:</label>
 
 						<?php if ( $attribute->is_taxonomy() ) : ?>
-							<strong><?php echo esc_html( wc_attribute_label( $attribute->get_name() ) ); ?></strong>
+							<strong><?php echo wc_attribute_label( $attribute->get_name() ); ?></strong>
 							<input type="hidden" name="attribute_names[<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $attribute->get_name() ); ?>" />
 						<?php else : ?>
 							<input type="text" class="attribute_name" name="attribute_names[<?php echo esc_attr( $i ); ?>]" value="<?php echo esc_attr( $attribute->get_name() ); ?>" />

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -38,6 +38,7 @@ add_filter( 'woocommerce_coupon_code', 'sanitize_text_field' );
 add_filter( 'woocommerce_coupon_code', 'wc_strtolower' );
 add_filter( 'woocommerce_stock_amount', 'intval' ); // Stock amounts are integers by default.
 add_filter( 'woocommerce_shipping_rate_label', 'sanitize_text_field' ); // Shipping rate label.
+add_filter( 'woocommerce_attribute_label', 'wp_kses_post', 100 );
 
 /**
  * Short Description (excerpt).

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -181,6 +181,11 @@ add_action( 'woocommerce_single_variation', 'woocommerce_single_variation', 10 )
 add_action( 'woocommerce_single_variation', 'woocommerce_single_variation_add_to_cart_button', 20 );
 
 /**
+ * Product attributes.
+ */
+add_filter( 'woocommerce_attribute_label', 'wp_kses_post', 100 );
+
+/**
  * Pagination after shop loops.
  *
  * @see woocommerce_pagination()

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -181,11 +181,6 @@ add_action( 'woocommerce_single_variation', 'woocommerce_single_variation', 10 )
 add_action( 'woocommerce_single_variation', 'woocommerce_single_variation_add_to_cart_button', 20 );
 
 /**
- * Product attributes.
- */
-add_filter( 'woocommerce_attribute_label', 'wp_kses_post', 100 );
-
-/**
  * Pagination after shop loops.
  *
  * @see woocommerce_pagination()

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -33,7 +33,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 			<tbody>
 				<?php foreach ( $attributes as $attribute_name => $options ) : ?>
 					<tr>
-						<td class="label"><label for="<?php echo esc_attr( sanitize_title( $attribute_name ) ); ?>"><?php echo esc_html( wc_attribute_label( $attribute_name ) ); ?></label></td>
+						<td class="label"><label for="<?php echo esc_attr( sanitize_title( $attribute_name ) ); ?>"><?php echo wc_attribute_label( $attribute_name ); ?></label></td>
 						<td class="value">
 							<?php
 								$selected = isset( $_REQUEST[ 'attribute_' . $attribute_name ] ) ? wc_clean( urldecode( wp_unslash( $_REQUEST[ 'attribute_' . $attribute_name ] ) ) ) : $product->get_variation_default_attribute( $attribute_name ); // WPCS: input var ok, CSRF ok, sanitization ok.


### PR DESCRIPTION
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This change allows the use of basic HTML when displaying an attribute label. A use case may be adding `strong` and `span` elements to the attribute label on the product page.

My swatches plugin is a good example of this: https://demos.iconicwp.com/woocommerce-product-configurator/product/timex-watch/

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

> Allow HTML when using `wc_attribute_label()`
