### PR TITLE
Remove non existing AN country from NA continent

### DIFF
--- a/i18n/continents.php
+++ b/i18n/continents.php
@@ -205,7 +205,6 @@ return array(
 		'countries' => array(
 			'AG',
 			'AI',
-			'AN',
 			'AW',
 			'BB',
 			'BL',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Remove non-existant Netherlands Antilles country from the North America continent list. Should have form part of https://github.com/woocommerce/woocommerce/commit/135316033067046dad462d86b50c2f7bcaa2b24b#diff-7af2f76a23c1a0a116c8e8a480ad55fe

Closes #21413

### How to test the changes in this Pull Request:

1. Check that NA is not part the North America continent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Remove Netherlands Antilles from the North America continent definitions.