### PR TITLE
Fix label for price filter for RTL sites

### DIFF
--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -1711,10 +1711,11 @@ p.demo_store,
 /**
  * Right to left styles
  */
-.rtl.woocommerce .price_label span {
-	unicode-bidi: embed;
+ .rtl.woocommerce .price_label, 
+ .rtl.woocommerce .price_label span {
 	/* rtl:ignore */
-    direction: ltr;
+	direction: ltr;
+	unicode-bidi: embed;
 }
 
 .woocommerce-message {


### PR DESCRIPTION
Previously the numbers were fixed to go LTR which is the proper direction for RTL sites when dealing with numbers - but the `price` label was still RTL. This now makes it all LTR.