### PR TITLE
Display price filter widget in LTR for RTL sites

### DIFF
--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -1715,6 +1715,12 @@ p.demo_store,
 	float: right;
 }
 
+.rtl.woocommerce .price_label span {
+	unicode-bidi: embed;
+	/* rtl:ignore */
+    direction: ltr;
+}
+
 .woocommerce-message {
 	border-top-color: #8fae1b;
 


### PR DESCRIPTION
When dealing with numeric properties, the direction should be in LTR for sites whose language is set to RTL.

Currently the price slider goes from LTR but the text below is RTL.
This PR changes the price filter widget label to be shown in LTR for RTL sites.

Previously:
![screen shot on 2018-05-23 at 09_41_52](https://user-images.githubusercontent.com/3220162/40512327-5900d242-5f57-11e8-829b-0f5825592ee9.png)

Now:
<img width="319" alt="screen shot on 2018-05-24 at 12_27_59" src="https://user-images.githubusercontent.com/3220162/40512332-5c5b8b4e-5f57-11e8-89a9-accd3f1fbb64.png">
