### PR TITLE
Outdated templates notice improvements

### DIFF
--- a/includes/admin/views/html-notice-template-check.php
+++ b/includes/admin/views/html-notice-template-check.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Admin View: Notice - Template Check
+ *
+ * @package WooCommerce/Views
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -10,8 +12,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 $theme = wp_get_theme();
 ?>
 <div id="message" class="updated woocommerce-message">
-	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'template_files' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php _e( 'Dismiss', 'woocommerce' ); ?></a>
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'template_files' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 
-	<p><?php printf( __( '<strong>Your theme (%1$s) contains outdated copies of some WooCommerce template files.</strong> These files may need updating to ensure they are compatible with the current version of WooCommerce. You can see which files are affected from the <a href="%2$s">system status page</a>. If in doubt, check with the author of the theme.', 'woocommerce' ), esc_html( $theme['Name'] ), esc_url( admin_url( 'admin.php?page=wc-status' ) ) ); ?></p>
-	<p class="submit"><a class="button-primary" href="https://docs.woocommerce.com/document/template-structure/" target="_blank"><?php _e( 'Learn more about templates', 'woocommerce' ); ?></a></p>
+	<p>
+		<?php /* translators: %s: theme name */ ?>
+		<?php printf( __( '<strong>Your theme (%s) contains outdated copies of some WooCommerce template files.</strong> These files may need updating to ensure they are compatible with the current version of WooCommerce. Suggestions to fix this:', 'woocommerce' ), esc_html( $theme['Name'] ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+		<ol>
+			<li><?php esc_html_e( 'Update your theme to the latest version. If no update is available contact your theme author asking about compatibility with the current WooCommerce version.', 'woocommerce' ); ?></li>
+			<li><?php esc_html_e( 'If you copied over a template file to change something, then you will need to copy the new version of the template and apply your changes again.', 'woocommerce' ); ?></li>
+		</ol>
+	</p>
+	<p class="submit">
+		<a class="button-primary" href="https://docs.woocommerce.com/document/template-structure/" target="_blank"><?php esc_html_e( 'Learn more about templates', 'woocommerce' ); ?></a>
+		<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status' ) ); ?>" target="_blank"><?php esc_html_e( 'View affected templates', 'woocommerce' ); ?></a>
+	</p>
 </div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR makes the outdated templates notice a bit easier to read and act upon.

![New outdated template notice](http://cld.wthms.co/Jrs9O9+)

Closes #20709 

### How to test the changes in this Pull Request:

1. Copy a template file over to your themes WooCommerce folder
2. Switch to another theme
3. Switch back to the theme with the outdated template
4. Head to WooCommerce -> Settings to view the notice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Easier to read and act upon the outdated template notice.
