### PR TITLE
Normalize parent tax class

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -902,7 +902,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		$class         = 'standard' === $class ? '' : $class;
 		$valid_classes = $this->get_valid_tax_classes();
 
-		if ( ! in_array( $class, $valid_classes ) ) {
+		if ( ! in_array( $class, $valid_classes, true ) ) {
 			$class = '';
 		}
 

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -426,6 +426,33 @@ class WC_Product_Variation extends WC_Product_Simple {
 	 * @param array $parent_data parent data array for this variation.
 	 */
 	public function set_parent_data( $parent_data ) {
+		$parent_data = wp_parse_args( $parent_data, array(
+			'title'              => '',
+			'status'             => '',
+			'sku'                => '',
+			'manage_stock'       => 'no',
+			'backorders'         => 'no',
+			'stock_quantity'     => '',
+			'weight'             => '',
+			'length'             => '',
+			'width'              => '',
+			'height'             => '',
+			'tax_class'          => '',
+			'shipping_class_id'  => 0,
+			'image_id'           => 0,
+			'purchase_note'      => '',
+			'catalog_visibility' => 'visible',
+		) );
+
+		// Normalize tax class.
+		$parent_data['tax_class'] = sanitize_title( $parent_data['tax_class'] );
+		$parent_data['tax_class'] = 'standard' === $parent_data['tax_class'] ? '' : $parent_data['tax_class'];
+		$valid_classes            = $this->get_valid_tax_classes();
+
+		if ( ! in_array( $parent_data['tax_class'], $valid_classes, true ) ) {
+			$parent_data['tax_class'] = '';
+		}
+
 		$this->parent_data = $parent_data;
 	}
 


### PR DESCRIPTION
Prevents invalid tax classes set on products from being inheritied by variations, where the raw value was in use.

Note; set_tax_class for products does validation to protect against this already.

Closes #20509

### How to test the changes in this Pull Request:

1. Force parent tax class to something invalid like in #20509
2. Setup variation with 'same as parent' tax class and add to cart
3. Confirm there are taxes in your cart after this patch.

### Changelog entry

> Normalize parent properties for variations to protect against invalid tax class values.
