### PR TITLE
OBW: Avoid Payment form breaking due to email validation on hidden field

### DIFF
--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -162,6 +162,7 @@ jQuery( function( $ ) {
 		if ( $( this ).is( ':checked' ) ) {
 			$( this ).closest( '.wc-wizard-service-settings' )
 				.find( 'input.payment-email-input' )
+				.attr( 'type', 'email' )
 				.prop( 'required', true );
 			$( this ).closest( '.wc-wizard-service-settings' )
 				.find( '.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_email' )
@@ -169,6 +170,7 @@ jQuery( function( $ ) {
 		} else {
 			$( this ).closest( '.wc-wizard-service-settings' )
 				.find( 'input.payment-email-input' )
+				.attr( 'type', null )
 				.prop( 'required', false );
 			$( this ).closest( '.wc-wizard-service-settings' )
 				.find( '.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_email' )


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Currently in the onboarding wizard on the Payment step's Stripe or PayPal options, if you enter a partial (or otherwise invalid) email address and subsequently uncheck the checkbox, the "Continue" button will do nothing except throw an error in the console. The same would happen if the default email address was somehow invalid.

![email-validation-on-hidden-field](https://user-images.githubusercontent.com/1867547/44922183-aab7f800-ad12-11e8-9144-1b7700d48f52.gif)

The exact behavior may be inconsistent among browsers – I tested in Chrome (68) only.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This change enhances existing logic toggling `required` state of these fields, by also toggling "email" `type`.