### PR TITLE
[REST API]Order/Product lookup table

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -812,10 +812,10 @@ CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
   order_id BIGINT UNSIGNED NOT NULL,
   product_id BIGINT UNSIGNED NOT NULL,
   customer_id BIGINT UNSIGNED NULL,
-  date_created datetime NOT NULL,
+  date_created timestamp NOT NULL,
   product_qty INT UNSIGNED NOT NULL,
   product_gross_revenue double DEFAULT 0 NOT NULL,
-  PRIMARY KEY  (order_item_id)
+  PRIMARY KEY  (order_item_id),
   KEY order_id (order_id),
   KEY product_id (product_id),
   KEY customer_id (customer_id),

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -807,13 +807,14 @@ CREATE TABLE {$wpdb->prefix}wc_order_stats (
   PRIMARY KEY (start_time)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
+  order_item_id BIGINT UNSIGNED NOT NULL,
   order_id BIGINT UNSIGNED NOT NULL,
   product_id BIGINT UNSIGNED NOT NULL,
-  order_item_id BIGINT UNSIGNED NOT NULL,
   customer_id BIGINT UNSIGNED NULL,
   date_completed datetime NOT NULL,
   product_qty INT UNSIGNED NOT NULL,
   product_gross_revenue double DEFAULT 0 NOT NULL,
+  PRIMARY KEY  (order_item_id)
   KEY order_id (order_id),
   KEY product_id (product_id),
   KEY customer_id (customer_id),

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -868,7 +868,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 			"{$wpdb->prefix}woocommerce_shipping_zones",
 			"{$wpdb->prefix}woocommerce_tax_rate_locations",
 			"{$wpdb->prefix}woocommerce_tax_rates",
-			"{$wpdb->prefix}wc_order_product_lookup",
+			"{$wpdb->prefix}wc_order_stats",
 			"{$wpdb->prefix}wc_order_product_lookup",
 		);
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -811,14 +811,14 @@ CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
   order_id BIGINT UNSIGNED NOT NULL,
   product_id BIGINT UNSIGNED NOT NULL,
   customer_id BIGINT UNSIGNED NULL,
-  date_completed datetime NOT NULL,
+  date_created datetime NOT NULL,
   product_qty INT UNSIGNED NOT NULL,
   product_gross_revenue double DEFAULT 0 NOT NULL,
   PRIMARY KEY  (order_item_id)
   KEY order_id (order_id),
   KEY product_id (product_id),
   KEY customer_id (customer_id),
-  KEY date_completed (date_completed)
+  KEY date_created (date_created)
 ) $collate;
 
 		";

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -115,6 +115,7 @@ class WC_Install {
 		),
 		'3.5.0' => array(
 			'wc_update_350_order_customer_id',
+			'wc_update_350_order_product_lookup',
 			'wc_update_350_db_version',
 		),
 	);

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -812,7 +812,7 @@ CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
   order_id BIGINT UNSIGNED NOT NULL,
   product_id BIGINT UNSIGNED NOT NULL,
   customer_id BIGINT UNSIGNED NULL,
-  date_created timestamp NOT NULL,
+  date_created timestamp DEFAULT '0000-00-00 00:00:00' NOT NULL,
   product_qty INT UNSIGNED NOT NULL,
   product_gross_revenue double DEFAULT 0 NOT NULL,
   PRIMARY KEY  (order_item_id),

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -806,6 +806,20 @@ CREATE TABLE {$wpdb->prefix}wc_order_stats (
   orders_net_total double DEFAULT 0 NOT NULL,
   PRIMARY KEY (start_time)
 ) $collate;
+CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
+  order_id BIGINT UNSIGNED NOT NULL,
+  product_id BIGINT UNSIGNED NOT NULL,
+  order_item_id BIGINT UNSIGNED NOT NULL,
+  customer_id BIGINT UNSIGNED NULL,
+  date_completed datetime NOT NULL,
+  product_qty INT UNSIGNED NOT NULL,
+  product_gross_revenue double DEFAULT 0 NOT NULL,
+  KEY order_id (order_id),
+  KEY product_id (product_id),
+  KEY customer_id (customer_id),
+  KEY date_completed (date_completed)
+) $collate;
+
 		";
 
 		/**
@@ -854,6 +868,8 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 			"{$wpdb->prefix}woocommerce_shipping_zones",
 			"{$wpdb->prefix}woocommerce_tax_rate_locations",
 			"{$wpdb->prefix}woocommerce_tax_rates",
+			"{$wpdb->prefix}wc_order_product_lookup",
+			"{$wpdb->prefix}wc_order_product_lookup",
 		);
 
 		if ( ! function_exists( 'get_term_meta' ) ) {

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -1073,4 +1073,4 @@ function wc_order_product_lookup_entry( $order_id ) {
 		);
 	}
 }
-add_action( 'woocommerce_new_order', 'wc_order_product_lookup_entry', 10, 1 );
+add_action( 'save_post', 'wc_order_product_lookup_entry', 10, 1 );

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -1059,6 +1059,7 @@ function wc_order_product_lookup_entry( $order_id ) {
 				'customer_id'           => $order->get_customer_id( 'edit' ),
 				'product_qty'           => $order_item->get_quantity( 'edit' ),
 				'product_gross_revenue' => $order_item->get_subtotal( 'edit' ),
+				'date_created'          => $order->get_date_created()->getTimestamp(),
 			),
 			array(
 				'%d',
@@ -1067,6 +1068,7 @@ function wc_order_product_lookup_entry( $order_id ) {
 				'%d',
 				'%d',
 				'%f',
+				'%s',
 			)
 		);
 	}

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -294,7 +294,6 @@ function wc_register_order_type( $type, $args = array() ) {
 /**
  * Return the count of processing orders.
  *
- * @access public
  * @return int
  */
 function wc_processing_order_count() {
@@ -1034,3 +1033,42 @@ function wc_create_order_note( $order_id, $note, $is_customer_note = false, $add
 function wc_delete_order_note( $note_id ) {
 	return wp_delete_comment( $note_id, true );
 }
+
+/**
+ * Make an entry in the wc_order_product_lookup table for an order.
+ *
+ * @since 3.5.0
+ * @param int $order_id Order ID.
+ * @return void
+ */
+function wc_order_product_lookup_entry( $order_id ) {
+	global $wpdb;
+
+	$order = wc_get_order( $order_id );
+	if ( ! $order ) {
+		return;
+	}
+
+	foreach ( $order->get_items() as $order_item ) {
+		$wpdb->replace(
+			$wpdb->prefix . 'wc_order_product_lookup',
+			array(
+				'order_item_id'         => $order_item->get_id(),
+				'order_id'              => $order->get_id(),
+				'product_id'            => $order_item->get_product_id( 'edit' ),
+				'customer_id'           => $order->get_customer_id( 'edit' ),
+				'product_qty'           => $order_item->get_quantity( 'edit' ),
+				'product_gross_revenue' => $order_item->get_subtotal( 'edit' ),
+			),
+			array(
+				'%d',
+				'%d',
+				'%d',
+				'%d',
+				'%d',
+				'%f',
+			)
+		);
+	}
+}
+add_action( 'woocommerce_new_order', 'wc_order_product_lookup_entry', 10, 1 );

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -1056,10 +1056,10 @@ function wc_order_product_lookup_entry( $order_id ) {
 				'order_item_id'         => $order_item->get_id(),
 				'order_id'              => $order->get_id(),
 				'product_id'            => $order_item->get_product_id( 'edit' ),
-				'customer_id'           => $order->get_customer_id( 'edit' ),
+				'customer_id'           => ( 0 < $order->get_customer_id( 'edit' ) ) ? $order->get_customer_id( 'edit' ) : null,
 				'product_qty'           => $order_item->get_quantity( 'edit' ),
 				'product_gross_revenue' => $order_item->get_subtotal( 'edit' ),
-				'date_created'          => $order->get_date_created()->getTimestamp(),
+				'date_created'          => date( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
 			),
 			array(
 				'%d',

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2006,10 +2006,10 @@ function wc_update_350_order_product_lookup( $updater = false ) {
 					'order_item_id'         => $order_item->get_id(),
 					'order_id'              => $order->get_id(),
 					'product_id'            => $order_item->get_product_id( 'edit' ),
-					'customer_id'           => $order->get_customer_id( 'edit' ),
+					'customer_id'           => ( 0 < $order->get_customer_id( 'edit' ) ) ? $order->get_customer_id( 'edit' ) : null,
 					'product_qty'           => $order_item->get_quantity( 'edit' ),
 					'product_gross_revenue' => $order_item->get_subtotal( 'edit' ),
-					'date_created'          => $order->get_date_created()->getTimestamp(),
+					'date_created'          => date( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
 				),
 				array(
 					'%d',

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1995,7 +1995,6 @@ function wc_update_350_order_product_lookup( $updater = false ) {
 
 	// Process orders untill close to running out of memory timeouts on large sites then requeue.
 	foreach ( $orders as $order_id ) {
-		$order_count++;
 		$order = wc_get_order( $order_id );
 		if ( ! $order ) {
 			continue;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR creates and populates a lookup table for orders/products/customers that can be used to quickly access order/product related data in the reports.

The table will get populated periodically via a background job, this can change to on the fly population should the need arrise.

Closes #20768

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
