### PR TITLE
Remove icanhazip service from ip lookup

### DIFF
--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -44,7 +44,6 @@ class WC_Geolocation {
 	 * @var array
 	 */
 	private static $ip_lookup_apis = array(
-		'icanhazip'         => 'http://icanhazip.com',
 		'ipify'             => 'http://api.ipify.org/',
 		'ipecho'            => 'http://ipecho.net/plain',
 		'ident'             => 'http://ident.me',


### PR DESCRIPTION
… blocked by most servers.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR removes the icanhazip service from the list of available IP lookup services offered. See #21195 for details .
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21195 

### How to test the changes in this Pull Request:

1. Make sure WooCommerce does not make use of the icanhazip lookup service when visiting a page with geolocation enabled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Remove icanhazip from geolocation services.
