### PR TITLE
Added test for _fields for system_status endpoint.

### DIFF
--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -404,14 +404,14 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'settings', $data );
 
 		// Fields not selected omitted from response.
-		$this->assertTrue( ! isset( $item['environment'] ) );
-		$this->assertTrue( ! isset( $item['database'] ) );
-		$this->assertTrue( ! isset( $item['active_plugins'] ) );
-		$this->assertTrue( ! isset( $item['security'] ) );
-		$this->assertTrue( ! isset( $item['pages'] ) );
+		$this->assertTrue( ! isset( $data['environment'] ) );
+		$this->assertTrue( ! isset( $data['database'] ) );
+		$this->assertTrue( ! isset( $data['active_plugins'] ) );
+		$this->assertTrue( ! isset( $data['security'] ) );
+		$this->assertTrue( ! isset( $data['pages'] ) );
 
 		// Non existing field is ignored.
-		$this->assertTrue( ! isset( $item['nonexisting'] ) );
+		$this->assertTrue( ! isset( $data['nonexisting'] ) );
 	}
 
 	/**

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -404,14 +404,14 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'settings', $data );
 
 		// Fields not selected omitted from response.
-		$this->assertTrue( ! isset( $data['environment'] ) );
-		$this->assertTrue( ! isset( $data['database'] ) );
-		$this->assertTrue( ! isset( $data['active_plugins'] ) );
-		$this->assertTrue( ! isset( $data['security'] ) );
-		$this->assertTrue( ! isset( $data['pages'] ) );
+		$this->assertArrayNotHasKey( 'environment', $data );
+		$this->assertArrayNotHasKey( 'database', $data );
+		$this->assertArrayNotHasKey( 'active_plugins', $data );
+		$this->assertArrayNotHasKey( 'security', $data );
+		$this->assertArrayNotHasKey( 'pages', $data );
 
 		// Non existing field is ignored.
-		$this->assertTrue( ! isset( $data['nonexisting'] ) );
+		$this->assertArrayNotHasKey( 'nonexisting', $data );
 	}
 
 	/**

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -380,6 +380,40 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 
 	}
 
+
+	/**
+	 * Test system_status _filter query parameter.
+	 */
+	public function test_get_system_status_info_filtered() {
+		wp_set_current_user( $this->user );
+
+		$query_params = array(
+			'_fields' => 'theme,settings,nonexisting',
+		);
+		$request      = new WP_REST_Request( 'GET', '/wc/v2/system_status' );
+		$request->set_query_params( $query_params );
+
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $data ) );
+
+		// Selected fields returned in the response.
+		$this->assertArrayHasKey( 'theme', $data );
+		$this->assertArrayHasKey( 'settings', $data );
+
+		// Fields not selected omitted from response.
+		$this->assertTrue( ! isset( $item['environment'] ) );
+		$this->assertTrue( ! isset( $item['database'] ) );
+		$this->assertTrue( ! isset( $item['active_plugins'] ) );
+		$this->assertTrue( ! isset( $item['security'] ) );
+		$this->assertTrue( ! isset( $item['pages'] ) );
+
+		// Non existing field is ignored.
+		$this->assertTrue( ! isset( $item['nonexisting'] ) );
+	}
+
 	/**
 	 * Provides a mocked response for external requests performed by WC_REST_System_Status_Controller.
 	 * This way it is not necessary to perform a regular request to an external server which would


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21144  .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> REST endpoint wc/v2/system_status now supports _fields query parameter..
