### PR TITLE
Limit number of webhooks loaded in each request

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -644,7 +644,9 @@ final class WooCommerce {
 			return;
 		}
 
-		wc_load_webhooks( 'active' );
+		$limit = apply_filters( 'woocommerce_load_webhooks_limit', 100 );
+
+		wc_load_webhooks( 'active', $limit );
 	}
 
 	/**

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -644,7 +644,7 @@ final class WooCommerce {
 			return;
 		}
 
-		wc_load_webhooks();
+		wc_load_webhooks( 'active' );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -202,9 +202,10 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 	 * @since  3.3.0
 	 * @throws InvalidArgumentException If a $status value is passed in that is not in the known wc_get_webhook_statuses() keys.
 	 * @param  string   $status Optional - status to filter results by. Must be a key in return value of @see wc_get_webhook_statuses(). @since 3.5.0.
+	 * @param  null|int $limit Limit returned results. @since 3.5.0.
 	 * @return int[]
 	 */
-	public function get_webhooks_ids( $status = '' ) {
+	public function get_webhooks_ids( $status = '', $limit = null ) {
 		global $wpdb;
 
 		if ( ! empty( $status ) ) {
@@ -222,6 +223,10 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 			);
 			$ids = array_map( 'intval', $ids );
 			set_transient( $this->get_transient_key( $status ), $ids );
+		}
+
+		if ( null !== $limit && $limit > 0 ) {
+			$ids = array_slice( $ids, 0, absint( $limit ) );
 		}
 
 		return $ids;

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -206,7 +206,6 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 	 * @return int[]
 	 */
 	public function get_webhooks_ids( $status = '', $limit = null ) {
-		global $wpdb;
 
 		if ( ! empty( $status ) ) {
 			$this->validate_status( $status );

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -242,7 +242,8 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 		global $wpdb;
 
 		$args = wp_parse_args(
-			$args, array(
+			$args,
+			array(
 				'limit'   => 10,
 				'offset'  => 0,
 				'order'   => 'DESC',

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -214,16 +214,13 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 		$ids = get_transient( $this->get_transient_key( $status ) );
 
 		if ( false === $ids ) {
-
-			$query = "SELECT webhook_id FROM {$wpdb->prefix}wc_webhooks";
-
-			if ( ! empty( $status ) ) {
-				$query .= $wpdb->prepare( " AND status = %s", $status );
-			}
-
-			$results = $wpdb->get_results( $query ); // WPCS: cache ok, DB call ok.
-			$ids     = array_map( 'intval', wp_list_pluck( $results, 'webhook_id' ) );
-
+			$ids = $this->search_webhooks(
+				array(
+					'limit'  => -1,
+					'status' => $status,
+				)
+			);
+			$ids = array_map( 'intval', $ids );
 			set_transient( $this->get_transient_key( $status ), $ids );
 		}
 

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -152,6 +152,10 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 
 		$webhook->apply_changes();
 
+		if ( isset( $changes['status'] ) ) {
+			// We need to delete all transients, because we can't be sure of the old status.
+			$this->delete_transients( 'all' );
+		}
 		wp_cache_delete( $webhook->get_id(), 'webhooks' );
 		WC_Cache_Helper::incr_cache_prefix( 'webhooks' );
 

--- a/includes/interfaces/class-wc-webhooks-data-store-interface.php
+++ b/includes/interfaces/class-wc-webhooks-data-store-interface.php
@@ -30,7 +30,8 @@ interface WC_Webhook_Data_Store_Interface {
 	 * @since  3.2.0
 	 * @throws InvalidArgumentException If a $status value is passed in that is not in the known wc_get_webhook_statuses() keys.
 	 * @param  string   $status Optional - status to filter results by. Must be a key in return value of @see wc_get_webhook_statuses(). @since 3.5.0.
+	 * @param  null|int $limit Limit returned results. @since 3.5.0.
 	 * @return int[]
 	 */
-	public function get_webhooks_ids( $status = '' );
+	public function get_webhooks_ids( $status = '', $limit = null );
 }

--- a/includes/interfaces/class-wc-webhooks-data-store-interface.php
+++ b/includes/interfaces/class-wc-webhooks-data-store-interface.php
@@ -28,7 +28,9 @@ interface WC_Webhook_Data_Store_Interface {
 	 * Get all webhooks IDs.
 	 *
 	 * @since  3.2.0
+	 * @throws InvalidArgumentException If a $status value is passed in that is not in the known wc_get_webhook_statuses() keys.
+	 * @param  string   $status Optional - status to filter results by. Must be a key in return value of @see wc_get_webhook_statuses(). @since 3.5.0.
 	 * @return int[]
 	 */
-	public function get_webhooks_ids();
+	public function get_webhooks_ids( $status = '' );
 }

--- a/includes/wc-webhook-functions.php
+++ b/includes/wc-webhook-functions.php
@@ -129,11 +129,12 @@ function wc_get_webhook_statuses() {
  * @since  3.3.0
  * @throws Exception If webhook cannot be read/found and $data parameter of WC_Webhook class constructor is set.
  * @param  string   $status Optional - status to filter results by. Must be a key in return value of @see wc_get_webhook_statuses(). @since 3.5.0.
+ * @param  null|int $limit Limit number of webhooks loaded. @since 3.5.0.
  * @return bool
  */
-function wc_load_webhooks( $status = '' ) {
+function wc_load_webhooks( $status = '', $limit = null ) {
 	$data_store = WC_Data_Store::load( 'webhook' );
-	$webhooks   = $data_store->get_webhooks_ids( $status );
+	$webhooks   = $data_store->get_webhooks_ids( $status, $limit );
 	$loaded     = false;
 
 	foreach ( $webhooks as $webhook_id ) {

--- a/includes/wc-webhook-functions.php
+++ b/includes/wc-webhook-functions.php
@@ -128,11 +128,12 @@ function wc_get_webhook_statuses() {
  *
  * @since  3.3.0
  * @throws Exception If webhook cannot be read/found and $data parameter of WC_Webhook class constructor is set.
+ * @param  string   $status Optional - status to filter results by. Must be a key in return value of @see wc_get_webhook_statuses(). @since 3.5.0.
  * @return bool
  */
-function wc_load_webhooks() {
+function wc_load_webhooks( $status = '' ) {
 	$data_store = WC_Data_Store::load( 'webhook' );
-	$webhooks   = $data_store->get_webhooks_ids();
+	$webhooks   = $data_store->get_webhooks_ids( $status );
 	$loaded     = false;
 
 	foreach ( $webhooks as $webhook_id ) {

--- a/includes/wc-webhook-functions.php
+++ b/includes/wc-webhook-functions.php
@@ -20,6 +20,7 @@ function wc_webhook_process_delivery( $webhook, $arg ) {
 	// so as to avoid delays or failures in delivery from affecting the
 	// user who triggered it.
 	if ( apply_filters( 'woocommerce_webhook_deliver_async', true, $webhook, $arg ) ) {
+
 		$queue_args = array(
 			'webhook_id' => $webhook->get_id(),
 			'arg'        => $arg,

--- a/tests/unit-tests/webhooks/functions.php
+++ b/tests/unit-tests/webhooks/functions.php
@@ -189,17 +189,19 @@ class WC_Tests_Webhook_Functions extends WC_Unit_Test_Case {
 	public function test_wc_load_webhooks_status_and_limit( $status ) {
 		global $wp_filter;
 
-		$webhook_one = $this->create_webhook( 'action.woocommerce_one_test', $status );
-		$webhook_two = $this->create_webhook( 'action.woocommerce_two_test', $status );
+		$action_one  = 'woocommerce_one_test_status_' . $status;
+		$webhook_one = $this->create_webhook( 'action.' . $action_one, $status );
+		$action_two  = 'woocommerce_two_test_status_' . $status;
+		$webhook_two = $this->create_webhook( 'action.' . $action_two, $status );
 
 		$this->assertTrue( wc_load_webhooks( $status, 1 ) );
-		$this->assertFalse( isset( $wp_filter['woocommerce_one_test'] ) );
+		$this->assertFalse( isset( $wp_filter[ $action_one ] ) );
 
 		// Only active webhooks are loaded.
 		if ( 'active' === $status ) {
-			$this->assertTrue( isset( $wp_filter['woocommerce_two_test'] ) );
+			$this->assertTrue( isset( $wp_filter[ $action_two ] ) );
 		} else {
-			$this->assertFalse( isset( $wp_filter['woocommerce_two_test'] ) );
+			$this->assertFalse( isset( $wp_filter[ $action_two ] ) );
 		}
 
 		$webhook_two->delete( true );
@@ -207,9 +209,9 @@ class WC_Tests_Webhook_Functions extends WC_Unit_Test_Case {
 		$this->assertTrue( wc_load_webhooks( $status, 1 ) );
 
 		if ( 'active' === $status ) {
-			$this->assertTrue( isset( $wp_filter['woocommerce_one_test'] ) );
+			$this->assertTrue( isset( $wp_filter[ $action_one ] ) );
 		} else {
-			$this->assertFalse( isset( $wp_filter['woocommerce_one_test'] ) );
+			$this->assertFalse( isset( $wp_filter[ $action_one ] ) );
 		}
 
 		$webhook_one->delete( true );

--- a/tests/unit-tests/webhooks/functions.php
+++ b/tests/unit-tests/webhooks/functions.php
@@ -196,23 +196,12 @@ class WC_Tests_Webhook_Functions extends WC_Unit_Test_Case {
 
 		$this->assertTrue( wc_load_webhooks( $status, 1 ) );
 		$this->assertFalse( isset( $wp_filter[ $action_one ] ) );
-
-		// Only active webhooks are loaded.
-		if ( 'active' === $status ) {
-			$this->assertTrue( isset( $wp_filter[ $action_two ] ) );
-		} else {
-			$this->assertFalse( isset( $wp_filter[ $action_two ] ) );
-		}
+		$this->assertTrue( isset( $wp_filter[ $action_two ] ) );
 
 		$webhook_two->delete( true );
 
 		$this->assertTrue( wc_load_webhooks( $status, 1 ) );
-
-		if ( 'active' === $status ) {
-			$this->assertTrue( isset( $wp_filter[ $action_one ] ) );
-		} else {
-			$this->assertFalse( isset( $wp_filter[ $action_one ] ) );
-		}
+		$this->assertTrue( isset( $wp_filter[ $action_one ] ) );
 
 		$webhook_one->delete( true );
 		$this->assertFalse( wc_load_webhooks( $status, 1 ) );

--- a/tests/unit-tests/webhooks/functions.php
+++ b/tests/unit-tests/webhooks/functions.php
@@ -103,6 +103,14 @@ class WC_Tests_Webhook_Functions extends WC_Unit_Test_Case {
 	 * @since 3.2.0
 	 */
 	public function test_wc_load_webhooks() {
+		$webhook = $this->create_webhook();
+		$this->assertTrue( wc_load_webhooks() );
+		$webhook->delete( true );
+		$this->assertFalse( wc_load_webhooks() );
+	}
+
+	protected function create_webhook( $topic = 'action.woocommerce_some_action' ) {
+
 		$webhook = new WC_Webhook();
 		$webhook->set_props(
 			array(
@@ -111,15 +119,12 @@ class WC_Tests_Webhook_Functions extends WC_Unit_Test_Case {
 				'user_id'      => 0,
 				'delivery_url' => 'https://requestb.in/17jajv31',
 				'secret'       => 'secret',
-				'topic'        => 'action.woocommerce_some_action',
+				'topic'        => $topic,
 				'api_version'  => 2,
 			)
 		);
 		$webhook->save();
 
-		$this->assertTrue( wc_load_webhooks() );
-
-		$webhook->delete( true );
-		$this->assertFalse( wc_load_webhooks() );
+		return $webhook;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR proposes changing how webhooks are loaded on each request to:

1. only load those that are active; and
1. set a limit on the number loaded.

At the moment, all webhooks are loaded on all requests, regardless of how many there are, and whether those webhooks are disabled or paused. This can cause severe performance issues when there are large number of webhooks in the database. Even if those webhooks are disabled (or worse, corrupted data).

The limit can be increased on sites that actually have more than 100 active webhooks they need to run.

#### Note on Backward Compatibility

**Limiting the number of webhooks loaded could be considered a breaking change**. If a site has >100 webhooks, then some of those webhooks would cease to work after updating. To address that, the limit could be increased, or the limit could be removed until version 4.0.

Loading only active webhooks could also be a breaking change if a site was somehow relying on disabled or paused webhooks to still have `WC_Webhook::process()` attached to the hooks. The actual processing of the webhook won't differ, because the first thing `WC_Webhook::process()` does is check if the webhook is active before proceeding (by calling `WC_Webhook::should_deliver()`). However, because `WC_Webhook::enqueue()` will no longer be called for disabled and paused webhooks, `WC_Webhook::process()` will no longer be attached to hooks associated with the topic, so there is a slight change to public APIs. I feel like this is obscure enough that it should not prevent its inclusion in a minor release.

#### Backstory

I recently came across this issue on a site with 16,300 webhook rows in the database. Each row had just the default `WC_Webhook::$data` values (i.e. http://pic.pros.pr/e497b001a3c0 ). Meaning they all had the default status of `disabled` and an empty `name`, `delivery_url` and `topic`. That indicates they were probably created by some rogue infinite loop.

Despite that, all 16,300 webhooks were being initialised on every request. While it only took half a millisecond to load each webhook, loading 16,300 lead to a 5-10 second increase in page load times, as seen in this New Relic snapshot: http://pic.pros.pr/b55880d87b6b

This continued until the corrupted webhooks were manually removed from the database and `'woocommerce_webhook_ids'` transient cache. This New Relic screenshot does a good job showing the impact over a 46 hours period including the state before and after: http://pic.pros.pr/3a1822c40548

### How to test the changes in this Pull Request:

0. Using `master`
1. Generate 20,000 webhooks with not data other than status set to `disabled`
2. Load a page on your site
3. Observe the slow load time

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

```
* Tweak - Load only active webhooks on each request to avoid performance issues loading large numbers of disabled webhooks.
* Tweak - Load a maximum of 100 webhooks per request by default to avoid performance issues on sites with an large set of invalid webhooks. 
```