### PR TITLE
Additional HTML5 INPUT types css for settings

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3512,12 +3512,32 @@
 		 input[type="text"],
 		 input[type="email"],
 		 input[type="number"],
+		 input[type="password"],
+		 input[type="datetime"],
+		 input[type="datetime-local"],
+		 input[type="date"],
+		 input[type="time"],
+		 input[type="week"],
+		 input[type="url"],
+		 input[type="tel"],
 		 input.regular-input {
 			 width: 400px;
 			 margin: 0;
 			 padding: 6px;
 			 box-sizing: border-box;
 			 vertical-align: top;
+		 }
+		 
+		 
+		 input[type="datetime-local"],
+		 input[type="date"],
+		 input[type="week"],
+		 input[type="tel"] {
+			 width: 200px;
+		 }
+		 
+		 input[type="time"] {
+			 width: 100px;
 		 }
 
 		 select {

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3527,16 +3527,13 @@
 			 box-sizing: border-box;
 			 vertical-align: top;
 		 }
-		 
+
 		 input[type="datetime-local"],
 		 input[type="date"],
+		 input[type="time"],
 		 input[type="week"],
 		 input[type="tel"] {
 			 width: 200px;
-		 }
-		 
-		 input[type="time"] {
-			 width: 100px;
 		 }
 
 		 select {

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3528,7 +3528,6 @@
 			 vertical-align: top;
 		 }
 		 
-		 
 		 input[type="datetime-local"],
 		 input[type="date"],
 		 input[type="week"],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On class-wc-admin-settings.php output_fields(), WooCommerce implements rendering for several HTML5 INPUT types, to be used on WooCommerce settings pages, but there's no CSS styling for most of them. This change implements the missing CSS declarations. Those can be useful for other plugins using the WooCommerce settings fields API.

Closes #20981 

### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Adds missing HTML5 INPUT CSS declarations for WooCommerce settings fields
