### PR TITLE
Fix cron_interval property support in WP_Background_Process

### DIFF
--- a/includes/libraries/wp-background-process.php
+++ b/includes/libraries/wp-background-process.php
@@ -414,7 +414,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 		$interval = apply_filters( $this->identifier . '_cron_interval', 5 );
 
 		if ( property_exists( $this, 'cron_interval' ) ) {
-			$interval = apply_filters( $this->identifier . '_cron_interval', $this->cron_interval_identifier );
+			$interval = apply_filters( $this->identifier . '_cron_interval', $this->cron_interval );
 		}
 
 		// Adds every 5 minutes to the existing schedules.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This PR contains the latest changes from A5hleyRich/wp-background-processing@a7be647cbe6195a9b9440a808348cd8cf1f21b49. Currently you can define a `cron_interval` property in your background processes class, but it won't be used, since in `WP_Background_Process` abstract class `schedule_cron_healthcheck` method is using `cron_interval_identifier` instead to set the `$interval`. This PR fixes this issue.

### How to test the changes in this Pull Request:

Create your own background processes class by extending `WP_Background_Process` abstract class. Add `cron_interval` property and test your process. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix cron_interval property support in WP_Background_Process
