### PR TITLE
Fix/variable product cache miss

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -504,7 +504,7 @@ class WC_Product_Variable extends WC_Product {
 
 		if ( false === $has_weight ) {
 			$has_weight = $this->data_store->child_has_weight( $this );
-			set_transient( $transient_name, ( int ) $has_weight, DAY_IN_SECONDS * 30 );
+			set_transient( $transient_name, (int) $has_weight, DAY_IN_SECONDS * 30 );
 		}
 
 		return (bool) $has_weight;
@@ -521,7 +521,7 @@ class WC_Product_Variable extends WC_Product {
 
 		if ( false === $has_dimension ) {
 			$has_dimension = $this->data_store->child_has_dimensions( $this );
-			set_transient( $transient_name, ( int ) $has_dimension, DAY_IN_SECONDS * 30 );
+			set_transient( $transient_name, (int) $has_dimension, DAY_IN_SECONDS * 30 );
 		}
 
 		return (bool) $has_dimension;

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -504,7 +504,7 @@ class WC_Product_Variable extends WC_Product {
 
 		if ( false === $has_weight ) {
 			$has_weight = $this->data_store->child_has_weight( $this );
-			set_transient( $transient_name, $has_weight, DAY_IN_SECONDS * 30 );
+			set_transient( $transient_name, (int) $has_weight, DAY_IN_SECONDS * 30 );
 		}
 
 		return (bool) $has_weight;
@@ -521,7 +521,7 @@ class WC_Product_Variable extends WC_Product {
 
 		if ( false === $has_dimension ) {
 			$has_dimension = $this->data_store->child_has_dimensions( $this );
-			set_transient( $transient_name, $has_dimension, DAY_IN_SECONDS * 30 );
+			set_transient( $transient_name, (int) $has_dimension, DAY_IN_SECONDS * 30 );
 		}
 
 		return (bool) $has_dimension;

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -504,7 +504,7 @@ class WC_Product_Variable extends WC_Product {
 
 		if ( false === $has_weight ) {
 			$has_weight = $this->data_store->child_has_weight( $this );
-			set_transient( $transient_name, (int) $has_weight, DAY_IN_SECONDS * 30 );
+			set_transient( $transient_name, ( int ) $has_weight, DAY_IN_SECONDS * 30 );
 		}
 
 		return (bool) $has_weight;
@@ -521,7 +521,7 @@ class WC_Product_Variable extends WC_Product {
 
 		if ( false === $has_dimension ) {
 			$has_dimension = $this->data_store->child_has_dimensions( $this );
-			set_transient( $transient_name, (int) $has_dimension, DAY_IN_SECONDS * 30 );
+			set_transient( $transient_name, ( int ) $has_dimension, DAY_IN_SECONDS * 30 );
 		}
 
 		return (bool) $has_dimension;


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

A variable product that has no weight or dimensions in it's childs is not storing that calculation correctly, it makes those 2 queries every time that product page is visited.


### How to test the changes in this Pull Request:

1. Load any variable product page which has childs without any dimensions nor weight
2. Check 2 less queries is being done
3.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?


### Changelog entry

> Fix weight and dimensions cache of variable products if childs doesn't have any of those params
