### PR TITLE
Make city field optional and hidden for Singapore addresses

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1058,6 +1058,10 @@ class WC_Countries {
 						'state' => array(
 							'required' => false,
 						),
+						'city'  => array(
+							'required' => false,
+							'hidden'   => true,
+						),
 					),
 					'SK' => array(
 						'postcode' => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21016 .

### How to test the changes in this Pull Request:

1. Add a product to the cart
2. Go to checkout
3. Select Singapore as your country
4. The **Town / City** field should be hidden and you should not encounter **Billing City field is required** error

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Make city field optional and hidden for Singapore addresses