### PR TITLE
Fix encoded special chars in layered nav "Any %s" string.

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -293,7 +293,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 				if ( jQuery().selectWoo ) {
 					var wc_layered_nav_select = function() {
 						jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).selectWoo( {
-							placeholder: '" . wp_specialchars_decode( esc_js( $any_label ), ENT_QUOTES, get_bloginfo( 'charset' ) ) . "',
+							placeholder: '" . wp_specialchars_decode( esc_js( $any_label ), ENT_QUOTES ) . "',
 							minimumResultsForSearch: 5,
 							width: '100%',
 							allowClear: " . ( $multiple ? 'false' : 'true' ) . ",

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -293,7 +293,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 				if ( jQuery().selectWoo ) {
 					var wc_layered_nav_select = function() {
 						jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).selectWoo( {
-							placeholder: '" . wp_specialchars_decode( esc_js( $any_label ), ENT_QUOTES ) . "',
+							placeholder: '" . wp_json_encode( (string) wp_specialchars_decode( $any_label, ENT_QUOTES ) ) . "',
 							minimumResultsForSearch: 5,
 							width: '100%',
 							allowClear: " . ( $multiple ? 'false' : 'true' ) . ",

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -293,7 +293,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 				if ( jQuery().selectWoo ) {
 					var wc_layered_nav_select = function() {
 						jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).selectWoo( {
-							placeholder: '" . esc_js( $any_label ) . "',
+							placeholder: '" . wp_specialchars_decode( esc_js( $any_label ), ENT_QUOTES, get_bloginfo( 'charset' ) ) . "',
 							minimumResultsForSearch: 5,
 							width: '100%',
 							allowClear: " . ( $multiple ? 'false' : 'true' ) . ",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue with the Any %s string when using the layered nav widget where it will show the encoded special chars instead of the actual character.

Closes #21295 

### How to test the changes in this Pull Request:

1. Create a global attribute with quotes in the name.
2. Assign the attribute to a product
3. View the layered nav widget, the Any Attribute Name string should show the actual quote and not the HTML entity code.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Fix Layered Nav Widget where special HTML entities did not display correctly in the "Any %s" string.
