### PR TITLE
[REST API] Fixed typo in reports results

### DIFF
--- a/includes/api/class-wc-rest-reports-controller.php
+++ b/includes/api/class-wc-rest-reports-controller.php
@@ -40,7 +40,7 @@ class WC_REST_Reports_Controller extends WC_REST_Reports_V2_Controller {
 		);
 		$reports[] = array(
 			'slug'        => 'products/totals',
-			'description' => __( 'Customers totals.', 'woocommerce' ),
+			'description' => __( 'Products totals.', 'woocommerce' ),
 		);
 		$reports[] = array(
 			'slug'        => 'customers/totals',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Just fixing a typo.

### How to test the changes in this Pull Request:

1. GET `/wp-json/wc/v3/reports` and check the results.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
