### PR TITLE
Add filter to control the restore refunded items chekbox default

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -253,7 +253,12 @@ if ( wc_tax_enabled() ) {
 		<?php if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) : ?>
 			<tr>
 				<td class="label"><label for="restock_refunded_items"><?php esc_html_e( 'Restock refunded items', 'woocommerce' ); ?>:</label></td>
-				<td class="total"><input type="checkbox" id="restock_refunded_items" name="restock_refunded_items" checked="checked" /></td>
+				<?php
+				if ( 'yes' === get_option( 'woocommerce_restock_refunded_items' ) ) {
+					$checked = 'checked="checked"';
+				}
+				?>
+				<td class="total"><input type="checkbox" id="restock_refunded_items" name="restock_refunded_items"<?php echo esc_attr( $checked, 'woocommerce' ); ?> /></td>
 			</tr>
 		<?php endif; ?>
 		<tr>

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -253,14 +253,7 @@ if ( wc_tax_enabled() ) {
 		<?php if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) : ?>
 			<tr>
 				<td class="label"><label for="restock_refunded_items"><?php esc_html_e( 'Restock refunded items', 'woocommerce' ); ?>:</label></td>
-				<?php
-				if ( apply_filter( 'woocommerce_restock_refunded_items', false ) ) {
-					$checked = 1;
-				} else {
-					$checked = 0;
-				}
-				?>
-				<td class="total"><input type="checkbox" id="restock_refunded_items" name="restock_refunded_items"<?php checked( 1, $checked, true ); ?> /></td>
+				<td class="total"><input type="checkbox" id="restock_refunded_items" name="restock_refunded_items" <?php checked( apply_filters( 'woocommerce_restock_refunded_items', true ) ); ?> /></td>
 			</tr>
 		<?php endif; ?>
 		<tr>

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -254,11 +254,13 @@ if ( wc_tax_enabled() ) {
 			<tr>
 				<td class="label"><label for="restock_refunded_items"><?php esc_html_e( 'Restock refunded items', 'woocommerce' ); ?>:</label></td>
 				<?php
-				if ( 'yes' === get_option( 'woocommerce_restock_refunded_items' ) ) {
-					$checked = 'checked="checked"';
+				if ( apply_filter( 'woocommerce_restock_refunded_items', false ) ) {
+					$checked = 1;
+				} else {
+					$checked = 0;
 				}
 				?>
-				<td class="total"><input type="checkbox" id="restock_refunded_items" name="restock_refunded_items"<?php echo esc_attr( $checked, 'woocommerce' ); ?> /></td>
+				<td class="total"><input type="checkbox" id="restock_refunded_items" name="restock_refunded_items"<?php checked( 1, $checked, true ); ?> /></td>
 			</tr>
 		<?php endif; ?>
 		<tr>

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -140,14 +140,6 @@ class WC_Settings_Products extends WC_Settings_Page {
 					),
 
 					array(
-						'title'   => __( 'Restock refunded items', 'woocommerce' ),
-						'desc'    => __( 'Uncheck this to default to NOT restocking items when refunding', 'woocommerce' ),
-						'id'      => 'woocommerce_restock_refunded_items',
-						'default' => 'yes',
-						'type'    => 'checkbox',
-					),
-
-					array(
 						'title'             => __( 'Hold stock (minutes)', 'woocommerce' ),
 						'desc'              => __( 'Hold stock (for unpaid orders) for x minutes. When this limit is reached, the pending order will be cancelled. Leave blank to disable.', 'woocommerce' ),
 						'id'                => 'woocommerce_hold_stock_minutes',

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -140,6 +140,14 @@ class WC_Settings_Products extends WC_Settings_Page {
 					),
 
 					array(
+						'title'   => __( 'Restock refunded items', 'woocommerce' ),
+						'desc'    => __( 'Uncheck this to default to NOT restocking items when refunding', 'woocommerce' ),
+						'id'      => 'woocommerce_restock_refunded_items',
+						'default' => 'yes',
+						'type'    => 'checkbox',
+					),
+
+					array(
 						'title'             => __( 'Hold stock (minutes)', 'woocommerce' ),
 						'desc'              => __( 'Hold stock (for unpaid orders) for x minutes. When this limit is reached, the pending order will be cancelled. Leave blank to disable.', 'woocommerce' ),
 						'id'                => 'woocommerce_hold_stock_minutes',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR replaces #20823 It keeps the original author commits as to give credit, and I just updated it to reflect the changes that I would have liked, a filter instead of an option.

A new filter woocommerce_restock_refunded_items can be set to true if you want the checkbox checked by default, it defaults to unchecked.

Closes #20822

### How to test the changes in this Pull Request:

1. Add the following code to your site `add_filter( 'woocommerce_restock_refunded_items', '__return_true' );
2. Check that when refunding an item from an order the restore stock option is checked by default.
3. Remove the code and check that the option is not checked by default.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - woocommerce_restock_refunded_items filter to control default state of the restock option when refunding items on an order.
