### PR TITLE
Added tests for _fields query param for system_status/tools endpoint.

### DIFF
--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -254,7 +254,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$query_params = array(
 			'_fields' => 'id,name,nonexisting',
 		);
-		$request = new WP_REST_Request( 'GET', '/wc/v2/system_status/tools' );
+		$request = new WP_REST_Request( 'GET', '/wc/v3/system_status/tools' );
 		$request->set_query_params( $query_params );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
@@ -320,7 +320,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$query_params = array(
 			'_fields' => 'id,name,nonexisting',
 		);
-		$request = new WP_REST_Request( 'GET', '/wc/v2/system_status/tools/recount_terms' );
+		$request = new WP_REST_Request( 'GET', '/wc/v3/system_status/tools/recount_terms' );
 		$request->set_query_params( $query_params );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
@@ -379,7 +379,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$query_params = array(
 			'_fields' => 'id,success,nonexisting',
 		);
-		$request      = new WP_REST_Request( 'PUT', '/wc/v2/system_status/tools/recount_terms' );
+		$request      = new WP_REST_Request( 'PUT', '/wc/v3/system_status/tools/recount_terms' );
 		$request->set_query_params( $query_params );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -250,6 +250,37 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 			),
 			$data
 		);
+
+		$query_params = array(
+			'_fields' => 'id,name,nonexisting',
+		);
+		$request = new WP_REST_Request( 'GET', '/wc/v2/system_status/tools' );
+		$request->set_query_params( $query_params );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( count( $raw_tools ), count( $data ) );
+		$this->assertContains(
+			array(
+				'id'          => 'reset_tracking',
+				'name'        => 'Reset usage tracking',
+			),
+			$data
+		);
+		foreach ( $data as $item ) {
+			// Fields that are not requested are not returned in response.
+			$this->assertArrayNotHasKey( 'action', $item );
+			$this->assertArrayNotHasKey( 'description', $item );
+			// Links are part of data in collections, so excluded if not explicitly requested.
+			$this->assertArrayNotHasKey( '_links', $item );
+			// Non existing field is ignored.
+			$this->assertArrayNotHasKey( 'nonexisting', $item );
+		}
+
+		// Links are part of data, not links in collections.
+		$links = $response->get_links();
+		$this->assertEquals( 0, count( $links ) );
 	}
 
 	/**
@@ -284,6 +315,28 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'Term counts', $data['name'] );
 		$this->assertEquals( 'Recount terms', $data['action'] );
 		$this->assertEquals( 'This tool will recount product terms - useful when changing your settings in a way which hides products from the catalog.', $data['description'] );
+
+		// Test for _fields query parameter.
+		$query_params = array(
+			'_fields' => 'id,name,nonexisting',
+		);
+		$request = new WP_REST_Request( 'GET', '/wc/v2/system_status/tools/recount_terms' );
+		$request->set_query_params( $query_params );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertEquals( 'recount_terms', $data['id'] );
+		$this->assertEquals( 'Term counts', $data['name'] );
+		$this->assertArrayNotHasKey( 'action', $data );
+		$this->assertArrayNotHasKey( 'description', $data );
+		// Links are part of links, not data in single items.
+		$this->assertArrayNotHasKey( '_links', $data );
+
+		// Links are part of links, not data in single item response.
+		$links = $response->get_links();
+		$this->assertEquals( 1, count( $links ) );
 	}
 
 	/**
@@ -321,6 +374,32 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'POST', '/wc/v2/system_status/tools/not_a_real_tool' ) );
 		$this->assertEquals( 404, $response->get_status() );
+
+		// Test _fields for execute system tool request.
+		$query_params = array(
+			'_fields' => 'id,success,nonexisting',
+		);
+		$request      = new WP_REST_Request( 'PUT', '/wc/v2/system_status/tools/recount_terms' );
+		$request->set_query_params( $query_params );
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 'recount_terms', $data['id'] );
+		$this->assertTrue( $data['success'] );
+
+		// Fields that are not requested are not returned in response.
+		$this->assertArrayNotHasKey( 'action', $data );
+		$this->assertArrayNotHasKey( 'name', $data );
+		$this->assertArrayNotHasKey( 'description', $data );
+		// Links are part of links, not data in single item response.
+		$this->assertArrayNotHasKey( '_links', $data );
+		// Non existing field is ignored.
+		$this->assertArrayNotHasKey( 'nonexisting', $data );
+
+		// Links are part of links, not data in single item response.
+		$links = $response->get_links();
+		$this->assertEquals( 1, count( $links ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21145  .

### How to test the changes in this Pull Request:

As the required functionality was already in place, added the tests to check it works correctly.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added tests for _fields query param for system_status/tools endpoint.
