### PR TITLE
Hide "Stock status" field for grouped products

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Displays the inventory tab in the product data meta box.
+ *
+ * @package WooCommerce\Admin
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -94,7 +94,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			array(
 				'id'            => '_stock_status',
 				'value'         => $product_object->get_stock_status( 'edit' ),
-				'wrapper_class' => 'stock_status_field hide_if_variable hide_if_external',
+				'wrapper_class' => 'stock_status_field hide_if_variable hide_if_external hide_if_grouped',
 				'label'         => __( 'Stock status', 'woocommerce' ),
 				'options'       => wc_get_product_stock_status_options(),
 				'desc_tip'      => true,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In the product admin page, the field "Stock status" should be hidden for grouped products as stock is controlled individually for each of the child products and setting a stock status in the parent product has no effect.

This PR also includes PHPCS fixes in a separate commit.

Fixes #20927

### How to test the changes in this Pull Request:

1. In the product admin page, check that the field "Stock status" is not displayed anymore for grouped products.
2. Check that the same field still appears for simple products and that it still works

### Changelog entry

> Fix: hide "Stock status" field for grouped products as setting the stock status of the parent product has no effect.