### PR TITLE
Dont modify attributes orderby when ordering by name

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -480,6 +480,12 @@ function wc_terms_clauses( $clauses, $taxonomies, $args ) {
 
 	foreach ( (array) $taxonomies as $taxonomy ) {
 		if ( taxonomy_is_product_attribute( $taxonomy ) || in_array( $taxonomy, apply_filters( 'woocommerce_sortable_taxonomies', array( 'product_cat' ) ), true ) ) {
+
+			// Don't modify the orderby when we're ordering attributes by name.
+			if ( taxonomy_is_product_attribute( $taxonomy ) && 'name' === wc_attribute_orderby( $taxonomy ) ) {
+				return $clauses;
+			}
+
 			$found = true;
 			break;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21269.

The underlying issues is that we were [checking for the default 'name' orderby to determine whether to add custom sorting to the query](https://github.com/woocommerce/woocommerce/compare/fix/21269?expand=1#diff-2d93f735345ddb617a321e1980770841R463), and this didn't take into account whether the default 'name' is actually how we want terms sorted. This PR refines the logic a little bit so that it works correctly for the 'name' sorting.

### How to test the changes in this Pull Request:

1. Set up an attribute ordered by name. Verify ordering is correct in product attribute select dropdown on a single product page.
2. Set up an attribute ordered by custom ordering. Verify ordering is correct in product attribute select dropdown on a single product page.
3. Set up an attribute ordered by term id. Verify ordering is correct in product attribute select dropdown on a single product page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
