### PR TITLE
Remove class="cart" from external product types

### DIFF
--- a/templates/single-product/add-to-cart/external.php
+++ b/templates/single-product/add-to-cart/external.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 
 do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
-<form class="cart" action="<?php echo esc_url( $product_url ); ?>" method="get">
+<form action="<?php echo esc_url( $product_url ); ?>" method="get">
 	<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 
 	<button type="submit" class="single_add_to_cart_button button alt"><?php echo esc_html( $button_text ); ?></button>


### PR DESCRIPTION
Having this class is forcing the "add-to-cart" function, however, because this is an external link, this should not be called. This prevents the link to be called. Removing this class fixes the issue.