### PR TITLE
If wp_doing_ajax is defined return it

### DIFF
--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -262,6 +262,10 @@ if ( ! function_exists( 'is_ajax' ) ) {
 	 * @return bool
 	 */
 	function is_ajax() {
+		if ( function_exists( 'wp_doing_ajax' ) ) {
+			return wp_doing_ajax();
+		}
+
 		return defined( 'DOING_AJAX' );
 	}
 }

--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -262,11 +262,7 @@ if ( ! function_exists( 'is_ajax' ) ) {
 	 * @return bool
 	 */
 	function is_ajax() {
-		if ( function_exists( 'wp_doing_ajax' ) ) {
-			return wp_doing_ajax();
-		}
-
-		return defined( 'DOING_AJAX' );
+		return function_exists( 'wp_doing_ajax' ) ? wp_doing_ajax() : defined( 'DOING_AJAX' );
 	}
 }
 


### PR DESCRIPTION
The `wp_doing_ajax` is available then use it for is_ajax() . As the function was introduced in WP 4.7 