### PR TITLE
Fix log file deletion

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -162,7 +162,7 @@ class WC_Admin_Status {
 	 * @return string
 	 */
 	public static function get_log_file_handle( $filename ) {
-		return substr( $filename, 0, strlen( $filename ) > 37 ? strlen( $filename ) - 37 : strlen( $filename ) - 4 );
+		return substr( $filename, 0, strlen( $filename ) > 48 ? strlen( $filename ) - 48 : strlen( $filename ) - 4 );
 	}
 
 	/**

--- a/includes/admin/views/html-admin-page-status-logs.php
+++ b/includes/admin/views/html-admin-page-status-logs.php
@@ -15,8 +15,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<div class="alignleft">
 			<h2>
 				<?php echo esc_html( $viewed_log ); ?>
-				<?php if ( ! empty( $handle ) ) : ?>
-					<a class="page-title-action" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'handle' => $handle ), admin_url( 'admin.php?page=wc-status&tab=logs' ) ), 'remove_log' ) ); ?>" class="button"><?php esc_html_e( 'Delete log', 'woocommerce' ); ?></a>
+				<?php if ( ! empty( $viewed_log ) ) : ?>
+					<a class="page-title-action" href="<?php echo esc_url( wp_nonce_url( add_query_arg( array( 'handle' => $viewed_log ), admin_url( 'admin.php?page=wc-status&tab=logs' ) ), 'remove_log' ) ); ?>" class="button"><?php esc_html_e( 'Delete log', 'woocommerce' ); ?></a>
 				<?php endif; ?>
 			</h2>
 		</div>

--- a/includes/log-handlers/class-wc-log-handler-file.php
+++ b/includes/log-handlers/class-wc-log-handler-file.php
@@ -248,16 +248,14 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 	 */
 	public function remove( $handle ) {
 		$removed = false;
-		$file    = self::get_log_file_path( $handle );
-
+		$file = trailingslashit( WC_LOG_DIR ) . $handle;
 		if ( $file ) {
 			if ( is_file( $file ) && is_writable( $file ) ) { // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_is_writable
-				$this->close( $handle ); // Close first to be certain no processes keep it alive after it is unlinked.
+				$this->close( $file ); // Close first to be certain no processes keep it alive after it is unlinked.
 				$removed = unlink( $file ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink
 			}
 			do_action( 'woocommerce_log_remove', $handle, $removed );
 		}
-
 		return $removed;
 	}
 

--- a/tests/unit-tests/log/log-handler-file.php
+++ b/tests/unit-tests/log/log-handler-file.php
@@ -11,25 +11,25 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 		$log_files = array(
 			'unit-tests',
 			'log',
-			 '_test_clear',
-			 '_test_remove',
-			 '_test_log_rotate',
-			 '_test_log_rotate.0',
-			 '_test_log_rotate.1',
-			 '_test_log_rotate.2',
-			 '_test_log_rotate.3',
-			 '_test_log_rotate.4',
-			 '_test_log_rotate.5',
-			 '_test_log_rotate.6',
-			 '_test_log_rotate.7',
-			 '_test_log_rotate.8',
-			 '_test_log_rotate.9',
+			'_test_clear',
+			'_test_remove',
+			'_test_log_rotate',
+			'_test_log_rotate.0',
+			'_test_log_rotate.1',
+			'_test_log_rotate.2',
+			'_test_log_rotate.3',
+			'_test_log_rotate.4',
+			'_test_log_rotate.5',
+			'_test_log_rotate.6',
+			'_test_log_rotate.7',
+			'_test_log_rotate.8',
+			'_test_log_rotate.9',
 		);
 
 		foreach ( $log_files as $file ) {
 			$file_path = WC_Log_Handler_File::get_log_file_path( $file );
-			if ( file_exists( $file_path ) && is_writable( $file_path ) ) {
-				unlink( $file_path );
+			if ( file_exists( $file_path ) && is_writable( $file_path ) ) { // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_is_writable
+				unlink( $file_path ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink
 			}
 		}
 		parent::tearDown();
@@ -47,7 +47,10 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 	public function test_legacy_format() {
 		$handler = new WC_Log_Handler_File( array( 'threshold' => 'debug' ) );
 
-		$handler->handle( time(), 'info', 'this is a message', array( 'source' => 'unit-tests', '_legacy' => true ) );
+		$handler->handle( time(), 'info', 'this is a message', array(
+			'source' => 'unit-tests',
+			'_legacy' => true,
+		) );
 
 		$this->assertStringMatchesFormat( '%d-%d-%d @ %d:%d:%d - %s', $this->read_content( 'unit-tests' ) );
 		$this->assertStringEndsWith( ' - this is a message' . PHP_EOL, $this->read_content( 'unit-tests' ) );
@@ -172,7 +175,7 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 
 		// Write some files to ensure they've rotated correctly
 		for ( $i = 0; $i < 10; $i++ ) {
-			file_put_contents( WC_Log_Handler_File::get_log_file_path( $log_name . ".{$i}" ), $i );
+			file_put_contents( WC_Log_Handler_File::get_log_file_path( $log_name . ".{$i}" ), $i ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_file_put_contents
 		}
 
 		$context_source = array( 'source' => $log_name );

--- a/tests/unit-tests/log/log-handler-file.php
+++ b/tests/unit-tests/log/log-handler-file.php
@@ -75,7 +75,7 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 		$handler = new WC_Log_Handler_File();
 		$log_name = '_test_remove';
 		$handler->handle( time(), 'debug', 'debug', array( 'source' => $log_name ) );
-		$handler->remove( $log_name );
+		$handler->remove( wc_get_log_file_name( $log_name ) );
 		$this->assertFileNotExists( WC_Log_Handler_File::get_log_file_path( $log_name ) );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue where log files were passing the log filename to the method that deletes is and that method used another function that was appending the current date to file causing the incorrect filename and path to be used when trying to delete.

Closes #20716

### How to test the changes in this Pull Request:

1. Go to WooCommerce -> Status -> Logs
2. Select a log file to view
3. Click the delete button and the log file should be deleted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Log file deletion.
