### PR TITLE
Use view context so true is not returned if parent is stock managed and not the variation

### DIFF
--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -89,7 +89,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<?php if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) : ?>
 					<label class="tips" data-tip="<?php esc_html_e( 'Enable this option to enable stock management at variation level', 'woocommerce' ); ?>">
 						<?php esc_html_e( 'Manage stock?', 'woocommerce' ); ?>
-						<input type="checkbox" class="checkbox variable_manage_stock" name="variable_manage_stock[<?php echo esc_attr( $loop ); ?>]" <?php checked( $variation_object->get_manage_stock( 'edit' ), true ); ?> />
+						<input type="checkbox" class="checkbox variable_manage_stock" name="variable_manage_stock[<?php echo esc_attr( $loop ); ?>]" <?php checked( $variation_object->get_manage_stock(), true ); // Use view context so 'parent' is considered. ?> />
 					</label>
 				<?php endif; ?>
 


### PR DESCRIPTION
Fixes #16620

To test:

- Create stock managed simple product. Save. Check frontend.
- Edit the product. Change to variable. Add variable attribute and a single variation.
- Give the single variation a cost, but don't check the stock boxes. 'Save variations'
- Manage stock checks itself before this patch.