### PR TITLE
Wootenberg JITM

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -389,7 +389,7 @@ class WC_Admin_Notices {
 	 * Notice about trying the Products block.
 	 */
 	public static function wootenberg_feature_plugin_notice() {
-		if ( is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) {
+		if ( get_user_meta( get_current_user_id(), 'dismissed_wootenberg_notice', true ) || is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) {
 			self::remove_notice( 'wootenberg' );
 			return;
 		}

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -34,6 +34,7 @@ class WC_Admin_Notices {
 		'simplify_commerce'       => 'simplify_commerce_notice',
 		'regenerating_thumbnails' => 'regenerating_thumbnails_notice',
 		'no_secure_connection'    => 'secure_connection_notice',
+		'wootenberg'              => 'wootenberg_feature_plugin_notice',
 	);
 
 	/**
@@ -49,6 +50,7 @@ class WC_Admin_Notices {
 
 		if ( current_user_can( 'manage_woocommerce' ) ) {
 			add_action( 'admin_print_styles', array( __CLASS__, 'add_notices' ) );
+			add_action( 'activate_gutenberg/gutenberg.php', array( __CLASS__, 'add_wootenberg_feature_plugin_notice_on_gutenberg_activate' ) );
 		}
 	}
 
@@ -91,6 +93,7 @@ class WC_Admin_Notices {
 			WC_Admin_Notices::add_notice( 'no_secure_connection' );
 		}
 
+		WC_Admin_Notices::add_wootenberg_feature_plugin_notice();
 		self::add_notice( 'template_files' );
 	}
 
@@ -356,6 +359,42 @@ class WC_Admin_Notices {
 		}
 
 		include dirname( __FILE__ ) . '/views/html-notice-secure-connection.php';
+	}
+
+	/**
+	 * If Gutenberg is active, tell people about the Products block feature plugin.
+	 *
+	 * @since 3.4.3
+	 * @todo Remove this notice and associated code once the feature plugin has been merged into core.
+	 */
+	public static function add_wootenberg_feature_plugin_notice() {
+		if ( is_plugin_active( 'gutenberg/gutenberg.php' ) && ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) {
+			self::add_notice( 'wootenberg' );
+		}
+	}
+
+	/**
+	 * Tell people about the Products block feature plugin when they activate Gutenberg.
+	 *
+	 * @since 3.4.3
+	 * @todo Remove this notice and associated code once the feature plugin has been merged into core.
+	 */
+	public static function add_wootenberg_feature_plugin_notice_on_gutenberg_activate() {
+		if ( ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) {
+			self::add_notice( 'wootenberg' );
+		}
+	}
+
+	/**
+	 * Notice about trying the Products block.
+	 */
+	public static function wootenberg_feature_plugin_notice() {
+		if ( is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) {
+			self::remove_notice( 'wootenberg' );
+			return;
+		}
+
+		include dirname( __FILE__ ) . '/views/html-notice-wootenberg.php';
 	}
 }
 

--- a/includes/admin/views/html-notice-wootenberg.php
+++ b/includes/admin/views/html-notice-wootenberg.php
@@ -12,12 +12,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'wootenberg' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 
 	<p>
-		<?php
-		printf(
-			/* translators: %s: Gutenberg Products Block plugin URL */
-			wp_kses_post( __( 'Make sure you try the <a href="%s" target="_blank" rel="nofollow">WooCommerce Gutenberg Products Block</a> for a powerful new way to feature products in your Gutenberg posts!', 'woocommerce' ) ),
-			'https://wordpress.org/plugins/woo-gutenberg-products-block/'
-		);
-		?>
+		<?php echo wp_kses_post( __( "We noticed you're experimenting with Gutenberg: Try the WooCommerce Gutenberg Products Block for a powerful new way to feature products in posts.", 'woocommerce' ) ); ?>
 	</p>
+	<?php if ( file_exists( WP_PLUGIN_DIR . '/woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) && ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) && current_user_can( 'activate_plugin', 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) : ?>
+		<p>
+			<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php&plugin_status=active' ), 'activate-plugin_woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Active the Gutenberg Products Block', 'woocommerce' ); ?></a>
+		</p>
+	<?php else : ?>
+		<?php
+		if ( current_user_can( 'install_plugins' ) ) {
+			$url = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=woo-gutenberg-products-block' ), 'install-plugin_woo-gutenberg-products-block' );
+		} else {
+			$url = 'https://wordpress.org/plugins/woo-gutenberg-products-block/';
+		}
+		?>
+		<p>
+			<a href="<?php echo esc_url( $url ); ?>" class="button button-primary"><?php esc_html_e( 'Install the WooCommerce Gutenberg Products Block', 'woocommerce' ); ?></a>
+		</p>
+	<?php endif; ?>
 </div>

--- a/includes/admin/views/html-notice-wootenberg.php
+++ b/includes/admin/views/html-notice-wootenberg.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Admin View: Notice - Wootenberg Feature Plugin
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+<div id="message" class="updated woocommerce-message woocommerce-wootenberg-promo-messages">
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'wootenberg' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
+
+	<p>
+		<?php
+		printf(
+			/* translators: %s: Gutenberg Products Block plugin URL */
+			wp_kses_post( __( 'Make sure you try the <a href="%s" target="_blank" rel="nofollow">WooCommerce Gutenberg Products Block</a> for a powerful new way to feature products in your Gutenberg posts!', 'woocommerce' ) ),
+			'https://wordpress.org/plugins/woo-gutenberg-products-block/'
+		);
+		?>
+	</p>
+</div>


### PR DESCRIPTION
Adds a notice with a link to the .org plugin page about trying out the Gutenberg Products Block feature plugin:

<img width="1406" alt="screen shot 2018-06-13 at 11 38 04 am" src="https://user-images.githubusercontent.com/7317227/41371178-65f37f02-6efe-11e8-8e31-f473f80dff11.png">

This notice will be triggered in two possible ways (if the Products Block feature plugin isn't active):
1. When the user upgrades WooCommerce if they have Gutenberg already active.
2. When the user activates the Gutenberg plugin.

Could use some feedback around the wording of the message.

To test:
1. Make sure Gutenberg and the Products Block feature plugin are deactivated.
2. Activate the Gutenberg plugin.
3. Observe the notice displays.
4. Activate the Products Block feature plugin.
5. Observe the notice automatically goes away.

 