### PR TITLE
Added support for extended product info.

### DIFF
--- a/includes/api/class-wc-rest-reports-products-controller.php
+++ b/includes/api/class-wc-rest-reports-products-controller.php
@@ -243,6 +243,13 @@ class WC_REST_Reports_Products_Controller extends WC_REST_Reports_Controller {
 				'type' => 'integer',
 			),
 		);
+		$params['extended_product_info'] = array(
+			'description'       => __( 'Add additional piece of info about each product to the report.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'default'           => false,
+			'sanitize_callback' => 'wc_string_to_bool',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
 
 		return $params;
 	}

--- a/includes/data-stores/class-wc-reports-data-store.php
+++ b/includes/data-stores/class-wc-reports-data-store.php
@@ -61,9 +61,10 @@ class WC_Reports_Data_Store {
 	 */
 	protected function cast_numbers( $array ) {
 		$retyped_array = array();
+		$column_types = apply_filters( 'woocommerce_rest_reports_column_types', $this->column_types, $array );
 		foreach ( $array as $column_name => $value ) {
-			if ( isset( $this->column_types[ $column_name ] ) ) {
-				$retyped_array[ $column_name ] = $this->column_types[ $column_name ]( $value );
+			if ( isset( $column_types[ $column_name ] ) ) {
+				$retyped_array[ $column_name ] = $column_types[ $column_name ]( $value );
 			} else {
 				$retyped_array[ $column_name ] = $value;
 			}


### PR DESCRIPTION
Based on a request from mobile team and Isotope.

![extended_product_info](https://user-images.githubusercontent.com/2207451/44088072-22bb6e62-9fc2-11e8-9738-262e9dd88dd2.png)

