### PR TITLE
Only suppress comments number on unsupported theme shop page

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -212,7 +212,7 @@ class WC_Template_Loader {
 	private static function unsupported_theme_shop_page_init() {
 		add_filter( 'the_content', array( __CLASS__, 'unsupported_theme_shop_content_filter' ), 10 );
 		add_filter( 'the_title', array( __CLASS__, 'unsupported_theme_title_filter' ), 10, 2 );
-		add_filter( 'comments_number', '__return_empty_string' );
+		add_filter( 'comments_number', array( __CLASS__, 'unsupported_theme_comments_number_filter' ) );
 	}
 
 	/**
@@ -499,6 +499,21 @@ class WC_Template_Loader {
 		self::$in_content_filter = false;
 
 		return $content;
+	}
+
+	/**
+	 * Suppress the comments number on the Shop page for unsupported themes since there is no commenting on the Shop page.
+	 *
+	 * @since 3.4.5
+	 * @param string $comments_number The comments number text.
+	 * @return string
+	 */
+	public static function unsupported_theme_comments_number_filter( $comments_number ) {
+		if ( is_page( self::$shop_page_id ) ) {
+			return '';
+		}
+
+		return $comments_number;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21161 .

### How to test the changes in this Pull Request:

1. Add the following code somewhere after the opening `<body>` tag on an unsupported theme (e.g. Bassist theme):
```
<?php
if ( comments_open() ) {
	echo "THERE SHOULD BE A LINK HERE: ";
	comments_popup_link( 'Leave a Comment' );
}
?>
```
2. Go to a regular Post (e.g. "Hello World"). Before this patch the link will not display. After this patch the link will display.
3. Go to the Shop page and verify there is no link.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Only suppress comments number on unsupported theme shop page
