### PR TITLE
Change caption of image in full screen when variation is selected.

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -594,6 +594,7 @@
 			$product_img.wc_set_variation_attr( 'srcset', variation.image.srcset );
 			$product_img.wc_set_variation_attr( 'sizes', variation.image.sizes );
 			$product_img.wc_set_variation_attr( 'title', variation.image.title );
+			$product_img.wc_set_variation_attr( 'data-caption', variation.image.caption );
 			$product_img.wc_set_variation_attr( 'alt', variation.image.alt );
 			$product_img.wc_set_variation_attr( 'data-src', variation.image.full_src );
 			$product_img.wc_set_variation_attr( 'data-large_image', variation.image.full_src );
@@ -632,6 +633,7 @@
 		$product_img.wc_reset_variation_attr( 'srcset' );
 		$product_img.wc_reset_variation_attr( 'sizes' );
 		$product_img.wc_reset_variation_attr( 'title' );
+		$product_img.wc_reset_variation_attr( 'data-caption' );
 		$product_img.wc_reset_variation_attr( 'alt' );
 		$product_img.wc_reset_variation_attr( 'data-src' );
 		$product_img.wc_reset_variation_attr( 'data-large_image' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20878.

### How to test the changes in this Pull Request:

1. Create variable product with at least 2 variations, assign a different image with a different caption to each variation.
2. Go to single product page, click on image to open it full screen, see the caption of the main product image.
3. Switch to a variation with a different image, click on the image to open it in full screen. 
4. Observe the caption comes from the main image.
5. Click on 'Clear' to go back to main image (i.e. to deselect a variation)
6. Check the caption, still shows the main image.
7. Apply branch.
8. Step 4 now shows image caption of variation image.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Variation image in fullscreen now shows correct caption for the respective image.
