### PR TITLE
Allowing API deletion of grouped products. #20666

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1359,8 +1359,10 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 			} elseif ( $object->is_type( 'grouped' ) ) {
 				foreach ( $object->get_children() as $child_id ) {
 					$child = wc_get_product( $child_id );
-					$child->set_parent_id( 0 );
-					$child->save();
+					if ( ! empty( $child ) ) {
+						$child->set_parent_id( 0 );
+						$child->save();
+					}
 				}
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I have added a check that the child product exists before the API code attempts to set the parent ID. 

I am a little concerned that this PR fixes the symptom, and perhaps the parent id no longer needs setting on grouped product children?

Closes #20666 .

### How to test the changes in this Pull Request:

1. Use the JSON from #20666 to create and delete batch products via the api. 
2. If the grouped product is successfully deleted, this patch solves the issue. 

### Changelog entry

> When deleting grouped products via the API, non-existent children will no longer cause the API to fail. 
