### PR TITLE
Settings not showing up when array keys exist

### DIFF
--- a/includes/admin/settings/class-wc-settings-advanced.php
+++ b/includes/admin/settings/class-wc-settings-advanced.php
@@ -128,7 +128,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 						'id'    => 'checkout_process_options',
 					),
 
-					'force_ssl_checkout'   => array(
+					array(
 						'title'           => __( 'Secure checkout', 'woocommerce' ),
 						'desc'            => __( 'Force secure checkout', 'woocommerce' ),
 						'id'              => 'woocommerce_force_ssl_checkout',
@@ -140,7 +140,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 						'desc_tip'        => sprintf( __( 'Force SSL (HTTPS) on the checkout pages (<a href="%s" target="_blank">an SSL Certificate is required</a>).', 'woocommerce' ), 'https://docs.woocommerce.com/document/ssl-and-https/#section-3' ),
 					),
 
-					'unforce_ssl_checkout' => array(
+					array(
 						'desc'            => __( 'Force HTTP when leaving the checkout', 'woocommerce' ),
 						'id'              => 'woocommerce_unforce_ssl_checkout',
 						'default'         => 'no',


### PR DESCRIPTION
Unknown why, Jason Adams in Slack asked where the force ssl setting was, I looked and the setting was in the code but not in the page. I removed the array keys because none of the other settings had them, and the setting appeared.

Props Jason for finding the bug.

### Changelog entry

Removed array keys from force ssl settings, bug was causing settings to not appear on advanced settings screen.
