### PR TITLE
Mailing list - update form action

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -2154,7 +2154,7 @@ class WC_Admin_Setup_Wizard {
 
 		<div class="woocommerce-message woocommerce-newsletter">
 			<p><?php esc_html_e( "We're here for you — get tips, product updates, and inspiration straight to your mailbox.", 'woocommerce' ); ?></p>
-			<form action="//woocommerce.us8.list-manage.com/subscribe/post?u=2c1434dc56f9506bf3c3ecd21&amp;id=13860df971" method="post" target="_blank" novalidate>
+			<form action="//woocommerce.us8.list-manage.com/subscribe/post?u=2c1434dc56f9506bf3c3ecd21&amp;id=13860df971&amp;SIGNUPPAGE=plugin" method="post" target="_blank" novalidate>
 				<div class="newsletter-form-container">
 					<input
 						class="newsletter-form-email"


### PR DESCRIPTION
Mailing list form now identifies itself to the mailing list server. The form is on the last step of the setup wizard:

<img width="735" alt="screen shot 2018-06-15 at 2 26 39 pm" src="https://user-images.githubusercontent.com/15386509/41490519-4f09ca56-70a9-11e8-8a67-5d9e5ac9bdb9.png">

### How to test the changes in this Pull Request:

1. Go to `/wp-admin/index.php?page=wc-setup&step=next_steps`
2. In the signup box, enter an email address that is not already on the mailing list
3. The email will be added just as before, but the record will be flagged as being from "plugin"