### PR TITLE
Download path type & unit tests

### DIFF
--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -52,7 +52,7 @@ class WC_Product_Download implements ArrayAccess {
 	 */
 	public function get_type_of_file_path( $file_path = '' ) {
 		$file_path = $file_path ? $file_path : $this->get_file();
-		if ( 0 === strpos( $file_path, 'http' ) || 0 === strpos( $file_path, '//' ) ) {
+		if ( 0 === strpos( $file_path, 'http' ) || ( 0 === strpos( $file_path, '//' ) && ! file_exists( $file_path ) ) ) {
 			return 'absolute';
 		} elseif ( '[' === substr( $file_path, 0, 1 ) && ']' === substr( $file_path, -1 ) ) {
 			return 'shortcode';

--- a/tests/unit-tests/product/class-wc-tests-product-download.php
+++ b/tests/unit-tests/product/class-wc-tests-product-download.php
@@ -1,0 +1,76 @@
+<?php
+
+class WC_Tests_Product_Download extends WC_Unit_Test_Case {
+
+	/**
+	 * Test get_allowed_mime_types
+	 *
+	 * @return void
+	 */
+	public function test_get_allowed_mime_types() {
+		$download = new WC_Product_Download();
+		$this->assertEquals( $download->get_allowed_mime_types(), get_allowed_mime_types() );
+	}
+
+	/**
+	 * Test download filepath types
+	 *
+	 * @return void
+	 */
+	public function test_get_type_of_file_path() {
+		$download = new WC_Product_Download();
+		$download->set_file( 'http//example.com/file.png' );
+
+		// Check that url paths are supported and return absolute
+		$this->assertEquals( 'absolute', $download->get_type_of_file_path() );
+
+		// Check that current server paths are not resolveable to absolute
+		$download->set_file( get_home_path() );
+		$this->assertNotEquals( 'absolute', $download->get_type_of_file_path() );
+
+		// Check that shortcodes are supported as a type
+		$download->set_file( '[s3 bucket="" file=""]' );
+		$this->assertEquals( 'shortcode', $download->get_type_of_file_path() );
+
+		// Test relative path
+		$download->set_file( get_home_path() . 'wp-config.php' );
+		$this->assertEquals( 'relative', $download->get_type_of_file_path() );
+	}
+
+	/**
+	 * Test get_file_type
+	 *
+	 * @return void
+	 */
+	public function test_get_file_type() {
+		$download = new WC_Product_Download();
+		$download->set_file( plugins_url( 'assets/images/help.png', WC_PLUGIN_FILE ) );
+		$this->assertEquals( 'image/png', $download->get_file_type() );
+	}
+
+	/**
+	 * Test get_file_extension
+	 *
+	 * @return void
+	 */
+	public function test_get_file_extension() {
+		$download = new WC_Product_Download();
+		$download->set_file( plugins_url( 'assets/images/help.png', WC_PLUGIN_FILE ) );
+		$this->assertEquals( 'png', $download->get_file_extension() );
+	}
+
+	/**
+	 * Test is_allowed_filetype
+	 *
+	 * @return void
+	 */
+	public function test_is_allowed_filetype() {
+		$download = new WC_Product_Download();
+		$download->set_file( plugins_url( 'assets/images/help.png', WC_PLUGIN_FILE ) );
+		$this->assertTrue( $download->is_allowed_filetype() );
+
+		// Check for non allowed filetype
+		$download->set_file( get_home_path() . 'wp-config.php' );
+		$this->assertFalse( $download->is_allowed_filetype() );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR tweaks the download path type method to ensure it does not return server files as absolute types. It also introduces unit tests for the WC_Product_Download class.

### How to test the changes in this Pull Request:

1. Make sure tests pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
