### PR TITLE
Removed 'orders_count' and 'total_spent' fields from customer v3 API.

### DIFF
--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -24,4 +24,327 @@ class WC_REST_Customers_Controller extends WC_REST_Customers_V2_Controller {
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Get formatted item data.
+	 *
+	 * @since  3.0.0
+	 * @param  WC_Data $object WC_Data instance.
+	 * @return array
+	 */
+	protected function get_formatted_item_data( $object ) {
+		$data        = $object->get_data();
+		$format_date = array( 'date_created', 'date_modified' );
+
+		// Format date values.
+		foreach ( $format_date as $key ) {
+			$datetime              = $data[ $key ];
+			$data[ $key ]          = wc_rest_prepare_date_response( $datetime, false );
+			$data[ $key . '_gmt' ] = wc_rest_prepare_date_response( $datetime );
+		}
+
+		return array(
+			'id'                 => $object->get_id(),
+			'date_created'       => $data['date_created'],
+			'date_created_gmt'   => $data['date_created_gmt'],
+			'date_modified'      => $data['date_modified'],
+			'date_modified_gmt'  => $data['date_modified_gmt'],
+			'email'              => $data['email'],
+			'first_name'         => $data['first_name'],
+			'last_name'          => $data['last_name'],
+			'role'               => $data['role'],
+			'username'           => $data['username'],
+			'billing'            => $data['billing'],
+			'shipping'           => $data['shipping'],
+			'is_paying_customer' => $data['is_paying_customer'],
+			'avatar_url'         => $object->get_avatar_url(),
+			'meta_data'          => $data['meta_data'],
+		);
+	}
+
+	/**
+	 * Prepare a single customer output for response.
+	 *
+	 * @param  WP_User         $user_data User object.
+	 * @param  WP_REST_Request $request   Request object.
+	 * @return WP_REST_Response $response  Response data.
+	 */
+	public function prepare_item_for_response( $user_data, $request ) {
+		$customer = new WC_Customer( $user_data->ID );
+		$data     = $this->get_formatted_item_data( $customer );
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data     = $this->add_additional_fields_to_object( $data, $request );
+		$data     = $this->filter_response_by_context( $data, $context );
+		$response = rest_ensure_response( $data );
+		$response->add_links( $this->prepare_links( $user_data ) );
+
+		/**
+		 * Filter customer data returned from the REST API.
+		 *
+		 * @param WP_REST_Response $response   The response object.
+		 * @param WP_User          $user_data  User object used to create response.
+		 * @param WP_REST_Request  $request    Request object.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_customer', $response, $user_data, $request );
+	}
+
+	/**
+	 * Update customer meta fields.
+	 *
+	 * @param WC_Customer     $customer Customer data.
+	 * @param WP_REST_Request $request  Request data.
+	 */
+	protected function update_customer_meta_fields( $customer, $request ) {
+		parent::update_customer_meta_fields( $customer, $request );
+
+		// Meta data.
+		if ( isset( $request['meta_data'] ) ) {
+			if ( is_array( $request['meta_data'] ) ) {
+				foreach ( $request['meta_data'] as $meta ) {
+					$customer->update_meta_data( $meta['key'], $meta['value'], isset( $meta['id'] ) ? $meta['id'] : '' );
+				}
+			}
+		}
+	}
+
+	/**
+	 * Get the Customer's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'customer',
+			'type'       => 'object',
+			'properties' => array(
+				'id'                 => array(
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created'       => array(
+					'description' => __( "The date the customer was created, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created_gmt'   => array(
+					'description' => __( 'The date the order was created, as GMT.', 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_modified'      => array(
+					'description' => __( "The date the customer was last modified, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_modified_gmt'  => array(
+					'description' => __( 'The date the customer was last modified, as GMT.', 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'email'              => array(
+					'description' => __( 'The email address for the customer.', 'woocommerce' ),
+					'type'        => 'string',
+					'format'      => 'email',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'first_name'         => array(
+					'description' => __( 'Customer first name.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+				'last_name'          => array(
+					'description' => __( 'Customer last name.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_text_field',
+					),
+				),
+				'role'               => array(
+					'description' => __( 'Customer role.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'username'           => array(
+					'description' => __( 'Customer login name.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'sanitize_user',
+					),
+				),
+				'password'           => array(
+					'description' => __( 'Customer password.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'edit' ),
+				),
+				'billing'            => array(
+					'description' => __( 'List of billing address data.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'first_name' => array(
+							'description' => __( 'First name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'last_name'  => array(
+							'description' => __( 'Last name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'company'    => array(
+							'description' => __( 'Company name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'address_1'  => array(
+							'description' => __( 'Address line 1', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'address_2'  => array(
+							'description' => __( 'Address line 2', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'city'       => array(
+							'description' => __( 'City name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'state'      => array(
+							'description' => __( 'ISO code or name of the state, province or district.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'postcode'   => array(
+							'description' => __( 'Postal code.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'country'    => array(
+							'description' => __( 'ISO code of the country.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'email'      => array(
+							'description' => __( 'Email address.', 'woocommerce' ),
+							'type'        => 'string',
+							'format'      => 'email',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'phone'      => array(
+							'description' => __( 'Phone number.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'shipping'           => array(
+					'description' => __( 'List of shipping address data.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'properties'  => array(
+						'first_name' => array(
+							'description' => __( 'First name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'last_name'  => array(
+							'description' => __( 'Last name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'company'    => array(
+							'description' => __( 'Company name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'address_1'  => array(
+							'description' => __( 'Address line 1', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'address_2'  => array(
+							'description' => __( 'Address line 2', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'city'       => array(
+							'description' => __( 'City name.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'state'      => array(
+							'description' => __( 'ISO code or name of the state, province or district.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'postcode'   => array(
+							'description' => __( 'Postal code.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+						'country'    => array(
+							'description' => __( 'ISO code of the country.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
+					),
+				),
+				'is_paying_customer' => array(
+					'description' => __( 'Is the customer a paying customer?', 'woocommerce' ),
+					'type'        => 'bool',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'avatar_url'         => array(
+					'description' => __( 'Avatar URL.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'meta_data'          => array(
+					'description' => __( 'Meta data.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'id'    => array(
+								'description' => __( 'Meta ID.', 'woocommerce' ),
+								'type'        => 'integer',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'key'   => array(
+								'description' => __( 'Meta key.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
+							'value' => array(
+								'description' => __( 'Meta value.', 'woocommerce' ),
+								'type'        => 'mixed',
+								'context'     => array( 'view', 'edit' ),
+							),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
 }

--- a/includes/api/class-wc-rest-customers-controller.php
+++ b/includes/api/class-wc-rest-customers-controller.php
@@ -63,51 +63,6 @@ class WC_REST_Customers_Controller extends WC_REST_Customers_V2_Controller {
 	}
 
 	/**
-	 * Prepare a single customer output for response.
-	 *
-	 * @param  WP_User         $user_data User object.
-	 * @param  WP_REST_Request $request   Request object.
-	 * @return WP_REST_Response $response  Response data.
-	 */
-	public function prepare_item_for_response( $user_data, $request ) {
-		$customer = new WC_Customer( $user_data->ID );
-		$data     = $this->get_formatted_item_data( $customer );
-		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data     = $this->add_additional_fields_to_object( $data, $request );
-		$data     = $this->filter_response_by_context( $data, $context );
-		$response = rest_ensure_response( $data );
-		$response->add_links( $this->prepare_links( $user_data ) );
-
-		/**
-		 * Filter customer data returned from the REST API.
-		 *
-		 * @param WP_REST_Response $response   The response object.
-		 * @param WP_User          $user_data  User object used to create response.
-		 * @param WP_REST_Request  $request    Request object.
-		 */
-		return apply_filters( 'woocommerce_rest_prepare_customer', $response, $user_data, $request );
-	}
-
-	/**
-	 * Update customer meta fields.
-	 *
-	 * @param WC_Customer     $customer Customer data.
-	 * @param WP_REST_Request $request  Request data.
-	 */
-	protected function update_customer_meta_fields( $customer, $request ) {
-		parent::update_customer_meta_fields( $customer, $request );
-
-		// Meta data.
-		if ( isset( $request['meta_data'] ) ) {
-			if ( is_array( $request['meta_data'] ) ) {
-				foreach ( $request['meta_data'] as $meta ) {
-					$customer->update_meta_data( $meta['key'], $meta['value'], isset( $meta['id'] ) ? $meta['id'] : '' );
-				}
-			}
-		}
-	}
-
-	/**
 	 * Get the Customer's schema, conforming to JSON Schema.
 	 *
 	 * @return array


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/woocommerce/wc-api-dev/issues/53 .

### How to test the changes in this Pull Request:

1. Compare request to v3 and v2 API version (e.g. https://local.wordpress.test/wp-json/wc/v3/customers/ and https://local.wordpress.test/wp-json/wc/v2/customers/), 
2. v3 should be missing ` "orders_count": X` and `"total_spent": "XX.YY"`


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Removed `orders_count` and `total_spent` attributes from customer path for performance reasons.
