### PR TITLE
Updated URL's tab parameter to fix broken edit webhook button

### DIFF
--- a/includes/admin/class-wc-admin-webhooks-table-list.php
+++ b/includes/admin/class-wc-admin-webhooks-table-list.php
@@ -69,7 +69,7 @@ class WC_Admin_Webhooks_Table_List extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_title( $webhook ) {
-		$edit_link = admin_url( 'admin.php?page=wc-settings&amp;tab=api&amp;section=webhooks&amp;edit-webhook=' . $webhook->get_id() );
+		$edit_link = admin_url( 'admin.php?page=wc-settings&amp;tab=advanced&amp;section=webhooks&amp;edit-webhook=' . $webhook->get_id() );
 		$output    = '';
 
 		// Title.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Updates the webhook edit url from `api` to `advanced`.

Closes #20240

### How to test the changes in this Pull Request:

1.Go to WC > Settings > Advanced > Webhooks
2.Add some webhooks
3.From the main screen, try clicking the webhooks "edit" links and ensure the page displays correctly.