### PR TITLE
Tax display in cart now depends on whether customer is tax exempt.

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -104,7 +104,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function __construct() {
 		$this->session          = new WC_Cart_Session( $this );
 		$this->fees_api         = new WC_Cart_Fees( $this );
-		$this->tax_display_cart = get_option( 'woocommerce_tax_display_cart' );
+		$this->tax_display_cart = $this->is_tax_displayed();
 
 		// Register hooks for the objects.
 		$this->session->init();
@@ -1939,5 +1939,18 @@ class WC_Cart extends WC_Legacy_Cart {
 		$this->totals = $this->default_totals;
 		$this->fees_api->remove_all_fees();
 		do_action( 'woocommerce_cart_reset', $this, false );
+	}
+
+	/**
+	 * Returns 'incl' if tax should be included in cart, otherwise returns 'excl'.
+	 *
+	 * @return string
+	 */
+	private function is_tax_displayed() {
+		if ( $this->get_customer() && $this->get_customer()->get_is_vat_exempt() ) {
+			return 'excl';
+		}
+
+		return get_option( 'woocommerce_tax_display_cart' );
 	}
 }

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -486,8 +486,9 @@ final class WooCommerce {
 			$this->session = new $session_class();
 			$this->session->init();
 
-			$this->cart     = new WC_Cart();
 			$this->customer = new WC_Customer( get_current_user_id(), true );
+			// Cart needs the customer info.
+			$this->cart = new WC_Cart();
 
 			// Customer should be saved during shutdown.
 			add_action( 'shutdown', array( $this->customer, 'save' ), 10 );

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -86,8 +86,6 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 		WC()->cart->add_discount( $coupon->get_code() );
 
 		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'add_cart_fees_callback' ) );
-
-		$this->totals = new WC_Cart_Totals( WC()->cart );
 	}
 
 	/**
@@ -108,6 +106,8 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 		WC_Helper_Shipping::delete_simple_flat_rate();
 		remove_action( 'woocommerce_cart_calculate_fees', array( $this, 'add_cart_fees_callback' ) );
 
+		WC()->customer->set_is_vat_exempt( false );
+
 		parent::tearDown();
 	}
 
@@ -115,6 +115,9 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 	 * Test get and set items.
 	 */
 	public function test_get_totals() {
+		WC()->customer->set_is_vat_exempt( false );
+		$this->totals = new WC_Cart_Totals( WC()->cart );
+
 		$this->assertEquals(
 			array(
 				'fees_total'          => 40.00,
@@ -134,9 +137,36 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test get totals for tax exempt customer.
+	 */
+	public function test_get_totals_tax_exempt_customer() {
+		WC()->customer->set_is_vat_exempt( true );
+		$this->totals = new WC_Cart_Totals( WC()->cart );
+
+		$this->assertEquals(
+			array(
+				'fees_total'          => 40.00,
+				'fees_total_tax'      => 0.00,
+				'items_subtotal'      => 40.00,
+				'items_subtotal_tax'  => 0.00,
+				'items_total'         => 36.00,
+				'items_total_tax'     => 0.00,
+				'total'               => 86.00,
+				'shipping_total'      => 10,
+				'shipping_tax_total'  => 0.00,
+				'discounts_total'     => 4.00,
+				'discounts_tax_total' => 0.00,
+			),
+			$this->totals->get_totals()
+		);
+	}
+
+	/**
 	 * Test that cart totals get updated.
 	 */
 	public function test_cart_totals() {
+		WC()->customer->set_is_vat_exempt( false );
+		$this->totals = new WC_Cart_Totals( WC()->cart );
 		$cart = WC()->cart;
 
 		$this->assertEquals( 40.00, $cart->get_fee_total() );
@@ -163,5 +193,39 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 		$this->assertEquals( 40.00, $cart->fee_total );
 		$this->assertEquals( 10, $cart->shipping_total );
 		$this->assertEquals( 2, $cart->shipping_tax_total );
+	}
+
+	/**
+	 * Test that cart totals get updated for tax exempt customer.
+	 */
+	public function test_cart_totals_tax_exempt_customer() {
+		WC()->customer->set_is_vat_exempt( true );
+		$this->totals = new WC_Cart_Totals( WC()->cart );
+		$cart = WC()->cart;
+
+		$this->assertEquals( 40.00, $cart->get_fee_total() );
+		$this->assertEquals( 36.00, $cart->get_cart_contents_total() );
+		$this->assertEquals( 86.00, $cart->get_total( 'edit' ) );
+		$this->assertEquals( 40.00, $cart->get_subtotal() );
+		$this->assertEquals( 0.00, $cart->get_subtotal_tax() );
+		$this->assertEquals( 0.00, $cart->get_cart_contents_tax() );
+		$this->assertEquals( 0.00, array_sum( $cart->get_cart_contents_taxes() ) );
+		$this->assertEquals( 0.00, $cart->get_fee_tax() );
+		$this->assertEquals( 0.00, array_sum( $cart->get_fee_taxes() ) );
+		$this->assertEquals( 4, $cart->get_discount_total() );
+		$this->assertEquals( 0.00, $cart->get_discount_tax() );
+		$this->assertEquals( 10, $cart->get_shipping_total() );
+		$this->assertEquals( 0.00, $cart->get_shipping_tax() );
+
+		$this->assertEquals( 36.00, $cart->cart_contents_total );
+		$this->assertEquals( 86.00, $cart->total );
+		$this->assertEquals( 40.00, $cart->subtotal );
+		$this->assertEquals( 40.00, $cart->subtotal_ex_tax );
+		$this->assertEquals( 0.00, $cart->tax_total );
+		$this->assertEquals( 4, $cart->discount_cart );
+		$this->assertEquals( 0.00, $cart->discount_cart_tax );
+		$this->assertEquals( 40.00, $cart->fee_total );
+		$this->assertEquals( 10, $cart->shipping_total );
+		$this->assertEquals( 0.00, $cart->shipping_tax_total );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21091 .

One thing I'm not 100% sure about is swapping the order of initialization of cart and customer in `class-woocommerce.php`. If someone knows that it might break something, maybe this needs a different solution.

### How to test the changes in this Pull Request:

1. Set up taxes according to https://github.com/woocommerce/woocommerce-eu-vat-number/issues/119
2. Add cart widget to sidebar.
3. Make logged in user tax exempt, e.g. by using a snippet from here: https://github.com/woocommerce/woocommerce-eu-vat-number/issues/119#issuecomment-413881541
4. Check that all discrepancies listed in https://github.com/woocommerce/woocommerce-eu-vat-number/issues/119 are fixed, namely: cart item, checkout order review item, cart widget item.
5. Check that order review received by the customer also displays taxes correctly for both tax exempt and normal customer.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tax display in cart now depends on whether customer is tax exempt.
