### PR TITLE
Make sample tax rate URL clickable

### DIFF
--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -245,7 +245,14 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 		echo '<p>' . esc_html__( 'Hi there! Upload a CSV file containing tax rates to import the contents into your shop. Choose a .csv file to upload, then click "Upload file and import".', 'woocommerce' ) . '</p>';
 
 		/* translators: 1: Link to tax rates sample file */
-		echo '<p>' . sprintf( wp_kses( 'Tax rates need to be defined with columns in a specific order (10 columns). <a href="%s">Click here to download a sample</a>.', 'woocommerce' ), esc_url( WC()->plugin_url() ) . '/sample-data/sample_tax_rates.csv' ) . '</p>';
+		echo wp_kses(
+			'<p>' . sprintf( __( 'Tax rates need to be defined with columns in a specific order (10 columns). <a href="%s">Click here to download a sample</a>.', 'woocommerce' ), esc_url( WC()->plugin_url() ) . '/sample-data/sample_tax_rates.csv' ) . '</p>'
+			, array(
+					'a' => array(
+						'href'  => array(),
+					),
+				)
+		);
 
 		$action = 'admin.php?import=woocommerce_tax_rate_csv&step=1';
 

--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -245,14 +245,8 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 		echo '<p>' . esc_html__( 'Hi there! Upload a CSV file containing tax rates to import the contents into your shop. Choose a .csv file to upload, then click "Upload file and import".', 'woocommerce' ) . '</p>';
 
 		/* translators: 1: Link to tax rates sample file */
-		echo wp_kses(
-			'<p>' . sprintf( __( 'Tax rates need to be defined with columns in a specific order (10 columns). <a href="%s">Click here to download a sample</a>.', 'woocommerce' ), esc_url( WC()->plugin_url() ) . '/sample-data/sample_tax_rates.csv' ) . '</p>'
-			, array(
-					'a' => array(
-						'href'  => array(),
-					),
-				)
-		);
+		echo '<p>' . sprintf( __( 'Tax rates need to be defined with columns in a specific order (10 columns). <a href="%s">Click here to download a sample</a>.', 'woocommerce' ), esc_url( WC()->plugin_url() ) . '/sample-data/sample_tax_rates.csv' ) . '</p>';
+
 
 		$action = 'admin.php?import=woocommerce_tax_rate_csv&step=1';
 

--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -245,7 +245,7 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 		echo '<p>' . esc_html__( 'Hi there! Upload a CSV file containing tax rates to import the contents into your shop. Choose a .csv file to upload, then click "Upload file and import".', 'woocommerce' ) . '</p>';
 
 		/* translators: 1: Link to tax rates sample file */
-		echo '<p>' . sprintf( esc_html__( 'Tax rates need to be defined with columns in a specific order (10 columns). <a href="%s">Click here to download a sample</a>.', 'woocommerce' ), esc_url( WC()->plugin_url() ) . '/sample-data/sample_tax_rates.csv' ) . '</p>';
+		echo '<p>' . sprintf( wp_kses( 'Tax rates need to be defined with columns in a specific order (10 columns). <a href="%s">Click here to download a sample</a>.', 'woocommerce' ), esc_url( WC()->plugin_url() ) . '/sample-data/sample_tax_rates.csv' ) . '</p>';
 
 		$action = 'admin.php?import=woocommerce_tax_rate_csv&step=1';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Make the download sample tax rates file URL clickable.

Closes #20271.

### How to test the changes in this Pull Request:

1. go to '../wp-admin/admin.php?import=woocommerce_tax_rate_csv'
2. Click `Click here to download a sample`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix download sample tax rates URL format
