### PR TITLE
[#20404] Fix custom webhook topic selection in dropdown

### DIFF
--- a/includes/admin/settings/views/html-webhooks-edit.php
+++ b/includes/admin/settings/views/html-webhooks-edit.php
@@ -86,9 +86,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 							foreach ( $topics as $topic_slug => $topic_name ) :
 
-							$selected = $topic_slug === $topic_data['topic'] || $topic_slug === $topic_data['resource'] . '.' . $topic_data['event'];
+								$selected = $topic_slug === $topic_data['topic'] || $topic_slug === $topic_data['resource'] . '.' . $topic_data['event'];
 
-							?>
+								?>
 								<option value="<?php echo esc_attr( $topic_slug ); ?>" <?php selected( $selected, true, true ); ?>><?php echo esc_html( $topic_name ); ?></option>
 						<?php endforeach; ?>
 					</select>

--- a/includes/admin/settings/views/html-webhooks-edit.php
+++ b/includes/admin/settings/views/html-webhooks-edit.php
@@ -89,7 +89,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							$selected = $topic_slug === $topic_data['topic'] || $topic_slug === $topic_data['resource'] . '.' . $topic_data['event'];
 
 							?>
-							<option value="<?php echo esc_attr( $topic_slug ); ?>" <?php selected( $selected, true, true ); ?>><?php echo esc_html( $topic_name ); ?></option>
+								<option value="<?php echo esc_attr( $topic_slug ); ?>" <?php selected( $selected, true, true ); ?>><?php echo esc_html( $topic_name ); ?></option>
 						<?php endforeach; ?>
 					</select>
 				</td>

--- a/includes/admin/settings/views/html-webhooks-edit.php
+++ b/includes/admin/settings/views/html-webhooks-edit.php
@@ -85,8 +85,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 							);
 
 							foreach ( $topics as $topic_slug => $topic_name ) :
-								?>
-							<option value="<?php echo esc_attr( $topic_slug ); ?>" <?php selected( $topic_data['resource'] . '.' . $topic_data['event'], $topic_slug, true ); ?>><?php echo esc_html( $topic_name ); ?></option>
+
+							$selected = $topic_slug === $topic_data['topic'] || $topic_slug === $topic_data['resource'] . '.' . $topic_data['event'];
+
+							?>
+							<option value="<?php echo esc_attr( $topic_slug ); ?>" <?php selected( $selected, true, true ); ?>><?php echo esc_html( $topic_name ); ?></option>
 						<?php endforeach; ?>
 					</select>
 				</td>

--- a/includes/admin/settings/views/html-webhooks-edit.php
+++ b/includes/admin/settings/views/html-webhooks-edit.php
@@ -86,7 +86,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 							foreach ( $topics as $topic_slug => $topic_name ) :
 								?>
-							<option value="<?php echo esc_attr( $topic_slug ); ?>" <?php selected( $topic_data['topic'], $topic_slug, true ); ?>><?php echo esc_html( $topic_name ); ?></option>
+							<option value="<?php echo esc_attr( $topic_slug ); ?>" <?php selected( $topic_data['resource'] . '.' . $topic_data['event'], $topic_slug, true ); ?>><?php echo esc_html( $topic_name ); ?></option>
 						<?php endforeach; ?>
 					</select>
 				</td>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `selected()` function used for webhook topics does not account for custom topics and therefore fails to make them selected, making the dropdown always empty, despite being saved. This PR addresses that.

Closes #20404

### How to test the changes in this Pull Request:

1. Follow steps in #20404 
2. Try also saving / viewing / editing a core Webhook, they won't be affected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> * Fix - Ensure custom webhook topic selections are correctly persisted on the webhook admin edit screen