### PR TITLE
Show empty terms in admin dropdown

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -293,6 +293,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 			wc_product_dropdown_categories(
 				array(
 					'option_select_text' => __( 'Filter by category', 'woocommerce' ),
+					'hide_empty'         => 0,
 				)
 			);
 		} else {


### PR DESCRIPTION
Shows empty terms in admin category dropdown. Private posts are not included in the count, so categories with just private posts would otherwise be hidden.

This does have the side effect of showing really empty terms, but there is no way around this.

Closes #20312

### How to test the changes in this Pull Request:

1. Create a private product in a new category.
2. See if it's listed in the product screen's category filter dropdown.