### PR TITLE
Wrapper function to get full mysql version string with mariadb handling

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -235,18 +235,18 @@ $untested_plugins = $plugin_updates->get_untested_plugins( WC()->version, 'minor
 
 		<?php
 
-		if ( ! empty( $wpdb->is_mysql ) ) :
+		if ( $environment['mysql_version'] ) :
 			?>
 			<tr>
 				<td data-export-label="MySQL Version"><?php esc_html_e( 'MySQL version', 'woocommerce' ); ?>:</td>
 				<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of MySQL installed on your hosting server.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 				<td>
 					<?php
-					if ( version_compare( $environment['mysql_version'], '5.6', '<' ) ) {
+					if ( version_compare( $environment['mysql_version'], '5.6', '<' ) && ! strstr( $environment['mysql_version_string'], 'MariaDB' ) ) {
 						/* Translators: %1$s: MySQL version, %2$s: Recommended MySQL version. */
-						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend a minimum MySQL version of 5.6. See: %2$s', 'woocommerce' ), esc_html( $environment['mysql_version'] ), '<a href="https://wordpress.org/about/requirements/" target="_blank">' . esc_html__( 'WordPress requirements', 'woocommerce' ) . '</a>' ) . '</mark>';
+						echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . sprintf( esc_html__( '%1$s - We recommend a minimum MySQL version of 5.6. See: %2$s', 'woocommerce' ), esc_html( $environment['mysql_version_string'] ), '<a href="https://wordpress.org/about/requirements/" target="_blank">' . esc_html__( 'WordPress requirements', 'woocommerce' ) . '</a>' ) . '</mark>';
 					} else {
-						echo '<mark class="yes">' . esc_html( $environment['mysql_version'] ) . '</mark>';
+						echo '<mark class="yes">' . esc_html( $environment['mysql_version_string'] ) . '</mark>';
 					}
 					?>
 				</td>

--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -228,6 +228,12 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 							'context'     => array( 'view' ),
 							'readonly'    => true,
 						),
+						'mysql_version_string'             => array(
+							'description' => __( 'MySQL version string.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view' ),
+							'readonly'    => true,
+						),
 						'default_timezone'          => array(
 							'description' => __( 'Default timezone.', 'woocommerce' ),
 							'type'        => 'string',
@@ -597,6 +603,8 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 			$get_response_successful = true;
 		}
 
+		$database_version = wc_get_server_database_version();
+
 		// Return all environment info. Described by JSON Schema.
 		return array(
 			'home_url'                  => get_option( 'home' ),
@@ -619,7 +627,8 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 			'curl_version'              => $curl_version,
 			'suhosin_installed'         => extension_loaded( 'suhosin' ),
 			'max_upload_size'           => wp_max_upload_size(),
-			'mysql_version'             => ( ! empty( $wpdb->is_mysql ) ? $wpdb->db_version() : '' ),
+			'mysql_version'             => $database_version['number'],
+			'mysql_version_string'      => $database_version['string'],
 			'default_timezone'          => date_default_timezone_get(),
 			'fsockopen_or_curl_enabled' => ( function_exists( 'fsockopen' ) || function_exists( 'curl_init' ) ),
 			'soapclient_enabled'        => class_exists( 'SoapClient' ),

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -200,8 +200,8 @@ class WC_Tracker {
 			$server_data['php_suhosin'] = extension_loaded( 'suhosin' ) ? 'Yes' : 'No';
 		}
 
-		global $wpdb;
-		$server_data['mysql_version'] = $wpdb->db_version();
+		$database_version             = wc_get_server_database_version();
+		$server_data['mysql_version'] = $database_version['number'];
 
 		$server_data['php_max_upload_size'] = size_format( wp_max_upload_size() );
 		$server_data['php_default_timezone'] = date_default_timezone_get();

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2105,3 +2105,31 @@ function wc_selected( $value, $options ) {
 
 	return selected( $value, $options, false );
 }
+
+/**
+ * Retrieves the MySQL server version. Based on $wpdb.
+ *
+ * @since 3.4.1
+ * @return array Vesion information.
+ */
+function wc_get_server_database_version() {
+	global $wpdb;
+
+	if ( empty( $wpdb->is_mysql ) ) {
+		return array(
+			'string' => '',
+			'number' => '',
+		);
+	}
+
+	if ( $wpdb->use_mysqli ) {
+		$server_info = mysqli_get_server_info( $wpdb->dbh ); // @codingStandardsIgnoreLine.
+	} else {
+		$server_info = mysql_get_server_info( $wpdb->dbh ); // @codingStandardsIgnoreLine.
+	}
+
+	return array(
+		'string' => $server_info,
+		'number' => preg_replace( '/([^\d.]+).*/', '', $server_info ),
+	);
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Wrapper function which gets the full raw mysql version + version number which is then used in system status and the tracker.

Closes #20227

### How to test the changes in this Pull Request:

1. Check system status report shows full version string in the report, even when using mariadb
2. Mariadb should not show version warning.
