### PR TITLE
Fix/20987

### DIFF
--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -232,8 +232,15 @@ class WC_Data_Store_WP {
 				// Check for existing values if wildcard is used.
 				if ( '*' === $value ) {
 					$wp_query_args['meta_query'][] = array(
-						'key'     => '_' . $key,
-						'compare' => 'EXISTS',
+						array(
+							'key'     => '_' . $key,
+							'compare' => 'EXISTS',
+						),
+						array(
+							'key'     => '_' . $key,
+							'value'   => '',
+							'compare' => '!=',
+						),
 					);
 				} else {
 					$wp_query_args['meta_query'][] = array(

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -229,11 +229,19 @@ class WC_Data_Store_WP {
 
 			// Build meta queries out of vars that are stored in internal meta keys.
 			if ( in_array( '_' . $key, $this->internal_meta_keys, true ) ) {
-				$wp_query_args['meta_query'][] = array(
-					'key'     => '_' . $key,
-					'value'   => $value,
-					'compare' => is_array( $value ) ? 'IN' : '=',
-				);
+				// Check for existing values if wildcard is used.
+				if ( '*' === $value ) {
+					$wp_query_args['meta_query'][] = array(
+						'key'     => '_' . $key,
+						'compare' => 'EXISTS',
+					);
+				} else {
+					$wp_query_args['meta_query'][] = array(
+						'key'     => '_123' . $key,
+						'value'   => $value,
+						'compare' => is_array( $value ) ? 'IN' : '=',
+					);
+				}
 			} else { // Other vars get mapped to wp_query args or just left alone.
 				$key_mapping = array(
 					'parent'         => 'post_parent',
@@ -479,13 +487,17 @@ class WC_Data_Store_WP {
 	 */
 	protected function get_search_stopwords() {
 		// Translators: This is a comma-separated list of very common words that should be excluded from a search, like a, an, and the. These are usually called "stopwords". You should not simply translate these individual words into your language. Instead, look for and provide commonly accepted stopwords in your language.
-		$stopwords = array_map( 'wc_strtolower', array_map( 'trim', explode(
-			',', _x(
-				'about,an,are,as,at,be,by,com,for,from,how,in,is,it,of,on,or,that,the,this,to,was,what,when,where,who,will,with,www',
-				'Comma-separated list of search stopwords in your language',
-				'woocommerce'
+		$stopwords = array_map(
+			'wc_strtolower', array_map(
+				'trim', explode(
+					',', _x(
+						'about,an,are,as,at,be,by,com,for,from,how,in,is,it,of,on,or,that,the,this,to,was,what,when,where,who,will,with,www',
+						'Comma-separated list of search stopwords in your language',
+						'woocommerce'
+					)
+				)
 			)
-		) ) );
+		);
 
 		return apply_filters( 'wp_search_stopwords', $stopwords );
 	}

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -237,7 +237,7 @@ class WC_Data_Store_WP {
 					);
 				} else {
 					$wp_query_args['meta_query'][] = array(
-						'key'     => '_123' . $key,
+						'key'     => '_' . $key,
 						'value'   => $value,
 						'compare' => is_array( $value ) ? 'IN' : '=',
 					);

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1631,8 +1631,15 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			// Check for existing values if wildcard is used.
 			if ( '*' === $manual_queries['sku'] ) {
 				$wp_query_args['meta_query'][] = array(
-					'key'     => '_sku',
-					'compare' => 'EXISTS',
+					array(
+						'key'     => '_sku',
+						'compare' => 'EXISTS',
+					),
+					array(
+						'key'     => '_sku',
+						'value'   => '',
+						'compare' => '!=',
+					),
 				);
 			} else {
 				$wp_query_args['meta_query'][] = array(

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1628,11 +1628,19 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		// Handle SKU.
 		if ( $manual_queries['sku'] ) {
-			$wp_query_args['meta_query'][] = array(
-				'key'     => '_sku',
-				'value'   => $manual_queries['sku'],
-				'compare' => 'LIKE',
-			);
+			// Check for existing values if wildcard is used.
+			if ( '*' === $manual_queries['sku'] ) {
+				$wp_query_args['meta_query'][] = array(
+					'key'     => '_sku',
+					'compare' => 'EXISTS',
+				);
+			} else {
+				$wp_query_args['meta_query'][] = array(
+					'key'     => '_sku',
+					'value'   => $manual_queries['sku'],
+					'compare' => 'LIKE',
+				);
+			}
 		}
 
 		// Handle featured.

--- a/tests/unit-tests/product/query.php
+++ b/tests/unit-tests/product/query.php
@@ -38,7 +38,7 @@ class WC_Tests_WC_Product_Query extends WC_Unit_Test_Case {
 		$product2->save();
 
 		// Just get some products.
-		$query = new WC_Product_Query();
+		$query   = new WC_Product_Query();
 		$results = $query->get_products();
 		$this->assertEquals( 2, count( $results ) );
 
@@ -64,6 +64,12 @@ class WC_Tests_WC_Product_Query extends WC_Unit_Test_Case {
 		$query->set( 'limit', 1 );
 		$results = $query->get_products();
 		$this->assertEquals( 1, count( $results ) );
+
+		// Get multiple products using wildcard.
+		$query = new WC_Product_Query();
+		$query->set( 'sku', '*' );
+		$results = $query->get_products();
+		$this->assertEquals( 2, count( $results ) );
 	}
 
 	/**
@@ -72,45 +78,53 @@ class WC_Tests_WC_Product_Query extends WC_Unit_Test_Case {
 	 * @since 3.2
 	 */
 	public function test_product_query_meta_date_queries() {
-		$now = current_time( 'mysql', true );
-		$now_stamp = strtotime( $now );
-		$now_date = date( 'Y-m-d', $now_stamp );
-		$past_stamp = $now_stamp - DAY_IN_SECONDS;
-		$past = date( 'Y-m-d', $past_stamp );
+		$now          = current_time( 'mysql', true );
+		$now_stamp    = strtotime( $now );
+		$now_date     = date( 'Y-m-d', $now_stamp );
+		$past_stamp   = $now_stamp - DAY_IN_SECONDS;
+		$past         = date( 'Y-m-d', $past_stamp );
 		$future_stamp = $now_stamp + DAY_IN_SECONDS;
-		$future = date( 'Y-m-d', $future_stamp );
+		$future       = date( 'Y-m-d', $future_stamp );
 
 		$product = new WC_Product_Simple();
 		$product->set_date_on_sale_from( $now_stamp );
 		$product->save();
 
 		// Check WC_DateTime support.
-		$query = new WC_Product_Query( array(
-			'date_on_sale_from' => $product->get_date_on_sale_from(),
-		) );
+		$query    = new WC_Product_Query(
+			array(
+				'date_on_sale_from' => $product->get_date_on_sale_from(),
+			)
+		);
 		$products = $query->get_products();
 		$this->assertEquals( 1, count( $products ) );
 
 		// Check date support.
-		$query = new WC_Product_Query( array(
-			'date_on_sale_from' => $now_date,
-		) );
+		$query = new WC_Product_Query(
+			array(
+				'date_on_sale_from' => $now_date,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_products() ) );
 		$query->set( 'date_on_sale_from', $past );
 		$this->assertEquals( 0, count( $query->get_products() ) );
 
 		// Check timestamp support.
-		$query = new WC_Product_Query( array(
-			'date_on_sale_from' => $product->get_date_on_sale_from()->getTimestamp(),
-		) );
+		$query = new WC_Product_Query(
+			array(
+				'date_on_sale_from' => $product->get_date_on_sale_from()->getTimestamp(),
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_products() ) );
 		$query->set( 'date_on_sale_from', $future_stamp );
 		$this->assertEquals( 0, count( $query->get_products() ) );
 
 		// Check comparison support.
-		$query = new WC_Product_Query( array(
-			'date_on_sale_from' => '>' . $past,
-		) );
+		$query = new WC_Product_Query(
+			array(
+				'date_on_sale_from' => '>' . $past,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_products() ) );
 		$query->set( 'date_on_sale_from', '<' . $past );
 		$this->assertEquals( 0, count( $query->get_products() ) );
@@ -118,18 +132,22 @@ class WC_Tests_WC_Product_Query extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, count( $query->get_products() ) );
 
 		// Check timestamp comparison support.
-		$query = new WC_Product_Query( array(
-			'date_on_sale_from' => '<' . $future_stamp,
-		) );
+		$query = new WC_Product_Query(
+			array(
+				'date_on_sale_from' => '<' . $future_stamp,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_products() ) );
 		$query->set( 'date_on_sale_from', '<' . $past_stamp );
 		$this->assertEquals( 0, count( $query->get_products() ) );
 		$query->set( 'date_on_sale_from', '>=' . $now_stamp );
 
 		// Check date range support.
-		$query = new WC_Product_Query( array(
-			'date_on_sale_from' => $past . '...' . $future,
-		) );
+		$query = new WC_Product_Query(
+			array(
+				'date_on_sale_from' => $past . '...' . $future,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_products() ) );
 		$query->set( 'date_on_sale_from', $now_date . '...' . $future );
 		$this->assertEquals( 1, count( $query->get_products() ) );
@@ -137,9 +155,11 @@ class WC_Tests_WC_Product_Query extends WC_Unit_Test_Case {
 		$this->assertEquals( 0, count( $query->get_products() ) );
 
 		// Check timestamp range support.
-		$query = new WC_Product_Query( array(
-			'date_on_sale_from' => $past_stamp . '...' . $future_stamp,
-		) );
+		$query = new WC_Product_Query(
+			array(
+				'date_on_sale_from' => $past_stamp . '...' . $future_stamp,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_products() ) );
 		$query->set( 'date_on_sale_from', $now_stamp . '...' . $future_stamp );
 		$this->assertEquals( 1, count( $query->get_products() ) );

--- a/tests/unit-tests/product/query.php
+++ b/tests/unit-tests/product/query.php
@@ -65,9 +65,18 @@ class WC_Tests_WC_Product_Query extends WC_Unit_Test_Case {
 		$results = $query->get_products();
 		$this->assertEquals( 1, count( $results ) );
 
+		$product3 = new WC_Product_Simple();
+		$product3->save();
+
 		// Get multiple products using wildcard.
 		$query = new WC_Product_Query();
 		$query->set( 'sku', '*' );
+		$results = $query->get_products();
+		$this->assertEquals( 2, count( $results ) );
+
+		// Test another field using wildcard.
+		$query = new WC_Product_Query();
+		$query->set( 'sale_price', '*' );
 		$results = $query->get_products();
 		$this->assertEquals( 2, count( $results ) );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20987  .

### How to test the changes in this Pull Request:

1. Create a new Product Query - $query = new WC_Product_Query();
2. Set a wildcard for a property - $query->set( 'sku', '*' );
3. See that it returns all products that has a sku field set. - $query->get_products();

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Added a wildcard symbol '*' that can be used to find query products that have the particular field set.