### PR TITLE
Transactions, caching, and version transient cleanup issues

### DIFF
--- a/includes/api/legacy/v2/class-wc-api-orders.php
+++ b/includes/api/legacy/v2/class-wc-api-orders.php
@@ -360,8 +360,6 @@ class WC_API_Orders extends WC_API_Resource {
 	public function create_order( $data ) {
 		global $wpdb;
 
-		wc_transaction_query( 'start' );
-
 		try {
 			if ( ! isset( $data['order'] ) ) {
 				throw new WC_API_Exception( 'woocommerce_api_missing_order_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'order' ), 400 );
@@ -466,15 +464,10 @@ class WC_API_Orders extends WC_API_Resource {
 			do_action( 'woocommerce_api_create_order', $order->get_id(), $data, $this );
 			do_action( 'woocommerce_new_order', $order->get_id() );
 
-			wc_transaction_query( 'commit' );
-
 			return $this->get_order( $order->get_id() );
-
 		} catch ( WC_Data_Exception $e ) {
-			wc_transaction_query( 'rollback' );
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => 400 ) );
 		} catch ( WC_API_Exception $e ) {
-			wc_transaction_query( 'rollback' );
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
 	}

--- a/includes/api/legacy/v3/class-wc-api-orders.php
+++ b/includes/api/legacy/v3/class-wc-api-orders.php
@@ -389,15 +389,11 @@ class WC_API_Orders extends WC_API_Resource {
 	 * Create an order
 	 *
 	 * @since 2.2
-	 *
 	 * @param array $data raw order data
-	 *
 	 * @return array|WP_Error
 	 */
 	public function create_order( $data ) {
 		global $wpdb;
-
-		wc_transaction_query( 'start' );
 
 		try {
 			if ( ! isset( $data['order'] ) ) {
@@ -508,15 +504,10 @@ class WC_API_Orders extends WC_API_Resource {
 			do_action( 'woocommerce_api_create_order', $order->get_id(), $data, $this );
 			do_action( 'woocommerce_new_order', $order->get_id() );
 
-			wc_transaction_query( 'commit' );
-
 			return $this->get_order( $order->get_id() );
-
 		} catch ( WC_Data_Exception $e ) {
-			wc_transaction_query( 'rollback' );
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => 400 ) );
 		} catch ( WC_API_Exception $e ) {
-			wc_transaction_query( 'rollback' );
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
 	}

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -150,7 +150,7 @@ class WC_Cache_Helper {
 	 *
 	 * @param string $version Version of the transient to remove.
 	 */
-	protected function queue_delete_version_transients( $version = '' ) {
+	protected static function queue_delete_version_transients( $version = '' ) {
 		if ( ! wp_using_ext_object_cache() && ! empty( $version ) ) {
 			wp_schedule_single_event( time() + 30, 'delete_version_transients', array( $version ) );
 		}

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -134,11 +134,18 @@ class WC_Cache_Helper {
 	public static function get_transient_version( $group, $refresh = false ) {
 		$transient_name  = $group . '-transient-version';
 		$transient_value = get_transient( $transient_name );
+		$transient_value = strval( $transient_value ? $transient_value : '' );
 
-		if ( false === $transient_value || true === $refresh ) {
-			self::queue_delete_version_transients( $transient_value );
+		if ( '' === $transient_value || true === $refresh ) {
+			$old_transient_value = $transient_value;
+			$transient_value     = (string) time();
 
-			$transient_value = time();
+			if ( $old_transient_value === $transient_value ) {
+				// Time did not change but transient needs flushing now.
+				self::delete_version_transients( $transient_value );
+			} else {
+				self::queue_delete_version_transients( $transient_value );
+			}
 
 			set_transient( $transient_name, $transient_value );
 		}

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -102,8 +102,6 @@ class WC_Order extends WC_Abstract_Order {
 		}
 
 		try {
-			wc_transaction_query( 'start' );
-
 			do_action( 'woocommerce_pre_payment_complete', $this->get_id() );
 
 			if ( WC()->session ) {
@@ -124,20 +122,18 @@ class WC_Order extends WC_Abstract_Order {
 			} else {
 				do_action( 'woocommerce_payment_complete_order_status_' . $this->get_status(), $this->get_id() );
 			}
-
-			wc_transaction_query( 'commit' );
 		} catch ( Exception $e ) {
-			wc_transaction_query( 'rollback' );
-
+			/**
+			 * If there was an error completing the payment, log to a file and add an order note so the admin can take action.
+			 */
 			$logger = wc_get_logger();
 			$logger->error(
-				sprintf( 'Payment complete of order #%d failed!', $this->get_id() ), array(
+				sprintf( 'Error completing payment for order #%d', $this->get_id() ), array(
 					'order' => $this,
 					'error' => $e,
 				)
 			);
 			$this->add_order_note( __( 'Payment complete event failed.', 'woocommerce' ) . ' ' . $e->getMessage() );
-
 			return false;
 		}
 		return true;
@@ -320,18 +316,12 @@ class WC_Order extends WC_Abstract_Order {
 		}
 
 		try {
-			wc_transaction_query( 'start' );
-
 			$this->set_status( $new_status, $note, $manual );
 			$this->save();
-
-			wc_transaction_query( 'commit' );
 		} catch ( Exception $e ) {
-			wc_transaction_query( 'rollback' );
-
 			$logger = wc_get_logger();
 			$logger->error(
-				sprintf( 'Update status of order #%d failed!', $this->get_id() ), array(
+				sprintf( 'Error updating status for order #%d', $this->get_id() ), array(
 					'order' => $this,
 					'error' => $e,
 				)

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -324,7 +324,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		global $wpdb;
 
 		// Get from cache if available.
-		$items = wp_cache_get( 'order-items-' . $order->get_id(), 'orders' );
+		$items = 0 < $order->get_id() ? wp_cache_get( 'order-items-' . $order->get_id(), 'orders' ) : false;
 
 		if ( false === $items ) {
 			$items = $wpdb->get_results(
@@ -333,7 +333,9 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 			foreach ( $items as $item ) {
 				wp_cache_set( 'item-' . $item->order_item_id, $item, 'order-items' );
 			}
-			wp_cache_set( 'order-items-' . $order->get_id(), $items, 'orders' );
+			if ( 0 < $order->get_id() ) {
+				wp_cache_set( 'order-items-' . $order->get_id(), $items, 'orders' );
+			}
 		}
 
 		$items = wp_list_filter( $items, array( 'order_item_type' => $type ) );


### PR DESCRIPTION
3 changes here, all semi-related, which should be rolled out to prevent current conflicts.

This should also help with #17660, however we're not 100% sure as we're unable to replicate the cases in that thread.

This PR reverts some changes made in https://github.com/woocommerce/woocommerce/commit/1918e2e554ba3ea2a286786dbd3ce860e5cb3fb3 which has been causing odd issues on stores due to deadlocks, and is potentially guilty of causing double charges on woo.com (cc @kloon).

**To Test:**
- Create some test orders, ensure they go through without error. Try as a guest and logged in user.
- Ensure unit tests pass.

**Transactions**
Transactions were used so changes could be rolled back, however, it seems this is causing issue if large amounts of data are written due to all the hooks that fire. e.g. in #20528 Not using transactions could lead to partial updates, however, these are not expected and only occur if something (plugin?) causes an error. As such, _I'm confident logging will be enough for an admin to resolve._

Disabling transactions seemed to have a positive impact on woo.com, so rolling this out as a fix.

**Transient cleanup**
Related to the above and raised in #20528. I noticed cleanup runs immediately. We don't need to clean up right away and slow the current process. Deferring the event via cron will work.

**Cache ID 0**
Not confirmed, but we theorised caching for order ID 0 could be a factor in #17660. This PR simply checks to ensure there is an ID before using caching.

Closes #17660
Closes #20528
