### PR TITLE
Remove the Interfaces dependency on WC_Log_Levels

### DIFF
--- a/includes/interfaces/class-wc-logger-interface.php
+++ b/includes/interfaces/class-wc-logger-interface.php
@@ -31,7 +31,7 @@ interface WC_Logger_Interface {
 	 *
 	 * @return bool True if log was added, otherwise false.
 	 */
-	public function add( $handle, $message, $level = WC_Log_Levels::NOTICE );
+	public function add( $handle, $message, $level = 'notice' );
 
 	/**
 	 * Add a log entry.


### PR DESCRIPTION
Removing the dependency allows for easier re-use of the interface. With this dependency in place, the client needs to include both this interface file and the WC_Log_Levels class file.

The add function only really cares about the string value and doesn't explicitly need the WC_Log_Levels class.