### PR TITLE
[REST API] Order/Coupon lookup table

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -827,7 +827,7 @@ CREATE TABLE {$wpdb->prefix}wc_order_coupon_lookup (
   coupon_id BIGINT UNSIGNED NOT NULL,
   date_created timestamp DEFAULT '0000-00-00 00:00:00' NOT NULL,
   coupon_gross_discount double DEFAULT 0 NOT NULL,
-  PRIMARY KEY  (order_id),
+  KEY order_id (order_id),
   KEY coupon_id (coupon_id),
   KEY date_created (date_created)
 ) $collate;

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -822,6 +822,15 @@ CREATE TABLE {$wpdb->prefix}wc_order_product_lookup (
   KEY customer_id (customer_id),
   KEY date_created (date_created)
 ) $collate;
+CREATE TABLE {$wpdb->prefix}wc_order_coupon_lookup (
+  order_id BIGINT UNSIGNED NOT NULL,
+  coupon_id BIGINT UNSIGNED NOT NULL,
+  date_created timestamp DEFAULT '0000-00-00 00:00:00' NOT NULL,
+  coupon_gross_discount double DEFAULT 0 NOT NULL,
+  PRIMARY KEY  (order_id),
+  KEY coupon_id (coupon_id),
+  KEY date_created (date_created)
+) $collate;
 
 		";
 
@@ -873,6 +882,7 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 			"{$wpdb->prefix}woocommerce_tax_rates",
 			"{$wpdb->prefix}wc_order_stats",
 			"{$wpdb->prefix}wc_order_product_lookup",
+			"{$wpdb->prefix}wc_order_coupon_lookup",
 		);
 
 		if ( ! function_exists( 'get_term_meta' ) ) {

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -1074,3 +1074,39 @@ function wc_order_product_lookup_entry( $order_id ) {
 	}
 }
 add_action( 'save_post', 'wc_order_product_lookup_entry', 10, 1 );
+
+/**
+ * Make an entry in the wc_order_coupon_lookup table for an order.
+ *
+ * @since 3.5.0
+ * @param int $order_id Order ID.
+ * @return void
+ */
+function wc_order_coupon_lookup_entry( $order_id ) {
+	global $wpdb;
+
+	$order = wc_get_order( $order_id );
+	if ( ! $order ) {
+		return;
+	}
+
+	$coupon_items = $order->get_items( 'coupon' );
+	foreach ( $coupon_items as $coupon_item ) {
+		$wpdb->replace(
+			$wpdb->prefix . 'wc_order_coupon_lookup',
+			array(
+				'order_id'              => $order_id,
+				'coupon_id'             => $coupon_item->get_id(),
+				'coupon_gross_discount' => $coupon_item->get_discount(),
+				'date_created'          => date( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
+			),
+			array(
+				'%d',
+				'%d',
+				'%f',
+				'%s',
+			)
+		);
+	}
+}
+add_action( 'save_post', 'wc_order_coupon_lookup_entry', 10, 1 );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Lookup table correlating coupons and orders suitable for the `reports/coupons` and `reports/coupons/stats` endpoints. Next step after this is merged is creating the data store.

Closes #20769 .

### How to test the changes in this Pull Request:

1. Deactivate then reactivate WC
2. Create an order while using a coupon
3. Verify data gets created in table using mySQL
