### PR TITLE
Improve WC_Query::get_layered_nav_chosen_attributes() performance

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -176,8 +176,6 @@ class WC_Query {
 	/**
 	 * Add query vars.
 	 *
-	 * @access public
-	 *
 	 * @param array $vars Query vars.
 	 * @return array
 	 */
@@ -371,7 +369,6 @@ class WC_Query {
 	 *
 	 * Hooked into wpseo_ hook already, so no need for function_exist.
 	 *
-	 * @access public
 	 * @return string
 	 */
 	public function wpseo_metakey() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This commits improves the performance of the method WC_Query::get_layered_nav_chosen_attributes() when a site has a significant number of product attributes. Instead of looping over all existent product attributes to find which have been passed in the request, the new code loops over all the parameters sent in the request and checks which are valid product attributes.

On a test site with 2000 product attributes, the old version of WC_Query::get_layered_nav_chosen_attributes() was responsible for 25% of the shop page generation time. With the new version, the amount that this method contributes to the page generation time is negligible.

This PR also includes a separated commit to fix PHPCS violations in the modified file.

Related #20262

### How to test the changes in this Pull Request:

1. Make sure the "Filter products by attribute" widget is working as expected
2. If you would like to test the performance changes, it is necessary to create a few thousand product attributes and then profile the execution of the shop page using Xdebug. See https://github.com/woocommerce/woocommerce/issues/20262#issuecomment-397430461 for a snippet to generate the attributes.

### Changelog entry

> Improve WC_Query::get_layered_nav_chosen_attributes() performance for stores with a significant number of product attributes
