### PR TITLE
Do not use camel case for password reset request subject and heading

### DIFF
--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -79,7 +79,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( 'Password Reset Request for {site_title}', 'woocommerce' );
+			return __( 'Password reset request for {site_title}', 'woocommerce' );
 		}
 
 		/**
@@ -89,7 +89,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Password Reset Request', 'woocommerce' );
+			return __( 'Password reset request', 'woocommerce' );
 		}
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21347

### How to test the changes in this Pull Request:

1. Request a password reset
2. Check the email subject and heading reads `Password reset request for ...` Note the case.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
