### PR TITLE
[REST API] Allow apply and remove coupons in orders endpoint 

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -72,8 +72,15 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 							foreach ( $value as $item ) {
 								if ( is_array( $item ) ) {
 									if ( $this->item_is_null( $item ) || ( isset( $item['quantity'] ) && 0 === $item['quantity'] ) ) {
-										if ( ! empty( $item['id'] ) ) {
-											$order->remove_item( $item['id'] );
+										if ( ! empty( $item['id'] ) && empty( $item['code'] ) ) {
+											$coupons = $order->get_items( 'coupon' );
+
+											foreach ( $coupons as $item_id => $coupon ) {
+												if ( $item_id === $item['id'] ) {
+													$order->remove_coupon( $coupon->get_code() );
+													break;
+												}
+											}
 										} elseif ( ! empty( $item['code'] ) ) {
 											$order->remove_coupon( wc_clean( $item['code'] ) );
 										}

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -26,6 +26,100 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	protected $namespace = 'wc/v3';
 
 	/**
+	 * Prepare a single order for create or update.
+	 *
+	 * @throws WC_REST_Exception When fails to set any item.
+	 * @param  WP_REST_Request $request Request object.
+	 * @param  bool            $creating If is creating a new object.
+	 * @return WP_Error|WC_Data
+	 */
+	protected function prepare_object_for_database( $request, $creating = false ) {
+		$id        = isset( $request['id'] ) ? absint( $request['id'] ) : 0;
+		$order     = new WC_Order( $id );
+		$schema    = $this->get_item_schema();
+		$data_keys = array_keys( array_filter( $schema['properties'], array( $this, 'filter_writable_props' ) ) );
+
+		// Handle all writable props.
+		foreach ( $data_keys as $key ) {
+			$value = $request[ $key ];
+
+			if ( ! is_null( $value ) ) {
+				switch ( $key ) {
+					case 'status':
+						// Status change should be done later so transitions have new data.
+						break;
+					case 'billing':
+					case 'shipping':
+						$this->update_address( $order, $value, $key );
+						break;
+					case 'line_items':
+					case 'shipping_lines':
+					case 'fee_lines':
+						if ( is_array( $value ) ) {
+							foreach ( $value as $item ) {
+								if ( is_array( $item ) ) {
+									if ( $this->item_is_null( $item ) || ( isset( $item['quantity'] ) && 0 === $item['quantity'] ) ) {
+										$order->remove_item( $item['id'] );
+									} else {
+										$this->set_item( $order, $key, $item );
+									}
+								}
+							}
+						}
+						break;
+					case 'coupon_lines':
+						if ( is_array( $value ) ) {
+							foreach ( $value as $item ) {
+								if ( is_array( $item ) ) {
+									if ( $this->item_is_null( $item ) || ( isset( $item['quantity'] ) && 0 === $item['quantity'] ) ) {
+										if ( ! empty( $item['id'] ) ) {
+											$order->remove_item( $item['id'] );
+										} elseif ( ! empty( $item['code'] ) ) {
+											$order->remove_coupon( wc_clean( $item['code'] ) );
+										}
+									} else {
+										if ( ! empty( $item['id'] ) ) {
+											if ( empty( $item['code'] ) ) {
+												throw new WC_REST_Exception( 'woocommerce_rest_invalid_coupon_coupon', __( 'Coupon code is required.', 'woocommerce' ), 400 );
+											}
+										}
+
+										$order->apply_coupon( wc_clean( $item['code'] ) );
+									}
+								}
+							}
+						}
+						break;
+					case 'meta_data':
+						if ( is_array( $value ) ) {
+							foreach ( $value as $meta ) {
+								$order->update_meta_data( $meta['key'], $meta['value'], isset( $meta['id'] ) ? $meta['id'] : '' );
+							}
+						}
+						break;
+					default:
+						if ( is_callable( array( $order, "set_{$key}" ) ) ) {
+							$order->{"set_{$key}"}( $value );
+						}
+						break;
+				}
+			}
+		}
+
+		/**
+		 * Filters an object before it is inserted via the REST API.
+		 *
+		 * The dynamic portion of the hook name, `$this->post_type`,
+		 * refers to the object type slug.
+		 *
+		 * @param WC_Data         $order    Object object.
+		 * @param WP_REST_Request $request  Request object.
+		 * @param bool            $creating If is creating a new object.
+		 */
+		return apply_filters( "woocommerce_rest_pre_insert_{$this->post_type}_object", $order, $request, $creating );
+	}
+
+	/**
 	 * Prepare objects query.
 	 *
 	 * @since  3.0.0
@@ -49,6 +143,19 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 		}
 
 		return $args;
+	}
+
+	/**
+	 * Get the Order's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		$schema['properties']['coupon_lines']['items']['properties']['discount']['readonly'] = true;
+
+		return $schema;
 	}
 
 	/**

--- a/includes/api/v2/class-wc-rest-orders-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-orders-v2-controller.php
@@ -1397,7 +1397,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
-							'instance_id'    => array(
+							'instance_id'  => array(
 								'description' => __( 'Shipping instance ID.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -340,26 +340,26 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_order_add_coupons() {
 		wp_set_current_user( $this->user );
+
 		$order      = WC_Helper_Order::create_order();
 		$order_item = current( $order->get_items() );
 		$coupon     = WC_Helper_Coupon::create_coupon( 'fake-coupon' );
 		$coupon->set_amount( 5 );
 		$coupon->save();
+
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
 		$request->set_body_params(
 			array(
-				'coupon_lines' => array(
-					array(
-						'code'           => 'fake-coupon',
-						'discount_total' => '5',
-						'discount_tax'   => '0',
-					),
-				),
 				'line_items'   => array(
 					array(
 						'id'         => $order_item->get_id(),
 						'product_id' => $order_item->get_product_id(),
-						'total'      => '35.00',
+						'subtotal'   => '35.00',
+					),
+				),
+				'coupon_lines' => array(
+					array(
+						'code' => 'fake-coupon',
 					),
 				),
 			)

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -120,8 +120,8 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_item_refund_id() {
 		wp_set_current_user( $this->user );
-		$order  = WC_Helper_Order::create_order();
-		$refund = wc_create_refund( array(
+		$order    = WC_Helper_Order::create_order();
+		$refund   = wc_create_refund( array(
 			'order_id' => $order->get_id(),
 		) );
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/' . $refund->get_id() ) );

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -420,6 +420,33 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests updating an order with an invalid coupon.
+	 *
+	 * @since 3.5.0
+	 */
+	public function test_invalid_coupon() {
+		wp_set_current_user( $this->user );
+		$order   = WC_Helper_Order::create_order();
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
+
+		$request->set_body_params(
+			array(
+				'coupon_lines' => array(
+					array(
+						'code' => 'NON_EXISTING_COUPON',
+					),
+				),
+			)
+		);
+		$response = $this->server->dispatch( $request );
+		$data     = $response->get_data();
+
+		$this->assertEquals( 400, $response->get_status() );
+		$this->assertEquals( 'woocommerce_rest_invalid_coupon', $data['code'] );
+		$this->assertEquals( 'Coupon "non_existing_coupon" does not exist!', $data['message'] );
+	}
+
+	/**
 	 * Tests updating an order without the correct permissions.
 	 *
 	 * @since 3.5.0


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Use new Coupons/Discounts functionality in Orders endpoint.

Closes #21119.

### How to test the changes in this Pull Request:

1. Create some order.
2. Try update by REST API using something line:
```json
{
	"coupon_lines": [
		{
			"code": "COUPON_CODE"
		}
	]
}
```
3. Then try remove coupons:
```json
{
	"coupon_lines": []
}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - REST API - Allow apply and remove coupons in orders endpoint 
