### PR TITLE
Add/template form action hooks

### DIFF
--- a/templates/myaccount/form-edit-account.php
+++ b/templates/myaccount/form-edit-account.php
@@ -12,14 +12,14 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.4.0
+ * @version 3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 do_action( 'woocommerce_before_edit_account_form' ); ?>
 
-<form class="woocommerce-EditAccountForm edit-account" action="" method="post"<?php do_action( 'woocommerce_edit_account_form_tag' ); ?>>
+<form class="woocommerce-EditAccountForm edit-account" action="" method="post" <?php do_action( 'woocommerce_edit_account_form_tag' ); ?> >
 
 	<?php do_action( 'woocommerce_edit_account_form_start' ); ?>
 

--- a/templates/myaccount/form-edit-account.php
+++ b/templates/myaccount/form-edit-account.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 
 do_action( 'woocommerce_before_edit_account_form' ); ?>
 
-<form class="woocommerce-EditAccountForm edit-account" action="" method="post">
+<form class="woocommerce-EditAccountForm edit-account" action="" method="post"<?php do_action( 'woocommerce_edit_account_form_tag' ); ?>>
 
 	<?php do_action( 'woocommerce_edit_account_form_start' ); ?>
 

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -69,7 +69,7 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 
 		<h2><?php esc_html_e( 'Register', 'woocommerce' ); ?></h2>
 
-		<form method="post" class="woocommerce-form woocommerce-form-register register">
+		<form method="post" class="woocommerce-form woocommerce-form-register register"<?php do_action( 'woocommerce_register_form_tag' ); ?>>
 
 			<?php do_action( 'woocommerce_register_form_start' ); ?>
 

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.4.0
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -69,7 +69,7 @@ do_action( 'woocommerce_before_customer_login_form' ); ?>
 
 		<h2><?php esc_html_e( 'Register', 'woocommerce' ); ?></h2>
 
-		<form method="post" class="woocommerce-form woocommerce-form-register register"<?php do_action( 'woocommerce_register_form_tag' ); ?>>
+		<form method="post" class="woocommerce-form woocommerce-form-register register" <?php do_action( 'woocommerce_register_form_tag' ); ?> >
 
 			<?php do_action( 'woocommerce_register_form_start' ); ?>
 


### PR DESCRIPTION
This PR is based on some issues I ran into when adding new form fields to a user's account and then accessing them via the WooCommerce edit account & registration forms.

When trying to add the option for a user to upload a file (example: medical verification documents), the form does not allow for image uploads.

Currently, you'd need to override the template file within your plugin/theme and add in `enctype="multipart/form-data"` to each form.

In WordPress Core, there is currently an action hook for the edit profile screen, `user_edit_form_tag` in `wp-admin/user-edit.php`.

This PR follows that logic and adds action hooks into the form tags for both the edit account and register forms.

`woocommerce_edit_account_form_tag`

`woocommerce_register_form_tag`

This way, developers can add the specific form tags needed without having to override the template itself.

Example:

```
function make_form_accept_uploads() {
	echo ' enctype="multipart/form-data"';
}
add_action( 'woocommerce_edit_account_form_tag', 'make_form_accept_uploads' );```