### PR TITLE
Layout fix for My Account page

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -72,6 +72,8 @@ class WC_Shortcodes {
 		call_user_func( $function, $atts );
 		echo empty( $wrapper['after'] ) ? '</div>' : $wrapper['after'];
 		// @codingStandardsIgnoreEnd
+		//make sure the wrapper wraps around navigation links
+		echo '<div class="clearfix"></div>';
 
 		return ob_get_clean();
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Just a small layout fix, to make sure a wrapper-div is extended to the contained-divs

### How to test the changes in this Pull Request:

1. Go to MyAccount page, see that `<div class="woocommerce">` does not extend to its content
2. Apply the fix
3. Go to MyAccount page, now `<div class="woocommerce">` extends to its content, even if the navigation links are a long list

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added a clearfix div to make sure the My Account content wrapper does contain all of the navigation menus (even if more endpoints were added by an external plugin)
