### PR TITLE
Only run wc_update_340_states over CLI

### DIFF
--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1636,8 +1636,16 @@ function wc_update_330_db_version() {
 
 /**
  * Update state codes for Ireland and BD.
+ *
+ * This is a slow update and will only run over CLI.
+ *
+ * @param bool $force_run Force this to run outside of CLI.
  */
-function wc_update_340_states() {
+function wc_update_340_states( $force_run = false ) {
+	if ( ! $force_run && ! defined( 'WP_CLI' ) ) {
+		return;
+	}
+
 	global $wpdb;
 
 	$country_states = array(


### PR DESCRIPTION
Reported https://wordpress.org/support/topic/wc-3-4-database-update-complete-and-keeps-on-running/

`wc_update_340_states` does a lot of meta table updates and can time out. Since it's a single function, if it does timeout it will keep running indefinitely.

This change will let it run over CLI only.

Changelog:

> Updated the `wc_update_340_states` update routine to run over CLI manually due to performance concerns. If you have past orders from BD or IE and want the state codes to be updated, run CLI command `wp wc update` or call the `wc_update_340_states( true )` function manually. This data change is not critical.