### PR TITLE
Order stats lookup table

### DIFF
--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -24,4 +24,48 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_System_Status_Tools
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * A list of available tools for use in the system status section.
+	 * 'button' becomes 'action' in the API.
+	 *
+	 * @return array
+	 */
+	public function get_tools() {
+		return array_merge(
+			parent::get_tools(),
+			array(
+				'rebuild_stats' => array(
+					'name'   => __( 'Rebuild reports data', 'woocommerce' ),
+					'button' => __( 'Rebuild reports', 'woocommerce' ),
+					'desc'   => __( 'This tool will rebuild all of the information used by the reports.', 'woocommerce' ),
+				)
+			)
+		);
+	}
+
+	/**
+	 * Actually executes a tool.
+	 *
+	 * @param  string $tool Tool.
+	 * @return array
+	 */
+	public function execute_tool( $tool ) {
+		$ran = true;
+		$message = '';
+
+		switch ( $tool ) {
+			case 'rebuild_stats':
+				WC_Order_Stats::queue_order_stats_repopulate_database();
+				$message = __( 'Rebuilding reports data in the background . . .', 'woocommerce' );
+				break;
+			default:
+				return parent::execute_tool( $tool );
+		}
+
+		return array(
+			'success' => $ran,
+			'message' => $message,
+		);
+	}
 }

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -228,10 +228,11 @@ class WC_API extends WC_Legacy_API {
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-system-status-tools-controller.php';
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-shipping-methods-controller.php';
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-payment-gateways-controller.php';
+	/*	@todo this needs fixing
 		include_once dirname( __FILE__ ) . '/api/includes/api/class-wc-rest-data-continents-controller.php';
 		include_once dirname( __FILE__ ) . '/api/includes/api/class-wc-rest-data-controller.php';
 		include_once dirname( __FILE__ ) . '/api/includes/api/class-wc-rest-data-countries-controller.php';
-		include_once dirname( __FILE__ ) . '/api/includes/api/class-wc-rest-data-currencies-controller.php';
+		include_once dirname( __FILE__ ) . '/api/includes/api/class-wc-rest-data-currencies-controller.php';*/
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -745,6 +745,18 @@ CREATE TABLE {$wpdb->prefix}wc_download_log (
   KEY permission_id (permission_id),
   KEY timestamp (timestamp)
 ) $collate;
+CREATE TABLE {$wpdb->prefix}wc_order_stats (
+  start_time timestamp DEFAULT '0000-00-00 00:00:00' NOT NULL,
+  num_orders int(11) UNSIGNED DEFAULT 0 NOT NULL,
+  num_items_sold int(11) UNSIGNED DEFAULT 0 NOT NULL,
+  orders_gross_total double DEFAULT 0 NOT NULL,
+  orders_coupon_total double DEFAULT 0 NOT NULL,
+  orders_refund_total double DEFAULT 0 NOT NULL,
+  orders_tax_total double DEFAULT 0 NOT NULL,
+  orders_shipping_total double DEFAULT 0 NOT NULL,
+  orders_net_total double DEFAULT 0 NOT NULL,
+  PRIMARY KEY (start_time)
+) $collate;
 		";
 
 		/**

--- a/includes/class-wc-order-stats-background-process.php
+++ b/includes/class-wc-order-stats-background-process.php
@@ -35,10 +35,6 @@ class WC_Order_Stats_Background_Process extends WC_Background_Process {
 	 * @return bool
 	 */
 	protected function task( $item ) {
-		$logger     = wc_get_logger();
-		$logger->debug( $item );
-
-
 		if ( ! $item || empty( $item['start_time'] ) ) {
 			return false;
 		}

--- a/includes/class-wc-order-stats-background-process.php
+++ b/includes/class-wc-order-stats-background-process.php
@@ -43,7 +43,7 @@ class WC_Order_Stats_Background_Process extends WC_Background_Process {
 		$end_time = ! empty( $item['end_time'] ) ? $item['end_time'] : $start_time + HOUR_IN_SECONDS;
 
 		$data = WC_Order_Stats::summarize_orders( $start_time, $end_time );
-		WC_Order_Stats::update( $start_time, $end_time, $data );
+		WC_Order_Stats::update( $start_time, $data );
 
 		return false;
 	}

--- a/includes/class-wc-order-stats-background-process.php
+++ b/includes/class-wc-order-stats-background-process.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Order stats background process.
+ *
+ * @package WooCommerce/Classes
+ * @version 3.5.0
+ * @since   3.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'WC_Background_Process', false ) ) {
+	include_once dirname( __FILE__ ) . '/abstracts/class-wc-background-process.php';
+}
+
+/**
+ * WC_Order_Stats_Background_Process class.
+ */
+class WC_Order_Stats_Background_Process extends WC_Background_Process {
+
+	/**
+	 * Initiate new background process.
+	 */
+	public function __construct() {
+		// Uses unique prefix per blog so each blog has separate queue.
+		$this->prefix = 'wp_' . get_current_blog_id();
+		$this->action = 'wc_order_stats';
+		parent::__construct();
+	}
+
+	/**
+	 * Code to execute for each item in the queue
+	 *
+	 * @param string $item Queue item to iterate over.
+	 * @return bool
+	 */
+	protected function task( $item ) {
+		if ( ! $item || empty( $item['task'] ) ) {
+			return false;
+		}
+
+		$process_count = 0;
+		$process_limit = 20;
+
+		switch ( $item['task'] ) {
+			case 'trash_pending_orders':
+				$process_count = WC_Privacy::trash_pending_orders( $process_limit );
+				break;
+			case 'trash_failed_orders':
+				$process_count = WC_Privacy::trash_failed_orders( $process_limit );
+				break;
+			case 'trash_cancelled_orders':
+				$process_count = WC_Privacy::trash_cancelled_orders( $process_limit );
+				break;
+			case 'anonymize_completed_orders':
+				$process_count = WC_Privacy::anonymize_completed_orders( $process_limit );
+				break;
+			case 'delete_inactive_accounts':
+				$process_count = WC_Privacy::delete_inactive_accounts( $process_limit );
+				break;
+		}
+
+		if ( $process_limit === $process_count ) {
+			// Needs to run again.
+			return $item;
+		}
+
+		return false;
+	}
+}

--- a/includes/class-wc-order-stats-background-process.php
+++ b/includes/class-wc-order-stats-background-process.php
@@ -31,6 +31,8 @@ class WC_Order_Stats_Background_Process extends WC_Background_Process {
 	/**
 	 * Push to queue without scheduling duplicate recalculation events.
 	 * Overrides WC_Background_Process::push_to_queue.
+	 *
+	 * @param integer $data Timestamp of hour to generate stats.
 	 */
 	public function push_to_queue( $data ) {
 		$data = absint( $data );

--- a/includes/class-wc-order-stats.php
+++ b/includes/class-wc-order-stats.php
@@ -14,6 +14,8 @@ if ( ! class_exists( 'WC_Order_Stats_Background_Process', false ) ) {
 	include_once dirname( __FILE__ ) . '/class-wc-order-stats-background-process.php';
 }
 
+// then: button in tools for repopulating everything
+
 /**
  * Order stats class.
  */
@@ -163,13 +165,7 @@ class WC_Order_Stats {
 		$end_time = $start_time + HOUR_IN_SECONDS;
 
 		while ( $end_time < time() ) {
-			self::$background_process->push_to_queue(
-				array(
-					'start_time' => $start_time,
-					'end_time' => $end_time,
-				)
-			);
-
+			self::$background_process->push_to_queue( $start_time );
 			$start_time = $end_time;
 			$end_time = $start_time + HOUR_IN_SECONDS;
 		}
@@ -183,13 +179,7 @@ class WC_Order_Stats {
 	public function queue_update_recent_orders() {
 		// Populate the stats information for the previous hour.
 		$last_hour = strtotime( date( 'Y-m-d H:00:00' ) ) - HOUR_IN_SECONDS;
-		self::$background_process->push_to_queue(
-			array(
-				'start_time' => $last_hour,
-				'end_time' => $last_hour + HOUR_IN_SECONDS,
-			)
-		);
-
+		self::$background_process->push_to_queue( $last_hour );
 		self::$background_process->save();
 	}
 
@@ -207,18 +197,10 @@ class WC_Order_Stats {
 
 		$order_statuses = self::get_report_order_statuses();
 		if ( in_array( $new_status, $order_statuses, true ) || in_array( $old_status, $order_statuses, true ) ) {
-			self::$background_process->push_to_queue(
-				array(
-					'start_time' => $new_time,
-				)
-			);
+			self::$background_process->push_to_queue( $new_time );
 
 			if ( $old_time && $new_time !== $old_time ) {
-				self::$background_process->push_to_queue(
-					array(
-						'start_time' => $old_time,
-					)
-				);
+				self::$background_process->push_to_queue( $old_time );
 			}
 
 			self::$background_process->save();
@@ -320,12 +302,6 @@ class WC_Order_Stats {
 				'%f',
 			)
 		);
-	}
-
-	protected static function schedule_recalculation( $start_time ) {
-		$existing = get_post_meta
-
-
 	}
 
 	protected static function get_report_order_statuses() {

--- a/includes/class-wc-order-stats.php
+++ b/includes/class-wc-order-stats.php
@@ -33,7 +33,6 @@ class WC_Order_Stats {
 	 * Setup class.
 	 */
 	public function __construct() {
-		add_action( 'init', array( $this, 'install' ) ); // @todo Don't do this on every page load.
 		add_action( self::CRON_EVENT, array( $this, 'queue_update_recent_orders' ) );
 		add_action( 'woocommerce_before_order_object_save', array( $this, 'queue_update_modified_orders' ) );
 		add_action( 'shutdown', array( $this, 'dispatch_recalculator' ) );
@@ -100,35 +99,6 @@ class WC_Order_Stats {
 		);
 
 		return $wpdb->get_results( $query, ARRAY_A ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-	}
-
-	/**
-	 * Create the table that will hold the order stats information.
-	 */
-	public function install() {
-		global $wpdb;
-
-		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
-
-		$charset_collate = '';
-		if ( $wpdb->has_cap( 'collation' ) ) {
-			$charset_collate = $wpdb->get_charset_collate();
-		}
-
-		$table_name = $wpdb->prefix . self::TABLE_NAME;
-		$sql = "CREATE TABLE $table_name (
-			start_time timestamp DEFAULT '0000-00-00 00:00:00' NOT NULL,
-			num_orders int(11) UNSIGNED DEFAULT 0 NOT NULL,
-			num_items_sold int(11) UNSIGNED DEFAULT 0 NOT NULL,
-			orders_gross_total double DEFAULT 0 NOT NULL,
-			orders_coupon_total double DEFAULT 0 NOT NULL,
-			orders_refund_total double DEFAULT 0 NOT NULL,
-			orders_tax_total double DEFAULT 0 NOT NULL,
-			orders_shipping_total double DEFAULT 0 NOT NULL,
-			orders_net_total double DEFAULT 0 NOT NULL,
-			PRIMARY KEY (start_time)
-		) $charset_collate;";
-		dbDelta( $sql );
 	}
 
 	/**

--- a/includes/class-wc-order-stats.php
+++ b/includes/class-wc-order-stats.php
@@ -72,7 +72,6 @@ class WC_Order_Stats {
 			'start_time' => 'MIN(start_time) as start_time',
 			'num_orders' => 'SUM(num_orders) as num_orders',
 			'num_items_sold' => 'SUM(num_items_sold) as num_items_sold',
-			'num_products_sold' => 'SUM(num_products_sold) as num_products_sold',
 			'orders_gross_total' => 'SUM(orders_gross_total) as orders_gross_total',
 			'orders_coupon_total' => 'SUM(orders_coupon_total) as orders_coupon_total',
 			'orders_refund_total' => 'SUM(orders_refund_total) as orders_refund_total',
@@ -124,7 +123,6 @@ class WC_Order_Stats {
 			start_time int(11) DEFAULT 0 NOT NULL,
 			num_orders int(11) UNSIGNED DEFAULT 0 NOT NULL,
 			num_items_sold int(11) UNSIGNED DEFAULT 0 NOT NULL,
-			num_products_sold int(11) UNSIGNED DEFAULT 0 NOT NULL,
 			orders_gross_total double DEFAULT 0 NOT NULL,
 			orders_coupon_total double DEFAULT 0 NOT NULL,
 			orders_refund_total double DEFAULT 0 NOT NULL,
@@ -223,7 +221,6 @@ class WC_Order_Stats {
 		$summary = array(
 			'num_orders'            => 0,
 			'num_items_sold'        => 0,
-			'num_products_sold'     => 0,
 			'orders_gross_total'    => 0.0,
 			'orders_coupon_total'   => 0.0,
 			'orders_refund_total'   => 0.0,
@@ -244,7 +241,6 @@ class WC_Order_Stats {
 		// @todo The gross/net total logic may need tweaking. Verify that logic is correct.
 		$summary['num_orders']            = count( $orders );
 		$summary['num_items_sold']        = self::get_num_items_sold( $orders );
-		$summary['num_products_sold']     = self::get_num_products_sold( $orders );
 		$summary['orders_gross_total']    = self::get_orders_gross_total( $orders );
 		$summary['orders_coupon_total']   = self::get_orders_coupon_total( $orders );
 		$summary['orders_refund_total']   = self::get_orders_refund_total( $orders );
@@ -270,7 +266,6 @@ class WC_Order_Stats {
 			'start_time'            => $start_time,
 			'num_orders'            => 0,
 			'num_items_sold'        => 0,
-			'num_products_sold'     => 0,
 			'orders_gross_total'    => 0.0,
 			'orders_coupon_total'   => 0.0,
 			'orders_refund_total'   => 0.0,
@@ -298,7 +293,6 @@ class WC_Order_Stats {
 			$table_name,
 			$data,
 			array(
-				'%d',
 				'%d',
 				'%d',
 				'%d',
@@ -333,34 +327,6 @@ class WC_Order_Stats {
 		}
 
 		return $num_items;
-	}
-
-	/**
-	 * Get number of products sold among all orders.
-	 *
-	 * @param array $orders Array of WC_Order objects.
-	 * @return int
-	 */
-	protected static function get_num_products_sold( $orders ) {
-		$counted_products = array();
-		$num_products = 0;
-
-		foreach ( $orders as $order ) {
-			$line_items = $order->get_items( 'line_item' );
-			foreach ( $line_items as $line_item ) {
-				if ( ! method_exists( $line_item, 'get_product_id' ) ) {
-					continue;
-				}
-
-				$product_id = $line_item->get_product_id();
-				if ( ! isset( $counted_products[ $product_id ] ) ) {
-					$counted_products[ $product_id ] = 1;
-					++$num_products;
-				}
-			}
-		}
-
-		return $num_products;
 	}
 
 	/**

--- a/includes/class-wc-order-stats.php
+++ b/includes/class-wc-order-stats.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * WooCommerce Stats
+ * WooCommerce Orders Stats
  *
- * Handles the stats database and API.
+ * Handles the orders stats database and API.
  *s
  * @package WooCommerce/Classes
  * @since   3.5.0
@@ -11,11 +11,11 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Stats class.
+ * Order stats class.
  */
-class WC_Stats {
+class WC_Order_Stats {
 
-	const TABLE_NAME = 'wc_stats';
+	const TABLE_NAME = 'wc_order_stats';
 
 	/**
 	 * Setup class.
@@ -23,6 +23,13 @@ class WC_Stats {
 	public function __construct() {
 		add_action( 'init', array( $this, 'install' ) ); // @todo Don't do this on every page load.
 		add_action( 'init', array( $this, 'populate_database_naive' ), 99 );
+
+		// next steps:
+		// background process for populating (LEFT OFF HERE)
+		// tool for repopulating everything
+		// scheduler for adding new lines each hour
+		// handling for when old orders are updated
+		// easy method(s) for querying the stored data
 	}
 
 	public function install() {
@@ -36,25 +43,6 @@ class WC_Stats {
 		}
 
 		$table_name = $wpdb->prefix . self::TABLE_NAME;
-	/*
-
-CREATE TABLE wp_wc_stats (
-	start_date datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
-	end_date datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
-	num_orders smallint(5) UNSIGNED DEFAULT 0 NOT NULL,
-	num_items_sold smallint(5) UNSIGNED DEFAULT 0 NOT NULL,
-	num_products_sold smallint(5) UNSIGNED DEFAULT 0 NOT NULL,
-	orders_gross_total double DEFAULT 0 NOT NULL,
-	orders_coupon_total double DEFAULT 0 NOT NULL,
-	orders_refund_total double DEFAULT 0 NOT NULL,
-	orders_tax_total double DEFAULT 0 NOT NULL,
-	orders_shipping_total double DEFAULT 0 NOT NULL,
-	orders_net_total double DEFAULT 0 NOT NULL,
-	average_order_total double DEFAULT 0 NOT NULL,
-	PRIMARY KEY (start_date)
-);
-	*/
-
 		$sql = "CREATE TABLE $table_name (
 			start_date datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
 			end_date datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
@@ -148,8 +136,6 @@ CREATE TABLE wp_wc_stats (
 	}
 
 	public function update( $start, $end, $data ) {
-		// if line doesnt exist add it
-		// if it exists update it
 		global $wpdb;
 		$table_name = $wpdb->prefix . self::TABLE_NAME;
 
@@ -175,6 +161,10 @@ CREATE TABLE wp_wc_stats (
 			)
 		);
 	}
+
+	/**
+	 * Calculation methods.
+	 */
 
 	private function get_num_items_sold( $orders ) {
 		$num_items = 0;
@@ -233,7 +223,11 @@ CREATE TABLE wp_wc_stats (
 
 	private function get_orders_refund_total( $orders ) {
 		$total = 0.0;
-		// @todo
+
+		foreach ( $orders as $order ) {
+			$total += $order->get_total_refunded();
+		}
+
 		return $total;
 	}
 
@@ -257,4 +251,4 @@ CREATE TABLE wp_wc_stats (
 		return $total;
 	}
 }
-new WC_Stats();
+new WC_Order_Stats();

--- a/includes/class-wc-order-stats.php
+++ b/includes/class-wc-order-stats.php
@@ -275,19 +275,6 @@ class WC_Order_Stats {
 		);
 		$data = wp_parse_args( $data, $defaults );
 
-		// Don't store rows that don't have useful information.
-		if ( ! $data['num_orders'] ) {
-			return $wpdb->delete(
-				$table_name,
-				array(
-					'start_time' => $start_time,
-				),
-				array(
-					'%d',
-				)
-			);
-		}
-
 		// Update or add the information to the DB.
 		return $wpdb->replace(
 			$table_name,

--- a/includes/class-wc-order-stats.php
+++ b/includes/class-wc-order-stats.php
@@ -120,7 +120,7 @@ class WC_Order_Stats {
 
 		$table_name = $wpdb->prefix . self::TABLE_NAME;
 		$sql = "CREATE TABLE $table_name (
-			start_time int(11) DEFAULT 0 NOT NULL,
+			start_time timestamp DEFAULT '0000-00-00 00:00:00' NOT NULL,
 			num_orders int(11) UNSIGNED DEFAULT 0 NOT NULL,
 			num_items_sold int(11) UNSIGNED DEFAULT 0 NOT NULL,
 			orders_gross_total double DEFAULT 0 NOT NULL,
@@ -261,6 +261,7 @@ class WC_Order_Stats {
 	public static function update( $start_time, $data ) {
 		global $wpdb;
 		$table_name = $wpdb->prefix . self::TABLE_NAME;
+		$start_time = date( 'Y-m-d H:00:00', $start_time );
 
 		$defaults = array(
 			'start_time'            => $start_time,
@@ -280,7 +281,7 @@ class WC_Order_Stats {
 			$table_name,
 			$data,
 			array(
-				'%d',
+				'%s',
 				'%d',
 				'%d',
 				'%f',

--- a/includes/class-wc-stats.php
+++ b/includes/class-wc-stats.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * WooCommerce Stats
+ *
+ * Handles the stats database and API.
+ *s
+ * @package WooCommerce/Classes
+ * @since   3.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stats class.
+ */
+class WC_Stats {
+
+	const TABLE_NAME = 'wc_stats';
+
+	/**
+	 * Setup class.
+	 */
+	public function __construct() {
+		add_action( 'init', array( $this, 'install' ) ); // @todo Don't do this on every page load.
+		//add_action( 'init', array( $this, 'populate_database_naive' ), 99 );
+	}
+
+	public function install() {
+		global $wpdb;
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		$collate = '';
+		if ( $wpdb->has_cap( 'collation' ) ) {
+			$collate = $wpdb->get_charset_collate();
+		}
+
+		$table_name = $wpdb->prefix . self::TABLE_NAME;
+	/*
+
+CREATE TABLE wp_wc_stats (
+	start_date datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
+	end_date datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
+	num_orders smallint(5) UNSIGNED DEFAULT 0 NOT NULL,
+	num_items_sold smallint(5) UNSIGNED DEFAULT 0 NOT NULL,
+	num_products_sold smallint(5) UNSIGNED DEFAULT 0 NOT NULL,
+	orders_gross_total double DEFAULT 0 NOT NULL,
+	orders_coupon_total double DEFAULT 0 NOT NULL,
+	orders_refund_total double DEFAULT 0 NOT NULL,
+	orders_tax_total double DEFAULT 0 NOT NULL,
+	orders_shipping_total double DEFAULT 0 NOT NULL,
+	orders_net_total double DEFAULT 0 NOT NULL,
+	average_order_total double DEFAULT 0 NOT NULL,
+	PRIMARY KEY (start_date)
+);
+	*/
+
+		$sql = "CREATE TABLE $table_name (
+			start_date datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
+			end_date datetime DEFAULT '0000-00-00 00:00:00' NOT NULL,
+			num_orders smallint(5) UNSIGNED DEFAULT 0 NOT NULL,
+			num_items_sold smallint(5) UNSIGNED DEFAULT 0 NOT NULL,
+			num_products_sold smallint(5) UNSIGNED DEFAULT 0 NOT NULL,
+			orders_gross_total double DEFAULT 0 NOT NULL,
+			orders_coupon_total double DEFAULT 0 NOT NULL,
+			orders_refund_total double DEFAULT 0 NOT NULL,
+			orders_tax_total double DEFAULT 0 NOT NULL,
+			orders_shipping_total double DEFAULT 0 NOT NULL,
+			orders_net_total double DEFAULT 0 NOT NULL,
+			average_order_total double DEFAULT 0 NOT NULL,
+			PRIMARY KEY (start_date)
+		) $charset_collate;";
+
+		require_once( ABSPATH . 'wp-admin/includes/upgrade.php' );
+		dbDelta( $sql );
+	}
+
+	public function populate_database() {
+		// @todo do it this way instead of the naive way.
+		// start a background process to update
+		// each go-through of the process will process one hour's worth of orders
+	}
+
+	public function populate_database_naive() {
+		// To get the first start time, get the oldest order and round the completion time down to the nearest hour.
+		$oldest = wc_get_orders( array(
+			'limit'   => 1,
+			'orderby' => 'date',
+			'order'   => 'ASC',
+			'status'  => 'completed',
+		) );
+
+		$oldest = $oldest ? reset( $oldest ) : false;
+		if ( ! $oldest ) {
+			return;
+		}
+
+		$start_time = strtotime( $oldest->get_date_created()->date( 'Y-m-d\TH:0:0O' ) );
+		$end_time = $start_time + HOUR_IN_SECONDS;
+
+		while ( $end_time < time() ) {
+			$summary = $this->summarize_orders( $start_time, $end_time );
+			$this->update( $start_time, $end_time, $summary );
+
+			$start_time = $end_time;
+			$end_time = $start_time + HOUR_IN_SECONDS;
+		}
+	}
+
+	public function summarize_orders( $start_time, $end_time ) {
+		$summary = array(
+			'num_orders'            => 0,
+			'num_items_sold'        => 0,
+			'num_products_sold'     => 0,
+			'orders_gross_total'    => 0.0,
+			'orders_coupon_total'   => 0.0,
+			'orders_refund_total'   => 0.0,
+			'orders_tax_total'      => 0.0,
+			'orders_shipping_total' => 0.0,
+			'orders_net_total'      => 0.0,
+			'average_order_total'   => 0.0,
+		);
+
+		$orders = wc_get_orders( array(
+			'limit' => -1,
+			'orderby' => 'date',
+			'order' => 'ASC',
+			'status' => 'completed',
+			'date_created' => $start_time . '...' . $end_time,
+		) );
+
+		$summary['num_orders'] = count( $orders );
+		$summary['num_items_sold'] = $this->get_num_items_sold( $orders );
+		$summary['num_products_sold'] = $this->get_num_products_sold( $orders );
+
+		var_dump( $summary );
+
+		return $summary;
+	}
+
+	public function update( $start, $end, $data ) {
+		// if line doesnt exist add it
+		// if it exists update it
+		global $wpdb;
+		$table_name = $wpdb->prefix . self::TABLE_NAME;
+
+		$data['start_date'] = date( 'Y-m-d H-0-0', $start );
+		$data['end_date'] = date( 'Y-m-d H-0-0', $end );
+
+		$result = $wpdb->replace(
+			$table_name,
+			$data,
+			array(
+				'%d',
+				'%d',
+				'%d',
+				'%f',
+				'%f',
+				'%f',
+				'%f',
+				'%f',
+				'%f',
+				'%f',
+				'%s',
+				'%s',
+			)
+		);
+		var_dump( $result );
+	}
+
+	private function get_num_items_sold( $orders ) {
+		$num_items = 0;
+
+		foreach ( $orders as $order ) {
+			$line_items = $order->get_items( 'line_item' );
+			foreach ( $line_items as $line_item ) {
+				$num_items += $line_item->get_quantity();
+			}
+		}
+
+		return $num_items;
+	}
+
+	private function get_num_products_sold( $orders ) {
+		$counted_products = array();
+		$num_products = 0;
+
+		foreach ( $orders as $order ) {
+			$line_items = $order->get_items( 'line_item' );
+			foreach ( $line_items as $line_item ) {
+				if ( ! method_exists( $line_item, 'get_product_id' ) ) {
+					continue;
+				}
+
+				$product_id = $line_item->get_product_id();
+				if ( ! isset( $counted_products[ $product_id ] ) ) {
+					$counted_products[ $product_id ] = 1;
+					++$num_products;
+				}
+			}
+		}
+
+		return $num_products;
+	}
+
+}
+new WC_Stats();

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -361,7 +361,7 @@ final class WooCommerce {
 		/**
 		 * Stats API
 		 */
-		include_once WC_ABSPATH . 'includes/class-wc-stats.php';
+		include_once WC_ABSPATH . 'includes/class-wc-order-stats.php';
 
 		/**
 		 * REST API.

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -359,6 +359,11 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/data-stores/class-wc-webhook-data-store.php';
 
 		/**
+		 * Stats API
+		 */
+		include_once WC_ABSPATH . 'includes/class-wc-stats.php';
+
+		/**
 		 * REST API.
 		 */
 		include_once WC_ABSPATH . 'includes/legacy/class-wc-legacy-api.php';

--- a/tests/unit-tests/order/class-wc-tests-order-stats.php
+++ b/tests/unit-tests/order/class-wc-tests-order-stats.php
@@ -12,7 +12,7 @@ class WC_Tests_Order_Stats extends WC_Unit_Test_Case {
 	 * @since 3.5.0
 	 */
 	public function test_populate_and_query() {
-		// Populate all of the data.
+		//Populate all of the data.
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product' );
 		$product->set_regular_price( 25 );

--- a/tests/unit-tests/order/class-wc-tests-order-stats.php
+++ b/tests/unit-tests/order/class-wc-tests-order-stats.php
@@ -12,7 +12,7 @@ class WC_Tests_Order_Stats extends WC_Unit_Test_Case {
 	 * @since 3.5.0
 	 */
 	public function test_populate_and_query() {
-		//Populate all of the data.
+		// Populate all of the data.
 		$product = new WC_Product_Simple();
 		$product->set_name( 'Test Product' );
 		$product->set_regular_price( 25 );

--- a/tests/unit-tests/order/class-wc-tests-order-stats.php
+++ b/tests/unit-tests/order/class-wc-tests-order-stats.php
@@ -1,0 +1,178 @@
+<?php
+
+/**
+ * Order stats tests.
+ * @package WooCommerce\Tests\Orders
+ */
+class WC_Tests_Order_Stats extends WC_Unit_Test_Case {
+
+	/**
+	 * Test the calculations and querying works correctly for the base case of 1 order.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_populate_and_query() {
+		// Populate all of the data.
+		$product = new WC_Product_Simple();
+		$product->set_name( 'Test Product' );
+		$product->set_regular_price( 25 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order( 1, $product );
+		$order->set_status( 'completed' );
+		$order->set_shipping_total( 10 );
+		$order->set_discount_total( 20 );
+		$order->set_discount_tax( 0 );
+		$order->set_cart_tax( 5 );
+		$order->set_shipping_tax( 2 );
+		$order->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
+		$order->save();
+
+		// Test the calculations.
+		$start_time = time() - HOUR_IN_SECONDS;
+		$end_time = time() + 1;
+
+		$data = WC_Order_Stats::summarize_orders( $start_time, $end_time );
+
+		$expected_data = array(
+			'num_orders'            => 1,
+			'num_items_sold'        => 4,
+			'orders_gross_total'    => 97.0,
+			'orders_coupon_total'   => 20.0,
+			'orders_refund_total'   => 0.0,
+			'orders_tax_total'      => 7.0,
+			'orders_shipping_total' => 10.0,
+			'orders_net_total'      => 80.0,
+		);
+		$this->assertEquals( $expected_data, $data );
+
+		WC_Order_Stats::update( $start_time, $data );
+
+		$stats = WC_Order_Stats::query( $start_time, $end_time );
+		$first_hour_stats = $stats[0];
+		$expected_stats = array(
+			'start_time'            => date( 'Y-m-d H:00:00', $start_time ),
+			'num_orders'            => 1,
+			'num_items_sold'        => 4,
+			'orders_gross_total'    => 97,
+			'orders_coupon_total'   => 20,
+			'orders_refund_total'   => 0,
+			'orders_tax_total'      => 7,
+			'orders_shipping_total' => 10,
+			'orders_net_total'      => 80,
+		);
+		$this->assertEquals( $expected_stats, $first_hour_stats );
+	}
+
+	/**
+	 * Test the calculations and querying works correctly for the case of multiple orders.
+	 */
+	public function test_populate_and_query_multiple_intervals() {
+		// Populate all of the data.
+		$product1 = new WC_Product_Simple();
+		$product1->set_name( 'Test Product' );
+		$product1->set_regular_price( 25 );
+		$product1->save();
+
+		$product2 = new WC_Product_Simple();
+		$product2->set_name( 'Test Product 2' );
+		$product2->set_regular_price( 10 );
+		$product2->save();
+
+		$order1_time = time() - ( 2 * HOUR_IN_SECONDS );
+
+		$order1 = WC_Helper_Order::create_order( 1, $product1 );
+		$order1->set_date_created( $order1_time );
+		$order1->set_status( 'completed' );
+		$order1->set_shipping_total( 10 );
+		$order1->set_discount_total( 20 );
+		$order1->set_discount_tax( 0 );
+		$order1->set_cart_tax( 5 );
+		$order1->set_shipping_tax( 2 );
+		$order1->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
+		$order1->save();
+
+		$order2_time = time() - HOUR_IN_SECONDS + 1;
+
+		$order2 = WC_Helper_Order::create_order( 1, $product2 );
+		$order2->set_date_created( $order2_time );
+		$order2->set_status( 'processing' );
+		$order2->set_shipping_total( 5 );
+		$order2->set_discount_total( 0 );
+		$order2->set_discount_tax( 0 );
+		$order2->set_cart_tax( 3 );
+		$order2->set_shipping_tax( 1 );
+		$order2->set_total( 49 ); // $10x4 products + $5 shipping + $4 tax.
+		$order2->save();
+
+		// Test the calculations.
+		$start_time = $order1_time;
+		$end_time = $order2_time + HOUR_IN_SECONDS;
+
+		// Test aggregate raw summary data for both orders.
+		$data = WC_Order_Stats::summarize_orders( $start_time, $end_time );
+		$expected_data = array(
+			'num_orders'            => 2,
+			'num_items_sold'        => 8,
+			'orders_gross_total'    => 146.0,
+			'orders_coupon_total'   => 20.0,
+			'orders_refund_total'   => 0,
+			'orders_tax_total'      => 11.0,
+			'orders_shipping_total' => 15.0,
+			'orders_net_total'      => 120.0,
+		);
+		$this->assertEquals( $expected_data, $data );
+
+		// Calculate stats for each hour and save to DB.
+		$data = WC_Order_Stats::summarize_orders( $order1_time, $order1_time + HOUR_IN_SECONDS );
+		WC_Order_Stats::update( $order1_time, $data );
+		$data = WC_Order_Stats::summarize_orders( $order2_time, $order2_time + HOUR_IN_SECONDS );
+		WC_Order_Stats::update( $order2_time, $data );
+
+		// Test querying by hourly intervals.
+		$stats = WC_Order_Stats::query( $start_time, $end_time );
+		$first_hour_stats = $stats[0];
+		$expected_first_hour_stats = array(
+			'start_time'            => date( 'Y-m-d H:00:00', $order1_time ),
+			'num_orders'            => 1,
+			'num_items_sold'        => 4,
+			'orders_gross_total'    => 97,
+			'orders_coupon_total'   => 20,
+			'orders_refund_total'   => 0,
+			'orders_tax_total'      => 7,
+			'orders_shipping_total' => 10,
+			'orders_net_total'      => 80,
+		);
+		$this->assertEquals( $expected_first_hour_stats, $first_hour_stats );
+
+		$second_hour_stats = $stats[1];
+		$expected_second_hour_stats = array(
+			'start_time'            => date( 'Y-m-d H:00:00', $order2_time ),
+			'num_orders'            => 1,
+			'num_items_sold'        => 4,
+			'orders_gross_total'    => 49,
+			'orders_coupon_total'   => 0,
+			'orders_refund_total'   => 0,
+			'orders_tax_total'      => 4,
+			'orders_shipping_total' => 5,
+			'orders_net_total'      => 40,
+		);
+		$this->assertEquals( $expected_second_hour_stats, $second_hour_stats );
+
+		// Test querying by a weekly interval.
+		$stats = WC_Order_Stats::query( $start_time, $end_time, array( 'interval' => 'week' ) );
+		$first_week_stats = $stats[0];
+		$expected_first_week_stats = array(
+			'start_time'            => date( 'Y-m-d H:00:00', $order1_time ),
+			'num_orders'            => '2',
+			'num_items_sold'        => '8',
+			'orders_gross_total'    => '146',
+			'orders_coupon_total'   => '20',
+			'orders_refund_total'   => '0',
+			'orders_tax_total'      => '11',
+			'orders_shipping_total' => '15',
+			'orders_net_total'      => '120',
+		);
+		$this->assertEquals( $expected_first_week_stats, $first_week_stats );
+	}
+}

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 3.4.0-rc.1
+ * Version: 3.5.0-dev
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
This should be a production-ready version of the order stats lookup table. 

**It works like this:**
1. Creates a new table for storing order stats data at the hour level.
2. Using background processes, in the middle of each hour calculate the stats for the previous hour and any hours with orders modified in the last hour. Only store info for hours that have meaningful info to store (orders placed).
3. There is a `query` method that can retrieve and aggregate the data so you can get e.g. stats for the last week aggregated by day.

**To easily test the prototype:**
- Run unit tests.
or
- Deactivate & reactivate WC to build the tables. Use the repopulate tool in the WC system tools to build order stats. Examine the DB in mySQL.

**Next steps once this is merged:**
- Migrate the background process to use Action Scheduler (see #20030) 
- Update routine to pre-populate the table when user upgrades to 3.5 (I'm waiting until all the lookup tables are done so we can have one update routine for them all).