### PR TITLE
Make Bahrain state not required

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -788,6 +788,11 @@ class WC_Countries {
 							'label'    => __( 'Province', 'woocommerce' ),
 						),
 					),
+					'BH' => array(
+						'state' => array(
+							'required' => false,
+						),
+					),
 					'BI' => array(
 						'state' => array(
 							'required' => false,

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -281,7 +281,11 @@ function wc_cart_totals_coupon_html( $coupon ) {
 	$discount_amount_html = '-' . wc_price( $amount );
 
 	if ( $coupon->get_free_shipping() ) {
-		$discount_amount_html = __( 'Free shipping coupon', 'woocommerce' );
+		if ( empty( $amount ) ) {
+			$discount_amount_html = __( 'Free shipping coupon', 'woocommerce' );
+		} else {
+			$discount_amount_html .= __( ' (with free shipping)', 'woocommerce' );
+		}
 	}
 
 	$discount_amount_html = apply_filters( 'woocommerce_coupon_discount_amount_html', $discount_amount_html, $coupon );

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -281,11 +281,7 @@ function wc_cart_totals_coupon_html( $coupon ) {
 	$discount_amount_html = '-' . wc_price( $amount );
 
 	if ( $coupon->get_free_shipping() ) {
-		if ( empty( $amount ) ) {
-			$discount_amount_html = __( 'Free shipping coupon', 'woocommerce' );
-		} else {
-			$discount_amount_html .= __( ' (with free shipping)', 'woocommerce' );
-		}
+		$discount_amount_html = __( 'Free shipping coupon', 'woocommerce' );
 	}
 
 	$discount_amount_html = apply_filters( 'woocommerce_coupon_discount_amount_html', $discount_amount_html, $coupon );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Bahrein does not have any states, this PR disables the state validation when BH is selected as the country.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20358  .

### How to test the changes in this Pull Request:

1. Add products to cart
2. Head to checkout and select Bahrain as your country
3. Make sure no state field is visible and place the order
4. The order should place without an error that state is a required field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Make Bahrain bypass the state validation.
