### PR TITLE
Prevent JS Issue if `woocommerce_available_variation` filter return false

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -300,7 +300,9 @@ class WC_Product_Variable extends WC_Product {
 				continue;
 			}
 
-			$available_variations[] = $this->get_available_variation( $variation );
+			if( $this->get_available_variation( $variation ) ){
+			    $available_variations[] = $this->get_available_variation( $variation );
+			}
 		}
 		$available_variations = array_filter( $available_variations );
 

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -300,11 +300,9 @@ class WC_Product_Variable extends WC_Product {
 				continue;
 			}
 
-			if( $this->get_available_variation( $variation ) ){
-			    $available_variations[] = $this->get_available_variation( $variation );
-			}
+			$available_variations[] = $this->get_available_variation( $variation );
 		}
-		$available_variations = array_filter( $available_variations );
+		$available_variations = array_values( array_filter( $available_variations ) );
 
 		return $available_variations;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Re-indexing `get_available_variations` method return values.

Suppose you made changed with `woocommerce_available_variation` hook and skip returning some specific variation product with false value. 

There is `array_filter` function to filter empty values from `get_available_variations` method but it preserves array index which convert to js object rather then js array on `single-product/add-to-cart/variable.php` template variation form `data-product_variations` attribute, and select box dropdown doesn't show. 

Just added `array_values` PHP function to re-index after `array_filter` function which convert to js array rather then js object before `get_available_variations` function return.

### How to test the changes in this Pull Request:

1. Suppose you want to hide only out of stock variation product. But you don't want to do it from **Settings -> Inventory -> Out of stock visibility**, Because Out of stock Single product also hide from catalog also. So you wrote this code to hide it.

```
add_filter( 'woocommerce_available_variation', function ( $variation, $productObject, $variationObject ) {
    return $variationObject->is_in_stock() ? $variation : FALSE;
}, 10, 3 );
```
It's fine that `get_available_variations` method use `array_filter` function to filter empty array values but it keeps index, thats why on `single-product/add-to-cart/variable.php` `available_variations` variable generate js object rather then js array and Variable drop down doesn't show.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?