### PR TITLE
Sanitize endpoints before saving

### DIFF
--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -79,7 +79,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( 'Password reset request for {site_title}', 'woocommerce' );
+			return __( 'Password Reset Request for {site_title}', 'woocommerce' );
 		}
 
 		/**
@@ -89,7 +89,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Password reset request', 'woocommerce' );
+			return __( 'Password Reset Request', 'woocommerce' );
 		}
 
 		/**

--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -79,7 +79,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		 * @return string
 		 */
 		public function get_default_subject() {
-			return __( 'Password Reset Request for {site_title}', 'woocommerce' );
+			return __( 'Password reset request for {site_title}', 'woocommerce' );
 		}
 
 		/**
@@ -89,7 +89,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 		 * @return string
 		 */
 		public function get_default_heading() {
-			return __( 'Password Reset Request', 'woocommerce' );
+			return __( 'Password reset request', 'woocommerce' );
 		}
 
 		/**

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -1379,3 +1379,27 @@ function wc_parse_relative_date_option( $raw_value ) {
 
 	return $value;
 }
+
+/**
+ * Format the endpoint slug, strip out anything not allowed in a url.
+ *
+ * @since 3.5.0
+ * @param string $raw_value The raw value.
+ * @return string
+ */
+function wc_sanitize_endpoint_slug( $raw_value ) {
+	return sanitize_title( $raw_value );
+}
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_checkout_pay_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_checkout_order_received_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_add_payment_method_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_delete_payment_method_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_set_default_payment_method_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_orders_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_view_order_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_downloads_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_edit_account_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_edit_address_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_payment_methods_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_myaccount_lost_password_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );
+add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_logout_endpoint', 'wc_sanitize_endpoint_slug', 10, 1 );

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -986,4 +986,15 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 			),
 		), wc_array_merge_recursive_numeric( $a, $b, $c ) );
 	}
+
+	/**
+	 * Test the wc_sanitize_endpoint_slug function
+	 *
+	 * @return void
+	 */
+	public function test_wc_sanitize_endpoint_slug() {
+		$this->assertEquals( 'a-valid-slug', wc_sanitize_endpoint_slug( 'a-valid-slug' ) );
+		$this->assertEquals( 'an-invalid-slug', wc_sanitize_endpoint_slug( 'An invalid slug' ) );
+		$this->assertEquals( 'case-slug', wc_sanitize_endpoint_slug( 'case-SLUG' ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21334

### How to test the changes in this Pull Request:

1. Go to WooCommerce -> Settings -> Advanced
2. Enter invalid slugs in the enpoint fields, try spaces, capital letters etc and save.
3. Check that the slugs are sanitized to correct slugs.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Sanitize endpoint slugs upon saving
