### PR TITLE
[REST API] Updated order statuses slugs

### DIFF
--- a/includes/api/class-wc-rest-report-orders-totals-controller.php
+++ b/includes/api/class-wc-rest-report-orders-totals-controller.php
@@ -48,7 +48,7 @@ class WC_REST_Report_Orders_Totals_Controller extends WC_REST_Reports_Controller
 			}
 
 			$data[] = array(
-				'slug'  => $slug,
+				'slug'  => str_replace( 'wc-', '', $slug ),
 				'name'  => $name,
 				'total' => (int) $totals->$slug,
 			);

--- a/tests/unit-tests/api/reports-orders-totals.php
+++ b/tests/unit-tests/api/reports-orders-totals.php
@@ -49,7 +49,7 @@ class WC_Tests_API_Reports_Orders_Totals extends WC_REST_Unit_Test_Case {
 			}
 
 			$data[] = array(
-				'slug'  => $slug,
+				'slug'  => str_replace( 'wc-', '', $slug ),
 				'name'  => $name,
 				'total' => (int) $totals->$slug,
 			);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

All REST API does not include "wc-" prefix, removing here makes easy to work with all endpoint without care about any prefix.

### How to test the changes in this Pull Request:

1. GET `/wp-json/wc/v3/reports/orders/totas

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
