### PR TITLE
OBW: Disable (not hide) payment email input when opted out

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1060,6 +1060,10 @@ h3.jetpack-reasons {
 		color: #444;
 		background-color: #fff;
 		display: inline-block;
+
+		&[disabled] {
+			color: #aaa;
+		}
 	}
 }
 

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -163,18 +163,14 @@ jQuery( function( $ ) {
 			$( this ).closest( '.wc-wizard-service-settings' )
 				.find( 'input.payment-email-input' )
 				.attr( 'type', 'email' )
+				.prop( 'disabled', false )
 				.prop( 'required', true );
-			$( this ).closest( '.wc-wizard-service-settings' )
-				.find( '.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_email' )
-				.show();
 		} else {
 			$( this ).closest( '.wc-wizard-service-settings' )
 				.find( 'input.payment-email-input' )
 				.attr( 'type', null )
+				.prop( 'disabled', true )
 				.prop( 'required', false );
-			$( this ).closest( '.wc-wizard-service-settings' )
-				.find( '.wc-wizard-service-setting-stripe_email, .wc-wizard-service-setting-ppec_paypal_email' )
-				.hide();
 		}
 	} ).find( 'input#stripe_create_account, input#ppec_paypal_reroute_requests' ).change();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Disables (and visually tone down) the Stripe and PayPal payment email inputs when automated setup is opted out of:

![obw-disabled-email-input](https://user-images.githubusercontent.com/1867547/45846238-470f6200-bcf5-11e8-93cd-61cde769eca5.gif)

This is to avoid the hanging `:` when the text field is hidden [[screenshot](https://cloudup.com/cyz-X-bqQ35)].

### How to test the changes in this Pull Request:

1. Go to Payment step of setup wizard
2. Disable "Set up [Stripe|PayPal] for me using this email:"
3. Verify that the corresponding email field looks grayed out and cannot be edited
