### PR TITLE
Excluded children categories from WP_Query in product shortcode if cat_operator=AND

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -323,10 +323,16 @@ class WC_Shortcode_Products {
 			}
 
 			$query_args['tax_query'][] = array(
-				'taxonomy' => 'product_cat',
-				'terms'    => $categories,
-				'field'    => $field,
-				'operator' => $this->attributes['cat_operator'],
+				'taxonomy'         => 'product_cat',
+				'terms'            => $categories,
+				'field'            => $field,
+				'operator'         => $this->attributes['cat_operator'],
+
+				/*
+				 * When cat_operator is AND, the children categories should be excluded,
+				 * as only products belonging to all the children categories would be selected.
+				 */
+				'include_children' => 'AND' === $this->attributes['cat_operator'] ? false : true,
 			);
 		}
 	}

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -150,10 +150,11 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'fields'              => 'ids',
 		);
 		$expected4['tax_query'][] = array(
-			'taxonomy' => 'product_cat',
-			'terms'    => array( 'clothing' ),
-			'field'    => 'slug',
-			'operator' => 'IN',
+			'taxonomy'         => 'product_cat',
+			'terms'            => array( 'clothing' ),
+			'field'            => 'slug',
+			'operator'         => 'IN',
+			'include_children' => true,
 		);
 
 		$this->assertEquals( $expected4, $shortcode4->get_query_args() );
@@ -180,10 +181,11 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'fields'              => 'ids',
 		);
 		$expected4_id['tax_query'][] = array(
-			'taxonomy' => 'product_cat',
-			'terms'    => array( 123 ),
-			'field'    => 'term_id',
-			'operator' => 'IN',
+			'taxonomy'         => 'product_cat',
+			'terms'            => array( 123 ),
+			'field'            => 'term_id',
+			'operator'         => 'IN',
+			'include_children' => true,
 		);
 
 		$this->assertEquals( $expected4_id, $shortcode4_id->get_query_args() );
@@ -492,6 +494,63 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( $expected14, $shortcode14->get_query_args() );
+
+		// products shortcode -- select multiple categories using AND operator.
+		$shortcode15 = new WC_Shortcode_Products( array(
+			'category'     => 'cat1,cat2',
+			'cat_operator' => 'AND',
+		) );
+		$expected15  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'orderby'             => 'title',
+			'order'               => 'ASC',
+			'posts_per_page'      => -1,
+			'meta_query'          => $meta_query,
+			'tax_query'           => array_merge( $tax_query, array(
+				array(
+					'taxonomy'         => 'product_cat',
+					'terms'            => array( 'cat1', 'cat2' ),
+					'field'            => 'slug',
+					'operator'         => 'AND',
+					'include_children' => false,
+				),
+			) ),
+			'fields'              => 'ids',
+		);
+
+		$this->assertEquals( $expected15, $shortcode15->get_query_args() );
+
+		// products shortcode -- exclude multiple categories using NOT IN operator.
+		$shortcode16 = new WC_Shortcode_Products( array(
+			'category'     => 'cat1,cat2',
+			'cat_operator' => 'NOT IN',
+		) );
+		$expected16  = array(
+			'post_type'           => 'product',
+			'post_status'         => 'publish',
+			'ignore_sticky_posts' => true,
+			'no_found_rows'       => true,
+			'orderby'             => 'title',
+			'order'               => 'ASC',
+			'posts_per_page'      => -1,
+			'meta_query'          => $meta_query,
+			'tax_query'           => array_merge( $tax_query, array(
+				array(
+					'taxonomy'         => 'product_cat',
+					'terms'            => array( 'cat1', 'cat2' ),
+					'field'            => 'slug',
+					'operator'         => 'NOT IN',
+					'include_children' => true,
+				),
+			) ),
+			'fields'              => 'ids',
+		);
+
+		$this->assertEquals( $expected16, $shortcode16->get_query_args() );
+
 	}
 
 	/**


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

By default, the code includes child categories in the WP_Query, so it searches for products which belong to the specified categories but also to all their subcategories, (e.g. in case of subcategories `hoodies-with-zip`, `hoodies-with-logo`, only products assigned to all categories are shown). 

This makes sense for `cat_operator=IN`, where user probably expects products from child categories to be included. However, I think that's not expected for `cat_operator=AND`, so I added a fix which turns off child inclusion for `AND` category operator.

Closes #20185  .

### How to test the changes in this Pull Request:

1. Create categories cat1 and cat2, with one of them having child category, e.g. cat1.1
2. Create a product and assign it to cat1 and cat2.
3. In a post/page, use shortcode `[products category="cat1,cat2" cat_operator="AND"]`
4. See that nothing is displayed.
5. Apply branch.
6. See product from step 2 displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Excluded children categories from WP_Query in product shortcode if cat_operator=AND
