### PR TITLE
Make wc_get_attachment_image_attributes do what it is suppose to.

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -455,7 +455,7 @@ add_action( 'woocommerce_scheduled_sales', 'wc_scheduled_sales' );
  * @return array
  */
 function wc_get_attachment_image_attributes( $attr ) {
-	if ( isset( $attr[0] ) && strstr( $attr['src'][0], 'woocommerce_uploads/' ) ) {
+	if ( isset( $attr['src'][0] ) && strstr( $attr['src'][0], 'woocommerce_uploads/' ) ) {
 		$attr['src'][0] = wc_placeholder_img_src();
 	}
 	return $attr;

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -455,8 +455,8 @@ add_action( 'woocommerce_scheduled_sales', 'wc_scheduled_sales' );
  * @return array
  */
 function wc_get_attachment_image_attributes( $attr ) {
-	if ( isset( $attr['src'][0] ) && strstr( $attr['src'][0], 'woocommerce_uploads/' ) ) {
-		$attr['src'][0] = wc_placeholder_img_src();
+	if ( isset( $attr['src'] ) && strstr( $attr['src'], 'woocommerce_uploads/' ) ) {
+		$attr['src'] = wc_placeholder_img_src();
 	}
 	return $attr;
 }

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -455,7 +455,7 @@ add_action( 'woocommerce_scheduled_sales', 'wc_scheduled_sales' );
  * @return array
  */
 function wc_get_attachment_image_attributes( $attr ) {
-	if ( strstr( $attr['src'][0], 'woocommerce_uploads/' ) ) {
+	if ( isset( $attr[0] ) && strstr( $attr['src'][0], 'woocommerce_uploads/' ) ) {
 		$attr['src'][0] = wc_placeholder_img_src();
 	}
 	return $attr;

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -457,6 +457,10 @@ add_action( 'woocommerce_scheduled_sales', 'wc_scheduled_sales' );
 function wc_get_attachment_image_attributes( $attr ) {
 	if ( isset( $attr['src'] ) && strstr( $attr['src'], 'woocommerce_uploads/' ) ) {
 		$attr['src'] = wc_placeholder_img_src();
+
+		if ( isset( $attr['srcset'] ) ) {
+			$attr['srcset'] = '';
+		}
 	}
 	return $attr;
 }

--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -897,8 +897,8 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-     * @expectedException WC_Data_Exception
-     */
+	 * @expectedException WC_Data_Exception
+	 */
 	public function test_wc_product_has_unique_sku() {
 		$product_1 = WC_Helper_Product::create_simple_product();
 
@@ -986,5 +986,46 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		$this->assertFalse( wc_is_attribute_in_product_name( 'L', 'Product' ) );
 		$this->assertFalse( wc_is_attribute_in_product_name( 'L', 'Product L Thing' ) );
 		$this->assertFalse( wc_is_attribute_in_product_name( 'Blue', 'Product &ndash; Large, Blueish' ) );
+	}
+
+	public function test_wc_get_attachment_image_attributes() {
+		$image_attr = array(
+			'src'    => 'https://wc.local/wp-content/uploads/2018/02/single-1-250x250.jpg',
+			'class'  => 'attachment-woocommerce_thumbnail size-woocommerce_thumbnail',
+			'alt'    => '',
+			'srcset' => 'https://wc.local/wp-content/uploads/2018/02/single-1-250x250.jpg 250w, https://wc.local/wp-content/uploads/2018/02/single-1-350x350.jpg 350w, https://wc.local/wp-content/uploads/2018/02/single-1-150x150.jpg 150w, https://wc.local/wp-content/uploads/2018/02/single-1-300x300.jpg 300w, https://wc.local/wp-content/uploads/2018/02/single-1-768x768.jpg 768w, https://wc.local/wp-content/uploads/2018/02/single-1-100x100.jpg 100w, https://wc.local/wp-content/uploads/2018/02/single-1.jpg 800w',
+			'sizes'  => '(max-width: 250px) 100vw, 250px',
+		);
+		// Test regular image attr
+		$this->assertEquals( $image_attr, wc_get_attachment_image_attributes( $image_attr ) );
+
+		$image_attr = array(
+			'src'    => '',
+			'class'  => 'attachment-woocommerce_thumbnail size-woocommerce_thumbnail',
+			'alt'    => '',
+			'srcset' => '',
+			'sizes'  => '(max-width: 250px) 100vw, 250px',
+		);
+		// Test blank src image attr, this is used in lazy loading.
+		$this->assertEquals( $image_attr, wc_get_attachment_image_attributes( $image_attr ) );
+
+		$image_attr = array(
+			'src'    => 'https://wc.local/wp-content/woocommerce_uploads/my-image.jpg',
+			'class'  => 'attachment-woocommerce_thumbnail size-woocommerce_thumbnail',
+			'alt'    => '',
+			'srcset' => '',
+			'sizes'  => '(max-width: 250px) 100vw, 250px',
+		);
+		$expected_attr = array(
+			'src'    => WC()->plugin_url() . '/assets/images/placeholder.png',
+			'class'  => 'attachment-woocommerce_thumbnail size-woocommerce_thumbnail',
+			'alt'    => '',
+			'srcset' => '',
+			'sizes'  => '(max-width: 250px) 100vw, 250px',
+		);
+		// Test image hosted in woocommerce_uploads which is not allowed, think shops selling photos.
+		$this->assertEquals( $expected_attr, wc_get_attachment_image_attributes( $image_attr ) );
+
+		unset( $image_attr, $expected_attr );
 	}
 }

--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -1013,7 +1013,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 			'src'    => 'https://wc.local/wp-content/woocommerce_uploads/my-image.jpg',
 			'class'  => 'attachment-woocommerce_thumbnail size-woocommerce_thumbnail',
 			'alt'    => '',
-			'srcset' => '',
+			'srcset' => 'https://wc.local/wp-content/woocommerce_uploads/my-image-250x250.jpg 250w, https://wc.local/wp-content/woocommerce_uploads/my-image-350x350 350w',
 			'sizes'  => '(max-width: 250px) 100vw, 250px',
 		);
 		$expected_attr = array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
wc_get_attachment_image_attributes was trying to reference a sub array of src which is not present in WordPress, instead it was referencing the first char only. This PR makes it so it checks the actual src string and ensure we do not display images in the woocommerce_uploads folder. It also fixes a undefined index as reported in 20844 due to the unsetting of src by lazy loading plugins.

Closes #20844  .

### How to test the changes in this Pull Request:

1. Run `vendor/bin/phpunit tests/unit-tests/product/functions.php` which has new tests specifically to test the various scenarios.
2. Alternatively, upload an image to the woocommerce_uploads folder and set it as the image of a product, it should not display the image but display the placeholder image instead.
3. Also test using a lazy load plugin to make sure #20844 does not occur.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Prohibit use of images located in the woocommerce_uploads folder.
