### PR TITLE
Condition Checking Improved

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1398,7 +1398,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			}
 		}
 
-		if ( $search_queries ) {
+		if ( ! empty( $search_queries ) ) {
 			$search_where = 'AND (' . implode( ') OR (', $search_queries ) . ')';
 		}
 


### PR DESCRIPTION
The expression `$search_queries` of type array is implicitly converted to a `boolean`. `! empty($expr)` is better I think.

Reference: https://scrutinizer-ci.com/g/woocommerce/woocommerce/code-structure/master/operation/%2Bglobal%5CWC_Product_Data_Store_CPT%3A%3Asearch_products 