### PR TITLE
Fix multisite dashboard widget to use proper order number

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -360,7 +360,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			<script type="text/template" id="network-orders-row-template">
 				<tr>
 					<td>
-						<a href="<%- edit_url %>" class="order-view"><strong>#<%- id %> <%- customer %></strong></a>
+						<a href="<%- edit_url %>" class="order-view"><strong>#<%- number %> <%- customer %></strong></a>
 						<br>
 						<em>
 							<%- blog.blogname %>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix multisite dashboard widget to use proper order number

Closes #20434 

### How to test the changes in this Pull Request:

1.  See dashboard widget with a filtered order number before this PR:

![screen shot 2018-06-08 at 11 54 09 am](https://user-images.githubusercontent.com/4983547/41168313-91411c12-6b13-11e8-8798-8049c5ea0423.png)

2. See dashboard widget with filtered order number after this PR:

![screen shot 2018-06-08 at 11 53 57 am](https://user-images.githubusercontent.com/4983547/41168336-9f93d7c8-6b13-11e8-91b0-d0cc6725cf1a.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fixes multisite orders dashboard widget to use order number rather than ID