### PR TITLE
Data store interface for v3 API reports endpoints.

### DIFF
--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -53,6 +53,7 @@ class WC_Data_Store {
 		'product-variation'     => 'WC_Product_Variation_Data_Store_CPT',
 		'shipping-zone'         => 'WC_Shipping_Zone_Data_Store',
 		'webhook'               => 'WC_Webhook_Data_Store',
+		'revenue-report'        => 'WC_Reports_Revenue_Data_Store',
 	);
 
 	/**

--- a/includes/class-wc-reports-interval.php
+++ b/includes/class-wc-reports-interval.php
@@ -178,6 +178,10 @@ class WC_Reports_Interval {
 	public static function next_month_start( $datetime ) {
 		$year  = $datetime->format( 'Y' );
 		$month = (int) $datetime->format( 'm' ) + 1;
+		if ( $month > 12 ) {
+			$month = 1;
+			$year++;
+		}
 		$day   = '01';
 		return new DateTime( "$year-$month-$day 00:00:00" );
 	}
@@ -191,6 +195,10 @@ class WC_Reports_Interval {
 	public static function next_quarter_start( $datetime ) {
 		$year  = $datetime->format( 'Y' );
 		$month = (int) $datetime->format( 'm' ) + 3;
+		if ( $month > 12 ) {
+			$month = $month - 12;
+			$year++;
+		}
 		$day   = '01';
 		return new DateTime( "$year-$month-$day 00:00:00" );
 	}

--- a/includes/class-wc-reports-interval.php
+++ b/includes/class-wc-reports-interval.php
@@ -1,0 +1,227 @@
+<?php
+/**
+ * Class for time interval handling for reports
+ *
+ * @package  WooCommerce/Classes
+ * @version  3.5.0
+ * @since    3.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+define( 'SECONDS_PER_DAY', 86400 );
+define( 'SECONDS_PER_HOUR', 3600 );
+
+/**
+ * Date & time interval handling class for Reporting API.
+ */
+class WC_Reports_Interval {
+
+	/**
+	 * Returns date format to be used as grouping clause in SQL.
+	 *
+	 * @param string $time_interval Time interval.
+	 * @return mixed
+	 */
+	public static function mysql_datetime_format( $time_interval ) {
+		$first_day_of_week = absint( get_option( 'start_of_week' ) );
+
+		if ( 1 === $first_day_of_week ) {
+			// Week begins on Monday.
+			$week_format = '%v';
+			$year_format = '%x';
+		} elseif ( 0 === $first_day_of_week ) {
+			// Week begins on Sunday.
+			$week_format = '%V';
+			$year_format = '%X';
+		} else {
+			// TODO: there are some countries where the week starts on Saturday (Egypt, etc), how to handle it in MySQL?
+			// maybe adapt this: https://stackoverflow.com/questions/10656996/week-of-the-year-for-weeks-starting-with-saturday.
+			$week_format = '%V';
+			$year_format = '%X';
+		}
+
+		$mysql_date_format_mapping = array(
+			'hour'    => "DATE_FORMAT(hour, '%Y-%m-%d %k')",
+			'day'     => "DATE_FORMAT(hour, '%Y-%m-%d')",
+			'week'    => "DATE_FORMAT(hour, '$year_format-$week_format')",
+			'month'   => "DATE_FORMAT(hour, '%Y-%m')",
+			'quarter' => "CONCAT(YEAR(hour), '-', QUARTER(hour))",
+			'year'    => 'YEAR(hour)',
+
+		);
+
+		return $mysql_date_format_mapping[ $time_interval ];
+	}
+
+	/**
+	 * Returns quarter for the DateTime.
+	 *
+	 * @param DateTime $datetime Date & time.
+	 * @return int|null
+	 */
+	public static function quarter( $datetime ) {
+		// TODO: is there a smarter way? Is floor((m - 1)/3) + 1 better?
+		switch ( (int) $datetime->format( 'm' ) ) {
+			case 1:
+			case 2:
+			case 3:
+				return 1;
+			case 4:
+			case 5:
+			case 6:
+				return 2;
+			case 7:
+			case 8:
+			case 9:
+				return 3;
+			case 10:
+			case 11:
+			case 12:
+				return 4;
+
+		}
+		return null;
+	}
+
+	/**
+	 * Returns time interval id for the DateTime.
+	 *
+	 * @param string   $time_interval Time interval type (week, day, etc).
+	 * @param DateTime $datetime      Date & time.
+	 * @return string
+	 */
+	public static function time_interval_id( $time_interval, $datetime ) {
+		$php_time_format_for = array(
+			'hour'    => 'Y-m-d H',
+			'day'     => 'Y-m-d',
+			'week'    => 'o-W',
+			'month'   => 'Y-m',
+			'quarter' => 'Y-' . WC_Reports_Interval::quarter( $datetime ),
+			'year'    => 'Y',
+		);
+
+		// If the week does not begin on Monday.
+		$first_day_of_week = absint( get_option( 'start_of_week' ) );
+		if ( 0 === $first_day_of_week ) {
+			$first_day_of_week = 7;
+		}
+		if ( 'week' === $time_interval && 1 !== $first_day_of_week ) {
+			// Side note: strftime week number %U is odd, so something else is needed.
+			$week_no     = $datetime->format( 'W' );
+			$year_no     = $datetime->format( 'Y' ); // maybe 'o' need to be used?
+			$day_of_week = $datetime->format( 'N' );
+			if ( $day_of_week >= $first_day_of_week ) {
+				$week_no++;
+			}
+			// TODO: this is not right, just an interim solution.
+			if ( $week_no >= 52 ) {
+				$week_no = 1;
+			}
+			return "$year_no-$week_no";
+		}
+
+		return $datetime->format( $php_time_format_for[ $time_interval ] );
+	}
+
+	/**
+	 * Returns DateTime object representing the next hour start.
+	 *
+	 * @param DateTime $datetime Date and time.
+	 * @return DateTime
+	 */
+	public static function next_hour_start( $datetime ) {
+		// Ignoring leap seconds.
+		$timestamp          = (int) $datetime->format( 'U' );
+		$next_day_timestamp = ( floor( $timestamp / SECONDS_PER_HOUR ) + 1 ) * SECONDS_PER_HOUR;
+		$next_day           = new DateTime();
+		$next_day->setTimestamp( $next_day_timestamp );
+		return $next_day;
+	}
+
+	/**
+	 * Returns DateTime object representing the next day start.
+	 *
+	 * @param DateTime $datetime Date and time.
+	 * @return DateTime
+	 */
+	public static function next_day_start( $datetime ) {
+		// Ignoring leap seconds.
+		$timestamp          = (int) $datetime->format( 'U' );
+		$next_day_timestamp = ( floor( $timestamp / SECONDS_PER_DAY ) + 1 ) * SECONDS_PER_DAY;
+		$next_day           = new DateTime();
+		$next_day->setTimestamp( $next_day_timestamp );
+		return $next_day;
+	}
+
+	/**
+	 * Returns DateTime object representing the next week start.
+	 *
+	 * @param DateTime $datetime Date and time.
+	 * @return DateTime
+	 */
+	public static function next_week_start( $datetime ) {
+		$first_day_of_week = absint( get_option( 'start_of_week' ) );
+		if ( $datetime->format( 'w' ) === $first_day_of_week ) {
+			return $datetime->modify( '+1 week' );
+		} else {
+			do {
+				$datetime = WC_Reports_Interval::next_day_start( $datetime );
+			} while ( $first_day_of_week !== (int) $datetime->format( 'w' ) );
+		}
+		return $datetime;
+	}
+
+	/**
+	 * Returns DateTime object representing the next month start.
+	 *
+	 * @param DateTime $datetime Date and time.
+	 * @return DateTime
+	 */
+	public static function next_month_start( $datetime ) {
+		$year  = $datetime->format( 'Y' );
+		$month = (int) $datetime->format( 'm' ) + 1;
+		$day   = '01';
+		return new DateTime( "$year-$month-$day 00:00:00" );
+	}
+
+	/**
+	 * Returns DateTime object representing the next quarter start.
+	 *
+	 * @param DateTime $datetime Date and time.
+	 * @return DateTime
+	 */
+	public static function next_quarter_start( $datetime ) {
+		$year  = $datetime->format( 'Y' );
+		$month = (int) $datetime->format( 'm' ) + 3;
+		$day   = '01';
+		return new DateTime( "$year-$month-$day 00:00:00" );
+	}
+
+	/**
+	 * Return DateTime object representing the next year start.
+	 *
+	 * @param DateTime $datetime Date and time.
+	 * @return DateTime
+	 */
+	public static function next_year_start( $datetime ) {
+		$year  = (int) $datetime->format( 'Y' ) + 1;
+		$month = '01';
+		$day   = '01';
+		return new DateTime( "$year-$month-$day 00:00:00" );
+	}
+
+	/**
+	 * Returns beginning of next time interval for provided DateTime.
+	 *
+	 * E.g. for current DateTime, beginning of next day, week, quarter, etc.
+	 *
+	 * @param DateTime $datetime      Date and time.
+	 * @param string   $time_interval Time interval, e.g. week, day, hour.
+	 * @return DateTime
+	 */
+	public static function iterate( $datetime, $time_interval ) {
+		return call_user_func( array( __CLASS__, "next_{$time_interval}_start" ), $datetime );
+	}
+
+}

--- a/includes/class-wc-reports-interval.php
+++ b/includes/class-wc-reports-interval.php
@@ -9,9 +9,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'SECONDS_PER_DAY', 86400 );
-define( 'SECONDS_PER_HOUR', 3600 );
-
 /**
  * Date & time interval handling class for Reporting API.
  */
@@ -133,7 +130,7 @@ class WC_Reports_Interval {
 	public static function next_hour_start( $datetime ) {
 		// Ignoring leap seconds.
 		$timestamp          = (int) $datetime->format( 'U' );
-		$next_day_timestamp = ( floor( $timestamp / SECONDS_PER_HOUR ) + 1 ) * SECONDS_PER_HOUR;
+		$next_day_timestamp = ( floor( $timestamp / HOUR_IN_SECONDS ) + 1 ) * HOUR_IN_SECONDS;
 		$next_day           = new DateTime();
 		$next_day->setTimestamp( $next_day_timestamp );
 		return $next_day;
@@ -148,7 +145,7 @@ class WC_Reports_Interval {
 	public static function next_day_start( $datetime ) {
 		// Ignoring leap seconds.
 		$timestamp          = (int) $datetime->format( 'U' );
-		$next_day_timestamp = ( floor( $timestamp / SECONDS_PER_DAY ) + 1 ) * SECONDS_PER_DAY;
+		$next_day_timestamp = ( floor( $timestamp / DAY_IN_SECONDS ) + 1 ) * DAY_IN_SECONDS;
 		$next_day           = new DateTime();
 		$next_day->setTimestamp( $next_day_timestamp );
 		return $next_day;

--- a/includes/class-wc-reports-query.php
+++ b/includes/class-wc-reports-query.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Class for parameter-based Reports querying
+ *
+ * @package  WooCommerce/Classes
+ * @version  3.5.0
+ * @since    3.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Reports_Query
+ *
+ * @version  3.5.0
+ */
+abstract class WC_Reports_Query extends WC_Object_Query {
+
+	/**
+	 * Get report data matching the current query vars.
+	 *
+	 * @return array|object of WC_Product objects
+	 */
+	public function get_data() {
+		/* translators: %s: Method name */
+		return new WP_Error( 'invalid-method', sprintf( __( "Method '%s' not implemented. Must be overridden in subclass.", 'woocommerce' ), __METHOD__ ), array( 'status' => 405 ) );
+	}
+
+}

--- a/includes/class-wc-reports-revenue-query.php
+++ b/includes/class-wc-reports-revenue-query.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Class for parameter-based Revenue Reports querying
+ *
+ * @package  WooCommerce/Classes
+ * @version  3.5.0
+ * @since    3.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Reports_Revenue_Query
+ *
+ * @version  3.5.0
+ */
+class WC_Reports_Revenue_Query extends WC_Reports_Query {
+
+	/**
+	 * Valid query vars for Revenue report.
+	 *
+	 * @return array
+	 */
+	protected function get_default_query_vars() {
+		return array(
+			'per_page' => get_option( 'posts_per_page' ), // not sure if this should be the default.
+			'page'     => 1,
+
+			'order'    => 'DESC',
+			'orderby'  => 'date',
+
+			'before'   => '',
+			'after'    => '',
+			'interval' => 'week',
+		);
+	}
+
+	/**
+	 * Get revenue data based on the current query vars.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		$args    = apply_filters( 'woocommerce_reports_revenue_query_args', $this->get_query_vars() );
+		$results = WC_Data_Store::load( 'revenue-report' )->get_data( $args );
+		return apply_filters( 'woocommerce_reports_revenue_select_query', $results, $args );
+	}
+
+}

--- a/includes/class-wc-reports-revenue-query.php
+++ b/includes/class-wc-reports-revenue-query.php
@@ -2,6 +2,15 @@
 /**
  * Class for parameter-based Revenue Reports querying
  *
+ * Example usage:
+ * $args = array(
+ *          'before' => '2018-07-19 00:00:00',
+ *          'after'  => '2018-07-05 00:00:00',
+ *          'interval' => 'week',
+ *         );
+ * $report = new WC_Reports_Revenue_Query( $args );
+ * $mydata = $report->get_data();
+ *
  * @package  WooCommerce/Classes
  * @version  3.5.0
  * @since    3.5.0

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -274,6 +274,7 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/interfaces/class-wc-logger-interface.php';
 		include_once WC_ABSPATH . 'includes/interfaces/class-wc-log-handler-interface.php';
 		include_once WC_ABSPATH . 'includes/interfaces/class-wc-webhooks-data-store-interface.php';
+		include_once WC_ABSPATH . 'includes/interfaces/class-wc-reports-data-store-interface.php';
 
 		/**
 		 * Abstract classes.
@@ -331,6 +332,7 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-structured-data.php';
 		include_once WC_ABSPATH . 'includes/class-wc-shortcodes.php';
 		include_once WC_ABSPATH . 'includes/class-wc-logger.php';
+		include_once WC_ABSPATH . 'includes/class-wc-reports-revenue-query.php';
 
 		/**
 		 * Data stores - used to store and retrieve CRUD object data from the database.
@@ -359,6 +361,8 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-data-store-cpt.php';
 		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-refund-data-store-cpt.php';
 		include_once WC_ABSPATH . 'includes/data-stores/class-wc-webhook-data-store.php';
+		include_once WC_ABSPATH . 'includes/data-stores/class-wc-reports-data-store.php';
+		include_once WC_ABSPATH . 'includes/data-stores/class-wc-reports-revenue-data-store.php';
 
 		/**
 		 * REST API.

--- a/includes/data-stores/class-wc-reports-data-store.php
+++ b/includes/data-stores/class-wc-reports-data-store.php
@@ -1,0 +1,279 @@
+<?php
+/**
+ * WC_Reports_Revenue_Store class file.
+ *
+ * @package WooCommerce/Classes
+ * @since 3.5.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Product Data Store: Stored in CPT.
+ * //extends WC_Data_Store_WP.
+ *
+ * @version  3.5.0
+ */
+class WC_Reports_Data_Store {
+
+	/**
+	 * Cache group for the reports.
+	 *
+	 * @var string
+	 */
+	protected $cache_group = 'reports';
+
+	/**
+	 * Time out for the cache.
+	 *
+	 * @var int
+	 */
+	protected $cache_timeout = 3600;
+
+	/**
+	 * Table used as a data store for this report.
+	 *
+	 * @var string
+	 */
+	protected $table_name = '';
+
+	/**
+	 * Name of the report.
+	 *
+	 * @var string
+	 */
+	protected $report_name = '';
+
+	// TODO: this does not really belong here, maybe factor out the comparison as separate class.
+	/**
+	 * Order by property, used in the cmp function.
+	 *
+	 * @var string
+	 */
+	private $order_by = '';
+
+	/**
+	 * Order property, used in the cmp function.
+	 *
+	 * @var string
+	 */
+	private $order = '';
+
+	/**
+	 * Returnss name of this report.
+	 *
+	 * @return int
+	 */
+	protected function get_report_name() {
+		return $this->report_name;
+	}
+
+	/**
+	 * Returns string to be used as cache key for the data.
+	 *
+	 * @param array $params Query parameters.
+	 * @return string
+	 */
+	protected function get_cache_key( $params ) {
+		return 'woocommerce_' . $this->get_report_name() . '_' . md5( implode( '-', $params ) . date( 'Y-m-d_H:i' ) );
+	}
+
+	/**
+	 * Compares two report data objects by pre-defined object property and ASC/DESC ordering.
+	 *
+	 * @param stdClass $a Object a.
+	 * @param stdClass $b Object b.
+	 * @return string
+	 */
+	private function interval_cmp( $a, $b ) {
+		if ( '' === $this->order_by || '' === $this->order ) {
+			return 0;
+			// TODO: should return WP_Error here perhaps?
+		}
+		if ( $a->{$this->order_by} === $b->{$this->order_by} ) {
+			return 0;
+		} elseif ( $a->{$this->order_by} > $b->{$this->order_by} ) {
+			return strtolower( $this->order ) === 'desc' ? -1 : 1;
+		} elseif ( $a->{$this->order_by} < $b->{$this->order_by} ) {
+			return strtolower( $this->order ) === 'desc' ? 1 : -1;
+		}
+	}
+
+	/**
+	 * Normalizes order_by clause to match to SQL query.
+	 *
+	 * @param string $order_by Order by option requeste by user.
+	 * @return string
+	 */
+	protected function normalize_order_by( $order_by ) {
+		if ( 'date' === $order_by ) {
+			return 'time_interval';
+		}
+
+		return $order_by;
+	}
+
+	/**
+	 * Sorts intervals according to user's request.
+	 *
+	 * They are pre-sorted in SQL, but after adding gaps, they need to be sorted including the added ones.
+	 *
+	 * @param stdClass $data      Data object, must contain an array under $data->intervals.
+	 * @param string   $sort_by   Ordering property.
+	 * @param string   $direction DESC/ASC.
+	 */
+	protected function sort_intervals( &$data, $sort_by, $direction ) {
+		$this->order_by = $this->normalize_order_by( $sort_by );
+		$this->order    = $direction;
+		usort( $data->intervals, array( $this, 'interval_cmp' ) );
+	}
+
+	/**
+	 * Fills in interval gaps from DB with 0-filled objects.
+	 *
+	 * @param DateTime $datetime_start Start date.
+	 * @param DateTime $datetime_end   End date.
+	 * @param string   $time_interval  Time interval, e.g. day, week, month.
+	 * @param stdClass $data           Data with SQL extracted intervals.
+	 * @return stdClass
+	 */
+	protected function fill_in_missing_intervals( $datetime_start, $datetime_end, $time_interval, &$data ) {
+		// TODO: this is incredibly basic for now,
+		// need to think about how to handle at least:
+		// - weeks starting on Saturday, Sunday, Monday, Wednesday, etc.
+		// - incorrect +1 month.
+		// - time zones, DST.
+		// - more?
+		// At this point, we don't know when we can stop iterating, as the ordering can be based on any value.
+		$end_datetime = new DateTime( $datetime_end );
+		$time_ids     = array_flip( wp_list_pluck( $data->intervals, 'time_interval' ) );
+		$datetime     = new DateTime( $datetime_start );
+		while ( $datetime <= $end_datetime ) {
+			$next_end = WC_Reports_Interval::iterate( $datetime, $time_interval );
+
+			$time_id = WC_Reports_Interval::time_interval_id( $time_interval, $datetime );
+			if ( array_key_exists( $time_id, $time_ids ) ) {
+				$record             = $data->intervals[ $time_ids[ $time_id ] ];
+				$record->date_start = $datetime->format( 'Y-m-d H:i:s' );
+				$record->date_end   = ( $next_end > $end_datetime ? $end_datetime : $next_end )->format( 'Y-m-d H:i:s' );
+			} else {
+				$record_arr                  = array();
+				$record_arr['time_interval'] = $time_id;
+				$record_arr['date_start']    = $datetime->format( 'Y-m-d H:i:s' );
+				$record_arr['date_end']      = ( $next_end > $end_datetime ? $end_datetime : $next_end )->format( 'Y-m-d H:i:s' );
+
+				// Totals object used to get all needed properties.
+				$totals_arr = get_object_vars( $data->totals );
+				foreach ( $totals_arr as $key => $val ) {
+					$totals_arr[ $key ] = 0;
+				}
+
+				$data->intervals[] = (object) array_merge( $record_arr, $totals_arr );
+			}
+			$datetime = $next_end;
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Removes extra records from intervals so that only requested number of records get returned.
+	 *
+	 * @param stdClass $data   Data from whose intervals the records get removed.
+	 * @param int      $offset Offset requested by the user.
+	 * @param int      $count  Number of records requested by the user.
+	 */
+	protected function remove_extra_records( &$data, $offset, $count ) {
+		$data->intervals = array_slice( $data->intervals, $offset * $count, $count );
+	}
+
+	/**
+	 * Fills where clause of SQL request for 'Totals' section of data response based on user supplied parameters.
+	 *
+	 * @param array $query_args Parameters supplied by the user.
+	 * @return array
+	 */
+	protected function get_totals_sql_params( $query_args ) {
+		$totals_query['where_clause'] = '';
+
+		if ( isset( $query_args['before'] ) && '' !== $query_args['before'] ) {
+			$hour                          = $query_args['before'];
+			$totals_query['where_clause'] .= " AND hour <= '$hour'";
+
+		}
+
+		if ( isset( $query_args['after'] ) && '' !== $query_args['after'] ) {
+			$hour                          = $query_args['after'];
+			$totals_query['where_clause'] .= " AND hour >= '$hour'";
+		}
+
+		return $totals_query;
+	}
+
+	/**
+	 * Fills clauses of SQL request for 'Intervals' section of data response based on user supplied parameters.
+	 *
+	 * @param array $query_args Parameters supplied by the user.
+	 * @return array
+	 */
+	protected function get_intervals_sql_params( $query_args ) {
+		$intervals_query = array();
+		$intervals_query['where_clause'] = '';
+
+		if ( isset( $query_args['before'] ) && '' !== $query_args['before'] ) {
+			$hour                             = $query_args['before'];
+			$intervals_query['where_clause'] .= " AND hour <= '$hour'";
+
+		}
+
+		if ( isset( $query_args['after'] ) && '' !== $query_args['after'] ) {
+			$hour                             = $query_args['after'];
+			$intervals_query['where_clause'] .= " AND hour >= '$hour'";
+		}
+
+		if ( isset( $query_args['interval'] ) && '' !== $query_args['interval'] ) {
+			$interval                         = $query_args['interval'];
+			$intervals_query['select_clause'] = WC_Reports_Interval::mysql_datetime_format( $interval );
+		}
+
+		$intervals_query['per_page'] = get_option( 'posts_per_page' );
+		if ( isset( $query_args['per_page'] ) && is_numeric( $query_args['per_page'] ) ) {
+			$intervals_query['per_page'] = (int) $query_args['per_page'];
+		}
+
+		$intervals_query['offset'] = 0;
+		if ( isset( $query_args['page'] ) ) {
+			$intervals_query['offset'] = ( (int) $query_args['page'] - 1 ) * $intervals_query['per_page'];
+		}
+
+		$intervals_query['order_by_clause'] = '';
+		if ( isset( $query_args['orderby'] ) ) {
+			$intervals_query['order_by_clause'] = $this->normalize_order_by( $query_args['orderby'] );
+		}
+
+		if ( isset( $query_args['order'] ) ) {
+			$intervals_query['order_by_clause'] .= ' ' . $query_args['order'];
+		} else {
+			$intervals_query['order_by_clause'] .= ' DESC';
+		}
+
+		return $intervals_query;
+	}
+
+	/**
+	 * Updates the LIMIT query part for Intervals query of the report.
+	 *
+	 * If there are less records in the database than time intervals, then we need to remap offset in SQL query
+	 * to fetch correct records.
+	 *
+	 * @param array $intervals_query            Array with clauses for the Intervals SQL query.
+	 * @param int   $db_records_within_interval Number of records in the db for requested time period.
+	 */
+	protected function update_intervals_sql_params( &$intervals_query, $db_records_within_interval ) {
+		$page_no                   = floor( ( $db_records_within_interval - 1 ) / $intervals_query['per_page'] ) + 1;
+		$intervals_query['offset'] = ( $page_no - 1 ) * $intervals_query['per_page'];
+	}
+
+}

--- a/includes/data-stores/class-wc-reports-revenue-data-store.php
+++ b/includes/data-stores/class-wc-reports-revenue-data-store.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * WC_Reports_Revenue_Store class file.
+ *
+ * Example usage:
+ * $args = array(
+ *          'before' => '2018-07-19 00:00:00',
+ *          'after'  => '2018-07-05 00:00:00',
+ *          'interval' => 'week',
+ *         );
+ * $report = new WC_Reports_Revenue_Query( $args );
+ * $mydata = $report->get_data();
+ *
+ * @package WooCommerce/Classes
+ * @since 3.5.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WC Product Data Store: Stored in CPT.
+ * //extends WC_Data_Store_WP.
+ *
+ * @version  3.5.0
+ */
+class WC_Reports_Revenue_Data_Store extends WC_Reports_Data_Store implements WC_Reports_Data_Store_Interface {
+
+	/**
+	 * Table used to get the data.
+	 *
+	 * @since 3.5.0
+	 * @var int
+	 */
+	protected $table_name = 'order_stats';
+
+	/**
+	 * Report name.
+	 *
+	 * @since 3.5.0
+	 * @var int
+	 */
+	protected $report_name = 'revenue_report';
+
+	/**
+	 * Returns the report data based on parameters supplied by the user.
+	 *
+	 * @since 3.5.0
+	 * @param array $query_args Query parameters.
+	 * @return array            Data.
+	 */
+	public function get_data( $query_args ) {
+		global $wpdb;
+
+		$cache_key = $this->get_cache_key( $query_args );
+		$data      = wp_cache_get( $cache_key, $this->cache_group );
+
+		if ( false === $data ) {
+			$totals_query    = $this->get_totals_sql_params( $query_args );
+			$intervals_query = $this->get_intervals_sql_params( $query_args );
+
+			$table_name = $wpdb->prefix . $this->table_name;
+			$totals     = $wpdb->get_results(
+				"SELECT
+							SUM(orders_gross_total) AS gross_revenue, 
+							SUM(orders_coupon_total) AS coupons, 
+							SUM(orders_shipping_total) AS shipping, 
+							SUM(orders_tax_total) AS taxes, 
+							SUM(orders_refund_total) AS refunds,
+							SUM(orders_gross_total) - SUM(orders_coupon_total) - SUM(orders_shipping_total) - SUM(orders_tax_total) - SUM(orders_refund_total) AS net_revenue,
+							SUM(num_orders) AS orders_count,
+							SUM(num_items_sold) AS items_sold
+						FROM 
+							{$table_name}
+						WHERE 
+							1=1 
+							{$totals_query['where_clause']}"); // WPCS: cache ok, DB call ok.
+
+			$db_records_within_interval = $wpdb->get_var(
+				"SELECT COUNT(*) FROM (
+							SELECT
+								{$intervals_query['select_clause']} AS time_interval
+							FROM 
+								{$table_name}
+							WHERE 
+								1 = 1
+								{$intervals_query['where_clause']}
+							GROUP BY
+								time_interval
+							) AS tt"
+			); // WPCS: cache ok, DB call ok.
+
+			$this->update_intervals_sql_params( $intervals_query, $db_records_within_interval );
+
+			$intervals = $wpdb->get_results(
+				"SELECT
+							{$intervals_query['select_clause']} AS time_interval,
+							MIN(hour) AS date_start,
+							MAX(hour) AS date_end,
+							SUM(orders_gross_total) AS gross_revenue, 
+							SUM(orders_coupon_total) AS coupons, 
+							SUM(orders_shipping_total) AS shipping, 
+							SUM(orders_tax_total) AS taxes, 
+							SUM(orders_refund_total) AS refunds,
+							SUM(orders_gross_total) - SUM(orders_coupon_total) - SUM(orders_shipping_total) - SUM(orders_tax_total) - SUM(orders_refund_total) AS net_revenue,
+							SUM(num_orders) AS orders_count,
+							SUM(num_items_sold) AS items_sold
+						FROM 
+							{$table_name}
+						WHERE 
+							1 = 1
+							{$intervals_query['where_clause']}
+						GROUP BY
+							time_interval
+						ORDER BY 
+							{$intervals_query['order_by_clause']}
+						LIMIT {$intervals_query['offset']}, {$intervals_query['per_page']}"
+			); // WPCS: cache ok, DB call ok.
+
+			if ( ! $totals || ! $intervals ) {
+				return new WP_Error( 'woocommerce_reports_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce' ) );
+			}
+
+			$data = (object) array(
+				'totals'    => $totals[0],
+				'intervals' => $intervals,
+			);
+
+			$this->fill_in_missing_intervals( $query_args['after'], $query_args['before'], $query_args['interval'], $data );
+			$this->sort_intervals( $data, $query_args['orderby'], $query_args['order'] );
+			$this->remove_extra_records( $data, $query_args['page'] - 1, $intervals_query['per_page'] );
+
+			wp_cache_set( $cache_key, $data, $this->cache_group, 3600 );
+		}
+
+		return $data;
+	}
+}

--- a/includes/data-stores/class-wc-reports-revenue-data-store.php
+++ b/includes/data-stores/class-wc-reports-revenue-data-store.php
@@ -2,15 +2,6 @@
 /**
  * WC_Reports_Revenue_Store class file.
  *
- * Example usage:
- * $args = array(
- *          'before' => '2018-07-19 00:00:00',
- *          'after'  => '2018-07-05 00:00:00',
- *          'interval' => 'week',
- *         );
- * $report = new WC_Reports_Revenue_Query( $args );
- * $mydata = $report->get_data();
- *
  * @package WooCommerce/Classes
  * @since 3.5.0
  */

--- a/includes/data-stores/class-wc-reports-revenue-data-store.php
+++ b/includes/data-stores/class-wc-reports-revenue-data-store.php
@@ -79,6 +79,7 @@ class WC_Reports_Revenue_Data_Store extends WC_Reports_Data_Store implements WC_
 								{$intervals_query['where_clause']}
 							GROUP BY
 								time_interval
+							LIMIT 0, {$intervals_query['per_page']}
 							) AS tt"
 			); // WPCS: cache ok, DB call ok.
 
@@ -118,9 +119,13 @@ class WC_Reports_Revenue_Data_Store extends WC_Reports_Data_Store implements WC_
 				'intervals' => $intervals,
 			);
 
-			$this->fill_in_missing_intervals( $query_args['after'], $query_args['before'], $query_args['interval'], $data );
-			$this->sort_intervals( $data, $query_args['orderby'], $query_args['order'] );
-			$this->remove_extra_records( $data, $query_args['page'] - 1, $intervals_query['per_page'] );
+			if ( $db_records_within_interval < $intervals_query['per_page'] ) {
+				$this->fill_in_missing_intervals( $query_args['after'], $query_args['before'], $query_args['interval'], $data );
+				$this->sort_intervals( $data, $query_args['orderby'], $query_args['order'] );
+				$this->remove_extra_records( $data, $query_args['page'] - 1, $intervals_query['per_page'] );
+			} else {
+				$this->update_dates( $query_args['after'], $query_args['before'], $query_args['interval'], $data );
+			}
 
 			wp_cache_set( $cache_key, $data, $this->cache_group, 3600 );
 		}

--- a/includes/interfaces/class-wc-reports-data-store-interface.php
+++ b/includes/interfaces/class-wc-reports-data-store-interface.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Reports Data Store Interface
+ *
+ * @version  3.5.0
+ * @package  WooCommerce/Interface
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * WooCommerce Reports data store interface.
+ *
+ * @since 3.5.0
+ */
+interface WC_Reports_Data_Store_Interface {
+
+	/**
+	 * Get the data based on args.
+	 *
+	 * @param array $args Query parameters.
+	 * @return array
+	 */
+	public function get_data( $args );
+}


### PR DESCRIPTION
I tried to follow a similar structure as we have for other data stores, Claudiu mentioned `WC_Product_Query` as an example, so I took the inspiration from that one.
I created a class 
`WC_Reports_Data_Store` as a common ancestor and one child class `WC_Reports_Revenue_Data_Store` as an example. 
Also defined a super simple common interface `WC_Reports_Data_Store_Interface `.

The idea was that the query class  `WC_Reports_Revenue_Query` then interfaces with the data store class and simply requests the data specified by the parameters from the user. It should also describe the default parameters accepted from the user/other code.

If it's too much abstraction, please let me know and I can try to reorganize things a bit.

I wasn't 100% sure how the order_stats table will work, so I assumed there might be some missing time intervals (I guess it could be quite wasteful to store all 0 values in case there were no orders, especially for smaller shops).
Therefore, we might need a solution to 'fill in' the missing time intervals with 0 data. As I see it, there are 2 solutions--either to fill the gaps in SQL query or fill the gaps in PHP. I opted for the latter, as I think PHP is a bit more flexible and if we used the former approach, we would need to create a sequencing virtual table each time we would run a query. This table would have to be then joined with actual data and can only have fixed size, which I don't like (solution is more thoroughly described in [this blog post](https://www.plumislandmedia.net/mysql/filling-missing-data-sequences-cardinal-integers/)).
The drawback of the PHP based solution is that it requires some more processing--one extra db query to count the number of rows in the db within the time period and using some arithmetic to correctly calculate offset in the LIMIT clause, plus sorting and filtering after the SQL query (as new 0 records are added to the array of intervals). 

If you feel we should switch to SQL solution, please let me know in comments. 

If this assumption is not true and we will have data for every hour of every day, then we can make things easier and make the code shorter and easier to understand.

Nevertheless, week numbering is a bit tricky. I went with two versions:
- one that is ISO 8601 compliant, that is supported by both PHP and MySQL -- if the week start is set to Monday
- the other where the first week of the year always starts on January 1st, then next week starts on the following [day of beginning of the week].

Pending: 
- [ ] tests