### PR TITLE
Fixes two product attributes issues when non-ASCII characters are used in the attribute name

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -978,7 +978,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	/**
 	 * Set low stock amount.
 	 *
-	 * @param int|string $amount Empty string if value not set
+	 * @param int|string $amount Empty string if value not set.
 	 * @since 3.5.0
 	 */
 	public function set_low_stock_amount( $amount ) {

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1104,7 +1104,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		$attributes = array_fill_keys( array_keys( $this->get_attributes( 'edit' ) ), null );
 		foreach ( $raw_attributes as $attribute ) {
 			if ( is_a( $attribute, 'WC_Product_Attribute' ) ) {
-				$attributes[ sanitize_title( $attribute->get_name() ) ] = $attribute;
+				$attributes[ sanitize_text_field( $attribute->get_name() ) ] = $attribute;
 			}
 		}
 

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -423,7 +423,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 				continue;
 			}
 
-			$filter_name    = 'filter_' . sanitize_title( str_replace( 'pa_', '', $taxonomy ) );
+			$filter_name    = 'filter_' . str_replace( 'pa_', '', $taxonomy );
 			$current_filter = isset( $_GET[ $filter_name ] ) ? explode( ',', wc_clean( wp_unslash( $_GET[ $filter_name ] ) ) ) : array(); // WPCS: input var ok, CSRF ok.
 			$current_filter = array_map( 'sanitize_title', $current_filter );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR implements two changes to the product attributes code to fix the following issues in the "Filter products by attribute" widget (see commit messages for a detailed explanation of the changes):

- Clearing filters don't work when non-ASCII characters are used in the product attribute name. Commit: 20fd569.
- The "Filter product by attributes" cache is not cleared when an attribute containing a non-ASCII character in the name is added to a product, resulting in the widget displaying the wrong information (wrong attributes available to filter or wrong number of products per attribute). Commit: 4d2530e.

This PR also includes PHPCS fixes in a separate commit.

Closes #21026
Supersedes #21028 

cc @rellect @plxrisa could you please test this PR to confirm if it fixes the issues you reported?

### How to test the changes in this Pull Request:

1. See #21026 and #21028 for instructions

### Changelog entry

> Fixes two product attributes issues when non-ASCII characters are used in the attribute name
