### PR TITLE
[REST API] Fixed order notes schema

### DIFF
--- a/includes/api/class-wc-rest-order-notes-controller.php
+++ b/includes/api/class-wc-rest-order-notes-controller.php
@@ -113,19 +113,61 @@ class WC_REST_Order_Notes_Controller extends WC_REST_Order_Notes_V2_Controller {
 	 * @return array
 	 */
 	public function get_item_schema() {
-		$schema                                = parent::get_item_schema();
-		$schema['properties']['author']        = array(
-			'description' => __( 'Order note author.', 'woocommerce' ),
-			'type'        => 'string',
-			'readonly'    => true,
-			'context'     => array( 'view', 'edit' ),
+		$schema = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'order_note',
+			'type'       => 'object',
+			'properties' => array(
+				'id'               => array(
+					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'author'           => array(
+					'description' => __( 'Order note author.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created'     => array(
+					'description' => __( "The date the order note was created, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created'     => array(
+					'description' => __( "The date the order note was created, in the site's timezone.", 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'date_created_gmt' => array(
+					'description' => __( 'The date the order note was created, as GMT.', 'woocommerce' ),
+					'type'        => 'date-time',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'note'             => array(
+					'description' => __( 'Order note content.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+				),
+				'customer_note'    => array(
+					'description' => __( 'If true, the note will be shown to customers and they will be notified. If false, the note will be for admin reference only.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'view', 'edit' ),
+				),
+				'added_by_user'    => array(
+					'description' => __( 'If true, this note will be attributed to the current user. If false, the note will be attributed to the system.', 'woocommerce' ),
+					'type'        => 'boolean',
+					'default'     => false,
+					'context'     => array( 'edit' ),
+				),
+			),
 		);
-		$schema['properties']['added_by_user'] = array(
-			'description' => __( 'If true, this note will be attributed to the current user. If false, the note will be attributed to the system.', 'woocommerce' ),
-			'type'        => 'boolean',
-			'default'     => false,
-			'context'     => array( 'edit' ),
-		);
-		return $schema;
+
+		return $this->add_additional_fields_schema( $schema );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes order notes schema, setting the correct order of items.

### How to test the changes in this Pull Request:

1. OPTIONS /wp-json/wc/v3/order/notes

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
