### PR TITLE
stopPropagation when payment method selected

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -89,7 +89,9 @@ jQuery( function( $ ) {
 		get_payment_method: function() {
 			return wc_checkout_form.$checkout_form.find( 'input[name="payment_method"]:checked' ).val();
 		},
-		payment_method_selected: function() {
+		payment_method_selected: function( e ) {
+			e.stopPropagation();
+
 			if ( $( '.payment_methods input.input-radio' ).length > 1 ) {
 				var target_payment_box = $( 'div.payment_box.' + $( this ).attr( 'ID' ) ),
 					is_checked         = $( this ).is( ':checked' );

--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -48,7 +48,7 @@ jQuery( function( $ ) {
 				return false;
 			}
 		} )
-		.on( 'focus', function() {
+		.on( 'click focus', function() {
 			var input       = $( this ),
 				parent      = input.parent(),
 				description = parent.find( 'span.description' );


### PR DESCRIPTION
Prevents fields losing focus when payment methods are init. The click event bubbled up to body, which in turn hides description boxes.

Closes #20399

### How to test the changes in this Pull Request:

1. See instructions/test plugin in 20399
2. Description box should remain open after click
3. Need to test with some gateways like Stripe to ensure they don't rely on propagation. 