### PR TITLE
Avoid price setting when synced with children

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -594,19 +594,24 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @param WC_Product $product Product Object.
 	 */
 	protected function handle_updated_props( &$product ) {
-		if ( in_array( 'regular_price', $this->updated_props, true ) || in_array( 'sale_price', $this->updated_props, true ) ) {
-			if ( $product->get_sale_price( 'edit' ) >= $product->get_regular_price( 'edit' ) ) {
-				update_post_meta( $product->get_id(), '_sale_price', '' );
-				$product->set_sale_price( '' );
+		$price_is_synced = $product->is_type( array( 'variable', 'grouped' ) );
+
+		if ( ! $price_is_synced ) {
+			if ( in_array( 'regular_price', $this->updated_props, true ) || in_array( 'sale_price', $this->updated_props, true ) ) {
+				if ( $product->get_sale_price( 'edit' ) >= $product->get_regular_price( 'edit' ) ) {
+					update_post_meta( $product->get_id(), '_sale_price', '' );
+					$product->set_sale_price( '' );
+				}
 			}
-		}
-		if ( in_array( 'date_on_sale_from', $this->updated_props, true ) || in_array( 'date_on_sale_to', $this->updated_props, true ) || in_array( 'regular_price', $this->updated_props, true ) || in_array( 'sale_price', $this->updated_props, true ) || in_array( 'product_type', $this->updated_props, true ) ) {
-			if ( $product->is_on_sale( 'edit' ) ) {
-				update_post_meta( $product->get_id(), '_price', $product->get_sale_price( 'edit' ) );
-				$product->set_price( $product->get_sale_price( 'edit' ) );
-			} else {
-				update_post_meta( $product->get_id(), '_price', $product->get_regular_price( 'edit' ) );
-				$product->set_price( $product->get_regular_price( 'edit' ) );
+
+			if ( in_array( 'date_on_sale_from', $this->updated_props, true ) || in_array( 'date_on_sale_to', $this->updated_props, true ) || in_array( 'regular_price', $this->updated_props, true ) || in_array( 'sale_price', $this->updated_props, true ) || in_array( 'product_type', $this->updated_props, true ) ) {
+				if ( $product->is_on_sale( 'edit' ) ) {
+					update_post_meta( $product->get_id(), '_price', $product->get_sale_price( 'edit' ) );
+					$product->set_price( $product->get_sale_price( 'edit' ) );
+				} else {
+					update_post_meta( $product->get_id(), '_price', $product->get_regular_price( 'edit' ) );
+					$product->set_price( $product->get_regular_price( 'edit' ) );
+				}
 			}
 		}
 

--- a/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-grouped-data-store-cpt.php
@@ -74,11 +74,13 @@ class WC_Product_Grouped_Data_Store_CPT extends WC_Product_Data_Store_CPT implem
 		foreach ( $product->get_children( 'edit' ) as $child_id ) {
 			$child = wc_get_product( $child_id );
 			if ( $child ) {
-				$child_prices[] = $child->get_price();
+				$child_prices[] = $child->get_price( 'edit' );
 			}
 		}
 		$child_prices = array_filter( $child_prices );
 		delete_post_meta( $product->get_id(), '_price' );
+		delete_post_meta( $product->get_id(), '_sale_price' );
+		delete_post_meta( $product->get_id(), '_regular_price' );
 
 		if ( ! empty( $child_prices ) ) {
 			add_post_meta( $product->get_id(), '_price', min( $child_prices ) );

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -515,6 +515,8 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 		$prices   = $children ? array_unique( $wpdb->get_col( "SELECT meta_value FROM $wpdb->postmeta WHERE meta_key = '_price' AND post_id IN ( " . implode( ',', array_map( 'absint', $children ) ) . ' )' ) ) : array(); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 
 		delete_post_meta( $product->get_id(), '_price' );
+		delete_post_meta( $product->get_id(), '_sale_price' );
+		delete_post_meta( $product->get_id(), '_regular_price' );
 
 		if ( $prices ) {
 			sort( $prices );

--- a/tests/unit-tests/product/query.php
+++ b/tests/unit-tests/product/query.php
@@ -31,7 +31,7 @@ class WC_Tests_WC_Product_Query extends WC_Unit_Test_Case {
 		$product1->set_sale_price( '5.00' );
 		$product1->save();
 
-		$product2 = new WC_Product_Grouped();
+		$product2 = new WC_Product_Simple();
 		$product2->set_sku( 'sku2' );
 		$product2->set_regular_price( '12.50' );
 		$product2->set_sale_price( '5.00' );


### PR DESCRIPTION
When type, price, or sale dates change, prices are set based on props.

For grouped and variable, this is not desirable because the price is synced with the children, and specifically in the case of grouped products already happens earlier via a child method.

Closes #20452

### How to test the changes in this Pull Request:

1. Create grouped product with children
2. Check DB that _price meta has values
3. Should appear sorted in the store.
