### PR TITLE
Moves cart hash calculation to WC_Cart class

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -178,7 +178,7 @@ class WC_AJAX {
 					'div.widget_shopping_cart_content' => '<div class="widget_shopping_cart_content">' . $mini_cart . '</div>',
 				)
 			),
-			'cart_hash' => apply_filters( 'woocommerce_add_to_cart_hash', WC()->cart->get_cart_for_session() ? md5( json_encode( WC()->cart->get_cart_for_session() ) ) : '', WC()->cart->get_cart_for_session() ),
+			'cart_hash' => WC()->cart->get_cart_hash(),
 		);
 
 		wp_send_json( $data );

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -228,7 +228,7 @@ final class WC_Cart_Session {
 	private function set_cart_cookies( $set = true ) {
 		if ( $set ) {
 			wc_setcookie( 'woocommerce_items_in_cart', 1 );
-			wc_setcookie( 'woocommerce_cart_hash', md5( wp_json_encode( $this->get_cart_for_session() ) ) );
+			wc_setcookie( 'woocommerce_cart_hash', WC()->cart->get_cart_hash() );
 		} elseif ( isset( $_COOKIE['woocommerce_items_in_cart'] ) ) { // WPCS: input var ok.
 			wc_setcookie( 'woocommerce_items_in_cart', 0, time() - HOUR_IN_SECONDS );
 			wc_setcookie( 'woocommerce_cart_hash', '', time() - HOUR_IN_SECONDS );

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1938,4 +1938,15 @@ class WC_Cart extends WC_Legacy_Cart {
 		$this->fees_api->remove_all_fees();
 		do_action( 'woocommerce_cart_reset', $this, false );
 	}
+
+	/**
+	 * Returns the hash based on cart contents.
+	 *
+	 * @return string hash for cart content
+	 */
+	public function get_cart_hash() {
+		$hash = $this->session->get_cart_for_session() ? md5( json_encode( $this->session->get_cart_for_session() ) ) : '';
+
+		return apply_filters( 'woocommerce_add_to_cart_hash', $hash, $this->get_cart_for_session() );
+	}
 }

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1945,8 +1945,9 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return string hash for cart content
 	 */
 	public function get_cart_hash() {
-		$hash = $this->session->get_cart_for_session() ? md5( json_encode( $this->session->get_cart_for_session() ) ) : '';
+		$cart = $this->session->get_cart_for_session();
+		$hash = $cart ? md5( json_encode( $cart ) ) : '';
 
-		return apply_filters( 'woocommerce_add_to_cart_hash', $hash, $this->get_cart_for_session() );
+		return apply_filters( 'woocommerce_add_to_cart_hash', $hash, $cart );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:
We are using the `woocommerce_add_to_cart_hash` filter in WC_AJAX to extend the woocommerce generated hash with our own data that should be considered as a signal to fetch new data from the refresh fragments endpoint.

While doing that we recognized that the filter is used very inconsistently only in the project so I consolidated it into a function in the WC_Cart class.

### Changelog entry

> More consistent handling of cart hash in the project