### PR TITLE
Add inline float style for email label to match order details styling

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3023,11 +3023,13 @@ if ( ! function_exists( 'wc_display_item_meta' ) ) {
 			'separator' => '</li><li>',
 			'echo'      => true,
 			'autop'     => false,
+			'label_before' => '<strong class="wc-item-meta-label">',
+			'label_after' => ':</strong> ',
 		) );
 
 		foreach ( $item->get_formatted_meta_data() as $meta_id => $meta ) {
 			$value     = $args['autop'] ? wp_kses_post( $meta->display_value ) : wp_kses_post( make_clickable( trim( $meta->display_value ) ) );
-			$strings[] = '<strong class="wc-item-meta-label">' . wp_kses_post( $meta->display_key ) . ':</strong> ' . $value;
+			$strings[] = $args['label_before'] . wp_kses_post( $meta->display_key ) . $args['label_after'] . $value;
 		}
 
 		if ( $strings ) {

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates/Emails
- * @version 3.4.0
+ * @version 3.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -56,7 +56,9 @@ foreach ( $items as $item_id => $item ) :
 		// allow other plugins to add additional product information here.
 		do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, $plain_text );
 
-		wc_display_item_meta( $item );
+		wc_display_item_meta( $item, array(
+			'label_before' => '<strong class="wc-item-meta-label" style="float: left; margin-right: .25em; clear: both">',
+		) );
 
 		// allow other plugins to add additional product information here.
 		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21389 .

### How to test the changes in this Pull Request:

1. Before applying this patch buy a product that has some attributes or is backordered. Observe in the order details the attributes/backorder are displayed inline:
<img width="400" alt="screen shot 2018-09-26 at 11 18 57 am" src="https://user-images.githubusercontent.com/7317227/46100417-2d9b6980-c17e-11e8-9bfd-56f878ce9577.png">

But in the e-mail they are displayed on multiple lines:
<img width="400" alt="screen shot 2018-09-26 at 11 16 07 am" src="https://user-images.githubusercontent.com/7317227/46100422-312ef080-c17e-11e8-9649-f5defea259d8.png">

2. Apply this patch and verify that in the e-mail the attributes/backorder are displayed on the same line like in the order details:
<img width="400" alt="screen shot 2018-09-26 at 11 17 04 am" src="https://user-images.githubusercontent.com/7317227/46100427-34c27780-c17e-11e8-96f3-d32e955b82f8.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Display label and meta on the same line in order emails to match frontend Order Details styling.
