### PR TITLE
Check if $product is an instance of WC_Product before using its methods

### DIFF
--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -11,7 +11,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.3.0
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -19,6 +19,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 global $product;
+
+if ( ! is_a( $product, 'WC_Product' ) ) {
+	return;
+}
+
 ?>
 <li>
 	<?php do_action( 'woocommerce_widget_product_item_start', $args ); ?>

--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -10,7 +10,6 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
  * @package WooCommerce/Templates
  * @version 3.3.0
  */
@@ -25,15 +24,15 @@ global $product;
 	<?php do_action( 'woocommerce_widget_product_item_start', $args ); ?>
 
 	<a href="<?php echo esc_url( $product->get_permalink() ); ?>">
-		<?php echo $product->get_image(); ?>
-		<span class="product-title"><?php echo $product->get_name(); ?></span>
+		<?php echo wp_kses_post( $product->get_image() ); ?>
+		<span class="product-title"><?php echo esc_html( $product->get_name() ); ?></span>
 	</a>
 
 	<?php if ( ! empty( $show_rating ) ) : ?>
-		<?php echo wc_get_rating_html( $product->get_average_rating() ); ?>
+		<?php echo wp_kses_post( wc_get_rating_html( $product->get_average_rating() ) ); ?>
 	<?php endif; ?>
 
-	<?php echo $product->get_price_html(); ?>
+	<?php echo wp_kses_post( $product->get_price_html() ); ?>
 
 	<?php do_action( 'woocommerce_widget_product_item_end', $args ); ?>
 </li>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a check to the code that is used to display product information inside a few widgets to make sure `$product` is an instance of `WC_Product` before using its methods. This is to protect against the fatal error reported in #20880. I was not able to reproduce the problem as the widget code that includes `content-widget-product.php` in the stack trace that was provided in the issue seems to only pass valid products:

https://github.com/woocommerce/woocommerce/blob/b329d81279defb9a02f659241ede9ddcb35dd351/includes/widgets/class-wc-widget-recently-viewed.php#L94

Anyway, it is probably a good idea to add this check.

This PR also includes fixes PHPCS violations in the modified file on a separate commit.

Closes #20880

### How to test the changes in this Pull Request:

1. Check that the "Recent viewed products" widget is working as expected and that escaping functions added as part of the PHPCS fixes are not breaking its output.

### Changelog entry

> Enhancement: Protect "Recent viewed products" widget against a possible PHP fatal in some rare circumstances.
