### PR TITLE
Add nonces to WC update database and force update database URLs

### DIFF
--- a/includes/admin/views/html-notice-update.php
+++ b/includes/admin/views/html-notice-update.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Admin View: Notice - Update
+ *
+ * @package WooCommerce\Admin
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -9,8 +11,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
-	<p><strong><?php _e( 'WooCommerce data update', 'woocommerce' ); ?></strong> &#8211; <?php _e( 'We need to update your store database to the latest version.', 'woocommerce' ); ?></p>
-	<p class="submit"><a href="<?php echo esc_url( add_query_arg( 'do_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ) ); ?>" class="wc-update-now button-primary"><?php _e( 'Run the updater', 'woocommerce' ); ?></a></p>
+	<p>
+		<strong><?php esc_html_e( 'WooCommerce data update', 'woocommerce' ); ?></strong> &#8211; <?php esc_html_e( 'We need to update your store database to the latest version.', 'woocommerce' ); ?>
+	</p>
+	<p class="submit">
+		<a href="<?php echo esc_url( add_query_arg( 'do_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ) ); ?>" class="wc-update-now button-primary">
+			<?php esc_html_e( 'Run the updater', 'woocommerce' ); ?>
+		</a>
+	</p>
 </div>
 <script type="text/javascript">
 	jQuery( '.wc-update-now' ).click( 'click', function() {

--- a/includes/admin/views/html-notice-update.php
+++ b/includes/admin/views/html-notice-update.php
@@ -9,13 +9,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+$update_url = wp_nonce_url(
+	add_query_arg( 'do_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ),
+	'wc_db_update',
+	'wc_db_update_nonce'
+);
+
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p>
 		<strong><?php esc_html_e( 'WooCommerce data update', 'woocommerce' ); ?></strong> &#8211; <?php esc_html_e( 'We need to update your store database to the latest version.', 'woocommerce' ); ?>
 	</p>
 	<p class="submit">
-		<a href="<?php echo esc_url( add_query_arg( 'do_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ) ); ?>" class="wc-update-now button-primary">
+		<a href="<?php echo esc_url( $update_url ); ?>" class="wc-update-now button-primary">
 			<?php esc_html_e( 'Run the updater', 'woocommerce' ); ?>
 		</a>
 	</p>

--- a/includes/admin/views/html-notice-updating.php
+++ b/includes/admin/views/html-notice-updating.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Admin View: Notice - Updating
+ *
+ * @package WooCommerce\Admin
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -9,5 +11,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
-	<p><strong><?php _e( 'WooCommerce data update', 'woocommerce' ); ?></strong> &#8211; <?php _e( 'Your database is being updated in the background.', 'woocommerce' ); ?> <a href="<?php echo esc_url( add_query_arg( 'force_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ) ); ?>"><?php _e( 'Taking a while? Click here to run it now.', 'woocommerce' ); ?></a></p>
+	<p>
+		<strong><?php esc_html_e( 'WooCommerce data update', 'woocommerce' ); ?></strong> &#8211; <?php esc_html_e( 'Your database is being updated in the background.', 'woocommerce' ); ?>
+		<a href="<?php echo esc_url( add_query_arg( 'force_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ) ); ?>">
+			<?php esc_html_e( 'Taking a while? Click here to run it now.', 'woocommerce' ); ?>
+		</a>
+	</p>
 </div>

--- a/includes/admin/views/html-notice-updating.php
+++ b/includes/admin/views/html-notice-updating.php
@@ -9,11 +9,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+$force_update_url = wp_nonce_url(
+	add_query_arg( 'force_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ),
+	'wc_force_db_update',
+	'wc_force_db_update_nonce'
+);
+
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p>
 		<strong><?php esc_html_e( 'WooCommerce data update', 'woocommerce' ); ?></strong> &#8211; <?php esc_html_e( 'Your database is being updated in the background.', 'woocommerce' ); ?>
-		<a href="<?php echo esc_url( add_query_arg( 'force_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ) ); ?>">
+		<a href="<?php echo esc_url( $force_update_url ); ?>">
 			<?php esc_html_e( 'Taking a while? Click here to run it now.', 'woocommerce' ); ?>
 		</a>
 	</p>

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -160,9 +160,14 @@ class WC_Install {
 			self::update();
 			WC_Admin_Notices::add_notice( 'update' );
 		}
-		if ( ! empty( $_GET['force_update_woocommerce'] ) ) { // WPCS: input var ok, CSRF ok.
+		if ( ! empty( $_GET['force_update_woocommerce'] ) ) { // WPCS: input var ok.
+			check_admin_referer( 'wc_force_db_update', 'wc_force_db_update_nonce' );
 			$blog_id = get_current_blog_id();
+
+			// Used to fire an action added in WP_Background_Process::_construct() that calls WP_Background_Process::handle_cron_healthcheck().
+			// This method will make sure the database updates are executed even if cron is disabled. Nothing will happen if the updates are already running.
 			do_action( 'wp_' . $blog_id . '_wc_updater_cron' );
+
 			wp_safe_redirect( admin_url( 'admin.php?page=wc-settings' ) );
 			exit;
 		}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -155,7 +155,8 @@ class WC_Install {
 	 * This function is hooked into admin_init to affect admin only.
 	 */
 	public static function install_actions() {
-		if ( ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok, CSRF ok.
+		if ( ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok.
+			check_admin_referer( 'wc_db_update', 'wc_db_update_nonce' );
 			self::update();
 			WC_Admin_Notices::add_notice( 'update' );
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds nonces to WC update database and force update database URLs. Doing this to check if the user has the intention to perform a WC database update or to force a WC database update before starting both processes.

PHPCS fixes for the modified files are also included in two separated commits.

### How to test the changes in this Pull Request:

1. Make sure WC database update and forced database update are still working
2. Verify that the nonces are correctly checked, and an admin user can't be tricked into starting a database update without intention.

### Changelog entry

> Add nonces to WC update database and force update database URLs