### PR TITLE
Clear transients tool; clear wc_layered_nav_counts

### DIFF
--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -409,6 +409,15 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 			case 'clear_transients':
 				wc_delete_product_transients();
 				wc_delete_shop_order_transients();
+
+				$attribute_taxonomies = wc_get_attribute_taxonomies();
+
+				if ( $attribute_taxonomies ) {
+					foreach ( $attribute_taxonomies as $attribute ) {
+						delete_transient( 'wc_layered_nav_counts_pa_' . $attribute->attribute_name );
+					}
+				}
+
 				WC_Cache_Helper::get_transient_version( 'shipping', true );
 				$message = __( 'Product transients cleared', 'woocommerce' );
 				break;


### PR DESCRIPTION
wc_layered_nav_counts can be cleared with other transients using the status tool.

Closes #20494

### How to test the changes in this Pull Request:

1. Check DB for %wc_layered_nav_counts_% transients
2. Clear via tool
3. Check they are gone from DB

### Changelog entry

> Clear wc_layered_nav_counts transients using system status tools.
