### PR TITLE
Adding product data to `removed_from_cart` event

### DIFF
--- a/assets/js/frontend/add-to-cart.js
+++ b/assets/js/frontend/add-to-cart.js
@@ -86,7 +86,7 @@ jQuery( function( $ ) {
 				window.location = $thisbutton.attr( 'href' );
 				return;
 			}
-			$( document.body ).trigger( 'removed_from_cart', [ response.fragments, response.cart_hash, $thisbutton.data() ] );
+			$( document.body ).trigger( 'removed_from_cart', [ response.fragments, response.cart_hash, $thisbutton ] );
 		}).fail( function() {
 			window.location = $thisbutton.attr( 'href' );
 			return;

--- a/assets/js/frontend/add-to-cart.js
+++ b/assets/js/frontend/add-to-cart.js
@@ -86,7 +86,7 @@ jQuery( function( $ ) {
 				window.location = $thisbutton.attr( 'href' );
 				return;
 			}
-			$( document.body ).trigger( 'removed_from_cart', [ response.fragments, response.cart_hash ] );
+			$( document.body ).trigger( 'removed_from_cart', [ response.fragments, response.cart_hash, $thisbutton.data() ] );
 		}).fail( function() {
 			window.location = $thisbutton.attr( 'href' );
 			return;


### PR DESCRIPTION
Adding `$thisbutton` to the arguments sent by the `removed_from_cart` event.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

The addition of `$thisbutton` (whose data object stores the removed product information `cart_item_key`, `product_id` and `sku`) to the arguments passed by the `removed_from_cart` event would help developers easily detect which product has just been removed from the cart and alter their theme/plugin accordingly. Moreover this addition would make the `removed_from_cart` event consistent to the `added_to_cart` one.

### How to test the changes in this Pull Request:

1. Add the following code to your theme or plugin script:
```
$( document.body ).on( 'removed_from_cart', function(event, fragments, cartHash, $thisbutton){
    console.log($thisbutton.data);
} );

```
2. When removing an item from the cart, you should be able to see the data object associated to `$thisbutton` in the console.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

The `removed_from_cart` event now passes also the product information stored in the cart button data object, in addition to the cart fragments and the cart hash.
