### PR TITLE
Unify scroll to notices for all browsers

### DIFF
--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -66,19 +66,10 @@ jQuery( function( $ ) {
 
 	// Common scroll to element code.
 	$.scroll_to_notices = function( scrollElement ) {
-		var isSmoothScrollSupported = 'scrollBehavior' in document.documentElement.style;
-
 		if ( scrollElement.length ) {
-			if ( isSmoothScrollSupported ) {
-				scrollElement[0].scrollIntoView({
-					behavior: 'smooth',
-					block:    'center'
-				});
-			} else {
-				$( 'html, body' ).animate( {
-					scrollTop: ( scrollElement.offset().top - 100 )
-				}, 1000 );
-			}
+			$( 'html, body' ).animate( {
+				scrollTop: ( scrollElement.offset().top - 100 )
+			}, 1000 );
 		}
 	};
 });


### PR DESCRIPTION
… cases.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20951.

### How to test the changes in this Pull Request:

1. Install Firefox 52.
2. Try to check out without filling in the form, see that scroll to notices is broken.
3. Apply branch, retest.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Unify scroll to notices for all browsers.
