### PR TITLE
setUpBeforeClass must always call its parent

### DIFF
--- a/tests/framework/class-wc-unit-test-case.php
+++ b/tests/framework/class-wc-unit-test-case.php
@@ -50,6 +50,8 @@ class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 	 * @since 3.5.0
 	 */
 	public static function setUpBeforeClass() {
+		parent::setUpBeforeClass();
+
 		// Terms are deleted in WP_UnitTestCase::tearDownAfterClass, then e.g. Uncategorized product_cat is missing.
 		WC_Install::create_terms();
 	}


### PR DESCRIPTION
Just a trivial fix to allow me to use `WC_Unit_Test_Case` as a parent class for my own test case.