### PR TITLE
Make postcode field optional and hidden for Nigeria and label State correctly

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1005,6 +1005,16 @@ class WC_Countries {
 							'label'    => __( 'Province', 'woocommerce' ),
 						),
 					),
+					'NG' => array(
+						'postcode' => array(
+							'label' => __( 'Postcode', 'woocommerce' ),
+							'required' => false,
+							'hidden'   => true,
+						),
+						'state'    => array(
+							'label'    => __( 'State', 'woocommerce' ),
+						),
+					),
 					'NZ' => array(
 						'postcode' => array(
 							'label' => __( 'Postcode', 'woocommerce' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21055.

### How to test the changes in this Pull Request:

1. Add a product to the cart
2. Go to checkout
3. Select Nigeria as your country
4. The **Postcode** field should be hidden and the **State / County** field should just say **State**

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Make postcode field optional and hidden for Nigeria and label State correctly