### PR TITLE
Remove unnecessary cleanup code from more unit tests

### DIFF
--- a/tests/unit-tests/api/product-variations.php
+++ b/tests/unit-tests/api/product-variations.php
@@ -499,10 +499,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		foreach ( $response_variations as $response_variation ) {
 			$this->assertContains( $response_variation['id'], $variations );
 		}
-
-		// Clean up.
-		wp_delete_term( $category['term_id'], 'product_cat' );
-		$variable_product->delete( true );
 	}
 
 	/**
@@ -565,11 +561,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertCount( 0, $response_variations );
-
-		$simple->delete( true );
-		$external->delete( true );
-		$variable->delete( true );
-		$grouped->delete( true );
 	}
 
 	/**
@@ -618,9 +609,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		foreach ( $response_variations as $response_variation ) {
 			$this->assertContains( $response_variation['id'], $nonfeat_variations );
 		}
-
-		$feat_product->delete( true );
-		$nonfeat_product->delete( true );
 	}
 
 	/**
@@ -676,10 +664,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 		foreach ( $response_variations as $response_variation ) {
 			$this->assertEquals( $response_variation['id'], $variations[1]['variation_id'] );
 		}
-
-		$variable->delete( true );
-		wp_delete_term( $shipping_class_1['term_id'], 'product_shipping_class' );
-		wp_delete_term( $shipping_class_2['term_id'], 'product_shipping_class' );
 	}
 
 	/**
@@ -725,10 +709,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 0, count( $response_variations ) );
-
-		$variable_product->delete( true );
-		$variable_product_2->delete( true );
-		wp_delete_term( $test_tag_1['term_id'], 'product_tag' );
 	}
 
 	/**
@@ -737,7 +717,6 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 	 * @since 3.5.0
 	 */
 	public function test_get_product_by_attribute() {
-		global $wpdb;
 		wp_set_current_user( $this->user );
 
 		// Variable product with 2 different variations.
@@ -776,7 +755,5 @@ class Product_Variations_API extends WC_REST_Unit_Test_Case {
 				$this->assertContains( $response_variation['id'], $expected_product_ids );
 			}
 		}
-
-		$variable_product->delete( true );
 	}
 }

--- a/tests/unit-tests/api/products.php
+++ b/tests/unit-tests/api/products.php
@@ -570,11 +570,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$this->assertCount( 1, $response_product['categories'] );
 		$this->assertEquals( 'uncategorized', $response_product['categories'][0]['slug'] );
 
-		// Clean up.
-		wp_delete_term( $category['term_id'], 'product_cat' );
-		$product->delete( true );
-		$product_2->delete( true );
-
 	}
 
 	/**
@@ -616,11 +611,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 				$this->assertContains( $response_product['id'], $product_ids_for_type[ $product_type ], 'REST API: ' . $product_type . ' not found correctly' );
 			}
 		}
-
-		$simple->delete( true );
-		$external->delete( true );
-		$variable->delete( true );
-		$grouped->delete( true );
 	}
 
 	/**
@@ -665,9 +655,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		foreach ( $response_products as $response_product ) {
 			$this->assertEquals( $nonfeat_product->get_id(), $response_product['id'], 'REST API: Featured product not found correctly' );
 		}
-
-		$feat_product->delete( true );
-		$nonfeat_product->delete( true );
 	}
 
 	/**
@@ -696,9 +683,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		foreach ( $response_products as $response_product ) {
 			$this->assertEquals( $product_1->get_id(), $response_product['id'] );
 		}
-
-		$product_1->delete( true );
-		wp_delete_term( $shipping_class_1['term_id'], 'product_shipping_class' );
 	}
 
 	/**
@@ -731,10 +715,6 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		foreach ( $response_products as $response_product ) {
 			$this->assertEquals( $product->get_id(), $response_product['id'] );
 		}
-
-		$product->delete( true );
-		$product_2->delete( true );
-		wp_delete_term( $test_tag_1['term_id'], 'product_tag' );
 	}
 
 	/**
@@ -806,9 +786,5 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		foreach ( $response_products as $response_product ) {
 			$this->assertContains( $response_product['id'], $expected_product_ids );
 		}
-
-		$variable_product->delete( true );
-		$product_1->delete( true );
-		$product_2->delete( true );
 	}
 }

--- a/tests/unit-tests/cart/functions.php
+++ b/tests/unit-tests/cart/functions.php
@@ -47,17 +47,10 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 		// Make sure pages exist
 		WC_Install::create_pages();
 
-		// Get the original setting
-		$o_setting = get_option( 'woocommerce_force_ssl_checkout' );
-
 		// Force SSL checkout
 		update_option( 'woocommerce_force_ssl_checkout', 'no' );
 
 		$this->assertEquals( $this->get_checkout_url(), wc_get_checkout_url() );
-
-		// Restore option
-		update_option( 'woocommerce_force_ssl_checkout', $o_setting );
-
 	}
 
 	/**
@@ -69,17 +62,10 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 		// Make sure pages exist
 		WC_Install::create_pages();
 
-		// Get the original setting
-		$o_setting = get_option( 'woocommerce_force_ssl_checkout' );
-
 		// Force SSL checkout
 		update_option( 'woocommerce_force_ssl_checkout', 'yes' );
 
 		$this->assertEquals( $this->get_checkout_url(), wc_get_checkout_url() );
-
-		// Restore option
-		update_option( 'woocommerce_force_ssl_checkout', $o_setting );
-
 	}
 
 	/**
@@ -99,9 +85,6 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 
 		// Check if the cart is empty
 		$this->assertEquals( 0, WC()->cart->get_cart_contents_count() );
-
-		// Delete the previously created product
-		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**
@@ -126,8 +109,6 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
 		$this->expectOutputString( wc_price( $product->get_price( 'edit' ) ), wc_cart_totals_subtotal_html() );
-
-		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**
@@ -139,8 +120,6 @@ class WC_Tests_Cart_Functions extends WC_Unit_Test_Case {
 		$coupon = WC_Helper_Coupon::create_coupon();
 
 		$this->expectOutputString( apply_filters( 'woocommerce_cart_totals_coupon_label', 'Coupon: ' . $coupon->get_code() ), wc_cart_totals_coupon_label( $coupon ) );
-
-		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
 	}
 
 	/**

--- a/tests/unit-tests/coupon/coupon.php
+++ b/tests/unit-tests/coupon/coupon.php
@@ -7,6 +7,13 @@
  */
 class WC_Tests_Coupon extends WC_Unit_Test_Case {
 
+	public function tearDown() {
+		WC()->cart->empty_cart();
+		WC()->cart->remove_coupons();
+
+		parent::tearDown();
+	}
+
 	/**
 	 * Test the code/id differentiation of the coupon constructor.
 	 *
@@ -66,15 +73,6 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 
 		// Test if total amount of coupons is 1
 		$this->assertEquals( 1, count( WC()->cart->get_applied_coupons() ) );
-
-		// Clean up the cart
-		WC()->cart->empty_cart();
-
-		// Remove coupons
-		WC()->cart->remove_coupons();
-
-		// Delete coupon
-		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
 	}
 
 	/**
@@ -95,18 +93,6 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 
 		// Test if total amount of coupons is 1
 		$this->assertEquals( 1, count( WC()->cart->get_applied_coupons() ) );
-
-		// Clearing WC notices
-		wc_clear_notices();
-
-		// Clean up the cart
-		WC()->cart->empty_cart();
-
-		// Remove coupons
-		WC()->cart->remove_coupons();
-
-		// Delete coupon
-		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
 	}
 
 	/**
@@ -129,11 +115,6 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		// Create a flat rate method
 		WC_Helper_Shipping::create_simple_flat_rate();
 
-		// We need this to have the calculate_totals() method calculate totals
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
-			define( 'WOOCOMMERCE_CHECKOUT', true );
-		}
-
 		// Add product to cart
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
@@ -146,25 +127,6 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 
 		// Test if the cart total amount is equal 15
 		$this->assertEquals( 15, WC()->cart->total );
-
-		// Clearing WC notices
-		wc_clear_notices();
-
-		// Clean up the cart
-		WC()->cart->empty_cart();
-
-		// Remove coupons
-		WC()->cart->remove_coupons();
-
-		// Delete the flat rate method
-		WC()->session->set( 'chosen_shipping_methods', array() );
-		WC_Helper_Shipping::delete_simple_flat_rate();
-
-		// Delete coupon
-		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
-
-		// Delete product
-		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**
@@ -187,11 +149,6 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		// Create a flat rate method - $10
 		WC_Helper_Shipping::create_simple_flat_rate();
 
-		// We need this to have the calculate_totals() method calculate totals
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
-			define( 'WOOCOMMERCE_CHECKOUT', true );
-		}
-
 		// Add fee - $10
 		WC_Helper_Fee::add_cart_fee();
 
@@ -207,28 +164,6 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 
 		// Test if the cart total amount is equal 25
 		$this->assertEquals( 25, WC()->cart->total );
-
-		// Clearing WC notices
-		wc_clear_notices();
-
-		// Clean up the cart
-		WC()->cart->empty_cart();
-
-		// Remove coupons
-		WC()->cart->remove_coupons();
-
-		// Remove fee
-		WC_Helper_Fee::remove_cart_fee();
-
-		// Delete the flat rate method
-		WC()->session->set( 'chosen_shipping_methods', array() );
-		WC_Helper_Shipping::delete_simple_flat_rate();
-
-		// Delete coupon
-		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
-
-		// Delete product
-		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**
@@ -251,11 +186,6 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		// Create a flat rate method
 		WC_Helper_Shipping::create_simple_flat_rate();
 
-		// We need this to have the calculate_totals() method calculate totals
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
-			define( 'WOOCOMMERCE_CHECKOUT', true );
-		}
-
 		// Add fee
 		WC_Helper_Fee::add_cart_fee();
 
@@ -271,28 +201,6 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 
 		// Test if the cart total amount is equal 29.5
 		$this->assertEquals( 29.5, WC()->cart->total );
-
-		// Clearing WC notices
-		wc_clear_notices();
-
-		// Clean up the cart
-		WC()->cart->empty_cart();
-
-		// Remove coupons
-		WC()->cart->remove_coupons();
-
-		// Remove fee
-		WC_Helper_Fee::remove_cart_fee();
-
-		// Delete the flat rate method
-		WC()->session->set( 'chosen_shipping_methods', array() );
-		WC_Helper_Shipping::delete_simple_flat_rate();
-
-		// Delete coupon
-		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
-
-		// Delete product
-		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**
@@ -345,13 +253,6 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 
 		// Test if the cart total amount is equal 19.5 (coupon only applying to one item).
 		$this->assertEquals( 19.5, WC()->cart->total );
-
-		// Clean up
-		wc_clear_notices();
-		WC()->cart->empty_cart();
-		WC()->cart->remove_coupons();
-		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
-		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	public function test_custom_discount_item_limit() {
@@ -370,11 +271,6 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 			'limit_usage_to_x_items' => 1,
 		) );
 
-		// We need this to have the calculate_totals() method calculate totals.
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
-			define( 'WOOCOMMERCE_CHECKOUT', true );
-		}
-
 		// Add 4 products and coupon to cart.
 		WC()->cart->add_to_cart( $product->get_id(), 4 );
 		WC()->cart->add_discount( $coupon->get_code() );
@@ -382,13 +278,5 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 
 		// Test if the cart total amount is equal 39.5 (coupon only applying to one item).
 		$this->assertEquals( 39.5, WC()->cart->total );
-
-		// Clean up
-		wc_clear_notices();
-		WC()->cart->empty_cart();
-		WC()->cart->remove_coupons();
-		WC_Helper_Coupon::delete_coupon( $coupon->get_id() );
-		WC_Helper_Product::delete_product( $product->get_id() );
-		WC_Helper_Coupon::unregister_custom_type( __FUNCTION__ );
 	}
 }

--- a/tests/unit-tests/customer/customer.php
+++ b/tests/unit-tests/customer/customer.php
@@ -51,9 +51,6 @@ class WC_Tests_Customer extends WC_Unit_Test_Case {
 
 		// Clean up the cart
 		WC()->cart->empty_cart();
-
-		// Clean up product
-		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 
 	/**
@@ -100,8 +97,5 @@ class WC_Tests_Customer extends WC_Unit_Test_Case {
 
 		// Clean up the cart
 		WC()->cart->empty_cart();
-
-		// Clean up product
-		WC_Helper_Product::delete_product( $product->get_id() );
 	}
 }

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -72,31 +72,6 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		WC()->cart->empty_cart();
 		WC()->cart->remove_coupons();
 
-		foreach ( $this->products as $product ) {
-			$product->delete( true );
-		}
-
-		foreach ( $this->coupons as $code => $coupon ) {
-			$coupon->delete( true );
-
-			// Temporarily necessary until https://github.com/woocommerce/woocommerce/pull/16767 is implemented.
-			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $code, 'coupons' );
-		}
-
-		foreach ( $this->orders as $order ) {
-			$order->delete( true );
-		}
-
-		if ( $this->last_test_data ) {
-			if ( isset( $this->last_test_data['wc_options'] ) ) {
-				foreach ( $this->last_test_data['wc_options'] as $_option_name => $_option_value ) {
-					update_option( $_option_name, $_option_value['revert'] );
-				}
-			}
-
-			$this->last_test_data = null;
-		}
-
 		parent::tearDown();
 	}
 
@@ -137,7 +112,6 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$discounts = new WC_Discounts();
 		$discounts->set_items_from_cart( false );
 		$this->assertEquals( array(), $discounts->get_items() );
-		$product->delete( true );
 	}
 
 	/**
@@ -174,7 +148,6 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$discounts->set_items_from_cart( WC()->cart );
 		$discounts->apply_coupon( $coupon );
 		$this->assertEquals( 0, $discounts->get_discounted_price( current( $discounts->get_items() ) ), print_r( $discounts->get_discounts(), true ) );
-		$product->delete( true );
 	}
 
 	/**
@@ -225,10 +198,6 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		}
 
 		$this->assertEquals( $test_data['expected_total_discount'], $discount_total, 'Failed (' . print_r( $test_data, true ) . ' - ' . print_r( $discounts->get_discounts(), true ) . ')' );
-
-		foreach ( $products as $product ) {
-			$product->delete( true );
-		}
 	}
 
 	/**
@@ -1423,13 +1392,5 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$this->assertEquals( 20, $discount_total );
 
 		remove_filter( 'woocommerce_coupon_get_discount_amount', array( $this, 'filter_woocommerce_coupon_get_discount_amount' ) );
-		WC()->cart->empty_cart();
-		WC()->cart->remove_coupons();
-		$product->delete( true );
-		$product2->delete( true );
-		$coupon->delete( true );
-
-		// Temporarily necessary until https://github.com/woocommerce/woocommerce/pull/16767 is implemented.
-		wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_test', 'coupons' );
 	}
 }

--- a/tests/unit-tests/gateways/gateways.php
+++ b/tests/unit-tests/gateways/gateways.php
@@ -32,9 +32,6 @@ class WC_Tests_Gateways extends WC_Unit_Test_Case {
 		$gateway->supports[] = 'refunds';
 
 		$this->assertTrue( $gateway->can_refund_order( $order ) );
-
-		// Cleanup.
-		$order->delete( true );
 	}
 
 	/**
@@ -66,10 +63,6 @@ class WC_Tests_Gateways extends WC_Unit_Test_Case {
 		$order->set_transaction_id( '' );
 		$order->save();
 		$this->assertFalse( $gateway->can_refund_order( $order ) );
-
-		// Cleanup.
-		delete_option( 'woocommerce_paypal_settings' );
-		$order->delete( true );
 	}
 }
 

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -58,12 +58,14 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		$prod_count = 0;
 		foreach ( $this->products as $product ) {
 			$item = new WC_Order_Item_Product();
-			$item->set_props( array(
-				'product'  => $product,
-				'quantity' => 3,
-				'subtotal' => $prices ? $prices[ $prod_count ] : wc_get_price_excluding_tax( $product, array( 'qty' => 3 ) ),
-				'total'    => $prices ? $prices[ $prod_count ] : wc_get_price_excluding_tax( $product, array( 'qty' => 3 ) ),
-			) );
+			$item->set_props(
+				array(
+					'product'  => $product,
+					'quantity' => 3,
+					'subtotal' => $prices ? $prices[ $prod_count ] : wc_get_price_excluding_tax( $product, array( 'qty' => 3 ) ),
+					'total'    => $prices ? $prices[ $prod_count ] : wc_get_price_excluding_tax( $product, array( 'qty' => 3 ) ),
+				)
+			);
 
 			$item->save();
 			$order->add_item( $item );
@@ -162,8 +164,10 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 			$shipping_total += $this->order->get_shipping_tax();
 		}
 		$epsilon = 0.01;
-		$this->assertTrue( abs( $shipping_total - floatval( $query_array['shipping_1'] ) ) < $epsilon,
-		'Shipping tax mismatch: shipping total=' . $shipping_total . ' vs request shipping=' . $query_array['shipping_1'] );
+		$this->assertTrue(
+			abs( $shipping_total - floatval( $query_array['shipping_1'] ) ) < $epsilon,
+			'Shipping tax mismatch: shipping total=' . $shipping_total . ' vs request shipping=' . $query_array['shipping_1']
+		);
 
 	}
 
@@ -203,7 +207,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		$query_string = wp_parse_url( $request_url, PHP_URL_QUERY )
 			? wp_parse_url( $request_url, PHP_URL_QUERY )
 			: '';
-		$query_array = array();
+		$query_array  = array();
 		parse_str( $query_string, $query_array );
 		foreach ( $fields_limited_to_127_chars as $field_name ) {
 			$this->assertLessThanOrEqual( 127, strlen( $query_array[ $field_name ] ) );
@@ -251,7 +255,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		$query_string = wp_parse_url( $request_url, PHP_URL_QUERY )
 			? wp_parse_url( $request_url, PHP_URL_QUERY )
 			: '';
-		$query_array = array();
+		$query_array  = array();
 		parse_str( $query_string, $query_array );
 
 		// Check that there are $product_count line items in the request URL.
@@ -291,7 +295,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	 */
 	protected function check_negative_amount( $testmode ) {
 		$shipping_tax_included = true;
-		$product_prices = array( 6, 6, 6, 6, -3 );
+		$product_prices        = array( 6, 6, 6, 6, -3 );
 		$this->check_small_order( count( $product_prices ), $shipping_tax_included, $testmode, $product_prices );
 	}
 
@@ -317,9 +321,11 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	 */
 	public function test_request_url() {
 		// User set up.
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 		wp_set_current_user( $this->user );
 
 		// wc_tax_enabled(), wc_prices_include_tax() and WC_Gateway_Paypal_Request::prepare_line_items() determine if

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -141,18 +141,6 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Clean up order, tax, deletes all products in order, too.
-	 */
-	protected function clean_up() {
-		global $wpdb;
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-
-		WC_Helper_Order::delete_order( $this->order->get_id() );
-		unset( $this->products, $this->order );
-	}
-
-	/**
 	 * Check if the shipping tax is included in the total according to $shipping_tax_included.
 	 *
 	 * @param array $query_array           Request URL parsed into associative array.
@@ -221,10 +209,6 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		$this->assertEquals( '_cart', $query_array['cmd'] );
 
 		$this->check_shipping_tax( $query_array, $shipping_tax_included );
-
-		// Remove order and created products.
-		$this->clean_up();
-
 	}
 
 
@@ -280,9 +264,6 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		}
 
 		$this->check_shipping_tax( $query_array, $shipping_tax_included );
-
-		// Remove order and created products.
-		$this->clean_up();
 	}
 
 	/**

--- a/tests/unit-tests/order-items/order-item-fee.php
+++ b/tests/unit-tests/order-items/order-item-fee.php
@@ -13,7 +13,7 @@ class WC_Tests_Order_Item_Fee extends WC_Unit_Test_Case {
 	 * @since 3.2.0
 	 */
 	public function test_setters_getters() {
-		$fee = new WC_Order_Item_Fee;
+		$fee = new WC_Order_Item_Fee();
 
 		$fee->set_amount( '20.00' );
 		$this->assertEquals( '20.00', $fee->get_amount() );
@@ -58,40 +58,44 @@ class WC_Tests_Order_Item_Fee extends WC_Unit_Test_Case {
 		$order = WC_Helper_Order::create_order();
 
 		// Positive fee.
-		$fee = new WC_Order_Item_Fee;
+		$fee = new WC_Order_Item_Fee();
 		$fee->set_amount( '5.00' );
 		$fee->set_total( '5.00' );
 		$fee->set_order_id( $order->get_id() );
 
-		$fee->calculate_taxes( array(
-			'country' => 'US',
-			'state' => 'OR',
-			'postcode' => 97266,
-			'city' => 'Portland',
-		) );
+		$fee->calculate_taxes(
+			array(
+				'country'  => 'US',
+				'state'    => 'OR',
+				'postcode' => 97266,
+				'city'     => 'Portland',
+			)
+		);
 
-		$taxes = $fee->get_taxes();
+		$taxes       = $fee->get_taxes();
 		$total_taxes = array_values( $taxes['total'] );
-		$expected = array( '0.5' );
+		$expected    = array( '0.5' );
 		$this->assertEquals( $expected, $total_taxes );
 		$this->assertEquals( '0.5', $fee->get_total_tax() );
 
 		// Negative fee.
-		$fee = new WC_Order_Item_Fee;
+		$fee = new WC_Order_Item_Fee();
 		$fee->set_amount( '-5.00' );
 		$fee->set_total( '-5.00' );
 		$fee->set_order_id( $order->get_id() );
 
-		$fee->calculate_taxes( array(
-			'country' => 'US',
-			'state' => 'OR',
-			'postcode' => 97266,
-			'city' => 'Portland',
-		) );
+		$fee->calculate_taxes(
+			array(
+				'country'  => 'US',
+				'state'    => 'OR',
+				'postcode' => 97266,
+				'city'     => 'Portland',
+			)
+		);
 
-		$taxes = $fee->get_taxes();
+		$taxes       = $fee->get_taxes();
 		$total_taxes = array_values( $taxes['total'] );
-		$expected = array( '-0.5' );
+		$expected    = array( '-0.5' );
 		$this->assertEquals( $expected, $total_taxes );
 		$this->assertEquals( '-0.5', $fee->get_total_tax() );
 

--- a/tests/unit-tests/order-items/order-item-fee.php
+++ b/tests/unit-tests/order-items/order-item-fee.php
@@ -41,7 +41,6 @@ class WC_Tests_Order_Item_Fee extends WC_Unit_Test_Case {
 	 * @since 3.2.0
 	 */
 	public function test_calculate_taxes() {
-		global $wpdb;
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		$tax_rate = array(
 			'tax_rate_country'  => '',
@@ -98,10 +97,5 @@ class WC_Tests_Order_Item_Fee extends WC_Unit_Test_Case {
 		$expected    = array( '-0.5' );
 		$this->assertEquals( $expected, $total_taxes );
 		$this->assertEquals( '-0.5', $fee->get_total_tax() );
-
-		// Clean up.
-		WC_Helper_Order::delete_order( $order->get_id() );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
 	}
 }

--- a/tests/unit-tests/order/coupons.php
+++ b/tests/unit-tests/order/coupons.php
@@ -16,10 +16,8 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	/**
 	 * Setup an order.
 	 */
-	public function setUp() {
-		$this->delete_objects();
-
-		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // @codingStandardsIgnoreLine.
+	protected function init_test() {
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1';
 
 		update_option( 'woocommerce_default_customer_address', 'base' );
 		update_option( 'woocommerce_tax_based_on', 'base' );
@@ -118,51 +116,12 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Clean up after test.
-	 */
-	public function tearDown() {
-		update_option( 'woocommerce_calc_taxes', 'no' );
-		update_option( 'woocommerce_prices_include_tax', 'no' );
-		$this->delete_objects();
-	}
-
-	/**
-	 * delete objects.
-	 */
-	protected function delete_objects() {
-		if ( isset( $this->objects['coupons'] ) ) {
-			foreach ( $this->objects['coupons'] as $object ) {
-				$object->delete( true );
-			}
-		}
-
-		if ( isset( $this->objects['products'] ) ) {
-			foreach ( $this->objects['products'] as $object ) {
-				$object->delete( true );
-			}
-		}
-
-		if ( isset( $this->objects['order'] ) ) {
-			$this->objects['order']->delete( true );
-		}
-
-		if ( isset( $this->objects['tax_rate_ids'] ) ) {
-			foreach ( $this->objects['tax_rate_ids'] as $tax_rate_id ) {
-				WC_Tax::_delete_tax_rate( $tax_rate_id );
-			}
-		}
-
-		$this->objects = array();
-		wp_cache_flush();
-	}
-
-	/**
 	 * Test: test_remove_coupon_from_order
 	 */
 	public function test_remove_coupon_from_order() {
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
@@ -180,7 +139,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$this->assertEquals( '1000', $order->get_total(), $order->get_total() );
 
 		// Reset.
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
@@ -202,7 +161,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	public function test_add_coupon_to_order() {
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
@@ -225,7 +184,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	public function test_remove_coupon_from_order_ex_tax() {
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
@@ -243,7 +202,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$this->assertEquals( '1100', $order->get_total(), $order->get_total() );
 
 		// Reset.
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
@@ -265,7 +224,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	public function test_add_coupon_to_order_ex_tax() {
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
@@ -281,7 +240,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	public function test_remove_coupon_from_order_no_tax() {
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'no' );
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
@@ -299,7 +258,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$this->assertEquals( '1000', $order->get_total(), $order->get_total() );
 
 		// Reset.
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
@@ -321,7 +280,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	public function test_add_coupon_to_order_no_tax() {
 		update_option( 'woocommerce_prices_include_tax', 'no' );
 		update_option( 'woocommerce_calc_taxes', 'no' );
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
@@ -336,7 +295,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	public function test_remove_coupon_from_order_no_tax_inc_prices_on() {
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'no' );
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
@@ -354,7 +313,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$this->assertEquals( '1000', $order->get_total(), $order->get_total() );
 
 		// Reset.
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );
@@ -376,7 +335,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	public function test_add_coupon_to_order_no_tax_inc_prices_on() {
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'no' );
-		$this->setUp();
+		$this->init_test();
 
 		$order_id = $this->objects['order']->get_id();
 		$order    = wc_get_order( $order_id );

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -227,7 +227,6 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 
 		$expected_attributes = array( 'pa_size' => array( 'small', 'large' ) );
 		$this->assertEquals( $expected_attributes, $product->get_variation_attributes() );
-		$product->delete();
 	}
 
 	/**
@@ -315,7 +314,6 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$product->set_name( 'Renamed Variable Product' );
 		$product->save();
 		$this->assertEquals( 'Renamed Variable Product', $product->get_name() );
-		$product->delete();
 	}
 
 	public function test_variation_save_attributes() {
@@ -674,11 +672,5 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$this->assertContains( $product2->get_id(), $results );
 		$this->assertNotContains( $product3->get_id(), $results );
 		$this->assertNotContains( $product4->get_id(), $results );
-
-		// Clean up.
-		$product->delete();
-		$product2->delete();
-		$product3->delete();
-		$product4->delete();
 	}
 }

--- a/tests/unit-tests/product/data.php
+++ b/tests/unit-tests/product/data.php
@@ -100,7 +100,6 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 		$product->set_image_id( $image_id[0] );
 		$product->save();
 		$this->assertEquals( $image_id[0], $product->get_image_id() );
-		$product->delete( true );
 	}
 
 	/**
@@ -224,8 +223,6 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_external_product_getters_and_setters() {
-		$time = time();
-
 		$getters_and_setters = array(
 			'button_text' => 'Test Button Text',
 			'product_url' => 'https://wordpress.org',
@@ -269,10 +266,5 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 		$product = wc_get_product( $product3_id );
 		$this->assertEquals( $product3_id, $product->get_id() );
 		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol">&pound;</span>50.00</span>', $product->get_price_html() );
-
-		// Clean up.
-		$product1->delete();
-		$product2->delete();
-		$product3->delete();
 	}
 }

--- a/tests/unit-tests/product/data.php
+++ b/tests/unit-tests/product/data.php
@@ -63,7 +63,7 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 			'menu_order'         => 2,
 			'gallery_image_ids'  => array(),
 			'download_expiry'    => -1,
-			'download_limit'     => 5
+			'download_limit'     => 5,
 		);
 
 		$product = new WC_Product();
@@ -79,14 +79,16 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 			$this->assertEquals( $value, $product->{"get_{$function}"}(), $function );
 		}
 		$this->assertCount( 1, $product->get_attributes() );
-		$this->assertContains( current( $product->get_attributes() )->get_data(), array(
-			'attribute_id' => 0,
-			'name'         => 'Test Attribute',
-			'options'      => array( 'Fish', 'Fingers' ),
-			'position'     => 0,
-			'visible'      => true,
-			'variation'    => false,
-		) );
+		$this->assertContains(
+			current( $product->get_attributes() )->get_data(), array(
+				'attribute_id' => 0,
+				'name'         => 'Test Attribute',
+				'options'      => array( 'Fish', 'Fingers' ),
+				'position'     => 0,
+				'visible'      => true,
+				'variation'    => false,
+			)
+		);
 		$this->assertEquals( $product->get_date_on_sale_from()->getTimestamp(), 1475798400 );
 		$this->assertEquals( $product->get_date_on_sale_to()->getTimestamp(), 1477267200 );
 
@@ -94,7 +96,7 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 
 		$this->assertNotWPError( $image_url );
 
-		$image_id  = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE guid = %s", $image_url ) );
+		$image_id = $wpdb->get_col( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE guid = %s", $image_url ) );
 		$product->set_image_id( $image_id[0] );
 		$product->save();
 		$this->assertEquals( $image_id[0], $product->get_image_id() );

--- a/tests/unit-tests/shipping-zones/shipping-zone.php
+++ b/tests/unit-tests/shipping-zones/shipping-zone.php
@@ -87,7 +87,7 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 
 		// Assert
 		$this->assertTrue( is_array( $zone->get_zone_locations() ) );
-		$this->assertTrue( 2 === sizeof( $zone->get_zone_locations() ) );
+		$this->assertTrue( 2 === count( $zone->get_zone_locations() ) );
 
 		// Clean
 		WC_Helper_Shipping_Zones::remove_mock_zones();
@@ -141,7 +141,7 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		$methods = $zone->get_shipping_methods();
 
 		// Assert
-		$this->assertTrue( 1 === sizeof( $methods ) );
+		$this->assertTrue( 1 === count( $methods ) );
 		$this->assertInstanceOf( 'WC_Shipping_Method', current( $methods ) );
 
 		// Clean
@@ -251,28 +251,32 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->clear_locations();
-		$zone->set_locations( array(
+		$zone->set_locations(
 			array(
-				'code' => 'US',
-				'type' => 'country',
-			),
-			array(
-				'code' => '90210',
-				'type' => 'postcode',
-			),
-		) );
+				array(
+					'code' => 'US',
+					'type' => 'country',
+				),
+				array(
+					'code' => '90210',
+					'type' => 'postcode',
+				),
+			)
+		);
 
 		// Assert
-		$this->assertEquals( $zone->get_zone_locations(), array(
-			0 => (object) array(
-				'code' => 'US',
-				'type' => 'country',
-			),
-			1 => (object) array(
-				'code' => '90210',
-				'type' => 'postcode',
-			),
-		) );
+		$this->assertEquals(
+			$zone->get_zone_locations(), array(
+				0 => (object) array(
+					'code' => 'US',
+					'type' => 'country',
+				),
+				1 => (object) array(
+					'code' => '90210',
+					'type' => 'postcode',
+				),
+			)
+		);
 
 		// Clean
 		WC_Helper_Shipping_Zones::remove_mock_zones();
@@ -306,7 +310,7 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		WC_Helper_Shipping_Zones::create_mock_zones();
 
 		// Test
-		$zone        = WC_Shipping_Zones::get_zone( 1 );
+		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->add_shipping_method( 'flat_rate' );
 		$zone->add_shipping_method( 'free_shipping' );
 
@@ -314,7 +318,7 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		$methods = $zone->get_shipping_methods();
 
 		// Assert
-		$this->assertTrue( 2 === sizeof( $methods ) );
+		$this->assertTrue( 2 === count( $methods ) );
 		$this->assertInstanceOf( 'WC_Shipping_Method', current( $methods ) );
 
 		// Clean

--- a/tests/unit-tests/shipping-zones/shipping-zone.php
+++ b/tests/unit-tests/shipping-zones/shipping-zone.php
@@ -6,100 +6,73 @@
  */
 class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 
+	public function setUp() {
+		parent::setUp();
+
+		WC_Helper_Shipping_Zones::create_mock_zones();
+	}
+
 	/**
 	 * Test: WC_Shipping_Zone::get_data
 	 */
 	public function test_get_data() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$data = $zone->get_data();
 
 		// Assert
 		$this->assertTrue( is_array( $data ) );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zones::get_id
 	 */
 	public function test_get_zone_id() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
 		// Assert
 		$this->assertEquals( $zone->get_id(), 1 );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zones::get_zone_name
 	 */
 	public function test_get_zone_name() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
 		// Assert
 		$this->assertEquals( $zone->get_zone_name(), 'Local' );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zones::get_zone_order
 	 */
 	public function test_get_zone_order() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
 		// Assert
 		$this->assertEquals( $zone->get_zone_order(), 1 );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zones::get_zone_locations
 	 */
 	public function test_get_zone_locations() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
 		// Assert
 		$this->assertTrue( is_array( $zone->get_zone_locations() ) );
 		$this->assertTrue( 2 === count( $zone->get_zone_locations() ) );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zones::get_formatted_location
 	 */
 	public function test_get_formatted_location() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
@@ -123,18 +96,12 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 
 		// Assert
 		$this->assertEquals( $zone->get_formatted_location(), 'United States (US)' );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zone::get_shipping_methods
 	 */
 	public function test_get_shipping_methods() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->add_shipping_method( 'flat_rate' );
@@ -143,71 +110,47 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		// Assert
 		$this->assertTrue( 1 === count( $methods ) );
 		$this->assertInstanceOf( 'WC_Shipping_Method', current( $methods ) );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zone::set_zone_name
 	 */
 	public function test_set_zone_name() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->set_zone_name( 'I am a fish' );
 
 		// Assert
 		$this->assertEquals( $zone->get_zone_name(), 'I am a fish' );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zone::set_zone_order
 	 */
 	public function test_set_zone_order() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->set_zone_order( 100 );
 
 		// Assert
 		$this->assertEquals( $zone->get_zone_order(), 100 );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zone::is_valid_location_type
 	 */
 	public function test_is_valid_location_type() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
 		// Assert
 		$this->assertEquals( $zone->get_zone_order(), 1 );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zone::add_location
 	 */
 	public function test_add_location() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
@@ -217,18 +160,12 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		$this->assertTrue( $zone->is_valid_location_type( 'continent' ) );
 		$this->assertTrue( $zone->is_valid_location_type( 'postcode' ) );
 		$this->assertFalse( $zone->is_valid_location_type( 'poop' ) );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zone::clear_locations
 	 */
 	public function test_clear_locations() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->clear_locations();
@@ -236,18 +173,12 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		// Assert
 		$zone_locations = $zone->get_zone_locations();
 		$this->assertTrue( empty( $zone_locations ) );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zone::set_locations
 	 */
 	public function test_set_locations() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->clear_locations();
@@ -277,18 +208,12 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 				),
 			)
 		);
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zone::save
 	 */
 	public function test_save() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->set_zone_name( 'I am a fish' );
@@ -297,18 +222,12 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 
 		// Assert
 		$this->assertEquals( $zone->get_zone_name(), 'I am a fish' );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zone::add_shipping_method
 	 */
 	public function test_add_shipping_method() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->add_shipping_method( 'flat_rate' );
@@ -320,9 +239,6 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		// Assert
 		$this->assertTrue( 2 === count( $methods ) );
 		$this->assertInstanceOf( 'WC_Shipping_Method', current( $methods ) );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**

--- a/tests/unit-tests/shipping-zones/shipping-zones.php
+++ b/tests/unit-tests/shipping-zones/shipping-zones.php
@@ -6,49 +6,40 @@
  */
 class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 
+	public function setUp() {
+		parent::setUp();
+
+		WC_Helper_Shipping_Zones::create_mock_zones();
+	}
+
 	/**
 	 * Test: WC_Shipping_Zones::get_zones
 	 */
 	public function test_get_zones() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zones = WC_Shipping_Zones::get_zones();
 
 		// Assert
 		$this->assertTrue( is_array( $zones ) );
 		$this->assertTrue( 4 === count( $zones ) );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zones::get_zone
 	 */
 	public function test_get_zone() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
 		// Assert that the first zone is our local zone
 		$this->assertInstanceOf( 'WC_Shipping_Zone', $zone );
 		$this->assertEquals( $zone->get_zone_name(), 'Local' );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zones::get_zone_by
 	 */
 	public function test_get_zone_by() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone = WC_Shipping_Zones::get_zone_by( 'zone_id', 2 );
 
@@ -64,18 +55,12 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 		// Assert
 		$this->assertInstanceOf( 'WC_Shipping_Zone', $zone );
 		$this->assertEquals( $zone->get_zone_name(), 'Europe' );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zones::get_shipping_method
 	 */
 	public function test_get_shipping_method() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone            = WC_Shipping_Zones::get_zone_by( 'zone_id', 1 );
 		$instance_id     = $zone->add_shipping_method( 'flat_rate' );
@@ -83,36 +68,24 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 
 		// Assert
 		$this->assertInstanceOf( 'WC_Shipping_Flat_Rate', $shipping_method );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zones::delete_zone
 	 */
 	public function test_delete_zone() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		WC_Shipping_Zones::delete_zone( 1 );
 		$zones = WC_Shipping_Zones::get_zones();
 
 		// Assert
 		$this->assertTrue( 3 === count( $zones ) );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 
 	/**
 	 * Test: WC_Shipping_Zones::get_zone_matching_package
 	 */
 	public function test_get_zone_matching_package() {
-		// Setup
-		WC_Helper_Shipping_Zones::create_mock_zones();
-
 		// Test
 		$zone1 = WC_Shipping_Zones::get_zone_matching_package(
 			array(
@@ -156,8 +129,5 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 		$this->assertEquals( 'Europe', $zone2->get_zone_name() );
 		$this->assertEquals( 'California', $zone3->get_zone_name() );
 		$this->assertEquals( 'US', $zone4->get_zone_name() );
-
-		// Clean
-		WC_Helper_Shipping_Zones::remove_mock_zones();
 	}
 }

--- a/tests/unit-tests/shipping-zones/shipping-zones.php
+++ b/tests/unit-tests/shipping-zones/shipping-zones.php
@@ -18,7 +18,7 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 
 		// Assert
 		$this->assertTrue( is_array( $zones ) );
-		$this->assertTrue( 4 === sizeof( $zones ) );
+		$this->assertTrue( 4 === count( $zones ) );
 
 		// Clean
 		WC_Helper_Shipping_Zones::remove_mock_zones();
@@ -100,7 +100,7 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 		$zones = WC_Shipping_Zones::get_zones();
 
 		// Assert
-		$this->assertTrue( 3 === sizeof( $zones ) );
+		$this->assertTrue( 3 === count( $zones ) );
 
 		// Clean
 		WC_Helper_Shipping_Zones::remove_mock_zones();
@@ -114,34 +114,42 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 		WC_Helper_Shipping_Zones::create_mock_zones();
 
 		// Test
-		$zone1 = WC_Shipping_Zones::get_zone_matching_package( array(
-			'destination' => array(
-				'country'  => 'GB',
-				'state'    => 'Cambs',
-				'postcode' => 'CB23 1GG',
-			),
-		) );
-		$zone2 = WC_Shipping_Zones::get_zone_matching_package( array(
-			'destination' => array(
-				'country'  => 'GB',
-				'state'    => 'Cambs',
-				'postcode' => 'PE12 1BG',
-			),
-		) );
-		$zone3 = WC_Shipping_Zones::get_zone_matching_package( array(
-			'destination' => array(
-				'country'  => 'US',
-				'state'    => 'CA',
-				'postcode' => '90210',
-			),
-		) );
-		$zone4 = WC_Shipping_Zones::get_zone_matching_package( array(
-			'destination' => array(
-				'country'  => 'US',
-				'state'    => 'AL',
-				'postcode' => '12345',
-			),
-		) );
+		$zone1 = WC_Shipping_Zones::get_zone_matching_package(
+			array(
+				'destination' => array(
+					'country'  => 'GB',
+					'state'    => 'Cambs',
+					'postcode' => 'CB23 1GG',
+				),
+			)
+		);
+		$zone2 = WC_Shipping_Zones::get_zone_matching_package(
+			array(
+				'destination' => array(
+					'country'  => 'GB',
+					'state'    => 'Cambs',
+					'postcode' => 'PE12 1BG',
+				),
+			)
+		);
+		$zone3 = WC_Shipping_Zones::get_zone_matching_package(
+			array(
+				'destination' => array(
+					'country'  => 'US',
+					'state'    => 'CA',
+					'postcode' => '90210',
+				),
+			)
+		);
+		$zone4 = WC_Shipping_Zones::get_zone_matching_package(
+			array(
+				'destination' => array(
+					'country'  => 'US',
+					'state'    => 'AL',
+					'postcode' => '12345',
+				),
+			)
+		);
 
 		// Assert
 		$this->assertEquals( 'Local', $zone1->get_zone_name() );

--- a/tests/unit-tests/tax/tax.php
+++ b/tests/unit-tests/tax/tax.php
@@ -32,14 +32,16 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 
 		$tax_rates = WC_Tax::get_rates();
 
-		$this->assertSame( $tax_rates, array(
-			$tax_rate_id => array(
-				'rate' => 20.0,
-				'label' => 'VAT',
-				'shipping' => 'yes',
-				'compound' => 'no',
-			),
-		) );
+		$this->assertSame(
+			$tax_rates, array(
+				$tax_rate_id => array(
+					'rate'     => 20.0,
+					'label'    => 'VAT',
+					'shipping' => 'yes',
+					'compound' => 'no',
+				),
+			)
+		);
 
 		WC_Tax::_delete_tax_rate( $tax_rate_id );
 
@@ -58,14 +60,16 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$tax_rate_catch_all_id = WC_Tax::_insert_tax_rate( $tax_rate_catch_all );
 
 		$tax_rates = WC_Tax::get_rates();
-		$this->assertSame( $tax_rates, array(
-			$tax_rate_catch_all_id => array(
-				'rate' => 0.0,
-				'label' => 'VAT',
-				'shipping' => 'yes',
-				'compound' => 'no',
-			),
-		) );
+		$this->assertSame(
+			$tax_rates, array(
+				$tax_rate_catch_all_id => array(
+					'rate'     => 0.0,
+					'label'    => 'VAT',
+					'shipping' => 'yes',
+					'compound' => 'no',
+				),
+			)
+		);
 
 		WC_Tax::_delete_tax_rate( $tax_rate_catch_all_id );
 	}
@@ -80,7 +84,7 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
 
 		$customer_location = WC_Tax::get_tax_location();
-		$tax_rate = array(
+		$tax_rate          = array(
 			'tax_rate_country'  => $customer_location[0],
 			'tax_rate_state'    => '',
 			'tax_rate'          => '20.0000',
@@ -96,7 +100,16 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 
 		$tax_rates = WC_Tax::get_shipping_tax_rates();
 
-		$this->assertEquals( $tax_rates, array( $tax_rate_id => array( 'rate' => '20.0000', 'label' => 'VAT', 'shipping' => 'yes', 'compound' => 'no' ) ), print_r( $tax_rates, true ) );
+		$this->assertEquals(
+			$tax_rates, array(
+				$tax_rate_id => array(
+					'rate'     => '20.0000',
+					'label'    => 'VAT',
+					'shipping' => 'yes',
+					'compound' => 'no',
+				),
+			), print_r( $tax_rates, true )
+		);
 
 		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
@@ -126,7 +139,16 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 
 		$tax_rates = WC_Tax::get_base_tax_rates();
 
-		$this->assertEquals( $tax_rates, array( $tax_rate_id => array( 'rate' => '20.0000', 'label' => 'VAT', 'shipping' => 'yes', 'compound' => 'no' ) ) );
+		$this->assertEquals(
+			$tax_rates, array(
+				$tax_rate_id => array(
+					'rate'     => '20.0000',
+					'label'    => 'VAT',
+					'shipping' => 'yes',
+					'compound' => 'no',
+				),
+			)
+		);
 
 		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
@@ -154,15 +176,26 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 
 		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 
-		$tax_rates = WC_Tax::find_rates( array(
-			'country'   => 'GB',
-			'state'     => 'Cambs',
-			'postcode'  => 'PE14 1XX',
-			'city'      => 'Somewhere',
-			'tax_class' => '',
-		) );
+		$tax_rates = WC_Tax::find_rates(
+			array(
+				'country'   => 'GB',
+				'state'     => 'Cambs',
+				'postcode'  => 'PE14 1XX',
+				'city'      => 'Somewhere',
+				'tax_class' => '',
+			)
+		);
 
-		$this->assertEquals( $tax_rates, array( $tax_rate_id => array( 'rate' => '20.0000', 'label' => 'VAT', 'shipping' => 'yes', 'compound' => 'no' ) ) );
+		$this->assertEquals(
+			$tax_rates, array(
+				$tax_rate_id => array(
+					'rate'     => '20.0000',
+					'label'    => 'VAT',
+					'shipping' => 'yes',
+					'compound' => 'no',
+				),
+			)
+		);
 
 		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
@@ -190,15 +223,26 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 
 		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 
-		$tax_rates = WC_Tax::find_shipping_rates( array(
-			'country'   => 'GB',
-			'state'     => 'Cambs',
-			'postcode'  => 'PE14 1XX',
-			'city'      => 'Somewhere',
-			'tax_class' => '',
-		) );
+		$tax_rates = WC_Tax::find_shipping_rates(
+			array(
+				'country'   => 'GB',
+				'state'     => 'Cambs',
+				'postcode'  => 'PE14 1XX',
+				'city'      => 'Somewhere',
+				'tax_class' => '',
+			)
+		);
 
-		$this->assertEquals( $tax_rates, array( $tax_rate_id => array( 'rate' => '20.0000', 'label' => 'VAT', 'shipping' => 'yes', 'compound' => 'no' ) ) );
+		$this->assertEquals(
+			$tax_rates, array(
+				$tax_rate_id => array(
+					'rate'     => '20.0000',
+					'label'    => 'VAT',
+					'shipping' => 'yes',
+					'compound' => 'no',
+				),
+			)
+		);
 
 		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
@@ -226,13 +270,15 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 
 		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 
-		$tax_rates = WC_Tax::find_rates( array(
-			'country'   => 'GB',
-			'state'     => 'Cambs',
-			'postcode'  => 'PE14 1XX',
-			'city'      => 'Somewhere',
-			'tax_class' => '',
-		) );
+		$tax_rates = WC_Tax::find_rates(
+			array(
+				'country'   => 'GB',
+				'state'     => 'Cambs',
+				'postcode'  => 'PE14 1XX',
+				'city'      => 'Somewhere',
+				'tax_class' => '',
+			)
+		);
 
 		$calced_tax = WC_Tax::calc_tax( '9.99', $tax_rates, true, false );
 
@@ -258,43 +304,50 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_default_state', 'QC' );
 
 		$tax_rate_1 = array(
-		  'tax_rate_country'  => 'CA',
-		  'tax_rate_state'    => '',
-		  'tax_rate'          => '5.0000',
-		  'tax_rate_name'     => 'GST',
-		  'tax_rate_priority' => '1',
-		  'tax_rate_compound' => '0',
-		  'tax_rate_shipping' => '1',
-		  'tax_rate_order'    => '1',
-		  'tax_rate_class'    => '',
+			'tax_rate_country'  => 'CA',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '5.0000',
+			'tax_rate_name'     => 'GST',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
 		);
 
 		$tax_rate_2 = array(
-		  'tax_rate_country'  => 'CA',
-		  'tax_rate_state'    => 'QC',
-		  'tax_rate'          => '8.5000',
-		  'tax_rate_name'     => 'PST',
-		  'tax_rate_priority' => '2',
-		  'tax_rate_compound' => '1',
-		  'tax_rate_shipping' => '1',
-		  'tax_rate_order'    => '2',
-		  'tax_rate_class'    => '',
+			'tax_rate_country'  => 'CA',
+			'tax_rate_state'    => 'QC',
+			'tax_rate'          => '8.5000',
+			'tax_rate_name'     => 'PST',
+			'tax_rate_priority' => '2',
+			'tax_rate_compound' => '1',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '2',
+			'tax_rate_class'    => '',
 		);
 
 		$tax_rate_1_id = WC_Tax::_insert_tax_rate( $tax_rate_1 );
 		$tax_rate_2_id = WC_Tax::_insert_tax_rate( $tax_rate_2 );
 
-		$tax_rates = WC_Tax::find_rates( array(
-		  'country'   => 'CA',
-		  'state'     => 'QC',
-		  'postcode'  => '12345',
-		  'city'      => '',
-		  'tax_class' => '',
-		) );
+		$tax_rates = WC_Tax::find_rates(
+			array(
+				'country'   => 'CA',
+				'state'     => 'QC',
+				'postcode'  => '12345',
+				'city'      => '',
+				'tax_class' => '',
+			)
+		);
 
 		// prices exclusive of tax
 		$calced_tax = WC_Tax::calc_tax( '100', $tax_rates, false, false );
-		$this->assertEquals( $calced_tax, array( $tax_rate_1_id => '5.0000', $tax_rate_2_id => '8.925' ) );
+		$this->assertEquals(
+			$calced_tax, array(
+				$tax_rate_1_id => '5.0000',
+				$tax_rate_2_id => '8.925',
+			)
+		);
 
 		// prices inclusive of tax
 		$calced_tax = WC_Tax::calc_tax( '100', $tax_rates, true, false );
@@ -337,13 +390,15 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 
 		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 
-		$tax_rates = WC_Tax::find_rates( array(
-			'country'   => 'GB',
-			'state'     => 'Cambs',
-			'postcode'  => 'PE14 1XX',
-			'city'      => 'Somewhere',
-			'tax_class' => '',
-		) );
+		$tax_rates = WC_Tax::find_rates(
+			array(
+				'country'   => 'GB',
+				'state'     => 'Cambs',
+				'postcode'  => 'PE14 1XX',
+				'city'      => 'Somewhere',
+				'tax_class' => '',
+			)
+		);
 
 		$calced_tax = WC_Tax::calc_shipping_tax( '10', $tax_rates );
 
@@ -545,7 +600,7 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 
 		// Update a rate
 		$tax_rate = array(
-			'tax_rate_country'  => 'US',
+			'tax_rate_country' => 'US',
 		);
 
 		// Run function
@@ -592,8 +647,8 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 	public function test__update_tax_rate_postcodes() {
 		global $wpdb;
 
-		$to_save = '12345;90210...90215';
-		$tax_rate          = array(
+		$to_save  = '12345;90210...90215';
+		$tax_rate = array(
 			'tax_rate_country'  => 'GB',
 			'tax_rate_state'    => '',
 			'tax_rate'          => '20.0000',

--- a/tests/unit-tests/tax/tax.php
+++ b/tests/unit-tests/tax/tax.php
@@ -10,11 +10,6 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 	 * Get rates.
 	 */
 	public function test_get_rates() {
-		global $wpdb;
-
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-
 		$customer_location = WC_Tax::get_tax_location();
 		$tax_rate          = array(
 			'tax_rate_country'  => $customer_location[0],
@@ -70,19 +65,12 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 				),
 			)
 		);
-
-		WC_Tax::_delete_tax_rate( $tax_rate_catch_all_id );
 	}
 
 	/**
 	 * Get rates.
 	 */
 	public function test_get_shipping_tax_rates() {
-		global $wpdb;
-
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-
 		$customer_location = WC_Tax::get_tax_location();
 		$tax_rate          = array(
 			'tax_rate_country'  => $customer_location[0],
@@ -110,19 +98,12 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 				),
 			), print_r( $tax_rates, true )
 		);
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
 	 * Get rates.
 	 */
 	public function test_get_base_tax_rates() {
-		global $wpdb;
-
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-
 		$tax_rate = array(
 			'tax_rate_country'  => 'GB',
 			'tax_rate_state'    => '',
@@ -149,19 +130,12 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 				),
 			)
 		);
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
 	 * Find tax rates.
 	 */
 	public function test_find_rates() {
-		global $wpdb;
-
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-
 		$tax_rate = array(
 			'tax_rate_country'  => 'GB',
 			'tax_rate_state'    => '',
@@ -196,19 +170,12 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 				),
 			)
 		);
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
 	 * Find tax rates.
 	 */
 	public function test_find_shipping_rates() {
-		global $wpdb;
-
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-
 		$tax_rate = array(
 			'tax_rate_country'  => 'GB',
 			'tax_rate_state'    => '',
@@ -243,19 +210,12 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 				),
 			)
 		);
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
 	 * Test tax amounts.
 	 */
 	public function test_calc_tax() {
-		global $wpdb;
-
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-
 		$tax_rate = array(
 			'tax_rate_country'  => 'GB',
 			'tax_rate_state'    => '',
@@ -287,19 +247,12 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$calced_tax = WC_Tax::calc_tax( '9.99', $tax_rates, false, false );
 
 		$this->assertEquals( $calced_tax, array( $tax_rate_id => '1.998' ) );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
 	 * Test compound tax amounts
 	 */
 	public function test_calc_compound_tax() {
-		global $wpdb;
-
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-
 		update_option( 'woocommerce_default_country', 'CA' );
 		update_option( 'woocommerce_default_state', 'QC' );
 
@@ -360,22 +313,12 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		 */
 		$this->assertEquals( round( $calced_tax[ $tax_rate_1_id ], 4 ), 4.3889 );
 		$this->assertEquals( round( $calced_tax[ $tax_rate_2_id ], 4 ), 7.8341 );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_1_id );
-		WC_Tax::_delete_tax_rate( $tax_rate_2_id );
-		update_option( 'woocommerce_default_country', 'GB' );
-		update_option( 'woocommerce_default_state', '' );
 	}
 
 	/**
 	 * Shipping tax amounts.
 	 */
 	public function test_calc_shipping_tax() {
-		global $wpdb;
-
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates" );
-		$wpdb->query( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations" );
-
 		$tax_rate = array(
 			'tax_rate_country'  => 'GB',
 			'tax_rate_state'    => '',
@@ -403,16 +346,12 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$calced_tax = WC_Tax::calc_shipping_tax( '10', $tax_rates );
 
 		$this->assertEquals( $calced_tax, array( $tax_rate_id => '2' ) );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
 	 * Test rate labels.
 	 */
 	public function test_get_rate_label() {
-		global $wpdb;
-
 		$tax_rate = array(
 			'tax_rate_country'  => 'GB',
 			'tax_rate_state'    => '',
@@ -428,16 +367,12 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 
 		$this->assertEquals( WC_Tax::get_rate_label( $tax_rate_id ), 'VAT' );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
 	 * Test rate percent.
 	 */
 	public function test_get_rate_percent() {
-		global $wpdb;
-
 		$tax_rate = array(
 			'tax_rate_country'  => 'GB',
 			'tax_rate_state'    => '',
@@ -453,16 +388,12 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 
 		$this->assertEquals( WC_Tax::get_rate_percent( $tax_rate_id ), '20%' );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
 	 * Test rate code.
 	 */
 	public function test_get_rate_code() {
-		global $wpdb;
-
 		$tax_rate = array(
 			'tax_rate_country'  => 'GB',
 			'tax_rate_state'    => '',
@@ -478,16 +409,12 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 
 		$this->assertEquals( WC_Tax::get_rate_code( $tax_rate_id ), 'GB-VAT-1' );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
 	 * Test is compound.
 	 */
 	public function test_is_compound() {
-		global $wpdb;
-
 		$tax_rate = array(
 			'tax_rate_country'  => 'GB',
 			'tax_rate_state'    => '',
@@ -503,8 +430,6 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$tax_rate_id = WC_Tax::_insert_tax_rate( $tax_rate );
 
 		$this->assertTrue( WC_Tax::is_compound( $tax_rate_id ) );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
@@ -572,8 +497,6 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$this->assertEquals( $new_row->tax_rate_shipping, '1' );
 		$this->assertEquals( $new_row->tax_rate_order, '1' );
 		$this->assertEquals( $new_row->tax_rate_class, '' );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
@@ -607,8 +530,6 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		WC_Tax::_update_tax_rate( $tax_rate_id, $tax_rate );
 
 		$this->assertNotFalse( $wpdb->last_result );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
@@ -637,8 +558,6 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		WC_Tax::_delete_tax_rate( $tax_rate_id );
 
 		$this->assertNotFalse( $wpdb->last_result );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
@@ -668,8 +587,6 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$results = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE tax_rate_id = %d ORDER BY location_code ASC", $tax_rate_id ) );
 
 		$this->assertEquals( array( '12345', '90210...90215' ), $results );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 
 	/**
@@ -699,7 +616,5 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$results = $wpdb->get_col( $wpdb->prepare( "SELECT location_code FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE tax_rate_id = %d ORDER BY location_code ASC", $tax_rate_id ) );
 
 		$this->assertEquals( array( 'SOMEWHERE', 'SOMEWHERE_ELSE' ), $results );
-
-		WC_Tax::_delete_tax_rate( $tax_rate_id );
 	}
 }

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -32,10 +32,6 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 
 		$this->ids = array();
 
-		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
-			define( 'WOOCOMMERCE_CHECKOUT', 1 );
-		}
-
 		$tax_rate    = array(
 			'tax_rate_country'  => '',
 			'tax_rate_state'    => '',
@@ -110,23 +106,9 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 		WC()->cart->empty_cart();
 		WC()->session->set( 'chosen_shipping_methods', array() );
 		WC_Helper_Shipping::delete_simple_flat_rate();
-		update_option( 'woocommerce_calc_taxes', 'no' );
 		remove_action( 'woocommerce_cart_calculate_fees', array( $this, 'add_cart_fees_callback' ) );
 
-		foreach ( $this->ids['products'] as $product ) {
-			$product->delete( true );
-		}
-
-		foreach ( $this->ids['coupons'] as $coupon ) {
-			$coupon->delete( true );
-			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $coupon->get_code(), 'coupons' );
-		}
-
-		foreach ( $this->ids['tax_rate_ids'] as $tax_rate_id ) {
-			WC_Tax::_delete_tax_rate( $tax_rate_id );
-		}
-
-		$this->ids = array();
+		parent::tearDown();
 	}
 
 	/**

--- a/tests/unit-tests/util/class-wc-tests-wc-query.php
+++ b/tests/unit-tests/util/class-wc-tests-wc-query.php
@@ -65,9 +65,6 @@ class WC_Tests_WC_Query extends WC_Unit_Test_Case {
 		WC()->query->init_query_vars();
 		$updated_vars = WC()->query->get_query_vars();
 		$this->assertEquals( 'order-pay-new', $updated_vars['order-pay'] );
-
-		// Clean up.
-		update_option( 'woocommerce_checkout_pay_endpoint', 'order-pay' );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Similar to what was done in #21150, this PR removes unnecessary cleanup code from unit tests. See #21150 for details on why the removed code is not necessary.

This PR also includes PHPCS fixes for the modified files in a separate commit.

### How to test the changes in this Pull Request:

1. Make sure tests are still passing