### PR TITLE
Refactor - form handler

### DIFF
--- a/includes/abstracts/abstract-wc-form-handler.php
+++ b/includes/abstracts/abstract-wc-form-handler.php
@@ -1,0 +1,114 @@
+<?php
+/**
+ * Form handler abstract class.
+ *
+ * @package WooCommerce/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Abstract_WC_Form_Handler class.
+ *
+ * @since 3.5.0
+ */
+abstract class Abstract_WC_Form_Handler {
+
+	/**
+	 * Nonce key. Nonce name and key derived from this value.
+	 *
+	 * @var string
+	 */
+	protected $nonce_key = '';
+
+	/**
+	 * Posted data.
+	 *
+	 * @var array
+	 */
+	protected $post_data = '';
+
+	/**
+	 * Process the form. Subclasses must extend this.
+	 *
+	 * @return void
+	 */
+	abstract public function process();
+
+	/**
+	 * Set the raw post data to process.
+	 *
+	 * @param array $post_data Post data (raw).
+	 */
+	public function set_post_data( $post_data ) {
+		$this->post_data = (array) $post_data;
+	}
+
+	/**
+	 * Get an item of post data, and optionally provide a default value.
+	 *
+	 * @param boolean $key Key to get.
+	 * @param string  $default Default value to fallback to.
+	 * @return mixed
+	 */
+	public function get_post_data( $key = false, $default = '' ) {
+		if ( false === $key ) {
+			return $this->post_data;
+		}
+		return isset( $this->post_data[ $key ] ) ? $this->post_data[ $key ] : $default;
+	}
+
+	/**
+	 * Get a global WP query var.
+	 *
+	 * @param boolean $key Key to get.
+	 * @param string  $default Default value to fallback to.
+	 * @return mixed
+	 */
+	public function get_wp_query_var( $key = false, $default = '' ) {
+		global $wp;
+
+		return isset( $wp->query_vars[ $key ] ) ? $wp->query_vars[ $key ] : $default;
+	}
+
+	/**
+	 * Handle error.
+	 *
+	 * @param Exception $e Exception object.
+	 */
+	public function handle_error( $e ) {
+		wc_add_notice( $e->getMessage(), 'error' );
+	}
+
+	/**
+	 * Perform a redirect.
+	 *
+	 * @param string $url URL to redirect to.
+	 */
+	protected function redirect_to( $url ) {
+		wp_redirect( $url );
+		exit;
+	}
+
+	/**
+	 * Check nonce is valid.
+	 *
+	 * @throws Exception On error.
+	 */
+	protected function check_nonce() {
+		if ( ! $this->is_nonce_valid() ) {
+			throw new Exception( __( 'Unable to process form. Please try again.', 'woocommerce' ) );
+		}
+	}
+
+	/**
+	 * Check posted nonce is valid.
+	 *
+	 * @return bool
+	 */
+	protected function is_nonce_valid() {
+		$nonce_value = isset( $this->post_data[ $this->nonce_key . '-nonce' ] ) ? $this->post_data[ $this->nonce_key . '-nonce' ] : false;
+
+		return wp_verify_nonce( $nonce_value, $this->nonce_key );
+	}
+}

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -29,7 +29,7 @@ class WC_AJAX {
 	 * @return string
 	 */
 	public static function get_endpoint( $request = '' ) {
-		return esc_url_raw( apply_filters( 'woocommerce_ajax_get_endpoint', add_query_arg( 'wc-ajax', $request, remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart' ), home_url( '/', 'relative' ) ) ), $request ) );
+		return esc_url_raw( apply_filters( 'woocommerce_ajax_get_endpoint', add_query_arg( 'wc-ajax', $request, remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart', 'order_again', '_wpnonce' ), home_url( '/', 'relative' ) ) ), $request ) );
 	}
 
 	/**

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -47,11 +47,11 @@ final class WC_Cart_Session {
 		add_action( 'wp_loaded', array( $this, 'get_cart_from_session' ) );
 		add_action( 'woocommerce_cart_emptied', array( $this, 'destroy_cart_session' ) );
 		add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 );
-		add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 );
 		add_action( 'woocommerce_add_to_cart', array( $this, 'maybe_set_cart_cookies' ) );
 		add_action( 'woocommerce_after_calculate_totals', array( $this, 'set_session' ) );
 		add_action( 'woocommerce_cart_loaded_from_session', array( $this, 'set_session' ) );
 		add_action( 'woocommerce_removed_coupon', array( $this, 'set_session' ) );
+		add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 );
 		add_action( 'woocommerce_cart_updated', array( $this, 'persistent_cart_update' ) );
 	}
 
@@ -61,74 +61,71 @@ final class WC_Cart_Session {
 	 * @since 3.2.0
 	 */
 	public function get_cart_from_session() {
-		// Flag to indicate the stored cart should be updated.
-		$update_cart_session = false;
-		$totals              = WC()->session->get( 'cart_totals', null );
-		$cart                = WC()->session->get( 'cart', null );
-
-		$this->cart->set_totals( $totals );
+		$this->cart->set_totals( WC()->session->get( 'cart_totals', null ) );
 		$this->cart->set_applied_coupons( WC()->session->get( 'applied_coupons', array() ) );
 		$this->cart->set_coupon_discount_totals( WC()->session->get( 'coupon_discount_totals', array() ) );
 		$this->cart->set_coupon_discount_tax_totals( WC()->session->get( 'coupon_discount_tax_totals', array() ) );
 		$this->cart->set_removed_cart_contents( WC()->session->get( 'removed_cart_contents', array() ) );
 
-		if ( apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
-			$saved_cart = get_user_meta( get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id(), true );
-		} else {
-			$saved_cart = false;
+		$update_cart_session = false; // Flag to indicate the stored cart should be updated.
+		$cart                = WC()->session->get( 'cart', null );
+		$merge_saved_cart    = (bool) get_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login', true );
+
+		// Merge saved cart with current cart.
+		if ( is_null( $cart ) || $merge_saved_cart ) {
+			$saved_cart          = $this->get_saved_cart();
+			$cart                = is_null( $cart ) ? array() : $cart;
+			$cart                = array_merge( $saved_cart, $cart );
+			$update_cart_session = true;
+
+			delete_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login' );
 		}
 
-		if ( is_null( $cart ) && $saved_cart ) {
-			$cart                = $saved_cart['cart'];
-			$update_cart_session = true;
-		} elseif ( is_null( $cart ) ) {
-			$cart = array();
-		} elseif ( is_array( $cart ) && $saved_cart ) {
-			$cart                = array_merge( $saved_cart['cart'], $cart );
-			$update_cart_session = true;
+		// Populate cart from order.
+		if ( isset( $_GET['order_again'], $_GET['_wpnonce'] ) && is_user_logged_in() && wp_verify_nonce( wp_unslash( $_GET['_wpnonce'] ), 'woocommerce-order_again' ) ) { // WPCS: input var ok, sanitization ok.
+			$cart = $this->populate_cart_from_order( absint( $_GET['order_again'] ), $cart ); // WPCS: input var ok.
 		}
 
-		if ( is_array( $cart ) ) {
-			$cart_contents = array();
+		// Prime caches to reduce future queries.
+		if ( is_callable( '_prime_post_caches' ) ) {
+			_prime_post_caches( wp_list_pluck( $cart, 'product_id' ) );
+		}
 
-			// Prime caches to reduce future queries.
-			if ( is_callable( '_prime_post_caches' ) ) {
-				_prime_post_caches( wp_list_pluck( $cart, 'product_id' ) );
+		$cart_contents = array();
+
+		foreach ( $cart as $key => $values ) {
+			$product = wc_get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'] );
+
+			if ( ! is_customize_preview() && 'customize-preview' === $key ) {
+				continue;
 			}
 
-			foreach ( $cart as $key => $values ) {
-				$product = wc_get_product( $values['variation_id'] ? $values['variation_id'] : $values['product_id'] );
+			if ( ! empty( $product ) && $product->exists() && $values['quantity'] > 0 ) {
 
-				if ( ! is_customize_preview() && 'customize-preview' === $key ) {
-					continue;
-				}
+				if ( ! $product->is_purchasable() ) {
+					$update_cart_session = true;
+					/* translators: %s: product name */
+					wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $product->get_name() ), 'error' );
+					do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
 
-				if ( ! empty( $product ) && $product->exists() && $values['quantity'] > 0 ) {
+				} elseif ( ! empty( $values['data_hash'] ) && ! hash_equals( $values['data_hash'], wc_get_cart_item_data_hash( $product ) ) ) { // phpcs:ignore PHPCompatibility.PHP.NewFunctions.hash_equalsFound
+					$update_cart_session = true;
+					/* translators: %1$s: product name. %2$s product permalink */
+					wc_add_notice( sprintf( __( '%1$s has been removed from your cart because it has since been modified. You can add it back to your cart <a href="%2$s">here</a>.', 'woocommerce' ), $product->get_name(), $product->get_permalink() ), 'notice' );
+					do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
 
-					if ( ! $product->is_purchasable() ) {
-						$update_cart_session = true;
-						/* translators: %s: product name */
-						wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $product->get_name() ), 'error' );
-						do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
+				} else {
+					// Put session data into array. Run through filter so other plugins can load their own session data.
+					$session_data = array_merge(
+						$values, array(
+							'data' => $product,
+						)
+					);
 
-					} elseif ( ! empty( $values['data_hash'] ) && ! hash_equals( $values['data_hash'], wc_get_cart_item_data_hash( $product ) ) ) { // phpcs:ignore PHPCompatibility.PHP.NewFunctions.hash_equalsFound
-						$update_cart_session = true;
-						/* translators: %1$s: product name. %2$s product permalink */
-						wc_add_notice( sprintf( __( '%1$s has been removed from your cart because it has since been modified. You can add it back to your cart <a href="%2$s">here</a>.', 'woocommerce' ), $product->get_name(), $product->get_permalink() ), 'notice' );
-						do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
+					$cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', $session_data, $values, $key );
 
-					} else {
-						// Put session data into array. Run through filter so other plugins can load their own session data.
-						$session_data          = array_merge(
-							$values, array(
-								'data' => $product,
-							)
-						);
-						$cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', $session_data, $values, $key );
-
-						// Add to cart right away so the product is visible in woocommerce_get_cart_item_from_session hook.
-						$this->cart->set_cart_contents( $cart_contents );
-					}
+					// Add to cart right away so the product is visible in woocommerce_get_cart_item_from_session hook.
+					$this->cart->set_cart_contents( $cart_contents );
 				}
 			}
 		}
@@ -218,7 +215,7 @@ final class WC_Cart_Session {
 	 * Delete the persistent cart permanently.
 	 */
 	public function persistent_cart_destroy() {
-		if ( get_current_user_id() && apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
+		if ( get_current_user_id() ) {
 			delete_user_meta( get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id() );
 		}
 	}
@@ -238,5 +235,126 @@ final class WC_Cart_Session {
 			wc_setcookie( 'woocommerce_cart_hash', '', time() - HOUR_IN_SECONDS );
 		}
 		do_action( 'woocommerce_set_cart_cookies', $set );
+	}
+
+	/**
+	 * Get the persistent cart from the database.
+	 *
+	 * @access private
+	 * @since  3.5.0
+	 * @return array
+	 */
+	private function get_saved_cart() {
+		$saved_cart = array();
+
+		if ( apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
+			$saved_cart_meta = get_user_meta( get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id(), true );
+
+			if ( isset( $saved_cart_meta['cart'] ) ) {
+				$saved_cart = array_filter( (array) $saved_cart_meta['cart'] );
+			}
+		}
+
+		return $saved_cart;
+	}
+
+	/**
+	 * Get a cart from an order, if user has permission.
+	 *
+	 * @access private
+	 * @since  3.5.0
+	 * @param int   $order_id Order ID to try to load.
+	 * @param array $cart Current cart array.
+	 * @return array
+	 */
+	private function populate_cart_from_order( $order_id, $cart ) {
+		$order = wc_get_order( $order_id );
+
+		if ( ! $order->get_id() || ! $order->has_status( apply_filters( 'woocommerce_valid_order_statuses_for_order_again', array( 'completed' ) ) ) || ! current_user_can( 'order_again', $order->get_id() ) ) {
+			return;
+		}
+
+		if ( apply_filters( 'woocommerce_empty_cart_when_order_again', true ) ) {
+			$cart = array();
+		}
+
+		$inital_cart_size = count( $cart );
+		$order_items      = $order->get_items();
+
+		foreach ( $order_items as $item ) {
+			$product_id     = (int) apply_filters( 'woocommerce_add_to_cart_product_id', $item->get_product_id() );
+			$quantity       = $item->get_quantity();
+			$variation_id   = (int) $item->get_variation_id();
+			$variations     = array();
+			$cart_item_data = apply_filters( 'woocommerce_order_again_cart_item_data', array(), $item, $order );
+			$product        = $item->get_product();
+
+			if ( ! $product ) {
+				continue;
+			}
+
+			// Prevent reordering variable products if no selected variation.
+			if ( ! $variation_id && $product->is_type( 'variable' ) ) {
+				continue;
+			}
+
+			foreach ( $item->get_meta_data() as $meta ) {
+				if ( taxonomy_is_product_attribute( $meta->key ) ) {
+					$term                     = get_term_by( 'slug', $meta->value, $meta->key );
+					$variations[ $meta->key ] = $term ? $term->name : $meta->value;
+				} elseif ( meta_is_product_attribute( $meta->key, $meta->value, $product_id ) ) {
+					$variations[ $meta->key ] = $meta->value;
+				}
+			}
+
+			if ( ! apply_filters( 'woocommerce_add_to_cart_validation', true, $product_id, $quantity, $variation_id, $variations, $cart_item_data ) ) {
+				continue;
+			}
+
+			// Add to cart directly.
+			$cart_id          = WC()->cart->generate_cart_id( $product_id, $variation_id, $variations, $cart_item_data );
+			$product_data     = wc_get_product( $variation_id ? $variation_id : $product_id );
+			$cart[ $cart_id ] = apply_filters(
+				'woocommerce_add_cart_item', array_merge(
+					$cart_item_data, array(
+						'key'          => $cart_id,
+						'product_id'   => $product_id,
+						'variation_id' => $variation_id,
+						'variation'    => $variations,
+						'quantity'     => $quantity,
+						'data'         => $product_data,
+						'data_hash'    => wc_get_cart_item_data_hash( $product_data ),
+					)
+				), $cart_id
+			);
+		}
+
+		do_action( 'woocommerce_ordered_again', $order->get_id() );
+
+		$num_items_in_cart           = count( $cart );
+		$num_items_in_original_order = count( $order_items );
+		$num_items_added             = $num_items_in_cart - $inital_cart_size;
+
+		if ( $num_items_in_original_order > $num_items_added ) {
+			wc_add_notice(
+				sprintf(
+					// Translators: %d item count.
+					_n(
+						'%d item from your previous order is currently unavailable and could not be added to your cart.',
+						'%d items from your previous order are currently unavailable and could not be added to your cart.',
+						$num_items_added,
+						'woocommerce'
+					),
+					$num_items_added
+				),
+				'error'
+			);
+		}
+
+		if ( 0 < $num_items_added ) {
+			wc_add_notice( __( 'The cart has been filled with the items from your previous order.', 'woocommerce' ) );
+		}
+
+		return $cart;
 	}
 }

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -567,7 +567,7 @@ class WC_Form_Handler {
 				wc_add_notice( $removed_notice );
 			}
 
-			$referer  = wp_get_referer() ? remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart' ), add_query_arg( 'removed_item', '1', wp_get_referer() ) ) : wc_get_cart_url();
+			$referer  = wp_get_referer() ? remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart', 'order_again', '_wpnonce' ), add_query_arg( 'removed_item', '1', wp_get_referer() ) ) : wc_get_cart_url();
 			wp_safe_redirect( $referer );
 			exit;
 

--- a/includes/form-handlers/class-wc-form-handler-edit-address.php
+++ b/includes/form-handlers/class-wc-form-handler-edit-address.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Form handler class.
+ *
+ * @package WooCommerce/Classes
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+if ( ! class_exists( 'Abstract_WC_Form_Handler', false ) ) {
+	include_once dirname( WC_PLUGIN_FILE ) . '/includes/abstracts/abstract-wc-form-handler.php';
+}
+
+/**
+ * WC_Form_Handler_Edit_Address class.
+ */
+class WC_Form_Handler_Edit_Address extends Abstract_WC_Form_Handler {
+
+	/**
+	 * Nonce key. Nonce name and key derived from this value.
+	 *
+	 * @var string
+	 */
+	protected $nonce_key = 'woocommerce-edit_address';
+
+	/**
+	 * Process the form.
+	 *
+	 * @throws Exception On error.
+	 */
+	public function process() {
+		$this->check_nonce();
+
+		$user_id = get_current_user_id();
+
+		if ( 0 === $user_id ) {
+			throw new Exception( __( 'Please log in to edit your account details.', 'woocommerce' ) );
+		}
+
+		$customer = new WC_Customer( $user_id );
+
+		if ( ! $customer ) {
+			throw new Exception( __( 'Unable to save account details. Please contact us if you continue to experience problems.', 'woocommerce' ) );
+		}
+
+		global $wp;
+
+		$load_address = isset( $wp->query_vars['edit-address'] ) ? wc_edit_address_i18n( sanitize_title( $wp->query_vars['edit-address'] ), true ) : 'billing';
+		$country      = $this->get_post_data( $load_address . '_country' );
+		$address      = WC()->countries->get_address_fields( $country, $load_address . '_' );
+
+		foreach ( $address as $key => $field ) {
+			if ( ! isset( $field['type'] ) ) {
+				$field['type'] = 'text';
+			}
+
+			$field_value = '';
+
+			// Get Value.
+			switch ( $field['type'] ) {
+				case 'checkbox':
+					$field_value = (int) $this->get_post_data( $key, false );
+					break;
+				default:
+					$field_value = wc_clean( $this->get_post_data( $key ) );
+					break;
+			}
+
+			// Hook to allow modification of value.
+			$field_value = apply_filters( 'woocommerce_process_myaccount_field_' . $key, $field_value );
+
+			// Validation: Required fields.
+			if ( ! empty( $field['required'] ) && empty( $field_value ) ) {
+				// Translators: %s field label.
+				throw new Exception( sprintf( __( '%s is a required field.', 'woocommerce' ), $field['label'] ) );
+			}
+
+			if ( ! empty( $field_value ) && ! empty( $field['validate'] ) && is_array( $field['validate'] ) ) {
+				foreach ( $field['validate'] as $rule ) {
+					switch ( $rule ) {
+						case 'postcode':
+							$field_value = strtoupper( str_replace( ' ', '', $field_value ) );
+
+							if ( ! WC_Validation::is_postcode( $field_value, $country ) ) {
+								throw new Exception( __( 'Please enter a valid postcode / ZIP.', 'woocommerce' ) );
+							}
+
+							$field_value = wc_format_postcode( $field_value, $country );
+							break;
+						case 'phone':
+							$field_value = wc_format_phone_number( $field_value );
+
+							if ( ! WC_Validation::is_phone( $field_value ) ) {
+								// Translators: %s field label.
+								throw new Exception( sprintf( __( '%s is not a valid phone number.', 'woocommerce' ), '<strong>' . $field['label'] . '</strong>' ) );
+							}
+							break;
+						case 'email':
+							$field_value = strtolower( $field_value );
+
+							if ( ! is_email( $field_value ) ) {
+								// Translators: %s field label.
+								throw new Exception( sprintf( __( '%s is not a valid email address.', 'woocommerce' ), '<strong>' . $field['label'] . '</strong>' ) );
+							}
+							break;
+					}
+				}
+			}
+
+			if ( is_callable( array( $customer, "set_$key" ) ) ) {
+				$customer->{"set_$key"}( $field_value );
+			} else {
+				$customer->update_meta_data( $key, $field_value );
+			}
+
+			if ( WC()->customer && is_callable( array( WC()->customer, "set_$key" ) ) ) {
+				WC()->customer->{"set_$key"}( $field_value );
+			}
+		}
+
+		do_action( 'woocommerce_after_save_address_validation', $user_id, $load_address, $address );
+
+		$customer->save();
+
+		wc_add_notice( __( 'Address changed successfully.', 'woocommerce' ) );
+
+		do_action( 'woocommerce_customer_save_address', $user_id, $load_address );
+
+		$this->redirect_to( wc_get_endpoint_url( 'edit-address', '', wc_get_page_permalink( 'myaccount' ) ) );
+	}
+
+	/**
+	 * Check posted nonce is valid.
+	 *
+	 * @return bool
+	 */
+	protected function is_nonce_valid() {
+		$nonce_value = isset( $this->post_data['_wpnonce'] ) ? $this->post_data['_wpnonce'] : '';
+		$nonce_value = isset( $this->post_data['woocommerce-edit-address-nonce'] ) ? $this->post_data['woocommerce-edit-address-nonce'] : $nonce_value;
+
+		return wp_verify_nonce( $nonce_value, $this->nonce_key );
+	}
+}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2429,7 +2429,8 @@ if ( ! function_exists( 'woocommerce_order_again_button' ) ) {
 		}
 
 		wc_get_template( 'order/order-again.php', array(
-			'order' => $order,
+			'order'           => $order,
+			'order_again_url' => wp_nonce_url( add_query_arg( 'order_again', $order->get_id(), wc_get_cart_url() ), 'woocommerce-order_again' ),
 		) );
 	}
 }

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -298,4 +298,4 @@ add_action( 'woocommerce_before_shop_loop', 'woocommerce_output_all_notices', 10
 add_action( 'woocommerce_before_single_product', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_cart', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_checkout_form', 'woocommerce_output_all_notices', 10 );
-add_action( 'woocommerce_account_content', 'woocommerce_output_all_notices', 10 );
+add_action( 'woocommerce_account_content', 'woocommerce_output_all_notices', 5 );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -683,6 +683,7 @@ add_action( 'wp_login', 'wc_maybe_store_user_agent', 10, 2 );
  */
 function wc_user_logged_in( $user_login, $user ) {
 	wc_update_user_last_active( $user->ID );
+	update_user_meta( $user->ID, '_woocommerce_load_saved_cart_after_login', 1 );
 }
 add_action( 'wp_login', 'wc_user_logged_in', 10, 2 );
 

--- a/templates/order/order-again.php
+++ b/templates/order/order-again.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 2.5.0
+ * @version 3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/order/order-again.php
+++ b/templates/order/order-again.php
@@ -10,17 +10,14 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
+ * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 2.3.0
+ * @version 2.5.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
+defined( 'ABSPATH' ) || exit;
 ?>
 
 <p class="order-again">
-	<a href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'order_again', $order->get_id() ) , 'woocommerce-order_again' ) ); ?>" class="button"><?php _e( 'Order again', 'woocommerce' ); ?></a>
+	<a href="<?php echo esc_url( $order_again_url ); ?>" class="button"><?php esc_html_e( 'Order again', 'woocommerce' ); ?></a>
 </p>


### PR DESCRIPTION
Following on from https://github.com/woocommerce/woocommerce/pull/20606, looking for feedback on this approach before doing more.

- Creates a form handler class for the main forms in WC.
- Main handler class sees what is posted and loads only the handler thats required. Currently all callbacks run on POST.
- Abstract class contains shared functionality.

This only takes care of the edit address form so far.

### How to test the changes in this Pull Request:

1. Account page - edit address
2. Make some changes. Leave required field blank. Error shown.
3. Fill in all fields. Save should work as normal.

@claudiulodro 