### PR TITLE
Reduce WC_Tests_Paypal_Gateway_Request::test_request_url() execution time

### DIFF
--- a/tests/framework/helpers/class-wc-helper-product.php
+++ b/tests/framework/helpers/class-wc-helper-product.php
@@ -25,11 +25,12 @@ class WC_Helper_Product {
 	 * @since 2.3
 	 * @return WC_Product_Simple
 	 */
-	public static function create_simple_product() {
+	public static function create_simple_product( $save = true ) {
 		$product = new WC_Product_Simple();
 		$product->set_props( array(
 			'name'          => 'Dummy Product',
 			'regular_price' => 10,
+			'price'         => 10,
 			'sku'           => 'DUMMY SKU',
 			'manage_stock'  => false,
 			'tax_status'    => 'taxable',
@@ -38,9 +39,13 @@ class WC_Helper_Product {
 			'stock_status'  => 'instock',
 			'weight'        => '1.1',
 		) );
-		$product->save();
 
-		return wc_get_product( $product->get_id() );
+		if ( $save ) {
+			$product->save();
+			return wc_get_product( $product->get_id() );
+		} else {
+			return $product;
+		}
 	}
 
 	/**

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -28,7 +28,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	protected function create_products( $product_count = 30 ) {
 		$this->products = array();
 		for ( $i = 0; $i < $product_count; $i++ ) {
-			$product = WC_Helper_Product::create_simple_product();
+			$product = WC_Helper_Product::create_simple_product( false );
 			$product->set_name( 'Dummy Product ' . $i );
 			$this->products[] = $product;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR reduces the execution time of the test WC_Tests_Paypal_Gateway_Request::test_request_url() from about 30s to about 6s (which is still super slow and even after this change this test is still the slowest in our test suite). This test creates several products that are needed to test different scenarios. To make it run faster, the code was changed to create the WC_Product objects without saving them to the database. Just interacting with the objects is enough to this test and skipping the database makes it run much faster. Other tests might benefit from the same technique.

### How to test the changes in this Pull Request:

1. Make sure all tests are still passing