### PR TITLE
Fix: order billing fields do overwrite value, even if provided

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -332,7 +332,9 @@ class WC_Meta_Box_Order_Data {
 
 								$field_name = 'billing_' . $key;
 
-								if ( is_callable( array( $order, 'get_' . $field_name ) ) ) {
+								if ( isset( $field['value'] ) ) {
+									$field_value = $field['value'];
+								} elseif ( is_callable( array( $order, 'get_' . $field_name ) ) ) {
 									$field_value = $order->{"get_$field_name"}( 'edit' );
 								} else {
 									$field_value = $order->get_meta( '_' . $field_name );
@@ -365,10 +367,12 @@ class WC_Meta_Box_Order_Data {
 
 								$field_name = 'billing_' . $key;
 
-								if ( is_callable( array( $order, 'get_' . $field_name ) ) ) {
-									$field['value'] = $order->{"get_$field_name"}( 'edit' );
-								} else {
-									$field['value'] = $order->get_meta( '_' . $field_name );
+								if ( ! isset( $field['value'] ) ) {
+									if ( is_callable( array( $order, 'get_' . $field_name ) ) ) {
+										$field['value'] = $order->{"get_$field_name"}( 'edit' );
+									} else {
+										$field['value'] = $order->get_meta( '_' . $field_name );
+									}
 								}
 
 								switch ( $field['type'] ) {


### PR DESCRIPTION
(overwriting introduced by 1fa36b5f1517333aa01ca0bcbfdd06211b4a4eb7)

### Changes proposed in this Pull Request:

Fix problem that arised with 1fa36b5f1517333aa01ca0bcbfdd06211b4a4eb7: custom billing fields with names not starting "billing_" stopped working and there is no reasonable workaround. See commit discussion under 1fa36b5f1517333aa01ca0bcbfdd06211b4a4eb7 for more information.

This change allows to construct the value on one's own and send it to field generator (without being overwritten).

### Changelog entry

Order billing fields do not overwrite value if provided.
