### PR TITLE
Update wc_maybe_define_constant Docblock

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -59,7 +59,7 @@ add_filter( 'woocommerce_short_description', array( $GLOBALS['wp_embed'], 'run_s
  *
  * @since 3.0.0
  * @param string $name  Constant name.
- * @param string $value Value.
+ * @param mixed  $value Value.
  */
 function wc_maybe_define_constant( $name, $value ) {
 	if ( ! defined( $name ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The second argument of `wc_maybe_define_constant` function, as it is used in WC, doesn't accept only `strings`, but also `booleans` : 
https://github.com/woocommerce/woocommerce/blob/820426a4d06a40448d33948535871d7582bf3c23/includes/class-wc-background-updater.php#L99
https://github.com/woocommerce/woocommerce/blob/0454f1539b11837a1b2698aa80c7a08d83da023f/includes/shortcodes/class-wc-shortcode-cart.php#L67

Furthermore, the type of the second argument could be any valid PHP type, so the docblock shoud reflect that.