### PR TITLE
Add offset to get_order_report_data to be able of pagination

### DIFF
--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -83,6 +83,7 @@ class WC_Admin_Report {
 			'group_by'            => '',
 			'order_by'            => '',
 			'limit'               => '',
+			'offset'              => '',
 			'filter_range'        => false,
 			'nocache'             => false,
 			'debug'               => false,
@@ -319,6 +320,10 @@ class WC_Admin_Report {
 		if ( $limit ) {
 			$query['limit'] = "LIMIT {$limit}";
 		}
+		
+		if ( $offset ) {
+            $query['offset'] = "OFFSET {$offset}";
+        }
 
 		$query          = apply_filters( 'woocommerce_reports_get_order_report_query', $query );
 		$query          = implode( ' ', $query );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Search for orders using get_order_report_data method of WC_Admin_Report class sending a param offset.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
