### PR TITLE
Replaced query attribute placeholder with actual value for header link.

### DIFF
--- a/includes/abstracts/abstract-wc-rest-crud-controller.php
+++ b/includes/abstracts/abstract-wc-rest-crud-controller.php
@@ -370,7 +370,21 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 		$response->header( 'X-WP-Total', $query_results['total'] );
 		$response->header( 'X-WP-TotalPages', (int) $max_pages );
 
-		$base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
+		$base          = $this->rest_base;
+		$attrib_prefix = '(?P<';
+		if ( strpos( $base, $attrib_prefix ) !== false ) {
+			$attrib_names = array();
+			preg_match( '/\(\?P<[^>]+>.*\)/', $base, $attrib_names, PREG_OFFSET_CAPTURE );
+			foreach ( $attrib_names as $attrib_name_match ) {
+				$beginning_offset = strlen( $attrib_prefix );
+				$attrib_name_end  = strpos( $attrib_name_match[0], '>', $attrib_name_match[1] );
+				$attrib_name      = substr( $attrib_name_match[0], $beginning_offset, $attrib_name_end - $beginning_offset );
+				if ( isset( $request[ $attrib_name ] ) ) {
+					$base  = str_replace( "(?P<$attrib_name>[\d]+)", $request[ $attrib_name ], $base );
+				}
+			}
+		}
+		$base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $base ) ) );
 
 		if ( $page > 1 ) {
 			$prev_page = $page - 1;

--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -344,7 +344,8 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		$max_pages = ceil( $total_terms / $per_page );
 		$response->header( 'X-WP-TotalPages', (int) $max_pages );
 
-		$base = add_query_arg( $request->get_query_params(), rest_url( '/' . $this->namespace . '/' . $this->rest_base ) );
+		$base  = str_replace( '(?P<attribute_id>[\d]+)', $request['attribute_id'], $this->rest_base );
+		$base = add_query_arg( $request->get_query_params(), rest_url( '/' . $this->namespace . '/' . $base ) );
 		if ( $page > 1 ) {
 			$prev_page = $page - 1;
 			if ( $prev_page > $max_pages ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20673  .

Did a quick check of the following endpoints:

 Path | Note 
------------ | -------------
/wp-json/wc/v2/customers/\<id>/downloads| not paginated
/wp-json/wc/v2/orders/\<id>/notes | not paginated
/wp-json/wc/v2/orders/\<id>/refunds | paginated, via \WC_REST_CRUD_Controller::get_items, fixed
/wp-json/wc/v2/products/<product_id>/reviews | not paginated
/wp-json/wc/v2/products/<product_id>/variations | paginated via \WC_REST_CRUD_Controller::get_items, fixed
/wp-json/wc/v2/products/attributes/<attribute_id>/terms | paginated via \WC_REST_Terms_Controller::get_items, fixed
/wp-json/wc/v2/webhooks/\<id>/deliveries | not paginated
/wp-json/wc/v2/shipping/zones/\<id>/locations | not paginated
/wp-json/wc/v2/shipping/zones/\<id>/methods | not paginated

### How to test the changes in this Pull Request:

1. Create some attribute with terms.
2. Go to `/wp-json/wc/v2/products/attributes/<attribute_id>/terms`
3. Check response header, it should contains something like `<https://local.wordpress.test/wp-json/wc/v2/products/attributes/(?P<attribute_id>%5B\d%5D&page=2>; rel="next"`
4. Apply branch
5. Check response again, it should contain correct link, e.g. `<https://local.wordpress.test/wp-json/wc/v2/products/attributes/4/terms?page=2>; rel="next"`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Links to next and previous page sent out in HTTP header via REST API fixed for some endpoints.
