### PR TITLE
Inconsistency in product URL when parent and child category assigned to the product and product peramlink set to Shop base with category

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -220,12 +220,11 @@ function wc_product_post_type_link( $permalink, $post ) {
 	$terms = get_the_terms( $post->ID, 'product_cat' );
 
 	if ( ! empty( $terms ) ) {
-                // Find the child terms.
-                $child_terms = wp_filter_object_list( $terms, array( 'parent' => 0 ), 'not');
-                if ( ! empty( $child_terms ) ) {
-                        $terms = $child_terms;
-                }
-            
+		// Find the child terms.
+		$child_terms = wp_filter_object_list( $terms, array( 'parent' => 0 ), 'not' );
+		if ( ! empty( $child_terms ) ) {
+			$terms = $child_terms;
+		}
 		if ( function_exists( 'wp_list_sort' ) ) {
 			$terms = wp_list_sort( $terms, 'term_id', 'ASC' );
 		} else {

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -220,6 +220,12 @@ function wc_product_post_type_link( $permalink, $post ) {
 	$terms = get_the_terms( $post->ID, 'product_cat' );
 
 	if ( ! empty( $terms ) ) {
+                // Find the child terms.
+                $child_terms = wp_filter_object_list( $terms, array( 'parent' => 0 ), 'not');
+                if ( ! empty( $child_terms ) ) {
+                        $terms = $child_terms;
+                }
+            
 		if ( function_exists( 'wp_list_sort' ) ) {
 			$terms = wp_list_sort( $terms, 'term_id', 'ASC' );
 		} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Generally, we create parent category first and then child category. In this case if we assign both the categories to the product then the URL will look like http://example.com/shop/parent-category/product-slug

Now if we create child category first and then the parent category and assign both the categories to the product then the URL will look like http://example.com/shop/parent-category/child-category/product-slug

Reason for this we are sorting the categories by IDs in ascending order.
``$terms = wp_list_sort( $terms, 'term_id', 'ASC' );`` 
So the category created first is assigned to the product.

I am just finding the child category first from the list and then sorting by ID so in any case the URL will remain same. And when there is no child category assign to the product then fallback to default logic.

### How to test the changes in this Pull Request:

1. Set the product permalink to ``Shop base with category`` 
2. Create a parent category then child category and assign both categories to a product. The URL will look like http://example.com/shop/parent-category/product-slug
3. Now create two categories, and edit the first category and assign second category as parent then the URL will be http://example.com/shop/parent-category/child-category/product-slug
4. Apply the changes proposed in this request and both the URLs will be same with child category appended in the URL.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed inconsistency in product URL when parent and child category assigned to the product.