### PR TITLE
sanitize_special_column_name_regex trim

### DIFF
--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -575,7 +575,7 @@ class WC_Product_CSV_Importer_Controller {
 	 * @return string
 	 */
 	protected function sanitize_special_column_name_regex( $value ) {
-		return '/' . str_replace( array( '%d', '%s' ), '(.*)', quotemeta( $value ) ) . '/';
+		return '/' . str_replace( array( '%d', '%s' ), '(.*)', trim( quotemeta( $value ) ) ) . '/';
 	}
 
 	/**


### PR DESCRIPTION
Trims mapped keys. I found the meta key had a space after `(.*)` which broke the matching. Localisation error.

Closes #20430

### How to test the changes in this Pull Request:

1. Change to FR language
2. Import CSV in 20430
3. Check attribute values field maps.