### PR TITLE
permission_id Constraint checks

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -545,13 +545,13 @@ class WC_Install {
 		}
 
 		// Get tables data types and check it matches before adding constraint.
-		$download_log_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}wc_download_log WHERE Field = `permission_id`", ARRAY_A );
+		$download_log_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}wc_download_log WHERE Field = 'permission_id'", ARRAY_A );
 		$download_log_column_type = '';
 		if ( isset( $download_log_columns[0]['Type'] ) ) {
 			$download_log_column_type = $download_log_columns[0]['Type'];
 		}
 
-		$download_permissions_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE Field = `permission_id`", ARRAY_A );
+		$download_permissions_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE Field = 'permission_id'", ARRAY_A );
 		$download_permissions_column_type = '';
 		if ( isset( $download_permissions_columns[0]['Type'] ) ) {
 			$download_permissions_column_type = $download_permissions_columns[0]['Type'];

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -544,22 +544,26 @@ class WC_Install {
 			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_type)" );
 		}
 
-		// Get tables data types and check it matches before adding constraint.
-		$download_log_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}wc_download_log WHERE Field = `permission_id`", ARRAY_A );
-		$download_log_column_type = '';
-		if ( isset( $download_log_columns[0]['Type'] ) ) {
-			$download_log_column_type = $download_log_columns[0]['Type'];
-		}
+		$constraint_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->prefix}wc_download_log WHERE column_name = 'permission_id' and key_name = 'permission_id'" );
+		if ( ! is_null( $index_exists ) ) {
 
-		$download_permissions_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE Field = `permission_id`", ARRAY_A );
-		$download_permissions_column_type = '';
-		if ( isset( $download_permissions_columns[0]['Type'] ) ) {
-			$download_permissions_column_type = $download_permissions_columns[0]['Type'];
-		}
+			// Get tables data types and check it matches before adding constraint.
+			$download_log_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}wc_download_log WHERE Field = `permission_id`", ARRAY_A );
+			$download_log_column_type = '';
+			if ( isset( $download_log_columns[0]['Type'] ) ) {
+				$download_log_column_type = $download_log_columns[0]['Type'];
+			}
 
-		// Add constraint to download logs if the columns matches.
-		if ( ! empty( $download_permissions_column_type ) && ! empty( $download_log_column_type ) && $download_permissions_column_type === $download_log_column_type ) {
-			$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log ADD FOREIGN KEY (permission_id) REFERENCES {$wpdb->prefix}woocommerce_downloadable_product_permissions(permission_id) ON DELETE CASCADE" );
+			$download_permissions_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE Field = `permission_id`", ARRAY_A );
+			$download_permissions_column_type = '';
+			if ( isset( $download_permissions_columns[0]['Type'] ) ) {
+				$download_permissions_column_type = $download_permissions_columns[0]['Type'];
+			}
+
+			// Add constraint to download logs if the columns matches.
+			if ( ! empty( $download_permissions_column_type ) && ! empty( $download_log_column_type ) && $download_permissions_column_type === $download_log_column_type ) {
+				$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log ADD FOREIGN KEY (permission_id) REFERENCES {$wpdb->prefix}woocommerce_downloadable_product_permissions(permission_id) ON DELETE CASCADE" );
+			}
 		}
 	}
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -545,20 +545,16 @@ class WC_Install {
 		}
 
 		// Get tables data types and check it matches before adding constraint.
-		$download_log_columns         = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}wc_download_log", ARRAY_A );
-		$download_log_column_type     = '';
-		foreach ( $download_log_columns as $column ) {
-			if ( isset( $column['Field'], $column['Type'] ) && 'permission_id' === $column['Field'] ) {
-				$download_log_column_type = $column['Type'];
-			}
+		$download_log_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}wc_download_log WHERE Field = `permission_id`", ARRAY_A );
+		$download_log_column_type = '';
+		if ( isset( $download_log_columns[0]['Type'] ) ) {
+			$download_log_column_type = $download_log_columns[0]['Type'];
 		}
 
-		$download_permissions_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions", ARRAY_A );
+		$download_permissions_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE Field = `permission_id`", ARRAY_A );
 		$download_permissions_column_type = '';
-		foreach ( $download_permissions_columns as $column ) {
-			if ( isset( $column['Field'], $column['Type'] ) && 'permission_id' === $column['Field'] ) {
-				$download_permissions_column_type = $column['Type'];
-			}
+		if ( isset( $download_permissions_columns[0]['Type'] ) ) {
+			$download_permissions_column_type = $download_permissions_columns[0]['Type'];
 		}
 
 		// Add constraint to download logs if the columns matches.

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -544,26 +544,22 @@ class WC_Install {
 			$wpdb->query( "ALTER TABLE {$wpdb->comments} ADD INDEX woo_idx_comment_type (comment_type)" );
 		}
 
-		$constraint_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->prefix}wc_download_log WHERE column_name = 'permission_id' and key_name = 'permission_id'" );
-		if ( ! is_null( $index_exists ) ) {
+		// Get tables data types and check it matches before adding constraint.
+		$download_log_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}wc_download_log WHERE Field = `permission_id`", ARRAY_A );
+		$download_log_column_type = '';
+		if ( isset( $download_log_columns[0]['Type'] ) ) {
+			$download_log_column_type = $download_log_columns[0]['Type'];
+		}
 
-			// Get tables data types and check it matches before adding constraint.
-			$download_log_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}wc_download_log WHERE Field = `permission_id`", ARRAY_A );
-			$download_log_column_type = '';
-			if ( isset( $download_log_columns[0]['Type'] ) ) {
-				$download_log_column_type = $download_log_columns[0]['Type'];
-			}
+		$download_permissions_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE Field = `permission_id`", ARRAY_A );
+		$download_permissions_column_type = '';
+		if ( isset( $download_permissions_columns[0]['Type'] ) ) {
+			$download_permissions_column_type = $download_permissions_columns[0]['Type'];
+		}
 
-			$download_permissions_columns     = $wpdb->get_results( "SHOW COLUMNS FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE Field = `permission_id`", ARRAY_A );
-			$download_permissions_column_type = '';
-			if ( isset( $download_permissions_columns[0]['Type'] ) ) {
-				$download_permissions_column_type = $download_permissions_columns[0]['Type'];
-			}
-
-			// Add constraint to download logs if the columns matches.
-			if ( ! empty( $download_permissions_column_type ) && ! empty( $download_log_column_type ) && $download_permissions_column_type === $download_log_column_type ) {
-				$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log ADD FOREIGN KEY (permission_id) REFERENCES {$wpdb->prefix}woocommerce_downloadable_product_permissions(permission_id) ON DELETE CASCADE" );
-			}
+		// Add constraint to download logs if the columns matches.
+		if ( ! empty( $download_permissions_column_type ) && ! empty( $download_log_column_type ) && $download_permissions_column_type === $download_log_column_type ) {
+			$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log ADD FOREIGN KEY (permission_id) REFERENCES {$wpdb->prefix}woocommerce_downloadable_product_permissions(permission_id) ON DELETE CASCADE" );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes a potential issue where adding a constraint to columns that do not match data types and lengths could result in an error. Some DB's are modified manually which could result in the data types becoming out of line.

### How to test the changes in this Pull Request:

1. Change the data type of permission_id in wc_download_log to a normal int
2. From WP Shell run `WC_Install::install();`
3. The constraint should not be added
4. Change data type back to bingint
5. From WP Shell run `WC_Install::install();`
6. The constraint should be added.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Only run constraint addition when the column types match.
