### PR TITLE
Do not build paypal pay link when no base country is set.

### DIFF
--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -141,14 +141,19 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 * @return string
 	 */
 	public function get_icon() {
+		// We need a base country for the link to work, bail if in the unlikely event no country is set.
+		$base_country = WC()->countries->get_base_country();
+		if ( empty( $base_country ) ) {
+			return '';
+		}
 		$icon_html = '';
-		$icon      = (array) $this->get_icon_image( WC()->countries->get_base_country() );
+		$icon      = (array) $this->get_icon_image( $base_country );
 
 		foreach ( $icon as $i ) {
 			$icon_html .= '<img src="' . esc_attr( $i ) . '" alt="' . esc_attr__( 'PayPal acceptance mark', 'woocommerce' ) . '" />';
 		}
 
-		$icon_html .= sprintf( '<a href="%1$s" class="about_paypal" onclick="javascript:window.open(\'%1$s\',\'WIPaypal\',\'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=1060, height=700\'); return false;">' . esc_attr__( 'What is PayPal?', 'woocommerce' ) . '</a>', esc_url( $this->get_icon_url( WC()->countries->get_base_country() ) ) );
+		$icon_html .= sprintf( '<a href="%1$s" class="about_paypal" onclick="javascript:window.open(\'%1$s\',\'WIPaypal\',\'toolbar=no, location=no, directories=no, status=no, menubar=no, scrollbars=yes, resizable=yes, width=1060, height=700\'); return false;">' . esc_attr__( 'What is PayPal?', 'woocommerce' ) . '</a>', esc_url( $this->get_icon_url( $base_country ) ) );
 
 		return apply_filters( 'woocommerce_gateway_icon', $icon_html, $this->id );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When you setup WooCommerce without saving the base country and enable paypal payments, the paypal pay link is broken due to it relying on the base country to build the URL.

This PR will remove the pay link when no base country is saved.

Closes #20804 .

### How to test the changes in this Pull Request:

1. Do a new WC install on a brand new DB without saving anything or doing the wizard.
2. Enable PayPal with the correct settings
3. Try and purchase a product, there should not be a link to make paypal payment.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Only allow paypal payments when the base country is set.
