### PR TITLE
Fix gallery thumbnails not opening a lightbox

### DIFF
--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -223,9 +223,8 @@ jQuery( function( $ ) {
 			this.$target.on( 'click', '.woocommerce-product-gallery__image a', function( e ) {
 				e.preventDefault();
 			});
-		} else {
-			this.$target.on( 'click', '.woocommerce-product-gallery__image a', this.openPhotoswipe );
 		}
+			this.$target.on( 'click', '.woocommerce-product-gallery__image a', this.openPhotoswipe );
 	};
 
 	/**


### PR DESCRIPTION
This commit introduced a bug which prevents gallery thumbnails from opening up in a lightbox: https://github.com/woocommerce/woocommerce/commit/ffbbf08b6130731802d73b2a7905bde6cde16bae#diff-70e6d5d85f9bbb3126dad3190f865c2f

The commit message is a bit vague but it sounds like the main change was just adding `e.preventDefault();` and then there was an `else` statement added after but not sure why. That else statement is not really needed because it’s not really doing an else, it’s just activating photoswipe for images after that if statement runs.

Removing the `else` brings back the lightbox for the gallery thumbnails.