### PR TITLE
Refactor "order again"

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -29,7 +29,7 @@ class WC_AJAX {
 	 * @return string
 	 */
 	public static function get_endpoint( $request = '' ) {
-		return esc_url_raw( apply_filters( 'woocommerce_ajax_get_endpoint', add_query_arg( 'wc-ajax', $request, remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart' ), home_url( '/', 'relative' ) ) ), $request ) );
+		return esc_url_raw( apply_filters( 'woocommerce_ajax_get_endpoint', add_query_arg( 'wc-ajax', $request, remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart', 'order_again', '_wpnonce' ), home_url( '/', 'relative' ) ) ), $request ) );
 	}
 
 	/**

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -47,11 +47,11 @@ final class WC_Cart_Session {
 		add_action( 'wp_loaded', array( $this, 'get_cart_from_session' ) );
 		add_action( 'woocommerce_cart_emptied', array( $this, 'destroy_cart_session' ) );
 		add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 );
-		add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 );
 		add_action( 'woocommerce_add_to_cart', array( $this, 'maybe_set_cart_cookies' ) );
 		add_action( 'woocommerce_after_calculate_totals', array( $this, 'set_session' ) );
 		add_action( 'woocommerce_cart_loaded_from_session', array( $this, 'set_session' ) );
 		add_action( 'woocommerce_removed_coupon', array( $this, 'set_session' ) );
+		add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 );
 		add_action( 'woocommerce_cart_updated', array( $this, 'persistent_cart_update' ) );
 	}
 
@@ -61,74 +61,71 @@ final class WC_Cart_Session {
 	 * @since 3.2.0
 	 */
 	public function get_cart_from_session() {
-		// Flag to indicate the stored cart should be updated.
-		$update_cart_session = false;
-		$totals              = WC()->session->get( 'cart_totals', null );
-		$cart                = WC()->session->get( 'cart', null );
-
-		$this->cart->set_totals( $totals );
+		$this->cart->set_totals( WC()->session->get( 'cart_totals', null ) );
 		$this->cart->set_applied_coupons( WC()->session->get( 'applied_coupons', array() ) );
 		$this->cart->set_coupon_discount_totals( WC()->session->get( 'coupon_discount_totals', array() ) );
 		$this->cart->set_coupon_discount_tax_totals( WC()->session->get( 'coupon_discount_tax_totals', array() ) );
 		$this->cart->set_removed_cart_contents( WC()->session->get( 'removed_cart_contents', array() ) );
 
-		if ( apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
-			$saved_cart = get_user_meta( get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id(), true );
-		} else {
-			$saved_cart = false;
+		$update_cart_session = false; // Flag to indicate the stored cart should be updated.
+		$cart                = WC()->session->get( 'cart', null );
+		$merge_saved_cart    = (bool) get_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login', true );
+
+		// Merge saved cart with current cart.
+		if ( is_null( $cart ) || $merge_saved_cart ) {
+			$saved_cart          = $this->get_saved_cart();
+			$cart                = is_null( $cart ) ? array() : $cart;
+			$cart                = array_merge( $saved_cart, $cart );
+			$update_cart_session = true;
+
+			delete_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login' );
 		}
 
-		if ( is_null( $cart ) && $saved_cart ) {
-			$cart                = $saved_cart['cart'];
-			$update_cart_session = true;
-		} elseif ( is_null( $cart ) ) {
-			$cart = array();
-		} elseif ( is_array( $cart ) && $saved_cart ) {
-			$cart                = array_merge( $saved_cart['cart'], $cart );
-			$update_cart_session = true;
+		// Populate cart from order.
+		if ( isset( $_GET['order_again'], $_GET['_wpnonce'] ) && is_user_logged_in() && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'woocommerce-order_again' ) ) { // WPCS: input var ok, sanitization ok.
+			$cart = $this->populate_cart_from_order( absint( $_GET['order_again'] ), $cart ); // WPCS: input var ok.
 		}
 
-		if ( is_array( $cart ) ) {
-			$cart_contents = array();
+		// Prime caches to reduce future queries.
+		if ( is_callable( '_prime_post_caches' ) ) {
+			_prime_post_caches( wp_list_pluck( $cart, 'product_id' ) );
+		}
 
-			// Prime caches to reduce future queries.
-			if ( is_callable( '_prime_post_caches' ) ) {
-				_prime_post_caches( wp_list_pluck( $cart, 'product_id' ) );
+		$cart_contents = array();
+
+		foreach ( $cart as $key => $values ) {
+			$product = wc_get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'] );
+
+			if ( ! is_customize_preview() && 'customize-preview' === $key ) {
+				continue;
 			}
 
-			foreach ( $cart as $key => $values ) {
-				$product = wc_get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'] );
+			if ( ! empty( $product ) && $product->exists() && $values['quantity'] > 0 ) {
 
-				if ( ! is_customize_preview() && 'customize-preview' === $key ) {
-					continue;
-				}
+				if ( ! $product->is_purchasable() ) {
+					$update_cart_session = true;
+					/* translators: %s: product name */
+					wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $product->get_name() ), 'error' );
+					do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
 
-				if ( ! empty( $product ) && $product->exists() && $values['quantity'] > 0 ) {
+				} elseif ( ! empty( $values['data_hash'] ) && ! hash_equals( $values['data_hash'], wc_get_cart_item_data_hash( $product ) ) ) { // phpcs:ignore PHPCompatibility.PHP.NewFunctions.hash_equalsFound
+					$update_cart_session = true;
+					/* translators: %1$s: product name. %2$s product permalink */
+					wc_add_notice( sprintf( __( '%1$s has been removed from your cart because it has since been modified. You can add it back to your cart <a href="%2$s">here</a>.', 'woocommerce' ), $product->get_name(), $product->get_permalink() ), 'notice' );
+					do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
 
-					if ( ! $product->is_purchasable() ) {
-						$update_cart_session = true;
-						/* translators: %s: product name */
-						wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $product->get_name() ), 'error' );
-						do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
+				} else {
+					// Put session data into array. Run through filter so other plugins can load their own session data.
+					$session_data = array_merge(
+						$values, array(
+							'data' => $product,
+						)
+					);
 
-					} elseif ( ! empty( $values['data_hash'] ) && ! hash_equals( $values['data_hash'], wc_get_cart_item_data_hash( $product ) ) ) { // phpcs:ignore PHPCompatibility.PHP.NewFunctions.hash_equalsFound
-						$update_cart_session = true;
-						/* translators: %1$s: product name. %2$s product permalink */
-						wc_add_notice( sprintf( __( '%1$s has been removed from your cart because it has since been modified. You can add it back to your cart <a href="%2$s">here</a>.', 'woocommerce' ), $product->get_name(), $product->get_permalink() ), 'notice' );
-						do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
+					$cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', $session_data, $values, $key );
 
-					} else {
-						// Put session data into array. Run through filter so other plugins can load their own session data.
-						$session_data          = array_merge(
-							$values, array(
-								'data' => $product,
-							)
-						);
-						$cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', $session_data, $values, $key );
-
-						// Add to cart right away so the product is visible in woocommerce_get_cart_item_from_session hook.
-						$this->cart->set_cart_contents( $cart_contents );
-					}
+					// Add to cart right away so the product is visible in woocommerce_get_cart_item_from_session hook.
+					$this->cart->set_cart_contents( $cart_contents );
 				}
 			}
 		}
@@ -218,7 +215,7 @@ final class WC_Cart_Session {
 	 * Delete the persistent cart permanently.
 	 */
 	public function persistent_cart_destroy() {
-		if ( get_current_user_id() && apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
+		if ( get_current_user_id() ) {
 			delete_user_meta( get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id() );
 		}
 	}
@@ -238,5 +235,126 @@ final class WC_Cart_Session {
 			wc_setcookie( 'woocommerce_cart_hash', '', time() - HOUR_IN_SECONDS );
 		}
 		do_action( 'woocommerce_set_cart_cookies', $set );
+	}
+
+	/**
+	 * Get the persistent cart from the database.
+	 *
+	 * @access private
+	 * @since  3.5.0
+	 * @return array
+	 */
+	private function get_saved_cart() {
+		$saved_cart = array();
+
+		if ( apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
+			$saved_cart_meta = get_user_meta( get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id(), true );
+
+			if ( isset( $saved_cart_meta['cart'] ) ) {
+				$saved_cart = array_filter( (array) $saved_cart_meta['cart'] );
+			}
+		}
+
+		return $saved_cart;
+	}
+
+	/**
+	 * Get a cart from an order, if user has permission.
+	 *
+	 * @access private
+	 * @since  3.5.0
+	 * @param int   $order_id Order ID to try to load.
+	 * @param array $cart Current cart array.
+	 * @return array
+	 */
+	private function populate_cart_from_order( $order_id, $cart ) {
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order->get_id() || ! $order->has_status( apply_filters( 'woocommerce_valid_order_statuses_for_order_again', array( 'completed' ) ) ) || ! current_user_can( 'order_again', $order->get_id() ) ) {
+			return;
+		}
+
+		if ( apply_filters( 'woocommerce_empty_cart_when_order_again', true ) ) {
+			$cart = array();
+		}
+
+		$inital_cart_size = count( $cart );
+		$order_items      = $order->get_items();
+
+		foreach ( $order_items as $item ) {
+			$product_id     = (int) apply_filters( 'woocommerce_add_to_cart_product_id', $item->get_product_id() );
+			$quantity       = $item->get_quantity();
+			$variation_id   = (int) $item->get_variation_id();
+			$variations     = array();
+			$cart_item_data = apply_filters( 'woocommerce_order_again_cart_item_data', array(), $item, $order );
+			$product        = $item->get_product();
+
+			if ( ! $product ) {
+				continue;
+			}
+
+			// Prevent reordering variable products if no selected variation.
+			if ( ! $variation_id && $product->is_type( 'variable' ) ) {
+				continue;
+			}
+
+			foreach ( $item->get_meta_data() as $meta ) {
+				if ( taxonomy_is_product_attribute( $meta->key ) ) {
+					$term                     = get_term_by( 'slug', $meta->value, $meta->key );
+					$variations[ $meta->key ] = $term ? $term->name : $meta->value;
+				} elseif ( meta_is_product_attribute( $meta->key, $meta->value, $product_id ) ) {
+					$variations[ $meta->key ] = $meta->value;
+				}
+			}
+
+			if ( ! apply_filters( 'woocommerce_add_to_cart_validation', true, $product_id, $quantity, $variation_id, $variations, $cart_item_data ) ) {
+				continue;
+			}
+
+			// Add to cart directly.
+			$cart_id          = WC()->cart->generate_cart_id( $product_id, $variation_id, $variations, $cart_item_data );
+			$product_data     = wc_get_product( $variation_id ? $variation_id : $product_id );
+			$cart[ $cart_id ] = apply_filters(
+				'woocommerce_add_cart_item', array_merge(
+					$cart_item_data, array(
+						'key'          => $cart_id,
+						'product_id'   => $product_id,
+						'variation_id' => $variation_id,
+						'variation'    => $variations,
+						'quantity'     => $quantity,
+						'data'         => $product_data,
+						'data_hash'    => wc_get_cart_item_data_hash( $product_data ),
+					)
+				), $cart_id
+			);
+		}
+
+		do_action( 'woocommerce_ordered_again', $order->get_id() );
+
+		$num_items_in_cart           = count( $cart );
+		$num_items_in_original_order = count( $order_items );
+		$num_items_added             = $num_items_in_cart - $inital_cart_size;
+
+		if ( $num_items_in_original_order > $num_items_added ) {
+			wc_add_notice(
+				sprintf(
+					// Translators: %d item count.
+					_n(
+						'%d item from your previous order is currently unavailable and could not be added to your cart.',
+						'%d items from your previous order are currently unavailable and could not be added to your cart.',
+						$num_items_added,
+						'woocommerce'
+					),
+					$num_items_added
+				),
+				'error'
+			);
+		}
+
+		if ( 0 < $num_items_added ) {
+			wc_add_notice( __( 'The cart has been filled with the items from your previous order.', 'woocommerce' ) );
+		}
+
+		return $cart;
 	}
 }

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -223,7 +223,6 @@ final class WC_Cart_Session {
 	/**
 	 * Set cart hash cookie and items in cart.
 	 *
-	 * @access private
 	 * @param bool $set Should cookies be set (true) or unset.
 	 */
 	private function set_cart_cookies( $set = true ) {
@@ -240,7 +239,6 @@ final class WC_Cart_Session {
 	/**
 	 * Get the persistent cart from the database.
 	 *
-	 * @access private
 	 * @since  3.5.0
 	 * @return array
 	 */
@@ -261,7 +259,6 @@ final class WC_Cart_Session {
 	/**
 	 * Get a cart from an order, if user has permission.
 	 *
-	 * @access private
 	 * @since  3.5.0
 	 * @param int   $order_id Order ID to try to load.
 	 * @param array $cart Current cart array.
@@ -338,7 +335,7 @@ final class WC_Cart_Session {
 		if ( $num_items_in_original_order > $num_items_added ) {
 			wc_add_notice(
 				sprintf(
-					// Translators: %d item count.
+					/* translators: %d item count */
 					_n(
 						'%d item from your previous order is currently unavailable and could not be added to your cart.',
 						'%d items from your previous order are currently unavailable and could not be added to your cart.',

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -567,7 +567,7 @@ class WC_Form_Handler {
 				wc_add_notice( $removed_notice );
 			}
 
-			$referer  = wp_get_referer() ? remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart' ), add_query_arg( 'removed_item', '1', wp_get_referer() ) ) : wc_get_cart_url();
+			$referer  = wp_get_referer() ? remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart', 'order_again', '_wpnonce' ), add_query_arg( 'removed_item', '1', wp_get_referer() ) ) : wc_get_cart_url();
 			wp_safe_redirect( $referer );
 			exit;
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2429,7 +2429,8 @@ if ( ! function_exists( 'woocommerce_order_again_button' ) ) {
 		}
 
 		wc_get_template( 'order/order-again.php', array(
-			'order' => $order,
+			'order'           => $order,
+			'order_again_url' => wp_nonce_url( add_query_arg( 'order_again', $order->get_id(), wc_get_cart_url() ), 'woocommerce-order_again' ),
 		) );
 	}
 }

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -683,6 +683,7 @@ add_action( 'wp_login', 'wc_maybe_store_user_agent', 10, 2 );
  */
 function wc_user_logged_in( $user_login, $user ) {
 	wc_update_user_last_active( $user->ID );
+	update_user_meta( $user->ID, '_woocommerce_load_saved_cart_after_login', 1 );
 }
 add_action( 'wp_login', 'wc_user_logged_in', 10, 2 );
 

--- a/templates/order/order-again.php
+++ b/templates/order/order-again.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 2.5.0
+ * @version 3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/order/order-again.php
+++ b/templates/order/order-again.php
@@ -10,17 +10,14 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
+ * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 2.3.0
+ * @version 2.5.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
+defined( 'ABSPATH' ) || exit;
 ?>
 
 <p class="order-again">
-	<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'order_again', $order->get_id() ) , 'woocommerce-order_again' ) ); ?>" class="button"><?php _e( 'Order again', 'woocommerce' ); ?></a>
+	<a href="<?php echo esc_url( $order_again_url ); ?>" class="button"><?php esc_html_e( 'Order again', 'woocommerce' ); ?></a>
 </p>


### PR DESCRIPTION
I've been looking at the form handlers and trying to refactor parts. Rather than do all at once, I'm splitting this off into chunks. In this PR, I've moved 'order again' out (this is not a form).

- Moves order again logic into cart session handler
- Session handler loads order and merges with cart if used
- Session handler was merging persistent cart on every page load. I've fixed that with an item of meta added on login.

### How to test the changes in this Pull Request:

1. Place orders, ensure some are completed.
2. Go to my account > orders > view and test 'order again' button.
3. Cart should clear, items should be re-added to cart.

additionally, 

1. Add items to cart whilst logged in.
2. Logout. Cart is empty.
3. Login. Cart is back.
4. Repeat test but this time add some more items whilst logged out.
5. Login. Cart is merged with logged out cart.