### PR TITLE
Fixes an issue with the 'woocommerce_grant_product_download_access' hook

### DIFF
--- a/includes/data-stores/class-wc-customer-download-data-store.php
+++ b/includes/data-stores/class-wc-customer-download-data-store.php
@@ -61,12 +61,12 @@ class WC_Customer_Download_Data_Store implements WC_Customer_Download_Data_Store
 			apply_filters( 'woocommerce_downloadable_file_permission_format', $format, $data )
 		);
 
-		do_action( 'woocommerce_grant_product_download_access', $data );
-
 		if ( $result ) {
 			$download->set_id( $wpdb->insert_id );
 			$download->apply_changes();
 		}
+
+		do_action( 'woocommerce_grant_product_download_access', $data );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #20904 

cc @mattyza @gedex 

### Changes proposed in this Pull Request:

This PR just moves the following line:

`do_action( 'woocommerce_grant_product_download_access', $data );`

to the bottom of the `create()` function in the `WC_Customer_Download_Data_Store` class.

### How to test the changes in this Pull Request:

Provided in #20904 

### Changelog entry

> Fixes an issue with the `woocommerce_grant_product_download_access` hook