### PR TITLE
Fix for warning in wc_get_logger when woocommerce_logging_class retur…

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1633,7 +1633,7 @@ function wc_get_logger() {
 
 	$class = apply_filters( 'woocommerce_logging_class', 'WC_Logger' );
 
-	if ( null !== $logger && is_a( $logger, $class ) ) {
+	if ( null !== $logger && is_string( $class ) && is_a( $logger, $class ) ) {
 		return $logger;
 	}
 

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -301,7 +301,7 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 
 		$logger = wc_get_logger();
 
-		$this->assertInstanceOf( 'WC_Logger_Instance', $logger, '`wc_get_logger()` should return valid Dummy_WC_Logger instance' );
+		$this->assertInstanceOf( 'WC_Logger_Interface', $logger, '`wc_get_logger()` should return valid Dummy_WC_Logger instance' );
 	}
 
 	/**

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -268,8 +268,8 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	 * @since 2.4
 	 */
 	public function test_wc_get_log_file_path() {
-		$log_dir   = trailingslashit( WC_LOG_DIR );
-		$hash_name = sanitize_file_name( wp_hash( 'unit-tests' ) );
+		$log_dir     = trailingslashit( WC_LOG_DIR );
+		$hash_name   = sanitize_file_name( wp_hash( 'unit-tests' ) );
 		$date_suffix = date( 'Y-m-d', current_time( 'timestamp', true ) );
 
 		$this->assertEquals( $log_dir . 'unit-tests-' . $date_suffix . '-' . $hash_name . '.log', wc_get_log_file_path( 'unit-tests' ) );
@@ -291,6 +291,26 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		$this->assertInstanceOf( 'WC_Logger', $log_a );
 		$this->assertInstanceOf( 'WC_Logger', $log_b );
 		$this->assertSame( $log_a, $log_b, '`wc_get_logger()` should return the same instance' );
+	}
+
+	/**
+	 * Test wc_get_logger() to check if can return instance when given in filter.
+	 */
+	public function test_wc_get_logger_for_instance() {
+		add_filter( 'woocommerce_logging_class', array( $this, 'return_valid_logger_instance' ) );
+
+		$logger = wc_get_logger();
+
+		$this->assertInstanceOf( 'WC_Logger_Instance', $logger, '`wc_get_logger()` should return valid Dummy_WC_Logger instance' );
+	}
+
+	/**
+	 * Return valid logger instance that implements WC_Logger_Interface.
+	 *
+	 * @return WC_Logger_Interface
+	 */
+	public function return_valid_logger_instance() {
+		return new Dummy_WC_Logger();
 	}
 
 	/**
@@ -326,7 +346,7 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals(
 			array(
 				'country' => 'US',
-				'state' => 'CA',
+				'state'   => 'CA',
 			),
 			wc_format_country_state_string( 'US:CA' )
 		);
@@ -335,7 +355,7 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals(
 			array(
 				'country' => 'US-CA',
-				'state' => '',
+				'state'   => '',
 			),
 			wc_format_country_state_string( 'US-CA' )
 		);
@@ -483,26 +503,32 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_currency', $new_currency );
 
 		// New order should be created using shop currency.
-		$order = wc_create_order( array(
-			'status'      => 'pending',
-			'customer_id' => 1,
-			'created_via' => 'unit tests',
-			'cart_hash'   => '',
-		) );
+		$order = wc_create_order(
+			array(
+				'status'      => 'pending',
+				'customer_id' => 1,
+				'created_via' => 'unit tests',
+				'cart_hash'   => '',
+			)
+		);
 		$this->assertEquals( $new_currency, $order->get_currency() );
 
 		update_option( 'woocommerce_currency', $old_currency );
 
 		// Currency should not change when order is updated.
-		$order = wc_update_order( array(
-			'customer_id' => 2,
-			'order_id'    => $order->get_id(),
-		) );
+		$order = wc_update_order(
+			array(
+				'customer_id' => 2,
+				'order_id'    => $order->get_id(),
+			)
+		);
 		$this->assertEquals( $new_currency, $order->get_currency() );
 
-		$order = wc_update_order( array(
-			'customer_id' => 2,
-		) );
+		$order = wc_update_order(
+			array(
+				'customer_id' => 2,
+			)
+		);
 		$this->assertInstanceOf( 'WP_Error', $order );
 	}
 
@@ -577,25 +603,29 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_wc_get_page_children() {
-		$page_id = wp_insert_post( array(
-			'post_title'  => 'Parent Page',
-			'post_type'   => 'page',
-			'post_name'   => 'parent-page',
-			'post_status' => 'publish',
-			'post_author' => 1,
-			'menu_order'  => 0,
-		) );
+		$page_id = wp_insert_post(
+			array(
+				'post_title'  => 'Parent Page',
+				'post_type'   => 'page',
+				'post_name'   => 'parent-page',
+				'post_status' => 'publish',
+				'post_author' => 1,
+				'menu_order'  => 0,
+			)
+		);
 
-		$child_page_id = wp_insert_post( array(
-			'post_parent' => $page_id,
-			'post_title'  => 'Parent Page',
-			'post_type'   => 'page',
-			'post_name'   => 'parent-page',
-			'post_status' => 'publish',
-			'post_author' => 1,
-			'menu_order'  => 0,
-		) );
-		$children = wc_get_page_children( $page_id );
+		$child_page_id = wp_insert_post(
+			array(
+				'post_parent' => $page_id,
+				'post_title'  => 'Parent Page',
+				'post_type'   => 'page',
+				'post_name'   => 'parent-page',
+				'post_status' => 'publish',
+				'post_author' => 1,
+				'menu_order'  => 0,
+			)
+		);
+		$children      = wc_get_page_children( $page_id );
 		$this->assertEquals( $child_page_id, $children[0] );
 
 		wp_delete_post( $page_id, true );
@@ -721,7 +751,7 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 
 		foreach ( $test_cases as $test_case ) {
 			list( $value, $options, $result ) = $test_case;
-			$actual_result = $result ? " selected='selected'" : '';
+			$actual_result                    = $result ? " selected='selected'" : '';
 			$this->assertEquals( wc_selected( $value, $options ), $actual_result );
 		}
 	}
@@ -815,7 +845,7 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_wc_get_user_agent() {
-		$example_user_agent = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
+		$example_user_agent         = 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/51.0.2704.103 Safari/537.36';
 		$_SERVER['HTTP_USER_AGENT'] = $example_user_agent;
 		$this->assertEquals( $example_user_agent, wc_get_user_agent() );
 	}

--- a/tests/unit-tests/util/dummy-wc-logger.php
+++ b/tests/unit-tests/util/dummy-wc-logger.php
@@ -1,0 +1,103 @@
+<?php
+
+/**
+ * Dummy Logger implements WC_Logger_Interface.
+ */
+class Dummy_WC_Logger implements WC_Logger_Interface {
+
+
+	/**
+	 * Do nothing.
+	 *
+	 * @param string $handle
+	 * @param string $message
+	 * @param string $level
+	 *
+	 * @return bool|void
+	 */
+	public function add( $handle, $message, $level = WC_Log_Levels::NOTICE ) {
+	}
+
+	/**
+	 * Do nothing.
+	 *
+	 * @param string $level
+	 * @param string $message
+	 * @param array $context
+	 */
+	public function log( $level, $message, $context = [] ) {
+	}
+
+	/**
+	 * Do nothing.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 */
+	public function emergency( $message, $context = [] ) {
+	}
+
+	/**
+	 * Do nothing.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 */
+	public function alert( $message, $context = [] ) {
+	}
+
+	/**
+	 * Do nothing.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 */
+	public function critical( $message, $context = [] ) {
+	}
+
+	/**
+	 * Do nothing.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 */
+	public function error( $message, $context = [] ) {
+	}
+
+	/**
+	 * Do nothing.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 */
+	public function warning( $message, $context = [] ) {
+	}
+
+	/**
+	 * Do nothing.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 */
+	public function notice( $message, $context = [] ) {
+	}
+
+	/**
+	 * Do nothing.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 */
+	public function info( $message, $context = [] ) {
+	}
+
+	/**
+	 * Do nothing.
+	 *
+	 * @param string $message
+	 * @param array $context
+	 */
+	public function debug( $message, $context = [] ) {
+	}
+
+}

--- a/tests/unit-tests/util/dummy-wc-logger.php
+++ b/tests/unit-tests/util/dummy-wc-logger.php
@@ -25,7 +25,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * @param string $message
 	 * @param array $context
 	 */
-	public function log( $level, $message, $context = [] ) {
+	public function log( $level, $message, $context = array() ) {
 	}
 
 	/**
@@ -34,7 +34,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * @param string $message
 	 * @param array $context
 	 */
-	public function emergency( $message, $context = [] ) {
+	public function emergency( $message, $context = array() ) {
 	}
 
 	/**
@@ -43,7 +43,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * @param string $message
 	 * @param array $context
 	 */
-	public function alert( $message, $context = [] ) {
+	public function alert( $message, $context = array() ) {
 	}
 
 	/**
@@ -52,7 +52,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * @param string $message
 	 * @param array $context
 	 */
-	public function critical( $message, $context = [] ) {
+	public function critical( $message, $context = array() ) {
 	}
 
 	/**
@@ -61,7 +61,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * @param string $message
 	 * @param array $context
 	 */
-	public function error( $message, $context = [] ) {
+	public function error( $message, $context = array() ) {
 	}
 
 	/**
@@ -70,7 +70,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * @param string $message
 	 * @param array $context
 	 */
-	public function warning( $message, $context = [] ) {
+	public function warning( $message, $context = array() ) {
 	}
 
 	/**
@@ -79,7 +79,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * @param string $message
 	 * @param array $context
 	 */
-	public function notice( $message, $context = [] ) {
+	public function notice( $message, $context = array() ) {
 	}
 
 	/**
@@ -88,7 +88,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * @param string $message
 	 * @param array $context
 	 */
-	public function info( $message, $context = [] ) {
+	public function info( $message, $context = array() ) {
 	}
 
 	/**
@@ -97,7 +97,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * @param string $message
 	 * @param array $context
 	 */
-	public function debug( $message, $context = [] ) {
+	public function debug( $message, $context = array() ) {
 	}
 
 }


### PR DESCRIPTION
When filter woocommerce_logging_class returns valid instance that implements WC_Logger_Instance the warning is shown:

`PHP Warning:  is_a() expects parameter 2 to be string, object given in /var/www/html/wp-content/plugins/woocommerce/includes/wc-core-functions.php on line 1637`

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

### How to test the changes in this Pull Request:

1. Put some dummy instance that implements WC_Logger_Interface
2. use wc_get_logger function
3. watch for warnings

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix - Tweak behaviour when using logger instance in woocommerce_logging_class filter
