### PR TITLE
Fix: orderby and order parameters in WC_Customer_Download_Log_Data_Store::get_download_logs()

### DIFF
--- a/includes/data-stores/class-wc-customer-download-log-data-store.php
+++ b/includes/data-stores/class-wc-customer-download-log-data-store.php
@@ -162,7 +162,7 @@ class WC_Customer_Download_Log_Data_Store implements WC_Customer_Download_Log_Da
 			'user_id'         => '',
 			'user_ip_address' => '',
 			'orderby'         => 'download_log_id',
-			'order'           => 'DESC',
+			'order'           => 'ASC',
 			'limit'           => -1,
 			'page'            => 1,
 			'return'          => 'objects',
@@ -185,9 +185,9 @@ class WC_Customer_Download_Log_Data_Store implements WC_Customer_Download_Log_Da
 		}
 
 		$allowed_orders = array( 'download_log_id', 'timestamp', 'permission_id', 'user_id' );
-		$order          = in_array( $args['order'], $allowed_orders, true ) ? $args['order'] : 'download_log_id';
-		$orderby        = 'DESC' === strtoupper( $args['orderby'] ) ? 'DESC' : 'ASC';
-		$orderby_sql    = sanitize_sql_orderby( "{$order} {$orderby}" );
+		$orderby        = in_array( $args['orderby'], $allowed_orders, true ) ? $args['orderby'] : 'download_log_id';
+		$order          = 'DESC' === strtoupper( $args['order'] ) ? 'DESC' : 'ASC';
+		$orderby_sql    = sanitize_sql_orderby( "{$orderby} {$order}" );
 		$query[]        = "ORDER BY {$orderby_sql}";
 
 		if ( 0 < $args['limit'] ) {

--- a/tests/unit-tests/customer/class-wc-customer-download-log-data-store.php
+++ b/tests/unit-tests/customer/class-wc-customer-download-log-data-store.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Class WC_Tests_Customer_Download_Log_Data_Store file.
+ *
+ * @version  3.5.0
+ * @package WooCommerce\Tests\Customer
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Tests_Customer_Download_Log_Data_Store class.
+ */
+class WC_Tests_Customer_Download_Log_Data_Store extends WC_Unit_Test_Case {
+	/**
+	 * Test WC_Customer_Download_Log_Data_Store::get_download_logs()
+	 */
+	public function test_get_download_logs() {
+		$customer_id_1 = wc_create_new_customer( 'test@example.com', 'testuser', 'testpassword' );
+		$download_1    = new WC_Customer_Download();
+		$download_1->set_user_id( $customer_id_1 );
+		$download_1->set_order_id( 1 );
+		$download_1->save();
+
+		$customer_id_2 = wc_create_new_customer( 'test2@example.com', 'testuser2', 'testpassword' );
+		$download_2    = new WC_Customer_Download();
+		$download_2->set_user_id( $customer_id_2 );
+		$download_2->set_order_id( 1 );
+		$download_2->save();
+
+		$download_log_1 = new WC_Customer_Download_Log();
+		$download_log_1->set_permission_id( $download_1->get_id() );
+		$download_log_1->set_user_id( $customer_id_1 );
+		$download_log_1->set_user_ip_address( '1.2.3.4' );
+		$download_log_1->save();
+
+		$download_log_2 = new WC_Customer_Download_Log();
+		$download_log_2->set_permission_id( $download_2->get_id() );
+		$download_log_2->set_user_id( $customer_id_2 );
+		$download_log_2->set_user_ip_address( '1.2.3.5' );
+		$download_log_2->save();
+
+		$data_store = WC_Data_Store::load( 'customer-download-log' );
+		$logs       = $data_store->get_download_logs(
+			array(
+				'return'  => 'ids',
+				'orderby' => 'user_id',
+				'order'   => 'DESC',
+			)
+		);
+
+		$expected_result = array( (string) $download_log_2->get_id(), (string) $download_log_1->get_id() );
+		$this->assertEquals( $expected_result, $logs );
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a bug in WC_Customer_Download_Log_Data_Store::get_download_logs() that made impossible to change the order in which the query returned the results. This method accepts the arguments order_by and order, but it was ignoring them and always using the default values ('download_log_id' and 'ASC' respectively).

It also introduces a very basic unit test to cover the method main functionality and to make sure that the parameters order and orderby are not ignored anymore.

It seems that the modified method was inspired in WC_Customer_Download_Data_Store::get_downloads() before the same bug was fixed in #18620.

### How to test the changes in this Pull Request:

1. Call  WC_Customer_Download_Log_Data_Store::get_download_logs() and make sure that it is possible to control the order in which the download logs are returned.

### Changelog entry

> Fix: orderby and order parameters in WC_Customer_Download_Log_Data_Store::get_download_logs() were ignored
