### PR TITLE
Adding config for making the "restock refunded items" checked/unchecked

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -253,7 +253,12 @@ if ( wc_tax_enabled() ) {
 		<?php if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) : ?>
 			<tr>
 				<td class="label"><label for="restock_refunded_items"><?php esc_html_e( 'Restock refunded items', 'woocommerce' ); ?>:</label></td>
-				<td class="total"><input type="checkbox" id="restock_refunded_items" name="restock_refunded_items" checked="checked" /></td>
+				<?php
+				if ( 'yes' === get_option( 'woocommerce_restock_refunded_items' ) ) {
+					$checked = 'checked="checked"';
+				}
+				?>
+				<td class="total"><input type="checkbox" id="restock_refunded_items" name="restock_refunded_items"<?php echo esc_attr( $checked, 'woocommerce' ); ?> /></td>
 			</tr>
 		<?php endif; ?>
 		<tr>

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -140,6 +140,14 @@ class WC_Settings_Products extends WC_Settings_Page {
 					),
 
 					array(
+						'title'   => __( 'Restock refunded items', 'woocommerce' ),
+						'desc'    => __( 'Uncheck this to default to NOT restocking items when refunding', 'woocommerce' ),
+						'id'      => 'woocommerce_restock_refunded_items',
+						'default' => 'yes',
+						'type'    => 'checkbox',
+					),
+
+					array(
 						'title'             => __( 'Hold stock (minutes)', 'woocommerce' ),
 						'desc'              => __( 'Hold stock (for unpaid orders) for x minutes. When this limit is reached, the pending order will be cancelled. Leave blank to disable.', 'woocommerce' ),
 						'id'                => 'woocommerce_hold_stock_minutes',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Adds a checkbox config in Settings>Products>Inventory to default the "restock refunded items" checkbox to check or unchecked.

Closes #20822.

### How to test the changes in this Pull Request:

1. The setting defaults to TRUE to be backwards compatible. Go to Settings>Products>Inventory and UNcheck the box
2. Go to a refund on an order and notice the "restocked refunded items" checkbox is UNchecked.
3. After processing the refund, confirm the stock was not incremented.

### Note
The PHP/html mix in `html-order-items.php` is pretty ugly, but it passes the sniffer. If there's a better way to do this, happy to improve it.
