### PR TITLE
PHPDoc Fixed | Used Unused Variable | Else Removed

### DIFF
--- a/includes/class-wc-privacy-exporters.php
+++ b/includes/class-wc-privacy-exporters.php
@@ -95,10 +95,11 @@ class WC_Privacy_Exporters {
 	 * @since 3.4.0
 	 * @param string $email_address The user email address.
 	 * @param int    $page  Page.
+	 * @throws Exception When WC_Data_Store validation fails.
 	 * @return array An array of personal data in name value pairs
 	 */
 	public static function download_data_exporter( $email_address, $page ) {
-		$done            = false;
+		$done            = true;
 		$page            = (int) $page;
 		$user            = get_user_by( 'email', $email_address ); // Check if user has an ID in the DB to load stored personal data.
 		$data_to_export  = array();
@@ -153,8 +154,6 @@ class WC_Privacy_Exporters {
 				}
 			}
 			$done = 10 > count( $downloads );
-		} else {
-			$done = true;
 		}
 
 		return array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Description
- *PHPDoc* @throws Tag Fixed 
- Used Unused `$done` Variable 
- And `else` Removed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

