### PR TITLE
Expand fatal error logging and add file/line number to log entries

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -183,7 +183,7 @@ final class WooCommerce {
 	 */
 	public function log_errors() {
 		$error = error_get_last();
-		if ( E_ERROR === $error['type'] ) {
+		if ( in_array( $error['type'], array( E_ERROR, E_PARSE, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR ) ) ) {
 			$logger = wc_get_logger();
 			$logger->critical(
 				$error['message'] . PHP_EOL,

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -186,7 +186,8 @@ final class WooCommerce {
 		if ( in_array( $error['type'], array( E_ERROR, E_PARSE, E_COMPILE_ERROR, E_USER_ERROR, E_RECOVERABLE_ERROR ) ) ) {
 			$logger = wc_get_logger();
 			$logger->critical(
-				$error['message'] . PHP_EOL,
+				/* translators: 1: error message 2: file name and path 3: line number */
+				sprintf( __( '%1$s in %2$s on line %3$s', 'woocommerce' ), $error['message'], $error['file'], $error['line'] ) . PHP_EOL,
 				array(
 					'source' => 'fatal-errors',
 				)

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -192,6 +192,7 @@ final class WooCommerce {
 					'source' => 'fatal-errors',
 				)
 			);
+			do_action( 'woocommerce_shutdown_error', $error );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR proposes 3 tweaks to the (awesome) fatal error logging:

1. Include the file path and line number where an error occurred
1. Expand error logging to `E_ERROR` like errors, not just `E_ERROR` errors
1. Add `'woocommerce_shutdown_error'` action, which can be used by 3rd party code to do things like include a stack trace for the error in the log file using `debug_print_backtrace()`  (I figured it was worth leaving that out of core to avoid log bloat)

Providing this extra information (and API) will help make it easier and faster to diagnose the cause of errors logged in this file.

Example of a log entry before this patch:

```
2018-05-26T03:16:07+00:00 CRITICAL Call to a member function get_price() on boolean
```

Example of a log entry for the same error after this patch:

```
2018-05-26T03:16:07+00:00 CRITICAL Call to a member function get_price() on boolean in /home/user/public_html/wp-content/plugins/woocommerce-subscriptions/includes/wcs-time-functions.php on line 670
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

* Tweak - include the file path and line number where a fatal error occurred in the fatal errors log
* Dev -  add 'woocommerce_shutdown_error' hook triggered on request termination with an error