### PR TITLE
Check if array index exists before using it

### DIFF
--- a/includes/class-wc-geolite-integration.php
+++ b/includes/class-wc-geolite-integration.php
@@ -55,9 +55,12 @@ class WC_Geolite_Integration {
 		$iso_code = '';
 
 		try {
-			$reader   = new MaxMind\Db\Reader( $this->database ); // phpcs:ignore PHPCompatibility.PHP.NewLanguageConstructs.t_ns_separatorFound
-			$data     = $reader->get( $ip_address );
-			$iso_code = $data['country']['iso_code'];
+			$reader = new MaxMind\Db\Reader( $this->database ); // phpcs:ignore PHPCompatibility.PHP.NewLanguageConstructs.t_ns_separatorFound
+			$data   = $reader->get( $ip_address );
+
+			if ( isset( $data['country']['iso_code'] ) ) {
+				$iso_code = $data['country']['iso_code'];
+			}
 
 			$reader->close();
 		} catch ( Exception $e ) {

--- a/includes/class-wc-geolite-integration.php
+++ b/includes/class-wc-geolite-integration.php
@@ -46,7 +46,7 @@ class WC_Geolite_Integration {
 
 	/**
 	 * Get country 2-letters ISO by IP address.
-	 * Retuns empty string when not able to find any ISO code.
+	 * Returns empty string when not able to find any ISO code.
 	 *
 	 * @param string $ip_address User IP address.
 	 * @return string


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WC_Geolite_Integration::get_country_iso() sometimes returns null instead of an array, so this commit adds a check to account for that possibility before using the returned value. Doing this to prevent the following undefined index notice:

```
PHP Notice: Undefined index: country in wp-content/plugins/woocommerce/includes/class-wc-geolite-integration.php on line 60
```

Closes #20594

### Changelog entry

> FIx: add a check to prevent WC_Geolite_Integration::get_country_iso() from generating a PHP undefined index notice when unable to determine the country code for a given IP address