### PR TITLE
Set tabindex=1 for notices

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -118,9 +118,9 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 	// Output success messages.
 	if ( 'yes' === get_option( 'woocommerce_cart_redirect_after_add' ) ) {
 		$return_to = apply_filters( 'woocommerce_continue_shopping_redirect', wc_get_raw_referer() ? wp_validate_redirect( wc_get_raw_referer(), false ) : wc_get_page_permalink( 'shop' ) );
-		$message   = sprintf( '<a href="%s" class="button wc-forward">%s</a> %s', esc_url( $return_to ), esc_html__( 'Continue shopping', 'woocommerce' ), esc_html( $added_text ) );
+		$message   = sprintf( '<a href="%s" tabindex="1" class="button wc-forward">%s</a> %s', esc_url( $return_to ), esc_html__( 'Continue shopping', 'woocommerce' ), esc_html( $added_text ) );
 	} else {
-		$message = sprintf( '<a href="%s" class="button wc-forward">%s</a> %s', esc_url( wc_get_page_permalink( 'cart' ) ), esc_html__( 'View cart', 'woocommerce' ), esc_html( $added_text ) );
+		$message = sprintf( '<a href="%s" tabindex="1" class="button wc-forward">%s</a> %s', esc_url( wc_get_page_permalink( 'cart' ) ), esc_html__( 'View cart', 'woocommerce' ), esc_html( $added_text ) );
 	}
 
 	if ( has_filter( 'wc_add_to_cart_message' ) ) {

--- a/includes/wc-notice-functions.php
+++ b/includes/wc-notice-functions.php
@@ -144,7 +144,7 @@ function wc_print_notices( $return = false ) {
 
 	wc_clear_notices();
 
-	$notices = wp_kses_post( ob_get_clean() );
+	$notices = wc_kses_notice( ob_get_clean() );
 
 	if ( $return ) {
 		return $notices;
@@ -207,4 +207,24 @@ function wc_add_wp_error_notices( $errors ) {
 			wc_add_notice( $error, 'error' );
 		}
 	}
+}
+
+/**
+ * Filters out the same tags as wp_kses_post, but allows tabindex for <a> element.
+ *
+ * @since 3.5.0
+ * @param string $message Content to filter through kses.
+ * @return string
+ */
+function wc_kses_notice( $message ) {
+	return wp_kses( $message,
+		array_replace_recursive( // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
+			wp_kses_allowed_html( 'post' ),
+			array(
+				'a' => array(
+					'tabindex' => true,
+				),
+			)
+		)
+	);
 }

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3397,3 +3397,23 @@ if ( ! function_exists( 'woocommerce_product_reviews_tab' ) ) {
 		wc_deprecated_function( 'woocommerce_product_reviews_tab', '2.4' );
 	}
 }
+
+/**
+ * Filters out the same tags as wp_kses_post, but allows tabindex for <a> element.
+ *
+ * @since 3.5.0
+ * @param string $message Content to filter through kses.
+ * @return string
+ */
+function wc_kses_notice( $message ) {
+	return wp_kses( $message,
+		array_replace_recursive( // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
+			wp_kses_allowed_html( 'post' ),
+			array(
+				'a' => array(
+					'tabindex' => true,
+				),
+			)
+		)
+	);
+}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3394,23 +3394,3 @@ if ( ! function_exists( 'woocommerce_product_reviews_tab' ) ) {
 		wc_deprecated_function( 'woocommerce_product_reviews_tab', '2.4' );
 	}
 }
-
-/**
- * Filters out the same tags as wp_kses_post, but allows tabindex for <a> element.
- *
- * @since 3.5.0
- * @param string $message Content to filter through kses.
- * @return string
- */
-function wc_kses_notice( $message ) {
-	return wp_kses( $message,
-		array_replace_recursive( // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
-			wp_kses_allowed_html( 'post' ),
-			array(
-				'a' => array(
-					'tabindex' => true,
-				),
-			)
-		)
-	);
-}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -237,11 +237,8 @@ function woocommerce_product_loop() {
 /**
  * Output generator tag to aid debugging.
  *
- * @access public
- *
  * @param string $gen Generator.
  * @param string $type Type.
- *
  * @return string
  */
 function wc_generator_tag( $gen, $type ) {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -49,7 +49,7 @@
 	</rule>
 	<rule ref="WordPress.XSS.EscapeOutput">
 		<properties>
-			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip,wc_selected" />
+			<property name="customEscapingFunctions" type="array" value="wc_help_tip,wc_sanitize_tooltip,wc_selected,wc_kses_notice" />
 		</properties>
 	</rule>
 	<rule ref="WordPress.WP.I18n">

--- a/templates/notices/error.php
+++ b/templates/notices/error.php
@@ -11,9 +11,8 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @author      WooThemes
  * @package     WooCommerce/Templates
- * @version     3.3.0
+ * @version     3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -29,16 +28,7 @@ if ( ! $messages ) {
 	<?php foreach ( $messages as $message ) : ?>
 		<li>
 			<?php
-				echo wp_kses( $message,
-					array_replace_recursive(
-						wp_kses_allowed_html( 'post' ),
-						array(
-							'a' => array(
-								'tabindex' => true,
-							),
-						)
-					) // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
-				);
+				echo wc_kses_notice( $message ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 			?>
 		</li>
 	<?php endforeach; ?>

--- a/templates/notices/error.php
+++ b/templates/notices/error.php
@@ -27,6 +27,19 @@ if ( ! $messages ) {
 ?>
 <ul class="woocommerce-error" role="alert">
 	<?php foreach ( $messages as $message ) : ?>
-		<li><?php echo wp_kses_post( $message ); ?></li>
+		<li>
+			<?php
+				echo wp_kses( $message,
+					array_replace_recursive(
+						wp_kses_allowed_html( 'post' ),
+						array(
+							'a' => array(
+								'tabindex' => true,
+							),
+						)
+					) // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
+				);
+			?>
+		</li>
 	<?php endforeach; ?>
 </ul>

--- a/templates/notices/error.php
+++ b/templates/notices/error.php
@@ -10,9 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @author      WooThemes
+ * @package     WooCommerce/Templates
  * @version     3.3.0
  */
 

--- a/templates/notices/error.php
+++ b/templates/notices/error.php
@@ -28,7 +28,7 @@ if ( ! $messages ) {
 	<?php foreach ( $messages as $message ) : ?>
 		<li>
 			<?php
-				echo wc_kses_notice( $message ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+				echo wc_kses_notice( $message );
 			?>
 		</li>
 	<?php endforeach; ?>

--- a/templates/notices/notice.php
+++ b/templates/notices/notice.php
@@ -11,9 +11,8 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @author      WooThemes
  * @package     WooCommerce/Templates
- * @version     1.6.4
+ * @version     3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -29,16 +28,7 @@ if ( ! $messages ) {
 <?php foreach ( $messages as $message ) : ?>
 	<div class="woocommerce-info">
 		<?php
-			echo wp_kses( $message,
-				array_replace_recursive(
-					wp_kses_allowed_html( 'post' ),
-					array(
-						'a' => array(
-							'tabindex' => true,
-						),
-					)
-				) // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
-			);
+			echo wc_kses_notice( $message ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 		?>
 	</div>
 <?php endforeach; ?>

--- a/templates/notices/notice.php
+++ b/templates/notices/notice.php
@@ -10,14 +10,14 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @author      WooThemes
+ * @package     WooCommerce/Templates
  * @version     1.6.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! $messages ) {

--- a/templates/notices/notice.php
+++ b/templates/notices/notice.php
@@ -28,7 +28,7 @@ if ( ! $messages ) {
 <?php foreach ( $messages as $message ) : ?>
 	<div class="woocommerce-info">
 		<?php
-			echo wc_kses_notice( $message ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+			echo wc_kses_notice( $message );
 		?>
 	</div>
 <?php endforeach; ?>

--- a/templates/notices/notice.php
+++ b/templates/notices/notice.php
@@ -27,5 +27,18 @@ if ( ! $messages ) {
 ?>
 
 <?php foreach ( $messages as $message ) : ?>
-	<div class="woocommerce-info"><?php echo wp_kses_post( $message ); ?></div>
+	<div class="woocommerce-info">
+		<?php
+			echo wp_kses( $message,
+				array_replace_recursive(
+					wp_kses_allowed_html( 'post' ),
+					array(
+						'a' => array(
+							'tabindex' => true,
+						),
+					)
+				) // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
+			);
+		?>
+	</div>
 <?php endforeach; ?>

--- a/templates/notices/success.php
+++ b/templates/notices/success.php
@@ -11,9 +11,8 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @author      WooThemes
  * @package     WooCommerce/Templates
- * @version     3.3.0
+ * @version     3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -29,16 +28,7 @@ if ( ! $messages ) {
 <?php foreach ( $messages as $message ) : ?>
 	<div class="woocommerce-message" role="alert">
 		<?php
-			echo wp_kses( $message,
-				array_replace_recursive(
-					wp_kses_allowed_html( 'post' ),
-					array(
-						'a' => array(
-							'tabindex' => true,
-						),
-					)
-				) // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
-			);
+			echo wc_kses_notice( $message ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 		?>
 	</div>
 <?php endforeach; ?>

--- a/templates/notices/success.php
+++ b/templates/notices/success.php
@@ -28,7 +28,7 @@ if ( ! $messages ) {
 <?php foreach ( $messages as $message ) : ?>
 	<div class="woocommerce-message" role="alert">
 		<?php
-			echo wc_kses_notice( $message ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+			echo wc_kses_notice( $message );
 		?>
 	</div>
 <?php endforeach; ?>

--- a/templates/notices/success.php
+++ b/templates/notices/success.php
@@ -27,5 +27,18 @@ if ( ! $messages ) {
 ?>
 
 <?php foreach ( $messages as $message ) : ?>
-	<div class="woocommerce-message" role="alert"><?php echo wp_kses_post( $message ); ?></div>
+	<div class="woocommerce-message" role="alert">
+		<?php
+			echo wp_kses( $message,
+				array_replace_recursive(
+					wp_kses_allowed_html( 'post' ),
+					array(
+						'a' => array(
+							'tabindex' => true,
+						),
+					)
+				) // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
+			);
+		?>
+	</div>
 <?php endforeach; ?>

--- a/templates/notices/success.php
+++ b/templates/notices/success.php
@@ -10,9 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @author      WooThemes
+ * @package     WooCommerce/Templates
  * @version     3.3.0
  */
 

--- a/tests/unit-tests/cart/functions.php
+++ b/tests/unit-tests/cart/functions.php
@@ -161,21 +161,21 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 		$product = WC_Helper_Product::create_simple_product();
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 1 ), false, true );
-		$this->assertEquals( '<a href="http://example.org" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 3 ), false, true );
-		$this->assertEquals( '<a href="http://example.org" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 1 ), true, true );
-		$this->assertEquals( '<a href="http://example.org" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
 
 		$message = wc_add_to_cart_message( array( $product->get_id() => 3 ), true, true );
-		$this->assertEquals( '<a href="http://example.org" class="button wc-forward">View cart</a> 3 &times; &ldquo;Dummy Product&rdquo; have been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> 3 &times; &ldquo;Dummy Product&rdquo; have been added to your cart.', $message );
 
 		$message = wc_add_to_cart_message( $product->get_id(), false, true );
-		$this->assertEquals( '<a href="http://example.org" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
 
 		$message = wc_add_to_cart_message( $product->get_id(), true, true );
-		$this->assertEquals( '<a href="http://example.org" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
+		$this->assertEquals( '<a href="http://example.org" tabindex="1" class="button wc-forward">View cart</a> &ldquo;Dummy Product&rdquo; has been added to your cart.', $message );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21025  .

### How to test the changes in this Pull Request:

1. Add a product to cart, try to tab to the 'View cart' link, see you need to go through a lot of links first.
2. Apply branch.
3. Link 'View cart' should now be at tab index 1. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add to cart notice actions (View cart/Continue shopping) now have tabindex 1.
