### PR TITLE
Restrict category creation in importer to appropriate permissions

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -364,6 +364,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 
 				if ( is_array( $term ) ) {
 					$term_id = $term['term_id'];
+					// Don't allow users without capabilities to create new categories.
+				} elseif ( ! current_user_can( 'manage_product_terms' ) ) {
+					break;
 				} else {
 					$term = wp_insert_term( $_term, 'product_cat', array( 'parent' => intval( $parent ) ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20979 .

### How to test the changes in this Pull Request:

1. Create a user with the Editor role. Add product and import permissions to the Editor role using a plugin like Capability Manager Enhanced. Make sure the role does not have the ability to manage product categories.
2. Create a CSV with a mix of existing/nonexisting categories (easiest way is to change some of the category names in the sample products CSV).
3. Import the CSV. Observe imported products are assigned to existing categories when possible and  have the "Uncategorized" category for nonexistent categories.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Don't allow users without manage_product_terms permissions to create categories using the product importer.
