### PR TITLE
Don't sanitize the filter name in the "Filter By Attrbiute" widget

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -423,7 +423,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 				continue;
 			}
 
-			$filter_name    = 'filter_' . sanitize_title( str_replace( 'pa_', '', $taxonomy ) );
+			$filter_name    = 'filter_' . wc_clean( str_replace( 'pa_', '', $taxonomy ) );
 			$current_filter = isset( $_GET[ $filter_name ] ) ? explode( ',', wc_clean( wp_unslash( $_GET[ $filter_name ] ) ) ) : array(); // WPCS: input var ok, CSRF ok.
 			$current_filter = array_map( 'sanitize_title', $current_filter );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I had an issue that prevented clearing active filters in the "Filter By Attrbiute" widget. I could filter by attrbiutes, but couldn't clear them afterwards.
Important to note is this only happend with filters that used non-latin slugs.
I found that the cause for this issue was the use of "sanitize_title" on the filter name, which encoded the non-lating slug and as a result it couldn't be later cleared from the URL in the following line
```
$link = remove_query_arg( $filter_name, $this->get_current_page_url() );
```


I think this also resolve #21026 as it sounds like the same bug.

### How to test the changes in this Pull Request:

1. Create an attribute and use a slug in any language except English. For example: בדיקה
2. Create a widget to filter by this attrbiute
3. Create a product and associate it to this attribute with any value
4. Go to the frontend and try to filter by this attrbiute, and then try to remove the attrbiute

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix clearing filters that uses non-latin slugs
