### PR TITLE
Search for matching keys when updating meta data

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -420,11 +420,34 @@ abstract class WC_Data {
 
 		$this->maybe_read_meta_data();
 
-		$array_key = $meta_id ? array_keys( wp_list_pluck( $this->meta_data, 'id' ), $meta_id ) : '';
+		$array_key = false;
+
+		if ( $meta_id ) {
+			$array_keys = array_keys( wp_list_pluck( $this->meta_data, 'id' ), $meta_id, true );
+			$array_key  = $array_keys ? current( $array_keys ) : false;
+		} else {
+			// Find matches by key.
+			$matches     = array();
+			$ids_to_keys = wp_list_pluck( $this->meta_data, 'key', 'id' );
+
+			foreach ( $this->meta_data as $meta_data_array_key => $meta ) {
+				if ( $meta->key === $key ) {
+					$matches[] = $meta_data_array_key;
+				}
+			}
+
+			if ( ! empty( $matches ) ) {
+				// Set matches to null so only one key gets the new value.
+				foreach ( $matches as $meta_data_array_key ) {
+					$this->meta_data[ $meta_data_array_key ]->value = null;
+				}
+				$array_key = current( $matches );
+			}
+		}
 
 		if ( $array_key ) {
-			$meta = $this->meta_data[ current( $array_key ) ];
-			$meta->key = $key;
+			$meta        = $this->meta_data[ $array_key ];
+			$meta->key   = $key;
 			$meta->value = $value;
 		} else {
 			$this->add_meta_data( $key, $value, true );


### PR DESCRIPTION
Adjusts WC_Data `update_meta_data` method to search for existing meta data by key before adding new meta.

If multiple metas have the same key, only one will remain after the update. This matches WP Core behaviour.

Closes #20431

### How to test the changes in this Pull Request:

1. Instructions in 20431, or 
2. Do a manual meta update using some procedural code. Check ID in data base after update.

### Changelog entry

> Improved WC_Data `update_meta_data` to avoid deleting and recreating meta on save.
