### PR TITLE
Include URL for the last element in breadcrumb list

### DIFF
--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -213,7 +213,7 @@ class WC_Breadcrumb {
 
 		$this->prepend_shop_page();
 		$this->term_ancestors( $current_term->term_id, 'product_cat' );
-		$this->add_crumb( $current_term->name );
+		$this->add_crumb( $current_term->name, get_term_link( $current_term, 'product_cat' ) );
 	}
 
 	/**
@@ -225,7 +225,7 @@ class WC_Breadcrumb {
 		$this->prepend_shop_page();
 
 		/* translators: %s: product tag */
-		$this->add_crumb( sprintf( __( 'Products tagged &ldquo;%s&rdquo;', 'woocommerce' ), $current_term->name ) );
+		$this->add_crumb( sprintf( __( 'Products tagged &ldquo;%s&rdquo;', 'woocommerce' ), $current_term->name ), get_term_link( $current_term, 'product_tag' ) );
 	}
 
 	/**

--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -140,6 +140,10 @@ class WC_Breadcrumb {
 			$post = get_post( $post_id ); // WPCS: override ok.
 		}
 
+		if ( ! $permalink ) {
+			$permalink = get_permalink( $post );
+		}
+
 		if ( 'product' === get_post_type( $post ) ) {
 			$this->prepend_shop_page();
 

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -337,7 +337,7 @@ class WC_Structured_Data {
 				),
 			);
 
-			if ( ! empty( $crumb[1] ) && count( $crumbs ) !== $key + 1 ) {
+			if ( ! empty( $crumb[1] ) ) {
 				$markup['itemListElement'][ $key ]['item'] += array( '@id' => $crumb[1] );
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I noticed that the structured data generated by WooCommerce doesn't pass Google Structured Data validation (https://search.google.com/structured-data/testing-tool) due to the following error in the last element of the BreadcrumbList:

"The value provided for item.id must be a valid URL."

This happens because the code was explicitly omitting the URL for the last element. This commit simply removes this check and now an URL is included for every element (unless there is no URL set).

It is important to note that I don't know much about Structured Data and I don't know if there is a reason for the code to omit the URL for the last element, I simply saw the error in the testing tool mentioned above while working on a fix for #21057 and checked if it was easy to fix it. Thus, it is important that this PR is reviewed by someone who is familiar with this functionality. 

cc @ebrahimdabiri in case you can help here as you opened #21057 and @opportus as you are the original author of the structured data code.

### How to test the changes in this Pull Request:

1. Open the source code of a few WooCommerce pages and copy the contents of the following tag `<script type="application/ld+json">`
2. Paste it in the Google Structured Data Testing Tool (https://search.google.com/structured-data/testing-tool) and check that there are no errors

### Changelog entry

> Fix: structured data breadcrumb elements should always contain an URL
