### PR TITLE
Show system status updates for woocommerce wp.org plugins

### DIFF
--- a/includes/api/class-wc-rest-system-status-controller.php
+++ b/includes/api/class-wc-rest-system-status-controller.php
@@ -796,7 +796,7 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 				$version_data = get_transient( md5( $plugin ) . '_version_data' );
 				if ( false === $version_data ) {
 					$changelog = wp_safe_remote_get( 'http://dzv365zjfbd8v.cloudfront.net/changelogs/' . $dirname . '/changelog.txt' );
-					if ( '200' === wp_remote_retrieve_response_code( $changelog ) ) {
+					if ( 200 === wp_remote_retrieve_response_code( $changelog ) ) {
 						$cl_lines = explode( "\n", wp_remote_retrieve_body( $changelog ) );
 						if ( ! empty( $cl_lines ) ) {
 							foreach ( $cl_lines as $line_num => $cl_line ) {
@@ -821,28 +821,20 @@ class WC_REST_System_Status_Controller extends WC_REST_Controller {
 						);
 						$request = array(
 							'action'  => 'plugin_information',
-							'request' => wp_json_encode( $args ),
+							'request' => serialize( $args ),
 						);
 						$plugin_info = wp_safe_remote_post( 'http://api.wordpress.org/plugins/info/1.0/', array( 'body' => $request ) );
-						if ( '200' === wp_remote_retrieve_response_code( $plugin_info ) ) {
-							$body     = wp_remote_retrieve_body( $plugin_info );
-							$cl_lines = explode( "\n", $body->changelog );
-							if ( ! empty( $cl_lines ) ) {
-								foreach ( $cl_lines as $line_num => $cl_line ) {
-									if ( preg_match( '/^[0-9]/', $cl_line ) ) {
-										$date         = $body->last_updated;
-										$version      = $body->version;
-										$update       = trim( str_replace( '*', '', $cl_lines[ $line_num + 1 ] ) );
-										$version_data = array(
-											'date'      => $date,
-											'version'   => $version,
-											'update'    => $update,
-											'changelog' => $body->changelog,
-										);
-										set_transient( md5( $plugin ) . '_version_data', $version_data, DAY_IN_SECONDS );
-										break;
-									}
-								}
+						if ( 200 === wp_remote_retrieve_response_code( $plugin_info ) ) {
+							$body = maybe_unserialize( wp_remote_retrieve_body( $plugin_info ) );
+							if ( is_object( $body ) && isset( $body->sections['changelog'] ) ) {
+								$version_data = array(
+									'date'      => $body->last_updated,
+									'version'   => $body->version,
+									'update'    => $body->sections['changelog'],
+									'changelog' => $body->sections['changelog'],
+								);
+								set_transient( md5( $plugin ) . '_version_data', $version_data, DAY_IN_SECONDS );
+								break;
 							}
 						}
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds additional checks to the system status active plugins section to show if updated versions are available for WooCommerce developed plugins hosted on WordPress.org.

Closes #20694 

### How to test the changes in this Pull Request:

1. Install and activate https://wordpress.org/plugins/woocommerce-gateway-paypal-express-checkout/
2. Once installed and activated edit the main plugin file and change the version to something else and save
3. Go to the system status report and check under the `Active Plugins` section, there should now be a message that an update is available next to WooCommerce PayPal Checkout Gateway

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Show update notices on the System Status page for WordPress.org hosted  Official WooCommerce extensions.
