### PR TITLE
Ensure tests use ISO 3166-1 alpha-2 country codes

### DIFF
--- a/tests/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/unit-tests/order/class-wc-tests-order-functions.php
@@ -950,7 +950,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 				'billing_city'        => 'Portland',
 				'billing_state'       => 'OR',
 				'billing_postcode'    => '97266',
-				'billing_country'     => 'USA',
+				'billing_country'     => 'US',
 				'billing_phone'       => '503-123-4567',
 				'shipping_first_name' => 'Jane',
 				'shipping_last_name'  => 'Powers',
@@ -960,7 +960,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 				'shipping_city'       => 'Milwaukie',
 				'shipping_state'      => 'OR',
 				'shipping_postcode'   => '97222',
-				'shipping_country'    => 'USA',
+				'shipping_country'    => 'US',
 			)
 		);
 		$order1->save();
@@ -978,7 +978,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 				'billing_city'        => 'Vancouver',
 				'billing_state'       => 'WA',
 				'billing_postcode'    => '97267',
-				'billing_country'     => 'USA',
+				'billing_country'     => 'US',
 				'billing_phone'       => '503-333-3333',
 				'shipping_first_name' => 'Joseph',
 				'shipping_last_name'  => 'Thunder',
@@ -988,7 +988,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 				'shipping_city'       => 'Vancouver',
 				'shipping_state'      => 'WA',
 				'shipping_postcode'   => '97233',
-				'shipping_country'    => 'USA',
+				'shipping_country'    => 'US',
 			)
 		);
 		$order2->save();
@@ -1077,7 +1077,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 
 		$orders   = wc_get_orders(
 			array(
-				'billing_country' => 'USA',
+				'billing_country' => 'US',
 				'orderby'         => 'ID',
 				'order'           => 'ASC',
 				'return'          => 'ids',
@@ -1169,7 +1169,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 
 		$orders   = wc_get_orders(
 			array(
-				'shipping_country' => 'USA',
+				'shipping_country' => 'US',
 				'orderby'          => 'ID',
 				'order'            => 'ASC',
 				'return'           => 'ids',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

[According to the WooCommerce wiki](https://github.com/woocommerce/woocommerce/wiki/Order-and-Order-Line-Item-Data) and `WC_REST_Orders_Controller`, WooCommerce stores country codes using the ISO 3166-1 alpha-2 (2 character) standard. However, the `WC_Tests_Order_Functions::test_wc_get_order_address_params()` test method was using 'USA' instead of 'US'.

### Changelog entry

> Refactored order tests to ensure two-character country codes (ISO 3166-1 alpha-2) are being used.
