### PR TITLE
jquery-blockui dependency for wc-add-to-cart and wc-add-to-cart-variation scripts.

### DIFF
--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -256,12 +256,12 @@ class WC_Frontend_Scripts {
 			),
 			'wc-add-to-cart'             => array(
 				'src'     => self::get_asset_url( 'assets/js/frontend/add-to-cart' . $suffix . '.js' ),
-				'deps'    => array( 'jquery' ),
+				'deps'    => array( 'jquery', 'jquery-blockui' ),
 				'version' => WC_VERSION,
 			),
 			'wc-add-to-cart-variation'   => array(
 				'src'     => self::get_asset_url( 'assets/js/frontend/add-to-cart-variation' . $suffix . '.js' ),
-				'deps'    => array( 'jquery', 'wp-util' ),
+				'deps'    => array( 'jquery', 'wp-util', 'jquery-blockui' ),
 				'version' => WC_VERSION,
 			),
 			'wc-geolocation'             => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This makes the wc-add-to-cart and wc-add-to-cart-variation scripts have a jquery-blockui dependency since it uses that and does not have the woocommerce script as a dependency which by default includes jquery-blockui as a dependency. Although in most cases the woocommerce script will always be loaded on the frontend there are cases where it could be dequeued for a specific reason which will cause the ajax add to cart to not function.

Closes #21000 

### How to test the changes in this Pull Request:

1. Load a product page on the frontend with ajax add to cart enable
2. Check that the jquery-blockui script is loaded.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Make jQuery UI a dependency for add to cart scripts.
