### PR TITLE
Remove unused variable and unnecessary else if

### DIFF
--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -180,8 +180,6 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 					}
 				}
 			}
-		} elseif ( WC()->cart && WC()->cart->needs_shipping() ) {
-			$needs_shipping = true;
 		}
 
 		$needs_shipping = apply_filters( 'woocommerce_cart_needs_shipping', $needs_shipping );
@@ -193,7 +191,6 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 
 		// Only apply if all packages are being shipped via chosen method, or order is virtual.
 		if ( ! empty( $this->enable_for_methods ) && $needs_shipping ) {
-			$canonical_rate_ids              = array();
 			$order_shipping_items            = is_object( $order ) ? $order->get_shipping_methods() : false;
 			$chosen_shipping_methods_session = WC()->session->get( 'chosen_shipping_methods' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Description
- The bottom `elseif` isn't needed as we are setting the `$needs_shipping = true` in the top `if`.
- No need of the unused variable `$canonical_rate_ids` declaration.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?