### PR TITLE
Wizard, do not make flat rate cost field mandatory

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -766,7 +766,7 @@ class WC_Admin_Setup_Wizard {
 						'type'          => 'text',
 						'default_value' => __( 'Cost', 'woocommerce' ),
 						'description'   => __( 'What would you like to charge for flat rate shipping?', 'woocommerce' ),
-						'required'      => true,
+						'required'      => false,
 					),
 				),
 			),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When setting up shipping via the wizard you can enable flat rate as an option to cover shipping for all other zones, however, this option can be disabled so the user should not be forced to enter a value in the cost field.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20252 .

### How to test the changes in this Pull Request:

1. Run the wizard
2. On the shipping tab you should be able to leave the cost field blank for flat rate

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Allow blank in flat rate cost field on the setup wizard.
