### PR TITLE
Add unit tests for importing taxes

### DIFF
--- a/tests/unit-tests/importer/sample_tax_rates.csv
+++ b/tests/unit-tests/importer/sample_tax_rates.csv
@@ -1,0 +1,6 @@
+Country Code,State Code,ZIP/Postcode,City,Rate %,Tax Name,Priority,Compound,Shipping,Tax Class
+GB,*,*,*,20.0000,VAT,1,1,1,
+GB,*,*,*,5.0000,VAT,1,1,1,reduced-rate
+GB,*,*,*,0.0000,VAT,1,1,1,zero-rate
+US,*,*,*,10.0000,US,1,1,1,
+US,AL,12345; 123456,*,2.0000,US AL,2,1,1,

--- a/tests/unit-tests/importer/tax.php
+++ b/tests/unit-tests/importer/tax.php
@@ -34,8 +34,8 @@ class WC_Tests_Tax_CSV_Importer extends WC_Unit_Test_Case {
 		global $wpdb;
 		$importer = new WC_Tax_Rate_Importer();
 		ob_start();
-		$results = $importer->import( $this->csv_file );
-		$results = ob_get_clean();
+		$importer->import( $this->csv_file );
+		ob_get_clean();
 		$rate_count = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rates" );
 		$this->assertEquals( 5, $rate_count );
 	}

--- a/tests/unit-tests/importer/tax.php
+++ b/tests/unit-tests/importer/tax.php
@@ -35,7 +35,7 @@ class WC_Tests_Tax_CSV_Importer extends WC_Unit_Test_Case {
 		$importer = new WC_Tax_Rate_Importer();
 		ob_start();
 		$importer->import( $this->csv_file );
-		ob_get_clean();
+		ob_end_clean();
 		$rate_count = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rates" );
 		$this->assertEquals( 5, $rate_count );
 	}

--- a/tests/unit-tests/importer/tax.php
+++ b/tests/unit-tests/importer/tax.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Meta
+ * @package WooCommerce\Tests\Importer
+ */
+class WC_Tests_Tax_CSV_Importer extends WC_Unit_Test_Case {
+
+	/**
+	 * Test CSV file path.
+	 *
+	 * @var string
+	 */
+	protected $csv_file = '';
+
+	/**
+	 * Load up the importer classes since they aren't loaded by default.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->csv_file = dirname( __FILE__ ) . '/sample_tax_rates.csv';
+
+		$bootstrap = WC_Unit_Tests_Bootstrap::instance();
+		require_once ABSPATH . '/wp-admin/includes/class-wp-importer.php';
+		require_once $bootstrap->plugin_dir . '/includes/admin/importers/class-wc-tax-rate-importer.php';
+	}
+
+	/**
+	 * Test import.
+	 * @since 3.1.0
+	 */
+	public function test_import() {
+		global $wpdb;
+		$importer = new WC_Tax_Rate_Importer();
+		ob_start();
+		$results = $importer->import( $this->csv_file );
+		$results = ob_get_clean();
+		$rate_count = $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_tax_rates" );
+		$this->assertEquals( 5, $rate_count );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This adds a unit test to ensure tax rates are imported correctly, to prevent issues like #20253

### How to test the changes in this Pull Request:
1. Run phpunit tests/unit-tests/importer/tax.php
2. Test should pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
