### PR TITLE
Break up update routine and allow it run to multuple times

### DIFF
--- a/includes/class-wc-background-updater.php
+++ b/includes/class-wc-background-updater.php
@@ -102,15 +102,22 @@ class WC_Background_Updater extends WC_Background_Process {
 
 		include_once dirname( __FILE__ ) . '/wc-update-functions.php';
 
+		$result = false;
+
 		if ( is_callable( $callback ) ) {
 			$logger->info( sprintf( 'Running %s callback', $callback ), array( 'source' => 'wc_db_updates' ) );
-			call_user_func( $callback );
-			$logger->info( sprintf( 'Finished %s callback', $callback ), array( 'source' => 'wc_db_updates' ) );
+			$result = (bool) call_user_func( $callback );
+
+			if ( $result ) {
+				$logger->info( sprintf( '%s callback needs to run again', $callback ), array( 'source' => 'wc_db_updates' ) );
+			} else {
+				$logger->info( sprintf( 'Finished running %s callback', $callback ), array( 'source' => 'wc_db_updates' ) );
+			}
 		} else {
 			$logger->notice( sprintf( 'Could not find %s callback', $callback ), array( 'source' => 'wc_db_updates' ) );
 		}
 
-		return false;
+		return $result;
 	}
 
 	/**

--- a/includes/class-wc-background-updater.php
+++ b/includes/class-wc-background-updater.php
@@ -93,7 +93,7 @@ class WC_Background_Updater extends WC_Background_Process {
 	 * item from the queue.
 	 *
 	 * @param string $callback Update callback function.
-	 * @return mixed
+	 * @return string|bool
 	 */
 	protected function task( $callback ) {
 		wc_maybe_define_constant( 'WC_UPDATING', true );
@@ -117,7 +117,7 @@ class WC_Background_Updater extends WC_Background_Process {
 			$logger->notice( sprintf( 'Could not find %s callback', $callback ), array( 'source' => 'wc_db_updates' ) );
 		}
 
-		return $result;
+		return $result ? $callback : false;
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -101,6 +101,7 @@ class WC_Install {
 		),
 		'3.4.0' => array(
 			'wc_update_340_states',
+			'wc_update_340_state',
 			'wc_update_340_last_active',
 			'wc_update_340_db_version',
 		),

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1718,7 +1718,7 @@ function wc_update_340_states() {
 /**
  * Update next state in the queue.
  *
- * @return void
+ * @return bool True to run again, false if completed.
  */
 function wc_update_340_state() {
 	global $wpdb;

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1638,8 +1638,6 @@ function wc_update_330_db_version() {
  * Update state codes for Ireland and BD.
  */
 function wc_update_340_states() {
-	global $wpdb;
-
 	$country_states = array(
 		'IE' => array(
 			'CK' => 'CO',
@@ -1714,6 +1712,23 @@ function wc_update_340_states() {
 		),
 	);
 
+	update_option( 'woocommerce_update_340_states', $country_states );
+}
+
+/**
+ * Update next state in the queue.
+ *
+ * @return void
+ */
+function wc_update_340_state() {
+	global $wpdb;
+
+	$country_states = array_filter( (array) get_option( 'woocommerce_update_340_states', array() ) );
+
+	if ( empty( $country_states ) ) {
+		return false;
+	}
+
 	foreach ( $country_states as $country => $states ) {
 		foreach ( $states as $old => $new ) {
 			$wpdb->query(
@@ -1743,8 +1758,22 @@ function wc_update_340_states() {
 					'tax_rate_state' => strtoupper( $old ),
 				)
 			);
+			unset( $country_states[ $country ][ $old ] );
+
+			if ( empty( $country_states[ $country ] ) ) {
+				unset( $country_states[ $country ] );
+			}
+			break 2;
 		}
 	}
+
+	if ( ! empty( $country_states ) ) {
+		return update_option( 'woocommerce_update_340_states', $country_states );
+	}
+
+	delete_option( 'woocommerce_update_340_states' );
+
+	return false;
 }
 
 /**


### PR DESCRIPTION
This breaks up the 3.4 state update routine into multiple jobs and allows jobs in the background process to run multiple times.

To test:

1. Set DB version `woocommerce_db_version` to 3.3.0
2. Activate WooCommerce
3. Run updater
4. Check the db update logs. You'll see:

```
2018-05-24T12:46:50+00:00 INFO Running wc_update_340_state callback
2018-05-24T12:46:50+00:00 INFO wc_update_340_state callback needs to run again
2018-05-24T12:46:50+00:00 INFO Running wc_update_340_state callback
2018-05-24T12:46:50+00:00 INFO wc_update_340_state callback needs to run again
2018-05-24T12:46:50+00:00 INFO Running wc_update_340_state callback
2018-05-24T12:46:50+00:00 INFO wc_update_340_state callback needs to run again
2018-05-24T12:46:50+00:00 INFO Running wc_update_340_state callback
2018-05-24T12:46:50+00:00 INFO Finished running wc_update_340_state callback
2018-05-24T12:46:50+00:00 INFO Data update complete
```

This does one call per state.

This is an alternative to https://github.com/woocommerce/woocommerce/pull/20238