### PR TITLE
Check plugin properties exist when listening to auto_update_plugin hook

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1931,6 +1931,10 @@ add_filter( 'extra_plugin_headers', 'wc_enable_wc_plugin_headers' );
  * @return bool
  */
 function wc_prevent_dangerous_auto_updates( $should_update, $plugin ) {
+	if ( ! isset( $plugin->plugin, $plugin->new_version ) ) {
+		return $should_update;
+	}
+
 	if ( 'woocommerce/woocommerce.php' !== $plugin->plugin ) {
 		return $should_update;
 	}


### PR DESCRIPTION
Adds some checks within `wc_prevent_dangerous_auto_updates` to ensure `$plugin` has the properties we want to compare.

Unable to replicate the issue so I suspect a plugin is causing this, but we can defend against it.

Closes #20228