### PR TITLE
Enable SCRIPT_DEBUG on e2e tests

### DIFF
--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -175,6 +175,7 @@ install_e2e_site() {
 		php wp-cli.phar core config --dbname=$DB_NAME --dbuser=$DB_USER --dbpass=$DB_PASS --dbhost=$DB_HOST --dbprefix=wp_ --extra-php <<PHP
 /* Change WP_MEMORY_LIMIT to increase the memory limit for public pages. */
 define('WP_MEMORY_LIMIT', '256M');
+define('SCRIPT_DEBUG', true);
 PHP
 		php wp-cli.phar core install --url="$WP_SITE_URL" --title="Example" --admin_user=admin --admin_password=password --admin_email=info@example.com --path=$WP_CORE_DIR --skip-email
 		php wp-cli.phar db import $WP_DB_DATA


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR enables SCRIPT_DEBUG for the e2e tests since when developing we do not minify scripts but only change the original script. Minification of JS files only happens when we do a release. This ensures that the e2e tests always run with the latest JS changes.

### How to test the changes in this Pull Request:

1. Check e2e test results pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

