### PR TITLE
Made path /orders/refund_id return invalid order id msg instead of error.

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -127,14 +127,20 @@ class WC_REST_Orders_Controller extends WC_REST_Legacy_Orders_Controller {
 	}
 
 	/**
-	 * Get object.
+	 * Get object. Return false if object is not of required type.
 	 *
 	 * @since  3.0.0
 	 * @param  int $id Object ID.
-	 * @return WC_Data
+	 * @return WC_Data|bool
 	 */
 	protected function get_object( $id ) {
-		return wc_get_order( $id );
+		$order = wc_get_order( $id );
+		// In case id is a refund's id (or it's not an order at all), don't expose it via /orders/ path.
+		if ( ! $order || 'shop_order_refund' === $order->get_type() ) {
+			return false;
+		}
+
+		return $order;
 	}
 
 	/**

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -115,6 +115,20 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests getting an order with an invalid ID.
+	 * @since 3.4.3
+	 */
+	public function test_get_item_refund_id() {
+		wp_set_current_user( $this->user );
+		$order  = WC_Helper_Order::create_order();
+		$refund = wc_create_refund( array(
+			'order_id' => $order->get_id(),
+		) );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/orders/' . $refund->get_id() ) );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
 	 * Tests creating an order.
 	 * @since 3.0.0
 	 */

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -116,7 +116,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 	/**
 	 * Tests getting an order with an invalid ID.
-	 * @since 3.4.3
+	 * @since 3.5.0
 	 */
 	public function test_get_item_refund_id() {
 		wp_set_current_user( $this->user );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20386  .

Don't try to return order response for `/orders/<refund_id>`. Instead, return 
```
{
    "code": "woocommerce_rest_shop_order_invalid_id",
    "message": "Invalid ID.",
    "data": {
        "status": 404
    }
}
```

### How to test the changes in this Pull Request:

1. Create order.
2. Refund order, get refund's id, e.g. via `/wc/v2/orders/<order_id>/refunds`
3. Access `/wc/v2/orders/<refund_id>`, get error.
4. Apply branch.
5. Check `/wc/v2/orders/<refund_id>`, it should return 404.
6. Check `/wc/v2/orders/<order_id>`, it should still work fine.
7. Check `/wc/v2/orders/<order_id>/refunds`, it should still work fine.
8. Check `/wc/v2/orders/<order_id>/refunds/<refund_id>`, it should still work fine.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Path /orders/refund_id now returns invalid order id message with 404 status instead of error.
