### PR TITLE
Attempt to reduce noise in PRs generated by codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -21,6 +21,6 @@ parsers:
       macro: no
 
 comment:
-  layout: "reach, diff, flags, files, footer"
+  layout: "files"
   behavior: default
-  require_changes: no
+  require_changes: yes


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This commit is an attempt to reduce the noise in PRs generated by the code coverage comment posted automatically by Codecov. It changes Codecov configuration to post a comment to a PR only if it changes the code coverage and it also removes reach graph, the diff image and the flags from the comment content. Leaving only a list of the files impacted by the PR. My initial plan was to leave in the comment content only a link to the full report, but I couldn't find a way to do that in the documentation (https://docs.codecov.io/docs/pull-request-comments).

### How to test the changes in this Pull Request:

1. I'm not sure what is the best way to test this PR. I'm assuming Codecov won't post a comment here as there should be no code coverage change here. Since this is not critical, maybe the easiest way is to merge, monitor future PRs, and make any adjustments that might be necessary in another PR.