### PR TITLE
Initialize payment gateways before running bulk actions

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -644,6 +644,9 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 
 			// Sanity check: bail out if this is actually not a status, or is not a registered status.
 			if ( isset( $order_statuses[ 'wc-' . $new_status ] ) ) {
+				// Initialize payment gateways in case order has hooked status transition actions.
+				wc()->payment_gateways();
+
 				foreach ( $ids as $id ) {
 					$order = wc_get_order( $id );
 					$order->update_status( $new_status, __( 'Order status changed by bulk edit:', 'woocommerce' ), true );


### PR DESCRIPTION
Initialize payment gateways before running bulk actions so those listening for status change events can run their logic. e.g. capture payment.

Closes #20466 (test instructions in there too)

@claudiulodro Just a note, this is code smell. We'll need a better system in future for gateways to handle events, without loading all gateways in random places.
