### PR TITLE
Use WC()->shipping() + Doc return changes

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1731,7 +1731,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$shipping = __( 'Free!', 'woocommerce' );
 		}
 
-		return apply_filters( 'woocommerce_order_shipping_to_display', $shipping, $this );
+		return apply_filters( 'woocommerce_order_shipping_to_display', $shipping, $this, $tax_display );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -224,7 +224,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * Return calculated rates for a package.
 	 *
 	 * @since 2.6.0
-	 * @param object $package Package array.
+	 * @param array $package Package array.
 	 * @return array
 	 */
 	public function get_rates_for_package( $package ) {

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -66,7 +66,7 @@ if ( wc_tax_enabled() ) {
 		</tbody>
 		<tbody id="order_shipping_line_items">
 			<?php
-			$shipping_methods = WC()->shipping() ? WC()->shipping->load_shipping_methods() : array();
+			$shipping_methods = WC()->shipping() ? WC()->shipping()->load_shipping_methods() : array();
 			foreach ( $line_items_shipping as $item_id => $item ) {
 				include 'html-order-shipping.php';
 			}

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -51,7 +51,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 
 		if ( ! defined( 'WC_INSTALLING' ) ) {
 			// Load shipping methods so we can show any global options they may have.
-			$shipping_methods = WC()->shipping->load_shipping_methods();
+			$shipping_methods = WC()->shipping()->load_shipping_methods();
 
 			foreach ( $shipping_methods as $method ) {
 				if ( ! $method->has_settings() ) {
@@ -146,7 +146,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		global $current_section, $hide_save_button;
 
 		// Load shipping methods so we can show any global options they may have.
-		$shipping_methods = WC()->shipping->load_shipping_methods();
+		$shipping_methods = WC()->shipping()->load_shipping_methods();
 
 		if ( '' === $current_section ) {
 			$this->output_zones_screen();

--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -183,7 +183,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 							<select name="add_method_id">
 								<?php
-								foreach ( WC()->shipping->load_shipping_methods() as $method ) {
+								foreach ( WC()->shipping()->load_shipping_methods() as $method ) {
 									if ( ! $method->supports( 'shipping-zones' ) ) {
 										continue;
 									}

--- a/includes/admin/settings/views/html-admin-page-shipping-zones.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zones.php
@@ -104,7 +104,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 							<select name="add_method_id">
 								<?php
-								foreach ( WC()->shipping->load_shipping_methods() as $method ) {
+								foreach ( WC()->shipping()->load_shipping_methods() as $method ) {
 									if ( ! $method->supports( 'shipping-zones' ) ) {
 										continue;
 									}

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -978,7 +978,7 @@ class WC_AJAX {
 			$order_id         = absint( $_POST['order_id'] );
 			$order            = wc_get_order( $order_id );
 			$order_taxes      = $order->get_taxes();
-			$shipping_methods = WC()->shipping() ? WC()->shipping->load_shipping_methods() : array();
+			$shipping_methods = WC()->shipping() ? WC()->shipping()->load_shipping_methods() : array();
 
 			// Add new shipping
 			$item = new WC_Order_Item_Shipping();

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1226,7 +1226,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * Uses the shipping class to calculate shipping then gets the totals when its finished.
 	 */
 	public function calculate_shipping() {
-		$this->shipping_methods = $this->needs_shipping() ? $this->get_chosen_shipping_methods( WC()->shipping->calculate_shipping( $this->get_shipping_packages() ) ) : array();
+		$this->shipping_methods = $this->needs_shipping() ? $this->get_chosen_shipping_methods( WC()->shipping()->calculate_shipping( $this->get_shipping_packages() ) ) : array();
 
 		$shipping_taxes = wp_list_pluck( $this->shipping_methods, 'taxes' );
 		$merged_taxes   = array();
@@ -1608,7 +1608,7 @@ class WC_Cart extends WC_Legacy_Cart {
 
 		// Choose free shipping.
 		if ( $the_coupon->get_free_shipping() ) {
-			$packages                = WC()->shipping->get_packages();
+			$packages                = WC()->shipping()->get_packages();
 			$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
 
 			foreach ( $packages as $i => $package ) {

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -346,7 +346,7 @@ class WC_Checkout {
 			$order->set_total( WC()->cart->get_total( 'edit' ) );
 			$this->create_order_line_items( $order, WC()->cart );
 			$this->create_order_fee_lines( $order, WC()->cart );
-			$this->create_order_shipping_lines( $order, WC()->session->get( 'chosen_shipping_methods' ), WC()->shipping->get_packages() );
+			$this->create_order_shipping_lines( $order, WC()->session->get( 'chosen_shipping_methods' ), WC()->shipping()->get_packages() );
 			$this->create_order_tax_lines( $order, WC()->cart );
 			$this->create_order_coupon_lines( $order, WC()->cart );
 
@@ -770,7 +770,7 @@ class WC_Checkout {
 			} else {
 				$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
 
-				foreach ( WC()->shipping->get_packages() as $i => $package ) {
+				foreach ( WC()->shipping()->get_packages() as $i => $package ) {
 					if ( ! isset( $chosen_shipping_methods[ $i ], $package['rates'][ $chosen_shipping_methods[ $i ] ] ) ) {
 						$errors->add( 'shipping', __( 'No shipping method has been selected. Please double check your address, or contact us if you need any help.', 'woocommerce' ) );
 					}

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -18,7 +18,7 @@ class WC_Emails {
 	/**
 	 * Array of email notification classes
 	 *
-	 * @var array
+	 * @var WC_Email[]
 	 */
 	public $emails = array();
 
@@ -231,7 +231,7 @@ class WC_Emails {
 	/**
 	 * Return the email classes - used in admin to load settings.
 	 *
-	 * @return array
+	 * @return WC_Email[]
 	 */
 	public function get_emails() {
 		return $this->emails;

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -151,7 +151,7 @@ class WC_Shipping {
 	 * If a $package is passed some methods may add themselves conditionally and zones will be used.
 	 *
 	 * @param array $package Package information.
-	 * @return array
+	 * @return WC_Shipping_Method[]
 	 */
 	public function load_shipping_methods( $package = array() ) {
 		if ( ! empty( $package ) ) {
@@ -209,7 +209,7 @@ class WC_Shipping {
 	/**
 	 * Returns all registered shipping methods for usage.
 	 *
-	 * @return array
+	 * @return WC_Shipping_Method[]
 	 */
 	public function get_shipping_methods() {
 		if ( is_null( $this->shipping_methods ) ) {

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -401,7 +401,7 @@ class WC_Tracker {
 	 */
 	private static function get_active_shipping_methods() {
 		$active_methods   = array();
-		$shipping_methods = WC()->shipping->get_shipping_methods();
+		$shipping_methods = WC()->shipping()->get_shipping_methods();
 		foreach ( $shipping_methods as $id => $shipping_method ) {
 			if ( isset( $shipping_method->enabled ) && 'yes' === $shipping_method->enabled ) {
 				$active_methods[ $id ] = array(

--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -237,7 +237,7 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 	 */
 	private function get_canonical_package_rate_ids( $chosen_package_rate_ids ) {
 
-		$shipping_packages  = WC()->shipping->get_packages();
+		$shipping_packages  = WC()->shipping()->get_packages();
 		$canonical_rate_ids = array();
 
 		if ( ! empty( $chosen_package_rate_ids ) && is_array( $chosen_package_rate_ids ) ) {

--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -159,7 +159,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		}
 
 		// Add shipping class costs.
-		$shipping_classes = WC()->shipping->get_shipping_classes();
+		$shipping_classes = WC()->shipping()->get_shipping_classes();
 
 		if ( ! empty( $shipping_classes ) ) {
 			$found_shipping_classes = $this->find_shipping_classes( $package );

--- a/includes/shipping/flat-rate/includes/settings-flat-rate.php
+++ b/includes/shipping/flat-rate/includes/settings-flat-rate.php
@@ -38,7 +38,7 @@ $settings = array(
 	),
 );
 
-$shipping_classes = WC()->shipping->get_shipping_classes();
+$shipping_classes = WC()->shipping()->get_shipping_classes();
 
 if ( ! empty( $shipping_classes ) ) {
 	$settings['class_costs'] = array(

--- a/includes/shipping/legacy-flat-rate/includes/settings-flat-rate.php
+++ b/includes/shipping/legacy-flat-rate/includes/settings-flat-rate.php
@@ -69,7 +69,7 @@ $settings = array(
 	),
 );
 
-$shipping_classes = WC()->shipping->get_shipping_classes();
+$shipping_classes = WC()->shipping()->get_shipping_classes();
 
 if ( ! empty( $shipping_classes ) ) {
 	$settings['class_costs'] = array(

--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -22,7 +22,7 @@ class WC_Shortcode_Cart {
 	 */
 	public static function calculate_shipping() {
 		try {
-			WC()->shipping->reset_shipping();
+			WC()->shipping()->reset_shipping();
 
 			$address = array();
 

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -203,7 +203,7 @@ function wc_cart_totals_subtotal_html() {
  * Get shipping methods.
  */
 function wc_cart_totals_shipping_html() {
-	$packages           = WC()->shipping->get_packages();
+	$packages           = WC()->shipping()->get_packages();
 	$first              = true;
 
 	foreach ( $packages as $i => $package ) {

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1283,7 +1283,7 @@ function wc_get_checkout_url() {
  * @param string|object $shipping_method class name (string) or a class object.
  */
 function woocommerce_register_shipping_method( $shipping_method ) {
-	WC()->shipping->register_shipping_method( $shipping_method );
+	WC()->shipping()->register_shipping_method( $shipping_method );
 }
 
 if ( ! function_exists( 'wc_get_shipping_zone' ) ) {
@@ -1453,7 +1453,7 @@ function wc_get_shipping_method_count( $include_legacy = false ) {
 
 		if ( $include_legacy ) {
 			// Count activated methods that don't support shipping zones.
-			$methods = WC()->shipping->get_shipping_methods();
+			$methods = WC()->shipping()->get_shipping_methods();
 
 			foreach ( $methods as $method ) {
 				if ( isset( $method->enabled ) && 'yes' === $method->enabled && ! $method->supports( 'shipping-zones' ) ) {

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -541,7 +541,7 @@ add_filter( 'terms_clauses', 'wc_terms_clauses', 99, 3 );
  * Function for recounting product terms, ignoring hidden products.
  *
  * @param array  $terms                       List of terms.
- * @param string $taxonomy                    Taxonomy.
+ * @param object $taxonomy                    Taxonomy.
  * @param bool   $callback                    Callback.
  * @param bool   $terms_are_term_taxonomy_ids If terms are from term_taxonomy_id column.
  */

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -737,7 +737,7 @@ function wc_update_240_shipping_methods() {
 	foreach ( $shipping_methods as $flat_rate_option_key => $shipping_method ) {
 		// Stop this running more than once if routine is repeated.
 		if ( version_compare( $shipping_method->get_option( 'version', 0 ), '2.4.0', '<' ) ) {
-			$has_classes                      = count( WC()->shipping->get_shipping_classes() ) > 0;
+			$has_classes                      = count( WC()->shipping()->get_shipping_classes() ) > 0;
 			$cost_key                         = $has_classes ? 'no_class_cost' : 'cost';
 			$min_fee                          = $shipping_method->get_option( 'minimum_fee' );
 			$math_cost_strings                = array(
@@ -752,7 +752,7 @@ function wc_update_240_shipping_methods() {
 				$math_cost_strings[ $cost_key ][] = strstr( $fee, '%' ) ? '[fee percent="' . str_replace( '%', '', $fee ) . '" min="' . esc_attr( $min_fee ) . '"]' : $fee;
 			}
 
-			foreach ( WC()->shipping->get_shipping_classes() as $shipping_class ) {
+			foreach ( WC()->shipping()->get_shipping_classes() as $shipping_class ) {
 				$rate_key                       = 'class_cost_' . $shipping_class->slug;
 				$math_cost_strings[ $rate_key ] = $math_cost_strings['no_class_cost'];
 			}

--- a/tests/framework/helpers/class-wc-helper-shipping.php
+++ b/tests/framework/helpers/class-wc-helper-shipping.php
@@ -25,7 +25,7 @@ class WC_Helper_Shipping {
 		update_option( 'woocommerce_flat_rate_settings', $flat_rate_settings );
 		update_option( 'woocommerce_flat_rate', array() );
 		WC_Cache_Helper::get_transient_version( 'shipping', true );
-		WC()->shipping->load_shipping_methods();
+		WC()->shipping()->load_shipping_methods();
 	}
 
 	/**
@@ -37,6 +37,6 @@ class WC_Helper_Shipping {
 		delete_option( 'woocommerce_flat_rate_settings' );
 		delete_option( 'woocommerce_flat_rate' );
 		WC_Cache_Helper::get_transient_version( 'shipping', true );
-		WC()->shipping->unregister_shipping_methods();
+		WC()->shipping()->unregister_shipping_methods();
 	}
 }

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -675,7 +675,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_flat_rate_settings', $flat_rate_settings );
 		update_option( 'woocommerce_flat_rate', array() );
 		WC_Cache_Helper::get_transient_version( 'shipping', true );
-		WC()->shipping->load_shipping_methods();
+		WC()->shipping()->load_shipping_methods();
 
 		// Create the product and add it to the cart.
 		$product = new WC_Product_Simple();


### PR DESCRIPTION
- Use the `WC()->shipping()` method call instead of `WC()->shipping` property through magic method (helps IDEs understand whats returned). 

- Change some `@return` docs to have the array of objects defined. 

- One argument added to the `woocommerce_order_shipping_to_display` filter as this can be passed as a custom argument to the method too. 