### PR TITLE
Update class-wc-product-data-store-cpt.php

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1074,8 +1074,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				// Note: Not all meta fields will be set which is why we check existance
 				foreach ( $sorted_meta as $post_id => $variation ) {
 					$match = true;
- 
-					foreach ( $match_attributes as $k => $v  ) {
+
+					foreach ( $match_attributes as $k => $v ) {
 						if ( array_key_exists( $k, $variation ) ) {
 							if ( $variation[ $k ] != $v && ! empty( $variation[ $k ] ) ) {
 								$match = false;

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
+/**a
  * WC Product Data Store: Stored in CPT.
  *
  * @version  3.0.0
@@ -1034,10 +1034,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @return int Matching variation ID or 0.
 	 */
 	public function find_matching_product_variation( $product, $match_attributes = array() ) {
-        global $wpdb;
+		global $wpdb;
 
 		$matched_variation  = 0;
-		$sorted_meta		= array();
+		$sorted_meta        = array();
 
 		// Get any variations of the main product
 		$variation_ids = $wpdb->get_results("
@@ -1048,8 +1048,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			AND {$wpdb->prefix}posts.post_type	  = 'product_variation'
 		", ARRAY_A);
 
-		if( $variation_ids ) {
-			foreach( $variation_ids as $ids ) {
+		if ( $variation_ids ) {
+			foreach ( $variation_ids as $ids ) {
 				$variations_string .= $ids['ID'] . ',';
 			}
 
@@ -1063,28 +1063,28 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				AND meta_key LIKE 'attribute%'
 			",
 			ARRAY_A);
- 
-			if( $attributes ) {
+
+			if ( $attributes ) {
 				// Sort them into a nice easy array for us to filter
-				foreach( $attributes as $m ) {
+				foreach ( $attributes as $m ) {
 					$sorted_meta[ $m['post_id'] ][ $m['meta_key'] ] = $m['meta_value'];
 				}
 
 				// Check each variation to find the one that matches the $match_attributes
 				// Note: Not all meta fields will be set which is why we check existance
-				foreach( $sorted_meta as $post_id => $variation ) {
+				foreach ( $sorted_meta as $post_id => $variation ) {
 					$match = true;
  
-					foreach( $match_attributes as $k => $v  ) {
-						if( array_key_exists( $k, $variation ) ) {
-							if( $variation[ $k ] != $v && !empty( $variation[ $k ] ) ) {
+					foreach ( $match_attributes as $k => $v  ) {
+						if ( array_key_exists( $k, $variation ) ) {
+							if ( $variation[ $k ] != $v && ! empty( $variation[ $k ] ) ) {
 								$match = false;
 							}
 						}
 					}
 
 					// Bingo
-					if( true == $match ) {
+					if ( true == $match ) {
 						$matched_variation = $post_id;
 					}
 				}


### PR DESCRIPTION
Updating find_matching_product_variation() function to be faster

### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Improving the speed of the variation lookup by filtering with PHP instead of a neat but super inefficient all in one DB query.
Note: the pre 2.4 comment about slug needs checking, I don't have an old site with variations to check the DB structure against, this is tested for WC 3+

Closes #12260 

### How to test the changes in this Pull Request:

1. Any function that looks for the variation ID: such as viewing a single variable product page

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x ] Have you written new tests for your changes, as applicable?
* [ x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Improving variation lookup speed
