### PR TITLE
Queue Coding Standards & fix incorrect variable being passed

### DIFF
--- a/includes/queue/class-wc-action-queue.php
+++ b/includes/queue/class-wc-action-queue.php
@@ -1,4 +1,3 @@
-
 <?php
 /**
  * Action Queue
@@ -23,10 +22,10 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	/**
 	 * Enqueue an action to run one time, as soon as possible
 	 *
-	 * @param string $hook The hook to trigger
-	 * @param array $args Arguments to pass when the hook triggers
-	 * @param string $group The group to assign this job to
-	 * @return string The action ID
+	 * @param string $hook The hook to trigger.
+	 * @param array  $args Arguments to pass when the hook triggers.
+	 * @param string $group The group to assign this job to.
+	 * @return string The action ID.
 	 */
 	public function add( $hook, $args = array(), $group = '' ) {
 		return $this->schedule_single( time(), $hook, $args, $group );
@@ -35,11 +34,11 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	/**
 	 * Schedule an action to run once at some time in the future
 	 *
-	 * @param int $timestamp When the job will run
-	 * @param string $hook The hook to trigger
-	 * @param array $args Arguments to pass when the hook triggers
-	 * @param string $group The group to assign this job to
-	 * @return string The action ID
+	 * @param int    $timestamp When the job will run.
+	 * @param string $hook The hook to trigger.
+	 * @param array  $args Arguments to pass when the hook triggers.
+	 * @param string $group The group to assign this job to.
+	 * @return string The action ID.
 	 */
 	public function schedule_single( $timestamp, $hook, $args = array(), $group = '' ) {
 		return wc_schedule_single_action( $timestamp, $hook, $args, $group );
@@ -48,12 +47,12 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	/**
 	 * Schedule a recurring action
 	 *
-	 * @param int $timestamp When the first instance of the job will run
-	 * @param int $interval_in_seconds How long to wait between runs
-	 * @param string $hook The hook to trigger
-	 * @param array $args Arguments to pass when the hook triggers
-	 * @param string $group The group to assign this job to
-	 * @return string The action ID
+	 * @param int    $timestamp When the first instance of the job will run.
+	 * @param int    $interval_in_seconds How long to wait between runs.
+	 * @param string $hook The hook to trigger.
+	 * @param array  $args Arguments to pass when the hook triggers.
+	 * @param string $group The group to assign this job to.
+	 * @return string The action ID.
 	 */
 	public function schedule_recurring( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
 		return wc_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group );
@@ -62,8 +61,8 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	/**
 	 * Schedule an action that recurs on a cron-like schedule.
 	 *
-	 * @param int $timestamp The schedule will start on or after this time
-	 * @param string $cron_schedule A cron-link schedule string
+	 * @param int    $timestamp The schedule will start on or after this time.
+	 * @param string $cron_schedule A cron-link schedule string.
 	 * @see http://en.wikipedia.org/wiki/Cron
 	 *   *    *    *    *    *    *
 	 *   ┬    ┬    ┬    ┬    ┬    ┬
@@ -74,13 +73,13 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 *   |    |    +--------------- day of month (1 - 31)
 	 *   |    +-------------------- hour (0 - 23)
 	 *   +------------------------- min (0 - 59)
-	 * @param string $hook The hook to trigger
-	 * @param array $args Arguments to pass when the hook triggers
-	 * @param string $group The group to assign this job to
+	 * @param string $hook The hook to trigger.
+	 * @param array  $args Arguments to pass when the hook triggers.
+	 * @param string $group The group to assign this job to.
 	 * @return string The action ID
 	 */
 	public function schedule_cron( $timestamp, $cron_schedule, $hook, $args = array(), $group = '' ) {
-		return wc_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group );
+		return wc_schedule_cron_action( $timestamp, $cron_schedule, $hook, $args, $group );
 	}
 
 	/**
@@ -92,9 +91,9 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * in the sequence is scheduled after the previous one is run, so only the next scheduled action needs to
 	 * be cancelled/dequeued to stop the sequence.
 	 *
-	 * @param string $hook The hook that the job will trigger
-	 * @param array $args Args that would have been passed to the job
-	 * @param string $group
+	 * @param string $hook The hook that the job will trigger.
+	 * @param array  $args Args that would have been passed to the job.
+	 * @param string $group Group name.
 	 */
 	public function cancel( $hook, $args = array(), $group = '' ) {
 		wc_unschedule_action( $hook, $args, $group );
@@ -104,11 +103,10 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * Get the date and time for the next scheduled occurence of an action with a given hook
 	 * (an optionally that matches certain args and group), if any.
 	 *
-	 * @param string $hook
-	 * @param array $args
-	 * @param string $group
-	 * @return int|bool The timestamp for the next occurrence, or false if nothing was found
-	 * @return WC_DateTime|null The date and time for the next occurrence, or null if there is no pending, scheduled action for the given hook
+	 * @param string $hook Hook name.
+	 * @param array  $args Arguments.
+	 * @param string $group Group name.
+	 * @return WC_DateTime|null The date and time for the next occurrence, or null if there is no pending, scheduled action for the given hook.
 	 */
 	public function get_next( $hook, $args = null, $group = '' ) {
 
@@ -124,7 +122,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	/**
 	 * Find scheduled actions
 	 *
-	 * @param array $args Possible arguments, with their default values:
+	 * @param array  $args Possible arguments, with their default values:
 	 *        'hook' => '' - the name of the action that will be triggered
 	 *        'args' => null - the args array that will be passed with the action
 	 *        'date' => null - the scheduled date of the action. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
@@ -137,10 +135,9 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 *        'per_page' => 5 - Number of results to return
 	 *        'offset' => 0
 	 *        'orderby' => 'date' - accepted values are 'hook', 'group', 'modified', or 'date'
-	 *        'order' => 'ASC'
+	 *        'order' => 'ASC'.
 	 *
-	 * @param string $return_format OBJECT, ARRAY_A, or ids
-	 *
+	 * @param string $return_format OBJECT, ARRAY_A, or ids.
 	 * @return array
 	 */
 	public function search( $args = array(), $return_format = OBJECT ) {

--- a/includes/queue/class-wc-queue.php
+++ b/includes/queue/class-wc-queue.php
@@ -34,12 +34,14 @@ class WC_Queue {
 	protected static $default_cass = 'WC_Action_Queue';
 
 	/**
+	 * Single instance of WC_Queue_Interface
+	 *
 	 * @return WC_Queue_Interface
 	 */
 	final public static function instance() {
 
 		if ( is_null( self::$instance ) ) {
-			$class = self::get_class();
+			$class          = self::get_class();
 			self::$instance = new $class();
 			self::$instance = self::validate_instance( self::$instance );
 		}
@@ -50,7 +52,7 @@ class WC_Queue {
 	 * Get class to instantiate
 	 *
 	 * And make sure 3rd party code has the chance to attach a custom queue class.
- 	 *
+	 *
 	 * @return string
 	 */
 	protected static function get_class() {
@@ -62,13 +64,15 @@ class WC_Queue {
 	}
 
 	/**
-	 * Enforce a WC_Queue_Interface is 
- 	 *
+	 * Enforce a WC_Queue_Interface
+	 *
+	 * @param WC_Queue_Interface $instance Instance class.
 	 * @return WC_Queue_Interface
 	 */
 	protected static function validate_instance( $instance ) {
 		if ( false === ( $instance instanceof WC_Queue_Interface ) ) {
 			$default_class = self::$default_cass;
+			/* translators: %s: Default class name */
 			wc_doing_it_wrong( __FUNCTION__, sprintf( __( 'The class attached to the "woocommerce_queue_class" does not implement the WC_Queue_Interface interface. The default %s class will be used instead.', 'woocommerce' ), $default_class ), '3.5.0' );
 			$instance = new $default_class();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR fixes up the coding standards for the new Queue classes and also fixes an issue where the schedule_cron method was not passing on the correct parameter to the function it calls.

### How to test the changes in this Pull Request:


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

