### PR TITLE
Fix - on webhook bulk action footer delete selection

### DIFF
--- a/includes/admin/class-wc-admin-webhooks-table-list.php
+++ b/includes/admin/class-wc-admin-webhooks-table-list.php
@@ -208,6 +208,22 @@ class WC_Admin_Webhooks_Table_List extends WP_List_Table {
 	}
 
 	/**
+	 * Process bulk actions.
+	 */
+	public function process_bulk_action() {
+		$action   = $this->current_action();
+		$webhooks = isset( $_REQUEST['webhook'] ) ? array_map( 'absint', (array) $_REQUEST['webhook'] ) : array(); // WPCS: input var okay, CSRF ok.
+
+		if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			wp_die( esc_html__( 'You do not have permission to edit Webhooks', 'woocommerce' ) );
+		}
+
+		if ( 'delete' === $action ) {
+			WC_Admin_Webhooks::bulk_delete( $webhooks );
+		}
+	}
+
+	/**
 	 * Generate the table navigation above or below the table.
 	 * Included to remove extra nonce input.
 	 *

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -150,7 +150,7 @@ class WC_Admin_Webhooks {
 	 *
 	 * @param array $webhooks List of webhooks IDs.
 	 */
-	private function bulk_delete( $webhooks ) {
+	public function bulk_delete( $webhooks ) {
 		foreach ( $webhooks as $webhook_id ) {
 			$webhook = new WC_Webhook( (int) $webhook_id );
 			$webhook->delete( true );
@@ -180,27 +180,6 @@ class WC_Admin_Webhooks {
 	}
 
 	/**
-	 * Bulk actions.
-	 */
-	private function bulk_actions() {
-		check_admin_referer( 'woocommerce-settings' );
-
-		if ( ! current_user_can( 'manage_woocommerce' ) ) {
-			wp_die( esc_html__( 'You do not have permission to edit Webhooks', 'woocommerce' ) );
-		}
-
-		if ( isset( $_REQUEST['action'] ) || isset( $_REQUEST['action2'] ) ) { // WPCS: input var okay, CSRF ok.
-			$webhooks = isset( $_REQUEST['webhook'] ) ? array_map( 'absint', (array) $_REQUEST['webhook'] ) : array(); // WPCS: input var okay, CSRF ok.
-			$action   = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) ); // WPCS: input var okay, CSRF ok.
-			$action2  = sanitize_text_field( wp_unslash( $_REQUEST['action2'] ) ); // WPCS: input var okay, CSRF ok.
-
-			if ( 'delete' === $action || 'delete' === $action2 ) {
-				$this->bulk_delete( $webhooks );
-			}
-		}
-	}
-
-	/**
 	 * Webhooks admin actions.
 	 */
 	public function actions() {
@@ -208,11 +187,6 @@ class WC_Admin_Webhooks {
 			// Save.
 			if ( isset( $_POST['save'] ) && isset( $_POST['webhook_id'] ) ) { // WPCS: input var okay, CSRF ok.
 				$this->save();
-			}
-
-			// Bulk actions.
-			if ( isset( $_REQUEST['action'] ) && isset( $_REQUEST['webhook'] ) ) { // WPCS: input var okay, CSRF ok.
-				$this->bulk_actions();
 			}
 
 			// Delete webhook.
@@ -299,6 +273,7 @@ class WC_Admin_Webhooks {
 		$count      = count( $data_store->get_webhooks_ids() );
 
 		if ( 0 < $count ) {
+			$webhooks_table_list->process_bulk_action();
 			$webhooks_table_list->prepare_items();
 
 			echo '<input type="hidden" name="page" value="wc-settings" />';

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -189,12 +189,12 @@ class WC_Admin_Webhooks {
 			wp_die( esc_html__( 'You do not have permission to edit Webhooks', 'woocommerce' ) );
 		}
 
-		if ( isset( $_REQUEST['action'] ) ) { // WPCS: input var okay, CSRF ok.
+		if ( isset( $_REQUEST['action'] ) || isset( $_REQUEST['action2'] ) ) { // WPCS: input var okay, CSRF ok.
 			$webhooks = isset( $_REQUEST['webhook'] ) ? array_map( 'absint', (array) $_REQUEST['webhook'] ) : array(); // WPCS: input var okay, CSRF ok.
+			$action   = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) ); // WPCS: input var okay, CSRF ok.
+			$action2  = sanitize_text_field( wp_unslash( $_REQUEST['action2'] ) ); // WPCS: input var okay, CSRF ok.
 
-			$action = sanitize_text_field( wp_unslash( $_REQUEST['action'] ) ); // WPCS: input var okay, CSRF ok.
-
-			if ( 'delete' === $action ) {
+			if ( 'delete' === $action || 'delete' === $action2 ) {
 				$this->bulk_delete( $webhooks );
 			}
 		}

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -150,7 +150,7 @@ class WC_Admin_Webhooks {
 	 *
 	 * @param array $webhooks List of webhooks IDs.
 	 */
-	public function bulk_delete( $webhooks ) {
+	public static function bulk_delete( $webhooks ) {
 		foreach ( $webhooks as $webhook_id ) {
 			$webhook = new WC_Webhook( (int) $webhook_id );
 			$webhook->delete( true );


### PR DESCRIPTION
On Webhooks  List Table the bottom bulk action2 "Delete Permanently" was not working as expected. This PR resolves that.
 
![woocommerce settings themegrill wordpress](https://user-images.githubusercontent.com/37620532/41143362-b4bc61ce-6b18-11e8-86ab-90c59bea8cfa.png)
