### PR TITLE
[REST API] Use more flexible table for order revenue stats

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -795,16 +795,17 @@ CREATE TABLE {$wpdb->prefix}wc_download_log (
   KEY timestamp (timestamp)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_order_stats (
-  start_time timestamp DEFAULT '0000-00-00 00:00:00' NOT NULL,
-  num_orders int(11) UNSIGNED DEFAULT 0 NOT NULL,
+  order_id bigint(20) unsigned NOT NULL,
+  date_created timestamp DEFAULT '0000-00-00 00:00:00' NOT NULL,
   num_items_sold int(11) UNSIGNED DEFAULT 0 NOT NULL,
-  orders_gross_total double DEFAULT 0 NOT NULL,
-  orders_coupon_total double DEFAULT 0 NOT NULL,
-  orders_refund_total double DEFAULT 0 NOT NULL,
-  orders_tax_total double DEFAULT 0 NOT NULL,
-  orders_shipping_total double DEFAULT 0 NOT NULL,
-  orders_net_total double DEFAULT 0 NOT NULL,
-  PRIMARY KEY (start_time)
+  gross_total double DEFAULT 0 NOT NULL,
+  coupon_total double DEFAULT 0 NOT NULL,
+  refund_total double DEFAULT 0 NOT NULL,
+  tax_total double DEFAULT 0 NOT NULL,
+  shipping_total double DEFAULT 0 NOT NULL,
+  net_total double DEFAULT 0 NOT NULL,
+  PRIMARY KEY (order_id),
+  KEY date_created (date_created)
 ) $collate;
 		";
 

--- a/includes/class-wc-order-stats-background-process.php
+++ b/includes/class-wc-order-stats-background-process.php
@@ -68,12 +68,11 @@ class WC_Order_Stats_Background_Process extends WC_Background_Process {
 			return false;
 		}
 
-		$start_time = $item;
-		$end_time = $start_time + HOUR_IN_SECONDS;
+		$order = wc_get_order( $item );
+		if ( ! $order ) {
+			return false;
+		}
 
-		$data = WC_Reports_Orders_Data_Store::summarize_orders( $start_time, $end_time );
-		WC_Reports_Orders_Data_Store::update( $start_time, $data );
-
-		return false;
+		WC_Reports_Orders_Data_Store::update( $order );
 	}
 }

--- a/includes/class-wc-order-stats-background-process.php
+++ b/includes/class-wc-order-stats-background-process.php
@@ -74,5 +74,6 @@ class WC_Order_Stats_Background_Process extends WC_Background_Process {
 		}
 
 		WC_Reports_Orders_Data_Store::update( $order );
+		return false;
 	}
 }

--- a/includes/class-wc-reports-interval.php
+++ b/includes/class-wc-reports-interval.php
@@ -32,20 +32,20 @@ class WC_Reports_Interval {
 
 		if ( 1 === $first_day_of_week ) {
 			// Week begins on Monday, ISO 8601.
-			$week_format = "DATE_FORMAT(start_time, '%x-%v')";
+			$week_format = "DATE_FORMAT(date_created, '%x-%v')";
 		} else {
 			// Week begins on day other than specified by ISO 8601, needs to be in sync with function simple_week_number.
-			$week_format = "CONCAT(YEAR(start_time), '-', LPAD( FLOOR( ( DAYOFYEAR(start_time) + ( ( DATE_FORMAT(MAKEDATE(YEAR(start_time),1), '%w') - $first_day_of_week + 7 ) % 7 ) - 1 ) / 7  ) + 1 , 2, '0'))";
+			$week_format = "CONCAT(YEAR(date_created), '-', LPAD( FLOOR( ( DAYOFYEAR(date_created) + ( ( DATE_FORMAT(MAKEDATE(YEAR(date_created),1), '%w') - $first_day_of_week + 7 ) % 7 ) - 1 ) / 7  ) + 1 , 2, '0'))";
 
 		}
 
 		$mysql_date_format_mapping = array(
-			'hour'    => "DATE_FORMAT(start_time, '%Y-%m-%d %k')",
-			'day'     => "DATE_FORMAT(start_time, '%Y-%m-%d')",
+			'hour'    => "DATE_FORMAT(date_created, '%Y-%m-%d %k')",
+			'day'     => "DATE_FORMAT(date_created, '%Y-%m-%d')",
 			'week'    => $week_format,
-			'month'   => "DATE_FORMAT(start_time, '%Y-%m')",
-			'quarter' => "CONCAT(YEAR(start_time), '-', QUARTER(start_time))",
-			'year'    => 'YEAR(start_time)',
+			'month'   => "DATE_FORMAT(date_created, '%Y-%m')",
+			'quarter' => "CONCAT(YEAR(date_created), '-', QUARTER(date_created))",
+			'year'    => 'YEAR(date_created)',
 
 		);
 

--- a/includes/data-stores/class-wc-reports-data-store.php
+++ b/includes/data-stores/class-wc-reports-data-store.php
@@ -107,14 +107,14 @@ class WC_Reports_Data_Store {
 		if ( isset( $query_args['before'] ) && '' !== $query_args['before'] ) {
 			$datetime                      = new DateTime( $query_args['before'] );
 			$datetime_str                  = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
-			$totals_query['where_clause'] .= " AND start_time <= '$datetime_str'";
+			$totals_query['where_clause'] .= " AND date_created <= '$datetime_str'";
 
 		}
 
 		if ( isset( $query_args['after'] ) && '' !== $query_args['after'] ) {
 			$datetime                      = new DateTime( $query_args['after'] );
 			$datetime_str                  = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
-			$totals_query['where_clause'] .= " AND start_time >= '$datetime_str'";
+			$totals_query['where_clause'] .= " AND date_created >= '$datetime_str'";
 		}
 
 		return $totals_query;
@@ -133,14 +133,14 @@ class WC_Reports_Data_Store {
 		if ( isset( $query_args['before'] ) && '' !== $query_args['before'] ) {
 			$datetime                         = new DateTime( $query_args['before'] );
 			$datetime_str                     = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
-			$intervals_query['where_clause'] .= " AND start_time <= '$datetime_str'";
+			$intervals_query['where_clause'] .= " AND date_created <= '$datetime_str'";
 
 		}
 
 		if ( isset( $query_args['after'] ) && '' !== $query_args['after'] ) {
 			$datetime                         = new DateTime( $query_args['after'] );
 			$datetime_str                     = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
-			$intervals_query['where_clause'] .= " AND start_time >= '$datetime_str'";
+			$intervals_query['where_clause'] .= " AND date_created >= '$datetime_str'";
 		}
 
 		if ( isset( $query_args['interval'] ) && '' !== $query_args['interval'] ) {

--- a/includes/data-stores/class-wc-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-reports-orders-data-store.php
@@ -51,14 +51,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 	 * Set up all the hooks for maintaining and populating table data.
 	 */
 	public static function init() {
-		add_action( self::CRON_EVENT, array( __CLASS__, 'queue_update_recent_orders' ) );
-		add_action( 'woocommerce_before_order_object_save', array( __CLASS__, 'queue_update_modified_orders' ) );
-		add_action( 'shutdown', array( __CLASS__, 'dispatch_recalculator' ) );
-
-		// Each hour update the DB with info for the previous hour.
-		if ( ! wp_next_scheduled( self::CRON_EVENT ) ) {
-			wp_schedule_event( strtotime( date( 'Y-m-d H:30:00' ) ), 'hourly', self::CRON_EVENT );
-		}
+//		add_action( 'woocommerce_before_order_object_save', array( __CLASS__, 'queue_update_modified_orders' ) );
 
 		if ( ! self::$background_process ) {
 			self::$background_process = new WC_Order_Stats_Background_Process();
@@ -120,23 +113,24 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 		$cache_key = $this->get_cache_key( $query_args );
 		$data      = wp_cache_get( $cache_key, $this->cache_group );
 
-		if ( false === $data ) {
+		if ( true || false === $data ) {
 			$totals_query    = $this->get_totals_sql_params( $query_args );
 			$intervals_query = $this->get_intervals_sql_params( $query_args );
 
+			// todo
 			$selections = array(
-				'date_start'          => 'MIN(start_time) AS date_start',
-				'date_end'            => 'MAX(start_time) AS date_end',
-				'orders_count'        => 'SUM(num_orders) as orders_count',
+				'date_start'          => 'MIN(date_created) AS date_start',
+				'date_end'            => 'MAX(date_created) AS date_end',
+				//'orders_count'        => 'SUM(num_orders) as orders_count',
 				'num_items_sold'      => 'SUM(num_items_sold) as num_items_sold',
-				'gross_revenue'       => 'SUM(orders_gross_total) AS gross_revenue',
-				'coupons'             => 'SUM(orders_coupon_total) AS coupons',
-				'refunds'             => 'SUM(orders_refund_total) AS refunds',
-				'taxes'               => 'SUM(orders_tax_total) AS taxes',
-				'shipping'            => 'SUM(orders_shipping_total) AS shipping',
-				'net_revenue'         => 'SUM(orders_net_total) AS net_revenue',
-				'avg_items_per_order' => 'num_items_sold / num_orders AS avg_items_per_order',
-				'avg_order_value'     => 'orders_gross_total / num_orders AS avg_order_value',
+				'gross_revenue'       => 'SUM(gross_total) AS gross_revenue',
+				'coupons'             => 'SUM(coupon_total) AS coupons',
+				'refunds'             => 'SUM(refund_total) AS refunds',
+				'taxes'               => 'SUM(tax_total) AS taxes',
+				'shipping'            => 'SUM(shipping_total) AS shipping',
+				'net_revenue'         => 'SUM(net_total) AS net_revenue',
+			//	'avg_items_per_order' => 'num_items_sold / num_orders AS avg_items_per_order',
+			//	'avg_order_value'     => 'gross_total / num_orders AS avg_order_value',
 			);
 
 			if ( isset( $query_args['fields'] ) && is_array( $query_args['fields'] ) ) {
@@ -237,156 +231,62 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 
 	/**
 	 * Queue a background process that will repopulate the entire orders stats database.
+	 *
+	 * @todo Make this work on large DBs.
 	 */
 	public static function queue_order_stats_repopulate_database() {
-		// To get the first start time, get the oldest order and round the completion time down to the nearest hour.
-		$oldest = wc_get_orders( array(
-			'limit'   => 1,
-			'orderby' => 'date',
-			'order'   => 'ASC',
-			'status'  => self::get_report_order_statuses(),
-			'type'    => 'shop_order',
+
+		// This needs to be updated to work in batches instead of getting all orders, as
+		// that will not work well on DBs with more than a few hundred orders.
+		$order_ids = wc_get_orders( array(
+			'limit'  => -1,
+			'status' => self::get_report_order_statuses(),
+			'type'   => 'shop_order',
+    		'return' => 'ids',
 		) );
 
-		$oldest = $oldest ? reset( $oldest ) : false;
-		if ( ! $oldest ) {
-			return;
-		}
-
-		$start_time = strtotime( $oldest->get_date_created()->format( 'Y-m-d\TH:00:00O' ) );
-		$end_time   = $start_time + HOUR_IN_SECONDS;
-
-		while ( $end_time < time() ) {
-			self::$background_process->push_to_queue( $start_time );
-			$start_time = $end_time;
-			$end_time   = $start_time + HOUR_IN_SECONDS;
+		foreach ( $order_ids as $id ) {
+			self::$background_process->push_to_queue( $id );
 		}
 
 		self::$background_process->save();
-	}
-
-	/**
-	 * Queue a background process that will update the database with stats info from the last hour.
-	 */
-	public static function queue_update_recent_orders() {
-		// Populate the stats information for the previous hour.
-		$last_hour = strtotime( date( 'Y-m-d H:00:00' ) ) - HOUR_IN_SECONDS;
-		self::$background_process->push_to_queue( $last_hour );
-		self::$background_process->save();
-	}
-
-	/**
-	 * Schedule a recalculation for an order's time when the order gets updated.
-	 * This schedules for the order's current time and for the time the order used to be in if necessary.
-	 *
-	 * @param WC_Order $order Order that is in the process of getting modified.
-	 */
-	public static function queue_update_modified_orders( $order ) {
-		$date_created = $order->get_date_created();
-		if ( ! $date_created ) {
-			return;
-		}
-		$new_time   = strtotime( $date_created->format( 'Y-m-d\TH:00:00O' ) );
-		$old_time   = false;
-		$new_status = $order->get_status();
-		$old_status = false;
-
-		if ( $order->get_id() ) {
-			$old_order  = wc_get_order( $order->get_id() );
-			$old_time   = strtotime( $old_order->get_date_created()->format( 'Y-m-d\TH:00:00O' ) );
-			$old_status = $old_order->get_status();
-		}
-
-		$order_statuses = self::get_report_order_statuses();
-		if ( in_array( $new_status, $order_statuses, true ) || in_array( $old_status, $order_statuses, true ) ) {
-			self::$background_process->push_to_queue( $new_time );
-
-			if ( $old_time && $new_time !== $old_time ) {
-				self::$background_process->push_to_queue( $old_time );
-			}
-
-			self::$background_process->save();
-		}
-	}
-
-	/**
-	 * Kick off any scheduled data recalculations.
-	 */
-	public static function dispatch_recalculator() {
 		self::$background_process->dispatch();
-	}
-
-	/**
-	 * Get stats summary information for orders between two time frames.
-	 *
-	 * @param int $start_time Timestamp.
-	 * @param int $end_time Timestamp.
-	 * @return Array of stats.
-	 */
-	public static function summarize_orders( $start_time, $end_time ) {
-		$summary = array(
-			'num_orders'            => 0,
-			'num_items_sold'        => 0,
-			'orders_gross_total'    => 0.0,
-			'orders_coupon_total'   => 0.0,
-			'orders_refund_total'   => 0.0,
-			'orders_tax_total'      => 0.0,
-			'orders_shipping_total' => 0.0,
-			'orders_net_total'      => 0.0,
-		);
-
-		$orders = wc_get_orders( array(
-			'limit'        => -1,
-			'type'         => 'shop_order',
-			'orderby'      => 'none',
-			'status'       => self::get_report_order_statuses(),
-			'date_created' => $start_time . '...' . $end_time,
-		) );
-
-		$summary['num_orders']            = count( $orders );
-		$summary['num_items_sold']        = self::get_num_items_sold( $orders );
-		$summary['orders_gross_total']    = self::get_orders_gross_total( $orders );
-		$summary['orders_coupon_total']   = self::get_orders_coupon_total( $orders );
-		$summary['orders_refund_total']   = self::get_orders_refund_total( $orders );
-		$summary['orders_tax_total']      = self::get_orders_tax_total( $orders );
-		$summary['orders_shipping_total'] = self::get_orders_shipping_total( $orders );
-		$summary['orders_net_total']      = $summary['orders_gross_total'] - $summary['orders_tax_total'] - $summary['orders_shipping_total'];
-
-		return $summary;
 	}
 
 	/**
 	 * Update the database with stats data.
 	 *
-	 * @param int   $start_time Timestamp.
+	 * @param WC_Order $order Order to update row for.
 	 * @param array $data Stats data.
 	 * @return int/bool Number or rows modified or false on failure.
 	 */
-	public static function update( $start_time, $data ) {
+	public static function update( $order ) {
 		global $wpdb;
 		$table_name = $wpdb->prefix . self::TABLE_NAME;
-		$start_time = date( 'Y-m-d H:00:00', $start_time );
 
-		$defaults = array(
-			'start_time'            => $start_time,
-			'num_orders'            => 0,
-			'num_items_sold'        => 0,
-			'orders_gross_total'    => 0.0,
-			'orders_coupon_total'   => 0.0,
-			'orders_refund_total'   => 0.0,
-			'orders_tax_total'      => 0.0,
-			'orders_shipping_total' => 0.0,
-			'orders_net_total'      => 0.0,
+		if ( ! $order->get_id() || ! $order->get_date_created() ) {
+			return false;
+		}
+
+		$data = array(
+			'order_id' => $order->get_id(),
+			'date_created' => $order->get_date_created()->date( 'Y-m-d H:i:s' ),
+			'num_items_sold' => self::get_num_items_sold( $order ),
+			'gross_total' => $order->get_total(),
+			'coupon_total' => $order->get_total_discount(),
+			'refund_total' => $order->get_total_refunded(),
+			'tax_total' => $order->get_total_tax(),
+			'shipping_total' => $order->get_shipping_total(),
+			'net_total' => $order->get_total() - $order->get_total_tax() - $order->get_shipping_total(),
 		);
-		$data = wp_parse_args( $data, $defaults );
 
 		// Update or add the information to the DB.
 		return $wpdb->replace(
 			$table_name,
 			$data,
 			array(
-				'%s',
 				'%d',
+				'%s',
 				'%d',
 				'%f',
 				'%f',
@@ -414,99 +314,17 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 	/**
 	 * Get number of items sold among all orders.
 	 *
-	 * @param array $orders Array of WC_Order objects.
+	 * @param array $order WC_Order object.
 	 * @return int
 	 */
-	protected static function get_num_items_sold( $orders ) {
+	protected static function get_num_items_sold( $order ) {
 		$num_items = 0;
 
-		foreach ( $orders as $order ) {
-			$line_items = $order->get_items( 'line_item' );
-			foreach ( $line_items as $line_item ) {
-				$num_items += $line_item->get_quantity();
-			}
+		$line_items = $order->get_items( 'line_item' );
+		foreach ( $line_items as $line_item ) {
+			$num_items += $line_item->get_quantity();
 		}
 
 		return $num_items;
-	}
-
-	/**
-	 * Get the gross total for all orders.
-	 *
-	 * @param array $orders Array of WC_Order objects.
-	 * @return float
-	 */
-	protected static function get_orders_gross_total( $orders ) {
-		$total = 0.0;
-
-		foreach ( $orders as $order ) {
-			$total += $order->get_total();
-		}
-
-		return $total;
-	}
-
-	/**
-	 * Get the coupon total for all orders.
-	 *
-	 * @param array $orders Array of WC_Order objects.
-	 * @return float
-	 */
-	protected static function get_orders_coupon_total( $orders ) {
-		$total = 0.0;
-
-		foreach ( $orders as $order ) {
-			$total += $order->get_discount_total();
-		}
-
-		return $total;
-	}
-
-	/**
-	 * Get the refund total for all orders.
-	 *
-	 * @param array $orders Array of WC_Order objects.
-	 * @return float
-	 */
-	protected static function get_orders_refund_total( $orders ) {
-		$total = 0.0;
-
-		foreach ( $orders as $order ) {
-			$total += $order->get_total_refunded();
-		}
-
-		return $total;
-	}
-
-	/**
-	 * Get the tax total for all orders.
-	 *
-	 * @param array $orders Array of WC_Order objects.
-	 * @return float
-	 */
-	protected static function get_orders_tax_total( $orders ) {
-		$total = 0.0;
-
-		foreach ( $orders as $order ) {
-			$total += $order->get_total_tax();
-		}
-
-		return $total;
-	}
-
-	/**
-	 * Get the shipping total for all orders.
-	 *
-	 * @param array $orders Array of WC_Order objects.
-	 * @return float
-	 */
-	protected static function get_orders_shipping_total( $orders ) {
-		$total = 0.0;
-
-		foreach ( $orders as $order ) {
-			$total += $order->get_shipping_total();
-		}
-
-		return $total;
 	}
 }

--- a/tests/unit-tests/reports/class-wc-tests-reports-orders.php
+++ b/tests/unit-tests/reports/class-wc-tests-reports-orders.php
@@ -22,6 +22,8 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 	 * @since 3.5.0
 	 */
 	public function test_populate_and_query() {
+				global $wpdb;
+
 		$this->reset_stats_db();
 
 		// Populate all of the data.
@@ -40,33 +42,17 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$order->set_total( 97 ); // $25x4 products + $10 shipping - $20 discount + $7 tax.
 		$order->save();
 
-		// Test the calculations.
-		$start_time = time() - HOUR_IN_SECONDS;
-		$end_time = time() + 1;
-
 		$data_store = new WC_Reports_Orders_Data_Store();
+		$data_store::update( $order );
 
-		$data = $data_store::summarize_orders( $start_time, $end_time );
-
-		$expected_data = array(
-			'num_orders'            => 1,
-			'num_items_sold'        => 4,
-			'orders_gross_total'    => 97.0,
-			'orders_coupon_total'   => 20.0,
-			'orders_refund_total'   => 0.0,
-			'orders_tax_total'      => 7.0,
-			'orders_shipping_total' => 10.0,
-			'orders_net_total'      => 80.0,
-		);
-		$this->assertEquals( $expected_data, $data );
-
-		$data_store::update( $start_time, $data );
+		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getTimestamp() );
+		$end_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getTimestamp() + HOUR_IN_SECONDS );
 
 		$args = array();
 		$expected_stats = array(
 			'totals' => array(
-				'date_start'            => date( 'Y-m-d H:00:00', $start_time ),
-				'date_end'              => date( 'Y-m-d H:00:00', $end_time ),
+				'date_start'            => $start_time,
+				'date_end'              => $end_time,
 				'num_orders'            => '1',
 				'num_items_sold'        => '4',
 				'orders_gross_total'    => '97',
@@ -81,8 +67,8 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 			'intervals' => array(
 				array(
 					'time_interval'         => '',
-					'date_start'            => date( 'Y-m-d H:00:00', $start_time ),
-					'date_end'              => date( 'Y-m-d H:00:00', $end_time ),
+					'date_start'            => $start_time,
+					'date_end'              => $end_time,
 					'num_orders'            => '1',
 					'num_items_sold'        => '4',
 					'orders_gross_total'    => '97',

--- a/tests/unit-tests/reports/class-wc-tests-reports-orders.php
+++ b/tests/unit-tests/reports/class-wc-tests-reports-orders.php
@@ -48,39 +48,40 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getTimestamp() );
 		$end_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getTimestamp() + HOUR_IN_SECONDS );
 
-		$args = array();
+		$args = array( 'interval' => 'hour' );
 		$expected_stats = array(
 			'totals' => array(
-				'date_start'            => $start_time,
-				'date_end'              => $end_time,
-				'num_orders'            => '1',
-				'num_items_sold'        => '4',
-				'orders_gross_total'    => '97',
-				'orders_coupon_total'   => '20',
-				'orders_refund_total'   => '0',
-				'orders_tax_total'      => '7',
-				'orders_shipping_total' => '10',
-				'orders_net_total'      => '80',
-				'avg_items_per_order'   => '4.0000',
-				'avg_order_value'       => '97',
+				'orders_count'        => 1,
+				'num_items_sold'      => 4,
+				'avg_items_per_order' => 4,
+				'avg_order_value'     => 97,
+				'gross_revenue'       => 97,
+				'coupons'             => 20,
+				'refunds'             => 0,
+				'taxes'               => 7,
+				'shipping'            => 10,
+				'net_revenue'         => 80,
 			),
 			'intervals' => array(
 				array(
-					'time_interval'         => '',
-					'date_start'            => $start_time,
-					'date_end'              => $end_time,
-					'num_orders'            => '1',
-					'num_items_sold'        => '4',
-					'orders_gross_total'    => '97',
-					'orders_coupon_total'   => '20',
-					'orders_refund_total'   => '0',
-					'orders_tax_total'      => '7',
-					'orders_shipping_total' => '10',
-					'orders_net_total'      => '80',
-					'avg_order_value'       => '97',
-					'avg_items_per_order'   => '4.0000',
+					'time_interval'       => date( 'Y-m-d H', $order->get_date_created()->getTimestamp() ),
+					'date_start'          => $start_time,
+					'date_end'            => $end_time,
+					'orders_count'        => 1,
+					'num_items_sold'      => 4,
+					'avg_order_value'     => 97,
+					'avg_items_per_order' => 4,
+					'gross_revenue'       => 97,
+					'coupons'             => 20,
+					'refunds'             => 0,
+					'taxes'               => 7,
+					'shipping'            => 10,
+					'net_revenue'         => 80,
 				),
 			),
+			'total'   => 1,
+			'pages'   => 1,
+			'page_no' => 1,
 		);
 
 		// Test retrieving the stats from the data store.


### PR DESCRIPTION
Implements the table proposed in https://github.com/woocommerce/woocommerce/pull/20581#discussion_r204211777

Having the stats for each order available will make it possible to aggregate the stats in a variety of ways on a variety of filters.

To test:
- In MySQL delete `wp_wc_order_stats` and also delete the order stats table from the unit testing DB.
- Deactivate then reactivate WC to get the new table format.
- `phpunit tests/unit-tests/reports/class-wc-tests-reports-orders` will populate and run a query with one order. There is one small bug in the returned output with the end date (but that's less bugs than there used to be in the test! :P)
- Can also use the Regenerate Reports button in the WC status tools and the `/wp-json/wc/v3/reports/revenue/stats` endpoint to test and verify output looks reasonable.