### PR TITLE
Humanize emails

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -133,7 +133,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'css'         => 'width:300px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),
 					'type'        => 'textarea',
-					'default'     => '{site_title} - Powered by <a href="https://woocommerce.com/">WooCommerce</a>',
+					'default'     => '{site_title}<br/>Powered by <a href="https://woocommerce.com/">WooCommerce</a>',
 					'autoload'    => false,
 					'desc_tip'    => true,
 				),

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -108,6 +108,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				array(
 					'title' => __( 'Email template', 'woocommerce' ),
 					'type'  => 'title',
+					/* translators: %s: Nonced email preview link */
 					'desc'  => sprintf( __( 'This section lets you customize the WooCommerce emails. <a href="%s" target="_blank">Click here to preview your email template</a>.', 'woocommerce' ), wp_nonce_url( admin_url( '?preview_woocommerce_mail=true' ), 'preview-mail' ) ),
 					'id'    => 'email_template_options',
 				),
@@ -126,12 +127,13 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 				array(
 					'title'       => __( 'Footer text', 'woocommerce' ),
+					/* translators: %s: Available placeholders for use */
 					'desc'        => __( 'The text to appear in the footer of WooCommerce emails.', 'woocommerce' ) . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title}' ),
 					'id'          => 'woocommerce_email_footer_text',
 					'css'         => 'width:300px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),
 					'type'        => 'textarea',
-					'default'     => '{site_title}',
+					'default'     => '{site_title} - Powered by <a href="https://woocommerce.com/">WooCommerce</a>',
 					'autoload'    => false,
 					'desc_tip'    => true,
 				),
@@ -282,7 +284,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 								switch ( $key ) {
 									case 'name':
 										echo '<td class="wc-email-settings-table-' . esc_attr( $key ) . '">
-										<a href="' . admin_url( 'admin.php?page=wc-settings&tab=email&section=' . strtolower( $email_key ) ) . '">' . $email->get_title() . '</a>
+										<a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=email&section=' . strtolower( $email_key ) ) ) . '">' . esc_html( $email->get_title() ) . '</a>
 										' . wc_help_tip( $email->get_description() ) . '
 									</td>';
 										break;
@@ -311,7 +313,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 										break;
 									case 'actions':
 										echo '<td class="wc-email-settings-table-' . esc_attr( $key ) . '">
-										<a class="button alignright" href="' . admin_url( 'admin.php?page=wc-settings&tab=email&section=' . strtolower( $email_key ) ) . '">' . esc_html__( 'Manage', 'woocommerce' ) . '</a>
+										<a class="button alignright" href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=email&section=' . strtolower( $email_key ) ) ) . '">' . esc_html__( 'Manage', 'woocommerce' ) . '</a>
 									</td>';
 										break;
 									default:

--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -57,7 +57,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( '{site_title}: {order_billing_full_name} has cancelled order {order_number}', 'woocommerce' );
+			return __( '[{site_title}]: {order_billing_full_name} has cancelled order #{order_number}', 'woocommerce' );
 		}
 
 		/**
@@ -67,7 +67,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Order Cancelled: {order_number}', 'woocommerce' );
+			return __( 'Order Cancelled: #{order_number}', 'woocommerce' );
 		}
 
 		/**

--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -33,9 +33,10 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 			$this->template_html  = 'emails/admin-cancelled-order.php';
 			$this->template_plain = 'emails/plain/admin-cancelled-order.php';
 			$this->placeholders   = array(
-				'{site_title}'   => $this->get_blogname(),
-				'{order_date}'   => '',
-				'{order_number}' => '',
+				'{site_title}'              => $this->get_blogname(),
+				'{order_date}'              => '',
+				'{order_number}'            => '',
+				'{order_billing_full_name}' => '',
 			);
 
 			// Triggers for this email.
@@ -56,7 +57,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( '[{site_title}] Cancelled order ({order_number})', 'woocommerce' );
+			return __( '{site_title}: {order_billing_full_name} has cancelled order {order_number}', 'woocommerce' );
 		}
 
 		/**
@@ -66,7 +67,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Cancelled order', 'woocommerce' );
+			return __( 'Order Cancelled: {order_number}', 'woocommerce' );
 		}
 
 		/**
@@ -83,9 +84,10 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 			}
 
 			if ( is_a( $order, 'WC_Order' ) ) {
-				$this->object                         = $order;
-				$this->placeholders['{order_date}']   = wc_format_datetime( $this->object->get_date_created() );
-				$this->placeholders['{order_number}'] = $this->object->get_order_number();
+				$this->object                                    = $order;
+				$this->placeholders['{order_date}']              = wc_format_datetime( $this->object->get_date_created() );
+				$this->placeholders['{order_number}']            = $this->object->get_order_number();
+				$this->placeholders['{order_billing_full_name}'] = $this->object->get_formatted_billing_full_name();
 			}
 
 			if ( $this->is_enabled() && $this->get_recipient() ) {
@@ -98,7 +100,6 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 		/**
 		 * Get content html.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_html() {

--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -80,7 +80,7 @@ if ( ! class_exists( 'WC_Email_Customer_Completed_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( 'Your {site_title} order from {order_date} is complete', 'woocommerce' );
+			return __( 'Your {site_title} order is now complete', 'woocommerce' );
 		}
 
 		/**
@@ -90,13 +90,12 @@ if ( ! class_exists( 'WC_Email_Customer_Completed_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Your order is complete', 'woocommerce' );
+			return __( 'Thanks for shipping with us', 'woocommerce' );
 		}
 
 		/**
 		 * Get content html.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_html() {

--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -90,7 +90,7 @@ if ( ! class_exists( 'WC_Email_Customer_Completed_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Thanks for shipping with us', 'woocommerce' );
+			return __( 'Thanks for shopping with us', 'woocommerce' );
 		}
 
 		/**

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -54,7 +54,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		 */
 		public function get_default_subject( $paid = false ) {
 			if ( $paid ) {
-				return __( 'Invoice for order {order_number} on {site_title}', 'woocommerce' );
+				return __( 'Invoice for order #{order_number} on {site_title}', 'woocommerce' );
 			} else {
 				return __( 'Your latest {site_title} invoice', 'woocommerce' );
 			}
@@ -69,9 +69,9 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		 */
 		public function get_default_heading( $paid = false ) {
 			if ( $paid ) {
-				return __( 'Invoice for order {order_number}', 'woocommerce' );
+				return __( 'Invoice for order #{order_number}', 'woocommerce' );
 			} else {
-				return __( 'Your invoice for order {order_number}', 'woocommerce' );
+				return __( 'Your invoice for order #{order_number}', 'woocommerce' );
 			}
 		}
 

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 	 * An email sent to the customer via admin.
 	 *
 	 * @class       WC_Email_Customer_Invoice
-	 * @version     2.3.0
+	 * @version     3.5.0
 	 * @package     WooCommerce/Classes/Emails
 	 * @extends     WC_Email
 	 */
@@ -54,9 +54,9 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		 */
 		public function get_default_subject( $paid = false ) {
 			if ( $paid ) {
-				return __( 'Your {site_title} order from {order_date}', 'woocommerce' );
+				return __( 'Invoice for order {order_number} on {site_title}', 'woocommerce' );
 			} else {
-				return __( 'Invoice for order {order_number}', 'woocommerce' );
+				return __( 'Your latest {site_title} invoice', 'woocommerce' );
 			}
 		}
 
@@ -69,16 +69,15 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		 */
 		public function get_default_heading( $paid = false ) {
 			if ( $paid ) {
-				return __( 'Your order details', 'woocommerce' );
-			} else {
 				return __( 'Invoice for order {order_number}', 'woocommerce' );
+			} else {
+				return __( 'Your invoice for order {order_number}', 'woocommerce' );
 			}
 		}
 
 		/**
 		 * Get email subject.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_subject() {
@@ -95,7 +94,6 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		/**
 		 * Get email heading.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_heading() {
@@ -138,7 +136,6 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		/**
 		 * Get content html.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_html() {
@@ -156,7 +153,6 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		/**
 		 * Get content plain.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_plain() {

--- a/includes/emails/class-wc-email-customer-new-account.php
+++ b/includes/emails/class-wc-email-customer-new-account.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 	 * An email sent to the customer when they create an account.
 	 *
 	 * @class       WC_Email_Customer_New_Account
-	 * @version     2.3.0
+	 * @version     3.5.0
 	 * @package     WooCommerce/Classes/Emails
 	 * @extends     WC_Email
 	 */
@@ -73,7 +73,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( 'Your account on {site_title}', 'woocommerce' );
+			return __( 'Your {site_title} account has been created!', 'woocommerce' );
 		}
 
 		/**
@@ -116,7 +116,6 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 		/**
 		 * Get content html.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_html() {
@@ -137,7 +136,6 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 		/**
 		 * Get content plain.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_plain() {

--- a/includes/emails/class-wc-email-customer-note.php
+++ b/includes/emails/class-wc-email-customer-note.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'WC_Email_Customer_Note', false ) ) :
 	 * Customer note emails are sent when you add a note to an order.
 	 *
 	 * @class       WC_Email_Customer_Note
-	 * @version     2.3.0
+	 * @version     3.5.0
 	 * @package     WooCommerce/Classes/Emails
 	 * @extends     WC_Email
 	 */
@@ -114,7 +114,6 @@ if ( ! class_exists( 'WC_Email_Customer_Note', false ) ) :
 		/**
 		 * Get content html.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_html() {
@@ -133,7 +132,6 @@ if ( ! class_exists( 'WC_Email_Customer_Note', false ) ) :
 		/**
 		 * Get content plain.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_plain() {

--- a/includes/emails/class-wc-email-customer-on-hold-order.php
+++ b/includes/emails/class-wc-email-customer-on-hold-order.php
@@ -54,7 +54,7 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( 'Your {site_title} order receipt from {order_date}', 'woocommerce' );
+			return __( 'Your {site_title} order has been received!', 'woocommerce' );
 		}
 
 		/**
@@ -97,7 +97,6 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 		/**
 		 * Get content html.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_html() {
@@ -115,7 +114,6 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 		/**
 		 * Get content plain.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_plain() {

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( 'Your {site_title} order is now complete', 'woocommerce' );
+			return __( 'Payment received for your order', 'woocommerce' );
 		}
 
 		/**
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Thanks for shopping with us', 'woocommerce' );
+			return __( 'Thank you for your payment', 'woocommerce' );
 		}
 
 		/**

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 	 * An email sent to the customer when a new order is paid for.
 	 *
 	 * @class       WC_Email_Customer_Processing_Order
-	 * @version     2.0.0
+	 * @version     3.5.0
 	 * @package     WooCommerce/Classes/Emails
 	 * @extends     WC_Email
 	 */
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( 'Your {site_title} order receipt from {order_date}', 'woocommerce' );
+			return __( 'Your {site_title} order is now complete', 'woocommerce' );
 		}
 
 		/**
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Thank you for your order', 'woocommerce' );
+			return __( 'Thanks for shopping with us', 'woocommerce' );
 		}
 
 		/**
@@ -99,7 +99,6 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 		/**
 		 * Get content html.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_html() {
@@ -117,7 +116,6 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 		/**
 		 * Get content plain.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_plain() {

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -70,9 +70,9 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		 */
 		public function get_default_subject( $partial = false ) {
 			if ( $partial ) {
-				return __( 'Your {site_title} order {order_number} has been partially refunded', 'woocommerce' );
+				return __( 'Your {site_title} order #{order_number} has been partially refunded', 'woocommerce' );
 			} else {
-				return __( 'Your {site_title} order {order_number} has been refunded', 'woocommerce' );
+				return __( 'Your {site_title} order #{order_number} has been refunded', 'woocommerce' );
 			}
 		}
 

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 	 * Order refunded emails are sent to the customer when the order is marked refunded.
 	 *
 	 * @class    WC_Email_Customer_Refunded_Order
-	 * @version  2.4.0
+	 * @version  3.5.0
 	 * @package  WooCommerce/Classes/Emails
 	 * @extends  WC_Email
 	 */
@@ -70,9 +70,9 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		 */
 		public function get_default_subject( $partial = false ) {
 			if ( $partial ) {
-				return __( 'Your {site_title} order from {order_date} has been partially refunded', 'woocommerce' );
+				return __( 'Your {site_title} order {order_number} has been partially refunded', 'woocommerce' );
 			} else {
-				return __( 'Your {site_title} order from {order_date} has been refunded', 'woocommerce' );
+				return __( 'Your {site_title} order {order_number} has been refunded', 'woocommerce' );
 			}
 		}
 
@@ -85,16 +85,15 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		 */
 		public function get_default_heading( $partial = false ) {
 			if ( $partial ) {
-				return __( 'Your order has been partially refunded', 'woocommerce' );
+				return __( 'Partial Refund: Order {order_number}', 'woocommerce' );
 			} else {
-				return __( 'Order {order_number} details', 'woocommerce' );
+				return __( 'Order Refunded: {order_number}', 'woocommerce' );
 			}
 		}
 
 		/**
 		 * Get email subject.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_subject() {
@@ -109,7 +108,6 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		/**
 		 * Get email heading.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_heading() {
@@ -184,7 +182,6 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 		/**
 		 * Get content html.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_html() {

--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -17,7 +17,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 	 * An email sent to the customer when they reset their password.
 	 *
 	 * @class       WC_Email_Customer_Reset_Password
-	 * @version     2.3.0
+	 * @version     3.5.0
 	 * @package     WooCommerce/Classes/Emails
 	 * @extends     WC_Email
 	 */
@@ -79,7 +79,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( 'Password reset for {site_title}', 'woocommerce' );
+			return __( 'Password Reset Request for {site_title}', 'woocommerce' );
 		}
 
 		/**
@@ -89,7 +89,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Password reset instructions', 'woocommerce' );
+			return __( 'Password Reset Request', 'woocommerce' );
 		}
 
 		/**
@@ -120,7 +120,6 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		/**
 		 * Get content html.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_html() {
@@ -141,7 +140,6 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		/**
 		 * Get content plain.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_plain() {

--- a/includes/emails/class-wc-email-failed-order.php
+++ b/includes/emails/class-wc-email-failed-order.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( '{site_title}: Order {order_number} has failed', 'woocommerce' );
+			return __( '[{site_title}]: Order #{order_number} has failed', 'woocommerce' );
 		}
 
 		/**

--- a/includes/emails/class-wc-email-failed-order.php
+++ b/includes/emails/class-wc-email-failed-order.php
@@ -56,7 +56,7 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( '[{site_title}] Failed order ({order_number})', 'woocommerce' );
+			return __( '{site_title}: Order {order_number} has failed', 'woocommerce' );
 		}
 
 		/**
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Failed order', 'woocommerce' );
+			return __( 'Order Failed: {order_number}', 'woocommerce' );
 		}
 
 		/**
@@ -98,7 +98,6 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 		/**
 		 * Get content html.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_html() {

--- a/includes/emails/class-wc-email-failed-order.php
+++ b/includes/emails/class-wc-email-failed-order.php
@@ -66,7 +66,7 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Order Failed: {order_number}', 'woocommerce' );
+			return __( 'Order Failed: #{order_number}', 'woocommerce' );
 		}
 
 		/**

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -60,7 +60,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( '{site_title} has a new order -- woo!', 'woocommerce' );
+			return __( '[{site_title}]: New order #{order_number}', 'woocommerce' );
 		}
 
 		/**
@@ -70,7 +70,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'New Order: {order_number}', 'woocommerce' );
+			return __( 'New Order: #{order_number}', 'woocommerce' );
 		}
 
 		/**

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -60,7 +60,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( '[{site_title}] New customer order ({order_number}) - {order_date}', 'woocommerce' );
+			return __( '{site_title} has a new order -- woo!', 'woocommerce' );
 		}
 
 		/**
@@ -70,7 +70,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'New customer order', 'woocommerce' );
+			return __( 'New Order: {order_number}', 'woocommerce' );
 		}
 
 		/**
@@ -102,7 +102,6 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		/**
 		 * Get content html.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_html() {
@@ -120,7 +119,6 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		/**
 		 * Get content plain.
 		 *
-		 * @access public
 		 * @return string
 		 */
 		public function get_content_plain() {

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -602,7 +602,6 @@ class WC_Email extends WC_Settings_API {
 
 		$message = apply_filters( 'woocommerce_mail_content', $this->style_inline( $message ) );
 		$return  = wp_mail( $to, $subject, $message, $headers, $attachments );
-
 		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
 		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 		remove_filter( 'wp_mail_content_type', array( $this, 'get_content_type' ) );

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -602,6 +602,7 @@ class WC_Email extends WC_Settings_API {
 
 		$message = apply_filters( 'woocommerce_mail_content', $this->style_inline( $message ) );
 		$return  = wp_mail( $to, $subject, $message, $headers, $attachments );
+
 		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
 		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 		remove_filter( 'wp_mail_content_type', array( $this, 'get_content_type' ) );

--- a/templates/emails/admin-cancelled-order.php
+++ b/templates/emails/admin-cancelled-order.php
@@ -10,45 +10,50 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
+ * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates/Emails
- * @version 2.5.0
+ * @version 3.5.0
  */
 
- if ( ! defined( 'ABSPATH' ) ) {
- 	exit;
- }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
- /**
-  * @hooked WC_Emails::email_header() Output the email header
-  */
- do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+*/
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
- <p><?php printf( __( 'The order #%1$s from %2$s has been cancelled. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ); ?></p>
+<?php /* translators: %1$s: Customer full name. %2$s: Order numer */ ?>
+<p><?php printf( __( 'Alas. Just to let you know -- %1$s has cancelled order %2$s:', 'woocommerce' ), $order->get_formatted_billing_full_name(), $order->get_order_number() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 
- <?php
+<?php
 
- /**
-  * @hooked WC_Emails::order_details() Shows the order details table.
-  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
-  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
-  * @since 2.5.0
-  */
- do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+/*
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ * @since 2.5.0
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
- /**
-  * @hooked WC_Emails::order_meta() Shows order meta data.
-  */
- do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+/*
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
- /**
-  * @hooked WC_Emails::customer_details() Shows customer details
-  * @hooked WC_Emails::email_address() Shows email address
-  */
- do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+/*
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+?>
+<p>
+<?php _e( 'Read more about <a href="https://docs.woocommerce.com/document/managing-orders/">managing orders</a>, or get tips for <a href="https://woocommerce.com/2018/03/10-ways-to-make-your-next-sale/">making your next sale</a>.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+</p>
+<?php
 
- /**
-  * @hooked WC_Emails::email_footer() Output the email footer
-  */
- do_action( 'woocommerce_email_footer', $email );
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/admin-cancelled-order.php
+++ b/templates/emails/admin-cancelled-order.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %1$s: Customer full name. %2$s: Order numer */ ?>
-<p><?php printf( __( 'Alas. Just to let you know -- %1$s has cancelled order %2$s:', 'woocommerce' ), $order->get_formatted_billing_full_name(), $order->get_order_number() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( esc_html__( 'Alas. Just to let you know -- %1$s has cancelled order #%2$s:', 'woocommerce' ), esc_html( $order->get_formatted_billing_full_name() ), esc_html( $order->get_order_number() ) ); ?></p>
 
 <?php
 
@@ -49,7 +49,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 ?>
 <p>
-<?php _e( 'Read more about <a href="https://docs.woocommerce.com/document/managing-orders/">managing orders</a>, or get tips for <a href="https://woocommerce.com/2018/03/10-ways-to-make-your-next-sale/">making your next sale</a>.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+<?php esc_html_e( 'Thanks for reading.', 'woocommerce' ); ?>
 </p>
 <?php
 

--- a/templates/emails/admin-failed-order.php
+++ b/templates/emails/admin-failed-order.php
@@ -49,7 +49,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 ?>
 <p>
-<?php esc_html_e( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/#section-10">troubleshooting failed payments</a>.', 'woocommerce' ); ?>
+<?php echo wp_kses_post( __( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/#section-10">troubleshooting failed payments</a>.', 'woocommerce' ) ); ?>
 </p>
 <?php
 

--- a/templates/emails/admin-failed-order.php
+++ b/templates/emails/admin-failed-order.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %1$s: Order number. %2$s: Customer full name. */ ?>
-<p><?php printf( __( 'Oh dear! Payment for order #%1$s from %2$s has failed. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( esc_html__( 'Payment for order #%1$s from %2$s has failed. The order was as follows:', 'woocommerce' ), esc_html( $order->get_order_number() ), esc_html( $order->get_formatted_billing_full_name() ) ); ?></p>
 
 <?php
 
@@ -49,7 +49,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 ?>
 <p>
-<?php _e( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/#section-10">troubleshooting failed payments</a>.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+<?php esc_html_e( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/#section-10">troubleshooting failed payments</a>.', 'woocommerce' ); ?>
 </p>
 <?php
 

--- a/templates/emails/admin-failed-order.php
+++ b/templates/emails/admin-failed-order.php
@@ -10,45 +10,50 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
+ * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates/Emails
- * @version 2.5.0
+ * @version 3.5.0
  */
 
- if ( ! defined( 'ABSPATH' ) ) {
- 	exit;
- }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
- /**
-  * @hooked WC_Emails::email_header() Output the email header
-  */
- do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
- <p><?php printf( __( 'Payment for order #%1$s from %2$s has failed. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ); ?></p>
+<?php /* translators: %1$s: Order number. %2$s: Customer full name. */ ?>
+<p><?php printf( __( 'Oh dear! Payment for order #%1$s from %2$s has failed. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 
- <?php
+<?php
 
- /**
-  * @hooked WC_Emails::order_details() Shows the order details table.
-  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
-  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
-  * @since 2.5.0
-  */
- do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
+/*
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ * @since 2.5.0
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
- /**
-  * @hooked WC_Emails::order_meta() Shows order meta data.
-  */
- do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+/*
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
- /**
-  * @hooked WC_Emails::customer_details() Shows customer details
-  * @hooked WC_Emails::email_address() Shows email address
-  */
- do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+/*
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+?>
+<p>
+<?php _e( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/#section-10">troubleshooting failed payments</a>.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+</p>
+<?php
 
- /**
-  * @hooked WC_Emails::email_footer() Output the email footer
-  */
- do_action( 'woocommerce_email_footer', $email );
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+*/
+do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/admin-new-order.php
+++ b/templates/emails/admin-new-order.php
@@ -10,45 +10,47 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author WooThemes
+ * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates/Emails/HTML
- * @version 2.5.0
+ * @version 3.5.0
  */
 
- if ( ! defined( 'ABSPATH' ) ) {
- 	exit;
- }
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
- /**
-  * @hooked WC_Emails::email_header() Output the email header
-  */
- do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
+/*
+ * @hooked WC_Emails::email_header() Output the email header
+ */
+do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
- <p><?php printf( __( 'You have received an order from %s. The order is as follows:', 'woocommerce' ), $order->get_formatted_billing_full_name() ); ?></p>
+<?php /* translators: %s: Customer billing full name */ ?>
+<p><?php printf( __( 'You’ve received the following order from %s', 'woocommerce' ), $order->get_formatted_billing_full_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<?php
 
- <?php
+/*
+ * @hooked WC_Emails::order_details() Shows the order details table.
+ * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
+ * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
+ * @since 2.5.0
+ */
+do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
- /**
-  * @hooked WC_Emails::order_details() Shows the order details table.
-  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
-  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
-  * @since 2.5.0
-  */
- do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
-
- /**
-  * @hooked WC_Emails::order_meta() Shows order meta data.
-  */
+/*
+ * @hooked WC_Emails::order_meta() Shows order meta data.
+ */
  do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
- /**
-  * @hooked WC_Emails::customer_details() Shows customer details
-  * @hooked WC_Emails::email_address() Shows email address
-  */
- do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+/*
+ * @hooked WC_Emails::customer_details() Shows customer details
+ * @hooked WC_Emails::email_address() Shows email address
+ */
+do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+?>
+<p><?php _esc_html_e( 'Woo! Over to you.', 'woocommerce' ); ?>
+<?php
 
- /**
-  * @hooked WC_Emails::email_footer() Output the email footer
-  */
- do_action( 'woocommerce_email_footer', $email );
+/*
+ * @hooked WC_Emails::email_footer() Output the email footer
+ */
+do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/admin-new-order.php
+++ b/templates/emails/admin-new-order.php
@@ -47,7 +47,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 ?>
-<p><?php _esc_html_e( 'Woo! Over to you.', 'woocommerce' ); ?></p>
+<p><?php esc_html_e( 'Woo! Over to you.', 'woocommerce' ); ?></p>
 <?php
 
 /*

--- a/templates/emails/admin-new-order.php
+++ b/templates/emails/admin-new-order.php
@@ -39,7 +39,7 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
 /*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
- do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
+do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
 /*
  * @hooked WC_Emails::customer_details() Shows customer details
@@ -47,7 +47,7 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 ?>
-<p><?php _esc_html_e( 'Woo! Over to you.', 'woocommerce' ); ?>
+<p><?php _esc_html_e( 'Woo! Over to you.', 'woocommerce' ); ?></p>
 <?php
 
 /*

--- a/templates/emails/admin-new-order.php
+++ b/templates/emails/admin-new-order.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer billing full name */ ?>
-<p><?php printf( __( 'You’ve received the following order from %s', 'woocommerce' ), $order->get_formatted_billing_full_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( __( 'You’ve received the following order from %s:', 'woocommerce' ), $order->get_formatted_billing_full_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 <?php
 
 /*
@@ -47,7 +47,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 ?>
-<p><?php esc_html_e( 'Woo! Over to you.', 'woocommerce' ); ?></p>
+<p><?php esc_html_e( 'Over to you.', 'woocommerce' ); ?></p>
 <?php
 
 /*

--- a/templates/emails/customer-completed-order.php
+++ b/templates/emails/customer-completed-order.php
@@ -25,9 +25,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
 <?php /* translators: %s: Site title */ ?>
-<p><?php printf( __( 'Your %s order has been marked complete on our side. We hope you enjoy it!', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( esc_html__( 'Your %s order has been marked complete on our side.', 'woocommerce' ), esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) ); ?></p>
 <?php
 
 /*
@@ -51,7 +51,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
 
 ?>
 <p>
-<?php _e( 'Thanks for shopping with us.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+<?php esc_html_e( 'Thanks for shopping with us.', 'woocommerce' ); ?>
 </p>
 <?php
 

--- a/templates/emails/customer-completed-order.php
+++ b/templates/emails/customer-completed-order.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 <?php /* translators: %s: Site title */ ?>
 <p><?php printf( __( 'Your %s order has been marked complete on our side. We hope you enjoy it!', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 <?php

--- a/templates/emails/customer-completed-order.php
+++ b/templates/emails/customer-completed-order.php
@@ -10,26 +10,27 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates/Emails
- * @version     2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
+/*
  * @hooked WC_Emails::email_header() Output the email header
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-<p><?php printf( __( "Hi there. Your recent order on %s has been completed. Your order details are shown below for your reference:", 'woocommerce' ), get_option( 'blogname' ) ); ?></p>
-
+<?php /* translators: %s: Customer first name */ ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<?php /* translators: %s: Site title */ ?>
+<p><?php printf( __( 'Your %s order has been marked complete on our side. We hope you enjoy it!', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 <?php
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -37,18 +38,24 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
  */
 do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+?>
+<p>
+<?php _e( 'Thanks for shopping with us.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+</p>
+<?php
+
+/*
  * @hooked WC_Emails::email_footer() Output the email footer
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -52,7 +52,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 	<p>
 	<?php
 		/* translators: %s Order date */
-		printf( __( 'Here are the details of your order placed on %s:', 'woocommerce' ), wc_format_datetime( $order->get_date_created() ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+		printf( esc_html__( 'Here are the details of your order placed on %s:', 'woocommerce' ), esc_html( wc_format_datetime( $order->get_date_created() ) ) );
 	?>
 	</p>
 <?php
@@ -85,7 +85,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
 
 ?>
 <p>
-<?php esc_html_e( 'Have a great day.', 'woocommerce' ); ?>
+<?php esc_html_e( 'Thanks for reading.', 'woocommerce' ); ?>
 </p>
 <?php
 

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -52,7 +52,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 	<p>
 	<?php
 		/* translators: %s Order date */
-		printf( __( 'Here are the details of your order placed on %s:', 'woocommerce' ), wc_format_datetime( $this->object->get_date_created() ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+		printf( __( 'Here are the details of your order placed on %s:', 'woocommerce' ), wc_format_datetime( $order->get_date_created() ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 	?>
 	</p>
 <?php

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -10,10 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see         https://docs.woocommerce.com/document/template-structure/
- * @author      WooThemes
- * @package     WooCommerce/Templates/Emails
- * @version     3.3.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -27,13 +26,16 @@ if ( ! defined( 'ABSPATH' ) ) {
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-<?php if ( $order->has_status( 'pending' ) ) : ?>
+<?php /* translators: %s: Customer first name */ ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+
+<?php if ( $order->has_status( 'pending' ) ) { ?>
 	<p>
 	<?php
 	printf(
 		wp_kses(
-			/* translators: %1s item is the name of the site, %2s is a html link */
-			__( 'An order has been created for you on %1$s. %2$s', 'woocommerce' ),
+			/* translators: %1$s Site title, %2$s Order pay link */
+			__( 'An order has been created for you on %1$s. Your invoice is below, with a link to make payment when you’re ready: %2$s', 'woocommerce' ),
 			array(
 				'a' => array(
 					'href' => array(),
@@ -45,9 +47,16 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 	);
 	?>
 	</p>
-<?php endif; ?>
 
+<?php } else { ?>
+	<p>
+	<?php
+		/* translators: %s Order date */
+		printf( __( 'Here are the details of your order placed on %s:', 'woocommerce' ), wc_format_datetime( $this->object->get_date_created() ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+	?>
+	</p>
 <?php
+}
 
 /**
  * Hook for the woocommerce_email_order_details.
@@ -73,6 +82,12 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+?>
+<p>
+<?php _e( 'Have a great day.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+</p>
+<?php
 
 /**
  * Executes the email footer.

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
 
 <?php if ( $order->has_status( 'pending' ) ) { ?>
 	<p>
@@ -85,7 +85,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
 
 ?>
 <p>
-<?php _e( 'Have a great day.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+<?php esc_html_e( 'Have a great day.', 'woocommerce' ); ?>
 </p>
 <?php
 

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 
 <?php if ( $order->has_status( 'pending' ) ) { ?>
 	<p>

--- a/templates/emails/customer-new-account.php
+++ b/templates/emails/customer-new-account.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s Customer first name */ ?>
-<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_first_name() ) ); ?></p>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
 <?php /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */ ?>
 <p><?php printf( __( 'Thanks for creating an account on %1$s. As a reminder, the username you chose is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>', make_clickable( esc_url( wc_get_page_permalink( 'myaccount' ) ) ) ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 

--- a/templates/emails/customer-new-account.php
+++ b/templates/emails/customer-new-account.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s Customer first name */ ?>
-<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ); ?></p>
 <?php /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */ ?>
 <p><?php printf( __( 'Thanks for creating an account on %1$s. As a reminder, the username you chose is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>', make_clickable( esc_url( wc_get_page_permalink( 'myaccount' ) ) ) ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 

--- a/templates/emails/customer-new-account.php
+++ b/templates/emails/customer-new-account.php
@@ -10,28 +10,30 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates/Emails
- * @version     1.6.4
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 ?>
 
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-	<p><?php printf( __( 'Thanks for creating an account on %1$s. Your username is %2$s', 'woocommerce' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>' ); ?></p>
+<?php /* translators: %s Customer first name */ ?>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_first_name() ) ); ?></p>
+<?php /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */ ?>
+<p><?php printf( __( 'Thanks for creating an account on %1$s. As a reminder, the username you chose is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>', make_clickable( esc_url( wc_get_page_permalink( 'myaccount' ) ) ) ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 
 <?php if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && $password_generated ) : ?>
-
-	<p><?php printf( __( 'Your password has been automatically generated: %s', 'woocommerce' ), '<strong>' . esc_html( $user_pass ) . '</strong>' ); ?></p>
-
+	<?php /* translators: %s Auto generated password */ ?>
+	<p><?php printf( esc_html__( 'Your password has been automatically generated: %s', 'woocommerce' ), '<strong>' . esc_html( $user_pass ) . '</strong>' ); ?></p>
 <?php endif; ?>
 
-	<p><?php printf( __( 'You can access your account area to view your orders and change your password here: %s.', 'woocommerce' ), make_clickable( esc_url( wc_get_page_permalink( 'myaccount' ) ) ) ); ?></p>
+<p><?php esc_html_e( 'We look forward to seeing you soon.', 'woocommerce' ); ?></p>
 
-<?php do_action( 'woocommerce_email_footer', $email );
+<?php
+do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/customer-note.php
+++ b/templates/emails/customer-note.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
 <p><?php esc_html_e( 'The following note has been added to your order:', 'woocommerce' ); ?></p>
 
 <blockquote><?php echo wpautop( wptexturize( $customer_note ) ); ?></blockquote><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
@@ -54,7 +54,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
 ?>
-<p><?php _e( 'Have a great day.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?></p>
+<p><?php esc_html_e( 'Thanks for reading.', 'woocommerce' ); ?></p>
 <?php
 
 /*

--- a/templates/emails/customer-note.php
+++ b/templates/emails/customer-note.php
@@ -10,30 +10,31 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates/Emails
- * @version     2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
+/*
  * @hooked WC_Emails::email_header() Output the email header
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-<p><?php _e( "Hello, a note has just been added to your order:", 'woocommerce' ); ?></p>
+<?php /* translators: %s: Customer first name */ ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php esc_html_e( 'The following note has been added to your order:', 'woocommerce' ); ?></p>
 
-<blockquote><?php echo wpautop( wptexturize( $customer_note ) ) ?></blockquote>
+<blockquote><?php echo wpautop( wptexturize( $customer_note ) ); ?></blockquote><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 
-<p><?php _e( "For your reference, your order details are shown below.", 'woocommerce' ); ?></p>
+<p><?php esc_html_e( 'As a reminder, here are your order details:', 'woocommerce' ); ?></p>
 
 <?php
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -41,18 +42,22 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
  */
 do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+?>
+<p><?php _e( 'Have a great day.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?></p>
+<?php
+
+/*
  * @hooked WC_Emails::email_footer() Output the email footer
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/customer-note.php
+++ b/templates/emails/customer-note.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 <p><?php esc_html_e( 'The following note has been added to your order:', 'woocommerce' ); ?></p>
 
 <blockquote><?php echo wpautop( wptexturize( $customer_note ) ); ?></blockquote><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>

--- a/templates/emails/customer-on-hold-order.php
+++ b/templates/emails/customer-on-hold-order.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 <p><?php _e( 'Thanks for your order. It’s on-hold until we confirm that payment has been received. In the meantime, here’s a reminder of what you ordered:', 'woocommerce' ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput ?>
 
 <?php

--- a/templates/emails/customer-on-hold-order.php
+++ b/templates/emails/customer-on-hold-order.php
@@ -10,26 +10,27 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates/Emails
- * @version     2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
+/*
  * @hooked WC_Emails::email_header() Output the email header
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-<p><?php _e( "Your order is on-hold until we confirm payment has been received. Your order details are shown below for your reference:", 'woocommerce' ); ?></p>
+<?php /* translators: %s: Customer first name */ ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php _e( 'Thanks for your order. It’s on-hold until we confirm that payment has been received. In the meantime, here’s a reminder of what you ordered:', 'woocommerce' ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput ?>
 
 <?php
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -37,18 +38,24 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
  */
 do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+?>
+<p>
+<?php _e( 'We look forward to fulfilling your order soon.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+</p>
+<?php
+
+/*
  * @hooked WC_Emails::email_footer() Output the email footer
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/customer-processing-order.php
+++ b/templates/emails/customer-processing-order.php
@@ -26,8 +26,8 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name */ ?>
 <p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
-<?php /* translators: %s: Site title */ ?>
-<p><?php printf( __( 'Your %s order has been marked complete on our side. We hope you enjoy it!', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<?php /* translators: %s: Order number */ ?>
+<p><?php printf( __( 'Just to let you know -- your payment has been confirmed, and order %s is now being processed:', 'woocommerce' ), $order->get_order_number() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 
 <?php
 

--- a/templates/emails/customer-processing-order.php
+++ b/templates/emails/customer-processing-order.php
@@ -10,26 +10,28 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates/Emails
- * @version     2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
+/*
  * @hooked WC_Emails::email_header() Output the email header
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-<p><?php _e( "Your order has been received and is now being processed. Your order details are shown below for your reference:", 'woocommerce' ); ?></p>
+<?php /* translators: %s: Customer first name */ ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<?php /* translators: %s: Site title */ ?>
+<p><?php printf( __( 'Your %s order has been marked complete on our side. We hope you enjoy it!', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 
 <?php
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -37,18 +39,24 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
  */
 do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+?>
+<p>
+<?php _e( 'Thanks for shopping with us.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+</p>
+<?php
+
+/*
  * @hooked WC_Emails::email_footer() Output the email footer
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/customer-processing-order.php
+++ b/templates/emails/customer-processing-order.php
@@ -25,9 +25,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
 <?php /* translators: %s: Order number */ ?>
-<p><?php printf( __( 'Just to let you know -- your payment has been confirmed, and order %s is now being processed:', 'woocommerce' ), $order->get_order_number() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( esc_html__( 'Just to let you know -- your payment has been confirmed, and order #%s is now being processed:', 'woocommerce' ), esc_html( $order->get_order_number() ) ); ?></p>
 
 <?php
 
@@ -52,7 +52,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
 
 ?>
 <p>
-<?php _e( 'Woo!', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+<?php esc_html_e( 'Thanks!', 'woocommerce' ); ?>
 </p>
 <?php
 

--- a/templates/emails/customer-processing-order.php
+++ b/templates/emails/customer-processing-order.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 <?php /* translators: %s: Order number */ ?>
 <p><?php printf( __( 'Just to let you know -- your payment has been confirmed, and order %s is now being processed:', 'woocommerce' ), $order->get_order_number() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 

--- a/templates/emails/customer-processing-order.php
+++ b/templates/emails/customer-processing-order.php
@@ -52,7 +52,7 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
 
 ?>
 <p>
-<?php _e( 'Thanks for shopping with us.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+<?php _e( 'Woo!', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
 </p>
 <?php
 

--- a/templates/emails/customer-refunded-order.php
+++ b/templates/emails/customer-refunded-order.php
@@ -25,7 +25,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s: Customer first name */ ?>
-<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 
 <p>
 <?php

--- a/templates/emails/customer-refunded-order.php
+++ b/templates/emails/customer-refunded-order.php
@@ -10,32 +10,37 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see      https://docs.woocommerce.com/document/template-structure/
- * @author   WooThemes
- * @package  WooCommerce/Templates/Emails
- * @version  2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-/**
+/*
  * @hooked WC_Emails::email_header() Output the email header
  */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-<p><?php
-	if ( $partial_refund ) {
-		printf( __( 'Hi there. Your order on %s has been partially refunded.', 'woocommerce' ), get_option( 'blogname' ) );
-	} else {
-		printf( __( 'Hi there. Your order on %s has been refunded.', 'woocommerce' ), get_option( 'blogname' ) );
-	}
-?></p>
+<?php /* translators: %s: Customer first name */ ?>
+<p><?php printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 
+<p>
+<?php
+if ( $partial_refund ) {
+	/* translators: %s: Site title */
+	printf( __( 'Your order on %s has been partially refunded. There are more details below for your reference:', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+} else {
+	/* translators: %s: Site title */
+	printf( __( 'Your order on %s has been refunded. There are more details below for your reference:', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+}
+?>
+</p>
 <?php
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -43,18 +48,24 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
  */
 do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+?>
+<p>
+<?php _e( 'We hope to see you again soon.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+</p>
+<?php
+
+/*
  * @hooked WC_Emails::email_footer() Output the email footer
  */
 do_action( 'woocommerce_email_footer', $email );

--- a/templates/emails/customer-reset-password.php
+++ b/templates/emails/customer-reset-password.php
@@ -24,12 +24,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
 <?php /* translators: %s Customer first name */ ?>
-<p><?php esc_html_e( 'Hi %s,', 'woocommerce' ); ?>
+<p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ); ?>
 <p><?php esc_html_e( 'Someone (hopefully you) has requested a password reset for the following account on:', 'woocommerce' ); ?></p>
 <?php /* translators: %s Store name */ ?>
 <p><?php printf( esc_html__( 'Store: %s', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 <?php /* translators: %s Customer username */ ?>
-<p><?php printf( esc_html__( 'Username: %s', 'woocommerce' ), $user_login ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php printf( esc_html__( 'Username: %s', 'woocommerce' ), esc_html( $user_login ) ); ?></p>
 <p><?php esc_html_e( 'If this was a mistake, just ignore this email and nothing will happen. Otherwise, follow this link to reset your password now:', 'woocommerce' ); ?></p>
 <p>
 	<a class="link" href="<?php echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ); ?>"><?php // phpcs:ignore ?>

--- a/templates/emails/customer-reset-password.php
+++ b/templates/emails/customer-reset-password.php
@@ -23,19 +23,18 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-<?php /* translators: %s Customer first name */ ?>
+<?php /* translators: %s: Customer first name */ ?>
 <p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ); ?>
-<p><?php esc_html_e( 'Someone (hopefully you) has requested a password reset for the following account on:', 'woocommerce' ); ?></p>
-<?php /* translators: %s Store name */ ?>
-<p><?php printf( esc_html__( 'Store: %s', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<?php /* translators: %s: Store name */ ?>
+<p><?php printf( esc_html__( 'Someone has requested a new password for the following account on %s:', 'woocommerce' ), esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) ); ?></p>
 <?php /* translators: %s Customer username */ ?>
 <p><?php printf( esc_html__( 'Username: %s', 'woocommerce' ), esc_html( $user_login ) ); ?></p>
-<p><?php esc_html_e( 'If this was a mistake, just ignore this email and nothing will happen. Otherwise, follow this link to reset your password now:', 'woocommerce' ); ?></p>
+<p><?php esc_html_e( 'If you didn\'t make this request, just ignore this email. If you\'d like to proceed:', 'woocommerce' ); ?></p>
 <p>
 	<a class="link" href="<?php echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ); ?>"><?php // phpcs:ignore ?>
 		<?php esc_html_e( 'Click here to reset your password', 'woocommerce' ); ?>
 	</a>
 </p>
-<p><?php esc_html_e( 'Good luck!', 'woocommerce' ); ?></p>
+<p><?php esc_html_e( 'Thanks for reading.', 'woocommerce' ); ?></p>
 
 <?php do_action( 'woocommerce_email_footer', $email ); ?>

--- a/templates/emails/customer-reset-password.php
+++ b/templates/emails/customer-reset-password.php
@@ -10,28 +10,32 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates/Emails
- * @version     2.0.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 ?>
 
 <?php do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-<p><?php _e( 'Someone requested that the password be reset for the following account:', 'woocommerce' ); ?></p>
-<p><?php printf( __( 'Username: %s', 'woocommerce' ), $user_login ); ?></p>
-<p><?php _e( 'If this was a mistake, just ignore this email and nothing will happen.', 'woocommerce' ); ?></p>
-<p><?php _e( 'To reset your password, visit the following address:', 'woocommerce' ); ?></p>
+<?php /* translators: %s Customer first name */ ?>
+<p><?php esc_html_e( 'Hi %s,', 'woocommerce' ); ?>
+<p><?php esc_html_e( 'Someone (hopefully you) has requested a password reset for the following account on:', 'woocommerce' ); ?></p>
+<?php /* translators: %s Store name */ ?>
+<p><?php printf( esc_html__( 'Store: %s', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<?php /* translators: %s Customer username */ ?>
+<p><?php printf( esc_html__( 'Username: %s', 'woocommerce' ), $user_login ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+<p><?php esc_html_e( 'If this was a mistake, just ignore this email and nothing will happen. Otherwise, follow this link to reset your password now:', 'woocommerce' ); ?></p>
 <p>
-	<a class="link" href="<?php echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ); ?>">
-			<?php _e( 'Click here to reset your password', 'woocommerce' ); ?></a>
+	<a class="link" href="<?php echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ); ?>"><?php // phpcs:ignore ?>
+		<?php esc_html_e( 'Click here to reset your password', 'woocommerce' ); ?>
+	</a>
 </p>
-<p></p>
+<p><?php esc_html_e( 'Good luck!', 'woocommerce' ); ?></p>
 
 <?php do_action( 'woocommerce_email_footer', $email ); ?>

--- a/templates/emails/email-order-details.php
+++ b/templates/emails/email-order-details.php
@@ -33,7 +33,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 		$after  = '';
 	}
 	/* translators: %s: Order ID. */
-	echo wp_kses_post( $before . sprintf( __( 'Order #%s', 'woocommerce' ) . $after . ' (<time datetime="%s">%s</time>)', $order->get_order_number(), $order->get_date_created()->format( 'c' ), wc_format_datetime( $order->get_date_created() ) ) );
+	echo wp_kses_post( $before . sprintf( __( '[Order #%s]', 'woocommerce' ) . $after . ' (<time datetime="%s">%s</time>)', $order->get_order_number(), $order->get_date_created()->format( 'c' ), wc_format_datetime( $order->get_date_created() ) ) );
 	?>
 </h2>
 

--- a/templates/emails/plain/admin-cancelled-order.php
+++ b/templates/emails/plain/admin-cancelled-order.php
@@ -10,23 +10,23 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author  	WooThemes
- * @package 	WooCommerce/Templates/Emails/Plain
- * @version 	2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo "= " . $email_heading . " =\n\n";
+echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
-echo sprintf( __( 'The order #%1$s from %2$s has been cancelled. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ) . "\n\n";
+/* translators: %1$s: Customer full name. %2$s: Order numer */
+echo printf( __( 'Alas. Just to let you know -- %1$s has cancelled order %2$s:', 'woocommerce' ), $order->get_formatted_billing_full_name(), $order->get_order_number() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -36,17 +36,18 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+echo __( 'Read more about managing orders (https://docs.woocommerce.com/document/managing-orders/), or get tips for making your next sale (https://woocommerce.com/2018/03/10-ways-to-make-your-next-sale/)', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/templates/emails/plain/admin-cancelled-order.php
+++ b/templates/emails/plain/admin-cancelled-order.php
@@ -19,10 +19,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
 /* translators: %1$s: Customer full name. %2$s: Order numer */
-echo printf( __( 'Alas. Just to let you know -- %1$s has cancelled order %2$s:', 'woocommerce' ), $order->get_formatted_billing_full_name(), $order->get_order_number() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( esc_html__( 'Alas. Just to let you know -- %1$s has cancelled order #%2$s:', 'woocommerce' ), esc_html( $order->get_formatted_billing_full_name() ), esc_html( $order->get_order_number() ) ) . "\n\n";
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
@@ -47,7 +47,8 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
-echo __( 'Read more about managing orders (https://docs.woocommerce.com/document/managing-orders/), or get tips for making your next sale (https://woocommerce.com/2018/03/10-ways-to-make-your-next-sale/)', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo esc_html__( 'Thanks for reading.', 'woocommerce' ) . "\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
+
+echo esc_html( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/templates/emails/plain/admin-failed-order.php
+++ b/templates/emails/plain/admin-failed-order.php
@@ -10,23 +10,23 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author		WooThemes
- * @package 	WooCommerce/Templates/Emails/Plain
- * @version		2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo "= " . $email_heading . " =\n\n";
+echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
-echo sprintf( __( 'Payment for order #%1$s from %2$s has failed. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ) . "\n\n";
+/* translators: %1$s: Order number. %2$s: Customer full name. */
+echo printf( __( 'Oh dear! Payment for order #%1$s from %2$s has failed. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -36,17 +36,19 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
+echo __( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/#section-10">troubleshooting failed payments</a>.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/templates/emails/plain/admin-failed-order.php
+++ b/templates/emails/plain/admin-failed-order.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 /* translators: %1$s: Order number. %2$s: Customer full name. */
-echo printf( __( 'Oh dear! Payment for order #%1$s from %2$s has failed. The order was as follows:', 'woocommerce' ), $order->get_order_number(), $order->get_formatted_billing_full_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( esc_html__( 'Payment for order #%1$s from %2$s has failed. The order was as follows:', 'woocommerce' ), esc_html( $order->get_order_number() ), esc_html( $order->get_formatted_billing_full_name() ) ) . "\n\n";
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
@@ -47,8 +47,8 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-echo __( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/#section-10">troubleshooting failed payments</a>.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo esc_html__( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/#section-10">troubleshooting failed payments</a>.', 'woocommerce' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo esc_html( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/templates/emails/plain/admin-new-order.php
+++ b/templates/emails/plain/admin-new-order.php
@@ -10,23 +10,23 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author		WooThemes
- * @package 	WooCommerce/Templates/Emails/Plain
- * @version		2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo "= " . $email_heading . " =\n\n";
+echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress
 
-echo sprintf( __( 'You have received an order from %s.', 'woocommerce' ), $order->get_formatted_billing_full_name() ) . "\n\n";
+/* translators: %s: Customer billing full name */
+echo sprintf( __( 'You’ve received the following order from %s.', 'woocommerce' ), $order->get_formatted_billing_full_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -36,12 +36,12 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
@@ -49,4 +49,6 @@ do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );
+echo __( 'Woo! Over to you.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/templates/emails/plain/admin-new-order.php
+++ b/templates/emails/plain/admin-new-order.php
@@ -19,10 +19,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress
+echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
 /* translators: %s: Customer billing full name */
-echo sprintf( __( 'You’ve received the following order from %s.', 'woocommerce' ), $order->get_formatted_billing_full_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( esc_html__( 'You’ve received the following order from %s:', 'woocommerce' ), esc_html( $order->get_formatted_billing_full_name() ) ) . "\n\n";
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
@@ -47,8 +47,8 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
+echo esc_html__( 'Over to you.', 'woocommerce' ) . "\n\n";
+
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo __( 'Woo! Over to you.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo esc_html( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/templates/emails/plain/customer-completed-order.php
+++ b/templates/emails/plain/customer-completed-order.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 /* translators: %s: Customer first name */
-printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 /* translators: %s: Site title */
 printf( __( 'Your %s order has been marked complete on our side. We hope you enjoy it!', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 

--- a/templates/emails/plain/customer-completed-order.php
+++ b/templates/emails/plain/customer-completed-order.php
@@ -19,12 +19,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
 /* translators: %s: Customer first name */
-printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ) . "\n\n";
 /* translators: %s: Site title */
-printf( __( 'Your %s order has been marked complete on our side. We hope you enjoy it!', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( esc_html__( 'Your %s order has been marked complete on our side.', 'woocommerce' ), esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) ) . "\n\n";
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
@@ -49,12 +49,8 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-?>
-<p>
-<?php _e( 'Thanks for shopping with us.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
-</p>
-<?php
+echo esc_html__( 'Thanks for shopping with us.', 'woocommerce' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo esc_html( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/templates/emails/plain/customer-completed-order.php
+++ b/templates/emails/plain/customer-completed-order.php
@@ -10,23 +10,25 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author		WooThemes
- * @package 	WooCommerce/Templates/Emails/Plain
- * @version		2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo "= " . $email_heading . " =\n\n";
+echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
-echo sprintf( __( "Hi there. Your recent order on %s has been completed. Your order details are shown below for your reference:", 'woocommerce' ), get_option( 'blogname' ) ) . "\n\n";
+/* translators: %s: Customer first name */
+printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+/* translators: %s: Site title */
+printf( __( 'Your %s order has been marked complete on our side. We hope you enjoy it!', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -36,17 +38,23 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
+?>
+<p>
+<?php _e( 'Thanks for shopping with us.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+</p>
+<?php
+
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -10,10 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author		WooThemes
- * @package 	WooCommerce/Templates/Emails/Plain
- * @version		2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,14 +21,27 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
-if ( $order->has_status( 'pending' ) ) {
+/* translators: %s: Customer first name */
+printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
-	echo sprintf(
-		/* translators: %1s item is the name of the site, %2s is a html link */
-		esc_html__( 'An order has been created for you on %1$s. %2$s', 'woocommerce' ),
+if ( $order->has_status( 'pending' ) ) {
+	printf(
+		wp_kses(
+			/* translators: %1$s Site title, %2$s Order pay link */
+			__( 'An order has been created for you on %1$s. Your invoice is below, with a link to make payment when you’re ready: %1$s', 'woocommerce' ),
+			array(
+				'a' => array(
+					'href' => array(),
+				),
+			)
+		),
 		esc_html( get_bloginfo( 'name', 'display' ) ),
-		esc_url( $order->get_checkout_payment_url() )
+		'<a href="' . esc_url( $order->get_checkout_payment_url() ) . '">' . esc_html__( 'Pay for this order', 'woocommerce' ) . '</a>'
 	) . "\n\n";
+
+} else {
+	/* translators: %s Order date */
+	printf( __( 'Here are the details of your order placed on %s:', 'woocommerce' ), wc_format_datetime( $this->object->get_date_created() ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 }
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
@@ -60,6 +72,8 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
+
+_e( 'Have a great day.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 

--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -22,10 +22,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
 /* translators: %s: Customer first name */
-printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ) . "\n\n";
 
 if ( $order->has_status( 'pending' ) ) {
-	printf(
+	echo sprintf(
 		wp_kses(
 			/* translators: %1$s Site title, %2$s Order pay link */
 			__( 'An order has been created for you on %1$s. Your invoice is below, with a link to make payment when you’re ready: %1$s', 'woocommerce' ),
@@ -41,9 +41,8 @@ if ( $order->has_status( 'pending' ) ) {
 
 } else {
 	/* translators: %s Order date */
-	printf( __( 'Here are the details of your order placed on %s:', 'woocommerce' ), wc_format_datetime( $this->object->get_date_created() ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+	echo sprintf( esc_html__( 'Here are the details of your order placed on %s:', 'woocommerce' ), esc_html( wc_format_datetime( $this->object->get_date_created() ) ) ) . "\n\n";
 }
-
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
 /**
@@ -73,7 +72,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-_e( 'Have a great day.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput
+echo esc_html__( 'Have a great day.', 'woocommerce' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 

--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
 /* translators: %s: Customer first name */
-printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 if ( $order->has_status( 'pending' ) ) {
 	printf(

--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -72,8 +72,8 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-echo esc_html__( 'Have a great day.', 'woocommerce' ) . "\n\n";
+echo esc_html__( 'Thanks for reading.', 'woocommerce' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo wp_kses_post( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );
+echo esc_html( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/templates/emails/plain/customer-new-account.php
+++ b/templates/emails/plain/customer-new-account.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
 /* translators: %s Customer first name */
-echo esc_html__( 'Hi %s,', 'woocommerce' ) . "\n\n";
+echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
 /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */
 echo sprintf( esc_html__( 'Thanks for creating an account on %1$s. As a reminder, the username you chose is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>', esc_html( wc_get_page_permalink( 'myaccount' ) ) ) . "\n\n";
 

--- a/templates/emails/plain/customer-new-account.php
+++ b/templates/emails/plain/customer-new-account.php
@@ -10,26 +10,29 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates/Emails/Plain
- * @version     2.0.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
-echo "= " . $email_heading . " =\n\n";
+echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
-echo sprintf( __( 'Thanks for creating an account on %1$s. Your username is %2$s', 'woocommerce' ), $blogname, '<strong>' . $user_login . '</strong>' ) . "\n\n";
+/* translators: %s Customer first name */
+echo esc_html__( 'Hi %s,', 'woocommerce' ) . "\n\n";
+/* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */
+echo sprintf( esc_html__( 'Thanks for creating an account on %1$s. As a reminder, the username you chose is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>', esc_html( wc_get_page_permalink( 'myaccount' ) ) ) . "\n\n";
 
 if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && $password_generated ) {
-	echo sprintf( __( 'Your password is %s.', 'woocommerce' ), '<strong>' . $user_pass . '</strong>' ) . "\n\n";
+	/* translators: %s Auto generated password */
+	echo sprintf( esc_html__( 'Your password has been automatically generated: %s.', 'woocommerce' ), esc_html( $user_pass ) ) . "\n\n";
 }
 
-echo sprintf( __( 'You can access your account area to view your orders and change your password here: %s.', 'woocommerce' ), wc_get_page_permalink( 'myaccount' ) ) . "\n\n";
+echo esc_html__( 'We look forward to seeing you soon.', 'woocommerce' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/templates/emails/plain/customer-note.php
+++ b/templates/emails/plain/customer-note.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
 /* translators: %s Customer first name */
-printf( esc_html__( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ) . "\n\n";
 echo esc_html__( 'The following note has been added to your order:', 'woocommerce' ) . "\n\n";
 
 echo "----------\n\n";
@@ -57,8 +57,8 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-esc_html_e( 'Have a great day.', 'woocommerce' );
+echo esc_html__( 'Thanks for reading.', 'woocommerce' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo esc_html( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/templates/emails/plain/customer-note.php
+++ b/templates/emails/plain/customer-note.php
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
 /* translators: %s Customer first name */
-printf( esc_html__( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+printf( esc_html__( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 echo esc_html__( 'The following note has been added to your order:', 'woocommerce' ) . "\n\n";
 
 echo "----------\n\n";

--- a/templates/emails/plain/customer-note.php
+++ b/templates/emails/plain/customer-note.php
@@ -10,31 +10,33 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author		WooThemes
- * @package 	WooCommerce/Templates/Emails/Plain
- * @version		2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo "= " . $email_heading . " =\n\n";
+echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
-echo __( "Hello, a note has just been added to your order:", 'woocommerce' ) . "\n\n";
-
-echo "----------\n\n";
-
-echo wptexturize( $customer_note ) . "\n\n";
+/* translators: %s Customer first name */
+printf( esc_html__( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo esc_html__( 'The following note has been added to your order:', 'woocommerce' ) . "\n\n";
 
 echo "----------\n\n";
 
-echo __( "For your reference, your order details are shown below.", 'woocommerce' ) . "\n\n";
+echo wptexturize( $customer_note ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+
+echo "----------\n\n";
+
+echo esc_html__( 'As a reminder, here are your order details:', 'woocommerce' ) . "\n\n";
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -44,17 +46,19 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
+esc_html_e( 'Have a great day.', 'woocommerce' );
+
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/templates/emails/plain/customer-on-hold-order.php
+++ b/templates/emails/plain/customer-on-hold-order.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 /* translators: %s: Customer first name */
-echo sprintf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 echo __( 'Thanks for your order. It’s on-hold until we confirm that payment has been received. In the meantime, here’s a reminder of what you ordered:', 'woocommerce' ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";

--- a/templates/emails/plain/customer-on-hold-order.php
+++ b/templates/emails/plain/customer-on-hold-order.php
@@ -10,23 +10,24 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author		WooThemes
- * @package 	WooCommerce/Templates/Emails/Plain
- * @version		2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo "= " . $email_heading . " =\n\n";
+echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
-echo __( "Your order is on-hold until we confirm payment has been received. Your order details are shown below for your reference:", 'woocommerce' ) . "\n\n";
+/* translators: %s: Customer first name */
+echo sprintf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo __( 'Thanks for your order. It’s on-hold until we confirm that payment has been received. In the meantime, here’s a reminder of what you ordered:', 'woocommerce' ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -36,17 +37,19 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
+_e( 'We look forward to fulfilling your order soon.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput
+
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput

--- a/templates/emails/plain/customer-processing-order.php
+++ b/templates/emails/plain/customer-processing-order.php
@@ -23,8 +23,8 @@ echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutpu
 
 /* translators: %s: Customer first name */
 printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-/* translators: %s: Site title */
-printf( __( 'Your %s order has been marked complete on our side. We hope you enjoy it!', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+/* translators: %s: Order number */
+printf( __( 'Just to let you know -- your payment has been confirmed, and order %s is now being processed:', 'woocommerce' ), $order->get_order_number() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 

--- a/templates/emails/plain/customer-processing-order.php
+++ b/templates/emails/plain/customer-processing-order.php
@@ -19,12 +19,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
 /* translators: %s: Customer first name */
-printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ) . "\n\n";
 /* translators: %s: Order number */
-printf( __( 'Just to let you know -- your payment has been confirmed, and order %s is now being processed:', 'woocommerce' ), $order->get_order_number() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( esc_html__( 'Just to let you know -- your payment has been confirmed, and order #%s is now being processed:', 'woocommerce' ), esc_html( $order->get_order_number() ) ) . "\n\n";
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
@@ -49,8 +49,8 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-_e( 'Woo!', 'woocommerce' ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput
+echo esc_html_e( 'Thanks!', 'woocommerce' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo esc_html( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/templates/emails/plain/customer-processing-order.php
+++ b/templates/emails/plain/customer-processing-order.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 /* translators: %s: Customer first name */
-printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+printf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 /* translators: %s: Order number */
 printf( __( 'Just to let you know -- your payment has been confirmed, and order %s is now being processed:', 'woocommerce' ), $order->get_order_number() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 

--- a/templates/emails/plain/customer-processing-order.php
+++ b/templates/emails/plain/customer-processing-order.php
@@ -49,7 +49,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-_e( 'Thanks for shopping with us.', 'woocommerce' ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput
+_e( 'Woo!', 'woocommerce' ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 

--- a/templates/emails/plain/customer-processing-order.php
+++ b/templates/emails/plain/customer-processing-order.php
@@ -10,23 +10,25 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author		WooThemes
- * @package 	WooCommerce/Templates/Emails/Plain
- * @version		2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo "= " . $email_heading . " =\n\n";
+echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
-echo __( "Your order has been received and is now being processed. Your order details are shown below for your reference:", 'woocommerce' ) . "\n\n";
+/* translators: %s: Customer first name */
+printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+/* translators: %s: Site title */
+printf( __( 'Your %s order has been marked complete on our side. We hope you enjoy it!', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -36,17 +38,19 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
+_e( 'Thanks for shopping with us.', 'woocommerce' ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput
+
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/templates/emails/plain/customer-refunded-order.php
+++ b/templates/emails/plain/customer-refunded-order.php
@@ -10,23 +10,29 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author		WooThemes
- * @package 	WooCommerce/Templates/Emails/Plain
- * @version		2.5.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails/Plain
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-echo "= " . $email_heading . " =\n\n";
+echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
-echo sprintf( __( "Hi there. Your order on %s has been refunded. Your order details are shown below for your reference:", 'woocommerce' ), get_option( 'blogname' ) ) . "\n\n";
-
+/* translators: %s: Customer first name */
+printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+if ( $partial_refund ) {
+	/* translators: %s: Site title */
+	printf( __( 'Your order on %s has been partially refunded. There are more details below for your reference:', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+} else {
+	/* translators: %s: Site title */
+	printf( __( 'Your order on %s has been refunded. There are more details below for your reference:', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+}
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_details() Shows the order details table.
  * @hooked WC_Structured_Data::generate_order_data() Generates structured data.
  * @hooked WC_Structured_Data::output_structured_data() Outputs structured data.
@@ -36,17 +42,23 @@ do_action( 'woocommerce_email_order_details', $order, $sent_to_admin, $plain_tex
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-/**
+/*
  * @hooked WC_Emails::order_meta() Shows order meta data.
  */
 do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, $email );
 
-/**
+/*
  * @hooked WC_Emails::customer_details() Shows customer details
  * @hooked WC_Emails::email_address() Shows email address
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
+?>
+<p>
+<?php _e( 'We hope to see you again soon.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+</p>
+<?php
+
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/templates/emails/plain/customer-refunded-order.php
+++ b/templates/emails/plain/customer-refunded-order.php
@@ -53,11 +53,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-?>
-<p>
-<?php _e( 'We hope to see you again soon.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput ?>
-</p>
-<?php
+_e( 'We hope to see you again soon.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 

--- a/templates/emails/plain/customer-refunded-order.php
+++ b/templates/emails/plain/customer-refunded-order.php
@@ -22,13 +22,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . $email_heading . " =\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 /* translators: %s: Customer first name */
-printf( __( 'Hi %s,', 'woocommerce' ), $order->get_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( __( 'Hi %s,', 'woocommerce' ), $order->get_billing_first_name() ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 if ( $partial_refund ) {
 	/* translators: %s: Site title */
-	printf( __( 'Your order on %s has been partially refunded. There are more details below for your reference:', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+	echo sprintf( __( 'Your order on %s has been partially refunded. There are more details below for your reference:', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 } else {
 	/* translators: %s: Site title */
-	printf( __( 'Your order on %s has been refunded. There are more details below for your reference:', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+	echo sprintf( __( 'Your order on %s has been refunded. There are more details below for your reference:', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n"; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 }
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
@@ -53,7 +53,7 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-_e( 'We hope to see you again soon.', 'woocommerce' ); // phpcs:ignore WordPress.XSS.EscapeOutput
+echo esc_html__( 'We hope to see you again soon.', 'woocommerce' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 

--- a/templates/emails/plain/customer-reset-password.php
+++ b/templates/emails/plain/customer-reset-password.php
@@ -22,12 +22,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
 /* translators: %s Customer first name */
-echo esc_html__( 'Hi %s,', 'woocommerce' ) . "\n\n";
+echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
 echo esc_html__( 'Someone (hopefully you) has requested a password reset for the following account on:', 'woocommerce' ) . "\n\n";
 /* translators: %s Store name */
-printf( esc_html__( 'Store: %s', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n";// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( esc_html__( 'Store: %s', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n";// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 /* translators: %s Customer username */
-printf( esc_html__( 'Username: %s', 'woocommerce' ), $user_login ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo sprintf( esc_html__( 'Username: %s', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
 echo esc_html__( 'If this was a mistake, just ignore this email and nothing will happen. Otherwise, follow this link to reset your password now:', 'woocommerce' ) . "\n\n";
 echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ) . "\n\n"; // phpcs:ignore
 echo esc_html__( 'Good luck!', 'woocommerce' ) . "\n\n";

--- a/templates/emails/plain/customer-reset-password.php
+++ b/templates/emails/plain/customer-reset-password.php
@@ -10,26 +10,28 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
+ * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates/Emails/Plain
- * @version 2.3.0
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
-echo "= " . $email_heading . " =\n\n";
+echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
-echo __( 'Someone requested that the password be reset for the following account:', 'woocommerce' ) . "\r\n\r\n";
-echo esc_url( network_home_url( '/' ) ) . "\r\n\r\n";
-echo sprintf( __( 'Username: %s', 'woocommerce' ), $user_login ) . "\r\n\r\n";
-echo __( 'If this was a mistake, just ignore this email and nothing will happen.', 'woocommerce' ) . "\r\n\r\n";
-echo __( 'To reset your password, visit the following address:', 'woocommerce' ) . "\r\n\r\n";
-
-echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ) . "\r\n";
+/* translators: %s Customer first name */
+echo esc_html__( 'Hi %s,', 'woocommerce' ) . "\n\n";
+echo esc_html__( 'Someone (hopefully you) has requested a password reset for the following account on:', 'woocommerce' ) . "\n\n";
+/* translators: %s Store name */
+printf( esc_html__( 'Store: %s', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n";// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+/* translators: %s Customer username */
+printf( esc_html__( 'Username: %s', 'woocommerce' ), $user_login ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo esc_html__( 'If this was a mistake, just ignore this email and nothing will happen. Otherwise, follow this link to reset your password now:', 'woocommerce' ) . "\n\n";
+echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ) . "\n\n"; // phpcs:ignore
+echo esc_html__( 'Good luck!', 'woocommerce' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );
+echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/templates/emails/plain/customer-reset-password.php
+++ b/templates/emails/plain/customer-reset-password.php
@@ -21,17 +21,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 echo '= ' . esc_html( $email_heading ) . " =\n\n";
 
-/* translators: %s Customer first name */
+/* translators: %s: Customer first name */
 echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
-echo esc_html__( 'Someone (hopefully you) has requested a password reset for the following account on:', 'woocommerce' ) . "\n\n";
-/* translators: %s Store name */
-echo sprintf( esc_html__( 'Store: %s', 'woocommerce' ), wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) . "\n\n";// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-/* translators: %s Customer username */
+/* translators: %s: Store name */
+echo sprintf( esc_html__( 'Someone has requested a new password for the following account on %s:', 'woocommerce' ), esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) ) . "\n\n";
+/* translators: %s: Customer username */
 echo sprintf( esc_html__( 'Username: %s', 'woocommerce' ), esc_html( $user_login ) ) . "\n\n";
-echo esc_html__( 'If this was a mistake, just ignore this email and nothing will happen. Otherwise, follow this link to reset your password now:', 'woocommerce' ) . "\n\n";
+echo esc_html__( 'If you didn\'t make this request, just ignore this email. If you\'d like to proceed:', 'woocommerce' ) . "\n\n";
 echo esc_url( add_query_arg( array( 'key' => $reset_key, 'id' => $user_id ), wc_get_endpoint_url( 'lost-password', '', wc_get_page_permalink( 'myaccount' ) ) ) ) . "\n\n"; // phpcs:ignore
-echo esc_html__( 'Good luck!', 'woocommerce' ) . "\n\n";
+echo esc_html__( 'Thanks for reading.', 'woocommerce' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 
-echo apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) );// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+echo esc_html( apply_filters( 'woocommerce_email_footer_text', get_option( 'woocommerce_email_footer_text' ) ) );

--- a/templates/emails/plain/email-order-details.php
+++ b/templates/emails/plain/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates/Emails
- * @version 3.4.0
+ * @version 3.5.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -21,9 +21,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plain_text, $email );
 
-/* translators: %s: Order ID. */
-echo wp_kses_post( wc_strtoupper( sprintf( __( 'Order number: %s', 'woocommerce' ), $order->get_order_number() ) ) ) . "\n";
-echo wc_format_datetime( $order->get_date_created() ) . "\n";  // WPCS: XSS ok.
+/* translators: %1$s: Order ID. %2$s: Order date */
+echo wp_kses_post( wc_strtoupper( sprintf( __( '[Order #%1$s] (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) ) . "\n";
 echo "\n" . wc_get_email_order_items( $order, array( // WPCS: XSS ok.
 	'show_sku'      => $sent_to_admin,
 	'show_image'    => false,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the copy of all the emails to make it more human and inviting to store admins and customers.

Closes #21233

### How to test the changes in this Pull Request:

1. Test all emails using HTML and plain text modes and ensure everything looks good and there are no grammer errors.
2. Admin emails to test: new order, cancelled order, failed order
3. Customer emails to test: on-hold, processing, completed, refunded both full and partially, invoice both with a pending and non-pending status, customer notes, password reset, new account.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - Improve the default copy of all store emails.
