### PR TITLE
Updated shipping class count and posts query to account for variations correctly.

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -39,6 +39,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		add_filter( 'query_vars', array( $this, 'add_custom_query_var' ) );
 		add_filter( 'views_edit-product', array( $this, 'product_views' ) );
 		add_filter( 'get_search_query', array( $this, 'search_label' ) );
+		add_filter( 'posts_clauses', array( $this, 'add_variation_parents_for_shipping_class' ), 10, 2 );
 	}
 
 	/**
@@ -497,4 +498,26 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 
 		return wc_clean( wp_unslash( $_GET['s'] ) ); // WPCS: input var ok, sanitization ok.
 	}
+
+	/**
+	 * Modifies post query so that it includes parent products whose variations have particular shipping class assigned.
+	 *
+	 * @param array    $pieces   Array of SELECT statement pieces (from, where, etc).
+	 * @param WP_Query $wp_query WP_Query instance.
+	 * @return array             Array of products, including parents of variations.
+	 */
+	public function add_variation_parents_for_shipping_class( $pieces, $wp_query ) {
+		global $wpdb;
+		if ( isset( $_GET['product_shipping_class'] ) && '0' !== $_GET['product_shipping_class'] ) { // WPCS: input var ok.
+			$replaced_where   = str_replace( ".post_type = 'product'", ".post_type = 'product_variation'", $pieces['where'] );
+			$pieces['where'] .= " OR {$wpdb->posts}.ID in (
+				SELECT {$wpdb->posts}.post_parent FROM 
+				wp_posts  LEFT JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)
+				WHERE 1=1 $replaced_where
+			)";
+			return $pieces;
+		}
+		return $pieces;
+	}
+
 }

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -209,7 +209,6 @@ class WC_Shipping {
 	/**
 	 * Returns all registered shipping methods for usage.
 	 *
-	 * @access public
 	 * @return array
 	 */
 	public function get_shipping_methods() {
@@ -222,7 +221,6 @@ class WC_Shipping {
 	/**
 	 * Get an array of shipping classes.
 	 *
-	 * @access public
 	 * @return array
 	 */
 	public function get_shipping_classes() {

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -231,24 +231,6 @@ class WC_Shipping {
 					'orderby'    => 'name',
 				)
 			);
-			// Update counts for variations -> parent products.
-			$counts   = array();
-			$term_ids = wp_list_pluck( $classes, 'term_id' );
-			foreach ( $term_ids as $term_id ) {
-				$parent_products = array();
-				$product_ids     = get_objects_in_term( $term_id, 'product_shipping_class' );
-				$products        = array_map( 'wc_get_product', $product_ids );
-				foreach ( $products as $product ) {
-					$id                     = $product->get_parent_id() ? $product->get_parent_id() : $product->get_id();
-					$parent_products[ $id ] = true;
-				}
-				$counts[ $term_id ] = count( array_keys( $parent_products ) );
-			}
-
-			foreach ( $classes as $i => $class ) {
-				$classes[ $i ]->count = $counts[ $class->term_id ];
-			}
-
 			$this->shipping_classes = ! is_wp_error( $classes ) ? $classes : array();
 		}
 		return apply_filters( 'woocommerce_get_shipping_classes', $this->shipping_classes );

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -233,6 +233,24 @@ class WC_Shipping {
 					'orderby'    => 'name',
 				)
 			);
+			// Update counts for variations -> parent products.
+			$counts   = array();
+			$term_ids = wp_list_pluck( $classes, 'term_id' );
+			foreach ( $term_ids as $term_id ) {
+				$parent_products = array();
+				$product_ids     = get_objects_in_term( $term_id, 'product_shipping_class' );
+				$products        = array_map( 'wc_get_product', $product_ids );
+				foreach ( $products as $product ) {
+					$id                     = $product->get_parent_id() ? $product->get_parent_id() : $product->get_id();
+					$parent_products[ $id ] = true;
+				}
+				$counts[ $term_id ] = count( array_keys( $parent_products ) );
+			}
+
+			foreach ( $classes as $i => $class ) {
+				$classes[ $i ]->count = $counts[ $class->term_id ];
+			}
+
 			$this->shipping_classes = ! is_wp_error( $classes ) ? $classes : array();
 		}
 		return apply_filters( 'woocommerce_get_shipping_classes', $this->shipping_classes );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #20989  .

The current change 
- updates counts in admin to not include all variations, but counts their parent products instead and 
- updates posts query to include parent products of variations that have a particular shipping class assigned

This is, however, not ideal, as e.g. there could be a variable (parent) product which belongs to shipping class A, but has variations belonging to shipping class B and C. Should it be shown in admin if user wants to display products that belong to shipping class B? Some users might say yes, some could prefer the answer to be no...

### How to test the changes in this Pull Request:

1. Create some shipping classes.
2. Add shipping class A to several products and variations.
3. Check WooCommerce > Settings > Shipping > Shipping classes to see if correct number of products is shown in the table (i.e. all variations from single parent products should be counted as 1 product, if shipping class is assigned to both parent and variation, it should count as 1, etc)
4. Click on the 'count' link and check list of products which should show correct parent products, including if the parent does not belong to shipping class A, only some of its variations.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
