### PR TITLE
Do not disable empty attribute values in the attribute dropdown

### DIFF
--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -466,8 +466,8 @@ jQuery( function( $ ) {
 
 				// Make sure the dropdown is not disabled for empty value attributes.
 				var nr_elements = original_data.length / 6;
-				for ( i = 0; i < nr_elements; i++ ) {
-					if ( typeof( original_data ) != 'undefined' && original_data[ i * 6 + 2 ].value === '' ) {
+				for ( var i = 0; i < nr_elements; i++ ) {
+					if ( typeof( original_data ) !== 'undefined' && original_data[ i * 6 + 2 ].value === '' ) {
 						$( 'select.attribute_taxonomy' ).find( 'option[value="' + original_data[ i * 6 ].value + '"]' ).removeAttr( 'disabled' );
 					}
 				}

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -467,7 +467,7 @@ jQuery( function( $ ) {
 				// Make sure the dropdown is not disabled for empty value attributes.
 				var nr_elements = original_data.length / 6;
 				for ( i = 0; i < nr_elements; i++ ) {
-					if ( typeof( original_data ) != "undefined" && original_data[ i * 6 + 2 ].value === "" ) {
+					if ( typeof( original_data ) != 'undefined' && original_data[ i * 6 + 2 ].value === '' ) {
 						$( 'select.attribute_taxonomy' ).find( 'option[value="' + original_data[ i * 6 ].value + '"]' ).removeAttr( 'disabled' );
 					}
 				}

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -446,11 +446,11 @@ jQuery( function( $ ) {
 				opacity: 0.6
 			}
 		});
-
+		var original_data = $( '.product_attributes' ).find( 'input, select, textarea' );
 		var data = {
 			post_id     : woocommerce_admin_meta_boxes.post_id,
 			product_type: $( '#product-type' ).val(),
-			data        : $( '.product_attributes' ).find( 'input, select, textarea' ).serialize(),
+			data        : original_data.serialize(),
 			action      : 'woocommerce_save_attributes',
 			security    : woocommerce_admin_meta_boxes.save_attributes_nonce
 		};
@@ -463,6 +463,14 @@ jQuery( function( $ ) {
 				// Success.
 				$( '.product_attributes' ).html( response.data.html );
 				$( '.product_attributes' ).unblock();
+
+				// Make sure the dropdown is not disabled for empty value attributes.
+				var nr_elements = original_data.length / 6;
+				for ( i = 0; i < nr_elements; i++ ) {
+					if ( typeof( original_data ) != "undefined" && original_data[ i * 6 + 2 ].value === "" ) {
+						$( 'select.attribute_taxonomy' ).find( 'option[value="' + original_data[ i * 6 ].value + '"]' ).removeAttr( 'disabled' );
+					}
+				}
 
 				// Reload variations panel.
 				var this_page = window.location.toString();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When saving attributes on product and you do not enter any values the attribute is not saved, this PR adds a check to not keep the dropdown disabled when you save an attribute with no values.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21383 

### How to test the changes in this Pull Request:

1. Create a product
2. Add an attribute from the dropdown and check the attribute is disabled in the dropdown
3. Without adding any values click the save attributes button
4. Check that the attribute did not save and also that the attribute is enabled in the dropdown again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Enable attribute in product attribute dropdown when saving fails with no values.
