### PR TITLE
Added action 'woocommerce_variation_header' after actions in variations list

### DIFF
--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -48,6 +48,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 		?>
 		<input type="hidden" name="variable_post_id[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $variation_id ); ?>" />
 		<input type="hidden" class="variation_menu_order" name="variation_menu_order[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $variation_object->get_menu_order( 'edit' ) ); ?>" />
+		
+		<?php
+		/**
+		 * woocommerce_variation_header action.
+		 *
+		 * @since 2.5.0
+		 *
+		 * @param array   $variation_data
+		 * @param WP_Post $variation
+		 */
+		do_action( 'woocommerce_variation_header', $variation_data, $variation ); ?>
 	</h3>
 	<div class="woocommerce_variable_attributes wc-metabox-content" style="display: none;">
 		<div class="data">

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -53,12 +53,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 		/**
 		 * woocommerce_variation_header action.
 		 *
-		 * @since 2.5.0
+		 * @since 3.6.0
 		 *
-		 * @param array   $variation_data
 		 * @param WP_Post $variation
 		 */
-		do_action( 'woocommerce_variation_header', $variation_data, $variation ); ?>
+		do_action( 'woocommerce_variation_header', $variation ); ?>
 	</h3>
 	<div class="woocommerce_variable_attributes wc-metabox-content" style="display: none;">
 		<div class="data">

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -48,16 +48,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 		?>
 		<input type="hidden" name="variable_post_id[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $variation_id ); ?>" />
 		<input type="hidden" class="variation_menu_order" name="variation_menu_order[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $variation_object->get_menu_order( 'edit' ) ); ?>" />
-		
+
 		<?php
 		/**
 		 * woocommerce_variation_header action.
 		 *
 		 * @since 3.6.0
 		 *
-		 * @param WP_Post $variation
+		 * @param WP_Post $variation .
 		 */
-		do_action( 'woocommerce_variation_header', $variation ); ?>
+		do_action( 'woocommerce_variation_header', $variation );
+		?>
 	</h3>
 	<div class="woocommerce_variable_attributes wc-metabox-content" style="display: none;">
 		<div class="data">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added a new action called `woocommerce_variation_header` to the variations list in product editing screen, in the variation header (h3 tag) after all the actions (e.g. remove, sort, etc.).

This allows developers to add their own actions or information to the variation list.

I took inspiration from [the `woocommerce_variation_options` action](https://github.com/woocommerce/woocommerce/blob/8fd34983a5504a5dd428707dbb083d3a133f0f2c/includes/admin/meta-boxes/views/html-variation-admin.php#L96) in the same file.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added `woocommerce_variation_header` hook in variations list