### PR TITLE
Retry e2e tests automatically in case of failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,7 @@ before_script:
 script:
   - bash tests/bin/phpunit.sh
   - bash tests/bin/phpcs.sh
-  - bash tests/bin/run-e2e-CI.sh
+  - travis_retry bash tests/bin/run-e2e-CI.sh
 
 after_script:
   - bash tests/bin/travis.sh after


### PR DESCRIPTION
Tests should be consistent. That is true for our unit tests suite, but it is something that is harder to achieve for functional tests. Our end to end tests often fail due to factors outside of our control, and simply manually restarting the Travis build is enough to make them pass (example: https://github.com/woocommerce/woocommerce/pull/21150#issuecomment-415132390). This commit uses `travis_retry` to make Travis automatically retry a maximum of three times to run WC e2e tests in case of a failure, hopefully reducing the number of times we have to restart it ourselves manually.