### PR TITLE
Remove Malta checkout 'State' field

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -120,6 +120,7 @@ class WC_Countries {
 			'LB' => array(),
 			'LU' => array(),
 			'MQ' => array(),
+			'MT' => array(),
 			'NL' => array(),
 			'NO' => array(),
 			'PL' => array(),
@@ -987,6 +988,11 @@ class WC_Countries {
 						),
 					),
 					'MQ' => array(
+						'state' => array(
+							'required' => false,
+						),
+					),
+					'MT' => array(
 						'state' => array(
 							'required' => false,
 						),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Malta postal addresses don't contain states, as far as I can tell: https://www.mca.org.mt/content/post-how-should-i-address-letters-and-parcels. (Customers have been writing 'N/A' in the field in the past.)

### How to test the changes in this Pull Request:

1. Checkout using a Malta address
2. See that the 'State' field not longer displays and isn't required

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Removed Malta state field