### PR TITLE
Wrapped 'FREE' with a filter to allow different use cases

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1405,7 +1405,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				return $return;
 			}
 		} else {
-			return apply_filters( 'woocommerce_shipping_cost_returns_free', __( 'Free!', 'woocommerce' ) );
+			return apply_filters( 'woocommerce_cart_shipping_cost_returns_free', __( 'Free!', 'woocommerce' ) );
 		}
 	}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1385,28 +1385,28 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string price or string for the shipping total
 	 */
 	public function get_cart_shipping_total() {
+		
+		// Default total assumes Free shipping
+		$total = __( 'Free!', 'woocommerce' );
+		
 		if ( 0 < $this->get_shipping_total() ) {
 
 			if ( $this->display_prices_including_tax() ) {
-				$return = wc_price( $this->shipping_total + $this->shipping_tax_total );
+				$total = wc_price( $this->shipping_total + $this->shipping_tax_total );
 
 				if ( $this->shipping_tax_total > 0 && ! wc_prices_include_tax() ) {
-					$return .= ' <small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>';
+					$total .= ' <small class="tax_label">' . WC()->countries->inc_tax_or_vat() . '</small>';
 				}
-
-				return $return;
 			} else {
-				$return = wc_price( $this->shipping_total );
+				$total = wc_price( $this->shipping_total );
 
 				if ( $this->shipping_tax_total > 0 && wc_prices_include_tax() ) {
-					$return .= ' <small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>';
+					$total .= ' <small class="tax_label">' . WC()->countries->ex_tax_or_vat() . '</small>';
 				}
-
-				return $return;
 			}
-		} else {
-			return apply_filters( 'woocommerce_cart_shipping_cost_returns_free', __( 'Free!', 'woocommerce' ), $this );
 		}
+		
+		return apply_filters( 'woocommerce_cart_shipping_total', $total, $this );
 	}
 
 	/**

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1405,7 +1405,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				return $return;
 			}
 		} else {
-			return apply_filters( 'woocommerce_cart_shipping_cost_returns_free', __( 'Free!', 'woocommerce' ) );
+			return apply_filters( 'woocommerce_cart_shipping_cost_returns_free', __( 'Free!', 'woocommerce' ), $this );
 		}
 	}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1385,10 +1385,10 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string price or string for the shipping total
 	 */
 	public function get_cart_shipping_total() {
-		
-		// Default total assumes Free shipping
+
+		// Default total assumes Free shipping.
 		$total = __( 'Free!', 'woocommerce' );
-		
+
 		if ( 0 < $this->get_shipping_total() ) {
 
 			if ( $this->display_prices_including_tax() ) {
@@ -1405,7 +1405,6 @@ class WC_Cart extends WC_Legacy_Cart {
 				}
 			}
 		}
-		
 		return apply_filters( 'woocommerce_cart_shipping_total', $total, $this );
 	}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1405,7 +1405,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				return $return;
 			}
 		} else {
-			return __( 'Free!', 'woocommerce' );
+			return apply_filters( 'woocommerce_shipping_cost_returns_free', __( 'Free!', 'woocommerce' ) );
 		}
 	}
 


### PR DESCRIPTION
...for no shipping rate returning

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Wrap "FREE" with a filter to be able to change the text and have it still translatable.

Closes #20590  .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added `woocommerce_shipping_cost_returns_free` filter to shipping rates that return no rate