### PR TITLE
Arguments passed to end function should be passed by reference

### DIFF
--- a/includes/wc-rest-functions.php
+++ b/includes/wc-rest-functions.php
@@ -102,7 +102,8 @@ function wc_rest_upload_image_from_url( $image_url ) {
 	if ( ! $wp_filetype['type'] ) {
 		$headers = wp_remote_retrieve_headers( $response );
 		if ( isset( $headers['content-disposition'] ) && strstr( $headers['content-disposition'], 'filename=' ) ) {
-			$disposition = end( explode( 'filename=', $headers['content-disposition'] ) );
+			$content = explode( 'filename=', $headers['content-disposition'] );
+			$disposition = end( $content );
 			$disposition = sanitize_file_name( $disposition );
 			$file_name   = $disposition;
 		} elseif ( isset( $headers['content-type'] ) && strstr( $headers['content-type'], 'image/' ) ) {


### PR DESCRIPTION
Arguments passed to end function should be passed by reference as stated in http://php.net/manual/en/function.end.php

Right now. If a request returns a response with a "Content-Disposition" header, the API returns at the beginning of response data:
```
<b>Notice</b>:  Only variables should be passed by reference in <b>[...]/woocommerce/includes/wc-rest-functions.php</b> on line <b>105</b><br />
```

Which breaks the `.json()` function. As is incapable of parse the response.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Create a product through the Woocommerce API uploading an image that generates a response that includes a "Content-Disposition" header. (e.g. [this image](https://www.filepicker.io/api/file/OpJb4LHRIOAeyUfLLHLg))

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Separation of explode and end functions in two lines. End function should get a reference as parameter.
