### PR TITLE
Prevent shipping method instance save action running on non-instance screens

### DIFF
--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -532,20 +532,10 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @return bool was anything saved?
 	 */
 	public function process_admin_options() {
-		if ( $this->instance_id ) {
-			return $this->process_instance_options();
+		if ( ! $this->instance_id ) {
+			return parent::process_admin_options();
 		}
 
-		return parent::process_admin_options();
-	}
-
-	/**
-	 * Processes and saves options for a shipping method instance.
-	 *
-	 * @since 3.4.1
-	 * @return bool was anything saved?
-	 */
-	public function process_instance_options() {
 		// Check we are processing the correct form for this instance.
 		if ( ! $this->instance_id || ! isset( $_REQUEST['instance_id'] ) || absint( $_REQUEST['instance_id'] ) !== $this->instance_id ) { // WPCS: input var ok, CSRF ok.
 			return false;

--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -537,7 +537,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 		}
 
 		// Check we are processing the correct form for this instance.
-		if ( ! $this->instance_id || ! isset( $_REQUEST['instance_id'] ) || absint( $_REQUEST['instance_id'] ) !== $this->instance_id ) { // WPCS: input var ok, CSRF ok.
+		if ( ! isset( $_REQUEST['instance_id'] ) || absint( $_REQUEST['instance_id'] ) !== $this->instance_id ) { // WPCS: input var ok, CSRF ok.
 			return false;
 		}
 


### PR DESCRIPTION
Co-Authored-By: grola <grola@users.noreply.github.com>

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Shipping method instances are loaded in the admin area as for 3.4, and due to this they end up listening for the woocommerce_update_options_x hooks.

When a shipping section is saved, it triggers save on all shipping instances too, resulting in lost settings because the form is not for them :(

This code is a mess--we definitely need to refactor in the future. For now this works around the issue by ensuring the posted form contains the current instance ID before saving anything.

Closes #20182

### How to test the changes in this Pull Request:

1. Install shipping plugin with both global and local settings.
2. Create instance in zone. Save settings.
3. Edit global settings. Save.
4. Go back to instance and ensure settings still exist.
5. Test other methods save in the zones section when edited in through the modal boxes.

cc @johndcoy