### PR TITLE
Allow saving 0 as stock value when using quick edit

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -2,8 +2,6 @@
 /**
  * Post Types Admin
  *
- * @author   Automattic
- * @category Admin
  * @package  WooCommerce/admin
  * @version  3.3.0
  */
@@ -120,6 +118,7 @@ class WC_Admin_Post_Types {
 
 		$messages['product'] = array(
 			0  => '', // Unused. Messages start at index 1.
+			/* translators: %s: Product view URL. */
 			1  => sprintf( __( 'Product updated. <a href="%s">View Product</a>', 'woocommerce' ), esc_url( get_permalink( $post->ID ) ) ),
 			2  => __( 'Custom field updated.', 'woocommerce' ),
 			3  => __( 'Custom field deleted.', 'woocommerce' ),
@@ -405,7 +404,7 @@ class WC_Admin_Post_Types {
 		$manage_stock = ! empty( $_REQUEST['_manage_stock'] ) && 'grouped' !== $product->get_type() ? 'yes' : 'no'; // WPCS: input var ok, sanitization ok.
 		$backorders   = ! empty( $_REQUEST['_backorders'] ) ? wc_clean( $_REQUEST['_backorders'] ) : 'no'; // WPCS: input var ok, sanitization ok.
 		$stock_status = ! empty( $_REQUEST['_stock_status'] ) ? wc_clean( $_REQUEST['_stock_status'] ) : 'instock'; // WPCS: input var ok, sanitization ok.
-		$stock_amount = 'yes' === $manage_stock && is_numeric( $_REQUEST['_stock'] ) ? wc_stock_amount( $_REQUEST['_stock'] ) : ''; // WPCS: input var ok, sanitization ok.
+		$stock_amount = 'yes' === $manage_stock && is_numeric( $_REQUEST['_stock'] ) ? wc_stock_amount( $_REQUEST['_stock'] ) : ''; // phpcs:ignore
 
 		$product->set_manage_stock( $manage_stock );
 		$product->set_backorders( $backorders );
@@ -823,14 +822,14 @@ class WC_Admin_Post_Types {
 	 * When editing the shop page, we should hide templates.
 	 *
 	 * @param array   $page_templates Templates array.
-	 * @param string  $class Classname.
+	 * @param string  $theme Classname.
 	 * @param WP_Post $post The current post object.
 	 * @return array
 	 */
 	public function hide_cpt_archive_templates( $page_templates, $theme, $post ) {
 		$shop_page_id = wc_get_page_id( 'shop' );
 
-		if ( $post && $shop_page_id === absint( $post->ID ) ) {
+		if ( $post && absint( $post->ID ) === $shop_page_id ) {
 			$page_templates = array();
 		}
 
@@ -845,8 +844,9 @@ class WC_Admin_Post_Types {
 	public function show_cpt_archive_notice( $post ) {
 		$shop_page_id = wc_get_page_id( 'shop' );
 
-		if ( $post && $shop_page_id === absint( $post->ID ) ) {
+		if ( $post && absint( $post->ID ) === $shop_page_id ) {
 			echo '<div class="notice notice-info">';
+			/* translators: %s: URL to read more about the shop page. */
 			echo '<p>' . sprintf( wp_kses_post( __( 'This is the WooCommerce shop page. The shop page is a special archive that lists your products. <a href="%s">You can read more about this here</a>.', 'woocommerce' ) ), 'https://docs.woocommerce.com/document/woocommerce-pages/#section-4' ) . '</p>';
 			echo '</div>';
 		}

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -405,7 +405,7 @@ class WC_Admin_Post_Types {
 		$manage_stock = ! empty( $_REQUEST['_manage_stock'] ) && 'grouped' !== $product->get_type() ? 'yes' : 'no'; // WPCS: input var ok, sanitization ok.
 		$backorders   = ! empty( $_REQUEST['_backorders'] ) ? wc_clean( $_REQUEST['_backorders'] ) : 'no'; // WPCS: input var ok, sanitization ok.
 		$stock_status = ! empty( $_REQUEST['_stock_status'] ) ? wc_clean( $_REQUEST['_stock_status'] ) : 'instock'; // WPCS: input var ok, sanitization ok.
-		$stock_amount = 'yes' === $manage_stock && ! empty( $_REQUEST['_stock'] ) ? wc_stock_amount( $_REQUEST['_stock'] ) : ''; // WPCS: input var ok, sanitization ok.
+		$stock_amount = 'yes' === $manage_stock && is_numeric( $_REQUEST['_stock'] ) ? wc_stock_amount( $_REQUEST['_stock'] ) : ''; // WPCS: input var ok, sanitization ok.
 
 		$product->set_manage_stock( $manage_stock );
 		$product->set_backorders( $backorders );

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -404,7 +404,7 @@ class WC_Admin_Post_Types {
 		$manage_stock = ! empty( $_REQUEST['_manage_stock'] ) && 'grouped' !== $product->get_type() ? 'yes' : 'no'; // WPCS: input var ok, sanitization ok.
 		$backorders   = ! empty( $_REQUEST['_backorders'] ) ? wc_clean( $_REQUEST['_backorders'] ) : 'no'; // WPCS: input var ok, sanitization ok.
 		$stock_status = ! empty( $_REQUEST['_stock_status'] ) ? wc_clean( $_REQUEST['_stock_status'] ) : 'instock'; // WPCS: input var ok, sanitization ok.
-		$stock_amount = 'yes' === $manage_stock && is_numeric( $_REQUEST['_stock'] ) ? wc_stock_amount( $_REQUEST['_stock'] ) : ''; // phpcs:ignore
+		$stock_amount = 'yes' === $manage_stock && isset( $_REQUEST['_stock'] ) && is_numeric( wp_unslash( $_REQUEST['_stock'] ) ) ? wc_stock_amount( wp_unslash( $_REQUEST['_stock'] ) ) : ''; // WPCS: input var ok, sanitization ok.
 
 		$product->set_manage_stock( $manage_stock );
 		$product->set_backorders( $backorders );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes an issue with the product quick edit functionality that did not allow you to save a stock quantity of 0.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21392

### How to test the changes in this Pull Request:

1. Quick edit a product
2. Set stock quantity to 0 and save
3. Open saved product and check that stock quantity is set to 0 and not just an empty string.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Allow saving a stock quantity of 0 using quick edit.
