### PR TITLE
More informative coupon label for coupons with discount and free shipping

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -280,7 +280,7 @@ function wc_cart_totals_coupon_html( $coupon ) {
 	$amount               = WC()->cart->get_coupon_discount_amount( $coupon->get_code(), WC()->cart->display_cart_ex_tax );
 	$discount_amount_html = '-' . wc_price( $amount );
 
-	if ( $coupon->get_free_shipping() ) {
+	if ( $coupon->get_free_shipping() && ! apply_filters( 'woocommerce_coupon_show_discount_amount', ! empty( $amount ), $coupon ) ) {
 		$discount_amount_html = __( 'Free shipping coupon', 'woocommerce' );
 	}
 

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -280,7 +280,7 @@ function wc_cart_totals_coupon_html( $coupon ) {
 	$amount               = WC()->cart->get_coupon_discount_amount( $coupon->get_code(), WC()->cart->display_cart_ex_tax );
 	$discount_amount_html = '-' . wc_price( $amount );
 
-	if ( $coupon->get_free_shipping() && ! apply_filters( 'woocommerce_coupon_show_discount_amount', ! empty( $amount ), $coupon ) ) {
+	if ( $coupon->get_free_shipping() && empty( $amount ) ) {
 		$discount_amount_html = __( 'Free shipping coupon', 'woocommerce' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Currently, if a coupon provides a discount and free shipping, "Free shipping coupon" is set as default value of `$discount_amount_html`. The discount amount of a coupon is likely more valuable information for the customer, especially since the free shipping method will be made available (duplicate information, with no indication to discount's amount).

This pull request introduces a filter that leaves the current functionality for coupons with free shipping, but for coupons providing both a discount and free shipping, changes the `$discount_amount_html` value to the coupon's discount amount (and the filter allows the current behavior to persist at developer's choice).

### How to test the changes in this Pull Request:

1. Create a coupon providing a discount (`off`).
1. Create a coupon providing free shipping (`freeship`).
1. Create a coupon providing a discount and free shipping (`off-freeship`).
1. Add a product to your cart.
1. Apply all three created coupons to your cart.
1. Note the labels for the coupons.
<img width="586" alt="screen shot 2018-05-31 at 8 58 15 pm" src="https://user-images.githubusercontent.com/4573033/40815571-7f6ddd30-6515-11e8-9cd4-a770ed3a77ca.png">

1. Set `add_filter( 'woocommerce_coupon_show_discount_amount', '__return_false' )`.
1. Note the labels for the coupons (this is current default behavior).
<img width="591" alt="screen shot 2018-05-31 at 9 00 16 pm" src="https://user-images.githubusercontent.com/4573033/40815613-af927f8e-6515-11e8-90be-9df1e50088bc.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Set default to present customer with discount amount for coupons that provide a discount and free shipping. Implements filter to allow for global or coupon-specific behavior change.
