### PR TITLE
Enable PDT handling for custom pending payment statuses

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-pdt-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-pdt-handler.php
@@ -93,7 +93,7 @@ class WC_Gateway_Paypal_PDT_Handler extends WC_Gateway_Paypal_Response {
 		$transaction = wc_clean( wp_unslash( $_REQUEST['tx'] ) ); // WPCS: input var ok, CSRF ok, sanitization ok.
 		$order       = $this->get_paypal_order( $order_id );
 
-		if ( ! $order || ! $order->has_status( 'pending' ) ) {
+		if ( ! $order || ! $order->needs_payment() ) {
 			return false;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Enable PDT for custom order statuses added through WooCommerce extensions.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21199  .

### How to test the changes in this Pull Request:

1. Install a WooCommerce extension that adds a custom pending payment status (i.e. WooCommerce Deposits with **Pending Deposit Payment**),
2. Set up PDT and save the Identity token in PayPal settings,
3. Create an order manually and set the custom pending status on it (in this case, **Pending Deposit Payment**),
4. Pay for the order using PayPal and observe the PDT is processed correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
Enable PDT for custom pending payment statuses added through WooCommerce extensions.
> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
