### PR TITLE
Shipping totals should show even if calculator is disabled.

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1373,8 +1373,8 @@ class WC_Cart extends WC_Legacy_Cart {
 			}
 		}
 
-		// If we're on the cart page, the user has not calculated shipping, and there is no calculator available, hide the area.
-		if ( is_cart() && ! $this->get_customer()->has_calculated_shipping() && 'no' === get_option( 'woocommerce_enable_shipping_calc' ) ) {
+		// If we're on the cart page, the user has not calculated shipping, hide the area.
+		if ( is_cart() && ! $this->get_customer()->has_calculated_shipping() ) {
 			return false;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR re-enables the functionality as per 3.4 where the shipping totals were still shown even when you had the calculator disabled on the cart page. A note on the shipping total, it will only show once an address is present so in some cases if you have your shipping set up in such a way it requires a country or state the total will not show unless you have that selected at checkout first.

Closes #21360

### How to test the changes in this Pull Request:

1. Setup a general shipping rule that requires no specific address
2. Disable the shipping calculator on the cart page
2. Add something to the cart
3. View the cart and ensure a shipping total is present.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Show shipping total on cart page even when the shipping calculator is disabled.
