### PR TITLE
Remove API enabled check from auth endpoint

### DIFF
--- a/includes/class-wc-auth.php
+++ b/includes/class-wc-auth.php
@@ -319,10 +319,6 @@ class WC_Auth {
 		$consumer_data = array();
 
 		try {
-			if ( 'yes' !== get_option( 'woocommerce_api_enabled' ) ) {
-				throw new Exception( __( 'API disabled!', 'woocommerce' ) );
-			}
-
 			$route = strtolower( wc_clean( $route ) );
 			$this->make_validation();
 


### PR DESCRIPTION
The auth endpoint (`/wc-auth/v1/authorize`) has a check to see if the API is enabled, but this setting is for the legacy API. There are cases where you'd want to use this endpoint and get keys for the new REST API.

Simply removes the check.

@claudiosanches Can you confirm this is desirable?

Closes #20496