### PR TITLE
Added triggering of JS events on "recalculate" action on Edit Order page

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -641,6 +641,8 @@ jQuery( function ( $ ) {
 					items:    $( 'table.woocommerce_order_items :input[name], .wc-order-totals-items :input[name]' ).serialize(),
 					security: woocommerce_admin_meta_boxes.calc_totals_nonce
 				} );
+				
+				$( document.body ).trigger( 'order-totals-recalculate-before', data );
 
 				$.ajax({
 					url:  woocommerce_admin_meta_boxes.ajax_url,
@@ -651,6 +653,11 @@ jQuery( function ( $ ) {
 						$( '#woocommerce-order-items' ).find( '.inside' ).append( response );
 						wc_meta_boxes_order_items.reloaded_items();
 						wc_meta_boxes_order_items.unblock();
+
+						$( document.body ).trigger( 'order-totals-recalculate-success', response );
+					},
+					complete: function( response ) {
+						$( document.body ).trigger( 'order-totals-recalculate-complete', response );
 					}
 				});
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Added a few JS events before and after the order total recalculation, so that they can be intercepted by 3rd parties:
* `order-totals-recalculate-before`, before the Ajax request is fired.
* `order-totals-recalculate-success`, on the jQuery.ajax "success" event.
* `order-totals-recalculate-complete`, on the jQuery.ajax "complete" event.

Ref. https://github.com/woocommerce/woocommerce/issues/21181

### Changelog entry
Added a JavaScript events before and after the order total recalculation on the Edit Order page.
