### PR TITLE
REST API] Make product's created date editable

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -161,14 +161,32 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	}
 
 	/**
-	 * Add new options for 'orderby' to the collection params.
+	 * Prepare a single product for create or update.
 	 *
-	 * @return array
+	 * @param  WP_REST_Request $request Request object.
+	 * @param  bool            $creating If is creating a new object.
+	 * @return WP_Error|WC_Data
 	 */
-	public function get_collection_params() {
-		$params                    = parent::get_collection_params();
-		$params['orderby']['enum'] = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating' ) );
-		return $params;
+	protected function prepare_object_for_database( $request, $creating = false ) {
+		$product = parent::prepare_object_for_database( $request, $creating );
+
+		if ( ! empty( $request['date_created'] ) ) {
+			$date = rest_parse_date( $request['date_created'] );
+
+			if ( $date ) {
+				$product->set_date_created( $date );
+			}
+		}
+
+		if ( ! empty( $request['date_created_gmt'] ) ) {
+			$date = rest_parse_date( $request['date_created_gmt'], true );
+
+			if ( $date ) {
+				$product->set_date_created_gmt( $date );
+			}
+		}
+
+		return $product;
 	}
 
 	/**
@@ -211,13 +229,11 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 					'description' => __( "The date the product was created, in the site's timezone.", 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
 				),
 				'date_created_gmt'      => array(
 					'description' => __( 'The date the product was created, as GMT.', 'woocommerce' ),
 					'type'        => 'date-time',
 					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
 				),
 				'date_modified'         => array(
 					'description' => __( "The date the product was last modified, in the site's timezone.", 'woocommerce' ),
@@ -786,5 +802,16 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			),
 		);
 		return $this->add_additional_fields_schema( $schema );
+	}
+
+	/**
+	 * Add new options for 'orderby' to the collection params.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                    = parent::get_collection_params();
+		$params['orderby']['enum'] = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating' ) );
+		return $params;
 	}
 }

--- a/tests/unit-tests/api/products.php
+++ b/tests/unit-tests/api/products.php
@@ -6,7 +6,7 @@
  * @since 3.0.0
  */
 
-class Products_API extends WC_REST_Unit_Test_Case {
+class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 
 	/**
 	 * Setup our test server, endpoints, and user info.
@@ -28,9 +28,9 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
-		$this->assertArrayHasKey( '/wc/v2/products', $routes );
-		$this->assertArrayHasKey( '/wc/v2/products/(?P<id>[\d]+)', $routes );
-		$this->assertArrayHasKey( '/wc/v2/products/batch', $routes );
+		$this->assertArrayHasKey( '/wc/v3/products', $routes );
+		$this->assertArrayHasKey( '/wc/v3/products/(?P<id>[\d]+)', $routes );
+		$this->assertArrayHasKey( '/wc/v3/products/batch', $routes );
 	}
 
 	/**
@@ -43,7 +43,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		WC_Helper_Product::create_external_product();
 		sleep( 1 ); // So both products have different timestamps.
 		WC_Helper_Product::create_simple_product();
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products' ) );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products' ) );
 		$products = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -63,7 +63,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	public function test_get_products_without_permission() {
 		wp_set_current_user( 0 );
 		WC_Helper_Product::create_simple_product();
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products' ) );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products' ) );
 		$this->assertEquals( 401, $response->get_status() );
 	}
 
@@ -75,7 +75,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	public function test_get_product() {
 		wp_set_current_user( $this->user );
 		$simple   = WC_Helper_Product::create_external_product();
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $simple->get_id() ) );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $simple->get_id() ) );
 		$product  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -99,7 +99,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	public function test_get_product_without_permission() {
 		wp_set_current_user( 0 );
 		$product  = WC_Helper_Product::create_simple_product();
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() ) );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() ) );
 		$this->assertEquals( 401, $response->get_status() );
 	}
 
@@ -112,12 +112,12 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$product = WC_Helper_Product::create_simple_product();
 
-		$request = new WP_REST_Request( 'DELETE', '/wc/v2/products/' . $product->get_id() );
+		$request = new WP_REST_Request( 'DELETE', '/wc/v3/products/' . $product->get_id() );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 
-		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products' ) );
+		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products' ) );
 		$variations = $response->get_data();
 		$this->assertEquals( 0, count( $variations ) );
 	}
@@ -130,7 +130,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	public function test_delete_product_without_permission() {
 		wp_set_current_user( 0 );
 		$product = WC_Helper_Product::create_simple_product();
-		$request = new WP_REST_Request( 'DELETE', '/wc/v2/products/' . $product->get_id() );
+		$request = new WP_REST_Request( 'DELETE', '/wc/v3/products/' . $product->get_id() );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
@@ -143,7 +143,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_product_with_invalid_id() {
 		wp_set_current_user( 0 );
-		$request = new WP_REST_Request( 'DELETE', '/wc/v2/products/0' );
+		$request = new WP_REST_Request( 'DELETE', '/wc/v3/products/0' );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
@@ -158,21 +158,23 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		// test simple products
-		$product  = WC_Helper_Product::create_simple_product();
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() ) );
-		$data     = $response->get_data();
+		$product      = WC_Helper_Product::create_simple_product();
+		$response     = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() ) );
+		$data         = $response->get_data();
+		$date_created = date( 'Y-m-d\TH:i:s', current_time( 'timestamp' ) );
 
 		$this->assertEquals( 'DUMMY SKU', $data['sku'] );
 		$this->assertEquals( 10, $data['regular_price'] );
 		$this->assertEmpty( $data['sale_price'] );
 
-		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() );
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/products/' . $product->get_id() );
 		$request->set_body_params(
 			array(
-				'sku'         => 'FIXED-SKU',
-				'sale_price'  => '8',
-				'description' => 'Testing',
-				'images'      => array(
+				'sku'          => 'FIXED-SKU',
+				'sale_price'   => '8',
+				'description'  => 'Testing',
+				'date_created' => $date_created,
+				'images'       => array(
 					array(
 						'position' => 0,
 						'src'      => 'http://cldup.com/Dr1Bczxq4q.png',
@@ -189,18 +191,19 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( '8', $data['sale_price'] );
 		$this->assertEquals( '10', $data['regular_price'] );
 		$this->assertEquals( 'FIXED-SKU', $data['sku'] );
+		$this->assertEquals( $date_created, $data['date_created'] );
 		$this->assertContains( 'Dr1Bczxq4q', $data['images'][0]['src'] );
 		$this->assertContains( 'test upload image', $data['images'][0]['alt'] );
 		$product->delete( true );
 
 		// test variable product (variations are tested in product-variations.php)
 		$product  = WC_Helper_Product::create_variation_product();
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() ) );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() ) );
 		$data     = $response->get_data();
 
 		$this->assertEquals( array( 'large', 'small' ), $data['attributes'][0]['options'] );
 
-		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() );
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/products/' . $product->get_id() );
 		$request->set_body_params( array(
 			'attributes' => array(
 				array(
@@ -233,13 +236,13 @@ class Products_API extends WC_REST_Unit_Test_Case {
 
 		// test external product
 		$product  = WC_Helper_Product::create_external_product();
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() ) );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() ) );
 		$data     = $response->get_data();
 
 		$this->assertEquals( 'Buy external product', $data['button_text'] );
 		$this->assertEquals( 'http://woocommerce.com', $data['external_url'] );
 
-		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() );
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/products/' . $product->get_id() );
 		$request->set_body_params(
 			array(
 				'button_text'  => 'Test API Update',
@@ -261,7 +264,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	public function test_update_product_without_permission() {
 		wp_set_current_user( 0 );
 		$product = WC_Helper_Product::create_simple_product();
-		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/' . $product->get_id() );
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/products/' . $product->get_id() );
 		$request->set_body_params(
 			array(
 				'sku' => 'FIXED-SKU-NO-PERMISSION',
@@ -279,7 +282,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	public function test_update_product_with_invalid_id() {
 		wp_set_current_user( $this->user );
 		$product = WC_Helper_Product::create_simple_product();
-		$request = new WP_REST_Request( 'PUT', '/wc/v2/products/0' );
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/products/0' );
 		$request->set_body_params(
 			array(
 				'sku' => 'FIXED-SKU-INVALID-ID',
@@ -297,7 +300,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	public function test_create_product() {
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'POST', '/wc/v2/products/shipping_classes' );
+		$request = new WP_REST_Request( 'POST', '/wc/v3/products/shipping_classes' );
 		$request->set_body_params(
 			array(
 				'name' => 'Test',
@@ -308,7 +311,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$shipping_class_id = $data['id'];
 
 		// Create simple
-		$request = new WP_REST_Request( 'POST', '/wc/v2/products' );
+		$request = new WP_REST_Request( 'POST', '/wc/v3/products' );
 		$request->set_body_params(
 			array(
 				'type'           => 'simple',
@@ -330,7 +333,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $shipping_class_id, $data['shipping_class_id'] );
 
 		// Create external
-		$request = new WP_REST_Request( 'POST', '/wc/v2/products' );
+		$request = new WP_REST_Request( 'POST', '/wc/v3/products' );
 		$request->set_body_params(
 			array(
 				'type'          => 'external',
@@ -354,7 +357,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'https://wordpress.org', $data['external_url'] );
 
 		// Create variable
-		$request = new WP_REST_Request( 'POST', '/wc/v2/products' );
+		$request = new WP_REST_Request( 'POST', '/wc/v3/products' );
 		$request->set_body_params(
 			array(
 				'type'       => 'variable',
@@ -382,7 +385,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'variable', $data['type'] );
 		$this->assertEquals( array( 'small', 'medium' ), $data['attributes'][0]['options'] );
 
-		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products' ) );
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products' ) );
 		$products = $response->get_data();
 		$this->assertEquals( 3, count( $products ) );
 	}
@@ -395,7 +398,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	public function test_create_product_without_permission() {
 		wp_set_current_user( 0 );
 
-		$request = new WP_REST_Request( 'POST', '/wc/v2/products' );
+		$request = new WP_REST_Request( 'POST', '/wc/v3/products' );
 		$request->set_body_params(
 			array(
 				'name'          => 'Test Product',
@@ -413,7 +416,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$product   = WC_Helper_Product::create_simple_product();
 		$product_2 = WC_Helper_Product::create_simple_product();
-		$request   = new WP_REST_Request( 'POST', '/wc/v2/products/batch' );
+		$request   = new WP_REST_Request( 'POST', '/wc/v3/products/batch' );
 		$request->set_body_params(
 			array(
 				'update' => array(
@@ -453,7 +456,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'simple', $data['create'][1]['type'] );
 		$this->assertEquals( $product_2->get_id(), $data['delete'][0]['id'] );
 
-		$request  = new WP_REST_Request( 'GET', '/wc/v2/products' );
+		$request  = new WP_REST_Request( 'GET', '/wc/v3/products' );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -481,7 +484,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		}
 
 		// Test filtering with status=publish
-		$request = new WP_REST_Request( 'GET', '/wc/v2/products' );
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
 		$request->set_param( 'status', 'publish' );
 		$response = $this->server->dispatch( $request );
 		$products = $response->get_data();
@@ -492,7 +495,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		}
 
 		// Test filtering with status=draft
-		$request = new WP_REST_Request( 'GET', '/wc/v2/products' );
+		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
 		$request->set_param( 'status', 'draft' );
 		$response = $this->server->dispatch( $request );
 		$products = $response->get_data();
@@ -503,7 +506,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 		}
 
 		// Test filtering with no filters - which should return 'any' (all 8)
-		$request  = new WP_REST_Request( 'GET', '/wc/v2/products' );
+		$request  = new WP_REST_Request( 'GET', '/wc/v3/products' );
 		$response = $this->server->dispatch( $request );
 		$products = $response->get_data();
 
@@ -518,7 +521,7 @@ class Products_API extends WC_REST_Unit_Test_Case {
 	public function test_product_schema() {
 		wp_set_current_user( $this->user );
 		$product    = WC_Helper_Product::create_simple_product();
-		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v2/products/' . $product->get_id() );
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v3/products/' . $product->get_id() );
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21117.

### How to test the changes in this Pull Request:

1. PUT request into `wp-json/wc/v3/products/33` updating `date_created` or `date_created_gmt`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - REST API - Allow update product's `date_created` and `date_created_gmt`.
