### PR TITLE
OBW: Change Stripe + PayPal account provisioning to be enabled by default.

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -960,8 +960,12 @@ h3.jetpack-reasons {
 		display: block;
 	}
 	
-	.plugin-install-info-list-item:not(:last-child)::after {
+	.plugin-install-info-list-item::after {
 		content: ', ';
+	}
+
+	.plugin-install-info-list-item:last-of-type::after {
+		content: '. ';
 	}
 
 	a {

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -193,12 +193,14 @@ jQuery( function( $ ) {
 
 	function updatePluginInfo() {
 		var pluginLinkBySlug = {};
+		var extraPlugins = [];
 
 		$( '.wc-wizard-service-enable input:checked' ).each( function() {
 			addPlugins( pluginLinkBySlug, $( this ), '.wc-wizard-service-item' );
 
 			var $container = $( this ).closest( '.wc-wizard-service-item' );
 			$container.find( 'input.payment-checkbox-input:checked' ).each( function() {
+				extraPlugins.push( $( this ).attr( 'id' ) );
 				addPlugins( pluginLinkBySlug, $( this ), '.wc-wizard-service-settings' );
 			} );
 			$container.find( '.wc-wizard-shipping-method-select .method' ).each( function() {
@@ -214,9 +216,22 @@ jQuery( function( $ ) {
 		} );
 
 		var $list = $( 'span.plugin-install-info-list' ).empty();
+
 		for ( var slug in pluginLinkBySlug ) {
 			$list.append( pluginLinkBySlug[ slug ] );
 		}
+
+		if (
+			extraPlugins &&
+			wc_setup_params.current_step &&
+			wc_setup_params.i18n.extra_plugins[ wc_setup_params.current_step ] &&
+			wc_setup_params.i18n.extra_plugins[ wc_setup_params.current_step ][ extraPlugins.join( ',' ) ]
+		) {
+			$list.append(
+				wc_setup_params.i18n.extra_plugins[ wc_setup_params.current_step ][ extraPlugins.join( ',' ) ]
+			);
+		}
+
 		$( 'span.plugin-install-info' ).toggle( $list.children().length > 0 );
 	}
 

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1273,9 +1273,10 @@ class WC_Admin_Setup_Wizard {
 				'repo-slug'   => 'woocommerce-gateway-stripe',
 				'settings'    => array(
 					'create_account' => array(
-						'label'       => __( 'Create a new Stripe account for me', 'woocommerce' ),
+						'label'       => __( 'Set up Stripe for me using this email:', 'woocommerce' ),
 						'type'        => 'checkbox',
 						'value'       => 'yes',
+						'default'     => 'yes',
 						'placeholder' => '',
 						'required'    => false,
 						'plugins'     => $this->get_wcs_requisite_plugins(),
@@ -1285,7 +1286,6 @@ class WC_Admin_Setup_Wizard {
 						'type'        => 'email',
 						'value'       => $user_email,
 						'placeholder' => __( 'Stripe email address', 'woocommerce' ),
-						'description' => __( "Enter your email address and we'll handle account creation. Powered by WooCommerce Services and Jetpack.", 'woocommerce' ),
 						'required'    => true,
 					),
 				),
@@ -1299,9 +1299,10 @@ class WC_Admin_Setup_Wizard {
 				'repo-slug'   => 'woocommerce-gateway-paypal-express-checkout',
 				'settings'    => array(
 					'reroute_requests' => array(
-						'label'       => __( 'Accept payments without linking a PayPal account', 'woocommerce' ),
+						'label'       => __( 'Set up PayPal for me using this email:', 'woocommerce' ),
 						'type'        => 'checkbox',
 						'value'       => 'yes',
+						'default'     => 'yes',
 						'placeholder' => '',
 						'required'    => false,
 						'plugins'     => $this->get_wcs_requisite_plugins(),
@@ -1311,7 +1312,6 @@ class WC_Admin_Setup_Wizard {
 						'type'        => 'email',
 						'value'       => $user_email,
 						'placeholder' => __( 'Email address to receive payments', 'woocommerce' ),
-						'description' => __( "Enter your email address and we'll authenticate payments for you. Powered by WooCommerce Services and Jetpack.", 'woocommerce' ),
 						'required'    => true,
 					),
 				),
@@ -1532,6 +1532,8 @@ class WC_Admin_Setup_Wizard {
 								$checked = false;
 								if ( isset( $previously_saved_settings[ $setting_id ] ) ) {
 									$checked = 'yes' === $previously_saved_settings[ $setting_id ];
+								} elseif ( false === $previously_saved_settings && isset( $setting['default'] ) ) {
+									$checked = 'yes' === $setting['default'];
 								}
 							}
 							if ( 'email' === $setting['type'] ) {

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -237,6 +237,16 @@ class WC_Admin_Setup_Wizard {
 			array(
 				'pending_jetpack_install' => $pending_jetpack ? 'yes' : 'no',
 				'states'                  => WC()->countries->get_states(),
+				'current_step'            => isset( $this->steps[ $this->step ] ) ? $this->step : false,
+				'i18n'                    => array(
+					'extra_plugins' => array(
+						'payment' => array(
+							'stripe_create_account'                              => __( 'Stripe setup is powered by Jetpack and WooCommerce Services.', 'woocommerce' ),
+							'ppec_paypal_reroute_requests'                       => __( 'PayPal setup is powered by Jetpack and WooCommerce Services.', 'woocommerce' ),
+							'stripe_create_account,ppec_paypal_reroute_requests' => __( 'Stripe and PayPal setup are powered by Jetpack and WooCommerce Services.', 'woocommerce' ),
+						),
+					),
+				),
 			)
 		);
 


### PR DESCRIPTION
Change automatic Stripe and PayPal gateway setup to be enabled by default in the OBW:

![screen shot 2018-08-29 at 5 23 49 pm](https://user-images.githubusercontent.com/63922/44821127-2e59d380-abb1-11e8-949f-e7b63b7b7178.png)

This PR:
* Makes a small tweak to the checkbox labels for gateway setup
* Adds a period after the last item in the "to be installed" list
* Moves the Jetpack + WooCommerce Services requirement description to the "to be installed" area

_See p7bbVw-2HG-p2 for full discussion._