### PR TITLE
Convert product categories widget to use selectWoo.

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -201,30 +201,6 @@ function wc_product_dropdown_categories( $args = array() ) {
 		$args['orderby']    = 'name';
 	}
 
-	wp_enqueue_script( 'selectWoo' );
-	wp_enqueue_style( 'select2' );
-
-	wc_enqueue_js(
-		"
-			if ( jQuery().selectWoo ) {
-				var wc_product_cat_select = function() {
-					jQuery( '.dropdown_product_cat' ).selectWoo( {
-						placeholder: '" . esc_js( __( 'Select a category', 'woocommerce' ) ) . "',
-						minimumResultsForSearch: 5,
-						width: '100%',
-						allowClear: true,
-						language: {
-							noResults: function() {
-								return '" . esc_js( _x( 'No matches found', 'enhanced select', 'woocommerce' ) ) . "';
-							}
-						}
-					} );
-				};
-				wc_product_cat_select();
-			}
-		"
-	);
-
 	wp_dropdown_categories( $args );
 }
 

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -201,6 +201,30 @@ function wc_product_dropdown_categories( $args = array() ) {
 		$args['orderby']    = 'name';
 	}
 
+	wp_enqueue_script( 'selectWoo' );
+	wp_enqueue_style( 'select2' );
+
+	wc_enqueue_js(
+		"
+			if ( jQuery().selectWoo ) {
+				var wc_product_cat_select = function() {
+					jQuery( '.dropdown_product_cat' ).selectWoo( {
+						placeholder: '" . esc_js( __( 'Select a category', 'woocommerce' ) ) . "',
+						minimumResultsForSearch: 5,
+						width: '100%',
+						allowClear: true,
+						language: {
+							noResults: function() {
+								return '" . esc_js( _x( 'No matches found', 'enhanced select', 'woocommerce' ) ) . "';
+							}
+						}
+					} );
+				};
+				wc_product_cat_select();
+			}
+		"
+	);
+
 	wp_dropdown_categories( $args );
 }
 

--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -233,6 +233,10 @@ class WC_Widget_Product_Categories extends WC_Widget {
 					)
 				)
 			);
+
+			wp_enqueue_script( 'selectWoo' );
+			wp_enqueue_style( 'select2' );
+
 			wc_enqueue_js(
 				"
 				jQuery( '.dropdown_product_cat' ).change( function() {
@@ -247,6 +251,23 @@ class WC_Widget_Product_Categories extends WC_Widget {
 						location.href = this_page;
 					}
 				});
+
+				if ( jQuery().selectWoo ) {
+					var wc_product_cat_select = function() {
+						jQuery( '.dropdown_product_cat' ).selectWoo( {
+							placeholder: '" . esc_js( __( 'Select a category', 'woocommerce' ) ) . "',
+							minimumResultsForSearch: 5,
+							width: '100%',
+							allowClear: true,
+							language: {
+								noResults: function() {
+									return '" . esc_js( _x( 'No matches found', 'enhanced select', 'woocommerce' ) ) . "';
+								}
+							}
+						} );
+					};
+					wc_product_cat_select();
+				}
 			"
 			);
 		} else {

--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -249,6 +249,8 @@ class WC_Widget_Product_Categories extends WC_Widget {
 							this_page = home_url + '?product_cat=' + jQuery(this).val();
 						}
 						location.href = this_page;
+					} else {
+						location.href = '" . esc_js( wc_get_page_permalink( 'shop' ) ) . "';
 					}
 				});
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Make product categories dropdown widget to use SelectWoo

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20603 

### How to test the changes in this Pull Request:

1. Add product categories widget with the dropdown option selected to a widget area.
2. Browse to the page where widget is added and a SelectWoo type dropdown should display.
3. Test when browsing to categories that the current category is selected in the dropdown as well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> New - SelectWoo enabled product categories dropdown widget
