### PR TITLE
Updated order of array traversal to respect user's order

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -631,7 +631,7 @@ class WC_AJAX {
 			$i          = -1;
 
 			foreach ( $data['attribute_names'] as $attribute_name ) {
-				$attribute = isset( $attributes[$attribute_name] ) ? $attributes[$attribute_name] : false;
+				$attribute = isset( $attributes[ $attribute_name ] ) ? $attributes[ $attribute_name ] : false;
 				if ( ! $attribute ) {
 					continue;
 				}

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -630,7 +630,8 @@ class WC_AJAX {
 			$attributes = $product->get_attributes( 'edit' );
 			$i          = -1;
 
-			foreach ( $attributes as $attribute ) {
+			foreach ( $data['attribute_names'] as $attribute_name ) {
+				$attribute = isset( $attributes[$attribute_name] ) ? $attributes[$attribute_name] : false;
 				if ( ! $attribute ) {
 					continue;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21079  .

The way I see it, there are two options here: 
1. Return attributes in whatever order they are in php and then sort them in JS according to `rel` attribute, similar to how it's done on page load: https://github.com/woocommerce/woocommerce/blob/d5e229f98afaf4c3ae528d49c180354072f5fc2c/assets/js/admin/meta-boxes-product.js#L272-L276

2. Return attributes in order that the user specified, as the information is available in the PHP.

I went for no 2, but if there are reasons why no 1 is preferable, I can update.

### How to test the changes in this Pull Request:

1. Go to edit variable product in admin.
2. Switch to Attributes.
3. Try to change the order of attributes and then hit save. It should not work before and should start working after applying the branch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Updated order of array traversal to respect user's order when changing order of attributes for variations.
