### PR TITLE
[REST API] [Experimental] Don't do interval fills and do store 0-value rows in lookup table.

### DIFF
--- a/includes/class-wc-reports-interval.php
+++ b/includes/class-wc-reports-interval.php
@@ -150,55 +150,6 @@ class WC_Reports_Interval {
 	}
 
 	/**
-	 * Calculates number of time intervals between two dates.
-	 *
-	 * @param string $start    Start date & time.
-	 * @param string $end      End date & time.
-	 * @param string $interval Time interval increment, e.g. hour, day, week.
-	 * @return int
-	 */
-	public static function intervals_between( $start, $end, $interval ) {
-		$start_datetime = new DateTime( $start );
-		$end_datetime   = new DateTime( $end );
-		$diff_timestamp = (int) $end_datetime->format( 'U' ) - (int) $start_datetime->format( 'U' );
-		$diff_datetime  = $end_datetime->diff( $start_datetime );
-
-		switch ( $interval ) {
-			case 'hour':
-				return (int) ceil( ( (int) $diff_timestamp ) / HOUR_IN_SECONDS );
-			case 'day':
-				return (int) ceil( ( (int) $diff_timestamp ) / DAY_IN_SECONDS );
-			case 'month':
-				$month_diff = $diff_datetime->m;
-				if ( $diff_datetime->d > 0 || $diff_datetime->h > 0 || $diff_datetime->i > 0 || $diff_datetime->s > 0 ) {
-					$month_diff++;
-				}
-				return $month_diff;
-			case 'querter':
-				$month_diff = $diff_datetime->m;
-				if ( $diff_datetime->d > 0 || $diff_datetime->h > 0 || $diff_datetime->i > 0 || $diff_datetime->s > 0 ) {
-					$month_diff++;
-				}
-				return (int) ceil( $month_diff / 3 );
-			case 'year':
-				$year_diff = $diff_datetime->y;
-				if ( $diff_datetime->m > 0 || $diff_datetime->d > 0 || $diff_datetime->h > 0 || $diff_datetime->i > 0 || $diff_datetime->s > 0 ) {
-					$year_diff++;
-				}
-				return $year_diff;
-			case 'week':
-				// TODO: optimize? approximately day count / 7, but year end is tricky, a week can have less days.
-				$week_count = 0;
-				do {
-					$start_datetime = WC_Reports_Interval::next_week_start( $start_datetime );
-					$week_count++;
-				} while ( $start_datetime <= $end_datetime );
-				return $week_count;
-		}
-		return 0;
-	}
-
-	/**
 	 * Returns a new DateTime object representing the next hour start.
 	 *
 	 * @param DateTime $datetime Date and time.

--- a/includes/data-stores/class-wc-reports-data-store.php
+++ b/includes/data-stores/class-wc-reports-data-store.php
@@ -43,7 +43,6 @@ class WC_Reports_Data_Store {
 	 * Returns string to be used as cache key for the data.
 	 *
 	 * @param array $params Query parameters.
-	 *
 	 * @return string
 	 */
 	protected function get_cache_key( $params ) {
@@ -54,7 +53,6 @@ class WC_Reports_Data_Store {
 	 * Normalizes order_by clause to match to SQL query.
 	 *
 	 * @param string $order_by Order by option requeste by user.
-	 *
 	 * @return string
 	 */
 	protected function normalize_order_by( $order_by ) {
@@ -74,7 +72,6 @@ class WC_Reports_Data_Store {
 	 * @param DateTime $datetime_end End date.
 	 * @param string   $time_interval Time interval, e.g. day, week, month.
 	 * @param stdClass $data Data with SQL extracted intervals.
-	 *
 	 * @return stdClass
 	 */
 	protected function update_interval_boundary_dates( $datetime_start, $datetime_end, $time_interval, &$data ) {
@@ -102,22 +99,21 @@ class WC_Reports_Data_Store {
 	 * Fills where clause of SQL request for 'Totals' section of data response based on user supplied parameters.
 	 *
 	 * @param array $query_args Parameters supplied by the user.
-	 *
 	 * @return array
 	 */
 	protected function get_totals_sql_params( $query_args ) {
 		$totals_query['where_clause'] = '';
 
 		if ( isset( $query_args['before'] ) && '' !== $query_args['before'] ) {
-			$datetime                     = new DateTime( $query_args['before'] );
-			$datetime_str                 = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime                      = new DateTime( $query_args['before'] );
+			$datetime_str                  = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
 			$totals_query['where_clause'] .= " AND start_time <= '$datetime_str'";
 
 		}
 
 		if ( isset( $query_args['after'] ) && '' !== $query_args['after'] ) {
-			$datetime                     = new DateTime( $query_args['after'] );
-			$datetime_str                 = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime                      = new DateTime( $query_args['after'] );
+			$datetime_str                  = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
 			$totals_query['where_clause'] .= " AND start_time >= '$datetime_str'";
 		}
 
@@ -128,7 +124,6 @@ class WC_Reports_Data_Store {
 	 * Fills clauses of SQL request for 'Intervals' section of data response based on user supplied parameters.
 	 *
 	 * @param array $query_args Parameters supplied by the user.
-	 *
 	 * @return array
 	 */
 	protected function get_intervals_sql_params( $query_args ) {
@@ -136,15 +131,15 @@ class WC_Reports_Data_Store {
 		$intervals_query['where_clause'] = '';
 
 		if ( isset( $query_args['before'] ) && '' !== $query_args['before'] ) {
-			$datetime                        = new DateTime( $query_args['before'] );
-			$datetime_str                    = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime                         = new DateTime( $query_args['before'] );
+			$datetime_str                     = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
 			$intervals_query['where_clause'] .= " AND start_time <= '$datetime_str'";
 
 		}
 
 		if ( isset( $query_args['after'] ) && '' !== $query_args['after'] ) {
-			$datetime                        = new DateTime( $query_args['after'] );
-			$datetime_str                    = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime                         = new DateTime( $query_args['after'] );
+			$datetime_str                     = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
 			$intervals_query['where_clause'] .= " AND start_time >= '$datetime_str'";
 		}
 

--- a/includes/data-stores/class-wc-reports-data-store.php
+++ b/includes/data-stores/class-wc-reports-data-store.php
@@ -39,25 +39,11 @@ class WC_Reports_Data_Store {
 	 */
 	protected $table_name = '';
 
-	// TODO: this does not really belong here, maybe factor out the comparison as separate class.
-	/**
-	 * Order by property, used in the cmp function.
-	 *
-	 * @var string
-	 */
-	private $order_by = '';
-
-	/**
-	 * Order property, used in the cmp function.
-	 *
-	 * @var string
-	 */
-	private $order = '';
-
 	/**
 	 * Returns string to be used as cache key for the data.
 	 *
 	 * @param array $params Query parameters.
+	 *
 	 * @return string
 	 */
 	protected function get_cache_key( $params ) {
@@ -65,30 +51,10 @@ class WC_Reports_Data_Store {
 	}
 
 	/**
-	 * Compares two report data objects by pre-defined object property and ASC/DESC ordering.
-	 *
-	 * @param stdClass $a Object a.
-	 * @param stdClass $b Object b.
-	 * @return string
-	 */
-	private function interval_cmp( $a, $b ) {
-		if ( '' === $this->order_by || '' === $this->order ) {
-			return 0;
-			// TODO: should return WP_Error here perhaps?
-		}
-		if ( $a->{$this->order_by} === $b->{$this->order_by} ) {
-			return 0;
-		} elseif ( $a->{$this->order_by} > $b->{$this->order_by} ) {
-			return strtolower( $this->order ) === 'desc' ? -1 : 1;
-		} elseif ( $a->{$this->order_by} < $b->{$this->order_by} ) {
-			return strtolower( $this->order ) === 'desc' ? 1 : -1;
-		}
-	}
-
-	/**
 	 * Normalizes order_by clause to match to SQL query.
 	 *
 	 * @param string $order_by Order by option requeste by user.
+	 *
 	 * @return string
 	 */
 	protected function normalize_order_by( $order_by ) {
@@ -100,15 +66,18 @@ class WC_Reports_Data_Store {
 	}
 
 	/**
-	 * Updates dates for intervals.
+	 * Updates start and end dates for intervals so that they represent intervals' borders, not times when data in db were recorded.
+	 *
+	 * E.g. if there are db records for only Tuesday and Thursday this week, the actual week interval is [Mon, Sun], not [Tue, Thu].
 	 *
 	 * @param DateTime $datetime_start Start date.
-	 * @param DateTime $datetime_end   End date.
-	 * @param string   $time_interval  Time interval, e.g. day, week, month.
-	 * @param stdClass $data           Data with SQL extracted intervals.
+	 * @param DateTime $datetime_end End date.
+	 * @param string   $time_interval Time interval, e.g. day, week, month.
+	 * @param stdClass $data Data with SQL extracted intervals.
+	 *
 	 * @return stdClass
 	 */
-	protected function update_dates( $datetime_start, $datetime_end, $time_interval, &$data ) {
+	protected function update_interval_boundary_dates( $datetime_start, $datetime_end, $time_interval, &$data ) {
 		$end_datetime = new DateTime( $datetime_end );
 		$time_ids     = array_flip( wp_list_pluck( $data->intervals, 'time_interval' ) );
 		$datetime     = new DateTime( $datetime_start );
@@ -133,21 +102,22 @@ class WC_Reports_Data_Store {
 	 * Fills where clause of SQL request for 'Totals' section of data response based on user supplied parameters.
 	 *
 	 * @param array $query_args Parameters supplied by the user.
+	 *
 	 * @return array
 	 */
 	protected function get_totals_sql_params( $query_args ) {
 		$totals_query['where_clause'] = '';
 
 		if ( isset( $query_args['before'] ) && '' !== $query_args['before'] ) {
-			$datetime                      = new DateTime( $query_args['before'] );
-			$datetime_str                  = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime                     = new DateTime( $query_args['before'] );
+			$datetime_str                 = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
 			$totals_query['where_clause'] .= " AND start_time <= '$datetime_str'";
 
 		}
 
 		if ( isset( $query_args['after'] ) && '' !== $query_args['after'] ) {
-			$datetime                      = new DateTime( $query_args['after'] );
-			$datetime_str                  = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime                     = new DateTime( $query_args['after'] );
+			$datetime_str                 = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
 			$totals_query['where_clause'] .= " AND start_time >= '$datetime_str'";
 		}
 
@@ -158,6 +128,7 @@ class WC_Reports_Data_Store {
 	 * Fills clauses of SQL request for 'Intervals' section of data response based on user supplied parameters.
 	 *
 	 * @param array $query_args Parameters supplied by the user.
+	 *
 	 * @return array
 	 */
 	protected function get_intervals_sql_params( $query_args ) {
@@ -165,15 +136,15 @@ class WC_Reports_Data_Store {
 		$intervals_query['where_clause'] = '';
 
 		if ( isset( $query_args['before'] ) && '' !== $query_args['before'] ) {
-			$datetime                         = new DateTime( $query_args['before'] );
-			$datetime_str                     = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime                        = new DateTime( $query_args['before'] );
+			$datetime_str                    = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
 			$intervals_query['where_clause'] .= " AND start_time <= '$datetime_str'";
 
 		}
 
 		if ( isset( $query_args['after'] ) && '' !== $query_args['after'] ) {
-			$datetime                         = new DateTime( $query_args['after'] );
-			$datetime_str                     = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime                        = new DateTime( $query_args['after'] );
+			$datetime_str                    = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
 			$intervals_query['where_clause'] .= " AND start_time >= '$datetime_str'";
 		}
 
@@ -206,97 +177,6 @@ class WC_Reports_Data_Store {
 		}
 
 		return $intervals_query;
-	}
-
-	/**
-	 * Updates the LIMIT query part for Intervals query of the report.
-	 *
-	 * If there are less records in the database than time intervals, then we need to remap offset in SQL query
-	 * to fetch correct records.
-	 *
-	 * @param array $intervals_query Array with clauses for the Intervals SQL query.
-	 * @param int   $db_records      Number of records in the db for requested time period.
-	 */
-	protected function update_intervals_sql_params( &$intervals_query, &$query_args, $db_interval_count, $expected_interval_count ) {
-		if ( $db_interval_count === $expected_interval_count ) {
-			return;
-		}
-
-		if ( 'date' === strtolower( $query_args['orderby'] ) ) {
-			// page X in request translates to slightly different dates in the db, in case some
-			// records are missing from the db.
-			if ( 'asc' === strtolower( $query_args['order'] ) ) {
-				// ORDER BY date ASC.
-				$new_start_date = new DateTime( $query_args['after'] );
-
-				$intervals_to_skip = ( $query_args['page'] - 1 ) * $intervals_query['per_page'];
-				$latest_end_date   = new DateTime( $query_args['before'] );
-				for ( $i = 0; $i < $intervals_to_skip; $i++ ) {
-					if ( $new_start_date > $latest_end_date ) {
-						$new_start_date = $latest_end_date;
-						break;
-					}
-					$new_start_date = WC_Reports_Interval::iterate( $new_start_date, $query_args['interval'] );
-				}
-
-				$new_end_date = clone $new_start_date;
-				for ( $i = 0; $i < $intervals_query['per_page']; $i++ ) {
-					if ( $new_end_date > $latest_end_date ) {
-						$new_end_date = $latest_end_date;
-						break;
-					}
-					$new_end_date = WC_Reports_Interval::iterate( $new_end_date, $query_args['interval'] );
-				}
-			} else {
-				// ORDER BY date DESC.
-				$new_end_date        = new DateTime( $query_args['before'] );
-				$intervals_to_skip   = ( $query_args['page'] - 1 ) * $intervals_query['per_page'];
-				$earliest_start_date = new DateTime( $query_args['after'] );
-				for ( $i = 0; $i < $intervals_to_skip; $i++ ) {
-					if ( $new_end_date < $earliest_start_date ) {
-						$new_end_date = $earliest_start_date;
-						break;
-					}
-					$new_end_date = WC_Reports_Interval::iterate( $new_end_date, $query_args['interval'], true );
-				}
-
-				$new_start_date = clone $new_end_date;
-
-				for ( $i = 0; $i < $intervals_query['per_page']; $i++ ) {
-					if ( $new_start_date < $earliest_start_date ) {
-						$new_start_date = $earliest_start_date;
-						break;
-					}
-					$new_start_date = WC_Reports_Interval::iterate( $new_start_date, $query_args['interval'], true );
-				}
-			}
-
-			$query_args['adj_after']  = $new_start_date->format( WC_Reports_Interval::$iso_datetime_format );
-			$query_args['adj_before'] = $new_end_date->format( WC_Reports_Interval::$iso_datetime_format );
-
-			$intervals_query['where_clause']  = '';
-			$intervals_query['where_clause'] .= " AND start_time <= '{$query_args['adj_before']}'";
-			$intervals_query['where_clause'] .= " AND start_time >= '{$query_args['adj_after']}'";
-			$intervals_query['limit']         = 'LIMIT 0,' . $intervals_query['per_page'];
-
-		} else {
-			if ( 'asc' === $query_args['order'] ) {
-				$offset = ( ( $query_args['page'] - 1 ) * $intervals_query['per_page'] ) - ( $expected_interval_count - $db_interval_count );
-				$offset = $offset < 0 ? 0 : $offset;
-
-				$count = $query_args['page'] * $intervals_query['per_page'] - ( $expected_interval_count - $db_interval_count );
-
-				if ( $count < 0 ) {
-					$count = 0;
-				} elseif ( $count > $intervals_query['per_page'] ) {
-					$count = $intervals_query['per_page'];
-				}
-				$intervals_query['limit'] = 'LIMIT ' . $offset . ',' . $count;
-			}
-			// Otherwise no change in limit clause.
-			$query_args['adj_after']  = $query_args['after'];
-			$query_args['adj_before'] = $query_args['before'];
-		}
 	}
 
 }

--- a/includes/data-stores/class-wc-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-reports-orders-data-store.php
@@ -91,72 +91,6 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 		return $retyped_array;
 	}
 
-
-	/**
-	 * Returns expected number of items on the page in case of date ordering.
-	 *
-	 * @param $expected_interval_count
-	 * @param $items_per_page
-	 * @param $page_no
-	 *
-	 * @return float|int
-	 */
-	protected function expected_intervals_on_page( $expected_interval_count, $items_per_page, $page_no ) {
-		$total_pages = (int) ceil( $expected_interval_count / $items_per_page );
-		if ( $page_no < $total_pages ) {
-			return $items_per_page;
-		} elseif ( $page_no === $total_pages ) {
-			return $expected_interval_count - ( $page_no - 1 ) * $items_per_page;
-		} else {
-			return 0;
-		}
-	}
-
-	/**
-	 * Returns true if there are any intervals that need to be filled in the response.
-	 *
-	 * @param $expected_interval_count
-	 * @param $db_records
-	 * @param $items_per_page
-	 * @param $page_no
-	 * @param $order
-	 * @param $order_by
-	 * @param $intervals_count
-	 *
-	 * @return bool
-	 */
-	protected function intervals_missing( $expected_interval_count, $db_records, $items_per_page, $page_no, $order, $order_by, $intervals_count ) {
-		if ( $expected_interval_count > $db_records ) {
-			if ( 'date' === $order_by ) {
-				$expected_intervals_on_page = $this->expected_intervals_on_page( $expected_interval_count, $items_per_page, $page_no );
-				if ( $intervals_count < $expected_intervals_on_page ) {
-					return true;
-				} else {
-					return false;
-				}
-			} else {
-				if ( 'desc' === $order ) {
-					if ( $page_no > floor( $db_records / $items_per_page ) ) {
-						return true;
-					} else {
-						return false;
-					}
-				} elseif ( 'asc' === $order ) {
-					if ( $page_no <= ceil( ( $expected_interval_count - $db_records ) / $items_per_page ) ) {
-						return true;
-					} else {
-						return false;
-					}
-				} else {
-					// Invalid ordering.
-					return false;
-				}
-			}
-		} else {
-			return false;
-		}
-	}
-
 	/**
 	 * Returns the report data based on parameters supplied by the user.
 	 *
@@ -296,14 +230,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 				'page_no'   => (int) $query_args['page'],
 			);
 
-			if ( $this->intervals_missing( $expected_interval_count, $db_interval_count, $intervals_query['per_page'], $query_args['page'], $query_args['order'], $query_args['orderby'], count( $intervals ) ) ) {
-				$this->fill_in_missing_intervals( $db_intervals, $query_args['adj_after'], $query_args['adj_before'], $query_args['interval'], $data );
-				$this->sort_intervals( $data, $query_args['orderby'], $query_args['order'] );
-				$this->remove_extra_records( $data, $query_args['page'], $intervals_query['per_page'], $db_interval_count, $expected_interval_count, $query_args['orderby'] );
-			} else {
-				$this->update_dates( $query_args['adj_after'], $query_args['adj_before'], $query_args['interval'], $data );
-			}
-
+			$this->update_dates( $query_args['adj_after'], $query_args['adj_before'], $query_args['interval'], $data );
 			wp_cache_set( $cache_key, $data, $this->cache_group );
 		}
 
@@ -454,19 +381,6 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 			'orders_net_total'      => 0.0,
 		);
 		$data = wp_parse_args( $data, $defaults );
-
-		// Don't store rows that don't have useful information.
-		if ( ! $data['num_orders'] ) {
-			return $wpdb->delete(
-				$table_name,
-				array(
-					'start_time' => $start_time,
-				),
-				array(
-					'%s',
-				)
-			);
-		}
 
 		// Update or add the information to the DB.
 		return $wpdb->replace(


### PR DESCRIPTION
This is an attempt at simplifying the complexity of the order revenue stats query interface by doing the following:

- Store 0-value rows in the order stats lookup table.
- Don't do interval filling for missing intervals when querying

This should make it much more simple to manage the intervals when querying, as you can just return the SQL query results without having to do a lot of post-processing on them.

Thoughts @peterfabian?
