### PR TITLE
Hide add to cart button for variable product if not purchasable

### DIFF
--- a/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -10,6 +10,26 @@
 defined( 'ABSPATH' ) || exit;
 
 global $product;
+
+if ( ! $product->is_purchasable() ) {
+	// variable product is not purchasable.
+	// check if all variations are not purchasable.
+	$variations_ids = $product->get_children();
+	$is_one_purchasable = false;
+	foreach ( $variations_ids as $variation_id ) {
+		$variation = wc_get_product( $variation_id );
+		if ( $variation && $variation->is_purchasable() ) {
+			$is_one_purchasable = true;
+			break;
+		}
+	}
+	// if at least one variation is purchasable we show the add to cart button.
+	// else we can omit it.
+	if ( ! $is_one_purchasable ) {
+		return;
+	}
+}
+
 ?>
 <div class="woocommerce-variation-add-to-cart variations_button">
 	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When overriding "is_purchasable" to false for a simple product, the add to cart button is not shown.
The same behaviour should be expected when overriding "is_purchasable" for a variable product and all of its variations.
I assume there is a case where it makes sense to have the variable product with is_purchasable() return false and one or more of its variations with is_purchasable() return true.
The assumption for this was based on the fact that making the variable product return false for is_purchasable() did not stop me from buying a variation (since we can't really buy the variable product).

Closes # .

### How to test the changes in this Pull Request:

1. Create 2 filters
```
add_filter('woocommerce_is_purchasable', 'temp_override', 10, 2);
if ( ! function_exists( 'temp_override' ) ) {
    function temp_override( $is_purchasable, $product ) {
        return false;
    }
}

add_filter('woocommerce_variation_is_purchasable', 'temp_override_2', 10, 2);
if ( ! function_exists( 'temp_override_2' ) ) {
    function temp_override_2( $is_purchasable, $product ) {
        return false;
    }
}
```
2. Create a variable product, set price for variations, set in stock and publish.
3. Click view product, add to cart button should not be visible.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> For single products the cart button gets hidden.
> The same behaviour should be expected for add to cart button on a variable product if the parent product and all variations are not purchasable.