### PR TITLE
Round items for order total

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1405,12 +1405,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->add_item( $item );
 		}
 
-		if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+		if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+			$this->set_shipping_tax( wc_round_tax_total( array_sum( array_map( 'wc_round_tax_total', $shipping_taxes ) ) ) );
+			$this->set_cart_tax( wc_round_tax_total( array_sum( array_map( 'wc_round_tax_total', $cart_taxes ) ) ) );
+		} else {
 			$this->set_shipping_tax( wc_round_tax_total( array_sum( $shipping_taxes ) ) );
 			$this->set_cart_tax( wc_round_tax_total( array_sum( $cart_taxes ) ) );
-		} else {
-			$this->set_shipping_tax( array_sum( $shipping_taxes ) );
-			$this->set_cart_tax( array_sum( $cart_taxes ) );
 		}
 
 		$this->save();


### PR DESCRIPTION
The cart class round item costs before generating the grand total.

The order class was instead using unrounded values, leading to the bug in #20505

Closes #20505

### How to test the changes in this Pull Request:

1. Taxes of 19%, shipping taxes unchecked
2. 3 items costing 6, 6, and 4.50
3. Shipping of 5.40
4. Prices incl. tax.
5. Place order. Total is 21.90
6. Recalc in the order backend. Total does not change.
