### PR TITLE
Unslashed the SKU for variation.

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -459,7 +459,7 @@ class WC_Meta_Box_Product_Data {
 						'stock_status'      => wc_clean( $_POST['variable_stock_status'][ $i ] ),
 						'image_id'          => wc_clean( $_POST['upload_image_id'][ $i ] ),
 						'attributes'        => self::prepare_set_attributes( $parent->get_attributes(), 'attribute_', $i ),
-						'sku'               => isset( $_POST['variable_sku'][ $i ] ) ? wc_clean( $_POST['variable_sku'][ $i ] ) : '',
+						'sku'               => isset( $_POST['variable_sku'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_sku'][ $i ] ) ) : '',
 						'weight'            => isset( $_POST['variable_weight'][ $i ] ) ? wc_clean( $_POST['variable_weight'][ $i ] ) : '',
 						'length'            => isset( $_POST['variable_length'][ $i ] ) ? wc_clean( $_POST['variable_length'][ $i ] ) : '',
 						'width'             => isset( $_POST['variable_width'][ $i ] ) ? wc_clean( $_POST['variable_width'][ $i ] ) : '',

--- a/tests/unit-tests/api/product-variations.php
+++ b/tests/unit-tests/api/product-variations.php
@@ -168,7 +168,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() . '/variations/' . $variation_id );
 		$request->set_body_params(
 			array(
-				'sku'         => 'FIXED-SKU',
+				'sku'         => 'FIXED-\'SKU',
 				'sale_price'  => '8',
 				'description' => 'O_O',
 				'image'       => array(
@@ -192,7 +192,7 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( '8', $variation['price'], print_r( $variation, true ) );
 		$this->assertEquals( '8', $variation['sale_price'], print_r( $variation, true ) );
 		$this->assertEquals( '10', $variation['regular_price'], print_r( $variation, true ) );
-		$this->assertEquals( 'FIXED-SKU', $variation['sku'], print_r( $variation, true ) );
+		$this->assertEquals( 'FIXED-\'SKU', $variation['sku'], print_r( $variation, true ) );
 		$this->assertEquals( 'medium', $variation['attributes'][0]['option'], print_r( $variation, true ) );
 		$this->assertContains( 'Dr1Bczxq4q', $variation['image']['src'], print_r( $variation, true ) );
 		$this->assertContains( 'test upload image', $variation['image']['alt'], print_r( $variation, true ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20224, again.

### How to test the changes in this Pull Request:

See https://github.com/woocommerce/woocommerce/issues/20224#issuecomment-411274582.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Prevent multiple slashing of variation's SKU.
