### PR TITLE
Fix product csv exporter get stock value

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -399,13 +399,17 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		$manage_stock   = $product->get_manage_stock( 'edit' );
 		$stock_quantity = $product->get_stock_quantity( 'edit' );
 
-		if ( $product->is_type( 'variation' && 'parent' === $manage_stock ) ) {
-			return 'parent';
-		} elseif ( $manage_stock ) {
+		if ( $manage_stock ) {
 			return $stock_quantity;
-		} else {
-			return '';
+		} else if ( $product->is_type( 'variation' ) ) {
+			if ( $product->get_parent_id( 'edit' ) ) {
+				$parent = wc_get_product( $product->get_parent_id( 'edit' ) );
+				if( $parent->get_manage_stock( 'edit' ) ) {
+					return 'parent';
+				}
+			}
 		}
+		return '';
 	}
 
 	/**

--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -399,7 +399,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		$manage_stock   = $product->get_manage_stock( 'edit' );
 		$stock_quantity = $product->get_stock_quantity( 'edit' );
 
-		if ( $product->is_type( 'variation') && 'parent' === $manage_stock ) {
+		if ( $product->is_type( 'variation' ) && 'parent' === $manage_stock ) {
 			return 'parent';
 		} elseif ( $manage_stock ) {
 			return $stock_quantity;

--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -399,17 +399,13 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		$manage_stock   = $product->get_manage_stock( 'edit' );
 		$stock_quantity = $product->get_stock_quantity( 'edit' );
 
-		if ( $manage_stock ) {
+		if ( $product->is_type( 'variation') && 'parent' === $manage_stock ) {
+			return 'parent';
+		} elseif ( $manage_stock ) {
 			return $stock_quantity;
-		} else if ( $product->is_type( 'variation' ) ) {
-			if ( $product->get_parent_id( 'edit' ) ) {
-				$parent = wc_get_product( $product->get_parent_id( 'edit' ) );
-				if( $parent->get_manage_stock( 'edit' ) ) {
-					return 'parent';
-				}
-			}
+		} else {
+			return '';
 		}
-		return '';
 	}
 
 	/**


### PR DESCRIPTION
seems the original get stock value is wrong, but I'm not sure if my change is correct...
what i'm considering is this line:  if ( $product->is_type( 'variation' && 'parent' === $manage_stock ) ) {

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
