### PR TITLE
Do not hide coupon form when a coupon is applied

### DIFF
--- a/templates/checkout/form-coupon.php
+++ b/templates/checkout/form-coupon.php
@@ -17,7 +17,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! wc_coupons_enabled() || ! empty( WC()->cart->applied_coupons ) ) { // @codingStandardsIgnoreLine.
+if ( ! wc_coupons_enabled() ) { // @codingStandardsIgnoreLine.
 	return;
 }
 

--- a/templates/checkout/form-coupon.php
+++ b/templates/checkout/form-coupon.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.4.0
+ * @version 3.4.4
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
You are allowed to apply more than one coupon in a store, this PR fixes an issue where the coupon form is hidden when you apply a coupon.

Closes #20885 

### How to test the changes in this Pull Request:

1. On checkout apply a coupon
2. Reload checkout and make sure the coupon form is still visible with the previous coupon applied.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
