### PR TITLE
Removed get_product_search_form else

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2701,11 +2701,11 @@ if ( ! function_exists( 'get_product_search_form' ) ) {
 
 		$form = apply_filters( 'get_product_search_form', ob_get_clean() );
 
-		if ( $echo ) {
-			echo $form; // WPCS: XSS ok.
-		} else {
+		if ( ! $echo ) {
 			return $form;
 		}
+
+		echo $form; // WPCS: XSS ok.
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Removed `get_product_search_form` function bottom `else`. It's more cleaner I think.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?