### PR TITLE
Cart fragment timeout and error handling

### DIFF
--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -38,6 +38,7 @@ jQuery( function( $ ) {
 	var $fragment_refresh = {
 		url: wc_cart_fragments_params.wc_ajax_url.toString().replace( '%%endpoint%%', 'get_refreshed_fragments' ),
 		type: 'POST',
+		timeout: 5000,
 		success: function( data ) {
 			if ( data && data.fragments ) {
 

--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -57,6 +57,9 @@ jQuery( function( $ ) {
 
 				$( document.body ).trigger( 'wc_fragments_refreshed' );
 			}
+		},
+		error: function() {
+			$( document.body ).trigger( 'wc_fragments_ajax_error' );
 		}
 	};
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In some circumstances the cart fragment ajax endpoint didn't respond at all or the server threw an error. These cases are not handled in the core today. So I just added a timeout and a js trigger in case of a timeout or error.

### Changelog entry

> Added error handling and timeout to cart fragment ajax call
