### PR TITLE
fix order by price clauses when search within terms

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -505,9 +505,9 @@ class WC_Query {
 		if ( isset( $wp_query->queried_object, $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy ) && is_a( $wp_query->queried_object, 'WP_Term' ) ) {
 			$search_within_terms = get_terms( array(
 				'taxonomy' => $wp_query->queried_object->taxonomy,
-				'parent' => $wp_query->queried_object->term_id,
-				'fields' => 'tt_ids',
-			));
+				'parent'   => $wp_query->queried_object->term_id,
+				'fields'   => 'tt_ids',
+			) );
 			$search_within_terms[] = $wp_query->queried_object->term_taxonomy_id;
 			$args['join'] .= " INNER JOIN (
 				SELECT post_id, max( meta_value+0 ) price
@@ -538,9 +538,9 @@ class WC_Query {
 		if ( isset( $wp_query->queried_object, $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy ) && is_a( $wp_query->queried_object, 'WP_Term' ) ) {
 			$search_within_terms = get_terms( array(
 				'taxonomy' => $wp_query->queried_object->taxonomy,
-				'parent' => $wp_query->queried_object->term_id,
-				'fields' => 'tt_ids',
-			));
+				'parent'   => $wp_query->queried_object->term_id,
+				'fields'   => 'tt_ids',
+			) );
 			$search_within_terms[] = $wp_query->queried_object->term_taxonomy_id;
 			$args['join'] .= " INNER JOIN (
 				SELECT post_id, max( meta_value+0 ) price

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -503,7 +503,11 @@ class WC_Query {
 		global $wpdb, $wp_query;
 
 		if ( isset( $wp_query->queried_object, $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy ) && is_a( $wp_query->queried_object, 'WP_Term' ) ) {
-			$search_within_terms   = get_term_children( $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy );
+			$search_within_terms = get_terms( array(
+				'taxonomy' => $wp_query->queried_object->taxonomy,
+				'parent' => $wp_query->queried_object->term_id,
+				'fields' => 'tt_ids',
+			));
 			$search_within_terms[] = $wp_query->queried_object->term_taxonomy_id;
 			$args['join'] .= " INNER JOIN (
 				SELECT post_id, max( meta_value+0 ) price
@@ -532,7 +536,11 @@ class WC_Query {
 		global $wpdb, $wp_query;
 
 		if ( isset( $wp_query->queried_object, $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy ) && is_a( $wp_query->queried_object, 'WP_Term' ) ) {
-			$search_within_terms   = get_term_children( $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy );
+			$search_within_terms = get_terms( array(
+				'taxonomy' => $wp_query->queried_object->taxonomy,
+				'parent' => $wp_query->queried_object->term_id,
+				'fields' => 'tt_ids',
+			));
 			$search_within_terms[] = $wp_query->queried_object->term_taxonomy_id;
 			$args['join'] .= " INNER JOIN (
 				SELECT post_id, max( meta_value+0 ) price


### PR DESCRIPTION
In case when filtering by category and using price ordering result product list might be different than expected. Reason:

get_term_children returns term_ids instead of term_taxonomy_ids. term_id != term_taxonomy_id