### PR TITLE
Feature/reports orders stats

### DIFF
--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -53,7 +53,8 @@ class WC_Data_Store {
 		'product-variation'     => 'WC_Product_Variation_Data_Store_CPT',
 		'shipping-zone'         => 'WC_Shipping_Zone_Data_Store',
 		'webhook'               => 'WC_Webhook_Data_Store',
-		'revenue-report'        => 'WC_Reports_Orders_Data_Store',
+		'report-revenue-stats'  => 'WC_Reports_Orders_Data_Store',
+		'report-orders-stats'   => 'WC_Reports_Orders_Data_Store',
 	);
 
 	/**

--- a/includes/class-wc-reports-interval.php
+++ b/includes/class-wc-reports-interval.php
@@ -22,6 +22,13 @@ class WC_Reports_Interval {
 	public static $iso_datetime_format = 'Y-m-d\TH:i:s\Z';
 
 	/**
+	 * Format string for use in SQL queries.
+	 *
+	 * @var string
+	 */
+	public static $sql_datetime_format = 'Y-m-d H:i:s';
+
+	/**
 	 * Returns date format to be used as grouping clause in SQL.
 	 *
 	 * @param string $time_interval Time interval.

--- a/includes/class-wc-reports-orders-stats-query.php
+++ b/includes/class-wc-reports-orders-stats-query.php
@@ -31,7 +31,7 @@ class WC_Reports_Orders_Stats_Query extends WC_Reports_Query {
 	const REPORT_NAME = 'report-orders-stats';
 
 	/**
-	 * Valid query vars for Revenue report.
+	 * Valid fields for Orders report.
 	 *
 	 * @return array
 	 */

--- a/includes/class-wc-reports-orders-stats-query.php
+++ b/includes/class-wc-reports-orders-stats-query.php
@@ -52,9 +52,9 @@ class WC_Reports_Orders_Stats_Query extends WC_Reports_Query {
 	 * @return array
 	 */
 	public function get_data() {
-		$args    = apply_filters( 'woocommerce_reports_revenue_query_args', $this->get_query_vars() );
+		$args    = apply_filters( 'woocommerce_reports_orders_stats_query_args', $this->get_query_vars() );
 		$results = WC_Data_Store::load( $this::REPORT_NAME )->get_data( $args );
-		return apply_filters( 'woocommerce_reports_revenue_select_query', $results, $args );
+		return apply_filters( 'woocommerce_reports_orders_stats_select_query', $results, $args );
 	}
 
 }

--- a/includes/class-wc-reports-orders-stats-query.php
+++ b/includes/class-wc-reports-orders-stats-query.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * Class for parameter-based Revenue Reports querying
+ *
+ * Example usage:
+ * $args = array(
+ *          'before'       => '2018-07-19 00:00:00',
+ *          'after'        => '2018-07-05 00:00:00',
+ *          'interval'     => 'week',
+ *          'categories'   => array(15, 18),
+ *          'coupons'      => array(138),
+ *          'order_status' => 'completed',
+ *         );
+ * $report = new WC_Reports_Orders_Stats_Query( $args );
+ * $mydata = $report->get_data();
+ *
+ * @package  WooCommerce/Classes
+ * @version  3.5.0
+ * @since    3.5.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Reports_Orders_Stats_Query
+ *
+ * @version  3.5.0
+ */
+class WC_Reports_Orders_Stats_Query extends WC_Reports_Query {
+
+	const REPORT_NAME = 'report-orders-stats';
+
+	/**
+	 * Valid query vars for Revenue report.
+	 *
+	 * @return array
+	 */
+	protected function get_default_query_vars() {
+		return array(
+			'fields' => array(
+				'net_revenue',
+				'avg_order_value',
+				'orders_count',
+				'avg_items_per_order',
+			),
+		);
+	}
+
+	/**
+	 * Get revenue data based on the current query vars.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		$args    = apply_filters( 'woocommerce_reports_revenue_query_args', $this->get_query_vars() );
+		$results = WC_Data_Store::load( $this::REPORT_NAME )->get_data( $args );
+		return apply_filters( 'woocommerce_reports_revenue_select_query', $results, $args );
+	}
+
+}

--- a/includes/class-wc-reports-revenue-query.php
+++ b/includes/class-wc-reports-revenue-query.php
@@ -25,6 +25,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_Reports_Revenue_Query extends WC_Reports_Query {
 
+	const REPORT_NAME = 'report-revenue-stats';
+
 	/**
 	 * Valid query vars for Revenue report.
 	 *
@@ -33,8 +35,6 @@ class WC_Reports_Revenue_Query extends WC_Reports_Query {
 	protected function get_default_query_vars() {
 		return array(
 			'fields' => array(
-				'date_start',
-				'date_end',
 				'orders_count',
 				'num_items_sold',
 				'gross_revenue',
@@ -54,7 +54,7 @@ class WC_Reports_Revenue_Query extends WC_Reports_Query {
 	 */
 	public function get_data() {
 		$args    = apply_filters( 'woocommerce_reports_revenue_query_args', $this->get_query_vars() );
-		$results = WC_Data_Store::load( 'revenue-report' )->get_data( $args );
+		$results = WC_Data_Store::load( $this::REPORT_NAME )->get_data( $args );
 		return apply_filters( 'woocommerce_reports_revenue_select_query', $results, $args );
 	}
 

--- a/includes/class-wc-reports-revenue-query.php
+++ b/includes/class-wc-reports-revenue-query.php
@@ -28,7 +28,7 @@ class WC_Reports_Revenue_Query extends WC_Reports_Query {
 	const REPORT_NAME = 'report-revenue-stats';
 
 	/**
-	 * Valid query vars for Revenue report.
+	 * Valid fields for Revenue report.
 	 *
 	 * @return array
 	 */

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -333,6 +333,7 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-shortcodes.php';
 		include_once WC_ABSPATH . 'includes/class-wc-logger.php';
 		include_once WC_ABSPATH . 'includes/class-wc-reports-revenue-query.php';
+		include_once WC_ABSPATH . 'includes/class-wc-reports-orders-stats-query.php';
 
 		/**
 		 * Data stores - used to store and retrieve CRUD object data from the database.

--- a/includes/data-stores/class-wc-reports-data-store.php
+++ b/includes/data-stores/class-wc-reports-data-store.php
@@ -37,7 +37,7 @@ class WC_Reports_Data_Store {
 	 *
 	 * @var string
 	 */
-	protected $table_name = '';
+	const TABLE_NAME = '';
 
 	/**
 	 * Returns string to be used as cache key for the data.
@@ -46,7 +46,7 @@ class WC_Reports_Data_Store {
 	 * @return string
 	 */
 	protected function get_cache_key( $params ) {
-		return 'woocommerce_' . $this->table_name . '_' . md5( wp_json_encode( $params ) . date( 'Y-m-d_H' ) );
+		return 'woocommerce_' . $this::TABLE_NAME . '_' . md5( wp_json_encode( $params ) );
 	}
 
 	/**
@@ -143,18 +143,21 @@ class WC_Reports_Data_Store {
 	 * @return array
 	 */
 	protected function get_totals_sql_params( $query_args ) {
-		$totals_query['where_clause'] = '';
+		$totals_query = array(
+			'from_clause'  => '',
+			'where_clause' => '',
+		);
 
 		if ( isset( $query_args['before'] ) && '' !== $query_args['before'] ) {
 			$datetime                      = new DateTime( $query_args['before'] );
-			$datetime_str                  = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime_str                  = $datetime->format( WC_Reports_Interval::$sql_datetime_format );
 			$totals_query['where_clause'] .= " AND date_created <= '$datetime_str'";
 
 		}
 
 		if ( isset( $query_args['after'] ) && '' !== $query_args['after'] ) {
 			$datetime                      = new DateTime( $query_args['after'] );
-			$datetime_str                  = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime_str                  = $datetime->format( WC_Reports_Interval::$sql_datetime_format );
 			$totals_query['where_clause'] .= " AND date_created >= '$datetime_str'";
 		}
 
@@ -168,19 +171,21 @@ class WC_Reports_Data_Store {
 	 * @return array
 	 */
 	protected function get_intervals_sql_params( $query_args ) {
-		$intervals_query                 = array();
-		$intervals_query['where_clause'] = '';
+		$intervals_query = array(
+			'from_clause'  => '',
+			'where_clause' => '',
+		);
 
 		if ( isset( $query_args['before'] ) && '' !== $query_args['before'] ) {
 			$datetime                         = new DateTime( $query_args['before'] );
-			$datetime_str                     = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime_str                     = $datetime->format( WC_Reports_Interval::$sql_datetime_format );
 			$intervals_query['where_clause'] .= " AND date_created <= '$datetime_str'";
 
 		}
 
 		if ( isset( $query_args['after'] ) && '' !== $query_args['after'] ) {
 			$datetime                         = new DateTime( $query_args['after'] );
-			$datetime_str                     = $datetime->format( WC_Reports_Interval::$iso_datetime_format );
+			$datetime_str                     = $datetime->format( WC_Reports_Interval::$sql_datetime_format );
 			$intervals_query['where_clause'] .= " AND date_created >= '$datetime_str'";
 		}
 

--- a/includes/data-stores/class-wc-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-reports-orders-data-store.php
@@ -196,7 +196,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 			'fields'       => '*',
 			'categories'   => array(),
 			'coupons'      => array(),
-			'order_status' => 'completed',
+			'order_status' => self::get_report_order_statuses(),
 		);
 		$query_args = wp_parse_args( $query_args, $defaults );
 

--- a/includes/data-stores/class-wc-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-reports-orders-data-store.php
@@ -65,7 +65,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 	 * @return array|WP_Error
 	 */
 	protected function cast_numbers( $array ) {
-		$type_for = array(
+		$type_for      = array(
 			'orders_count'        => 'intval',
 			'num_items_sold'      => 'intval',
 			'gross_revenue'       => 'floatval',
@@ -89,6 +89,88 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 	}
 
 	/**
+	 * Returns an array of products belonging to given categories.
+	 *
+	 * @param $categories
+	 * @return array|stdClass
+	 */
+	protected function get_products_by_cat_ids( $categories ) {
+		$product_categories = get_categories( array(
+			'hide_empty' => 0,
+			'taxonomy'   => 'product_cat',
+		) );
+		$cat_slugs          = array();
+		$categories         = array_flip( $categories );
+		foreach ( $product_categories as $product_cat ) {
+			if ( key_exists( $product_cat->cat_ID, $categories ) ) {
+				$cat_slugs[] = $product_cat->slug;
+			}
+		}
+		$args = array(
+			'category' => $cat_slugs,
+			'limit'    => -1,
+		);
+		return wc_get_products( $args );
+	}
+
+	/**
+	 * Updates the totals and intervals database queries with parameters used for Orders report: categories, coupons and order status.
+	 *
+	 * @param array $query_args      Query arguments supplied by the user.
+	 * @param array $totals_query    Array of options for totals db query.
+	 * @param array $intervals_query Array of options for intervals db query.
+	 */
+	protected function orders_stats_sql_filter( $query_args, &$totals_query, &$intervals_query ) {
+		// TODO: performance of all of this?
+		global $wpdb;
+
+		$where_clause = '';
+		$from_clause  = '';
+
+		$orders_stats_table = $wpdb->prefix . self::TABLE_NAME;
+		if ( count( $query_args['categories'] ) > 0 ) {
+			$allowed_products     = $this->get_products_by_cat_ids( $query_args['categories'] );
+			$allowed_product_ids  = wp_list_pluck( $allowed_products, 'id' );
+			$allowed_products_str = implode( ',', $allowed_product_ids );
+
+			$where_clause .= " AND {$orders_stats_table}.order_id IN ( 
+			SELECT 
+				DISTINCT {$wpdb->prefix}wc_order_product_lookup.order_id
+			FROM 
+				{$wpdb->prefix}wc_order_product_lookup
+			WHERE 
+				{$wpdb->prefix}wc_order_product_lookup.product_id IN ({$allowed_products_str})
+			)";
+		}
+
+		if ( count( $query_args['coupons'] ) > 0 ) {
+			$allowed_coupons_str = implode( ', ', $query_args['coupons'] );
+
+			$where_clause .= " AND {$orders_stats_table}.order_id IN ( 
+			SELECT 
+				DISTINCT {$wpdb->prefix}wc_order_coupon_lookup.order_id
+			FROM 
+				{$wpdb->prefix}wc_order_coupon_lookup
+			WHERE 
+				{$wpdb->prefix}wc_order_coupon_lookup.coupon_id IN ({$allowed_coupons_str})
+			)";
+		}
+
+		if ( '' !== $query_args['order_status'] ) {
+			$from_clause  .= " JOIN {$wpdb->prefix}posts ON {$orders_stats_table}.order_id = {$wpdb->prefix}posts.ID";
+			$where_clause .= " AND {$wpdb->prefix}posts.post_status = 'wc-{$query_args['order_status']}'";
+		}
+
+		// To avoid requesting the subqueries twice, the result is applied to all queries passed to the method.
+		$totals_query['where_clause']    .= $where_clause;
+		$totals_query['from_clause']     .= $from_clause;
+		$intervals_query['where_clause'] .= $where_clause;
+		$intervals_query['from_clause']  .= $from_clause;
+
+	}
+
+
+	/**
 	 * Returns the report data based on parameters supplied by the user.
 	 *
 	 * @since 3.5.0
@@ -99,19 +181,22 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 		global $wpdb;
 
 		$table_name = $wpdb->prefix . self::TABLE_NAME;
-		$now       = time();
-		$week_back = $now - WEEK_IN_SECONDS;
+		$now        = time();
+		$week_back  = $now - WEEK_IN_SECONDS;
 
-		// These defaults are only applied when not using REST API, as the API has its own defaults.
-		$defaults = array(
-			'per_page' => get_option( 'posts_per_page' ),
-			'page'     => 1,
-			'order'    => 'DESC',
-			'orderby'  => 'date',
-			'before'   => date( WC_Reports_Interval::$iso_datetime_format, $now ),
-			'after'    => date( WC_Reports_Interval::$iso_datetime_format, $week_back ),
-			'interval' => 'week',
-			'fields'   => '*',
+		// These defaults are only applied when not using REST API, as the API has its own defaults that overwrite these.
+		$defaults   = array(
+			'per_page'     => get_option( 'posts_per_page' ),
+			'page'         => 1,
+			'order'        => 'DESC',
+			'orderby'      => 'date',
+			'before'       => date( WC_Reports_Interval::$iso_datetime_format, $now ),
+			'after'        => date( WC_Reports_Interval::$iso_datetime_format, $week_back ),
+			'interval'     => 'week',
+			'fields'       => '*',
+			'categories'   => array(),
+			'coupons'      => array(),
+			'order_status' => 'completed',
 		);
 		$query_args = wp_parse_args( $query_args, $defaults );
 
@@ -148,11 +233,15 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 			$totals_query    = $this->get_totals_sql_params( $query_args );
 			$intervals_query = $this->get_intervals_sql_params( $query_args );
 
+			// Additional filtering for Orders report.
+			$this->orders_stats_sql_filter( $query_args, $totals_query, $intervals_query );
+
 			$totals = $wpdb->get_results(
 				"SELECT
 						{$selections}
 					FROM
 						{$table_name}
+						{$totals_query['from_clause']}
 					WHERE
 						1=1
 						{$totals_query['where_clause']}", ARRAY_A
@@ -174,6 +263,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 								{$intervals_query['select_clause']} AS time_interval
 							FROM
 								{$table_name}
+								{$intervals_query['from_clause']}
 							WHERE
 								1=1
 								{$intervals_query['where_clause']}
@@ -198,6 +288,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 							{$selections}
 						FROM
 							{$table_name}
+							{$intervals_query['from_clause']}
 						WHERE
 							1=1
 							{$intervals_query['where_clause']}
@@ -222,7 +313,6 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 				'pages'     => $total_pages,
 				'page_no'   => (int) $query_args['page'],
 			);
-
 
 			wp_cache_set( $cache_key, $data, $this->cache_group );
 		}

--- a/tests/unit-tests/reports/class-wc-tests-reports-orders.php
+++ b/tests/unit-tests/reports/class-wc-tests-reports-orders.php
@@ -45,8 +45,8 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 		$data_store = new WC_Reports_Orders_Data_Store();
 		$data_store::update( $order );
 
-		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getTimestamp() );
-		$end_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getTimestamp() + HOUR_IN_SECONDS );
+		$start_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() );
+		$end_time = date( 'Y-m-d H:00:00', $order->get_date_created()->getOffsetTimestamp() + HOUR_IN_SECONDS );
 
 		$args = array( 'interval' => 'hour' );
 		$expected_stats = array(
@@ -64,19 +64,23 @@ class WC_Tests_Reports_Orders extends WC_Unit_Test_Case {
 			),
 			'intervals' => array(
 				array(
-					'time_interval'       => date( 'Y-m-d H', $order->get_date_created()->getTimestamp() ),
-					'date_start'          => $start_time,
-					'date_end'            => $end_time,
-					'orders_count'        => 1,
-					'num_items_sold'      => 4,
-					'avg_order_value'     => 97,
-					'avg_items_per_order' => 4,
-					'gross_revenue'       => 97,
-					'coupons'             => 20,
-					'refunds'             => 0,
-					'taxes'               => 7,
-					'shipping'            => 10,
-					'net_revenue'         => 80,
+					'interval'       => 'hour',
+					'date_start'     => $start_time,
+					'date_start_gmt' => date( 'Y-m-d H:00:00', $order->get_date_created()->getTimestamp() ),
+					'date_end'       => $end_time,
+					'date_end_gmt'   => date( 'Y-m-d H:00:00', $order->get_date_created()->getTimestamp() + HOUR_IN_SECONDS ),
+					'subtotals'      => array(
+						'gross_revenue'       => 97,
+						'net_revenue'         => 80,
+						'coupons'             => 20,
+						'shipping'            => 10,
+						'taxes'               => 7,
+						'refunds'             => 0,
+						'orders_count'        => 1,
+						'num_items_sold'      => 4,
+						'avg_items_per_order' => 4,
+						'avg_order_value'     => 97,
+					),
 				),
 			),
 			'total'   => 1,


### PR DESCRIPTION
This PR should add the necessary support for `v3/reports/orders/stats/` endpoint from the side of db queries and data gathering. 

Currently this lacks the REST API infrastructure side that (I assume) @claudiosanches is working on as part of #20774.

It also depends on #20936 to be merged, as it uses the lookup table in case `categories` filter is used in the request (look up products in selected categories, then only include orders which include those products).

No performance testing yet. Especially the option of SQL join vs sub-SELECT, getting list of products to PHP vs another join in SQL should probably be checked if we want to be thorough.

The coupon filtering depends on `wc_order_coupon_lookup` table that does not exist, yet.

Nevertheless, nothing crashes unless those params are used in the request, so it should be possible to merge this without waiting for those items.