### PR TITLE
Add class names to `edit_category_fields()` to be inline with other f…

### DIFF
--- a/includes/admin/class-wc-admin-taxonomies.php
+++ b/includes/admin/class-wc-admin-taxonomies.php
@@ -200,7 +200,7 @@ class WC_Admin_Taxonomies {
 			$image = wc_placeholder_img_src();
 		}
 		?>
-		<tr class="form-field">
+		<tr class="form-field term-display-type-wrap">
 			<th scope="row" valign="top"><label><?php _e( 'Display type', 'woocommerce' ); ?></label></th>
 			<td>
 				<select id="display_type" name="display_type" class="postform">
@@ -211,7 +211,7 @@ class WC_Admin_Taxonomies {
 				</select>
 			</td>
 		</tr>
-		<tr class="form-field">
+		<tr class="form-field term-thumbnail-wrap">
 			<th scope="row" valign="top"><label><?php _e( 'Thumbnail', 'woocommerce' ); ?></label></th>
 			<td>
 				<div id="product_cat_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( $image ); ?>" width="60px" height="60px" /></div>


### PR DESCRIPTION
…ields

Class names are added in `add_category_fields()` but not `edit_category_fields()`. This brings them inline with each other and with other Wordpress term fields

NOTE - there are various coding standard errors which might need to be looked at

```
   8 | ERROR | @category tags are prohibited
   9 | ERROR | @author tags are prohibited
  13 | ERROR | Inline comments must end in full-stops, exclamation
     |       | marks, or question marks
  25 | ERROR | Inline comments must end in full-stops, exclamation
     |       | marks, or question marks
  29 | ERROR | Inline comments must end in full-stops, exclamation
     |       | marks, or question marks
  35 | ERROR | Inline comments must end in full-stops, exclamation
     |       | marks, or question marks
  43 | ERROR | Inline comments must end in full-stops, exclamation
     |       | marks, or question marks
  55 | ERROR | Inline comments must end in full-stops, exclamation
     |       | marks, or question marks
  62 | ERROR | Missing parameter comment
  63 | ERROR | Missing parameter comment
  64 | ERROR | Missing parameter comment
  79 | ERROR | Missing parameter comment
  97 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
  99 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 100 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 101 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 102 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 106 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 110 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 111 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 135 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 137 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 190 | ERROR | Parameter comment must end with a full stop
 204 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 207 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 208 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 209 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 210 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 215 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 219 | ERROR | All output should be run through an escaping function
     |       | (see the Security sections in the WordPress Developer
     |       | Handbooks), found '$thumbnail_id'.
 220 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 221 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 245 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 247 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 281 | ERROR | Doc comment short description must start with a
     |       | capital letter
 283 | ERROR | Parameter comment must end with a full stop
 284 | ERROR | Missing parameter comment
 285 | ERROR | Missing parameter comment
 288 | ERROR | Processing form data without nonce verification.
 289 | ERROR | Processing form data without nonce verification.
 289 | ERROR | Missing wp_unslash() before sanitization.
 289 | ERROR | Detected usage of a non-sanitized input variable:
     |       | $_POST
 291 | ERROR | Processing form data without nonce verification.
 292 | ERROR | Processing form data without nonce verification.
 300 | ERROR | All output should be run through an escaping function
     |       | (see the Security sections in the WordPress Developer
     |       | Handbooks), found 'wpautop'.
 313 | ERROR | All output should be run through an escaping function
     |       | (like esc_html_e() or esc_attr_e()), found '_e'.
 317 | ERROR | All output should be run through an escaping function
     |       | (see the Security sections in the WordPress Developer
     |       | Handbooks), found '__'.
 330 | ERROR | All output should be run through an escaping function
     |       | (see the Security sections in the WordPress Developer
     |       | Handbooks), found 'wpautop'.
 336 | ERROR | Missing parameter comment
 385 | ERROR | Missing wp_unslash() before sanitization.
 385 | ERROR | Detected usage of a non-sanitized input variable:
     |       | $_GET
 394 | ERROR | Missing parameter comment
 395 | ERROR | Missing parameter comment
 396 | ERROR | Missing parameter comment
 417 | ERROR | Inline comments must end in full-stops, exclamation
     |       | marks, or question marks
 430 | ERROR | Missing parameter comment
```

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Changelog entry

> Class names are added in `add_category_fields()` but not `edit_category_fields()`. This brings them inline with each other and with other Wordpress term fields
