### PR TITLE
Updated phone validation and formatting rules.

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -699,8 +699,6 @@ class WC_Checkout {
 				}
 
 				if ( in_array( 'phone', $format, true ) ) {
-					$data[ $key ] = wc_format_phone_number( $data[ $key ] );
-
 					if ( $validate_fieldset && '' !== $data[ $key ] && ! WC_Validation::is_phone( $data[ $key ] ) ) {
 						/* translators: %s: phone number */
 						$errors->add( 'validation', sprintf( __( '%s is not a valid phone number.', 'woocommerce' ), '<strong>' . esc_html( $field_label ) . '</strong>' ) );

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -130,8 +130,6 @@ class WC_Form_Handler {
 								}
 								break;
 							case 'phone' :
-								$_POST[ $key ] = wc_format_phone_number( $_POST[ $key ] );
-
 								if ( ! WC_Validation::is_phone( $_POST[ $key ] ) ) {
 									wc_add_notice( sprintf( __( '%s is not a valid phone number.', 'woocommerce' ), '<strong>' . $field['label'] . '</strong>' ), 'error' );
 								}

--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -30,7 +30,7 @@ class WC_Validation {
 	 * @return bool
 	 */
 	public static function is_phone( $phone ) {
-		if ( 0 < strlen( trim( preg_replace( '/[\s\#0-9_\-\+\/\(\)]/', '', $phone ) ) ) ) {
+		if ( 0 < strlen( trim( preg_replace( '/[\s\#0-9_\-\+\/\(\)\.]/', '', $phone ) ) ) ) {
 			return false;
 		}
 

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -941,6 +941,9 @@ function wc_normalize_postcode( $postcode ) {
  * @return string
  */
 function wc_format_phone_number( $phone ) {
+	if ( ! WC_Validation::is_phone( $phone ) ) {
+		return '';
+	}
 	return preg_replace( '/[^0-9\+\-\s]/', '-', preg_replace( '/[\x00-\x1F\x7F-\xFF]/', '', $phone ) );
 }
 

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -761,8 +761,9 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_format_phone_number() {
 		$this->assertEquals( '1-610-385-0000', wc_format_phone_number( '1.610.385.0000' ) );
-		$this->assertEquals( '+47 0000 00003', wc_format_phone_number( '‭+47 0000 00003‬' ) ); // This number contains non-visible unicode chars at the beginning and end of string, should remove all those.
+		$this->assertEquals( '', wc_format_phone_number( '‭+47 0000 00003‬' ) ); // This number contains non-visible unicode chars at the beginning and end of string, should remove all those.
 		$this->assertEquals( '27 00 00 0000', wc_format_phone_number( '27 00 00 0000' ) );
+		$this->assertEquals( '', wc_format_phone_number( '1-800-not a phone number' ) );
 	}
 
 	/**

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -761,7 +761,8 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_format_phone_number() {
 		$this->assertEquals( '1-610-385-0000', wc_format_phone_number( '1.610.385.0000' ) );
-		$this->assertEquals( '', wc_format_phone_number( '‭+47 0000 00003‬' ) ); // This number contains non-visible unicode chars at the beginning and end of string, should remove all those.
+		// This number contains non-visible unicode chars at the beginning and end of string, which makes it invalid phone number.
+		$this->assertEquals( '', wc_format_phone_number( '‭+47 0000 00003‬' ) );
 		$this->assertEquals( '27 00 00 0000', wc_format_phone_number( '27 00 00 0000' ) );
 		$this->assertEquals( '', wc_format_phone_number( '1-800-not a phone number' ) );
 	}

--- a/tests/unit-tests/util/validation.php
+++ b/tests/unit-tests/util/validation.php
@@ -27,7 +27,7 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 			array( true, WC_Validation::is_phone( '+00 000 00 00 000' ) ),
 			array( true, WC_Validation::is_phone( '+00-000-00-00-000' ) ),
 			array( true, WC_Validation::is_phone( '(000) 00 00 000' ) ),
-			array( false, WC_Validation::is_phone( '+00.000.00.00.000' ) ),
+			array( true, WC_Validation::is_phone( '+00.000.00.00.000' ) ),
 			array( false, WC_Validation::is_phone( '+00 aaa dd ee fff' ) ),
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21156 .

I don't think it makes sense to format phone number before the validation. From my point of view, formatting function should be called on a valid phone number object/string, not used as normalization.

Therefore, I also think the formatting function should return an empty string if the phone number is not valid, as I don't think it makes sense how it behaves now in some cases, e.g.:
- `wc_format_phone_number( '123 abc ±±~~,.?' )` returns "123 --- -------"
- `wc_format_phone_number( '1-800-FLOWERS' )` returns "1-800--------"

Additionally, `.` is a valid character in phone numbers, e.g. according to [this Wikipedia page](https://en.wikipedia.org/wiki/National_conventions_for_writing_telephone_numbers#Belgium), so I updated the validation function.

### How to test the changes in this Pull Request:

1. Try to checkout using phone number 'this is a valid phone number', that is allowed in master.
2. After saving, this becomes '---- -- - ----- ----- -------'.
3. Apply branch, this should no longer be allowed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Updated phone validation logic.
