### PR TITLE
#20943: Fix for potential issues.

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -87,8 +87,6 @@ class WC_Regenerate_Images {
 				$size_data = wc_get_image_size( $size );
 				return image_get_intermediate_size( $attachment_id, array( absint( $size_data['width'] ), absint( $size_data['height'] ) ) );
 			}
-
-			return false;
 		}
 
 		return $data;

--- a/templates/single-product/share.php
+++ b/templates/single-product/share.php
@@ -22,8 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 
-?>
-
-<?php do_action( 'woocommerce_share' ); // Sharing plugins can hook into here
+do_action( 'woocommerce_share' ); // Sharing plugins can hook into here
 
 /* Omit closing PHP tag at the end of PHP files to avoid "headers already sent" issues. */


### PR DESCRIPTION
**Changes proposed in this Pull Request:**

- templates\single-product\share.php
- Unnecessary close and open php tag includes\class-wc-regenerate-images.php - find this conditional if ( ! self::image_size_matches_settings( $data, $size ) ) { and inside it there is unnecessary return false; code because there is already if else statement and you can't get that case.

Fixed #20943 

**Changelog entry**

Fix: Removed unnecessary PHP tags and unreachable return statements 