### PR TITLE
Checked _fields query param support for REST endpoint system_status/tools.

### DIFF
--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -294,18 +294,9 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 	 * @return WP_REST_Response $response Response data.
 	 */
 	public function prepare_item_for_response( $item, $request ) {
-		$context         = empty( $request['context'] ) ? 'view' : $request['context'];
-		$selected_fields = $this->get_fields_for_response( $request );
-
-		$data = array();
-		foreach ( $selected_fields as $field_name ) {
-			if ( isset( $item[ $field_name ] ) ) {
-				$data[ $field_name ] = $item[ $field_name ];
-			}
-		}
-
-		$data = $this->add_additional_fields_to_object( $data, $request );
-		$data = $this->filter_response_by_context( $data, $context );
+		$context = empty( $request['context'] ) ? 'view' : $request['context'];
+		$data    = $this->add_additional_fields_to_object( $item, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
 
 		$response = rest_ensure_response( $data );
 

--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -294,9 +294,23 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 	 * @return WP_REST_Response $response Response data.
 	 */
 	public function prepare_item_for_response( $item, $request ) {
-		$context = empty( $request['context'] ) ? 'view' : $request['context'];
-		$data    = $this->add_additional_fields_to_object( $item, $request );
-		$data    = $this->filter_response_by_context( $data, $context );
+		$context           = empty( $request['context'] ) ? 'view' : $request['context'];
+		$fields            = $this->get_fields_for_response( $request );
+		$selectable_fields = array(
+			'id',
+			'name',
+			'action',
+			'description',
+		);
+		$data              = array();
+		foreach ( $selectable_fields as $selected_field_name ) {
+			if ( in_array( $selected_field_name, $fields, true ) ) {
+				$data[ $selected_field_name ] = $item[ $selected_field_name ];
+			}
+		}
+
+		$data = $this->add_additional_fields_to_object( $data, $request );
+		$data = $this->filter_response_by_context( $data, $context );
 
 		$response = rest_ensure_response( $data );
 

--- a/includes/api/class-wc-rest-system-status-tools-controller.php
+++ b/includes/api/class-wc-rest-system-status-tools-controller.php
@@ -294,18 +294,13 @@ class WC_REST_System_Status_Tools_Controller extends WC_REST_Controller {
 	 * @return WP_REST_Response $response Response data.
 	 */
 	public function prepare_item_for_response( $item, $request ) {
-		$context           = empty( $request['context'] ) ? 'view' : $request['context'];
-		$fields            = $this->get_fields_for_response( $request );
-		$selectable_fields = array(
-			'id',
-			'name',
-			'action',
-			'description',
-		);
-		$data              = array();
-		foreach ( $selectable_fields as $selected_field_name ) {
-			if ( in_array( $selected_field_name, $fields, true ) ) {
-				$data[ $selected_field_name ] = $item[ $selected_field_name ];
+		$context         = empty( $request['context'] ) ? 'view' : $request['context'];
+		$selected_fields = $this->get_fields_for_response( $request );
+
+		$data = array();
+		foreach ( $selected_fields as $field_name ) {
+			if ( isset( $item[ $field_name ] ) ) {
+				$data[ $field_name ] = $item[ $field_name ];
 			}
 		}
 

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -275,9 +275,15 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 			// Fields that are not requested are not returned in response.
 			$this->assertTrue( ! isset( $item['action'] ) );
 			$this->assertTrue( ! isset( $item['description'] ) );
+			// Links are part of data in collections, so excluded if not explicitly requested.
+			$this->assertTrue( ! isset( $item['_links'] ) );
 			// Non existing field is ignored.
 			$this->assertTrue( ! isset( $item['nonexisting'] ) );
 		}
+
+		// Links are part of data, not links in collections.
+		$links = $response->get_links();
+		$this->assertEquals( 0, count( $links ) );
 	}
 
 	/**
@@ -312,6 +318,28 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'Term counts', $data['name'] );
 		$this->assertEquals( 'Recount terms', $data['action'] );
 		$this->assertEquals( 'This tool will recount product terms - useful when changing your settings in a way which hides products from the catalog.', $data['description'] );
+
+		// Test for _fields query parameter.
+		$query_params = array(
+			'_fields' => 'id,name,nonexisting',
+		);
+		$request = new WP_REST_Request( 'GET', '/wc/v2/system_status/tools/recount_terms' );
+		$request->set_query_params( $query_params );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertEquals( 'recount_terms', $data['id'] );
+		$this->assertEquals( 'Term counts', $data['name'] );
+		$this->assertTrue( ! isset( $data['action'] ) );
+		$this->assertTrue( ! isset( $data['description'] ) );
+		// Links are part of links, not data in single items.
+		$this->assertTrue( ! isset( $data['_links'] ) );
+
+		// Links are part of links, not data in single item response.
+		$links = $response->get_links();
+		$this->assertEquals( 1, count( $links ) );
 	}
 
 	/**
@@ -368,9 +396,15 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 			$this->assertTrue( ! isset( $item['action'] ) );
 			$this->assertTrue( ! isset( $item['name'] ) );
 			$this->assertTrue( ! isset( $item['description'] ) );
+			// Links are part of links, not data in single item response.
+			$this->assertTrue( ! isset( $item['_links'] ) );
 			// Non existing field is ignored.
 			$this->assertTrue( ! isset( $item['nonexisting'] ) );
 		}
+
+		// Links are part of links, not data in single item response.
+		$links = $response->get_links();
+		$this->assertEquals( 1, count( $links ) );
 	}
 
 	/**

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -349,6 +349,28 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v2/system_status/tools/not_a_real_tool' ) );
 		$this->assertEquals( 404, $response->get_status() );
+
+		// Test _fields for execute system tool request.
+		$query_params = array(
+			'_fields' => (string) 'id,success,nonexisting',
+		);
+		$request      = new WP_REST_Request( 'PUT', '/wc/v2/system_status/tools/recount_terms' );
+		$request->set_query_params( $query_params );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'recount_terms', $data['id'] );
+		$this->assertTrue( $data['success'] );
+
+		foreach ( $data as $item ) {
+			// Fields that are not requested are not returned in response.
+			$this->assertTrue( ! isset( $item['action'] ) );
+			$this->assertTrue( ! isset( $item['name'] ) );
+			$this->assertTrue( ! isset( $item['description'] ) );
+			// Non existing field is ignored.
+			$this->assertTrue( ! isset( $item['nonexisting'] ) );
+		}
 	}
 
 	/**

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -253,6 +253,31 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 			),
 			$data
 		);
+
+		$query_params = array(
+			'_fields' => (string) 'id,name,nonexisting',
+		);
+		$request = new WP_REST_Request( 'GET', '/wc/v2/system_status/tools' );
+		$request->set_query_params( $query_params );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( count( $raw_tools ), count( $data ) );
+		$this->assertContains(
+			array(
+				'id'          => 'reset_tracking',
+				'name'        => 'Reset usage tracking',
+			),
+			$data
+		);
+		foreach ( $data as $item ) {
+			// Fields that are not requested are not returned in response.
+			$this->assertTrue( ! isset( $item['action'] ) );
+			$this->assertTrue( ! isset( $item['description'] ) );
+			// Non existing field is ignored.
+			$this->assertTrue( ! isset( $item['nonexisting'] ) );
+		}
 	}
 
 	/**

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -273,12 +273,12 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		);
 		foreach ( $data as $item ) {
 			// Fields that are not requested are not returned in response.
-			$this->assertTrue( ! isset( $item['action'] ) );
-			$this->assertTrue( ! isset( $item['description'] ) );
+			$this->assertArrayNotHasKey( 'action', $item );
+			$this->assertArrayNotHasKey( 'description', $item );
 			// Links are part of data in collections, so excluded if not explicitly requested.
-			$this->assertTrue( ! isset( $item['_links'] ) );
+			$this->assertArrayNotHasKey( '_links', $item );
 			// Non existing field is ignored.
-			$this->assertTrue( ! isset( $item['nonexisting'] ) );
+			$this->assertArrayNotHasKey( 'nonexisting', $item );
 		}
 
 		// Links are part of data, not links in collections.
@@ -332,10 +332,10 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 'recount_terms', $data['id'] );
 		$this->assertEquals( 'Term counts', $data['name'] );
-		$this->assertTrue( ! isset( $data['action'] ) );
-		$this->assertTrue( ! isset( $data['description'] ) );
+		$this->assertArrayNotHasKey( 'action', $data );
+		$this->assertArrayNotHasKey( 'description', $data );
 		// Links are part of links, not data in single items.
-		$this->assertTrue( ! isset( $data['_links'] ) );
+		$this->assertArrayNotHasKey( '_links', $data );
 
 		// Links are part of links, not data in single item response.
 		$links = $response->get_links();
@@ -392,13 +392,13 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$this->assertTrue( $data['success'] );
 
 		// Fields that are not requested are not returned in response.
-		$this->assertTrue( ! isset( $data['action'] ) );
-		$this->assertTrue( ! isset( $data['name'] ) );
-		$this->assertTrue( ! isset( $data['description'] ) );
+		$this->assertArrayNotHasKey( 'action', $data );
+		$this->assertArrayNotHasKey( 'name', $data );
+		$this->assertArrayNotHasKey( 'description', $data );
 		// Links are part of links, not data in single item response.
-		$this->assertTrue( ! isset( $data['_links'] ) );
+		$this->assertArrayNotHasKey( '_links', $data );
 		// Non existing field is ignored.
-		$this->assertTrue( ! isset( $data['nonexisting'] ) );
+		$this->assertArrayNotHasKey( 'nonexisting', $data );
 
 		// Links are part of links, not data in single item response.
 		$links = $response->get_links();

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -391,16 +391,14 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'recount_terms', $data['id'] );
 		$this->assertTrue( $data['success'] );
 
-		foreach ( $data as $item ) {
-			// Fields that are not requested are not returned in response.
-			$this->assertTrue( ! isset( $item['action'] ) );
-			$this->assertTrue( ! isset( $item['name'] ) );
-			$this->assertTrue( ! isset( $item['description'] ) );
-			// Links are part of links, not data in single item response.
-			$this->assertTrue( ! isset( $item['_links'] ) );
-			// Non existing field is ignored.
-			$this->assertTrue( ! isset( $item['nonexisting'] ) );
-		}
+		// Fields that are not requested are not returned in response.
+		$this->assertTrue( ! isset( $data['action'] ) );
+		$this->assertTrue( ! isset( $data['name'] ) );
+		$this->assertTrue( ! isset( $data['description'] ) );
+		// Links are part of links, not data in single item response.
+		$this->assertTrue( ! isset( $data['_links'] ) );
+		// Non existing field is ignored.
+		$this->assertTrue( ! isset( $data['nonexisting'] ) );
 
 		// Links are part of links, not data in single item response.
 		$links = $response->get_links();

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -255,7 +255,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		);
 
 		$query_params = array(
-			'_fields' => (string) 'id,name,nonexisting',
+			'_fields' => 'id,name,nonexisting',
 		);
 		$request = new WP_REST_Request( 'GET', '/wc/v2/system_status/tools' );
 		$request->set_query_params( $query_params );
@@ -352,7 +352,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 
 		// Test _fields for execute system tool request.
 		$query_params = array(
-			'_fields' => (string) 'id,success,nonexisting',
+			'_fields' => 'id,success,nonexisting',
 		);
 		$request      = new WP_REST_Request( 'PUT', '/wc/v2/system_status/tools/recount_terms' );
 		$request->set_query_params( $query_params );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21145 .

### How to test the changes in this Pull Request:

Test request to:

1. GET `wp-json/wc/v2/system_status/tools/`, it should return all of these fields: id, name, action, description and _links
2. PUT `wp-json/wc/v2/system_status/tools/`, it should return all of the above fields, plus message and success
3. GET `wp-json/wc/v2/system_status/tools/?_fields=id,name,nonexisting`, it should return only fields: id, name for each item
4. PUT `wp-json/wc/v2/system_status/tools/?_fields=id,success,nonexisting`, it should return only fields: id, name for each item


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> REST endpoint wc/v2/system_status/tools now supports _fields query parameter.
