### PR TITLE
apply bulk actions oldest to newest

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -623,7 +623,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 * @return string
 	 */
 	public function handle_bulk_actions( $redirect_to, $action, $ids ) {
-		$ids     = array_map( 'absint', $ids );
+		$ids     = array_reverse( array_map( 'absint', $ids ) );
 		$changed = 0;
 
 		if ( 'remove_personal_data' === $action ) {

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -623,7 +623,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 * @return string
 	 */
 	public function handle_bulk_actions( $redirect_to, $action, $ids ) {
-		$ids     = array_reverse( array_map( 'absint', $ids ) );
+		$ids     = apply_filters( 'woocommerce_bulk_action_ids', array_reverse( array_map( 'absint', $ids ) ), $action, 'order' );
 		$changed = 0;
 
 		if ( 'remove_personal_data' === $action ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Reverses the order of ids for processing bulk actions, so that older orders are processed first. In most cases this would be preferable, for example when orders are completed and this triggers the creation of invoices, it makes much more sense to do that in chronological order. There is currently no way to influence this by a filter either. I would propose to make old-to-new the default and perhaps add a filter for those who need the reverse.

### How to test the changes in this Pull Request:

1. Bulk select orders
2. Apply bulk action (such as completing)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Bulk actions for orders are now applied in chronological order