### PR TITLE
Support limiting search results

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1392,8 +1392,14 @@ class WC_AJAX {
 			wp_die();
 		}
 
+		if ( ! empty( $_GET['limit'] ) ) {
+			$limit = absint( $_GET['limit'] );
+		} else {
+			$limit = absint( apply_filters( 'woocommerce_json_search_limit', 30 ) );
+		}
+
 		$data_store = WC_Data_Store::load( 'product' );
-		$ids        = $data_store->search_products( $term, '', (bool) $include_variations );
+		$ids        = $data_store->search_products( $term, '', (bool) $include_variations, false, $limit );
 
 		if ( ! empty( $_GET['exclude'] ) ) {
 			$ids = array_diff( $ids, (array) $_GET['exclude'] );
@@ -1401,10 +1407,6 @@ class WC_AJAX {
 
 		if ( ! empty( $_GET['include'] ) ) {
 			$ids = array_intersect( $ids, (array) $_GET['include'] );
-		}
-
-		if ( ! empty( $_GET['limit'] ) ) {
-			$ids = array_slice( $ids, 0, absint( $_GET['limit'] ) );
 		}
 
 		$product_objects = array_filter( array_map( 'wc_get_product', $ids ), 'wc_products_array_filter_readable' );

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1359,6 +1359,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$type_join     = '';
 		$type_where    = '';
 		$status_where  = '';
+		$limit_query   = '';
 		$term          = wc_strtolower( $term );
 
 		// See if search term contains OR keywords.

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1344,13 +1344,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	/**
 	 * Search product data for a term and return ids.
 	 *
-	 * @param  string $term Search term.
-	 * @param  string $type Type of product.
-	 * @param  bool   $include_variations Include variations in search or not.
-	 * @param  bool   $all_statuses Should we search all statuses or limit to published.
+	 * @param  string   $term Search term.
+	 * @param  string   $type Type of product.
+	 * @param  bool     $include_variations Include variations in search or not.
+	 * @param  bool     $all_statuses Should we search all statuses or limit to published.
+	 * @param  null|int $limit Limit returned results. @since 3.5.0.
 	 * @return array of ids
 	 */
-	public function search_products( $term, $type = '', $include_variations = false, $all_statuses = false ) {
+	public function search_products( $term, $type = '', $include_variations = false, $all_statuses = false, $limit = null ) {
 		global $wpdb;
 
 		$post_types    = $include_variations ? array( 'product', 'product_variation' ) : array( 'product' );
@@ -1411,6 +1412,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$status_where = " AND posts.post_status IN ('" . implode( "','", $post_statuses ) . "') ";
 		}
 
+		if ( $limit ) {
+			$limit_query = $wpdb->prepare( ' LIMIT %d ', $limit );
+		}
+
 		// phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery
 		$search_results = $wpdb->get_results(
 			// phpcs:disable
@@ -1421,7 +1426,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$search_where
 			$status_where
 			$type_where
-			ORDER BY posts.post_parent ASC, posts.post_title ASC"
+			ORDER BY posts.post_parent ASC, posts.post_title ASC
+			$limit_query
+			"
 			// phpcs:enable
 		);
 


### PR DESCRIPTION
Closes #20454

Allows number of search results to be limited.

Default limit for JSON search is 30.

To test, search for common term on add product form when editing a product. No more than 30 results should return, or use the new filter to test a specific limit.
