### PR TITLE
Add hidden, screen-reader label on address line 2 input on checkout

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -662,6 +662,8 @@ class WC_Countries {
 				'priority'     => 50,
 			),
 			'address_2'  => array(
+				'label'        => __( 'Apartment, suite, or unit.', 'woocommerce' ),
+				'label_class'  => 'screen-reader-text',
 				'placeholder'  => esc_attr( $address_2_placeholder ),
 				'class'        => array( 'form-row-wide', 'address-field' ),
 				'autocomplete' => 'address-line2',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21182 .

### How to test the changes in this Pull Request:

1. Before applying patch, run aXe on the Checkout page and observe the following:
<img width="391" alt="screen shot 2018-08-24 at 11 58 33 am" src="https://user-images.githubusercontent.com/7317227/44602724-4ab2d600-a795-11e8-80cb-5810f7a2a560.png">

2. Apply patch, run aXe again and observe the error is not present. You can also inspect the label using dev tools to verify it exists.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Added hidden label for screen readers on checkout address line 2 input.
