### PR TITLE
Standardize case of button View cart

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1062,7 +1062,7 @@ class WC_Cart extends WC_Legacy_Cart {
 						sprintf(
 							'<a href="%s" class="button wc-forward">%s</a> %s',
 							wc_get_cart_url(),
-							__( 'View Cart', 'woocommerce' ),
+							__( 'View cart', 'woocommerce' ),
 							/* translators: 1: quantity in stock 2: current quantity */
 							sprintf( __( 'You cannot add that amount to the cart &mdash; we have %1$s in stock and you already have %2$s in your cart.', 'woocommerce' ), wc_format_stock_quantity_for_display( $product_data->get_stock_quantity(), $product_data ), wc_format_stock_quantity_for_display( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ], $product_data ) )
 						)


### PR DESCRIPTION
Hello,

In this WC_Cart class, there are two string for `View cart`.
Line 1037 and line 1065.

The other `button wc-forward` buttons are first character uppercase only.

The PR changes `View Cart` to `View cart`.
Thank you

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

