### PR TITLE
Improve performance of the query to delete version transients

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -181,7 +181,7 @@ class WC_Cache_Helper {
 				return;
 			}
 
-			$affected = $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s ORDER BY option_id LIMIT %d;", '\_transient\_%' . $version, $limit ) ); // WPCS: cache ok, db call ok.
+			$affected = $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->options} WHERE option_name LIKE %s LIMIT %d;", '\_transient\_%' . $version, $limit ) ); // WPCS: cache ok, db call ok.
 
 			// If affected rows is equal to limit, there are more rows to delete. Delete in 30 secs.
 			if ( $affected === $limit ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the `ORDER BY option_id` part of the query to remove the version transients from the `wp_options` table. This change should help users having performance issues with this query (see for example #21215) and, as far as I can see, ordering is not necessary in this context.

Removing the `ORDER BY` from the query means that MySQL won't have to use filesort:

```
MySQL [wccore]> explain DELETE FROM wp_options WHERE option_name LIKE '\\_transient\\_%1510258328' ORDER BY option_id LIMIT 1000;
+----+-------------+------------+------------+-------+---------------+-------------+---------+-------+------+----------+-----------------------------+
| id | select_type | table      | partitions | type  | possible_keys | key         | key_len | ref   | rows | filtered | Extra                       |
+----+-------------+------------+------------+-------+---------------+-------------+---------+-------+------+----------+-----------------------------+
|  1 | DELETE      | wp_options | NULL       | range | option_name   | option_name | 766     | const |   67 |   100.00 | Using where; Using filesort |
+----+-------------+------------+------------+-------+---------------+-------------+---------+-------+------+----------+-----------------------------+
1 row in set (0.02 sec)

MySQL [wccore]> explain DELETE FROM wp_options WHERE option_name LIKE '\\_transient\\_%1510258328' LIMIT 1000;
+----+-------------+------------+------------+-------+---------------+-------------+---------+-------+------+----------+-------------+
| id | select_type | table      | partitions | type  | possible_keys | key         | key_len | ref   | rows | filtered | Extra       |
+----+-------------+------------+------------+-------+---------------+-------------+---------+-------+------+----------+-------------+
|  1 | DELETE      | wp_options | NULL       | range | option_name   | option_name | 766     | const |   67 |   100.00 | Using where |
+----+-------------+------------+------------+-------+---------------+-------------+---------+-------+------+----------+-------------+
1 row in set (0.00 sec)
```

### How to test the changes in this Pull Request:

1. Check that calling WC_Cache_Helper::delete_version_transients() to delete transients.

### Changelog entry

> Improve performance of the query to delete version transients by removing unneeded "ORDER BY"
