### PR TITLE
Custom coupon item limit

### DIFF
--- a/tests/framework/helpers/class-wc-helper-coupon.php
+++ b/tests/framework/helpers/class-wc-helper-coupon.php
@@ -7,12 +7,17 @@
  */
 class WC_Helper_Coupon {
 
+	protected static $custom_types = array();
+
 	/**
 	 * Create a dummy coupon.
 	 *
+	 * @param string $coupon_code
+	 * @param array  $meta
+	 *
 	 * @return WC_Coupon
 	 */
-	public static function create_coupon( $coupon_code = 'dummycoupon' ) {
+	public static function create_coupon( $coupon_code = 'dummycoupon', $meta = array() ) {
 		// Insert post
 		$coupon_id = wp_insert_post( array(
 			'post_title'   => $coupon_code,
@@ -21,24 +26,30 @@ class WC_Helper_Coupon {
 			'post_excerpt' => 'This is a dummy coupon',
 		) );
 
-		// Update meta
-		update_post_meta( $coupon_id, 'discount_type', 'fixed_cart' );
-		update_post_meta( $coupon_id, 'coupon_amount', '1' );
-		update_post_meta( $coupon_id, 'individual_use', 'no' );
-		update_post_meta( $coupon_id, 'product_ids', '' );
-		update_post_meta( $coupon_id, 'exclude_product_ids', '' );
-		update_post_meta( $coupon_id, 'usage_limit', '' );
-		update_post_meta( $coupon_id, 'usage_limit_per_user', '' );
-		update_post_meta( $coupon_id, 'limit_usage_to_x_items', '' );
-		update_post_meta( $coupon_id, 'expiry_date', '' );
-		update_post_meta( $coupon_id, 'free_shipping', 'no' );
-		update_post_meta( $coupon_id, 'exclude_sale_items', 'no' );
-		update_post_meta( $coupon_id, 'product_categories', array() );
-		update_post_meta( $coupon_id, 'exclude_product_categories', array() );
-		update_post_meta( $coupon_id, 'minimum_amount', '' );
-		update_post_meta( $coupon_id, 'maximum_amount', '' );
-		update_post_meta( $coupon_id, 'customer_email', array() );
-		update_post_meta( $coupon_id, 'usage_count', '0' );
+		$meta = wp_parse_args( $meta, array(
+			'discount_type'              => 'fixed_cart',
+			'coupon_amount'              => '1',
+			'individual_use'             => 'no',
+			'product_ids'                => '',
+			'exclude_product_ids'        => '',
+			'usage_limit'                => '',
+			'usage_limit_per_user'       => '',
+			'limit_usage_to_x_items'     => '',
+			'expiry_date'                => '',
+			'free_shipping'              => 'no',
+			'exclude_sale_items'         => 'no',
+			'product_categories'         => array(),
+			'exclude_product_categories' => array(),
+			'minimum_amount'             => '',
+			'maximum_amount'             => '',
+			'customer_email'             => array(),
+			'usage_count'                => '0',
+		) );
+
+		// Update meta.
+		foreach ( $meta as $key => $value ) {
+			update_post_meta( $coupon_id, $key, $value );
+		}
 
 		return new WC_Coupon( $coupon_code );
 	}
@@ -52,6 +63,71 @@ class WC_Helper_Coupon {
 	 */
 	public static function delete_coupon( $coupon_id ) {
 		wp_delete_post( $coupon_id, true );
+
 		return true;
+	}
+
+	/**
+	 * Register a custom coupon type.
+	 *
+	 * @param string $coupon_type
+	 */
+	public static function register_custom_type( $coupon_type ) {
+		static $filters_added = false;
+		if ( isset( self::$custom_types[ $coupon_type ] ) ) {
+			return;
+		}
+
+		self::$custom_types[ $coupon_type ] = "Testing custom type {$coupon_type}";
+
+		if ( ! $filters_added ) {
+			add_filter( 'woocommerce_coupon_discount_types', array( __CLASS__, 'filter_discount_types' ) );
+			add_filter( 'woocommerce_coupon_get_discount_amount', array( __CLASS__, 'filter_get_discount_amount' ), 10, 5 );
+			add_filter( 'woocommerce_coupon_is_valid_for_product', '__return_true' );
+			$filters_added = true;
+		}
+	}
+
+	/**
+	 * Unregister custom coupon type.
+	 *
+	 * @param $coupon_type
+	 */
+	public static function unregister_custom_type( $coupon_type ) {
+		unset( self::$custom_types[ $coupon_type ] );
+		if ( empty( self::$custom_types ) ) {
+			remove_filter( 'woocommerce_coupon_discount_types', array( __CLASS__, 'filter_discount_types' ) );
+			remove_filter( 'woocommerce_coupon_get_discount_amount', array( __CLASS__, 'filter_get_discount_amount' ) );
+			remove_filter( 'woocommerce_coupon_is_valid_for_product', '__return_true' );
+		}
+	}
+
+	/**
+	 * Register custom discount types.
+	 *
+	 * @param array $discount_types
+	 * @return array
+	 */
+	public static function filter_discount_types( $discount_types ) {
+		return array_merge( $discount_types, self::$custom_types );
+	}
+
+	/**
+	 * Get custom discount type amount. Works like 'percent' type.
+	 *
+	 * @param float      $discount
+	 * @param float      $discounting_amount
+	 * @param array|null $item
+	 * @param bool       $single
+	 * @param WC_Coupon  $coupon
+	 *
+	 * @return float
+	 */
+	public static function filter_get_discount_amount( $discount, $discounting_amount, $item, $single, $coupon ) {
+		if ( ! isset( self::$custom_types [ $coupon->get_discount_type() ] ) ) {
+			return $discount;
+		}
+
+		return (float) $coupon->get_amount() * ( $discounting_amount / 100 );
 	}
 }

--- a/tests/unit-tests/coupon/coupon.php
+++ b/tests/unit-tests/coupon/coupon.php
@@ -3,6 +3,7 @@
 /**
  * Class Coupon.
  * @package WooCommerce\Tests\Coupon
+ * @group coupons
  */
 class WC_Tests_Coupon extends WC_Unit_Test_Case {
 
@@ -314,5 +315,80 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		$this->assertTrue( $valid_coupon->is_valid() );
 		$this->assertFalse( $expired_coupon->is_valid() );
 		$this->assertEquals( $expired_coupon->get_error_message(), $expired_coupon->get_coupon_error( WC_Coupon::E_WC_COUPON_EXPIRED ) );
+	}
+
+	/**
+	 * Test an item limit for percent discounts.
+	 */
+	public function test_percent_discount_item_limit() {
+		// Create product
+		$product = WC_Helper_Product::create_simple_product();
+		update_post_meta( $product->get_id(), '_price', '10' );
+		update_post_meta( $product->get_id(), '_regular_price', '10' );
+
+		// Create coupon
+		$coupon = WC_Helper_Coupon::create_coupon( 'dummycoupon', array(
+			'discount_type'          => 'percent',
+			'coupon_amount'          => '5',
+			'limit_usage_to_x_items' => 1,
+		) );
+
+		// We need this to have the calculate_totals() method calculate totals.
+		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
+			define( 'WOOCOMMERCE_CHECKOUT', true );
+		}
+
+		// Add 2 products and coupon to cart.
+		WC()->cart->add_to_cart( $product->get_id(), 2 );
+		WC()->cart->add_discount( $coupon->get_code() );
+		WC()->cart->calculate_totals();
+
+		// Test if the cart total amount is equal 19.5 (coupon only applying to one item).
+		$this->assertEquals( 19.5, WC()->cart->total );
+
+		// Clean up
+		wc_clear_notices();
+		WC()->cart->empty_cart();
+		WC()->cart->remove_coupons();
+		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+	}
+
+	public function test_custom_discount_item_limit() {
+		// Register custom discount type.
+		WC_Helper_Coupon::register_custom_type( __FUNCTION__ );
+
+		// Create product
+		$product = WC_Helper_Product::create_simple_product();
+		update_post_meta( $product->get_id(), '_price', '10' );
+		update_post_meta( $product->get_id(), '_regular_price', '10' );
+
+		// Create coupon
+		$coupon = WC_Helper_Coupon::create_coupon( 'dummycoupon', array(
+			'discount_type'          => __FUNCTION__,
+			'coupon_amount'          => '5',
+			'limit_usage_to_x_items' => 1,
+		) );
+
+		// We need this to have the calculate_totals() method calculate totals.
+		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
+			define( 'WOOCOMMERCE_CHECKOUT', true );
+		}
+
+		// Add 4 products and coupon to cart.
+		WC()->cart->add_to_cart( $product->get_id(), 4 );
+		WC()->cart->add_discount( $coupon->get_code() );
+		WC()->cart->calculate_totals();
+
+		// Test if the cart total amount is equal 39.5 (coupon only applying to one item).
+		$this->assertEquals( 39.5, WC()->cart->total );
+
+		// Clean up
+		wc_clear_notices();
+		WC()->cart->empty_cart();
+		WC()->cart->remove_coupons();
+		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
+		WC_Helper_Product::delete_product( $product->get_id() );
+		WC_Helper_Coupon::unregister_custom_type( __FUNCTION__ );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

* Add unit tests for the `limit_usage_to_x_items` coupon setting, including a test for custom coupon types.
* Update `WC_Discounts::apply_coupon_custom()` to properly account for the `limit_usage_to_x_items` setting.

Closes #20455.

### How to test the changes in this Pull Request:

This code can be added to a file in `wp-content/mu-plugins/`, or an existing codebase (such as WooCommerce Subscriptions) can be used that implements custom coupon types.

```php
$type = 'test_type';

/**
 * Add a custom coupon type to WooCommerce.
 *
 * @param array $discount_types Existing WC coupon types.
 * @return array
 */
$register_discount = function( $discount_types ) use ( $type ) {
	$discount_types[ $type ] = 'Testing custom type.';
	return $discount_types;
};

/**
 * Function to return the discount amount for the item. Works like 'percent' type.
 *
 * @param float      $discount
 * @param float      $discounting_amount
 * @param array|null $item
 * @param bool       $single
 * @param WC_Coupon  $coupon
 * @return float
 */
$calculate_discount = function( $discount, $discounting_amount, $item, $single, $coupon ) use ( $type ) {
	if ( $type !== $coupon->get_discount_type() ) {
		return $discount;
	}

	return (float) $coupon->get_amount() * ( $discounting_amount / 100 );
};

// Add filters to the appropriate locations.
add_filter( 'woocommerce_coupon_discount_types', $register_discount );
add_filter( 'woocommerce_coupon_get_discount_amount', $calculate_discount, 10, 5 );
add_filter( 'woocommerce_coupon_is_valid_for_product', '__return_true' );
```

These steps assume that you have a custom coupon type available.

1. Create a coupon of the custom type from WooCommerce > Coupons in the dashboard.
1. On the "Usage Limits" tab, set the "Limit usage to X items" setting to `1`.
1. Publish the coupon.
1. Add multiple of a valid product to the cart (2 or more of the same item).
1. Apply the coupon to the cart.
1. Notice that the discount is applied to only one item, rather than multiplied by all items.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?