### PR TITLE
Make wc_get_user_agent respect RFC2616

### DIFF
--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -390,7 +390,7 @@ class WC_Frontend_Scripts {
 		}
 
 		if ( 'geolocation_ajax' === get_option( 'woocommerce_default_customer_address' ) ) {
-			$ua = wc_get_user_agent(); // Exclude common bots from geolocation by user agent.
+			$ua = strtolower( wc_get_user_agent() ); // Exclude common bots from geolocation by user agent.
 
 			if ( ! strstr( $ua, 'bot' ) && ! strstr( $ua, 'spider' ) && ! strstr( $ua, 'crawl' ) ) {
 				self::enqueue_script( 'wc-geolocation' );

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1064,7 +1064,7 @@ function wc_get_customer_default_location() {
 		case 'geolocation_ajax':
 		case 'geolocation':
 			// Exclude common bots from geolocation by user agent.
-			$ua = wc_get_user_agent();
+			$ua = strtolower( wc_get_user_agent() );
 
 			if ( ! strstr( $ua, 'bot' ) && ! strstr( $ua, 'spider' ) && ! strstr( $ua, 'crawl' ) ) {
 				$location = WC_Geolocation::geolocate_ip( '', true, false );
@@ -1093,7 +1093,7 @@ function wc_get_customer_default_location() {
  * @return string
  */
 function wc_get_user_agent() {
-	return isset( $_SERVER['HTTP_USER_AGENT'] ) ? strtolower( wc_clean( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) ) : ''; // @codingStandardsIgnoreLine
+	return isset( $_SERVER['HTTP_USER_AGENT'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : ''; // @codingStandardsIgnoreLine
 }
 
 // This function can be removed when WP 3.9.2 or greater is required.

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -694,4 +694,15 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 			$this->assertEquals( wc_selected( $value, $options ), $actual_result );
 		}
 	}
+
+	/**
+	 * Test wc_get_user_agent function.
+	 *
+	 * @return void
+	 */
+	public function test_wc_get_user_agent() {
+		$example_user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+		$_SERVER['HTTP_USER_AGENT'] = $example_user_agent;
+		$this->assertEquals( $example_user_agent, wc_get_user_agent() );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
As per the rfc2616 HTTP header values are case sensitive. At present, we convert the user agent to lowercase in wc_get_user_agent before saving it to the order. The only reason I can see why we are doing this is to simplify the check for bots/crawlers when loading the geolocation functionality.

This PR modifies wc_get_user_agent to return the actual user agent as per the browser and moves the lowercase checks to where we are checking for bots/crawlers.

This PR replaces #20647

### How to test the changes in this Pull Request:

1. Create order
2. Check that the user agent is not saved in all lowercase

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - wc_get_user_agent now returns the user agent as defined by the browser and not in all lowercase.
