### PR TITLE
Change query to save session data 

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -212,17 +212,13 @@ class WC_Session_Handler extends WC_Session {
 		if ( $this->_dirty && $this->has_session() ) {
 			global $wpdb;
 
-			$wpdb->replace(
-				$this->_table,
-				array(
-					'session_key'    => $this->_customer_id,
-					'session_value'  => maybe_serialize( $this->_data ),
-					'session_expiry' => $this->_session_expiration,
-				),
-				array(
-					'%s',
-					'%s',
-					'%d',
+			$wpdb->query(
+				$wpdb->prepare(
+					"INSERT INTO {$wpdb->prefix}woocommerce_sessions (`session_key`, `session_value`, `session_expiry`) VALUES (%s, %s, %d)
+ 					ON DUPLICATE KEY UPDATE `session_value` = VALUES(`session_value`), `session_expiry` = VALUES(`session_expiry`)",
+					$this->_customer_id,
+					maybe_serialize( $this->_data ),
+					$this->_session_expiration
 				)
 			);
 

--- a/tests/unit-tests/session/class-wc-tests-session-handler.php
+++ b/tests/unit-tests/session/class-wc-tests-session-handler.php
@@ -1,0 +1,131 @@
+<?php
+/**
+ * Class WC_Tests_Session_Handler file.
+ *
+ * @package WooCommerce\Tests\Session
+ */
+
+/**
+ * Tests for the WC_Session_Handler class.
+ */
+class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
+
+	public function setUp() {
+		parent::setUp();
+
+		$this->handler = new WC_Session_Handler();
+		$this->create_session();
+	}
+
+	public function test_save_data_should_insert_new_row() {
+		$current_session_data = $this->get_session_from_db( $this->session_key );
+		// delete session to make sure a new row is created in the DB.
+		$this->handler->delete_session( $this->session_key );
+		$this->assertFalse( wp_cache_get( $this->cache_prefix . $this->session_key, WC_SESSION_CACHE_GROUP ) );
+
+		$this->handler->set( 'cart', 'new cart' );
+		$this->handler->save_data();
+
+		$updated_session_data = $this->get_session_from_db( $this->session_key );
+
+		$this->assertEquals( $current_session_data->session_id + 1, $updated_session_data->session_id );
+		$this->assertEquals( $this->session_key, $updated_session_data->session_key );
+		$this->assertEquals( maybe_serialize( array( 'cart' => 'new cart' ) ), $updated_session_data->session_value );
+		$this->assertTrue( is_numeric( $updated_session_data->session_expiry ) );
+		$this->assertEquals( array( 'cart' => 'new cart' ), wp_cache_get( $this->cache_prefix . $this->session_key, WC_SESSION_CACHE_GROUP ) );
+	}
+
+	public function test_save_data_should_replace_existing_row() {
+		$current_session_data = $this->get_session_from_db( $this->session_key );
+
+		$this->handler->set( 'cart', 'new cart' );
+		$this->handler->save_data();
+
+		$updated_session_data = $this->get_session_from_db( $this->session_key );
+
+		$this->assertEquals( $current_session_data->session_id, $updated_session_data->session_id );
+		$this->assertEquals( $this->session_key, $updated_session_data->session_key );
+		$this->assertEquals( maybe_serialize( array( 'cart' => 'new cart' ) ), $updated_session_data->session_value );
+		$this->assertTrue( is_numeric( $updated_session_data->session_expiry ) );
+	}
+
+	public function test_get_session_should_use_cache() {
+		$session = $this->handler->get_session( $this->session_key );
+		$this->assertEquals( array( 'cart' => 'fake cart' ), $session );
+	}
+
+	public function test_get_session_should_not_use_cache() {
+		wp_cache_delete( $this->cache_prefix . $this->session_key, WC_SESSION_CACHE_GROUP );
+		$session = $this->handler->get_session( $this->session_key );
+		$this->assertEquals( array( 'cart' => 'fake cart' ), $session );
+	}
+
+	public function test_get_session_should_return_default_value() {
+		$default_session = array( 'session' => 'default' );
+		$session = $this->handler->get_session( 'non-existent key', $default_session );
+		$this->assertEquals( $default_session, $session );
+	}
+
+	public function test_delete_session() {
+		global $wpdb;
+
+		$this->handler->delete_session( $this->session_key );
+
+		$session_id = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT `session_id` FROM {$wpdb->prefix}woocommerce_sessions WHERE session_key = %s",
+				$this->session_key
+			)
+		);
+
+		$this->assertFalse( wp_cache_get( $this->cache_prefix . $this->session_key, WC_SESSION_CACHE_GROUP ) );
+		$this->assertNull( $session_id );
+	}
+
+	public function test_update_session_timestamp() {
+		global $wpdb;
+
+		$timestamp = 1537970882;
+
+		$this->handler->update_session_timestamp( $this->session_key, $timestamp );
+
+		$session_expiry = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT session_expiry FROM {$wpdb->prefix}woocommerce_sessions WHERE session_key = %s",
+				$this->session_key
+			)
+		);
+		$this->assertEquals( $timestamp, $session_expiry );
+	}
+
+	/**
+	 * Helper function to create a WC session and save it to the DB.
+	 */
+	protected function create_session() {
+		$this->handler->init();
+		wp_set_current_user( 1 );
+		$this->handler->set( 'cart', 'fake cart' );
+		$this->handler->save_data();
+		$this->session_key = $this->handler->get_customer_id();
+		$this->cache_prefix = WC_Cache_Helper::get_cache_prefix( WC_SESSION_CACHE_GROUP );
+	}
+
+	/**
+	 * Helper function to get session data from DB.
+	 *
+	 * @param string $session_key
+	 * @return stdClass
+	 */
+	protected function get_session_from_db( $session_key ) {
+		global $wpdb;
+
+		$session_data = $wpdb->get_row(
+			$wpdb->prepare(
+				"SELECT * FROM {$wpdb->prefix}woocommerce_sessions WHERE `session_key` = %s",
+				$session_key
+			)
+		);
+
+		return $session_data;
+	}
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the query used to save session data from `REPLACE` to `INSERT ... ON DUPLICATE KEY UPDATE`. Doing this to prevent deadlocks in the `wp_woocommerce_sessions` table as reported in #20912. For more information on why this change should help prevent the deadlocks see https://github.com/woocommerce/woocommerce/issues/20912#issuecomment-420888726

I'm also including in this PR a commit that adds some unit tests to cover the basic functionality of part of the WC_Session_Handler methods, including the method that contains the query that was modified.

Closes #20912

### How to test the changes in this Pull Request:

Unfortunately, I don't think there is an easy way to reproduce the deadlocks and thus to test the fix proposed here. Anyway, it is important to make sure that saving session data is still working as expected with the new query. A few things to check:

1. An entry is added to wp_woocommerce_sessions when a logged in user or an anonymous user adds an item to the cart.
2. The same entry is updated when new items are added to cart or removed (check that the session_id value remains the same, before this change a new entry with a new session_id was created whenever the cart was updated)

### Changelog entry

> Change the query used to save session data to the database to protect against deadlocks.