### PR TITLE
Only try to upload screenshots if directory is not empty

### DIFF
--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -26,7 +26,9 @@ if [ $1 == 'after' ]; then
 		php ocular.phar code-coverage:upload --format=php-clover coverage.clover
 	fi
 
-	curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
-	artifacts upload
+	if [[ ${RUN_E2E} == 1 && $(ls -A $TRAVIS_BUILD_DIR/screenshots) ]]; then
+		curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
+		artifacts upload
+	fi
 
 fi


### PR DESCRIPTION
This commit adds a check before the code that uploads screenshots of failed e2e tests (see PR #20313) to make it run only if running the Travis build job that executed the tests and if the screenshots/ directory is not empty. There is no need to always download Travis artifacts and try to upload to S3 if there is nothing to upload.

cc @bsessions85 