### PR TITLE
Merging plugin's tax_queries on REST endpoint, fixes #20914

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -236,8 +236,13 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 			}
 		}
 
+		// Build tax_query if taxonomies are set.
 		if ( ! empty( $tax_query ) ) {
-			$args['tax_query'] = array_merge($tax_query, $args['tax_query']); // WPCS: slow query ok.
+			if ( empty( $args['tax_query'] ) ) {
+				$args['tax_query'] = $tax_query; // WPCS: slow query ok.
+			} else {
+				$args['tax_query'] = array_merge( $tax_query, $args['tax_query'] ); // WPCS: slow query ok.
+			}
 		}
 
 		// Filter featured.

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -237,7 +237,7 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 		}
 
 		if ( ! empty( $tax_query ) ) {
-			$args['tax_query'] = $tax_query; // WPCS: slow query ok.
+			$args['tax_query'] = array_merge($tax_query, $args['tax_query']); // WPCS: slow query ok.
 		}
 
 		// Filter featured.

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -238,10 +238,10 @@ class WC_REST_Products_Controller extends WC_REST_Legacy_Products_Controller {
 
 		// Build tax_query if taxonomies are set.
 		if ( ! empty( $tax_query ) ) {
-			if ( empty( $args['tax_query'] ) ) {
-				$args['tax_query'] = $tax_query; // WPCS: slow query ok.
-			} else {
+			if ( ! empty( $args['tax_query'] ) ) {
 				$args['tax_query'] = array_merge( $tax_query, $args['tax_query'] ); // WPCS: slow query ok.
+			} else {
+				$args['tax_query'] = $tax_query; // WPCS: slow query ok.
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This change ensures that third party plugin's ``tax_query``s are respected when the ``category`` argument is used on the product's REST endpoint.

Closes #20914 .

### How to test the changes in this Pull Request:

The plugin function in #20914 works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>  Third party plugin's ``tax_query``s are respected when the ``category`` argument is used on the product's REST endpoint.