### PR TITLE
OBW: Change name of PayPal Express Checkout gateway to match rebranding

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1238,10 +1238,10 @@ class WC_Admin_Setup_Wizard {
 			__( 'Accept debit and credit cards in 135+ currencies, methods such as Alipay, and one-touch checkout with Apple Pay. <a href="%s" target="_blank">Learn more</a>.', 'woocommerce' ),
 			'https://woocommerce.com/products/stripe/'
 		) . '</p>';
-		$paypal_ec_description = '<p>' . sprintf(
+		$paypal_checkout_description = '<p>' . sprintf(
 			/* translators: %s: URL */
 			__( 'Safe and secure payments using credit cards or your customer\'s PayPal account. <a href="%s" target="_blank">Learn more</a>.', 'woocommerce' ),
-			'https://woocommerce.com/products/woocommerce-gateway-paypal-express-checkout/'
+			'https://woocommerce.com/products/woocommerce-gateway-paypal-checkout/'
 		) . '</p>';
 		$klarna_checkout_description = '<p>' . sprintf(
 			/* translators: %s: URL */
@@ -1286,9 +1286,9 @@ class WC_Admin_Setup_Wizard {
 				),
 			),
 			'ppec_paypal'     => array(
-				'name'        => __( 'WooCommerce PayPal Express Checkout Gateway', 'woocommerce' ),
+				'name'        => __( 'WooCommerce PayPal Checkout Gateway', 'woocommerce' ),
 				'image'       => WC()->plugin_url() . '/assets/images/paypal.png',
-				'description' => $paypal_ec_description,
+				'description' => $paypal_checkout_description,
 				'enabled'     => true,
 				'class'       => 'checked paypal-logo',
 				'repo-slug'   => 'woocommerce-gateway-paypal-express-checkout',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Renames "PayPal Express Checkout" to "PayPal Checkout", to match that extension's rebranding in https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/441. (Discussion in p7bbVw-2vt-p2.)

The name is rendered in the `alt` text of the logo, and in the plugin installation indicator at bottom:
<img width="422" alt="screen shot 2018-07-04 at 10 49 24 am" src="https://user-images.githubusercontent.com/1867547/42283599-f225c8fc-7f77-11e8-8158-28d7e71507f1.png">
