### PR TITLE
Skip upload from forks

### DIFF
--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -27,8 +27,12 @@ if [ $1 == 'after' ]; then
 	fi
 
 	if [[ ${RUN_E2E} == 1 && $(ls -A $TRAVIS_BUILD_DIR/screenshots) ]]; then
-		curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
-		artifacts upload
+		if [[ -z "${ARTIFACTS_KEY}" ]]; then
+  			echo "Screenshots were not uploaded. Please run e2e tests locally to see failures."
+		else
+  			curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
+			artifacts upload
+		fi
 	fi
 
 fi

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -28,7 +28,7 @@ if [ $1 == 'after' ]; then
 
 	if [[ ${RUN_E2E} == 1 && $(ls -A $TRAVIS_BUILD_DIR/screenshots) ]]; then
 		if [[ -z "${ARTIFACTS_KEY}" ]]; then
-  			echo "Screenshots were not uploaded. Please run e2e tests locally to see failures."
+  			echo "Screenshots were not uploaded. Please run the e2e tests locally to see failures."
 		else
   			curl -sL https://raw.githubusercontent.com/travis-ci/artifacts/master/install | bash
 			artifacts upload

--- a/tests/e2e-tests/cart-page.js
+++ b/tests/e2e-tests/cart-page.js
@@ -11,7 +11,7 @@ const assert = chai.assert;
 let manager;
 let driver;
 
-test.describe( 'Cart page', function() {
+test.describe.only( 'Cart page', function() {
 	// open browser
 	test.before( function() {
 		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
@@ -50,7 +50,7 @@ test.describe( 'Cart page', function() {
 
 	test.it( 'should updates qty when updated via qty input', () => {
 		const cartPage = new CartPage( driver, { url: manager.getPageUrl( '/cart' ) } );
-		cartPage.getItem( 'Album', { qty: 2 } ).setQty( 4 );
+		cartPage.getItem( 'Aldbum', { qty: 2 } ).setQty( 4 );
 		cartPage.update();
 		cartPage.getItem( 'Polo', { qty: 1 } ).setQty( 3 );
 		cartPage.update();

--- a/tests/e2e-tests/cart-page.js
+++ b/tests/e2e-tests/cart-page.js
@@ -11,7 +11,7 @@ const assert = chai.assert;
 let manager;
 let driver;
 
-test.describe.only( 'Cart page', function() {
+test.describe( 'Cart page', function() {
 	// open browser
 	test.before( function() {
 		this.timeout( config.get( 'startBrowserTimeoutMs' ) );
@@ -50,7 +50,7 @@ test.describe.only( 'Cart page', function() {
 
 	test.it( 'should updates qty when updated via qty input', () => {
 		const cartPage = new CartPage( driver, { url: manager.getPageUrl( '/cart' ) } );
-		cartPage.getItem( 'Aldbum', { qty: 2 } ).setQty( 4 );
+		cartPage.getItem( 'Album', { qty: 2 } ).setQty( 4 );
 		cartPage.update();
 		cartPage.getItem( 'Polo', { qty: 1 } ).setQty( 3 );
 		cartPage.update();


### PR DESCRIPTION
### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This will skip the uploading of screenshots if the S3 key is not present. This will happen when there is a PR for a fork submitted. 

### How to test the changes in this Pull Request:

1. Remove the ARTIFACTS_KEY value from travis
2. Submit a PR with an e2e test that will fail
3. Ensure that you see a message that states that the screenshots were not uploaded.

### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x ] Have you written new tests for your changes, as applicable?
* [ x] Have you successfully ran tests with your changes locally?


