### PR TITLE
Cart widget Customizer selective refresh fix

### DIFF
--- a/includes/widgets/class-wc-widget-cart.php
+++ b/includes/widgets/class-wc-widget-cart.php
@@ -77,6 +77,9 @@ class WC_Widget_Cart extends WC_Widget {
 	/**
 	 * This method provides the JS script which will execute on addition of a new widget.
 	 *
+	 * @todo 1. In this function there is a redundency of code, which needs to be fixed.
+	 *       2. Also sort out a better way to fix the raw JS code block. May be using `wc_enqueue_js()`.
+	 *
 	 * @return void
 	 */
 	private function enqueue_ajax_script() {

--- a/includes/widgets/class-wc-widget-cart.php
+++ b/includes/widgets/class-wc-widget-cart.php
@@ -77,8 +77,8 @@ class WC_Widget_Cart extends WC_Widget {
 	/**
 	 * This method provides the JS script which will execute on addition of a new widget.
 	 *
-	 * @todo 1. In this function there is a redundency of code, which needs to be fixed.
-	 *       2. Also sort out a better way to fix the raw JS code block. May be using `wc_enqueue_js()`.
+	 * @todo 1. In this function there is redundency of code, which needs to be fixed.
+	 *       2. Also sort out a better way to fix the later raw JS code block. May be do it a more WordPress way.
 	 *
 	 * @return void
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20696 

This issue was actually happening because of related scripts not being enqueued. In this PR the scripts has been enqueued properly in Customizer mode and being fired as well.

### How to test the changes in this Pull Request:

1. Go to 'Appearance > Customize'
2. Click on 'Widgets' and choose your Sidebar
3. Put a 'Cart' widget
4. The widget **isn't** blank anymore. ***It's now responsive for Customizer selective refresh.***

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?