### PR TITLE
Fix relative logo URLs in email headers

### DIFF
--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -38,7 +38,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 									// if the path is relative, make it absolute
 									if ( '//' === substr( $img, 0, 2 ) ) {
 										// assume https
-										$img = 'https' . $img;
+										$img = 'https:' . $img;
 									} elseif ( null === parse_url( $img, PHP_URL_SCHEME ) && null === parse_url( $img, PHP_URL_HOST ) ) {
 										$img = site_url( $img );
 									}

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -36,10 +36,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<?php
 								if ( $img = get_option( 'woocommerce_email_header_image' ) ) {
 									// if the path is relative, make it absolute
-									if ( null === parse_url( $img, PHP_URL_SCHEME ) && null === parse_url( $img, PHP_URL_HOST ) ) {
+									if ( '//' === substr( $img, 0, 2 ) ) {
+										// assume https
+										$img = 'https' . $img;
+									} elseif ( null === parse_url( $img, PHP_URL_SCHEME ) && null === parse_url( $img, PHP_URL_HOST ) ) {
 										$img = site_url( $img );
 									}
-
+									
 									echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name', 'display' ) . '" /></p>';
 								}
 							?>

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -35,6 +35,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 						<div id="template_header_image">
 							<?php
 								if ( $img = get_option( 'woocommerce_email_header_image' ) ) {
+									// if the path is relative, make it absolute
+									if (parse_url($img, PHP_URL_SCHEME) === null && parse_url($img, PHP_URL_HOST) === null) {
+										$img = site_url($img);
+									}
 									echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name', 'display' ) . '" /></p>';
 								}
 							?>

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -36,9 +36,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<?php
 								if ( $img = get_option( 'woocommerce_email_header_image' ) ) {
 									// if the path is relative, make it absolute
-									if (parse_url($img, PHP_URL_SCHEME) === null && parse_url($img, PHP_URL_HOST) === null) {
-										$img = site_url($img);
+									if ( null === parse_url( $img, PHP_URL_SCHEME ) && null === parse_url( $img, PHP_URL_HOST ) ) {
+										$img = site_url( $img );
 									}
+
 									echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name', 'display' ) . '" /></p>';
 								}
 							?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If the email header image URL is relative, make it absolute by running the URL through `site_url()`. Relative image URLs show as broken images in email clients, since there isn't a hostname for the email client to resolve the URL to.

Also, image URLs with leading double slashes `//` (no protocol) are rewritten to `https://`. Many clients choke on URLs with no protocol (including gmail). I figured that taking the security-first approach was the best approach, and prefixed `https`. Also, using the double slash typically implies that both `http` and `https` protocols will work.

### How to test the changes in this Pull Request:

1. Send out any email that includes the header

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] **N/A** Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
  * Tested on www.logancoach.com:
    * Absolute URL: https://logancoach.com/wp-content/my-themes/LoganCoach.com/dist/images/header-logo.png
    * No protocol: //logancoach.com/wp-content/my-themes/LoganCoach.com/dist/images/header-logo.png
    * Relative URL: /wp-content/my-themes/LoganCoach.com/dist/images/header-logo.png

### Changelog entry

> Prevent broken email header images in email clients by making relative URLs absolute and using "https" if the URL is missing the protocol.