### PR TITLE
Product properties should not be accessed directly

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -701,7 +701,7 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		// Alt text.
 		$alt_text = array( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ), $props['caption'], wp_strip_all_tags( $attachment->post_title ) );
 
-		if ( $product ) {
+		if ( $product && $product instanceof WC_Product ) {
 			$alt_text[] = wp_strip_all_tags( get_the_title( $product->get_id() ) );
 		}
 

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -702,7 +702,7 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		$alt_text = array( wp_strip_all_tags( get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ) ), $props['caption'], wp_strip_all_tags( $attachment->post_title ) );
 
 		if ( $product ) {
-			$alt_text[] = wp_strip_all_tags( get_the_title( $product->ID ) );
+			$alt_text[] = wp_strip_all_tags( get_the_title( $product->get_id() ) );
 		}
 
 		$alt_text     = array_filter( $alt_text );


### PR DESCRIPTION
Use WC_Product::get_id() instead of WC_Product::ID as product properties should not be accessed directly. Also adds a check to make sure `$product` is an instance of `WC_Product` before calling `WC_Product::get_id()` to protect against a fatal error.

Fixes #20278

### How to test the changes in this Pull Request:

See #20278 for instructions on how to test.

### Changelog entry

> Fix product properties should not be accessed directly PHP notice when calling wc_get_product_attachment_props()
