### PR TITLE
Pass an instance of the background updater to the db update callbacks

### DIFF
--- a/includes/class-wc-background-updater.php
+++ b/includes/class-wc-background-updater.php
@@ -106,7 +106,7 @@ class WC_Background_Updater extends WC_Background_Process {
 
 		if ( is_callable( $callback ) ) {
 			$logger->info( sprintf( 'Running %s callback', $callback ), array( 'source' => 'wc_db_updates' ) );
-			$result = (bool) call_user_func( $callback );
+			$result = (bool) call_user_func( $callback, $this );
 
 			if ( $result ) {
 				$logger->info( sprintf( '%s callback needs to run again', $callback ), array( 'source' => 'wc_db_updates' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the way that WC_Background_Updater::task() calls the database update callbacks and adds the WC_Background_Updater instance as the first parameter to the callbacks. This is used in wc_update_350_order_customer_id() ([includes/wc-update-functions.php#L1870](https://github.com/woocommerce/woocommerce/blob/36b6bd79c0d61035e979b017a23b6c0c79accaba/includes/wc-update-functions.php#L1870))  to monitor memory usage while the function is running. This change was intended to ship with PR #17895 (see commit https://github.com/woocommerce/woocommerce/pull/17895/commits/c77b2f20f443647fd09c0de9705d2dbc214548c3) but was accidentally removed when merging commit 083c9947328df00c0af65cfdf300e31ea74aa337 from another PR.

Kudos to @jorgeatorres for finding and reporting this problem.

Fixes #20718

### How to test the changes in this Pull Request:

1. Start the 3.5 upgrade routine on a WC install with a large database from wp-admin
2. Monitor the background updater logs, while the process is running you should see a few `wc_update_350_order_customer_id callback needs to run again` entries. That means that the update callback was close to the memory limit and so it exited and will start again.