### PR TITLE
[menu] - change title to capitalized to match wp core

### DIFF
--- a/includes/admin/class-wc-admin-customize.php
+++ b/includes/admin/class-wc-admin-customize.php
@@ -38,8 +38,8 @@ if ( ! class_exists( 'WC_Admin_Customize', false ) ) :
 		 */
 		public function register_customize_nav_menu_item_types( $item_types ) {
 			$item_types[] = array(
-				'title'      => __( 'WooCommerce endpoints', 'woocommerce' ),
-				'type_label' => __( 'WooCommerce endpoint', 'woocommerce' ),
+				'title'      => __( 'WooCommerce Endpoints', 'woocommerce' ),
+				'type_label' => __( 'WooCommerce Endpoint', 'woocommerce' ),
 				'type'       => 'woocommerce_nav',
 				'object'     => 'woocommerce_endpoint',
 			);


### PR DESCRIPTION
I've changed the titles to Title case. This matches core. Looks a bit odd compared to "Custom Links".

![screen shot 2018-05-24 at 15 53 22](https://user-images.githubusercontent.com/5207147/40494642-38f9f922-5f6d-11e8-8fd6-6703b0feb5c0.png)

As an aside, I think, "WooCommerce endpoints" is a bit techinical, most people will not understand "endpoints". Should it be "WooCommerce Links"