### PR TITLE
Update Action Scheduler to v2.1.0

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,7 +5,7 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Prospress
  * Author URI: http://prospress.com/
- * Version: 2.0.0
+ * Version: 2.1.0
  * License: GPLv3
  *
  * Copyright 2018 Prospress, Inc.  (email : freedoms@prospress.com)
@@ -25,21 +25,21 @@
  *
  */
 
-if ( ! function_exists( 'action_scheduler_register_2_dot_0_dot_0' ) ) {
+if ( ! function_exists( 'action_scheduler_register_2_dot_1_dot_0' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_0_dot_0', 0, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_1_dot_0', 0, 0 );
 
-	function action_scheduler_register_2_dot_0_dot_0() {
+	function action_scheduler_register_2_dot_1_dot_0() {
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '2.0.0', 'action_scheduler_initialize_2_dot_0_dot_0' );
+		$versions->register( '2.1.0', 'action_scheduler_initialize_2_dot_1_dot_0' );
 	}
 
-	function action_scheduler_initialize_2_dot_0_dot_0() {
+	function action_scheduler_initialize_2_dot_1_dot_0() {
 		require_once( 'classes/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}

--- a/classes/ActionScheduler.php
+++ b/classes/ActionScheduler.php
@@ -67,8 +67,8 @@ abstract class ActionScheduler {
 			return;
 		}
 
-		if ( file_exists( $dir.$class.'.php' ) ) {
-			include( $dir.$class.'.php' );
+		if ( file_exists( "{$dir}{$class}.php" ) ) {
+			include( "{$dir}{$class}.php" );
 			return;
 		}
 	}
@@ -96,6 +96,10 @@ abstract class ActionScheduler {
 		add_action( 'init', array( $admin_view, 'init' ), 0, 0 ); // run before $store::init()
 
 		require_once( self::plugin_path('functions.php') );
+
+		if ( apply_filters( 'action_scheduler_load_deprecated_functions', true ) ) {
+			require_once( self::plugin_path('deprecated/functions.php') );
+		}
 
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			WP_CLI::add_command( 'action-scheduler', 'ActionScheduler_WPCLI_Scheduler_command' );

--- a/classes/ActionScheduler_Abstract_ListTable.php
+++ b/classes/ActionScheduler_Abstract_ListTable.php
@@ -275,7 +275,7 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 		$valid_sortable_columns = array_values( $this->sort_by );
 
 		if ( ! empty( $_GET['orderby'] ) && in_array( $_GET['orderby'], $valid_sortable_columns ) ) {
-			$orderby = wc_clean( $_GET['orderby'] );
+			$orderby = sanitize_text_field( $_GET['orderby'] );
 		} else {
 			$orderby = $valid_sortable_columns[0];
 		}

--- a/classes/ActionScheduler_Abstract_QueueRunner.php
+++ b/classes/ActionScheduler_Abstract_QueueRunner.php
@@ -15,6 +15,16 @@ abstract class ActionScheduler_Abstract_QueueRunner {
 	protected $store;
 
 	/**
+	 * The created time.
+	 *
+	 * Represents when the queue runner was constructed and used when calculating how long a PHP request has been running.
+	 * For this reason it should be as close as possible to the PHP request start time.
+	 *
+	 * @var int
+	 */
+	private $created_time;
+
+	/**
 	 * ActionScheduler_Abstract_QueueRunner constructor.
 	 *
 	 * @param ActionScheduler_Store             $store
@@ -22,6 +32,9 @@ abstract class ActionScheduler_Abstract_QueueRunner {
 	 * @param ActionScheduler_QueueCleaner      $cleaner
 	 */
 	public function __construct( ActionScheduler_Store $store = null, ActionScheduler_FatalErrorMonitor $monitor = null, ActionScheduler_QueueCleaner $cleaner = null ) {
+
+		$this->created_time = microtime( true );
+
 		$this->store   = $store ? $store : ActionScheduler_Store::instance();
 		$this->monitor = $monitor ? $monitor : new ActionScheduler_FatalErrorMonitor( $this->store );
 		$this->cleaner = $cleaner ? $cleaner : new ActionScheduler_QueueCleaner( $this->store );
@@ -35,6 +48,12 @@ abstract class ActionScheduler_Abstract_QueueRunner {
 	public function process_action( $action_id ) {
 		try {
 			do_action( 'action_scheduler_before_execute', $action_id );
+
+			if ( ActionScheduler_Store::STATUS_PENDING !== $this->store->get_status( $action_id ) ) {
+				do_action( 'action_scheduler_execution_ignored', $action_id );
+				return;
+			}
+
 			$action = $this->store->fetch_action( $action_id );
 			$this->store->log_execution( $action_id );
 			$action->execute();
@@ -77,6 +96,115 @@ abstract class ActionScheduler_Abstract_QueueRunner {
 	 */
 	public function get_allowed_concurrent_batches() {
 		return apply_filters( 'action_scheduler_queue_runner_concurrent_batches', 5 );
+	}
+
+	/**
+	 * Get the maximum number of seconds a batch can run for.
+	 *
+	 * @return int The number of seconds.
+	 */
+	protected function get_maximum_execution_time() {
+
+		// There are known hosts with a strict 60 second execution time.
+		if ( defined( 'WPENGINE_ACCOUNT' ) || defined( 'PANTHEON_ENVIRONMENT' ) ) {
+			$maximum_execution_time = 60;
+		} elseif ( false !== strpos( getenv( 'HOSTNAME' ), '.siteground.' ) ) {
+			$maximum_execution_time = 120;
+		} else {
+			$maximum_execution_time = ini_get( 'max_execution_time' );
+		}
+
+		return absint( apply_filters( 'action_scheduler_maximum_execution_time', $maximum_execution_time ) );
+	}
+
+	/**
+	 * Get the number of seconds a batch has run for.
+	 *
+	 * @return int The number of seconds.
+	 */
+	protected function get_execution_time() {
+		$execution_time = microtime( true ) - $this->created_time;
+
+		// Get the CPU time if the hosting environment uses it rather than wall-clock time to calculate a process's execution time.
+		if ( function_exists( 'getrusage' ) && apply_filters( 'action_scheduler_use_cpu_execution_time', defined( 'PANTHEON_ENVIRONMENT' ) ) ) {
+			$resource_usages = getrusage();
+
+			if ( isset( $resource_usages['ru_stime.tv_usec'], $resource_usages['ru_stime.tv_usec'] ) ) {
+				$execution_time = $resource_usages['ru_stime.tv_sec'] + ( $resource_usages['ru_stime.tv_usec'] / 1000000 );
+			}
+		}
+
+		return $execution_time;
+	}
+
+	/**
+	 * Check if the host's max execution time is (likely) to be exceeded if processing more actions.
+	 *
+	 * @param int $processed_actions The number of actions processed so far - used to determine the likelihood of exceeding the time limit if processing another action
+	 * @return bool
+	 */
+	protected function time_likely_to_be_exceeded( $processed_actions ) {
+
+		$execution_time        = $this->get_execution_time();
+		$max_execution_time    = $this->get_maximum_execution_time();
+		$time_per_action       = $execution_time / $processed_actions;
+		$estimated_time        = $execution_time + ( $time_per_action * 2 );
+		$likely_to_be_exceeded = $estimated_time > $this->get_maximum_execution_time();
+
+		return apply_filters( 'action_scheduler_maximum_execution_time_likely_to_be_exceeded', $likely_to_be_exceeded, $this, $processed_actions, $execution_time, $max_execution_time );
+	}
+
+	/**
+	 * Get memory limit
+	 *
+	 * Based on WP_Background_Process::get_memory_limit()
+	 *
+	 * @return int
+	 */
+	protected function get_memory_limit() {
+		if ( function_exists( 'ini_get' ) ) {
+			$memory_limit = ini_get( 'memory_limit' );
+		} else {
+			$memory_limit = '128M'; // Sensible default, and minimum required by WooCommerce
+		}
+
+		if ( ! $memory_limit || -1 === $memory_limit || '-1' === $memory_limit ) {
+			// Unlimited, set to 32GB.
+			$memory_limit = '32G';
+		}
+
+		return ActionScheduler_Compatibility::convert_hr_to_bytes( $memory_limit );
+	}
+
+	/**
+	 * Memory exceeded
+	 *
+	 * Ensures the batch process never exceeds 90% of the maximum WordPress memory.
+	 *
+	 * Based on WP_Background_Process::memory_exceeded()
+	 *
+	 * @return bool
+	 */
+	protected function memory_exceeded() {
+
+		$memory_limit    = $this->get_memory_limit() * 0.90;
+		$current_memory  = memory_get_usage( true );
+		$memory_exceeded = $current_memory >= $memory_limit;
+
+		return apply_filters( 'action_scheduler_memory_exceeded', $memory_exceeded, $this );
+	}
+
+	/**
+	 * See if the batch limits have been exceeded, which is when memory usage is almost at
+	 * the maximum limit, or the time to process more actions will exceed the max time limit.
+	 *
+	 * Based on WC_Background_Process::batch_limits_exceeded()
+	 *
+	 * @param int $processed_actions The number of actions processed so far - used to determine the likelihood of exceeding the time limit if processing another action
+	 * @return bool
+	 */
+	protected function batch_limits_exceeded( $processed_actions ) {
+		return $this->memory_exceeded() || $this->time_likely_to_be_exceeded( $processed_actions );
 	}
 
 	/**

--- a/classes/ActionScheduler_Compatibility.php
+++ b/classes/ActionScheduler_Compatibility.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Class ActionScheduler_Compatibility
+ */
+class ActionScheduler_Compatibility {
+
+	/**
+	 * Converts a shorthand byte value to an integer byte value.
+	 *
+	 * Wrapper for wp_convert_hr_to_bytes(), moved to load.php in WordPress 4.6 from media.php
+	 *
+	 * @link https://secure.php.net/manual/en/function.ini-get.php
+	 * @link https://secure.php.net/manual/en/faq.using.php#faq.using.shorthandbytes
+	 *
+	 * @param string $value A (PHP ini) byte value, either shorthand or ordinary.
+	 * @return int An integer byte value.
+	 */
+	public static function convert_hr_to_bytes( $value ) {
+		if ( function_exists( 'wp_convert_hr_to_bytes' ) ) {
+			return wp_convert_hr_to_bytes( $value );
+		}
+
+		$value = strtolower( trim( $value ) );
+		$bytes = (int) $value;
+
+		if ( false !== strpos( $value, 'g' ) ) {
+			$bytes *= GB_IN_BYTES;
+		} elseif ( false !== strpos( $value, 'm' ) ) {
+			$bytes *= MB_IN_BYTES;
+		} elseif ( false !== strpos( $value, 'k' ) ) {
+			$bytes *= KB_IN_BYTES;
+		}
+
+		// Deal with large (float) values which run into the maximum integer size.
+		return min( $bytes, PHP_INT_MAX );
+	}
+
+	/**
+	 * Attempts to raise the PHP memory limit for memory intensive processes.
+	 *
+	 * Only allows raising the existing limit and prevents lowering it.
+	 *
+	 * Wrapper for wp_raise_memory_limit(), added in WordPress v4.6.0
+	 *
+	 * @return bool|int|string The limit that was set or false on failure.
+	 */
+	public static function raise_memory_limit() {
+		if ( function_exists( 'wp_raise_memory_limit' ) ) {
+			return wp_raise_memory_limit( 'admin' );
+		}
+
+		$current_limit     = @ini_get( 'memory_limit' );
+		$current_limit_int = self::convert_hr_to_bytes( $current_limit );
+
+		if ( -1 === $current_limit_int ) {
+			return false;
+		}
+
+		$wp_max_limit       = WP_MAX_MEMORY_LIMIT;
+		$wp_max_limit_int   = self::convert_hr_to_bytes( $wp_max_limit );
+		$filtered_limit     = apply_filters( 'admin_memory_limit', $wp_max_limit );
+		$filtered_limit_int = self::convert_hr_to_bytes( $filtered_limit );
+
+		if ( -1 === $filtered_limit_int || ( $filtered_limit_int > $wp_max_limit_int && $filtered_limit_int > $current_limit_int ) ) {
+			if ( false !== @ini_set( 'memory_limit', $filtered_limit ) ) {
+				return $filtered_limit;
+			} else {
+				return false;
+			}
+		} elseif ( -1 === $wp_max_limit_int || $wp_max_limit_int > $current_limit_int ) {
+			if ( false !== @ini_set( 'memory_limit', $wp_max_limit ) ) {
+				return $wp_max_limit;
+			} else {
+				return false;
+			}
+		}
+		return false;
+	}
+}

--- a/classes/ActionScheduler_DateTime.php
+++ b/classes/ActionScheduler_DateTime.php
@@ -8,6 +8,16 @@
 class ActionScheduler_DateTime extends DateTime {
 
 	/**
+	 * UTC offset.
+	 *
+	 * Only used when a timezone is not set. When a timezone string is
+	 * used, this will be set to 0.
+	 *
+	 * @var int
+	 */
+	protected $utcOffset = 0;
+
+	/**
 	 * Get the unix timestamp of the current object.
 	 *
 	 * Missing in PHP 5.2 so just here so it can be supported consistently.
@@ -16,5 +26,51 @@ class ActionScheduler_DateTime extends DateTime {
 	 */
 	public function getTimestamp() {
 		return method_exists( 'DateTime', 'getTimestamp' ) ? parent::getTimestamp() : $this->format( 'U' );
+	}
+
+	/**
+	 * Set the UTC offset.
+	 *
+	 * This represents a fixed offset instead of a timezone setting.
+	 *
+	 * @param $offset
+	 */
+	public function setUtcOffset( $offset ) {
+		$this->utcOffset = intval( $offset );
+	}
+
+	/**
+	 * Returns the timezone offset.
+	 *
+	 * @return int
+	 * @link http://php.net/manual/en/datetime.getoffset.php
+	 */
+	public function getOffset() {
+		return $this->utcOffset ? $this->utcOffset : parent::getOffset();
+	}
+
+	/**
+	 * Set the TimeZone associated with the DateTime
+	 *
+	 * @param DateTimeZone $timezone
+	 *
+	 * @return static
+	 * @link http://php.net/manual/en/datetime.settimezone.php
+	 */
+	public function setTimezone( $timezone ) {
+		$this->utcOffset = 0;
+		parent::setTimezone( $timezone );
+
+		return $this;
+	}
+
+	/**
+	 * Get the timestamp with the WordPress timezone offset added or subtracted.
+	 *
+	 * @since  3.0.0
+	 * @return int
+	 */
+	public function getOffsetTimestamp() {
+		return $this->getTimestamp() + $this->getOffset();
 	}
 }

--- a/classes/ActionScheduler_Exception.php
+++ b/classes/ActionScheduler_Exception.php
@@ -1,0 +1,11 @@
+<?php
+
+/**
+ * ActionScheduler Exception Interface.
+ *
+ * Facilitates catching Exceptions unique to Action Scheduler.
+ *
+ * @package Prospress\ActionScheduler
+ * @since %VERSION%
+ */
+interface ActionScheduler_Exception {}

--- a/classes/ActionScheduler_FatalErrorMonitor.php
+++ b/classes/ActionScheduler_FatalErrorMonitor.php
@@ -19,6 +19,7 @@ class ActionScheduler_FatalErrorMonitor {
 		add_action( 'shutdown', array( $this, 'handle_unexpected_shutdown' ) );
 		add_action( 'action_scheduler_before_execute', array( $this, 'track_current_action' ), 0, 1 );
 		add_action( 'action_scheduler_after_execute',  array( $this, 'untrack_action' ), 0, 0 );
+		add_action( 'action_scheduler_execution_ignored',  array( $this, 'untrack_action' ), 0, 0 );
 		add_action( 'action_scheduler_failed_execution',  array( $this, 'untrack_action' ), 0, 0 );
 	}
 
@@ -26,9 +27,10 @@ class ActionScheduler_FatalErrorMonitor {
 		$this->claim = NULL;
 		$this->untrack_action();
 		remove_action( 'shutdown', array( $this, 'handle_unexpected_shutdown' ) );
-		remove_action( 'action_scheduler_before_execute', array( $this, 'track_current_action' ), 0, 1 );
-		remove_action( 'action_scheduler_after_execute',  array( $this, 'untrack_action' ), 0, 0 );
-		remove_action( 'action_scheduler_failed_execution',  array( $this, 'untrack_action' ), 0, 0 );
+		remove_action( 'action_scheduler_before_execute', array( $this, 'track_current_action' ), 0 );
+		remove_action( 'action_scheduler_after_execute',  array( $this, 'untrack_action' ), 0 );
+		remove_action( 'action_scheduler_execution_ignored',  array( $this, 'untrack_action' ), 0 );
+		remove_action( 'action_scheduler_failed_execution',  array( $this, 'untrack_action' ), 0 );
 	}
 
 	public function track_current_action( $action_id ) {
@@ -51,4 +53,3 @@ class ActionScheduler_FatalErrorMonitor {
 		}
 	}
 }
- 

--- a/classes/ActionScheduler_InvalidActionException.php
+++ b/classes/ActionScheduler_InvalidActionException.php
@@ -1,0 +1,28 @@
+<?php
+
+/**
+ * InvalidAction Exception.
+ *
+ * Used for identifying actions that are invalid in some way.
+ *
+ * @package Prospress\ActionScheduler
+ */
+class ActionScheduler_InvalidActionException extends \InvalidArgumentException implements ActionScheduler_Exception {
+
+	/**
+	 * Create a new exception when the action's args cannot be decoded to an array.
+	 *
+	 * @author Jeremy Pry
+	 *
+	 * @param string $action_id The action ID with bad args.
+	 * @return static
+	 */
+	public static function from_decoding_args( $action_id ) {
+		$message = sprintf(
+			__( 'Action [%s] has invalid arguments. It cannot be JSON decoded to an array.', 'action-scheduler' ),
+			$action_id
+		);
+
+		return new static( $message );
+	}
+}

--- a/classes/ActionScheduler_ListTable.php
+++ b/classes/ActionScheduler_ListTable.php
@@ -242,7 +242,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 
 		$row_html = '<ul>';
 		foreach ( $row['args'] as $key => $value ) {
-			$row_html .= sprintf( '<li><code>%s => %s</code></li>', esc_html( $key ), esc_html( $value ) );
+			$row_html .= sprintf( '<li><code>%s => %s</code></li>', esc_html( var_export( $key, true ) ), esc_html( var_export( $value, true ) ) );
 		}
 		$row_html .= '</ul>';
 

--- a/classes/ActionScheduler_Logger.php
+++ b/classes/ActionScheduler_Logger.php
@@ -41,7 +41,58 @@ abstract class ActionScheduler_Logger {
 	 */
 	abstract public function get_logs( $action_id );
 
-	abstract public function init();
 
+	/**
+	 * @codeCoverageIgnore
+	 */
+	public function init() {
+		add_action( 'action_scheduler_stored_action', array( $this, 'log_stored_action' ), 10, 1 );
+		add_action( 'action_scheduler_canceled_action', array( $this, 'log_canceled_action' ), 10, 1 );
+		add_action( 'action_scheduler_before_execute', array( $this, 'log_started_action' ), 10, 1 );
+		add_action( 'action_scheduler_after_execute', array( $this, 'log_completed_action' ), 10, 1 );
+		add_action( 'action_scheduler_failed_execution', array( $this, 'log_failed_action' ), 10, 2 );
+		add_action( 'action_scheduler_failed_action', array( $this, 'log_timed_out_action' ), 10, 2 );
+		add_action( 'action_scheduler_unexpected_shutdown', array( $this, 'log_unexpected_shutdown' ), 10, 2 );
+		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
+		add_action( 'action_scheduler_execution_ignored', array( $this, 'log_ignored_action' ), 10, 1 );
+	}
+
+	public function log_stored_action( $action_id ) {
+		$this->log( $action_id, __( 'action created', 'action-scheduler' ) );
+	}
+
+	public function log_canceled_action( $action_id ) {
+		$this->log( $action_id, __( 'action canceled', 'action-scheduler' ) );
+	}
+
+	public function log_started_action( $action_id ) {
+		$this->log( $action_id, __( 'action started', 'action-scheduler' ) );
+	}
+
+	public function log_completed_action( $action_id ) {
+		$this->log( $action_id, __( 'action complete', 'action-scheduler' ) );
+	}
+
+	public function log_failed_action( $action_id, \Exception $exception ) {
+		$this->log( $action_id, sprintf( __( 'action failed: %s', 'action-scheduler' ), $exception->getMessage() ) );
+	}
+
+	public function log_timed_out_action( $action_id, $timeout ) {
+		$this->log( $action_id, sprintf( __( 'action timed out after %s seconds', 'action-scheduler' ), $timeout ) );
+	}
+
+	public function log_unexpected_shutdown( $action_id, $error ) {
+		if ( ! empty( $error ) ) {
+			$this->log( $action_id, sprintf( __( 'unexpected shutdown: PHP Fatal error %s in %s on line %s', 'action-scheduler' ), $error['message'], $error['file'], $error['line'] ) );
+		}
+	}
+
+	public function log_reset_action( $action_id ) {
+		$this->log( $action_id, __( 'action reset', 'action_scheduler' ) );
+	}
+
+	public function log_ignored_action( $action_id ) {
+		$this->log( $action_id, __( 'action ignored', 'action-scheduler' ) );
+	}
 }
  

--- a/classes/ActionScheduler_Store.php
+++ b/classes/ActionScheduler_Store.php
@@ -168,18 +168,9 @@ abstract class ActionScheduler_Store {
 		if ( ! $next ) {
 			throw new InvalidArgumentException( __( 'Invalid schedule. Cannot save action.', 'action-scheduler' ) );
 		}
-		$next->setTimezone( $this->get_local_timezone() );
 
+		ActionScheduler_TimezoneHelper::set_local_timezone( $next );
 		return $next->format( 'Y-m-d H:i:s' );
-	}
-
-	/**
-	 * Get the site's local time. Wrapper for ActionScheduler_TimezoneHelper::get_local_timezone().
-	 *
-	 * @return DateTimeZone
-	 */
-	protected function get_local_timezone() {
-		return ActionScheduler_TimezoneHelper::get_local_timezone();
 	}
 
 	/**
@@ -206,5 +197,16 @@ abstract class ActionScheduler_Store {
 			self::$store = new $class();
 		}
 		return self::$store;
+	}
+
+	/**
+	 * Get the site's local time.
+	 *
+	 * @deprecated 2.1.0
+	 * @return DateTimeZone
+	 */
+	protected function get_local_timezone() {
+		_deprecated_function( __FUNCTION__, '2.1.0', 'ActionScheduler_TimezoneHelper::set_local_timezone()' );
+		return ActionScheduler_TimezoneHelper::get_local_timezone();
 	}
 }

--- a/classes/ActionScheduler_TimezoneHelper.php
+++ b/classes/ActionScheduler_TimezoneHelper.php
@@ -5,7 +5,102 @@
  */
 abstract class ActionScheduler_TimezoneHelper {
 	private static $local_timezone = NULL;
+
+	/**
+	 * Set a DateTime's timezone to the WordPress site's timezone, or a UTC offset
+	 * if no timezone string is available.
+	 *
+	 * @since  2.1.0
+	 *
+	 * @param DateTime $date
+	 * @return ActionScheduler_DateTime
+	 */
+	public static function set_local_timezone( DateTime $date ) {
+
+		// Accept a DateTime for easier backward compatibility, even though we require methods on ActionScheduler_DateTime
+		if ( ! is_a( $date, 'ActionScheduler_DateTime' ) ) {
+			$date = as_get_datetime_object( $date->format( 'U' ) );
+		}
+
+		if ( get_option( 'timezone_string' ) ) {
+			$date->setTimezone( new DateTimeZone( self::get_local_timezone_string() ) );
+		} else {
+			$date->setUtcOffset( self::get_local_timezone_offset() );
+		}
+
+		return $date;
+	}
+
+	/**
+	 * Helper to retrieve the timezone string for a site until a WP core method exists
+	 * (see https://core.trac.wordpress.org/ticket/24730).
+	 *
+	 * Adapted from wc_timezone_string() and https://secure.php.net/manual/en/function.timezone-name-from-abbr.php#89155.
+	 *
+	 * If no timezone string is set, and its not possible to match the UTC offset set for the site to a timezone
+	 * string, then an empty string will be returned, and the UTC offset should be used to set a DateTime's
+	 * timezone.
+	 *
+	 * @since 2.1.0
+	 * @return string PHP timezone string for the site or empty if no timezone string is available.
+	 */
+	protected static function get_local_timezone_string( $reset = false ) {
+		// If site timezone string exists, return it.
+		$timezone = get_option( 'timezone_string' );
+		if ( $timezone ) {
+			return $timezone;
+		}
+
+		// Get UTC offset, if it isn't set then return UTC.
+		$utc_offset = intval( get_option( 'gmt_offset', 0 ) );
+		if ( 0 === $utc_offset ) {
+			return 'UTC';
+		}
+
+		// Adjust UTC offset from hours to seconds.
+		$utc_offset *= 3600;
+
+		// Attempt to guess the timezone string from the UTC offset.
+		$timezone = timezone_name_from_abbr( '', $utc_offset );
+		if ( $timezone ) {
+			return $timezone;
+		}
+
+		// Last try, guess timezone string manually.
+		foreach ( timezone_abbreviations_list() as $abbr ) {
+			foreach ( $abbr as $city ) {
+				if ( (bool) date( 'I' ) === (bool) $city['dst'] && $city['timezone_id'] && intval( $city['offset'] ) === $utc_offset ) {
+					return $city['timezone_id'];
+				}
+			}
+		}
+
+		// No timezone string
+		return '';
+	}
+
+	/**
+	 * Get timezone offset in seconds.
+	 *
+	 * @since  2.1.0
+	 * @return float
+	 */
+	protected static function get_local_timezone_offset() {
+		$timezone = get_option( 'timezone_string' );
+
+		if ( $timezone ) {
+			$timezone_object = new DateTimeZone( $timezone );
+			return $timezone_object->getOffset( new DateTime( 'now' ) );
+		} else {
+			return floatval( get_option( 'gmt_offset', 0 ) ) * HOUR_IN_SECONDS;
+		}
+	}
+
+	/**
+	 * @deprecated 2.1.0
+	 */
 	public static function get_local_timezone( $reset = FALSE ) {
+		_deprecated_function( __FUNCTION__, '2.1.0', 'ActionScheduler_TimezoneHelper::set_local_timezone()' );
 		if ( $reset ) {
 			self::$local_timezone = NULL;
 		}
@@ -18,18 +113,32 @@ abstract class ActionScheduler_TimezoneHelper {
 					$tzstring = 'UTC';
 				} else {
 					$gmt_offset *= HOUR_IN_SECONDS;
-					$tzstring = timezone_name_from_abbr('', $gmt_offset);
+					$tzstring   = timezone_name_from_abbr( '', $gmt_offset, 1 );
+
+					// If there's no timezone string, try again with no DST.
+					if ( false === $tzstring ) {
+						$tzstring = timezone_name_from_abbr( '', $gmt_offset, 0 );
+					}
+
+					// Try mapping to the first abbreviation we can find.
 					if ( false === $tzstring ) {
 						$is_dst = date( 'I' );
 						foreach ( timezone_abbreviations_list() as $abbr ) {
 							foreach ( $abbr as $city ) {
 								if ( $city['dst'] == $is_dst && $city['offset'] == $gmt_offset ) {
+									// If there's no valid timezone ID, keep looking.
+									if ( null === $city['timezone_id'] ) {
+										continue;
+									}
+
 									$tzstring = $city['timezone_id'];
 									break 2;
 								}
 							}
 						}
 					}
+
+					// If we still have no valid string, then fall back to UTC.
 					if ( false === $tzstring ) {
 						$tzstring = 'UTC';
 					}
@@ -41,4 +150,3 @@ abstract class ActionScheduler_TimezoneHelper {
 		return self::$local_timezone;
 	}
 }
- 

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "prospress/action-scheduler",
-  "version": "2.0.0",
   "description": "Action Scheduler for WordPress and WooCommerce",
   "type": "wordpress-plugin",
   "license": "GPL-3.0",

--- a/deprecated/functions.php
+++ b/deprecated/functions.php
@@ -1,0 +1,126 @@
+<?php
+
+/**
+ * Deprecated API functions for scheduling actions
+ *
+ * Functions with the wc prefix were deprecated to avoid confusion with
+ * Action Scheduler being included in WooCommerce core, and it providing
+ * a different set of APIs for working with the action queue.
+ */
+
+/**
+ * Schedule an action to run one time
+ *
+ * @param int $timestamp When the job will run
+ * @param string $hook The hook to trigger
+ * @param array $args Arguments to pass when the hook triggers
+ * @param string $group The group to assign this job to
+ *
+ * @return string The job ID
+ */
+function wc_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_schedule_single_action()' );
+	return as_schedule_single_action( $timestamp, $hook, $args, $group );
+}
+
+/**
+ * Schedule a recurring action
+ *
+ * @param int $timestamp When the first instance of the job will run
+ * @param int $interval_in_seconds How long to wait between runs
+ * @param string $hook The hook to trigger
+ * @param array $args Arguments to pass when the hook triggers
+ * @param string $group The group to assign this job to
+ *
+ * @deprecated 2.1.0
+ *
+ * @return string The job ID
+ */
+function wc_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_schedule_recurring_action()' );
+	return as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group );
+}
+
+/**
+ * Schedule an action that recurs on a cron-like schedule.
+ *
+ * @param int $timestamp The schedule will start on or after this time
+ * @param string $schedule A cron-link schedule string
+ * @see http://en.wikipedia.org/wiki/Cron
+ *   *    *    *    *    *    *
+ *   ┬    ┬    ┬    ┬    ┬    ┬
+ *   |    |    |    |    |    |
+ *   |    |    |    |    |    + year [optional]
+ *   |    |    |    |    +----- day of week (0 - 7) (Sunday=0 or 7)
+ *   |    |    |    +---------- month (1 - 12)
+ *   |    |    +--------------- day of month (1 - 31)
+ *   |    +-------------------- hour (0 - 23)
+ *   +------------------------- min (0 - 59)
+ * @param string $hook The hook to trigger
+ * @param array $args Arguments to pass when the hook triggers
+ * @param string $group The group to assign this job to
+ *
+ * @deprecated 2.1.0
+ *
+ * @return string The job ID
+ */
+function wc_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_schedule_cron_action()' );
+	return as_schedule_cron_action( $timestamp, $schedule, $hook, $args, $group );
+}
+
+/**
+ * Cancel the next occurrence of a job.
+ *
+ * @param string $hook The hook that the job will trigger
+ * @param array $args Args that would have been passed to the job
+ * @param string $group
+ *
+ * @deprecated 2.1.0
+ */
+function wc_unschedule_action( $hook, $args = array(), $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_unschedule_action()' );
+	as_unschedule_action( $hook, $args, $group );
+}
+
+/**
+ * @param string $hook
+ * @param array $args
+ * @param string $group
+ *
+ * @deprecated 2.1.0
+ *
+ * @return int|bool The timestamp for the next occurrence, or false if nothing was found
+ */
+function wc_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_next_scheduled_action()' );
+	return as_next_scheduled_action( $hook, $args, $group );
+}
+
+/**
+ * Find scheduled actions
+ *
+ * @param array $args Possible arguments, with their default values:
+ *        'hook' => '' - the name of the action that will be triggered
+ *        'args' => NULL - the args array that will be passed with the action
+ *        'date' => NULL - the scheduled date of the action. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
+ *        'date_compare' => '<=' - operator for testing "date". accepted values are '!=', '>', '>=', '<', '<=', '='
+ *        'modified' => NULL - the date the action was last updated. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
+ *        'modified_compare' => '<=' - operator for testing "modified". accepted values are '!=', '>', '>=', '<', '<=', '='
+ *        'group' => '' - the group the action belongs to
+ *        'status' => '' - ActionScheduler_Store::STATUS_COMPLETE or ActionScheduler_Store::STATUS_PENDING
+ *        'claimed' => NULL - TRUE to find claimed actions, FALSE to find unclaimed actions, a string to find a specific claim ID
+ *        'per_page' => 5 - Number of results to return
+ *        'offset' => 0
+ *        'orderby' => 'date' - accepted values are 'hook', 'group', 'modified', or 'date'
+ *        'order' => 'ASC'
+ * @param string $return_format OBJECT, ARRAY_A, or ids
+ *
+ * @deprecated 2.1.0
+ *
+ * @return array
+ */
+function wc_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
+	_deprecated_function( __FUNCTION__, '2.1.0', 'as_get_scheduled_actions()' );
+	return as_get_scheduled_actions( $args, $return_format );
+}

--- a/functions.php
+++ b/functions.php
@@ -14,7 +14,7 @@
  *
  * @return string The job ID
  */
-function wc_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
+function as_schedule_single_action( $timestamp, $hook, $args = array(), $group = '' ) {
 	return ActionScheduler::factory()->single( $hook, $args, $timestamp, $group );
 }
 
@@ -29,7 +29,7 @@ function wc_schedule_single_action( $timestamp, $hook, $args = array(), $group =
  *
  * @return string The job ID
  */
-function wc_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
+function as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
 	return ActionScheduler::factory()->recurring( $hook, $args, $timestamp, $interval_in_seconds, $group );
 }
 
@@ -54,18 +54,27 @@ function wc_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, 
  *
  * @return string The job ID
  */
-function wc_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
+function as_schedule_cron_action( $timestamp, $schedule, $hook, $args = array(), $group = '' ) {
 	return ActionScheduler::factory()->cron( $hook, $args, $timestamp, $schedule, $group );
 }
 
 /**
- * Cancel the next occurrence of a job.
+ * Cancel the next occurrence of a scheduled action.
+ *
+ * While only the next instance of a recurring or cron action is unscheduled by this method, that will also prevent
+ * all future instances of that recurring or cron action from being run. Recurring and cron actions are scheduled in
+ * a sequence instead of all being scheduled at once. Each successive occurrence of a recurring action is scheduled
+ * only after the former action is run. If the next instance is never run, because it's unscheduled by this function,
+ * then the following instance will never be scheduled (or exist), which is effectively the same as being unscheduled
+ * by this method also.
  *
  * @param string $hook The hook that the job will trigger
  * @param array $args Args that would have been passed to the job
  * @param string $group
+ *
+ * @return string The scheduled action ID if a scheduled action was found, or empty string if no matching action found.
  */
-function wc_unschedule_action( $hook, $args = array(), $group = '' ) {
+function as_unschedule_action( $hook, $args = array(), $group = '' ) {
 	$params = array();
 	if ( is_array($args) ) {
 		$params['args'] = $args;
@@ -74,11 +83,25 @@ function wc_unschedule_action( $hook, $args = array(), $group = '' ) {
 		$params['group'] = $group;
 	}
 	$job_id = ActionScheduler::store()->find_action( $hook, $params );
-	if ( empty($job_id) ) {
-		return;
+
+	if ( ! empty( $job_id ) ) {
+		ActionScheduler::store()->cancel_action( $job_id );
 	}
 
-	ActionScheduler::store()->cancel_action( $job_id );
+	return $job_id;
+}
+
+/**
+ * Cancel all occurrences of a scheduled action.
+ *
+ * @param string $hook The hook that the job will trigger
+ * @param array $args Args that would have been passed to the job
+ * @param string $group
+ */
+function as_unschedule_all_actions( $hook, $args = array(), $group = '' ) {
+	do {
+		$unscheduled_action = as_unschedule_action( $hook, $args, $group );
+	} while ( ! empty( $unscheduled_action ) );
 }
 
 /**
@@ -88,7 +111,7 @@ function wc_unschedule_action( $hook, $args = array(), $group = '' ) {
  *
  * @return int|bool The timestamp for the next occurrence, or false if nothing was found
  */
-function wc_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
+function as_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
 	$params = array();
 	if ( is_array($args) ) {
 		$params['args'] = $args;
@@ -130,7 +153,7 @@ function wc_next_scheduled_action( $hook, $args = NULL, $group = '' ) {
  *
  * @return array
  */
-function wc_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
+function as_get_scheduled_actions( $args = array(), $return_format = OBJECT ) {
 	$store = ActionScheduler::store();
 	foreach ( array('date', 'modified') as $key ) {
 		if ( isset($args[$key]) ) {

--- a/includes/interfaces/class-wc-queue-interface.php
+++ b/includes/interfaces/class-wc-queue-interface.php
@@ -75,15 +75,24 @@ interface WC_Queue_Interface {
 	public function schedule_cron( $timestamp, $cron_schedule, $hook, $args = array(), $group = '' );
 
 	/**
-	 * Dequeue all actions with a matching hook (and optionally matching args and group) so they are not run.
+	 * Dequeue the next scheduled instance of an action with a matching hook (and optionally matching args and group).
 	 *
-	 * Any recurring actions with a matching hook will also be cancelled, not just the next scheduled action.
+	 * Any recurring actions with a matching hook should also be cancelled, not just the next scheduled action.
 	 *
 	 * @param string $hook The hook that the job will trigger
 	 * @param array $args Args that would have been passed to the job
 	 * @param string $group
 	 */
 	public function cancel( $hook, $args = array(), $group = '' );
+
+	/**
+	 * Dequeue all actions with a matching hook (and optionally matching args and group) so no matching actions are ever run.
+	 *
+	 * @param string $hook The hook that the job will trigger
+	 * @param array $args Args that would have been passed to the job
+	 * @param string $group
+	 */
+	public function cancel_all( $hook, $args = array(), $group = '' );
 
 	/**
 	 * Get the date and time for the next scheduled occurence of an action with a given hook

--- a/includes/interfaces/class-wc-queue-interface.php
+++ b/includes/interfaces/class-wc-queue-interface.php
@@ -22,9 +22,9 @@ interface WC_Queue_Interface {
 	/**
 	 * Enqueue an action to run one time, as soon as possible
 	 *
-	 * @param string $hook The hook to trigger
-	 * @param array $args Arguments to pass when the hook triggers
-	 * @param string $group The group to assign this job to
+	 * @param string $hook The hook to trigger.
+	 * @param array  $args Arguments to pass when the hook triggers.
+	 * @param string $group The group to assign this job to.
 	 * @return string The action ID
 	 */
 	public function add( $hook, $args = array(), $group = '' );
@@ -32,10 +32,10 @@ interface WC_Queue_Interface {
 	/**
 	 * Schedule an action to run once at some time in the future
 	 *
-	 * @param int $timestamp When the job will run
-	 * @param string $hook The hook to trigger
-	 * @param array $args Arguments to pass when the hook triggers
-	 * @param string $group The group to assign this job to
+	 * @param int    $timestamp When the job will run.
+	 * @param string $hook The hook to trigger.
+	 * @param array  $args Arguments to pass when the hook triggers.
+	 * @param string $group The group to assign this job to.
 	 * @return string The action ID
 	 */
 	public function schedule_single( $timestamp, $hook, $args = array(), $group = '' );
@@ -43,11 +43,11 @@ interface WC_Queue_Interface {
 	/**
 	 * Schedule a recurring action
 	 *
-	 * @param int $timestamp When the first instance of the job will run
-	 * @param int $interval_in_seconds How long to wait between runs
-	 * @param string $hook The hook to trigger
-	 * @param array $args Arguments to pass when the hook triggers
-	 * @param string $group The group to assign this job to
+	 * @param int    $timestamp When the first instance of the job will run.
+	 * @param int    $interval_in_seconds How long to wait between runs.
+	 * @param string $hook The hook to trigger.
+	 * @param array  $args Arguments to pass when the hook triggers.
+	 * @param string $group The group to assign this job to.
 	 * @return string The action ID
 	 */
 	public function schedule_recurring( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' );
@@ -55,8 +55,8 @@ interface WC_Queue_Interface {
 	/**
 	 * Schedule an action that recurs on a cron-like schedule.
 	 *
-	 * @param int $timestamp The schedule will start on or after this time
-	 * @param string $cron_schedule A cron-link schedule string
+	 * @param int    $timestamp The schedule will start on or after this time.
+	 * @param string $cron_schedule A cron-link schedule string.
 	 * @see http://en.wikipedia.org/wiki/Cron
 	 *   *    *    *    *    *    *
 	 *   ┬    ┬    ┬    ┬    ┬    ┬
@@ -67,9 +67,9 @@ interface WC_Queue_Interface {
 	 *   |    |    +--------------- day of month (1 - 31)
 	 *   |    +-------------------- hour (0 - 23)
 	 *   +------------------------- min (0 - 59)
-	 * @param string $hook The hook to trigger
-	 * @param array $args Arguments to pass when the hook triggers
-	 * @param string $group The group to assign this job to
+	 * @param string $hook The hook to trigger.
+	 * @param array  $args Arguments to pass when the hook triggers.
+	 * @param string $group The group to assign this job to.
 	 * @return string The action ID
 	 */
 	public function schedule_cron( $timestamp, $cron_schedule, $hook, $args = array(), $group = '' );
@@ -79,18 +79,18 @@ interface WC_Queue_Interface {
 	 *
 	 * Any recurring actions with a matching hook should also be cancelled, not just the next scheduled action.
 	 *
-	 * @param string $hook The hook that the job will trigger
-	 * @param array $args Args that would have been passed to the job
-	 * @param string $group
+	 * @param string $hook The hook that the job will trigger.
+	 * @param array  $args Args that would have been passed to the job.
+	 * @param string $group The group the job is assigned to (if any).
 	 */
 	public function cancel( $hook, $args = array(), $group = '' );
 
 	/**
 	 * Dequeue all actions with a matching hook (and optionally matching args and group) so no matching actions are ever run.
 	 *
-	 * @param string $hook The hook that the job will trigger
-	 * @param array $args Args that would have been passed to the job
-	 * @param string $group
+	 * @param string $hook The hook that the job will trigger.
+	 * @param array  $args Args that would have been passed to the job.
+	 * @param string $group The group the job is assigned to (if any).
 	 */
 	public function cancel_all( $hook, $args = array(), $group = '' );
 
@@ -98,32 +98,31 @@ interface WC_Queue_Interface {
 	 * Get the date and time for the next scheduled occurence of an action with a given hook
 	 * (an optionally that matches certain args and group), if any.
 	 *
-	 * @param string $hook
-	 * @param array $args
-	 * @param string $group
-	 * @return int|bool The timestamp for the next occurrence, or false if nothing was found
+	 * @param string $hook The hook that the job will trigger.
+	 * @param array  $args Filter to a hook with matching args that will be passed to the job when it runs.
+	 * @param string $group Filter to only actions assigned to a specific group.
 	 * @return WC_DateTime|null The date and time for the next occurrence, or null if there is no pending, scheduled action for the given hook
 	 */
 	public function get_next( $hook, $args = null, $group = '' );
 
 	/**
-	 * Find scheduled actions
+	 * Find scheduled actions.
 	 *
-	 * @param array $args Possible arguments, with their default values:
-	 *        'hook' => '' - the name of the action that will be triggered
-	 *        'args' => null - the args array that will be passed with the action
+	 * @param array  $args Possible arguments, with their default values.
+	 *        'hook' => '' - the name of the action that will be triggered.
+	 *        'args' => null - the args array that will be passed with the action.
 	 *        'date' => null - the scheduled date of the action. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
-	 *        'date_compare' => '<=' - operator for testing "date". accepted values are '!=', '>', '>=', '<', '<=', '='
+	 *        'date_compare' => '<=' - operator for testing "date". accepted values are '!=', '>', '>=', '<', '<=', '='.
 	 *        'modified' => null - the date the action was last updated. Expects a DateTime object, a unix timestamp, or a string that can parsed with strtotime(). Used in UTC timezone.
-	 *        'modified_compare' => '<=' - operator for testing "modified". accepted values are '!=', '>', '>=', '<', '<=', '='
-	 *        'group' => '' - the group the action belongs to
-	 *        'status' => '' - ActionScheduler_Store::STATUS_COMPLETE or ActionScheduler_Store::STATUS_PENDING
-	 *        'claimed' => null - TRUE to find claimed actions, FALSE to find unclaimed actions, a string to find a specific claim ID
-	 *        'per_page' => 5 - Number of results to return
-	 *        'offset' => 0
-	 *        'orderby' => 'date' - accepted values are 'hook', 'group', 'modified', or 'date'
-	 *        'order' => 'ASC'
-	 * @param string $return_format OBJECT, ARRAY_A, or ids
+	 *        'modified_compare' => '<=' - operator for testing "modified". accepted values are '!=', '>', '>=', '<', '<=', '='.
+	 *        'group' => '' - the group the action belongs to.
+	 *        'status' => '' - ActionScheduler_Store::STATUS_COMPLETE or ActionScheduler_Store::STATUS_PENDING.
+	 *        'claimed' => null - TRUE to find claimed actions, FALSE to find unclaimed actions, a string to find a specific claim ID.
+	 *        'per_page' => 5 - Number of results to return.
+	 *        'offset' => 0.
+	 *        'orderby' => 'date' - accepted values are 'hook', 'group', 'modified', or 'date'.
+	 *        'order' => 'ASC'.
+	 * @param string $return_format OBJECT, ARRAY_A, or ids.
 	 * @return array
 	 */
 	public function search( $args = array(), $return_format = OBJECT );

--- a/includes/queue/class-wc-action-queue.php
+++ b/includes/queue/class-wc-action-queue.php
@@ -96,7 +96,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 *
 	 * @param string $hook The hook that the job will trigger.
 	 * @param array  $args Args that would have been passed to the job.
-	 * @param string $group Group name.
+	 * @param string $group The group the job is assigned to (if any).
 	 */
 	public function cancel( $hook, $args = array(), $group = '' ) {
 		as_unschedule_action( $hook, $args, $group );
@@ -107,7 +107,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 *
 	 * @param string $hook The hook that the job will trigger.
 	 * @param array  $args Args that would have been passed to the job.
-	 * @param string $group Group name.
+	 * @param string $group The group the job is assigned to (if any).
 	 */
 	public function cancel_all( $hook, $args = array(), $group = '' ) {
 		as_unschedule_all_actions( $hook, $args, $group );
@@ -117,9 +117,9 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * Get the date and time for the next scheduled occurence of an action with a given hook
 	 * (an optionally that matches certain args and group), if any.
 	 *
-	 * @param string $hook Hook name.
-	 * @param array  $args Arguments.
-	 * @param string $group Group name.
+	 * @param string $hook The hook that the job will trigger.
+	 * @param array  $args Filter to a hook with matching args that will be passed to the job when it runs.
+	 * @param string $group Filter to only actions assigned to a specific group.
 	 * @return WC_DateTime|null The date and time for the next occurrence, or null if there is no pending, scheduled action for the given hook.
 	 */
 	public function get_next( $hook, $args = null, $group = '' ) {

--- a/includes/queue/class-wc-action-queue.php
+++ b/includes/queue/class-wc-action-queue.php
@@ -83,13 +83,16 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	}
 
 	/**
-	 * Dequeue all actions with a matching hook (and optionally matching args and group) so they are not run.
+	 * Dequeue the next scheduled instance of an action with a matching hook (and optionally matching args and group).
 	 *
-	 * Any recurring actions with a matching hook will also be cancelled, not just the next scheduled action.
+	 * Any recurring actions with a matching hook should also be cancelled, not just the next scheduled action.
 	 *
-	 * Technically, one action in a recurring or Cron action is scheduled at any one point in time. The next
-	 * in the sequence is scheduled after the previous one is run, so only the next scheduled action needs to
-	 * be cancelled/dequeued to stop the sequence.
+	 * While technically only the next instance of a recurring or cron action is unscheduled by this method, that will also
+	 * prevent all future instances of that recurring or cron action from being run. Recurring and cron actions are scheduled
+	 * in a sequence instead of all being scheduled at once. Each successive occurrence of a recurring action is scheduled
+	 * only after the former action is run. As the next instance is never run, because it's unscheduled by this function,
+	 * then the following instance will never be scheduled (or exist), which is effectively the same as being unscheduled
+	 * by this method also.
 	 *
 	 * @param string $hook The hook that the job will trigger.
 	 * @param array  $args Args that would have been passed to the job.
@@ -97,6 +100,17 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 */
 	public function cancel( $hook, $args = array(), $group = '' ) {
 		as_unschedule_action( $hook, $args, $group );
+	}
+
+	/**
+	 * Dequeue all actions with a matching hook (and optionally matching args and group) so no matching actions are ever run.
+	 *
+	 * @param string $hook The hook that the job will trigger.
+	 * @param array  $args Args that would have been passed to the job.
+	 * @param string $group Group name.
+	 */
+	public function cancel_all( $hook, $args = array(), $group = '' ) {
+		as_unschedule_all_actions( $hook, $args, $group );
 	}
 
 	/**

--- a/includes/queue/class-wc-action-queue.php
+++ b/includes/queue/class-wc-action-queue.php
@@ -41,7 +41,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * @return string The action ID.
 	 */
 	public function schedule_single( $timestamp, $hook, $args = array(), $group = '' ) {
-		return wc_schedule_single_action( $timestamp, $hook, $args, $group );
+		return as_schedule_single_action( $timestamp, $hook, $args, $group );
 	}
 
 	/**
@@ -55,7 +55,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * @return string The action ID.
 	 */
 	public function schedule_recurring( $timestamp, $interval_in_seconds, $hook, $args = array(), $group = '' ) {
-		return wc_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group );
+		return as_schedule_recurring_action( $timestamp, $interval_in_seconds, $hook, $args, $group );
 	}
 
 	/**
@@ -79,7 +79,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * @return string The action ID
 	 */
 	public function schedule_cron( $timestamp, $cron_schedule, $hook, $args = array(), $group = '' ) {
-		return wc_schedule_cron_action( $timestamp, $cron_schedule, $hook, $args, $group );
+		return as_schedule_cron_action( $timestamp, $cron_schedule, $hook, $args, $group );
 	}
 
 	/**
@@ -96,7 +96,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * @param string $group Group name.
 	 */
 	public function cancel( $hook, $args = array(), $group = '' ) {
-		wc_unschedule_action( $hook, $args, $group );
+		as_unschedule_action( $hook, $args, $group );
 	}
 
 	/**
@@ -110,7 +110,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 */
 	public function get_next( $hook, $args = null, $group = '' ) {
 
-		$next_timestamp = wc_next_scheduled_action( $hook, $args, $group );
+		$next_timestamp = as_next_scheduled_action( $hook, $args, $group );
 
 		if ( $next_timestamp ) {
 			return wc_string_to_datetime( $next_timestamp );
@@ -141,6 +141,6 @@ class WC_Action_Queue implements WC_Queue_Interface {
 	 * @return array
 	 */
 	public function search( $args = array(), $return_format = OBJECT ) {
-		return wc_get_scheduled_actions( $args, $return_format );
+		return as_get_scheduled_actions( $args, $return_format );
 	}
 }

--- a/tests/phpunit/helpers/ActionScheduler_TimezoneHelper_Test.php
+++ b/tests/phpunit/helpers/ActionScheduler_TimezoneHelper_Test.php
@@ -1,0 +1,100 @@
+<?php
+
+/**
+ * @group timezone
+ */
+class ActionScheduler_TimezoneHelper_Test extends ActionScheduler_UnitTestCase {
+
+	/**
+	 * Ensure that the timezone string we expect works properly.
+	 *
+	 * @dataProvider local_timezone_provider
+	 *
+	 * @param $timezone_string
+	 */
+	public function test_local_timezone_strings( $timezone_string ) {
+		$timezone_filter = function ( $tz ) use ( $timezone_string ) {
+			return $timezone_string;
+		};
+
+		add_filter( 'option_timezone_string', $timezone_filter );
+
+		$date     = new ActionScheduler_DateTime();
+		$timezone = ActionScheduler_TimezoneHelper::set_local_timezone( $date )->getTimezone();
+		$this->assertInstanceOf( 'DateTimeZone', $timezone );
+		$this->assertEquals( $timezone_string, $timezone->getName() );
+
+		remove_filter( 'option_timezone_string', $timezone_filter );
+	}
+
+	public function local_timezone_provider() {
+		return array(
+			array( 'America/New_York' ),
+			array( 'Australia/Melbourne' ),
+			array( 'UTC' ),
+		);
+	}
+
+	/**
+	 * Ensure that most GMT offsets don't return UTC as the timezone.
+	 *
+	 * @dataProvider local_timezone_offsets_provider
+	 *
+	 * @param $gmt_offset
+	 */
+	public function test_local_timezone_offsets( $gmt_offset ) {
+		$gmt_filter = function ( $gmt ) use ( $gmt_offset ) {
+			return $gmt_offset;
+		};
+
+		$date = new ActionScheduler_DateTime();
+
+		add_filter( 'option_gmt_offset', $gmt_filter );
+		ActionScheduler_TimezoneHelper::set_local_timezone( $date );
+		remove_filter( 'option_gmt_offset', $gmt_filter );
+
+		$offset_in_seconds = $gmt_offset * HOUR_IN_SECONDS;
+
+		$this->assertEquals( $offset_in_seconds, $date->getOffset() );
+		$this->assertEquals( $offset_in_seconds, $date->getOffsetTimestamp() - $date->getTimestamp() );
+	}
+
+	public function local_timezone_offsets_provider() {
+		return array(
+			array( '-11' ),
+			array( '-10.5' ),
+			array( '-10' ),
+			array( '-9' ),
+			array( '-8' ),
+			array( '-7' ),
+			array( '-6' ),
+			array( '-5' ),
+			array( '-4.5' ),
+			array( '-4' ),
+			array( '-3.5' ),
+			array( '-3' ),
+			array( '-2' ),
+			array( '-1' ),
+			array( '1' ),
+			array( '1.5' ),
+			array( '2' ),
+			array( '3' ),
+			array( '4' ),
+			array( '5' ),
+			array( '5.5' ),
+			array( '5.75' ),
+			array( '6' ),
+			array( '7' ),
+			array( '8' ),
+			array( '8.5' ),
+			array( '9' ),
+			array( '9.5' ),
+			array( '10' ),
+			array( '10.5' ),
+			array( '11' ),
+			array( '11.5' ),
+			array( '12' ),
+			array( '13' ),
+		);
+	}
+}

--- a/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
+++ b/tests/phpunit/jobstore/ActionScheduler_wpPostStore_Test.php
@@ -41,6 +41,29 @@ class ActionScheduler_wpPostStore_Test extends ActionScheduler_UnitTestCase {
 		$this->assertEquals($action->get_group(), $retrieved->get_group());
 	}
 
+	/**
+	 * @expectedException ActionScheduler_InvalidActionException
+	 * @dataProvider provide_bad_args
+	 *
+	 * @param string $content
+	 */
+	public function test_action_bad_args( $content ) {
+		$store   = new ActionScheduler_wpPostStore();
+		$post_id = wp_insert_post( array(
+			'post_type'    => ActionScheduler_wpPostStore::POST_TYPE,
+			'post_status'  => ActionScheduler_Store::STATUS_PENDING,
+			'post_content' => $content,
+		) );
+
+		$store->fetch_action( $post_id );
+	}
+
+	public function provide_bad_args() {
+		return array(
+			array( '{"bad_json":true}}' ),
+		);
+	}
+
 	public function test_cancel_action() {
 		$time = as_get_datetime_object();
 		$schedule = new ActionScheduler_SimpleSchedule($time);

--- a/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
+++ b/tests/phpunit/logging/ActionScheduler_wpCommentLogger_Test.php
@@ -12,11 +12,30 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	}
 
 	public function test_add_log_entry() {
-		$action_id = wc_schedule_single_action( time(), 'a hook' );
+		$action_id = as_schedule_single_action( time(), 'a hook' );
 		$logger = ActionScheduler::logger();
 		$message = 'Logging that something happened';
 		$log_id = $logger->log( $action_id, $message );
 		$entry = $logger->get_entry( $log_id );
+
+		$this->assertEquals( $action_id, $entry->get_action_id() );
+		$this->assertEquals( $message, $entry->get_message() );
+	}
+
+	public function test_add_log_datetime() {
+		$action_id = as_schedule_single_action( time(), 'a hook' );
+		$logger    = ActionScheduler::logger();
+		$message   = 'Logging that something happened';
+		$date      = new DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$log_id    = $logger->log( $action_id, $message, $date );
+		$entry     = $logger->get_entry( $log_id );
+
+		$this->assertEquals( $action_id, $entry->get_action_id() );
+		$this->assertEquals( $message, $entry->get_message() );
+
+		$date      = new ActionScheduler_DateTime( 'now', new DateTimeZone( 'UTC' ) );
+		$log_id    = $logger->log( $action_id, $message, $date );
+		$entry     = $logger->get_entry( $log_id );
 
 		$this->assertEquals( $action_id, $entry->get_action_id() );
 		$this->assertEquals( $message, $entry->get_message() );
@@ -42,7 +61,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	}
 
 	public function test_storage_comments() {
-		$action_id = wc_schedule_single_action( time(), 'a hook' );
+		$action_id = as_schedule_single_action( time(), 'a hook' );
 		$logger = ActionScheduler::logger();
 		$logs = $logger->get_logs( $action_id );
 		$expected = new ActionScheduler_LogEntry( $action_id, 'action created' );
@@ -62,7 +81,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	}
 
 	public function test_execution_comments() {
-		$action_id = wc_schedule_single_action( time(), 'a hook' );
+		$action_id = as_schedule_single_action( time(), 'a hook' );
 		$logger = ActionScheduler::logger();
 		$started = new ActionScheduler_LogEntry( $action_id, 'action started' );
 		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete' );
@@ -78,7 +97,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	public function test_failed_execution_comments() {
 		$hook = md5(rand());
 		add_action( $hook, array( $this, '_a_hook_callback_that_throws_an_exception' ) );
-		$action_id = wc_schedule_single_action( time(), $hook );
+		$action_id = as_schedule_single_action( time(), $hook );
 		$logger = ActionScheduler::logger();
 		$started = new ActionScheduler_LogEntry( $action_id, 'action started' );
 		$finished = new ActionScheduler_LogEntry( $action_id, 'action complete' );
@@ -95,7 +114,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 
 	public function test_fatal_error_comments() {
 		$hook = md5(rand());
-		$action_id = wc_schedule_single_action( time(), $hook );
+		$action_id = as_schedule_single_action( time(), $hook );
 		$logger = ActionScheduler::logger();
 		do_action( 'action_scheduler_unexpected_shutdown', $action_id, array(
 			'type' => E_ERROR,
@@ -115,8 +134,8 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 	}
 
 	public function test_canceled_action_comments() {
-		$action_id = wc_schedule_single_action( time(), 'a hook' );
-		wc_unschedule_action( 'a hook' );
+		$action_id = as_schedule_single_action( time(), 'a hook' );
+		as_unschedule_action( 'a hook' );
 		$logger = ActionScheduler::logger();
 		$logs = $logger->get_logs( $action_id );
 		$expected = new ActionScheduler_LogEntry( $action_id, 'action canceled' );
@@ -143,7 +162,7 @@ class ActionScheduler_wpCommentLogger_Test extends ActionScheduler_UnitTestCase 
 		$this->assertEquals( $comment_id, $comments[0]->comment_ID );
 
 
-		$action_id = wc_schedule_single_action( time(), 'a hook' );
+		$action_id = as_schedule_single_action( time(), 'a hook' );
 		$logger = ActionScheduler::logger();
 		$message = 'Logging that something happened';
 		$log_id = $logger->log( $action_id, $message );

--- a/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
+++ b/tests/phpunit/procedural_api/wc_get_scheduled_actions_Test.php
@@ -1,9 +1,9 @@
 <?php
 
 /**
- * Class wc_get_scheduled_actions_Test
+ * Class as_get_scheduled_actions_Test
  */
-class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
+class as_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 	private $hooks = array();
 	private $args = array();
 	private $groups = array();
@@ -30,13 +30,13 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_date_queries() {
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(30, $actions);
 
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'date_compare' => '>=',
 			'per_page' => -1,
@@ -45,13 +45,13 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_hook_queries() {
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'hook' => $this->hooks[2],
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(10, $actions);
 
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'hook' => $this->hooks[2],
 			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
 			'per_page' => -1,
@@ -60,20 +60,20 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_args_queries() {
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'args' => array($this->args[5]),
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(10, $actions);
 
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'args' => array($this->args[5]),
 			'hook' => $this->hooks[3],
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(1, $actions);
 
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'args' => array($this->args[5]),
 			'hook' => $this->hooks[3],
 			'date' => as_get_datetime_object(gmdate('Y-m-d 00:00:00')),
@@ -83,13 +83,13 @@ class wc_get_scheduled_actions_Test extends ActionScheduler_UnitTestCase {
 	}
 
 	public function test_group_queries() {
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'group' => $this->groups[1],
 			'per_page' => -1,
 		), 'ids');
 		$this->assertCount(10, $actions);
 
-		$actions = wc_get_scheduled_actions(array(
+		$actions = as_get_scheduled_actions(array(
 			'group' => $this->groups[1],
 			'hook' => $this->hooks[9],
 			'per_page' => -1,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates Action Scheduler to v2.1.0. This is primarily to follow up on the request to change Action Scheduler's function prefixes from `wc_` to `as_`. Original request for the prefix change: https://github.com/woocommerce/woocommerce/pull/20030#pullrequestreview-139753264

For the specific changeset for this, see https://github.com/Prospress/action-scheduler/pull/181

It also adds a new `WC_Queue_Interface::cancel_all()` method to help address some of the ambiguity with the existing `WC_Queue_Interface::cancel()` method (docblocks also updated). This came up previously here: https://github.com/woocommerce/woocommerce/pull/20030#issuecomment-408043930

For the specific changeset for this, see https://github.com/Prospress/action-scheduler/pull/201/

In addition to that, v2.1.0 fixes a rare timezone issue that was already being handled by WC since v3.0, so was likely encountered previously, and a few smaller issues. For details, see: https://github.com/Prospress/action-scheduler/milestone/3?closed=1

This should be the final piece of #18003.

Beyond the code, I'd also like to publish some docs, probably in the Developer Wiki, on how the job queue APIs can be used via 3rd party code. Please let me know if you'd like to proceed with those.

### How to test the changes in this Pull Request:

1. Checkout the branch
2. Make sure you have a webhook enabled
3. Run through the steps to trigger that webhook
4. Confirm the webhook was sent to the `Delivery URL`
5. Find the history of the webhook in [Action Scheduler's admin view](https://github.com/Prospress/action-scheduler/#managing-scheduled-actions)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? (New tests in Action Scheduler for `cancel_all()` method)
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

This changelog entries can be used for the changes added here and the initial addition of AS in #20030, which didn't include changelog entries: 

```
* Dev - Add an extensible/swappable job queue via WC_Action_Queue and WC_Queue_Interface. #20030
* Dev - Use WC_Action_Queue for schedule and delivery of webhooks. #20030
* Dev - Include Action Scheduler v2.1.0 and use it for the default job queue. #21424 /  #20030
```