### PR TITLE
Clear category 0 when deleting caches

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -222,7 +222,7 @@ class WC_Cache_Helper {
 		if ( 'product_cat' === $taxonomy ) {
 			$ids = is_array( $ids ) ? $ids : array( $ids );
 
-			$clear_ids = array();
+			$clear_ids = array( 0 );
 
 			foreach ( $ids as $id ) {
 				$clear_ids[] = $id;


### PR DESCRIPTION
Fixes an issue reported on Atomic sites with object caching.

When category caches are cleared, it clears the current saved ID plus it's ancestors. 0 is not returned as an ancestor so we need to clear it manually.

To test:

1. Show cats on shop page
2. Object caching must be enabled
3. Add a new category with product inside
4. Shop page should show new category.