### PR TITLE
Remove unwanted(double) condition for address line 2

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -693,12 +693,6 @@ class WC_Countries {
 			unset( $fields['company'] );
 		}
 
-		$address_2_visibility = get_option( 'woocommerce_checkout_address_2_field', 'optional' );
-
-		if ( 'hidden' === $address_2_visibility ) {
-			unset( $fields['address_2'] );
-		}
-
 		if ( 'hidden' === get_option( 'woocommerce_checkout_address_2_field', 'optional' ) ) {
 			unset( $fields['address_2'] );
 		}


### PR DESCRIPTION
There is a repeating condition to check address line 2 field's hidden condition. We can easily check in one condition, it's just case of repeating condition only.