### PR TITLE
Added filter on item name in quotes

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -107,7 +107,7 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 
 	foreach ( $products as $product_id => $qty ) {
 		/* translators: %s: product name */
-		$titles[] = ( $qty > 1 ? absint( $qty ) . ' &times; ' : '' ) . apply_filters( 'wc_add_to_cart_item_name_in_quotes', sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), strip_tags( get_the_title( $product_id ) ) ), $product_id );
+		$titles[] = ( $qty > 1 ? absint( $qty ) . ' &times; ' : '' ) . apply_filters( 'woocommerce_add_to_cart_item_name_in_quotes', sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), strip_tags( get_the_title( $product_id ) ) ), $product_id );
 		$count   += $qty;
 	}
 

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -107,7 +107,7 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 
 	foreach ( $products as $product_id => $qty ) {
 		/* translators: %s: product name */
-		$titles[] = ( $qty > 1 ? absint( $qty ) . ' &times; ' : '' ) . sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), strip_tags( get_the_title( $product_id ) ) );
+		$titles[] = ( $qty > 1 ? absint( $qty ) . ' &times; ' : '' ) . apply_filters( 'wc_add_to_cart_item_name_in_quotes', sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), strip_tags( get_the_title( $product_id ) ) ), $product_id );
 		$count   += $qty;
 	}
 


### PR DESCRIPTION
Filter added to item in quotes. 

Initially was thinking that is it needed to translate the quotes only? I can't find any languages that do this specifically, but if it's a RTL language, perhaps you'd swap around the quote direction.

The function `wc_add_to_cart_message` gives you the filter `wc_add_to_cart_message` to play with, but is already set in stone as HTML, and if you truly want to change the HTML of this message, you would need to rewrite the function.

Simply adding `<strong>` to the product title is not possible without preg_replacing or hooking into gettext

### Changelog entry

> Added new filter to 'Item in quotes' translation for messages