### PR TITLE
Update quick edit logic to show/hide Stock qty and Backorders fields

### DIFF
--- a/assets/js/admin/quick-edit.js
+++ b/assets/js/admin/quick-edit.js
@@ -70,11 +70,11 @@ jQuery(function( $ ) {
 
 		if ( product_supports_stock_fields ) {
 			if ( 'yes' === manage_stock ) {
-				$( '.stock_fields' ).show().removeAttr( 'style' );
+				$( '.stock_qty_field, .backorder_field', '.inline-edit-row' ).show().removeAttr( 'style' );
 				$( '.stock_status_field' ).hide();
 				$( '.manage_stock_field input' ).prop( 'checked', true );
 			} else {
-				$( '.stock_qty_field', '.inline-edit-row' ).hide();
+				$( '.stock_qty_field, .backorder_field', '.inline-edit-row' ).hide();
 				$( '.stock_status_field' ).show().removeAttr( 'style' );
 				$( '.manage_stock_field input' ).prop( 'checked', false );
 			}
@@ -103,10 +103,10 @@ jQuery(function( $ ) {
 	$( '#the-list' ).on( 'change', '.inline-edit-row input[name="_manage_stock"]', function() {
 
 		if ( $( this ).is( ':checked' ) ) {
-			$( '.stock_qty_field', '.inline-edit-row' ).show().removeAttr( 'style' );
+			$( '.stock_qty_field, .backorder_field', '.inline-edit-row' ).show().removeAttr( 'style' );
 			$( '.stock_status_field' ).hide();
 		} else {
-			$( '.stock_qty_field', '.inline-edit-row' ).hide();
+			$( '.stock_qty_field, .backorder_field', '.inline-edit-row' ).hide();
 			$( '.stock_status_field' ).show().removeAttr( 'style' );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This commit reverts some of the changes done in #20005. It fixes the following issues,
1. In the product list table open any simple product whose stock is not managing, then `.stock_qty_field`(the wrapper label class for _stock input) will be hidden. But after that, if we open the quick editor for simple product whose stock we are managing, `.stock_qty_field` still remains hidden.
2. Backorders field always visible for simple products even the Manage Stock checkbox is unchecked. According to the [WooCommerce documentation](https://docs.woocommerce.com/document/managing-products/#section-25), Manage Stock must be checked in order to make visible this Backorders field.

### How to test the changes in this Pull Request:

1. Open the quick editor for a simple product whose stock you're not managing. Now open a product whose stock you're managing. `Stock qty` field should be shown.
2. Check the `Manage Stock` checkbox, `Stock qty` and `Backorders` fields should be shown and `In Stock` field should be hidden. Unchecking will invert their visibility.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Fix - Update quick edit logic to show/hide Stock qty and Backorders fields
