### PR TITLE
Add coupon object param to get coupon data filter

### DIFF
--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -91,7 +91,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 		}
 
 		// This filter allows custom coupon objects to be created on the fly.
-		$coupon = apply_filters( 'woocommerce_get_shop_coupon_data', false, $data );
+		$coupon = apply_filters( 'woocommerce_get_shop_coupon_data', false, $data, $this );
 
 		if ( $coupon ) {
 			$this->read_manual_coupon( $data, $coupon );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This would allow for greater functionality with virtual coupons in WC via the `woocommerce_get_shop_coupon_data` filter. For example, recurring subscription coupons have extra properties that aren't available in this filter's `$data` array. With access to the current coupon object it will be possible to create more powerful virtual coupons.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Tweak - Add the current coupon object to the woocommerce_get_shop_coupon_data filter
