### PR TITLE
Do not use array_merge for appending to tax classes

### DIFF
--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -311,7 +311,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							'name'          => "variable_tax_class[{$loop}]",
 							'value'         => $variation_object->get_tax_class( 'edit' ),
 							'label'         => __( 'Tax class', 'woocommerce' ),
-							'options'       => array_merge( array( 'parent' => __( 'Same as parent', 'woocommerce' ) ), wc_get_product_tax_class_options() ),
+							'options'       => array( 'parent' => __( 'Same as parent', 'woocommerce' ) ) + wc_get_product_tax_class_options(),
 							'desc_tip'      => 'true',
 							'description'   => __( 'Choose a tax class for this product. Tax classes are used to apply different tax rates specific to certain types of product.', 'woocommerce' ),
 							'wrapper_class' => 'form-row form-row-full',

--- a/includes/admin/settings/views/settings-tax.php
+++ b/includes/admin/settings/views/settings-tax.php
@@ -50,7 +50,7 @@ $settings = array(
 		'default'  => 'inherit',
 		'type'     => 'select',
 		'class'    => 'wc-enhanced-select',
-		'options'  => array_merge( array( 'inherit' => __( 'Shipping tax class based on cart items', 'woocommerce' ) ), wc_get_product_tax_class_options() ),
+		'options'  => array( 'inherit' => __( 'Shipping tax class based on cart items', 'woocommerce' ) ) + wc_get_product_tax_class_options(),
 		'desc_tip' => true,
 	),
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Instead of using array_merge to append a parent or inherit tax class to the dropdowns rather just use the plus sign. Since we allow numeric names for tax classes array_merge will reindex numeric keys causing the values to save incorrectly.

PS. There is a bunch of PHPCS errors unrelated to my changes that I did not fix so the tests will likely fail.

Closes #20906

### How to test the changes in this Pull Request:

1. Create a tax class with a numeric name
2. Load a product and select the numeric named tax class and save
3. Reload the product page and ensure the saved tax class is selected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Issue with numeric named tax classes not saving correctly on products.
