### PR TITLE
Fix customer list query

### DIFF
--- a/includes/admin/reports/class-wc-report-customer-list.php
+++ b/includes/admin/reports/class-wc-report-customer-list.php
@@ -265,7 +265,7 @@ class WC_Report_Customer_List extends WP_List_Table {
 		 */
 		$admin_users = new WP_User_Query(
 			array(
-				'role'   => 'administrator1',
+				'role'   => 'administrator',
 				'fields' => 'ID',
 			)
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This fixes incorrect results in "Customers list" report.

### How to test the changes in this Pull Request:

1. Go to `admin.php?page=wc-reports&tab=customers&report=customer_list`
2. See that administrators aren't included anymore.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Excluded administrators from "Customer list" report.
