### PR TITLE
Allow items to be changed in wc_save_order_items function

### DIFF
--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -250,6 +250,9 @@ function wc_save_order_items( $order_id, $items ) {
 					}
 				}
 			}
+			
+			// Allow other plugins to change item object before it is saved.
+			do_action( 'woocommerce_before_save_order_item', $item, $item_data, $order_id );
 
 			$item->save();
 		}

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -250,7 +250,7 @@ function wc_save_order_items( $order_id, $items ) {
 					}
 				}
 			}
-			
+
 			// Allow other plugins to change item object before it is saved.
 			do_action( 'woocommerce_before_save_order_item', $item, $item_data, $order_id );
 

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -252,7 +252,7 @@ function wc_save_order_items( $order_id, $items ) {
 			}
 
 			// Allow other plugins to change item object before it is saved.
-			do_action( 'woocommerce_before_save_order_item', $item, $item_data, $order_id );
+			do_action( 'woocommerce_before_save_order_item', $item );
 
 			$item->save();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allow other plugins to be able to change $item object, for example to adjust line subtotal/total before its saved. 

My user case for this change is: 
Because I have custom booking product item, and attached custom inputs for the item ( checkin / checkout dates etc ). So whenever those inputs are changed in order edit page and ajax save button is triggered, I need to auto adjust booking item's line subtotal/total ( because of booking dates changed ) before item is saved.

Closes #20467 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
