### PR TITLE
Fix ajax responses not testable when calling wp_send_json_success in a try block

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -647,12 +647,12 @@ class WC_AJAX {
 			}
 
 			$response['html'] = ob_get_clean();
-
-			wp_send_json_success( $response );
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
-		wp_die();
+
+		// wp_send_json_success must be outside the try block not to break phpunit tests
+		wp_send_json_success( $response );
 	}
 
 	/**
@@ -897,14 +897,13 @@ class WC_AJAX {
 
 			ob_start();
 			include 'admin/meta-boxes/views/html-order-items.php';
-			wp_send_json_success(
-				array(
-					'html' => ob_get_clean(),
-				)
-			);
+			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
+
+		// wp_send_json_success must be outside the try block not to break phpunit tests
+		wp_send_json_success( $response );
 	}
 
 	/**
@@ -953,15 +952,13 @@ class WC_AJAX {
 
 			ob_start();
 			include 'admin/meta-boxes/views/html-order-items.php';
-
-			wp_send_json_success(
-				array(
-					'html' => ob_get_clean(),
-				)
-			);
+			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
+
+		// wp_send_json_success must be outside the try block not to break phpunit tests
+		wp_send_json_success( $response );
 	}
 
 	/**
@@ -988,15 +985,13 @@ class WC_AJAX {
 
 			ob_start();
 			include 'admin/meta-boxes/views/html-order-shipping.php';
-
-			wp_send_json_success(
-				array(
-					'html' => ob_get_clean(),
-				)
-			);
+			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
+
+		// wp_send_json_success must be outside the try block not to break phpunit tests
+		wp_send_json_success( $response );
 	}
 
 	/**
@@ -1023,15 +1018,13 @@ class WC_AJAX {
 
 			ob_start();
 			include 'admin/meta-boxes/views/html-order-items.php';
-
-			wp_send_json_success(
-				array(
-					'html' => ob_get_clean(),
-				)
-			);
+			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
+
+		// wp_send_json_success must be outside the try block not to break phpunit tests
+		wp_send_json_success( $response );
 	}
 
 	/**
@@ -1055,15 +1048,13 @@ class WC_AJAX {
 
 			ob_start();
 			include 'admin/meta-boxes/views/html-order-items.php';
-
-			wp_send_json_success(
-				array(
-					'html' => ob_get_clean(),
-				)
-			);
+			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
+
+		// wp_send_json_success must be outside the try block not to break phpunit tests
+		wp_send_json_success( $response );
 	}
 
 	/**
@@ -1084,15 +1075,13 @@ class WC_AJAX {
 
 			ob_start();
 			include 'admin/meta-boxes/views/html-order-items.php';
-
-			wp_send_json_success(
-				array(
-					'html' => ob_get_clean(),
-				)
-			);
+			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
+
+		// wp_send_json_success must be outside the try block not to break phpunit tests
+		wp_send_json_success( $response );
 	}
 
 	/**
@@ -1140,15 +1129,13 @@ class WC_AJAX {
 
 			ob_start();
 			include 'admin/meta-boxes/views/html-order-items.php';
-
-			wp_send_json_success(
-				array(
-					'html' => ob_get_clean(),
-				)
-			);
+			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
+
+		// wp_send_json_success must be outside the try block not to break phpunit tests
+		wp_send_json_success( $response );
 	}
 
 	/**
@@ -1172,15 +1159,13 @@ class WC_AJAX {
 
 			ob_start();
 			include 'admin/meta-boxes/views/html-order-items.php';
-
-			wp_send_json_success(
-				array(
-					'html' => ob_get_clean(),
-				)
-			);
+			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
+
+		// wp_send_json_success must be outside the try block not to break phpunit tests
+		wp_send_json_success( $response );
 	}
 
 	/**
@@ -1688,12 +1673,12 @@ class WC_AJAX {
 			if ( did_action( 'woocommerce_order_fully_refunded' ) ) {
 				$response_data['status'] = 'fully_refunded';
 			}
-
-			wp_send_json_success( $response_data );
-
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
+
+		// wp_send_json_success must be outside the try block not to break phpunit tests
+		wp_send_json_success( $response_data );
 	}
 
 	/**
@@ -1813,11 +1798,12 @@ class WC_AJAX {
 				$data['message']         = __( 'API Key generated successfully. Make sure to copy your new keys now as the secret key will be hidden once you leave this page.', 'woocommerce' );
 				$data['revoke_url']      = '<a style="color: #a00; text-decoration: none;" href="' . esc_url( wp_nonce_url( add_query_arg( array( 'revoke-key' => $key_id ), admin_url( 'admin.php?page=wc-settings&tab=advanced&section=keys' ) ), 'revoke' ) ) . '">' . __( 'Revoke key', 'woocommerce' ) . '</a>';
 			}
-
-			wp_send_json_success( $data );
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'message' => $e->getMessage() ) );
 		}
+
+		// wp_send_json_success must be outside the try block not to break phpunit tests
+		wp_send_json_success( $data );
 	}
 
 	/**

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -651,7 +651,7 @@ class WC_AJAX {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
 
-		// wp_send_json_success must be outside the try block not to break phpunit tests
+		// wp_send_json_success must be outside the try block not to break phpunit tests.
 		wp_send_json_success( $response );
 	}
 
@@ -902,7 +902,7 @@ class WC_AJAX {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
 
-		// wp_send_json_success must be outside the try block not to break phpunit tests
+		// wp_send_json_success must be outside the try block not to break phpunit tests.
 		wp_send_json_success( $response );
 	}
 
@@ -957,7 +957,7 @@ class WC_AJAX {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
 
-		// wp_send_json_success must be outside the try block not to break phpunit tests
+		// wp_send_json_success must be outside the try block not to break phpunit tests.
 		wp_send_json_success( $response );
 	}
 
@@ -990,7 +990,7 @@ class WC_AJAX {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
 
-		// wp_send_json_success must be outside the try block not to break phpunit tests
+		// wp_send_json_success must be outside the try block not to break phpunit tests.
 		wp_send_json_success( $response );
 	}
 
@@ -1023,7 +1023,7 @@ class WC_AJAX {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
 
-		// wp_send_json_success must be outside the try block not to break phpunit tests
+		// wp_send_json_success must be outside the try block not to break phpunit tests.
 		wp_send_json_success( $response );
 	}
 
@@ -1053,7 +1053,7 @@ class WC_AJAX {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
 
-		// wp_send_json_success must be outside the try block not to break phpunit tests
+		// wp_send_json_success must be outside the try block not to break phpunit tests.
 		wp_send_json_success( $response );
 	}
 
@@ -1080,7 +1080,7 @@ class WC_AJAX {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
 
-		// wp_send_json_success must be outside the try block not to break phpunit tests
+		// wp_send_json_success must be outside the try block not to break phpunit tests.
 		wp_send_json_success( $response );
 	}
 
@@ -1134,7 +1134,7 @@ class WC_AJAX {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
 
-		// wp_send_json_success must be outside the try block not to break phpunit tests
+		// wp_send_json_success must be outside the try block not to break phpunit tests.
 		wp_send_json_success( $response );
 	}
 
@@ -1164,7 +1164,7 @@ class WC_AJAX {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
 
-		// wp_send_json_success must be outside the try block not to break phpunit tests
+		// wp_send_json_success must be outside the try block not to break phpunit tests.
 		wp_send_json_success( $response );
 	}
 
@@ -1677,7 +1677,7 @@ class WC_AJAX {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
 		}
 
-		// wp_send_json_success must be outside the try block not to break phpunit tests
+		// wp_send_json_success must be outside the try block not to break phpunit tests.
 		wp_send_json_success( $response_data );
 	}
 
@@ -1802,7 +1802,7 @@ class WC_AJAX {
 			wp_send_json_error( array( 'message' => $e->getMessage() ) );
 		}
 
-		// wp_send_json_success must be outside the try block not to break phpunit tests
+		// wp_send_json_success must be outside the try block not to break phpunit tests.
 		wp_send_json_success( $data );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
I am testing the integration between an extension and WooCommerce using phpunit. I noticed that it's not possible to test ajax responses when `wp_send_json_success()` is included in a try block. The reason is that the WordPress test framework throws an exception to handle the `wp_die()` included in `wp_send_json_success()`. This exception is then catched in the catch block. Finally both sides of the try / catch are executed during the test. This result in a mismatch in the output buffering level and phpunit marks the test as risky.

I propose to call `wp_send_json_success()` outside the try block to fix the issue and make the code testable.