### PR TITLE
Allow custom menu ordering when set by another filter

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -215,10 +215,11 @@ class WC_Admin_Menus {
 	/**
 	 * Custom menu order.
 	 *
+	 * @param bool $enabled Whether custom menu ordering is already enabled.
 	 * @return bool
 	 */
-	public function custom_menu_order() {
-		return current_user_can( 'manage_woocommerce' );
+	public function custom_menu_order( $enabled ) {
+		return $enabled || current_user_can( 'manage_woocommerce' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This change causes WooCommerce to respect previously returned values from the [`custom_menu_order`](https://developer.wordpress.org/reference/hooks/custom_menu_order/) filter, used to [customize menu item ordering](https://developer.wordpress.org/reference/hooks/menu_order/).

Previously, if a 3rd-party plugin used that filter to enable custom menu ordering, WooCommerce would override and disable the custom ordering in some cases. Specifically, this would happen in the case where the 3rd-party plugin's filter is run _before_ WooCommerce's filter, and the current user does not have `manage_woocommerce` privileges.

This PR fixes that by checking the incoming value for the filter, and returning `true` if the incoming value is `true`. I.e. if another plugin enables menu customization, WooCommerce should not disable it.

For a real-world occurrence of this bug, see https://github.com/woocommerce/sensei-certificates/pull/151

### How to test the changes in this Pull Request:

1. Add the following code snippet to your site:

```
// Customize the side menu: set Dashboard, Posts, Comments to be at the top.
function custom_menu_order() {
	return array( 'index.php', 'edit.php', 'edit-comments.php' );
}
add_filter( 'custom_menu_order', '__return_true', 5 ); // Priority 5 so it runs *before* WooCommerce.
add_filter( 'menu_order', 'custom_menu_order' );


// Remove ability to manage WooCommerce.
function wc_cap_filter( $allcaps, $cap, $args ) {
	if ( 'manage_woocommerce' === $cap[0] ) {
		$allcaps[ $cap[0] ] = false;
	}
	return $allcaps;
}
add_filter( 'user_has_cap', 'wc_cap_filter', 10, 3 );
```

2. When you load the page, ensure that the top three menu items are Dashboard, Posts, and Comments.

3. Remove the line `add_filter( 'user_has_cap', 'wc_cap_filter', 10, 3 );`. The same three items should be at the top of the menu.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* ~[ ] Have you written new tests for your changes, as applicable?~
* ~[ ] Have you successfully ran tests with your changes locally?~

<!-- Mark completed items with an [x] -->