### PR TITLE
fix - State dropdown not showing exact match

### DIFF
--- a/assets/js/selectWoo/selectWoo.full.js
+++ b/assets/js/selectWoo/selectWoo.full.js
@@ -4961,7 +4961,7 @@ S2.define('select2/defaults',[
       var term = stripDiacritics(params.term).toUpperCase();
 
       // Check if the text contains the term
-      if (original.indexOf(term) > -1) {
+      if ( original.indexOf(term) == 0 ) {
         return data;
       }
 


### PR DESCRIPTION
Fixes ref #20575 

Afer researching and look https://select2.org/searching#customizing-how-results-are-matched. I found instead of original.indexOf(term) > -1 , original.indexOf(term) == 0 worked. So would you please check for the same and let me know if any changes required.

Thanks 


### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
