### PR TITLE
Custom tables - remove get terms

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -76,6 +76,8 @@ class WC_Admin_Post_Types {
 	 * @since 3.3.0
 	 */
 	public function setup_screen() {
+		global $wc_list_table;
+
 		$screen_id = false;
 
 		if ( function_exists( 'get_current_screen' ) ) {
@@ -90,15 +92,15 @@ class WC_Admin_Post_Types {
 		switch ( $screen_id ) {
 			case 'edit-shop_order':
 				include_once 'list-tables/class-wc-admin-list-table-orders.php';
-				new WC_Admin_List_Table_Orders();
+				$wc_list_table = new WC_Admin_List_Table_Orders();
 				break;
 			case 'edit-shop_coupon':
 				include_once 'list-tables/class-wc-admin-list-table-coupons.php';
-				new WC_Admin_List_Table_Coupons();
+				$wc_list_table = new WC_Admin_List_Table_Coupons();
 				break;
 			case 'edit-product':
 				include_once 'list-tables/class-wc-admin-list-table-products.php';
-				new WC_Admin_List_Table_Products();
+				$wc_list_table = new WC_Admin_List_Table_Products();
 				break;
 		}
 

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -337,36 +337,14 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 */
 	protected function render_products_type_filter() {
 		$current_product_type = isset( $_REQUEST['product_type'] ) ? wc_clean( wp_unslash( $_REQUEST['product_type'] ) ) : false; // WPCS: input var ok, sanitization ok.
-		$terms                = get_terms( 'product_type' );
 		$output               = '<select name="product_type" id="dropdown_product_type"><option value="">' . __( 'Filter by product type', 'woocommerce' ) . '</option>';
 
-		foreach ( $terms as $term ) {
-			$output .= '<option value="' . sanitize_title( $term->name ) . '" ';
-			$output .= selected( $term->slug, $current_product_type, false );
-			$output .= '>';
+		foreach ( wc_get_product_types() as $value => $label ) {
+			$output .= '<option value="' . esc_attr( $value ) . '" ';
+			$output .= selected( $value, $current_product_type, false );
+			$output .= '>' . esc_html( $label ) . '</option>';
 
-			switch ( $term->name ) {
-				case 'grouped':
-					$output .= __( 'Grouped product', 'woocommerce' );
-					break;
-				case 'external':
-					$output .= __( 'External/Affiliate product', 'woocommerce' );
-					break;
-				case 'variable':
-					$output .= __( 'Variable product', 'woocommerce' );
-					break;
-				case 'simple':
-					$output .= __( 'Simple product', 'woocommerce' );
-					break;
-				default:
-					// Assuming that we have other types in future.
-					$output .= ucfirst( $term->name );
-					break;
-			}
-
-			$output .= '</option>';
-
-			if ( 'simple' === $term->name ) {
+			if ( 'simple' === $value ) {
 
 				$output .= '<option value="downloadable" ';
 				$output .= selected( 'downloadable', $current_product_type, false );


### PR DESCRIPTION
@kloon some supporting changes for custom tables.

Removes get_terms direct usage.
Adds a global so we can unhook some filtering.