### PR TITLE
Update wc-template-functions.php - small written error (&& not &!)

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -623,7 +623,7 @@ function wc_get_product_class( $class = '', $product_id = null ) {
 	if ( apply_filters( 'woocommerce_get_product_class_include_taxonomies', false ) ) {
 		$taxonomies = get_taxonomies( array( 'public' => true ) );
 		foreach ( (array) $taxonomies as $taxonomy ) {
-			if ( is_object_in_taxonomy( $post->post_type, $taxonomy ) && in_array( $taxonomy, array( 'product_cat', 'product_tag' ), true ) ) {
+			if ( is_object_in_taxonomy( $post->post_type, $taxonomy ) &! in_array( $taxonomy, array( 'product_cat', 'product_tag' ), true ) ) {
 				$classes = array_merge( $classes, wc_get_product_taxonomy_class( (array) get_the_terms( $post->ID, $taxonomy ), $taxonomy ) );
 			}
 		}


### PR DESCRIPTION
it's supposed to check if it isn't (&!) in the array of taxonomies that are stated on the following rows not if it is (&&)... before rows 623 to 630 did nothing..
one could argue that it should be possible to set the taxonomies in the array it checks "( 'product_cat', 'product_tag' )" in the filter but i haven't thought that through
