### PR TITLE
Do not load all tables in multisite system status

### DIFF
--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -722,6 +722,12 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 		);
 
 		foreach ( $database_table_sizes as $table ) {
+			// Only include tables matching the prefix of the current site, this is to prevent displaying all tables on a MS install not relating to the current.
+			if ( is_multisite() ) {
+				if ( 0 !== strpos( $table->name, $wpdb->prefix ) ) {
+					continue;
+				}
+			}
 			$table_type = in_array( $table->name, $core_tables ) ? 'woocommerce' : 'other';
 
 			$tables[ $table_type ][ $table->name ] = array(

--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -721,12 +721,11 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 			'index' => 0,
 		);
 
+		$site_tables = $wpdb->tables( 'all', true );
 		foreach ( $database_table_sizes as $table ) {
 			// Only include tables matching the prefix of the current site, this is to prevent displaying all tables on a MS install not relating to the current.
-			if ( is_multisite() ) {
-				if ( 0 !== strpos( $table->name, $wpdb->prefix ) ) {
-					continue;
-				}
+			if ( is_multisite() && ! in_array( $table->name, $site_tables, true ) ) {
+				continue;
 			}
 			$table_type = in_array( $table->name, $core_tables ) ? 'woocommerce' : 'other';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR makes it that when on a multisite and opening up the system status report it should not load all the tables in the database for the multisite, but only ones matching the current blog.

Closes #20724

### How to test the changes in this Pull Request:

1. Create a WP multisite install
2. Setup two or more stores on the MS
3. Log into one of the stores and view the system status report, it should only display the tables matching that store.
4. Normal WP installs should still load tables present in the DB.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Only display the current site's tables for a multisite install when viewing the system status.
