### PR TITLE
Fix - nav error while saving setting form

### DIFF
--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -85,7 +85,7 @@
 			}
 		});
 
-		$( '.submit input' ).click( function() {
+		$( '.submit button' ).click( function() {
 			window.onbeforeunload = '';
 		});
 	});

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -85,7 +85,7 @@
 			}
 		});
 
-		$( '.submit button' ).click( function() {
+		$( '.submit :input' ).click( function() {
 			window.onbeforeunload = '';
 		});
 	});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### How to test the changes in this Pull Request:

1. Goto settings > Change any input field and try to navigate into new tab.
2. After save warn is displayed, stay on similar page and try to save the settings.
3. After trying to save again the save warn is displayed on save button, which shouldn't be in save btn.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> After input submit is changed to button. Seems like this error came up.

CC @claudiulodro 
