### PR TITLE
Change wp_woocommerce_sessions primary key

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -115,6 +115,7 @@ class WC_Install {
 		),
 		'3.5.0' => array(
 			'wc_update_350_order_customer_id',
+			'wc_update_350_change_woocommerce_sessions_schema',
 			'wc_update_350_db_version',
 		),
 	);
@@ -627,8 +628,8 @@ CREATE TABLE {$wpdb->prefix}woocommerce_sessions (
   session_key char(32) NOT NULL,
   session_value longtext NOT NULL,
   session_expiry BIGINT UNSIGNED NOT NULL,
-  PRIMARY KEY  (session_key),
-  UNIQUE KEY session_id (session_id)
+  PRIMARY KEY  (session_id),
+  UNIQUE KEY session_key (session_key)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_api_keys (
   key_id BIGINT UNSIGNED NOT NULL auto_increment,

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1976,6 +1976,24 @@ function wc_update_350_order_customer_id( $updater = false ) {
 }
 
 /**
+ * Change wp_woocommerce_sessions schema to use a bigint auto increment field
+ * instead of char(32) field as the primary key. Doing this change primarily as
+ * it should reduce the occurrence of deadlocks (see
+ * https://github.com/woocommerce/woocommerce/issues/20912), but also because
+ * it is not a good practice to use a char(32) field as the primary key of a
+ * table.
+ *
+ * @return void
+ */
+function wc_update_350_change_woocommerce_sessions_schema() {
+	global $wpdb;
+
+	$wpdb->query(
+		"ALTER TABLE `{$wpdb->prefix}woocommerce_sessions` DROP PRIMARY KEY, DROP KEY `session_id`, ADD PRIMARY KEY(`session_id`), ADD UNIQUE KEY(`session_key`)"
+	);
+}
+
+/**
  * Update DB Version.
  */
 function wc_update_350_db_version() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes wp_woocommerce_sessions primary key to the bigint field session_id. Before it was the char(32) field session_key. Doing this change primarily as it should reduce the occurrence of deadlocks, but also because it is not a good practice to use a char(32) field as the primary key of a table.

Refs #20912

### How to test the changes in this Pull Request:

1. Make sure the table wp_woocommerce_sessions is correctly created when installing WooCommerce and correctly updated when updating WooCommerce
2. Although this PR doesn't change any fields in the wp_woocommerce_sessions table (just keys), it is a good idea to check that the core session functionality is still working. Check that a new entry in the table is added when items are added to the cart for example.

### Changelog entry

> Change wp_woocommerce_sessions primary key to session_id
