### PR TITLE
Fix: properly output product structured data when product URL contains some non-ASCII characters

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -150,7 +150,7 @@ class WC_Structured_Data {
 	 */
 	public function output_structured_data() {
 		$types = $this->get_data_type_for_page();
-		$data  = wc_clean( $this->get_structured_data( $types ) );
+		$data  = $this->get_structured_data( $types );
 
 		if ( $data ) {
 			echo '<script type="application/ld+json">' . wp_json_encode( $data ) . '</script>';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This commit removes an unneeded call to wc_clean() before outputting product structured data to the browser. wp_json_encode() is called before the data is sent to the browser and it should be enough to escape it. wc_clean(), which calls sanitize_text_field() internally, was causing issues with the product URL when its name contained some non-ASCII characters.

The problem was happening because WordPress uses sanitize_title() before saving the product slug to the database. This function encodes some non-ASCII characters. Those same encoded characters are stripped by sanitize_text_field().

Using a product called `فروشگاه-های-دسته` as an example:

```
>>>‌‌ sanitize_title( 'فروشگاه-های-دسته' )
=> ‌%d9%81%d8%b1%d9%88%d8%b4%da%af%d8%a7%d9%87-%d9%87%d8%a7%db%8c-%d8%af%d8%b3%d8%aa%d9%87
>>> $p = wc_get_product( 95 )
=> WC_Product_Simple {#5452}
>>> $p->get_name()
=> "فروشگاه-های-دسته"
>>> $p->get_permalink()
=> "http://wc.test/product/%d9%81%d8%b1%d9%88%d8%b4%da%af%d8%a7%d9%87-%d9%87%d8%a7%db%8c-%d8%af%d8%b3%d8%aa%d9%87/"
>>> sanitize_text_field( $p->get_permalink() )
=> "http://wc.test/product/--/"
```

Closes #21057

### How to test the changes in this Pull Request:

1. Create a product called `فروشگاه-های-دسته`
2. Open the product page source HTML and check the generated structured data to make sure the URL is properly displayed (field name is ID)
3. Check that we are still generating a valid structured data (you can use https://search.google.com/structured-data/testing-tool)
4. Check that wc_clean() is indeed unnecessary, and it is safe to remove it

### Changelog entry

> Fix: properly output product structured data when product URL contains non-ASCII characters that are not replaced by sanitize_title()
