### PR TITLE
Use refund currency when displaying refund amount

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-refund.php
+++ b/includes/admin/meta-boxes/views/html-order-refund.php
@@ -1,11 +1,15 @@
 <?php
+/**
+ * Show order refund
+ *
+ * @var object $refund The refund object.
+ * @package WooCommerce\Admin
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
-/**
- * @var object $refund The refund object.
- */
 $who_refunded = new WP_User( $refund->get_refunded_by() );
 ?>
 <tr class="refund <?php echo ( ! empty( $class ) ) ? esc_attr( $class ) : ''; ?>" data-order_refund_id="<?php echo esc_attr( $refund->get_id() ); ?>">
@@ -17,8 +21,8 @@ $who_refunded = new WP_User( $refund->get_refunded_by() );
 			printf(
 				/* translators: 1: refund id 2: refund date 3: username */
 				esc_html__( 'Refund #%1$s - %2$s by %3$s', 'woocommerce' ),
-				$refund->get_id(),
-				wc_format_datetime( $refund->get_date_created(), get_option( 'date_format' ) . ', ' . get_option( 'time_format' ) ),
+				esc_html( $refund->get_id() ),
+				esc_html( wc_format_datetime( $refund->get_date_created(), get_option( 'date_format' ) . ', ' . get_option( 'time_format' ) ) ),
 				sprintf(
 					'<abbr class="refund_by" title="%1$s">%2$s</abbr>',
 					/* translators: 1: ID who refunded */
@@ -30,8 +34,8 @@ $who_refunded = new WP_User( $refund->get_refunded_by() );
 			printf(
 				/* translators: 1: refund id 2: refund date */
 				esc_html__( 'Refund #%1$s - %2$s', 'woocommerce' ),
-				$refund->get_id(),
-				wc_format_datetime( $refund->get_date_created(), get_option( 'date_format' ) . ', ' . get_option( 'time_format' ) )
+				esc_html( $refund->get_id() ),
+				esc_html( wc_format_datetime( $refund->get_date_created(), get_option( 'date_format' ) . ', ' . get_option( 'time_format' ) ) )
 			);
 		}
 		?>
@@ -48,7 +52,7 @@ $who_refunded = new WP_User( $refund->get_refunded_by() );
 
 	<td class="line_cost" width="1%">
 		<div class="view">
-			<?php echo wc_price( '-' . $refund->get_amount() ); ?>
+			<?php echo wp_kses_post( wc_price( '-' . $refund->get_amount() ) ); ?>
 		</div>
 	</td>
 

--- a/includes/admin/meta-boxes/views/html-order-refund.php
+++ b/includes/admin/meta-boxes/views/html-order-refund.php
@@ -52,7 +52,11 @@ $who_refunded = new WP_User( $refund->get_refunded_by() );
 
 	<td class="line_cost" width="1%">
 		<div class="view">
-			<?php echo wp_kses_post( wc_price( '-' . $refund->get_amount() ) ); ?>
+			<?php
+			echo wp_kses_post(
+				wc_price( '-' . $refund->get_amount(), array( 'currency' => $refund->get_currency() ) )
+			);
+			?>
 		</div>
 	</td>
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Use the refund currency when wc_price() is called to display the refund amount in the "Edit order" admin screen. Without this change, wc_price would use the store default currency which is a problem for stores that at some point changed their currency or stores using extensions which support multiple currencies.

This PR also includes PHPCS fixes in a separate commit.

@andreagrillo and @alarocca130, could you please test and confirm that this fixes the issue you reported?

While investigating this issue, I found PR #6472 which fixed the same problem for order items and shipping, I'm assuming that refunds were not included in that PR due to an oversight. cc @thenbrent in case there is a reason not to do this change for refunds that I'm missing.

Closes #21027 

### How to test the changes in this Pull Request:

1. Place an order and then refund it.
2. Change the store currency
3. Go to the edit order screen and check that the refund amount is displayed using the correct currency symbol. See #21027 for more details and a screenshot.

### Changelog entry

> Fix: use refund currency instead of store default currency when displaying refund amount in the edit order screen
