### PR TITLE
Ignore converting float meta value for registered post meta

### DIFF
--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -245,7 +245,7 @@ class WC_Post_Data {
 			wp_cache_delete( 'product-' . $object_id, 'products' );
 		}
 
-		if ( ! empty( $meta_value ) && is_float( $meta_value ) && in_array( get_post_type( $object_id ), array_merge( wc_get_order_types(), array( 'shop_coupon', 'product', 'product_variation' ) ), true ) ) {
+		if ( ! empty( $meta_value ) && is_float( $meta_value ) && ! registered_meta_key_exists( 'post', $meta_key ) && in_array( get_post_type( $object_id ), array_merge( wc_get_order_types(), array( 'shop_coupon', 'product', 'product_variation' ) ), true ) ) {
 
 			// Convert float to string.
 			$meta_value = wc_float_to_string( $meta_value );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This commit resolves the issue described in #21257. Like [Jetpack](https://github.com/Automattic/jetpack/blob/master/modules/geo-location/class.jetpack-geo-location.php#L85), if we register any meta with `register_meta_key` for any WC post type, and use a `sanitize_callback` which always returns a float value; then we got a nested function call scenario where `WC_Post_Data::update_post_metadata()` and the `sanitize_callback` functions are called one after another and php throws a fatal error like this,
```
PHP Fatal error:  Maximum function nesting level of '256' reached, aborting! in /Users/ediamin/www/woocommerce/wp-includes/cache.php on line 523
```

Closes #21257 .

### How to test the changes in this Pull Request:
Test this sample plugin without any modification in `WC_Post_Data::update_post_metadata()`. You'll see the php error described earlier. If you add the changes in your `class-wc-post-data.php` from this commit, the error will be gone.

```php
<?php
/**
 * Plugin Name: Myplugin
 */

if ( ! defined( 'ABSPATH' ) ) exit;

function myplugin_sanitize_meta( $number ) {
	if ( ! $number ) {
		return null;
	}

	return round( (float) $number, 3 );
}

function myplugin_register_meta() {
	register_meta( 'post', 'custom_float_type_registerd_meta', array(
		'sanitize_callback' => 'myplugin_sanitize_meta',
		'type_meta'         => 'float',
		'single'            => true,
	) );
}

add_action( 'init', 'myplugin_register_meta' );

function myplugin_update_product_meta( $product_id ) {
	update_post_meta( $product_id, 'custom_float_type_registerd_meta', 1.23456 );
	update_post_meta( $product_id, 'custom_float_type_non_registerd_meta', 9.87654 );
}

add_action( 'woocommerce_update_product', 'myplugin_update_product_meta' );
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Ignore converting float meta value for registered post meta
