### PR TITLE
Changed wc_clean to checking for valid utf8 for line items and password.

### DIFF
--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -208,7 +208,7 @@ function wc_save_order_items( $order_id, $items ) {
 			$item_data = array();
 
 			foreach ( $data_keys as $key => $default ) {
-				$item_data[ $key ] = isset( $items[ $key ][ $item_id ] ) ? wc_clean( wp_unslash( $items[ $key ][ $item_id ] ) ) : $default;
+				$item_data[ $key ] = isset( $items[ $key ][ $item_id ] ) ? wp_check_invalid_utf8( wp_unslash( $items[ $key ][ $item_id ] ) ) : $default;
 			}
 
 			if ( '0' === $item_data['order_item_qty'] ) {

--- a/includes/api/v1/class-wc-rest-customers-controller.php
+++ b/includes/api/v1/class-wc-rest-customers-controller.php
@@ -419,7 +419,7 @@ class WC_REST_Customers_V1_Controller extends WC_REST_Controller {
 
 			// Customer password.
 			if ( isset( $request['password'] ) ) {
-				$customer->set_password( wc_clean( $request['password'] ) );
+				$customer->set_password( wp_check_invalid_utf8( $request['password'] ) );
 			}
 
 			$this->update_customer_meta_fields( $customer, $request );

--- a/includes/api/v1/class-wc-rest-customers-controller.php
+++ b/includes/api/v1/class-wc-rest-customers-controller.php
@@ -419,7 +419,7 @@ class WC_REST_Customers_V1_Controller extends WC_REST_Controller {
 
 			// Customer password.
 			if ( isset( $request['password'] ) ) {
-				$customer->set_password( wp_check_invalid_utf8( $request['password'] ) );
+				$customer->set_password( $request['password'] );
 			}
 
 			$this->update_customer_meta_fields( $customer, $request );

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -615,6 +615,9 @@ class WC_Checkout {
 					case 'textarea':
 						$value = isset( $_POST[ $key ] ) ? wc_sanitize_textarea( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok.
 						break;
+					case 'password':
+						$value = isset( $_POST[ $key ] ) ? wp_check_invalid_utf8( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok.
+						break;
 					default:
 						$value = isset( $_POST[ $key ] ) ? wc_clean( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok.
 						break;

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -616,7 +616,7 @@ class WC_Checkout {
 						$value = isset( $_POST[ $key ] ) ? wc_sanitize_textarea( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok.
 						break;
 					case 'password':
-						$value = isset( $_POST[ $key ] ) ? wp_check_invalid_utf8( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok.
+						$value = isset( $_POST[ $key ] ) ? wp_check_invalid_utf8( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
 						break;
 					default:
 						$value = isset( $_POST[ $key ] ) ? wc_clean( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok.

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -616,7 +616,7 @@ class WC_Checkout {
 						$value = isset( $_POST[ $key ] ) ? wc_sanitize_textarea( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok.
 						break;
 					case 'password':
-						$value = isset( $_POST[ $key ] ) ? wp_check_invalid_utf8( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
+						$value = isset( $_POST[ $key ] ) ? wp_unslash( $_POST[ $key ] ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
 						break;
 					default:
 						$value = isset( $_POST[ $key ] ) ? wc_clean( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok.

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -294,7 +294,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param string $password Password.
 	 */
 	public function set_password( $password ) {
-		$this->password = wc_clean( $password );
+		$this->password = wp_check_invalid_utf8( $password );
 	}
 
 	/**

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -294,7 +294,7 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param string $password Password.
 	 */
 	public function set_password( $password ) {
-		$this->password = wp_check_invalid_utf8( $password );
+		$this->password = $password;
 	}
 
 	/**

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -186,7 +186,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 * @param string $value Item name.
 	 */
 	public function set_name( $value ) {
-		$this->set_prop( 'name', wc_clean( $value ) );
+		$this->set_prop( 'name', wp_check_invalid_utf8( $value ) );
 	}
 
 	/*


### PR DESCRIPTION
The input is later sanitized by WordPress db layer.

It caused issues in (at least) 2 places: Order item name (product name) and user's password.

I would appreciate review especially from the perspective of:
- security (as far as I can see, the order items are inserted/updated using `wp_insert` and `wp_update`, which sanitizes everything; user updates are done via `wp_update_user`, which is, again, correctly sanitized)
- completeness (have I missed anything?).

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20959.

### How to test the changes in this Pull Request:

1. Create a product with %100 in the name (or %ab etc).
2. While buying the product, create a new user with password `abc%100`.
3. Confirmation of the order and the product listing under 'My account' will be missing the % and two characters after '%'.
4. Log out & log back in using the password `abc%100`, it should fail.
5. Apply branch, repeat steps 1 to 4, product should display correctly and new password should work correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Changed wc_clean to checking for valid utf8 for line items and password.
