### PR TITLE
Fix: set order status to refunded when a PayPal transaction is refunded

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -292,7 +292,7 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 	 */
 	protected function payment_status_refunded( $order, $posted ) {
 		// Only handle full refunds, not partial.
-		if ( $order->get_total() === wc_format_decimal( $posted['mc_gross'] * -1 ) ) {
+		if ( $order->get_total() === wc_format_decimal( $posted['mc_gross'] * -1, wc_get_price_decimals() ) ) {
 
 			/* translators: %s: payment status. */
 			$order->update_status( 'refunded', sprintf( __( 'Payment %s via IPN.', 'woocommerce' ), strtolower( $posted['payment_status'] ) ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Commit c7a3fd2 changed the logic to check if the refund is a full refund to use the strict equal operator (`===`) in the following line:

https://github.com/woocommerce/woocommerce/blob/25be9fc13c67c9d2baf3139138a540756cb3f05f/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php#L295

This change broke the comparison as `$order->get_total()` will return the value respecting the number of decimals after the decimal point set in the option `woocommerce_price_num_decimals` and `wc_format_decimal()`, when called without a second parameter, will not format the received value to use the same number of decimals set in `woocommerce_price_num_decimals`. To fix this issue, this commit passes `wc_get_price_decimals()` as the second parameter to `wc_format_decimal()`. This way both values will always have the same number of decimals, and the comparison should work as expected.

Fixes #20551

### How to test the changes in this Pull Request:

See #20551 for testing instructions. I don't have PayPal Standard on my local environment, so I wasn't able to test this. @tubiz, could you please test and confirm if this PR fixes the issue you reported?

### Changelog entry

> Fix: set order status to refunded when a PayPal transaction is refunded
