### PR TITLE
If email @local include non alphabet

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -697,13 +697,14 @@ class WC_Checkout {
 				}
 
 				if ( in_array( 'email', $format, true ) && '' !== $data[ $key ] ) {
+					$email_is_valid = is_email( $data[ $key ] );
+					$data[ $key ] = sanitize_email( $data[ $key ] );
 
-					if ( $validate_fieldset && ! is_email( $data[ $key ] ) ) {
+					if ( $validate_fieldset && ! $email_is_valid ) {
 						/* translators: %s: email address */
 						$errors->add( 'validation', sprintf( __( '%s is not a valid email address.', 'woocommerce' ), '<strong>' . esc_html( $field_label ) . '</strong>' ) );
 						continue;
 					}
-					$data[ $key ] = sanitize_email( $data[ $key ] );
 				}
 
 				if ( '' !== $data[ $key ] && in_array( 'state', $format, true ) ) {

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -702,9 +702,8 @@ class WC_Checkout {
 						/* translators: %s: email address */
 						$errors->add( 'validation', sprintf( __( '%s is not a valid email address.', 'woocommerce' ), '<strong>' . esc_html( $field_label ) . '</strong>' ) );
 						continue;
-					}else{
-						$data[ $key ] = sanitize_email( $data[ $key ] );
 					}
+					$data[ $key ] = sanitize_email( $data[ $key ] );
 				}
 
 				if ( '' !== $data[ $key ] && in_array( 'state', $format, true ) ) {

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -697,12 +697,13 @@ class WC_Checkout {
 				}
 
 				if ( in_array( 'email', $format, true ) && '' !== $data[ $key ] ) {
-					$data[ $key ] = sanitize_email( $data[ $key ] );
 
 					if ( $validate_fieldset && ! is_email( $data[ $key ] ) ) {
 						/* translators: %s: email address */
 						$errors->add( 'validation', sprintf( __( '%s is not a valid email address.', 'woocommerce' ), '<strong>' . esc_html( $field_label ) . '</strong>' ) );
 						continue;
+					}else{
+						$data[ $key ] = sanitize_email( $data[ $key ] );
 					}
 				}
 


### PR DESCRIPTION
If I input infoおおお@test.com as billing email address, automatically change to info@test.com by sanitize_email function.

So at first check the email address by is_email function, after that we must use sanitize_email function.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
