### PR TITLE
Update status based on stock, always

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1314,7 +1314,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			$this->set_stock_status( 'onbackorder' );
 
 			// If the stock level is changing and we do now have enough, force in stock status.
-		} elseif ( $this->get_stock_quantity() > get_option( 'woocommerce_notify_no_stock_amount', 0 ) && ( array_key_exists( 'stock_quantity', $this->get_changes() ) || array_key_exists( 'manage_stock', $this->get_changes() ) ) ) {
+		} elseif ( $this->get_stock_quantity() > get_option( 'woocommerce_notify_no_stock_amount', 0 ) ) {
 			$this->set_stock_status( 'instock' );
 		}
 	}


### PR DESCRIPTION
I'm not sure why #20521 was caused by ACF exactly but I could replicate. It looks to be a race condition because variation and product is saved when update is pressed.

I did however notice that in the `validate_props` method we only update status is stock changed. This check was probably present because in old versions you could also manually set the stock status and we didn't want those changes to be ignored.

In later versions, stock status is set automatically. So we no longer need to block the status update.

Removing this check resolved the issue.

Closes #20521

@claudiulodro See anything wrong with this?

### How to test the changes in this Pull Request:

1. See #20521. I can send ACF via slack if needed @claudiulodro 

### Changelog entry

> Fix automatic stock status updates based on stock level.
