### PR TITLE
Fix: display products on sub-subcategories when sorting parent category by price

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -514,7 +514,7 @@ class WC_Query {
 		if ( isset( $wp_query->queried_object, $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy ) && is_a( $wp_query->queried_object, 'WP_Term' ) ) {
 			$search_within_terms = get_terms( array(
 				'taxonomy' => $wp_query->queried_object->taxonomy,
-				'parent'   => $wp_query->queried_object->term_id,
+				'child_of' => $wp_query->queried_object->term_id,
 				'fields'   => 'tt_ids',
 			) );
 			$search_within_terms[] = $wp_query->queried_object->term_taxonomy_id;
@@ -547,7 +547,7 @@ class WC_Query {
 		if ( isset( $wp_query->queried_object, $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy ) && is_a( $wp_query->queried_object, 'WP_Term' ) ) {
 			$search_within_terms = get_terms( array(
 				'taxonomy' => $wp_query->queried_object->taxonomy,
-				'parent'   => $wp_query->queried_object->term_id,
+				'child_of' => $wp_query->queried_object->term_id,
 				'fields'   => 'tt_ids',
 			) );
 			$search_within_terms[] = $wp_query->queried_object->term_taxonomy_id;

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -176,8 +176,6 @@ class WC_Query {
 	/**
 	 * Add query vars.
 	 *
-	 * @access public
-	 *
 	 * @param array $vars Query vars.
 	 * @return array
 	 */
@@ -371,7 +369,6 @@ class WC_Query {
 	 *
 	 * Hooked into wpseo_ hook already, so no need for function_exist.
 	 *
-	 * @access public
 	 * @return string
 	 */
 	public function wpseo_metakey() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The algorithm to add a list of product categories to the query that order products of a given category by price was including only first level sub-categories since PR #20391. This was happening because `get_terms()` when called with the argument `parent` will only return the parent term direct children. To fix this and get all children for a given product category, it was necessary to replace `parent` with the argument `child_of`.

See #20554 for a more detailed description of the issue that this PR fixes.

This PR also includes a separate commit that fixes PHPCS violations in the modified file.

Closes #20554.

### How to test the changes in this Pull Request:

1. See #20554 for instructions on how to reproduce the problem and confirm that this PR fixes it.

### Changelog entry

> Fix: display products on sub-subcategories when sorting parent category by price

cc @smazur and @parkinep in case you have time to test this change as you both worked on the code that this PR modifies.