### PR TITLE
Do not export a customer data group containing no data

### DIFF
--- a/includes/class-wc-privacy-exporters.php
+++ b/includes/class-wc-privacy-exporters.php
@@ -25,12 +25,15 @@ class WC_Privacy_Exporters {
 		$data_to_export = array();
 
 		if ( $user instanceof WP_User ) {
-			$data_to_export[] = array(
-				'group_id'    => 'woocommerce_customer',
-				'group_label' => __( 'Customer Data', 'woocommerce' ),
-				'item_id'     => 'user',
-				'data'        => self::get_customer_personal_data( $user ),
-			);
+			$customer_personal_data = self::get_customer_personal_data( $user );
+			if ( ! empty( $customer_personal_data ) ) {
+				$data_to_export[] = array(
+					'group_id'    => 'woocommerce_customer',
+					'group_label' => __( 'Customer Data', 'woocommerce' ),
+					'item_id'     => 'user',
+					'data'        => $customer_personal_data,
+				);
+			}
 		}
 
 		return array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #20346 

### How to test the changes in this Pull Request:

1. Add a customer in wp-admin > Users
2. Immediately create a personal data export request for them
3. Execute the request and ensure no "empty" customer data group is in there
4. Repeat with a customer with at least one piece of customer data in their profile (e.g. shipping country)
5. Create a personal data export request for them
6. Make sure the Customer Data group appears and has that data in it.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?
