### PR TITLE
Add edit_theme_options capability to shop manager role

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -109,6 +109,10 @@ class WC_Install {
 			'wc_update_343_cleanup_foreign_keys',
 			'wc_update_343_db_version',
 		),
+		'3.4.4' => array(
+			'wc_update_344_recreate_roles',
+			'wc_update_344_db_version',
+		),
 		'3.5.0' => array(
 			'wc_update_350_order_customer_id',
 			'wc_update_350_db_version',

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -955,6 +955,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 				'export'                 => true,
 				'import'                 => true,
 				'list_users'             => true,
+				'edit_theme_options'     => true,
 			)
 		);
 

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1837,6 +1837,25 @@ function wc_update_343_db_version() {
 }
 
 /**
+ * Recreate user roles so existing users will get the new capabilities.
+ *
+ * @return void
+ */
+function wc_update_344_recreate_roles() {
+	WC_Install::remove_roles();
+	WC_Install::create_roles();
+}
+
+/**
+ * Update DB version.
+ *
+ * @return void
+ */
+function wc_update_344_db_version() {
+	WC_Install::update_db_version( '3.4.4' );
+}
+
+/**
  * Copy order customer_id from post meta to post_author and set post_author to 0 for refunds.
  *
  * Two different strategies are used to copy data depending if the update is being executed from


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since the shop manager already have access to change various settings relating to the WooCommerce store via WooCommerce -> Settings and since we have move some of these settings to the Customizer this PR adds the edit_theme_options capability to the shop_manager role in order for them to also access the customizer and change the settings there, unfortunately in order to access the customizer you need the edit_theme_options capability, no way around it, I tested by just setting the customize capability but that failed.

It has to be noted that this also opens up other theme related settings to the shop_manager role, which I think is OK since this is a privileged role with the ability to change store settings which can also cause issues if the user does not know what they are doing.

Closes #20708

### How to test the changes in this Pull Request:

1. Create a use with a Shop Manager role
2. View the wp-admin dashboard, there should be an appearance menu which was not previously there, from there the user should be able to open the customizer.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Allow Shop Managers access to the customizer for changing settings there.
