### PR TITLE
Tokenization form refactor

### DIFF
--- a/assets/js/frontend/tokenization-form.js
+++ b/assets/js/frontend/tokenization-form.js
@@ -10,7 +10,8 @@ jQuery( function( $ ) {
 
 		// Params.
 		this.params = $.extend( {}, {
-			'is_registration_required': false
+			'is_registration_required': false,
+			'is_logged_in'            : false,
 		}, wc_tokenization_form_params );
 
 		// Bind functions to this.
@@ -21,7 +22,7 @@ jQuery( function( $ ) {
 		this.hideSaveNewCheckbox   = this.hideSaveNewCheckbox.bind( this );
 
 		// When a radio button is changed, make sure to show/hide our new CC info area.
-		this.$target.on( 'click', ':input.woocommerce-SavedPaymentMethods-tokenInput', { tokenizationForm: this }, this.onTokenChange );
+		this.$target.on( 'click change', ':input.woocommerce-SavedPaymentMethods-tokenInput', { tokenizationForm: this }, this.onTokenChange );
 
 		// OR if create account is checked.
 		$( 'input#createaccount' ).change( { tokenizationForm: this }, this.onCreateAccountChange );
@@ -38,21 +39,21 @@ jQuery( function( $ ) {
 
 		// Don't show the "use new" radio button if we only have one method..
 		if ( 0 === this.$target.data( 'count' ) ) {
-			$( '.woocommerce-SavedPaymentMethods-new', this.$target ).hide();
+			$( '.woocommerce-SavedPaymentMethods-new', this.$target ).remove();
 		}
-
-		// Trigger change event
-		$( ':input.woocommerce-SavedPaymentMethods-tokenInput:checked', this.$target ).trigger( 'change' );
 
 		// Hide "save card" if "Create Account" is not checked and registration is not forced.
 		var hasCreateAccountCheckbox = 0 < $( 'input#createaccount' ).length,
-			createAccount               = hasCreateAccountCheckbox && $('input#createaccount').is( ':checked' );
+			createAccount            = hasCreateAccountCheckbox && $( 'input#createaccount' ).is( ':checked' );
 
-		if ( createAccount || this.params.is_registration_required ) {
+		if ( createAccount || this.params.is_logged_in || this.params.is_registration_required ) {
 			this.showSaveNewCheckbox();
 		} else {
 			this.hideSaveNewCheckbox();
 		}
+
+		// Trigger change event
+		$( ':input.woocommerce-SavedPaymentMethods-tokenInput:checked', this.$target ).trigger( 'change' );
 	};
 
 	TokenizationForm.prototype.onTokenChange = function( event ) {
@@ -97,7 +98,7 @@ jQuery( function( $ ) {
 		return this;
 	};
 
-	/*
+	/**
 	 * Initialize.
 	 */
 	$( document.body ).on( 'updated_checkout wc-credit-card-form-init', function() {

--- a/assets/js/frontend/tokenization-form.js
+++ b/assets/js/frontend/tokenization-form.js
@@ -46,7 +46,7 @@ jQuery( function( $ ) {
 
 		// Hide "save card" if "Create Account" is not checked and registration is not forced.
 		var hasCreateAccountCheckbox = 0 < $( 'input#createaccount' ).length,
-			createAccount               = hasCreateAccountCheckbox && $('input#createaccount').is( ': checked' );
+			createAccount               = hasCreateAccountCheckbox && $('input#createaccount').is( ':checked' );
 
 		if ( createAccount || this.params.is_registration_required ) {
 			this.showSaveNewCheckbox();

--- a/assets/js/frontend/tokenization-form.js
+++ b/assets/js/frontend/tokenization-form.js
@@ -1,86 +1,114 @@
-( function( $ ) {
-	$( function() {
-		var wcTokenizationForm = (function() {
-			function wcTokenizationForm( target ) {
-				var $target             = $( target ),
-					$formWrap           = $target.closest( '.payment_box' ),
-					$wcTokenizationForm = this;
+/*global wc_tokenization_form_params */
+jQuery( function( $ ) {
 
-				this.onTokenChange = function() {
-					if ( 'new' === $( this ).val() ) {
-						 $wcTokenizationForm.showForm();
-						 $wcTokenizationForm.showSaveNewCheckbox();
-					} else {
-						 $wcTokenizationForm.hideForm();
-						 $wcTokenizationForm.hideSaveNewCheckbox();
-					}
-				};
+	/**
+	 * WCTokenizationForm class.
+	 */
+	var TokenizationForm = function( $target ) {
+		this.$target   = $target;
+		this.$formWrap = $target.closest( '.payment_box' );
 
-				this.onCreateAccountChange = function() {
-					if ( $( this ).is( ':checked' ) ) {
-						 $wcTokenizationForm.showSaveNewCheckbox();
-					} else {
-						 $wcTokenizationForm.hideSaveNewCheckbox();
-					}
-				};
+		// Params.
+		this.params = $.extend( {}, {
+			'is_registration_required': false
+		}, wc_tokenization_form_params );
 
-				this.onDisplay = function() {
-					// Make sure a radio button is selected if there is no is_default for this payment method..
-					if ( 0 === $( ':input.woocommerce-SavedPaymentMethods-tokenInput:checked', $target ).length ) {
-						$( ':input.woocommerce-SavedPaymentMethods-tokenInput:last', $target ).prop( 'checked', true );
-					}
+		// Bind functions to this.
+		this.onDisplay             = this.onDisplay.bind( this );
+		this.hideForm              = this.hideForm.bind( this );
+		this.showForm              = this.showForm.bind( this );
+		this.showSaveNewCheckbox   = this.showSaveNewCheckbox.bind( this );
+		this.hideSaveNewCheckbox   = this.hideSaveNewCheckbox.bind( this );
 
-					// Don't show the "use new" radio button if we only have one method..
-					if ( 0 === $target.data( 'count' ) ) {
-						$( '.woocommerce-SavedPaymentMethods-new', $target ).hide();
-					}
+		// When a radio button is changed, make sure to show/hide our new CC info area.
+		this.$target.on( 'click', ':input.woocommerce-SavedPaymentMethods-tokenInput', { tokenizationForm: this }, this.onTokenChange );
 
-					// Trigger change event
-					$( ':input.woocommerce-SavedPaymentMethods-tokenInput:checked', $target ).trigger( 'change' );
+		// OR if create account is checked.
+		$( 'input#createaccount' ).change( { tokenizationForm: this }, this.onCreateAccountChange );
 
-					// Hide "save card" if "Create Account" is not checked.
-					// Check that the field is shown in the form - some plugins and force create account remove it
-					if ( $( 'input#createaccount' ).length && ! $('input#createaccount').is( ':checked' ) ) {
-						$wcTokenizationForm.hideSaveNewCheckbox();
-					}
+		// First display.
+		this.onDisplay();
+	};
 
-				};
+	TokenizationForm.prototype.onDisplay = function() {
+		// Make sure a radio button is selected if there is no is_default for this payment method..
+		if ( 0 === $( ':input.woocommerce-SavedPaymentMethods-tokenInput:checked', this.$target ).length ) {
+			$( ':input.woocommerce-SavedPaymentMethods-tokenInput:last', this.$target ).prop( 'checked', true );
+		}
 
-				this.hideForm = function() {
-					$( '.wc-payment-form', $formWrap ).hide();
-				};
+		// Don't show the "use new" radio button if we only have one method..
+		if ( 0 === this.$target.data( 'count' ) ) {
+			$( '.woocommerce-SavedPaymentMethods-new', this.$target ).hide();
+		}
 
-				this.showForm = function() {
-					$( '.wc-payment-form', $formWrap ).show();
-				};
+		// Trigger change event
+		$( ':input.woocommerce-SavedPaymentMethods-tokenInput:checked', this.$target ).trigger( 'change' );
 
-				this.showSaveNewCheckbox = function() {
-					$( '.woocommerce-SavedPaymentMethods-saveNew', $formWrap ).show();
-				};
+		// Hide "save card" if "Create Account" is not checked and registration is not forced.
+		var hasCreateAccountCheckbox = 0 < $( 'input#createaccount' ).length,
+			createAccount               = hasCreateAccountCheckbox && $('input#createaccount').is( ': checked' );
 
-				this.hideSaveNewCheckbox = function() {
-					$( '.woocommerce-SavedPaymentMethods-saveNew', $formWrap ).hide();
-				};
+		if ( createAccount || this.params.is_registration_required ) {
+			this.showSaveNewCheckbox();
+		} else {
+			this.hideSaveNewCheckbox();
+		}
+	};
 
-				// When a radio button is changed, make sure to show/hide our new CC info area
-				$( ':input.woocommerce-SavedPaymentMethods-tokenInput', $target ).change( this.onTokenChange );
+	TokenizationForm.prototype.onTokenChange = function( event ) {
+		if ( 'new' === $( this ).val() ) {
+			event.data.tokenizationForm.showForm();
+			event.data.tokenizationForm.showSaveNewCheckbox();
+		} else {
+			event.data.tokenizationForm.hideForm();
+			event.data.tokenizationForm.hideSaveNewCheckbox();
+		}
+	};
 
-				// OR if create account is checked
-				$ ( 'input#createaccount' ).change( this.onCreateAccountChange );
+	TokenizationForm.prototype.onCreateAccountChange = function( event ) {
+		if ( $( this ).is( ':checked' ) ) {
+			event.data.tokenizationForm.showSaveNewCheckbox();
+		} else {
+			event.data.tokenizationForm.hideSaveNewCheckbox();
+		}
+	};
 
-				this.onDisplay();
-			}
+	TokenizationForm.prototype.hideForm = function() {
+		$( '.wc-payment-form', this.$formWrap ).hide();
+	};
 
-			return wcTokenizationForm;
-		})();
+	TokenizationForm.prototype.showForm = function() {
+		$( '.wc-payment-form', this.$formWrap ).show();
+	};
 
-		$( document.body ).on( 'updated_checkout wc-credit-card-form-init', function() {
-			// Loop over gateways with saved payment methods
-			var $saved_payment_methods = $( 'ul.woocommerce-SavedPaymentMethods' );
+	TokenizationForm.prototype.showSaveNewCheckbox = function() {
+		$( '.woocommerce-SavedPaymentMethods-saveNew', this.$formWrap ).show();
+	};
 
-			$saved_payment_methods.each( function() {
-				new wcTokenizationForm( this );
-			} );
+	TokenizationForm.prototype.hideSaveNewCheckbox = function() {
+		$( '.woocommerce-SavedPaymentMethods-saveNew', this.$formWrap ).hide();
+	};
+
+	/**
+	 * Function to call wc_product_gallery on jquery selector.
+	 */
+	$.fn.wc_tokenization_form = function( args ) {
+		new TokenizationForm( this, args );
+		return this;
+	};
+
+	/*
+	 * Initialize.
+	 */
+	$( document.body ).on( 'updated_checkout wc-credit-card-form-init', function() {
+		// Loop over gateways with saved payment methods
+		var $saved_payment_methods = $( 'ul.woocommerce-SavedPaymentMethods' );
+
+		$saved_payment_methods.each( function() {
+			$( this ).wc_tokenization_form();
 		} );
-	});
-})( jQuery );
+	} );
+
+	// Alias.
+	var wcTokenizationForm = TokenizationForm;
+} );

--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -441,6 +441,12 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			array( 'jquery' ),
 			WC()->version
 		);
+
+		wp_localize_script(
+			'woocommerce-tokenization-form', 'wc_tokenization_form_params', array(
+				'is_registration_required' => WC()->checkout()->is_registration_required(),
+			)
+		);
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -445,6 +445,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 		wp_localize_script(
 			'woocommerce-tokenization-form', 'wc_tokenization_form_params', array(
 				'is_registration_required' => WC()->checkout()->is_registration_required(),
+				'is_logged_in'             => is_user_logged_in(),
 			)
 		);
 	}


### PR DESCRIPTION
Tokenization form refactor.

- Handles save account when registration is off
- Prototype pattern so make it more readable. 
- Correctly handle new checkbox/save account display when no saved methods exist

Closes #20420

### How to test the changes in this Pull Request:

Few variations to test with this. Can test with Stripe + Simplify Commerce.

1. Logged in
2. Logged out - registration enabled
3. Logged out - registration disabled

In all cases:

- Test saved checkbox only appears when an account will exist, or does exist, and 'new' method is being added
- Check it shows/hides when you choose a saved method vs a new method
- Check console for errors.

Also see test instructions in #20420.

cc @bor0 
