### PR TITLE
Replace WooThemes by WooCommerce

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -122,7 +122,7 @@ class WC_Gateway_Paypal_Request {
 				'page_style'    => $this->gateway->get_option( 'page_style' ),
 				'image_url'     => esc_url_raw( $this->gateway->get_option( 'image_url' ) ),
 				'paymentaction' => $this->gateway->get_option( 'paymentaction' ),
-				'bn'            => 'WooThemes_Cart',
+				'bn'            => 'WooCommerce_Cart',
 				'invoice'       => $this->limit_length( $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number(), 127 ),
 				'custom'        => wp_json_encode(
 					array(


### PR DESCRIPTION
Replace old instance of WooThemes by WooCommerce here https://github.com/woocommerce/woocommerce/blob/d0491072e8a7d0a4535db0ec2bae4a6d43ff64fd/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php#L125

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21371 

### How to test the changes in this Pull Request:

1. Place an order with PayPal Standard

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Replaces `WooThemes` by `WooCommerce`