### PR TITLE
API: Return error code if parent is invalid when updating attributes.

### DIFF
--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -401,8 +401,18 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Products_Controller 
 
 		// Update taxonomies.
 		if ( isset( $request['attributes'] ) ) {
-			$attributes        = array();
-			$parent            = wc_get_product( $variation->get_parent_id() );
+			$attributes = array();
+			$parent     = wc_get_product( $variation->get_parent_id() );
+
+			if ( ! $parent ) {
+				return new WP_Error(
+					// Translators: %d parent ID.
+					"woocommerce_rest_{$this->post_type}_invalid_parent", sprintf( __( 'Cannot set attributes due to invalid parent product.', 'woocommerce' ), $variation->get_parent_id() ), array(
+						'status' => 404,
+					)
+				);
+			}
+
 			$parent_attributes = $parent->get_attributes();
 
 			foreach ( $request['attributes'] as $attribute ) {


### PR DESCRIPTION
Prevent fatal error if parent product cannot be read, and instead return 404 woocommerce_rest_product_variation_invalid_parent error.

Closes #20565

### Changelog entry

> Rest API: Prevent errors if variation parent is invalid and cannot be read.
