### PR TITLE
Clear needs_processing transient when adding a product to an order

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1182,6 +1182,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		$item->save();
 		$this->add_item( $item );
 		wc_do_deprecated_action( 'woocommerce_order_add_product', array( $this->get_id(), $item->get_id(), $product, $qty, $args ), '3.0', 'woocommerce_new_order_item action instead' );
+		delete_transient( 'wc_order_' . $this->get_id() . '_needs_processing' );
 		return $item->get_id();
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20369

### How to test the changes in this Pull Request:

See instructions in #20369.

### Changelog entry

> Clear needs_processing transient when adding a product to an order so correct status is set after manual payment.
