### PR TITLE
Add action for when system tools are run

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -39,6 +39,22 @@ class WC_Admin_Status {
 
 			if ( array_key_exists( $action, $tools ) ) {
 				$response = $tools_controller->execute_tool( $action );
+
+				$tool = $tools[ $action ];
+				$tool = array(
+					'id'          => $action,
+					'name'        => $tool['name'],
+					'action'      => $tool['button'],
+					'description' => $tool['desc'],
+				);
+				$tool = array_merge( $tool, $response );
+
+				/**
+				 * Fires after a WooCommerce system status tool has been executed.
+				 *
+				 * @param array  $tool  Details about the tool that has been executed.
+				 */
+				do_action( 'woocommerce_system_status_tool_executed', $tool );
 			} else {
 				$response = array(
 					'success' => false,
@@ -51,22 +67,6 @@ class WC_Admin_Status {
 			} else {
 				echo '<div class="error inline"><p>' . esc_html( $response['message'] ) . '</p></div>';
 			}
-
-			$tool = $tools[ $action ];
-			$tool = array(
-				'id'          => $action,
-				'name'        => $tool['name'],
-				'action'      => $tool['button'],
-				'description' => $tool['desc'],
-			);
-			$tool = array_merge( $tool, $response );
-
-			/**
-			 * Fires after a WooCommerce system status tool has been executed.
-			 *
-			 * @param array  $tool  Details about the tool that has been executed.
-			 */
-			do_action( 'woocommerce_system_status_tool_executed', $tool );
 		}
 
 		// Display message if settings settings have been saved.

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -51,6 +51,22 @@ class WC_Admin_Status {
 			} else {
 				echo '<div class="error inline"><p>' . esc_html( $response['message'] ) . '</p></div>';
 			}
+
+			$tool = $tools[ $action ];
+			$tool = array(
+				'id'          => $action,
+				'name'        => $tool['name'],
+				'action'      => $tool['button'],
+				'description' => $tool['desc'],
+			);
+			$tool = array_merge( $tool, $response );
+
+			/**
+			 * Fires after a WooCommerce system status tool has been executed.
+			 *
+			 * @param array  $tool  Details about the tool that has been executed.
+			 */
+			do_action( 'woocommerce_system_status_tool_executed', $tool );
 		}
 
 		// Display message if settings settings have been saved.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds an action to tell when tools are run from WooCommerce > Status > Tools, just like what exists for if the tools are run [via the rest API](https://github.com/woocommerce/woocommerce/blob/master/includes/api/class-wc-rest-system-status-tools-controller.php#L259-L287). 

### How to test the changes in this Pull Request:

1. Tie into the action
2. Run a tool

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Add action for when system tools are run.