### PR TITLE
Ability to apply coupon on a sale item even when the coupon is restricted to only non sale items

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -764,7 +764,7 @@ class WC_Discounts {
 	 * @return bool
 	 */
 	protected function validate_coupon_sale_items( $coupon ) {
-		if ( $coupon->get_exclude_sale_items() ) {
+		if ( $coupon->get_exclude_sale_items() && 'fixed_product' !== $coupon->get_discount_type() ) {
 			$valid = true;
 
 			foreach ( $this->get_items_to_validate() as $item ) {

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -765,11 +765,11 @@ class WC_Discounts {
 	 */
 	protected function validate_coupon_sale_items( $coupon ) {
 		if ( $coupon->get_exclude_sale_items() ) {
-			$valid = false;
+			$valid = true;
 
 			foreach ( $this->get_items_to_validate() as $item ) {
-				if ( $item->product && ! $item->product->is_on_sale() ) {
-					$valid = true;
+				if ( $item->product && $item->product->is_on_sale() ) {
+					$valid = false;
 					break;
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [X] I have followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)
* [X] My code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)
* [X] I have checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change

### Changes proposed in this Pull Request:
This PR will fix issue #21062 

### How to test the changes in this Pull Request:

1. While creating/updating coupon make sure "Exclude sale items" checkbox is checked
![image](https://user-images.githubusercontent.com/26460087/44297047-0aaca880-a2e8-11e8-9369-b71b8c8c84da.png)

2. Add On Sale Product and Normal Product ( Without sale ) product to cart
![image](https://user-images.githubusercontent.com/26460087/44297054-3334a280-a2e8-11e8-9f75-090e80bb43e8.png)
![image](https://user-images.githubusercontent.com/26460087/44297058-3e87ce00-a2e8-11e8-8ff3-28e767d9ec00.png)
![image](https://user-images.githubusercontent.com/26460087/44297065-4e071700-a2e8-11e8-8fa5-9645ae8452c1.png)

3. Apply coupon for that you have checked the "Exclude sale items" checkbox
https://www.useloom.com/share/ee9584fa475c4edc892fbb7dd7c7d79c