### PR TITLE
Feature/20774

### DIFF
--- a/includes/api/class-wc-rest-reports-orders-stats-controller.php
+++ b/includes/api/class-wc-rest-reports-orders-stats-controller.php
@@ -318,12 +318,15 @@ class WC_REST_Reports_Orders_Stats_Controller extends WC_REST_Reports_Controller
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['order_status'] = array(
-			'default'           => 'any',
-			'description'       => __( 'Limit result set to orders assigned a specific status.', 'woocommerce' ),
-			'type'              => 'string',
-			'enum'              => array_merge( array( 'any' ), $this->get_order_statuses() ),
-			'sanitize_callback' => 'sanitize_key',
+			'default'           => array( 'completed', 'processing', 'on-hold' ),
+			'description'       => __( 'Limit result set to orders assigned one or more statuses', 'woocommerce' ),
+			'type'              => 'array',
+			'sanitize_callback' => 'wp_parse_slug_list',
 			'validate_callback' => 'rest_validate_request_arg',
+			'items'             => array(
+				'enum' => $this->get_order_statuses(),
+				'type' => 'string',
+			),
 		);
 
 		return $params;

--- a/includes/api/class-wc-rest-reports-orders-stats-controller.php
+++ b/includes/api/class-wc-rest-reports-orders-stats-controller.php
@@ -63,8 +63,8 @@ class WC_REST_Reports_Orders_Stats_Controller extends WC_REST_Reports_Controller
 	 */
 	public function get_items( $request ) {
 		$query_args  = $this->prepare_reports_query( $request );
-		$data_store  = new WC_Reports_Orders_Data_Store( $query_args );
-		$report_data = $data_store->get_data();
+		$data_store  = new WC_Reports_Orders_Data_Store();
+		$report_data = $data_store->get_data( $query_args );
 
 		$out_data = array(
 			'totals'    => get_object_vars( $report_data->totals ),
@@ -164,7 +164,7 @@ class WC_REST_Reports_Orders_Stats_Controller extends WC_REST_Reports_Controller
 
 		$schema = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'report_revenue_stats',
+			'title'      => 'report_orders_stats',
 			'type'       => 'object',
 			'properties' => array(
 				'totals'    => array(

--- a/includes/api/class-wc-rest-reports-orders-stats-controller.php
+++ b/includes/api/class-wc-rest-reports-orders-stats-controller.php
@@ -66,8 +66,6 @@ class WC_REST_Reports_Orders_Stats_Controller extends WC_REST_Reports_Controller
 		$data_store  = new WC_Reports_Orders_Data_Store();
 		$report_data = $data_store->get_data( $query_args );
 
-		error_log( print_r( $report_data, true ) );
-
 		$out_data = array(
 			'totals'    => get_object_vars( $report_data->totals ),
 			'intervals' => array(),

--- a/includes/api/class-wc-rest-reports-orders-stats-controller.php
+++ b/includes/api/class-wc-rest-reports-orders-stats-controller.php
@@ -47,9 +47,9 @@ class WC_REST_Reports_Orders_Stats_Controller extends WC_REST_Reports_Controller
 		$args['per_page']     = $request['per_page'];
 		$args['orderby']      = $request['orderby'];
 		$args['order']        = $request['order'];
-		$args['categories']   = $request['categories'];
-		$args['coupons']      = $request['coupons'];
-		$args['products']     = $request['products'];
+		$args['categories']   = (array) $request['categories'];
+		$args['coupons']      = (array) $request['coupons'];
+		$args['products']     = (array) $request['products'];
 		$args['order_status'] = $request['order_status'];
 
 		return $args;
@@ -65,6 +65,8 @@ class WC_REST_Reports_Orders_Stats_Controller extends WC_REST_Reports_Controller
 		$query_args  = $this->prepare_reports_query( $request );
 		$data_store  = new WC_Reports_Orders_Data_Store();
 		$report_data = $data_store->get_data( $query_args );
+
+		error_log( print_r( $report_data, true ) );
 
 		$out_data = array(
 			'totals'    => get_object_vars( $report_data->totals ),

--- a/includes/api/class-wc-rest-reports-orders-stats-controller.php
+++ b/includes/api/class-wc-rest-reports-orders-stats-controller.php
@@ -39,14 +39,18 @@ class WC_REST_Reports_Orders_Stats_Controller extends WC_REST_Reports_Controller
 	 * @return array
 	 */
 	protected function prepare_reports_query( $request ) {
-		$args             = array();
-		$args['before']   = $request['before'];
-		$args['after']    = $request['after'];
-		$args['interval'] = $request['interval'];
-		$args['page']     = $request['page'];
-		$args['per_page'] = $request['per_page'];
-		$args['orderby']  = $request['orderby'];
-		$args['order']    = $request['order'];
+		$args                 = array();
+		$args['before']       = $request['before'];
+		$args['after']        = $request['after'];
+		$args['interval']     = $request['interval'];
+		$args['page']         = $request['page'];
+		$args['per_page']     = $request['per_page'];
+		$args['orderby']      = $request['orderby'];
+		$args['order']        = $request['order'];
+		$args['categories']   = $request['categories'];
+		$args['coupons']      = $request['coupons'];
+		$args['products']     = $request['products'];
+		$args['order_status'] = $request['order_status'];
 
 		return $args;
 	}

--- a/includes/api/class-wc-rest-reports-orders-stats-controller.php
+++ b/includes/api/class-wc-rest-reports-orders-stats-controller.php
@@ -62,8 +62,8 @@ class WC_REST_Reports_Orders_Stats_Controller extends WC_REST_Reports_Controller
 	 * @return array|WP_Error
 	 */
 	public function get_items( $request ) {
-		$query_args = $this->prepare_reports_query( $request );
-		// $data_store  = new WC_Reports_Orders_Data_Store( $query_args ); @todo need to merge this class first.
+		$query_args  = $this->prepare_reports_query( $request );
+		$data_store  = new WC_Reports_Orders_Data_Store( $query_args );
 		$report_data = $data_store->get_data();
 
 		$out_data = array(

--- a/includes/api/class-wc-rest-reports-orders-stats-controller.php
+++ b/includes/api/class-wc-rest-reports-orders-stats-controller.php
@@ -31,4 +31,312 @@ class WC_REST_Reports_Orders_Stats_Controller extends WC_REST_Reports_Controller
 	 * @var string
 	 */
 	protected $rest_base = 'reports/orders/stats';
+
+	/**
+	 * Maps query arguments from the REST request.
+	 *
+	 * @param array $request Request array.
+	 * @return array
+	 */
+	protected function prepare_reports_query( $request ) {
+		$args             = array();
+		$args['before']   = $request['before'];
+		$args['after']    = $request['after'];
+		$args['interval'] = $request['interval'];
+		$args['page']     = $request['page'];
+		$args['per_page'] = $request['per_page'];
+		$args['orderby']  = $request['orderby'];
+		$args['order']    = $request['order'];
+
+		return $args;
+	}
+
+	/**
+	 * Get all reports.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return array|WP_Error
+	 */
+	public function get_items( $request ) {
+		$query_args = $this->prepare_reports_query( $request );
+		// $data_store  = new WC_Reports_Orders_Data_Store( $query_args ); @todo need to merge this class first.
+		$report_data = $data_store->get_data();
+
+		$out_data = array(
+			'totals'    => get_object_vars( $report_data->totals ),
+			'intervals' => array(),
+		);
+
+		foreach ( $report_data->intervals as $interval_data ) {
+			$item                    = $this->prepare_item_for_response( (object) $interval_data, $request );
+			$out_data['intervals'][] = $this->prepare_response_for_collection( $item );
+		}
+
+		$response = rest_ensure_response( $out_data );
+		$response->header( 'X-WP-Total', (int) $report_data->total );
+		$response->header( 'X-WP-TotalPages', (int) $report_data->pages );
+
+		$page      = $report_data->page_no;
+		$max_pages = $report_data->pages;
+		$base      = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ) );
+		if ( $page > 1 ) {
+			$prev_page = $page - 1;
+			if ( $prev_page > $max_pages ) {
+				$prev_page = $max_pages;
+			}
+			$prev_link = add_query_arg( 'page', $prev_page, $base );
+			$response->link_header( 'prev', $prev_link );
+		}
+		if ( $max_pages > $page ) {
+			$next_page = $page + 1;
+			$next_link = add_query_arg( 'page', $next_page, $base );
+			$response->link_header( 'next', $next_link );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Prepare a report object for serialization.
+	 *
+	 * @param stdClass        $report  Report data.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $report, $request ) {
+		$data = get_object_vars( $report );
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+
+		/**
+		 * Filter a report returned from the API.
+		 *
+		 * Allows modification of the report data right before it is returned.
+		 *
+		 * @param WP_REST_Response $response The response object.
+		 * @param object           $report   The original report object.
+		 * @param WP_REST_Request  $request  Request used to generate the response.
+		 */
+		return apply_filters( 'woocommerce_rest_prepare_report_orders_stats', $response, $report, $request );
+	}
+
+	/**
+	 * Get the Report's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$totals = array(
+			'net_revenue'         => array(
+				'description' => __( 'Net revenue.', 'woocommerce' ),
+				'type'        => 'number',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'avg_order_value'     => array(
+				'description' => __( 'Average order value.', 'woocommerce' ),
+				'type'        => 'number',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'orders_count'        => array(
+				'description' => __( 'Amount of orders', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+			'avg_items_per_order' => array(
+				'description' => __( 'Average items per order', 'woocommerce' ),
+				'type'        => 'integer',
+				'context'     => array( 'view', 'edit' ),
+				'readonly'    => true,
+			),
+		);
+
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'report_revenue_stats',
+			'type'       => 'object',
+			'properties' => array(
+				'totals'    => array(
+					'description' => __( 'Totals data.', 'woocommerce' ),
+					'type'        => 'object',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'properties'  => $totals,
+				),
+				'intervals' => array(
+					'description' => __( 'Reports data grouped by intervals.', 'woocommerce' ),
+					'type'        => 'array',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+					'items'       => array(
+						'type'       => 'object',
+						'properties' => array(
+							'interval'       => array(
+								'description' => __( 'Type of interval.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'enum'        => array( 'day', 'week', 'month', 'year' ),
+							),
+							'date_start'     => array(
+								'description' => __( "The date the report start, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_start_gmt' => array(
+								'description' => __( 'The date the report start, as GMT.', 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_end'       => array(
+								'description' => __( "The date the report end, in the site's timezone.", 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'date_end_gmt'   => array(
+								'description' => __( 'The date the report end, as GMT.', 'woocommerce' ),
+								'type'        => 'date-time',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'subtotals'      => array(
+								'description' => __( 'Interval subtotals.', 'woocommerce' ),
+								'type'        => 'object',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+								'properties'  => $totals,
+							),
+						),
+					),
+				),
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Get the query params for collections.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                 = array();
+		$params['context']      = $this->get_context_param( array( 'default' => 'view' ) );
+		$params['page']         = array(
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
+			'type'              => 'integer',
+			'default'           => 1,
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+			'minimum'           => 1,
+		);
+		$params['per_page']     = array(
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
+			'type'              => 'integer',
+			'default'           => 10,
+			'minimum'           => 1,
+			'maximum'           => 100,
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['after']        = array(
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['before']       = array(
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['order']        = array(
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
+			'type'              => 'string',
+			'default'           => 'desc',
+			'enum'              => array( 'asc', 'desc' ),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['orderby']      = array(
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
+			'type'              => 'string',
+			'default'           => 'date',
+			'enum'              => array(
+				'date',
+				'net_revenue',
+				'orders_count',
+				'avg_order_value',
+			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['interval']     = array(
+			'description'       => __( 'Time interval to use for buckets in the returned data.', 'woocommerce' ),
+			'type'              => 'string',
+			'default'           => 'week',
+			'enum'              => array(
+				'hour',
+				'day',
+				'week',
+				'month',
+				'quarter',
+				'year',
+			),
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['categories']   = array(
+			'description'       => __( 'Limit result set to all items that have the specified term assigned in the categories taxonomy.', 'woocommerce' ),
+			'type'              => 'string',
+			'sanitize_callback' => 'wp_parse_id_list',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['coupons']      = array(
+			'description'       => __( 'Limit result set to all items that have the specified coupon assigned.', 'woocommerce' ),
+			'type'              => 'string',
+			'sanitize_callback' => 'wp_parse_id_list',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['products']     = array(
+			'description'       => __( 'Limit result set to all items that have the specified product assigned.', 'woocommerce' ),
+			'type'              => 'string',
+			'sanitize_callback' => 'wp_parse_id_list',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['order_status'] = array(
+			'default'           => 'any',
+			'description'       => __( 'Limit result set to orders assigned a specific status.', 'woocommerce' ),
+			'type'              => 'string',
+			'enum'              => array_merge( array( 'any' ), $this->get_order_statuses() ),
+			'sanitize_callback' => 'sanitize_key',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		return $params;
+	}
+
+	/**
+	 * Get order statuses without prefixes.
+	 *
+	 * @return array
+	 */
+	protected function get_order_statuses() {
+		$order_statuses = array();
+
+		foreach ( array_keys( wc_get_order_statuses() ) as $status ) {
+			$order_statuses[] = str_replace( 'wc-', '', $status );
+		}
+
+		return $order_statuses;
+	}
 }

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -332,6 +332,7 @@ class WC_API extends WC_Legacy_API {
 			'WC_REST_Product_Variations_Controller',
 			'WC_REST_Reports_Controller',
 			'WC_REST_Reports_Revenue_Stats_Controller',
+			'WC_REST_Reports_Orders_Stats_Controller',
 			'WC_REST_Settings_Controller',
 			'WC_REST_Setting_Options_Controller',
 			'WC_REST_Shipping_Zones_Controller',

--- a/includes/data-stores/class-wc-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-reports-orders-data-store.php
@@ -128,30 +128,30 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 		$from_clause  = '';
 
 		$orders_stats_table = $wpdb->prefix . self::TABLE_NAME;
-		if ( count( $query_args['categories'] ) > 0 ) {
+		if ( is_array( $query_args['categories'] ) && count( $query_args['categories'] ) > 0 ) {
 			$allowed_products     = $this->get_products_by_cat_ids( $query_args['categories'] );
 			$allowed_product_ids  = wp_list_pluck( $allowed_products, 'id' );
 			$allowed_products_str = implode( ',', $allowed_product_ids );
 
-			$where_clause .= " AND {$orders_stats_table}.order_id IN ( 
-			SELECT 
+			$where_clause .= " AND {$orders_stats_table}.order_id IN (
+			SELECT
 				DISTINCT {$wpdb->prefix}wc_order_product_lookup.order_id
-			FROM 
+			FROM
 				{$wpdb->prefix}wc_order_product_lookup
-			WHERE 
+			WHERE
 				{$wpdb->prefix}wc_order_product_lookup.product_id IN ({$allowed_products_str})
 			)";
 		}
 
-		if ( count( $query_args['coupons'] ) > 0 ) {
+		if ( is_array( $query_args['coupons'] ) && count( $query_args['coupons'] ) > 0 ) {
 			$allowed_coupons_str = implode( ', ', $query_args['coupons'] );
 
-			$where_clause .= " AND {$orders_stats_table}.order_id IN ( 
-			SELECT 
+			$where_clause .= " AND {$orders_stats_table}.order_id IN (
+			SELECT
 				DISTINCT {$wpdb->prefix}wc_order_coupon_lookup.order_id
-			FROM 
+			FROM
 				{$wpdb->prefix}wc_order_coupon_lookup
-			WHERE 
+			WHERE
 				{$wpdb->prefix}wc_order_coupon_lookup.coupon_id IN ({$allowed_coupons_str})
 			)";
 		}
@@ -233,7 +233,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 			$totals_query    = $this->get_totals_sql_params( $query_args );
 			$intervals_query = $this->get_intervals_sql_params( $query_args );
 
-			// Additional filtering for Orders report.
+			// Additional filtering131 for Orders report.
 			$this->orders_stats_sql_filter( $query_args, $totals_query, $intervals_query );
 
 			$totals = $wpdb->get_results(

--- a/includes/data-stores/class-wc-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-reports-orders-data-store.php
@@ -91,7 +91,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 	/**
 	 * Returns an array of products belonging to given categories.
 	 *
-	 * @param $categories
+	 * @param array $categories List of categories IDs.
 	 * @return array|stdClass
 	 */
 	protected function get_products_by_cat_ids( $categories ) {
@@ -243,8 +243,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 					WHERE
 						1=1
 						{$totals_query['where_clause']}", ARRAY_A
-			); // WPCS: cache ok, DB call ok.
-
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 			if ( null === $totals ) {
 				return new WP_Error( 'woocommerce_reports_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce' ) );
 			}
@@ -268,7 +267,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 							GROUP BY
 								time_interval
 					  		) AS tt"
-			); // WPCS: cache ok, DB call ok.
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			$total_pages = (int) ceil( $db_interval_count / $intervals_query['per_page'] );
 			if ( $query_args['page'] < 1 || $query_args['page'] > $total_pages ) {
@@ -295,7 +294,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 						ORDER BY
 							{$intervals_query['order_by_clause']}
 						{$intervals_query['limit']}", ARRAY_A
-			); // WPCS: cache ok, DB call ok.
+			); // WPCS: cache ok, DB call ok, unprepared SQL ok.
 
 			if ( null === $intervals ) {
 				return new WP_Error( 'woocommerce_reports_revenue_result_failed', __( 'Sorry, fetching revenue data failed.', 'woocommerce' ) );
@@ -331,7 +330,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 			'limit'  => -1,
 			'status' => self::get_report_order_statuses(),
 			'type'   => 'shop_order',
-    		'return' => 'ids',
+			'return' => 'ids',
 		) );
 
 		foreach ( $order_ids as $id ) {
@@ -364,8 +363,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 	 * Update the database with stats data.
 	 *
 	 * @param WC_Order $order Order to update row for.
-	 * @param array $data Stats data.
-	 * @return int/bool Number or rows modified or false on failure.
+	 * @return int|bool Number or rows modified or false on failure.
 	 */
 	public static function update( $order ) {
 		global $wpdb;
@@ -375,7 +373,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 			return false;
 		}
 
-		if ( ! in_array( $order->get_status(), self::get_report_order_statuses() ) ) {
+		if ( ! in_array( $order->get_status(), self::get_report_order_statuses(), true ) ) {
 			$wpdb->delete( $table_name, array(
 				'order_id' => $order->get_id(),
 			) );

--- a/includes/data-stores/class-wc-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-reports-orders-data-store.php
@@ -158,7 +158,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 
 		if ( '' !== $query_args['order_status'] ) {
 			$from_clause  .= " JOIN {$wpdb->prefix}posts ON {$orders_stats_table}.order_id = {$wpdb->prefix}posts.ID";
-			$where_clause .= " AND {$wpdb->prefix}posts.post_status = 'wc-{$query_args['order_status']}'";
+			$where_clause .= " AND {$wpdb->prefix}posts.post_status IN ( '" . implode( "','", $query_args['order_status'] ) . "' ) ";
 		}
 
 		// To avoid requesting the subqueries twice, the result is applied to all queries passed to the method.
@@ -166,9 +166,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 		$totals_query['from_clause']     .= $from_clause;
 		$intervals_query['where_clause'] .= $where_clause;
 		$intervals_query['from_clause']  .= $from_clause;
-
 	}
-
 
 	/**
 	 * Returns the report data based on parameters supplied by the user.

--- a/includes/data-stores/class-wc-reports-orders-data-store.php
+++ b/includes/data-stores/class-wc-reports-orders-data-store.php
@@ -233,7 +233,7 @@ class WC_Reports_Orders_Data_Store extends WC_Reports_Data_Store implements WC_R
 			$totals_query    = $this->get_totals_sql_params( $query_args );
 			$intervals_query = $this->get_intervals_sql_params( $query_args );
 
-			// Additional filtering131 for Orders report.
+			// Additional filtering for Orders report.
 			$this->orders_stats_sql_filter( $query_args, $totals_query, $intervals_query );
 
 			$totals = $wpdb->get_results(

--- a/tests/unit-tests/api/reports-orders-stats.php
+++ b/tests/unit-tests/api/reports-orders-stats.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Reports Orders Stats REST API Test
+ *
+ * @package WooCommerce\Tests\API
+ * @since 3.5.0
+ */
+class WC_Tests_API_Reports_Orders_Stats extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc/v3/reports/orders/stats';
+
+	/**
+	 * Setup test reports orders data.
+	 *
+	 * @since 3.5.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( $this->endpoint, $routes );
+	}
+
+	/**
+	 * Test getting reports.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports() {
+		wp_set_current_user( $this->user );
+
+		// @todo update after report interface is done.
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$reports  = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 0, count( $reports ) ); // @todo update results after implement report interface.
+		$this->assertEquals( array(), $reports ); // @todo update results after implement report interface.
+	}
+
+	/**
+	 * Test getting reports without valid permissions.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_get_reports_without_permission() {
+		wp_set_current_user( 0 );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', $this->endpoint ) );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test reports schema.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_reports_schema() {
+		wp_set_current_user( $this->user );
+
+		$request    = new WP_REST_Request( 'OPTIONS', $this->endpoint );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
+		$properties = $data['schema']['properties'];
+
+		$this->assertEquals( 2, count( $properties ) );
+		$this->assertArrayHasKey( 'totals', $properties );
+		$this->assertArrayHasKey( 'intervals', $properties );
+
+		$totals = $properties['totals']['properties'];
+		$this->assertEquals( 4, count( $totals ) );
+		$this->assertArrayHasKey( 'net_revenue', $totals );
+		$this->assertArrayHasKey( 'avg_order_value', $totals );
+		$this->assertArrayHasKey( 'orders_count', $totals );
+		$this->assertArrayHasKey( 'avg_items_per_order', $totals );
+
+		$intervals = $properties['intervals']['items']['properties'];
+		$this->assertEquals( 6, count( $intervals ) );
+		$this->assertArrayHasKey( 'interval', $intervals );
+		$this->assertArrayHasKey( 'date_start', $intervals );
+		$this->assertArrayHasKey( 'date_start_gmt', $intervals );
+		$this->assertArrayHasKey( 'date_end', $intervals );
+		$this->assertArrayHasKey( 'date_end_gmt', $intervals );
+		$this->assertArrayHasKey( 'subtotals', $intervals );
+
+		$subtotals = $properties['intervals']['items']['properties']['subtotals']['properties'];
+		$this->assertEquals( 4, count( $subtotals ) );
+		$this->assertArrayHasKey( 'net_revenue', $totals );
+		$this->assertArrayHasKey( 'avg_order_value', $totals );
+		$this->assertArrayHasKey( 'orders_count', $totals );
+		$this->assertArrayHasKey( 'avg_items_per_order', $totals );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Orders report implementation.

There is still a few PHP warnings, looks like need to patch first the data store class (cc @peterfabian ):

```php
[07-Aug-2018 14:40:30 UTC] PHP Warning:  count(): Parameter must be an array or an object that implements Countable in wp-content/plugins/woocommerce/includes/data-stores/class-wc-reports-orders-data-store.php on line 131
[07-Aug-2018 14:40:30 UTC] PHP Warning:  count(): Parameter must be an array or an object that implements Countable in wp-content/plugins/woocommerce/includes/data-stores/class-wc-reports-orders-data-store.php on line 146
```

Closes #20774.

### How to test the changes in this Pull Request:

1. GET `/wp-json/wc/v3/reports/orders/stats`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->