### PR TITLE
Make it easier to customize products list table filters

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -287,6 +287,27 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Render any custom filters and search inputs for the list table.
 	 */
 	protected function render_filters() {
+		$filters = apply_filters( 'woocommerce_products_admin_list_table_filters', array(
+			'product_category' => array( $this, 'render_products_category_filter' ),
+			'product_type'     => array( $this, 'render_products_type_filter' ),
+			'stock_status'     => array( $this, 'render_products_stock_status_filter' ),
+		) );
+
+		ob_start();
+		foreach ( $filters as $filter_callback ) {
+			call_user_func( $filter_callback );
+		}
+		$output = ob_get_clean();
+
+		echo apply_filters( 'woocommerce_product_filters', $output ); // WPCS: XSS ok.
+	}
+
+	/**
+	 * Render the product category filter for the list table.
+	 *
+	 * @since 3.5.0
+	 */
+	protected function render_products_category_filter() {
 		$categories_count = (int) wp_count_terms( 'product_cat' );
 
 		if ( $categories_count <= apply_filters( 'woocommerce_product_category_filter_threshold', 100 ) ) {
@@ -307,7 +328,14 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 			</select>
 			<?php
 		}
+	}
 
+	/**
+	 * Render the product type filter for the list table.
+	 *
+	 * @since 3.5.0
+	 */
+	protected function render_products_type_filter() {
 		$current_product_type = isset( $_REQUEST['product_type'] ) ? wc_clean( wp_unslash( $_REQUEST['product_type'] ) ) : false; // WPCS: input var ok, sanitization ok.
 		$terms                = get_terms( 'product_type' );
 		$output               = '<select name="product_type" id="dropdown_product_type"><option value="">' . __( 'Filter by product type', 'woocommerce' ) . '</option>';
@@ -351,18 +379,25 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		}
 
 		$output .= '</select>';
+		echo $output;
+	}
 
+	/**
+	 * Render the stock status filter for the list table.
+	 *
+	 * @since 3.5.0
+	 */
+	public function render_products_stock_status_filter() {
 		$current_stock_status = isset( $_REQUEST['stock_status'] ) ? wc_clean( wp_unslash( $_REQUEST['stock_status'] ) ) : false; // WPCS: input var ok, sanitization ok.
 		$stock_statuses       = wc_get_product_stock_status_options();
-		$output              .= '<select name="stock_status"><option value="">' . esc_html__( 'Filter by stock status', 'woocommerce' ) . '</option>';
+		$output               = '<select name="stock_status"><option value="">' . esc_html__( 'Filter by stock status', 'woocommerce' ) . '</option>';
 
 		foreach ( $stock_statuses as $status => $label ) {
 			$output .= '<option ' . selected( $status, $current_stock_status, false ) . ' value="' . esc_attr( $status ) . '">' . esc_html( $label ) . '</option>';
 		}
 
 		$output .= '</select>';
-
-		echo apply_filters( 'woocommerce_product_filters', $output ); // WPCS: XSS ok.
+		echo $output;
 	}
 
 	/**

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -379,7 +379,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		}
 
 		$output .= '</select>';
-		echo $output;
+		echo $output; // WPCS: XSS ok.
 	}
 
 	/**
@@ -397,7 +397,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		}
 
 		$output .= '</select>';
-		echo $output;
+		echo $output; // WPCS: XSS ok.
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20626.

### How to test the changes in this Pull Request:

1. Verify filters work correctly.
2. Add the following code somewhere:
```
add_filter( 'woocommerce_products_admin_list_table_filters', function( $filters ) {
	unset( $filters['product_type'] );

	$filters['my_custom'] = function(){
		?><select><option>CUSTOM FILTER</option></select><?php
	};

	return $filters;
} );
```
3. Verify products type filter is not present and new, custom filter is present.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Added 'woocommerce_products_admin_list_table_filters' filter to make it easier to customize the products list table filters.
