### PR TITLE
Switch travis codecoverage from xdebug to phpdbg

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
   - env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
 
 before_script:
+  - phpenv config-rm xdebug.ini
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION
   - bash tests/bin/travis.sh before

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ matrix:
     dist: precise
   - php: 7.2
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1 RUN_E2E=1
-  - php: 7.2
+  - php: 7.1
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   allow_failures:
   - env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1

--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [[ ${RUN_CODE_COVERAGE} == 1 ]]; then
-	phpdbg -qqr phpunit -c phpunit.xml --coverage-clover=coverage.clover
+	phpdbg -qrr phpunit -c phpunit.xml --coverage-clover=coverage.clover
 else
 	phpunit -c phpunit.xml
 fi

--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [[ ${RUN_CODE_COVERAGE} == 1 ]]; then
-	phpdbg -qrr phpunit -c phpunit.xml --coverage-clover=coverage.clover
+	phpdbg -qqr phpunit -c phpunit.xml --coverage-clover=coverage.clover
 else
 	phpunit -c phpunit.xml
 fi

--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [[ ${RUN_CODE_COVERAGE} == 1 ]]; then
-	phpdbg -qrr phpunit -c phpunit.xml --coverage-clover=coverage.clover
+	phpdbg -qrr vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover
 else
 	phpunit -c phpunit.xml
 fi

--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [[ ${RUN_CODE_COVERAGE} == 1 ]]; then
-	phpdbg -qrr .composer/vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover
+	phpdbg -qrr $HOME/.composer/vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover
 else
 	phpunit -c phpunit.xml
 fi

--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [[ ${RUN_CODE_COVERAGE} == 1 ]]; then
-	phpdbg -qrr $HOME/.composer/vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover
+	phpdbg -qrr -d memory_limit=-1 $HOME/.composer/vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover
 else
 	phpunit -c phpunit.xml
 fi

--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [[ ${RUN_CODE_COVERAGE} == 1 ]]; then
-	phpdbg -qrr -d memory_limit=-1 $HOME/.composer/vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover
+	phpdbg -qrr -d memory_limit=-1 $HOME/.composer/vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover --exclude-group=timeout
 else
 	phpunit -c phpunit.xml
 fi

--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [[ ${RUN_CODE_COVERAGE} == 1 ]]; then
-	phpdbg -qrr vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover
+	phpdbg -qrr .composer/vendor/bin/phpunit -c phpunit.xml --coverage-clover=coverage.clover
 else
 	phpunit -c phpunit.xml
 fi

--- a/tests/bin/phpunit.sh
+++ b/tests/bin/phpunit.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [[ ${RUN_CODE_COVERAGE} == 1 ]]; then
-	phpunit -c phpunit.xml --coverage-clover=coverage.clover
+	phpdbg -qrr phpunit -c phpunit.xml --coverage-clover=coverage.clover
 else
 	phpunit -c phpunit.xml
 fi

--- a/tests/bin/travis.sh
+++ b/tests/bin/travis.sh
@@ -3,12 +3,6 @@
 
 if [ $1 == 'before' ]; then
 
-	# Remove Xdebug from PHP runtime for all PHP version except 7.1 to speed up builds.
-	# We need Xdebug enabled in the PHP 7.1 build job as it is used to generate code coverage.
-	if [[ ${RUN_CODE_COVERAGE} != 1 ]]; then
-		phpenv config-rm xdebug.ini
-	fi
-
 	composer global require "phpunit/phpunit=6.*"
 
 	if [[ ${RUN_PHPCS} == 1 ]]; then

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -313,6 +313,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	/**
 	 * Test for request_url() method.
 	 *
+	 * @group timeout
 	 * @throws WC_Data_Exception
 	 */
 	public function test_request_url() {

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -48,7 +48,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	 * @param WC_Order $order Order to which the products should be added.
 	 * @param array    $prices Array of prices to use for created products. Leave empty for default prices.
 	 */
-	protected function add_products_to_order( $order, $prices = array() ) {
+	protected function add_products_to_order( &$order, $prices = array() ) {
 		// Remove previous items.
 		foreach ( $order->get_items() as $item ) {
 			$order->remove_item( $item->get_id() );
@@ -70,7 +70,6 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 
 			$prod_count++;
 		}
-
 	}
 
 	/**
@@ -148,7 +147,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
 
 		WC_Helper_Order::delete_order( $this->order->get_id() );
-
+		unset( $this->products, $this->order );
 	}
 
 	/**

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -11,9 +11,9 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 	/**
 	 * Test wc_get_product_class().
 	 *
-	 * @covers wc_product_class()
-	 * @covers wc_product_post_class()
-	 * @covers wc_get_product_taxonomy_class()
+	 * @covers ::wc_product_class()
+	 * @covers ::wc_product_post_class()
+	 * @covers ::wc_get_product_taxonomy_class()
 	 * @since 3.4.0
 	 */
 	public function test_wc_get_product_class() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR changes the travis codecoverage from using xdebug to phpdbg, phpdbg seems much faster and gives similar results.

Reason for switching is we have been running into constant timeouts on our codecoverage due to the 50min job limit on travis, which means our codecoverage has not been updated in a couple of months.

### How to test the changes in this Pull Request:

1. Check travis test results, the codecoverage job should complete without issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->