### PR TITLE
Use assertCount instead of assertEquals

### DIFF
--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -49,7 +49,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 		$draft->set_status( 'draft' );
 		$draft->save();
 
-		$this->assertEquals( 9, count( wc_get_products( array( 'return' => 'ids' ) ) ) );
+		$this->assertCount( 9, wc_get_products( array( 'return' => 'ids' ) ) );
 
 		// Test status.
 		$products = wc_get_products(
@@ -67,7 +67,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'type'   => 'variation',
 			)
 		);
-		$this->assertEquals( 2, count( $products ) );
+		$this->assertCount( 2, $products );
 
 		// Test parent.
 		$products = wc_get_products(
@@ -77,7 +77,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'parent' => $variation->get_id(),
 			)
 		);
-		$this->assertEquals( 2, count( $products ) );
+		$this->assertCount( 2, $products );
 
 		// Test parent_exclude.
 		$products = wc_get_products(
@@ -87,7 +87,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'parent_exclude' => array( $variation->get_id() ),
 			)
 		);
-		$this->assertEquals( 0, count( $products ) );
+		$this->assertCount( 0, $products );
 
 		// Test skus.
 		$products = wc_get_products(
@@ -96,7 +96,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'sku'    => 'GET TEST SKU',
 			)
 		);
-		$this->assertEquals( 2, count( $products ) );
+		$this->assertCount( 2, $products );
 		$this->assertContains( $product->get_id(), $products );
 		$this->assertContains( $external->get_id(), $products );
 
@@ -107,7 +107,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'category' => array( $term_cat_1->slug ),
 			)
 		);
-		$this->assertEquals( 3, count( $products ) );
+		$this->assertCount( 3, $products );
 
 		// Test tags.
 		$products = wc_get_products(
@@ -116,7 +116,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'tag'    => array( $term_tag_1->slug ),
 			)
 		);
-		$this->assertEquals( 2, count( $products ) );
+		$this->assertCount( 2, $products );
 
 		$products = wc_get_products(
 			array(
@@ -124,7 +124,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'tag'    => array( $term_tag_2->slug ),
 			)
 		);
-		$this->assertEquals( 1, count( $products ) );
+		$this->assertCount( 1, $products );
 
 		$products = wc_get_products(
 			array(
@@ -132,7 +132,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'tag'    => array( $term_tag_1->slug, $term_tag_2->slug ),
 			)
 		);
-		$this->assertEquals( 3, count( $products ) );
+		$this->assertCount( 3, $products );
 
 		// Test limit.
 		$products = wc_get_products(
@@ -141,7 +141,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'limit'  => 5,
 			)
 		);
-		$this->assertEquals( 5, count( $products ) );
+		$this->assertCount( 5, $products );
 
 		// Test offset.
 		$products        = wc_get_products(
@@ -157,8 +157,8 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'offset' => 2,
 			)
 		);
-		$this->assertEquals( 2, count( $products ) );
-		$this->assertEquals( 2, count( $products_offset ) );
+		$this->assertCount( 2, $products );
+		$this->assertCount( 2, $products_offset );
 		$this->assertNotEquals( $products, $products_offset );
 
 		// Test page.
@@ -175,8 +175,8 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'page'   => 2,
 			)
 		);
-		$this->assertEquals( 2, count( $products_page_1 ) );
-		$this->assertEquals( 2, count( $products_page_2 ) );
+		$this->assertCount( 2, $products_page_1 );
+		$this->assertCount( 2, $products_page_2 );
 		$this->assertNotEquals( $products_page_1, $products_page_2 );
 
 		// Test exclude.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21365.

### How to test the changes in this Pull Request:

Run the unit tests

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

This is the first step, as it only changes a single unit test file to start with:

- tests/unit-tests/product/functions.php
