### PR TITLE
Reduce WC_Tests_REST_System_Status tests execution time

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -110,10 +110,10 @@ class WC_Unit_Tests_Bootstrap {
 		require_once $this->tests_dir . '/framework/vendor/class-wp-test-spy-rest-server.php';
 
 		// test cases
+		require_once $this->tests_dir . '/includes/wp-http-testcase.php';
 		require_once $this->tests_dir . '/framework/class-wc-unit-test-case.php';
 		require_once $this->tests_dir . '/framework/class-wc-api-unit-test-case.php';
 		require_once $this->tests_dir . '/framework/class-wc-rest-unit-test-case.php';
-		require_once $this->tests_dir . '/includes/wp-http-testcase.php';
 
 		// Helpers
 		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-product.php';

--- a/tests/framework/class-wc-unit-test-case.php
+++ b/tests/framework/class-wc-unit-test-case.php
@@ -13,7 +13,7 @@
  *
  * @since 2.2
  */
-class WC_Unit_Test_Case extends WP_UnitTestCase {
+class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 
 	/**
 	 * Holds the WC_Unit_Test_Factory instance.

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -10,7 +10,7 @@
  *
  * @since 2.2
  */
-class WC_Tests_Formatting_Functions extends WP_HTTP_TestCase {
+class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
 	public function setUp() {
 		parent::setUp();

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -4,7 +4,7 @@
  * Meta
  * @package WooCommerce\Tests\Importer
  */
-class WC_Tests_Product_CSV_Importer extends WP_HTTP_TestCase {
+class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 
 	/**
 	 * Test CSV file path.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes WC_Tests_REST_System_Status tests to use artificial HTTP responses instead of performing external HTTP requests. With this change execution time for these tests dropped from 22s to 3s.

To make it easier for test classes to use artificial HTTP responses and also to make it possible for test classes to use functionality provided both by WP_HTTP_TestCase and WC_Unit_Test_Case, this PR also changes WC_Unit_Test_Case to extend WP_HTTP_TestCase instead of WP_UnitTestCase.

### How to test the changes in this Pull Request:

1. Compare test execution time before and after this PR
2. Make sure all tests pass in the Travis build