### PR TITLE
X_FORWARDED_FOR IPv6 Support

### DIFF
--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -140,7 +140,7 @@ class WC_Geolocation {
 		} elseif ( isset( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) { // WPCS: input var ok, CSRF ok.
 			// Proxy servers can send through this header like this: X-Forwarded-For: client1, proxy1, proxy2
 			// Make sure we always only send through the first IP in the list which should always be the client IP.
-			return (string) rest_is_ip_address( trim( current( preg_split( '/[,:]/', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) ) ) ) ); // WPCS: input var ok, CSRF ok.
+			return (string) rest_is_ip_address( trim( current( preg_split( '/,/', sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) ) ) ) ); // WPCS: input var ok, CSRF ok.
 		} elseif ( isset( $_SERVER['REMOTE_ADDR'] ) ) { // @codingStandardsIgnoreLine
 			return sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) ); // @codingStandardsIgnoreLine
 		}

--- a/tests/unit-tests/geolocation/class-wc-test-gelocation.php
+++ b/tests/unit-tests/geolocation/class-wc-test-gelocation.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Class Functions.
+ *
+ * @package WooCommerce\Tests\Geolocation
+ */
+
+/**
+ * Class WC_Tests_Geolocation
+ */
+class WC_Tests_Geolocation extends WC_Unit_Test_Case {
+	public function test_get_ip_address() {
+		$_SERVER['HTTP_X_REAL_IP'] = '208.67.220.220';
+		$this->assertEquals( '208.67.220.220', WC_Geolocation::get_ip_address() );
+		$_SERVER['HTTP_X_REAL_IP'] = '2620:0:ccc::2';
+		$this->assertEquals( '2620:0:ccc::2', WC_Geolocation::get_ip_address() );
+		unset( $_SERVER['HTTP_X_REAL_IP'] );
+
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '208.67.220.220';
+		$this->assertEquals( '208.67.220.220', WC_Geolocation::get_ip_address() );
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '2620:0:ccc::2';
+		$this->assertEquals( '2620:0:ccc::2', WC_Geolocation::get_ip_address() );
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '208.67.220.220, 8.8.8.8';
+		$this->assertEquals( '208.67.220.220', WC_Geolocation::get_ip_address() );
+		$_SERVER['HTTP_X_FORWARDED_FOR'] = '2620:0:ccc::2, 2001:4860:4860::8888';
+		$this->assertEquals( '2620:0:ccc::2', WC_Geolocation::get_ip_address() );
+		unset( $_SERVER['HTTP_X_FORWARDED_FOR'] );
+
+		$_SERVER['REMOTE_ADDR'] = '208.67.220.220';
+		$this->assertEquals( '208.67.220.220', WC_Geolocation::get_ip_address() );
+		$_SERVER['REMOTE_ADDR'] = '2620:0:ccc::2';
+		$this->assertEquals( '2620:0:ccc::2', WC_Geolocation::get_ip_address() );
+		unset( $_SERVER['REMOTE_ADDR'] );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The get_ip_address method in WC_Geolocation check for HTTP_X_FORWARDED_FOR, however, it splits the value by command and colon causing IPv6 address to not parse correctly, the syntax specification for HTTP_X_FORWARDED_FOR shows that the list should only be split by comma https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For

This PR removes the split by on colon to allow for IPv6 addresses to be parsed correctly and saved to an order.

Closes #20477.

### How to test the changes in this Pull Request:

1. Set `$_SERVER['HTTP_X_FORWARDED_FOR']` equal to an IPv6 address as per #20477
2. Place an order and ensure the full IPv6 address is added to the order.
3. Set `$_SERVER['HTTP_X_FORWARDED_FOR']` equal to an IPv4 address and place another order ensuring that the IPv4 address is also saved to the order correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - IPv6 support with HTTP_X_FORWARDED_FOR header.
