### PR TITLE
Giving the ability to add custom pricing data - read_price_data()

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -334,11 +334,10 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 					}
 				}		
 
-				$transient_cached_prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices_transient_array', array(
-					'price'         => $prices_array['price'],
-					'regular_price' => $prices_array['regular_price'],
-					'sale_price'    => $prices_array['sale_price'],
-				), $prices_array, $product );
+				// Add all pricing data to the transient array
+				foreach( $prices_array as $key => $values ) {
+					$transient_cached_prices_array[$price_hash][$key] = $values;
+				}
 				
 				set_transient( $transient_name, wp_json_encode( $transient_cached_prices_array ), DAY_IN_SECONDS * 30 );
 			}

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -334,9 +334,9 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 					}
 				}		
 
-				// Add all pricing data to the transient array
+				// Add all pricing data to the transient array.
 				foreach( $prices_array as $key => $values ) {
-					$transient_cached_prices_array[$price_hash][$key] = $values;
+					$transient_cached_prices_array[ $price_hash ][ $key ] = $values;
 				}
 				
 				set_transient( $transient_name, wp_json_encode( $transient_cached_prices_array ), DAY_IN_SECONDS * 30 );

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -260,9 +260,11 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 
 			// If the prices are not stored for this hash, generate them and add to the transient.
 			if ( empty( $transient_cached_prices_array[ $price_hash ] ) ) {
-				$prices         = array();
-				$regular_prices = array();
-				$sale_prices    = array();
+				$prices_array = array(
+					'price'         => array(),
+					'regular_price' => array(),
+					'sale_price'    => array(),
+				);
 				$variation_ids  = $product->get_visible_children();
 				foreach ( $variation_ids as $variation_id ) {
 					$variation = wc_get_product( $variation_id );
@@ -325,18 +327,19 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 							}
 						}
 
-						$prices[ $variation_id ]         = wc_format_decimal( $price, wc_get_price_decimals() );
-						$regular_prices[ $variation_id ] = wc_format_decimal( $regular_price, wc_get_price_decimals() );
-						$sale_prices[ $variation_id ]    = wc_format_decimal( $sale_price . '.00', wc_get_price_decimals() );
+						$prices_array['price'][ $variation_id ] 		= wc_format_decimal( $price, wc_get_price_decimals() );
+						$prices_array['regular_price'][ $variation_id ] = wc_format_decimal( $regular_price, wc_get_price_decimals() );
+						$prices_array['sale_price'][ $variation_id ]    = wc_format_decimal( $sale_price . '.00', wc_get_price_decimals() );
+						$prices_array = apply_filters( 'woocommerce_variation_prices_array', $prices_array, $variation, $for_display );
 					}
-				}
+				}		
 
-				$transient_cached_prices_array[ $price_hash ] = array(
-					'price'         => $prices,
-					'regular_price' => $regular_prices,
-					'sale_price'    => $sale_prices,
-				);
-
+				$transient_cached_prices_array[ $price_hash ] = apply_filters( 'woocommerce_variation_prices_transient_array', array(
+					'price'         => $prices_array['price'],
+					'regular_price' => $prices_array['regular_price'],
+					'sale_price'    => $prices_array['sale_price'],
+				), $prices_array, $product );
+				
 				set_transient( $transient_name, wp_json_encode( $transient_cached_prices_array ), DAY_IN_SECONDS * 30 );
 			}
 


### PR DESCRIPTION
I need to find a way to add custom pricing data to the function `read_price_data()` in the variation data store class.

This is so I can check which price to display on the product and category pages when using the `woocommerce_variable_price_html` hook, else I will be adding unnecessary load (especially on the category pages) by having to load each variation object via `wc_get_product()` to extract the data and meta I need.

This pull request gives a way to get the custom price data in the prices array and have it stored in the transients with minium overhead.

I can then do something like this:
```
add_filter( 'woocommerce_variation_prices_array', array( add_custom_variation_price_data', 10, 3 ) );

public static function add_custom_variation_price_data( $prices_array, $variation, $for_display ) {
	
       // add logic here as we have access to the $variation object
	
	$prices_array['special_price'][ $variation->get_id() ] = wc_format_decimal( $price, wc_get_price_decimals() );	
	return $prices_array;
}
```
So when I now call `$prices = $variable->get_variation_prices( true );` the extra pricing is listed without adding unessisary loading when cycling through each variation object for each variable product.