### PR TITLE
Check if $_POST['store_state'] is set before using it

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -515,7 +515,7 @@ class WC_Admin_Setup_Wizard {
 		$address_2      = sanitize_text_field( $_POST['store_address_2'] );
 		$city           = sanitize_text_field( $_POST['store_city'] );
 		$country        = sanitize_text_field( $_POST['store_country'] );
-		$state          = sanitize_text_field( $_POST['store_state'] );
+		$state          = isset( $_POST['store_state'] ) ? sanitize_text_field( $_POST['store_state'] ) : false;
 		$postcode       = sanitize_text_field( $_POST['store_postcode'] );
 		$currency_code  = sanitize_text_field( $_POST['currency_code'] );
 		$product_type   = sanitize_text_field( $_POST['product_type'] );

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -509,7 +509,8 @@ class WC_Admin_Setup_Wizard {
 	 */
 	public function wc_setup_store_setup_save() {
 		check_admin_referer( 'wc-setup' );
-		// @codingStandardsIgnoreStart
+
+		// phpcs:disable WordPress.VIP.SuperGlobalInputUsage.AccessDetected, WordPress.VIP.ValidatedSanitizedInput.InputNotValidated, WordPress.VIP.ValidatedSanitizedInput.MissingUnslash
 		$address        = sanitize_text_field( $_POST['store_address'] );
 		$address_2      = sanitize_text_field( $_POST['store_address_2'] );
 		$city           = sanitize_text_field( $_POST['store_city'] );
@@ -520,7 +521,7 @@ class WC_Admin_Setup_Wizard {
 		$product_type   = sanitize_text_field( $_POST['product_type'] );
 		$sell_in_person = isset( $_POST['sell_in_person'] ) && ( 'yes' === sanitize_text_field( $_POST['sell_in_person'] ) );
 		$tracking       = isset( $_POST['wc_tracker_checkbox'] ) && ( 'yes' === sanitize_text_field( $_POST['wc_tracker_checkbox'] ) );
-		// @codingStandardsIgnoreEnd
+		// phpcs:enable
 
 		if ( ! $state ) {
 			$state = '*';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR protects against the following PHP notice in the setup wizard by checking if `$_POST['store_state']` is set before using it.

```
PHP Notice: Undefined index: store_state in wp-content/plugins/woocommerce/includes/admin/class-wc-admin-setup-wizard.php on line 517
```

This PR also includes a commit to use `phpcs:disable` with a list of rules to ignore instead of the too generic `@codingStandardsIgnoreStart` that will ignore all rules.

Closes #20684

### How to test the changes in this Pull Request:

1. See issue #20684 for testing instructions

### Changelog entry

> Prevent a PHP notice in the setup wizard when store state is not selectable 
