### PR TITLE
Cast tax rate to float so that it can be treated as number further on.

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -409,7 +409,7 @@ class WC_Tax {
 			}
 
 			$matched_tax_rates[ $found_rate->tax_rate_id ] = array(
-				'rate'     => $found_rate->tax_rate,
+				'rate'     => (float) $found_rate->tax_rate,
 				'label'    => $found_rate->tax_rate_name,
 				'shipping' => $found_rate->tax_rate_shipping ? 'yes' : 'no',
 				'compound' => $found_rate->tax_rate_compound ? 'yes' : 'no',

--- a/tests/unit-tests/tax/tax.php
+++ b/tests/unit-tests/tax/tax.php
@@ -32,9 +32,42 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 
 		$tax_rates = WC_Tax::get_rates();
 
-		$this->assertEquals( $tax_rates, array( $tax_rate_id => array( 'rate' => '20.0000', 'label' => 'VAT', 'shipping' => 'yes', 'compound' => 'no' ) ) );
+		$this->assertSame( $tax_rates, array(
+			$tax_rate_id => array(
+				'rate' => 20.0,
+				'label' => 'VAT',
+				'shipping' => 'yes',
+				'compound' => 'no',
+			),
+		) );
 
 		WC_Tax::_delete_tax_rate( $tax_rate_id );
+
+		$tax_rate_catch_all = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '0.0000',
+			'tax_rate_name'     => 'VAT',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		);
+
+		$tax_rate_catch_all_id = WC_Tax::_insert_tax_rate( $tax_rate_catch_all );
+
+		$tax_rates = WC_Tax::get_rates();
+		$this->assertSame( $tax_rates, array(
+			$tax_rate_catch_all_id => array(
+				'rate' => 0.0,
+				'label' => 'VAT',
+				'shipping' => 'yes',
+				'compound' => 'no',
+			),
+		) );
+
+		WC_Tax::_delete_tax_rate( $tax_rate_catch_all_id );
 	}
 
 	/**


### PR DESCRIPTION
Somehow, I was able to get an empty string in my default tax rate. Even though that is an invalid state, I think we should treat tax rate as a floating point number rather than string, as it is used further on in arithmetic operations.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Set catch all tax rate to empty string in the db.
2. Try to check out using billing country that is not specified in other tax rates, so that it picks up the catch all rate.
3. See that the waiting for update of fragments never finishes as the AJAX response is not a valid JSON.
4. Apply branch.
5. Observe that the update to billing country now works, as the PHP notice is gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Cast tax rate to float so that it can be treated as number further on in the code.
