### PR TITLE
Fix for issue #21265

### DIFF
--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -98,7 +98,7 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 		ob_start();
 
 		$found         = false;
-		$rating_filter = isset( $_GET['rating_filter'] ) ? array_filter( array_map( 'absint', explode( ',', wp_unslash( $_GET['rating_filter'] ) ) ) ) : array(); // WPCS: input var ok, CSRF ok, sanitization ok.
+		$rating_filter = isset( $_GET['rating_filter'] ) ? absint( wp_unslash( $_GET['rating_filter'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
 
 		$this->widget_start( $args, $instance );
 

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -110,16 +110,13 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 				continue;
 			}
 			$found = true;
-			$link  = $this->get_current_page_url();
 
-			if ( in_array( $rating, $rating_filter, true ) ) {
-				$link_ratings = implode( ',', array_diff( $rating_filter, array( $rating ) ) );
-			} else {
-				$link_ratings = implode( ',', array_merge( $rating_filter, array( $rating ) ) );
-			}
+			$link = get_permalink( wc_get_page_id( 'shop' ) );
+			$link = $count > 0 ? add_query_arg( 'rating_filter', $rating, $link ) : remove_query_arg( 'rating_filter' );
+			$link = apply_filters( 'woocommerce_rating_filter_link', $link );
 
-			$class       = in_array( $rating, $rating_filter, true ) ? 'wc-layered-nav-rating chosen' : 'wc-layered-nav-rating';
-			$link        = apply_filters( 'woocommerce_rating_filter_link', $link_ratings ? add_query_arg( 'rating_filter', $link_ratings ) : remove_query_arg( 'rating_filter' ) );
+			$class = $rating === $rating_filter ? 'wc-layered-nav-rating chosen' : 'wc-layered-nav-rating';
+
 			$rating_html = wc_get_star_rating_html( $rating );
 			$count_html  = esc_html( apply_filters( 'woocommerce_rating_filter_count', "({$count})", $count, $rating ) );
 

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -104,6 +104,11 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 
 		echo '<ul>';
 
+		$link = get_permalink( wc_get_page_id( 'shop' ) );
+		if ( is_product_category() ) {
+			$link = get_term_link( get_queried_object_id() );
+		}
+
 		for ( $rating = 5; $rating >= 1; $rating-- ) {
 			$count = $this->get_filtered_product_count( $rating );
 			if ( empty( $count ) ) {
@@ -111,7 +116,6 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 			}
 			$found = true;
 
-			$link = get_permalink( wc_get_page_id( 'shop' ) );
 			$link = $count > 0 ? add_query_arg( 'rating_filter', $rating, $link ) : remove_query_arg( 'rating_filter' );
 			$link = apply_filters( 'woocommerce_rating_filter_link', $link );
 

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -97,8 +97,9 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 
 		ob_start();
 
-		$found         = false;
-		$rating_filter = isset( $_GET['rating_filter'] ) ? absint( wp_unslash( $_GET['rating_filter'] ) ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
+		$found = false;
+
+		$_GET['rating_filter'] = isset( $_GET['rating_filter'] ) ? absint( wp_unslash( $_GET['rating_filter'] ) ) : 0; // WPCS: input var ok, CSRF ok, sanitization ok.
 
 		$this->widget_start( $args, $instance );
 
@@ -109,17 +110,19 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 			$link = get_term_link( get_queried_object_id() );
 		}
 
-		for ( $rating = 5; $rating >= 1; $rating-- ) {
+		for ( $rating = 5; $rating > 0; $rating-- ) {
 			$count = $this->get_filtered_product_count( $rating );
 			if ( empty( $count ) ) {
 				continue;
 			}
 			$found = true;
 
-			$link = $count > 0 ? add_query_arg( 'rating_filter', $rating, $link ) : remove_query_arg( 'rating_filter' );
+			$_GET['rating_filter'] = $rating;
+
+			$link = $count > 0 ? add_query_arg( $_GET, $link ) : remove_query_arg( 'rating_filter' ); // WPCS: input var ok, CSRF ok.
 			$link = apply_filters( 'woocommerce_rating_filter_link', $link );
 
-			$class = $rating === $rating_filter ? 'wc-layered-nav-rating chosen' : 'wc-layered-nav-rating';
+			$class = $rating === $_GET['rating_filter'] ? 'wc-layered-nav-rating chosen' : 'wc-layered-nav-rating'; // WPCS: input var ok, CSRF ok.
 
 			$rating_html = wc_get_star_rating_html( $rating );
 			$count_html  = esc_html( apply_filters( 'woocommerce_rating_filter_count', "({$count})", $count, $rating ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This is a bug fix for an issue regarding ***Filter Products by Rating***  widget.

Closes #21265.

### How to test the changes in this Pull Request:

1. Add the Filter Products By Rating widget to a site that has products with published reviews
2. Go to any archive page (Shop/Product Category) where the number of products makes it split into multiple pages
3. Select one of these pages where no product listed has a review
4. Use the Filter Products By Rating widget to filter the page
5. **Now it'll show all the filtered product regarding `rating_filter` parameter**

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
