### PR TITLE
Use entire sentence for checkout address_2 placeholder string

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -616,10 +616,10 @@ class WC_Countries {
 	 * @return array
 	 */
 	public function get_default_address_fields() {
-		$address_2_placeholder = __( 'Apartment, suite, unit etc.', 'woocommerce' );
-
 		if ( 'optional' === get_option( 'woocommerce_checkout_address_2_field', 'optional' ) ) {
-			$address_2_placeholder .= ' (' . __( 'optional', 'woocommerce' ) . ')';
+			$address_2_placeholder = __( 'Apartment, suite, unit etc. (optional)', 'woocommerce' );
+		} else {
+			$address_2_placeholder = __( 'Apartment, suite, unit etc.', 'woocommerce' );
 		}
 
 		$fields = array(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The placeholder string that is displayed in the address_2 field in the checkout was changed in #20639 to hide the "(optional)" part when the field is mandatory. The problem is that this was done splitting the sentence in two parts which goes against i18n best practices (https://developer.wordpress.org/themes/functionality/internationalization/#best-practices-for-writing-strings) as the order of the words can be different depending on the language. This commit creates two full sentences one with the "(optional)" part and another one without it to better support the translation of both strings.

### How to test the changes in this Pull Request:

1. Go to the checkout page
2. Check the string displaying in the address_2 field. Test it both with the option `woocommerce_checkout_address_2_field` set to `optional` and `required`.

### Changelog entry

Fix i18n: Use entire sentence for checkout address_2 placeholder string
