### PR TITLE
Triggering woocommerce_order_edit_status on single order status edit.

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -262,6 +262,10 @@ class WC_Order extends WC_Abstract_Order {
 				'manual' => (bool) $manual_update,
 			);
 
+			if ( $manual_update ) {
+				do_action( 'woocommerce_order_edit_status', $this->get_id(), $result['to'] );
+			}
+
 			$this->maybe_set_date_paid();
 			$this->maybe_set_date_completed();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes [#21355](https://github.com/woocommerce/woocommerce/issues/21335).
`woocommerce_order_edit_status` was previously only triggered on bulk order edits and ajax order edits. This causes the WooCommerce Drip extension to not trigger events on order status update when a single order was updated. This PR expands the action to trigger on single order updates as well: 
![image](https://user-images.githubusercontent.com/6209518/45441564-2ea7a380-b674-11e8-813d-3c78a3971885.png)



### How to test the changes in this Pull Request:

1. Go to 'Edit order' (on any order from Orders list)
1. Modify order status
1. Click on 'Update'
1. `woocommerce_order_edit_status` is triggered.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Triggering woocommerce_order_edit_status on single order status edit.
