### PR TITLE
Fix infinite loop with importing tax rates (#20253).

### DIFF
--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -162,6 +162,8 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 					$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 					WC_Tax::_update_tax_rate_postcodes( $tax_rate_id, wc_clean( $postcode ) );
 					WC_Tax::_update_tax_rate_cities( $tax_rate_id, wc_clean( $city ) );
+
+					$row = fgetcsv( $handle, 0, $this->delimiter );
 				}
 			} else {
 				$this->import_error( __( 'The CSV is invalid.', 'woocommerce' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently, there is an infinite loop issue when importing tax rates from a CSV, as described in #20253. During this infinite loop, the import script continually adds more and more copies of the same tax rate entry into the `wp_woocommerce_tax_rates` table until you force the script to stop.

The issue was caused by a simple logic error where the importer reads a single row from the CSV into a variable called `$row` before proceeding into the `while` loop, but the `while` loop didn't read in any more rows; thus, the condition `false !== $row` always held, and therefore, the `while` loop never terminated.

The proposed fix is to read a row from the CSV into `$row` from within the `while` loop. 

Closes #20253.

### How to test the changes in this Pull Request:

1. Go to _Tools_ > _Import_ > WooCommerce tax rates (CSV) > _Run importer_.
1. Choose a properly formatted CSV to import (e.g. `sample-data/sample_tax_rates.csv` included with WooCommerce plugin).
1. Click on _Upload the file and import_.
1. Ensure that the tax rates have been properly imported into the standard, reduced, and zero-rate rate groups.

### Changelog entry

> Fix - Infinite loop when importing tax rates via CSV.