### PR TITLE
Fix for issue 20943: Removed unnecessary php tag [point 2] and removed a return false stat…

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -5,7 +5,7 @@
  * All functionality pertaining to regenerating product images in realtime.
  *
  * @package WooCommerce/Classes
- * @version 3.3.0
+ * @version 3.5.0
  * @since   3.3.0
  */
 
@@ -87,9 +87,7 @@ class WC_Regenerate_Images {
 				$size_data = wc_get_image_size( $size );
 				return image_get_intermediate_size( $attachment_id, array( absint( $size_data['width'] ), absint( $size_data['height'] ) ) );
 			}
-
 		}
-
 		return $data;
 	}
 

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -88,7 +88,6 @@ class WC_Regenerate_Images {
 				return image_get_intermediate_size( $attachment_id, array( absint( $size_data['width'] ), absint( $size_data['height'] ) ) );
 			}
 
-			return false;
 		}
 
 		return $data;

--- a/templates/single-product/share.php
+++ b/templates/single-product/share.php
@@ -22,8 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-?>
-
-<?php do_action( 'woocommerce_share' ); // Sharing plugins can hook into here
+do_action( 'woocommerce_share' ); // Sharing plugins can hook into here
 
 /* Omit closing PHP tag at the end of PHP files to avoid "headers already sent" issues. */

--- a/templates/single-product/share.php
+++ b/templates/single-product/share.php
@@ -15,7 +15,7 @@
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @author 		WooThemes
  * @package 	WooCommerce/Templates
- * @version     1.6.4
+ * @version     3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
…ement[point 3]

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

This pull request is for the issue #20943

Removed an extra pair of php tag, which was not required in template/single-product/share.php file and also removed a return false statement in includes/class-wc-regenerate-images.php file. 