### PR TITLE
Escape sku input properly for quick edit

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -352,7 +352,7 @@ class WC_Admin_Post_Types {
 				if ( ! empty( $new_sku ) ) {
 					$unique_sku = wc_product_has_unique_sku( $post_id, $new_sku );
 					if ( $unique_sku ) {
-						$product->set_sku( $new_sku );
+						$product->set_sku( wc_clean( wp_unslash( $new_sku ) ) );
 					}
 				} else {
 					$product->set_sku( '' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20224 

### How to test the changes in this Pull Request:

1. Load the product list table in wp-admin
2. Quick edit a product
3. Use an apostrophe in the sku field and save the changes
4. Check that it is not prepended with a forward slash when the product list table loads again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Better escaping on product quick edit.
