### PR TITLE
Download Log FK Contraint check

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -566,15 +566,18 @@ class WC_Install {
 		// Add constraint to download logs if the columns matches.
 		if ( ! empty( $download_permissions_column_type ) && ! empty( $download_log_column_type ) && $download_permissions_column_type === $download_log_column_type ) {
 			$wpdb->query( "
-				IF NOT EXISTS ( SELECT NULL FROM information_schema.TABLE_CONSTRAINTS WHERE
-					CONSTRAINT_SCHEMA = '{$wpdb->dbname}' AND
-					(
-						CONSTRAINT_NAME LIKE '%wc_download_log_ib%' OR
-						CONSTRAINT_NAME = 'fk_wc_download_log_permission_id' OR
+				IF NOT EXISTS (
+					SELECT NULL FROM information_schema.TABLE_CONSTRAINTS
+					WHERE
+						CONSTRAINT_SCHEMA = '{$wpdb->dbname}' AND
+						(
+							CONSTRAINT_NAME LIKE '%wc_download_log_ib%' OR
+							CONSTRAINT_NAME = 'fk_wc_download_log_permission_id' OR
+						)
+						AND CONSTRAINT_TYPE = 'FOREIGN KEY'
 					)
-					AND CONSTRAINT_TYPE = 'FOREIGN KEY')
 				THEN
-					ALTER TABLE {$wpdb->prefix}wc_download_log
+					ALTER TABLE `{$wpdb->prefix}wc_download_log`
 					ADD CONSTRAINT `fk_wc_download_log_permission_id`
 					FOREIGN KEY (permission_id)
 					REFERENCES {$wpdb->prefix}woocommerce_downloadable_product_permissions(permission_id) ON DELETE CASCADE

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -572,12 +572,10 @@ class WC_Install {
 			$wpdb->query( "
 				IF NOT EXISTS (
 					SELECT NULL FROM information_schema.TABLE_CONSTRAINTS
-					WHERE
-						CONSTRAINT_SCHEMA = '{$wpdb->dbname}' AND
-						CONSTRAINT_NAME = 'fk_wc_download_log_permission_id'
-						AND CONSTRAINT_TYPE = 'FOREIGN KEY'
-					)
-				THEN
+					WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
+					AND CONSTRAINT_NAME = 'fk_wc_download_log_permission_id'
+					AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+				) THEN
 					ALTER TABLE `{$wpdb->prefix}wc_download_log`
 					ADD CONSTRAINT `fk_wc_download_log_permission_id`
 					FOREIGN KEY (`permission_id`)

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -574,10 +574,7 @@ class WC_Install {
 					SELECT NULL FROM information_schema.TABLE_CONSTRAINTS
 					WHERE
 						CONSTRAINT_SCHEMA = '{$wpdb->dbname}' AND
-						(
-							CONSTRAINT_NAME LIKE '%wc_download_log_ib%' OR
-							CONSTRAINT_NAME = 'fk_wc_download_log_permission_id'
-						)
+						CONSTRAINT_NAME = 'fk_wc_download_log_permission_id'
 						AND CONSTRAINT_TYPE = 'FOREIGN KEY'
 					)
 				THEN

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -575,6 +575,7 @@ class WC_Install {
 				WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
 				AND CONSTRAINT_NAME = 'fk_wc_download_log_permission_id'
 				AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+				AND TABLE_NAME = '{$wpdb->prefix}wc_download_log'
 			" );
 			if ( 0 === (int) $fk_result->fk_count ) {
 				$wpdb->query( "

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -569,19 +569,21 @@ class WC_Install {
 
 		// Add constraint to download logs if the columns matches.
 		if ( ! empty( $download_permissions_column_type ) && ! empty( $download_log_column_type ) && $download_permissions_column_type === $download_log_column_type ) {
-			$wpdb->query( "
-				IF NOT EXISTS (
-					SELECT NULL FROM information_schema.TABLE_CONSTRAINTS
-					WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
-					AND CONSTRAINT_NAME = 'fk_wc_download_log_permission_id'
-					AND CONSTRAINT_TYPE = 'FOREIGN KEY'
-				) THEN
+			$fk_result = $wpdb->get_row( "
+				SELECT COUNT(*) AS fk_count
+				FROM information_schema.TABLE_CONSTRAINTS
+				WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
+				AND CONSTRAINT_NAME = 'fk_wc_download_log_permission_id'
+				AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+			" );
+			if ( 0 === (int) $fk_result->fk_count ) {
+				$wpdb->query( "
 					ALTER TABLE `{$wpdb->prefix}wc_download_log`
 					ADD CONSTRAINT `fk_wc_download_log_permission_id`
 					FOREIGN KEY (`permission_id`)
 					REFERENCES `{$wpdb->prefix}woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE;
-				END IF
-			" );
+				" );
+			}
 		}
 	}
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -105,6 +105,10 @@ class WC_Install {
 			'wc_update_340_last_active',
 			'wc_update_340_db_version',
 		),
+		'3.4.3' => array(
+			'wc_update_343_cleanup_foreign_keys',
+			'wc_update_343_db_version',
+		),
 	);
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -579,8 +579,8 @@ class WC_Install {
 				THEN
 					ALTER TABLE `{$wpdb->prefix}wc_download_log`
 					ADD CONSTRAINT `fk_wc_download_log_permission_id`
-					FOREIGN KEY (permission_id)
-					REFERENCES {$wpdb->prefix}woocommerce_downloadable_product_permissions(permission_id) ON DELETE CASCADE
+					FOREIGN KEY (`permission_id`)
+					REFERENCES `{$wpdb->prefix}woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE;
 				END IF
 			" );
 		}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -565,7 +565,21 @@ class WC_Install {
 
 		// Add constraint to download logs if the columns matches.
 		if ( ! empty( $download_permissions_column_type ) && ! empty( $download_log_column_type ) && $download_permissions_column_type === $download_log_column_type ) {
-			$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log ADD FOREIGN KEY (permission_id) REFERENCES {$wpdb->prefix}woocommerce_downloadable_product_permissions(permission_id) ON DELETE CASCADE" );
+			$wpdb->query( "
+				IF NOT EXISTS ( SELECT NULL FROM information_schema.TABLE_CONSTRAINTS WHERE
+					CONSTRAINT_SCHEMA = '{$wpdb->dbname}' AND
+					(
+						CONSTRAINT_NAME LIKE '%wc_download_log_ib%' OR
+						CONSTRAINT_NAME = 'fk_wc_download_log_permission_id' OR
+					)
+					AND CONSTRAINT_TYPE = 'FOREIGN KEY')
+				THEN
+					ALTER TABLE {$wpdb->prefix}wc_download_log
+					ADD CONSTRAINT `fk_wc_download_log_permission_id`
+					FOREIGN KEY (permission_id)
+					REFERENCES {$wpdb->prefix}woocommerce_downloadable_product_permissions(permission_id) ON DELETE CASCADE
+				END IF
+			" );
 		}
 	}
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -572,7 +572,7 @@ class WC_Install {
 						CONSTRAINT_SCHEMA = '{$wpdb->dbname}' AND
 						(
 							CONSTRAINT_NAME LIKE '%wc_download_log_ib%' OR
-							CONSTRAINT_NAME = 'fk_wc_download_log_permission_id' OR
+							CONSTRAINT_NAME = 'fk_wc_download_log_permission_id'
 						)
 						AND CONSTRAINT_TYPE = 'FOREIGN KEY'
 					)

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1822,7 +1822,7 @@ function wc_update_343_cleanup_foreign_keys() {
 
 	if ( $results ) {
 		foreach ( $results as $fk ) {
-			$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log} DROP FOREIGN KEY {$fk->CONSTRAINT_NAME}" ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+			$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log DROP FOREIGN KEY {$fk->CONSTRAINT_NAME}" ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 		}
 	}
 }

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1821,7 +1821,7 @@ function wc_update_343_cleanup_foreign_keys() {
 
 	if ( $results ) {
 		foreach ( $results as $fk ) {
-			$wpdb->query( "ALTER TABLE {$fk->TABLE_NAME} DROP FOREIGN KEY {$fk->CONSTRAINT_NAME}" ); // phpcs:ignore
+			$wpdb->query( "ALTER TABLE {$fk->TABLE_NAME} DROP FOREIGN KEY {$fk->CONSTRAINT_NAME}" ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 		}
 	}
 }

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1812,16 +1812,17 @@ function wc_update_343_cleanup_foreign_keys() {
 	global $wpdb;
 
 	$results = $wpdb->get_results( "
-		SELECT CONSTRAINT_NAME, TABLE_NAME
+		SELECT CONSTRAINT_NAME
 		FROM information_schema.TABLE_CONSTRAINTS
 		WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
 		AND CONSTRAINT_NAME LIKE '%wc_download_log_ib%'
 		AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+		AND TABLE_NAME = '{$wpdb->prefix}wc_download_log'
 	" );
 
 	if ( $results ) {
 		foreach ( $results as $fk ) {
-			$wpdb->query( "ALTER TABLE {$fk->TABLE_NAME} DROP FOREIGN KEY {$fk->CONSTRAINT_NAME}" ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+			$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log} DROP FOREIGN KEY {$fk->CONSTRAINT_NAME}" ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 		}
 	}
 }

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1802,3 +1802,35 @@ function wc_update_340_last_active() {
 function wc_update_340_db_version() {
 	WC_Install::update_db_version( '3.4.0' );
 }
+
+/**
+ * Remove duplicate foreign keys
+ *
+ * @return void
+ */
+function wc_update_343_cleanup_foreign_keys() {
+	global $wpdb;
+
+	$results = $wpdb->get_results( "
+		SELECT CONSTRAINT_NAME, TABLE_NAME
+		FROM information_schema.TABLE_CONSTRAINTS
+		WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
+		AND CONSTRAINT_NAME LIKE '%wc_download_log_ib%'
+		AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+	" );
+
+	if ( $results ) {
+		foreach ( $results as $fk ) {
+			$wpdb->query( "ALTER TABLE {$fk->TABLE_NAME} DROP FOREIGN KEY {$fk->CONSTRAINT_NAME}" ); // phpcs:ignore
+		}
+	}
+}
+
+/**
+ * Update DB version.
+ *
+ * @return void
+ */
+function wc_update_343_db_version() {
+	WC_Install::update_db_version( '3.4.3' );
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR introduces a check on the permission_id FK to ensure that it is not added multiple times on upgrades. It also names the key specifically to ensure future changes to the key can be targeted properly.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20473 .

### How to test the changes in this Pull Request:

1. Check out this path, and go through WooCommerce setup it not already set up.
2. Check FK existence by running the following SQL `SELECT * FROM information_schema.TABLE_CONSTRAINTS` and checking for any foreign keys on the download_log table.
3. Change the wc_version option in the options table to 3.3 `wp option update woocommerce_version '3.3'`
4. Open up wp-admin and let it finish loading, now check the SQL command from nr 2 above again, no additional FK's should be present and there should also be no error log entries referring to foreign keys.
5. Delete all foreign keys for the wc_download_log table using this sql command `alter table wp_wc_download_log drop foreign key wp_wc_download_log_ibfk_1` replace `wp_wc_download_log_ibfk_1` with the constraint name if diffirent and repeat for each FK entry for the table.
6. Repeat step 3
7. Run SQL query from step 2 again and check that only 1 FK is present with the name `fk_wc_download_log_permission_id`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Add check to ensure download log FK does not exist before adding it.
