### PR TITLE
The orderby=ID argument needs to be uppercase.

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -459,6 +459,9 @@ class WC_Query {
 		);
 
 		switch ( $orderby ) {
+			case 'id':
+				$args['orderby'] = 'ID';
+				break;
 			case 'menu_order':
 				$args['orderby'] = 'menu_order title';
 				break;

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -86,7 +86,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 
 		// products shortcode with attributes.
 		$shortcode2 = new WC_Shortcode_Products( array(
-			'orderby' => 'id',
+			'orderby' => 'ID',
 			'order'   => 'DESC',
 		) );
 		$expected2  = array(
@@ -94,7 +94,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => true,
-			'orderby'             => 'id',
+			'orderby'             => 'ID',
 			'order'               => 'DESC',
 			'posts_per_page'      => '-1',
 			'meta_query'          => $meta_query,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

The `orderby=ID` argument requires ID to be in uppercase:
https://codex.wordpress.org/Class_Reference/WP_Query#Order_.26_Orderby_Parameters

But we are filtering query arguments and turning this to lowercase:
https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-query.php#L453

When WP tries to run the query, 'id' in lowercase is not a valid orderby value and its discarded, defaulting to date instead.

With these changes, we force `orderby=ID` argument to stay in uppercase.

### How to test the changes in this Pull Request:

Add this shortcode to a page and inspect the results:
`[recent_products per_page="4" columns="4" orderby="ID" order="DESC"]`

If you look at the query used, its sorting by `date ID` instead.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix sorting product queries by ID.