### PR TITLE
Check for customer before checking for VAT exemption

### DIFF
--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -168,7 +168,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @return boolean
 	 */
 	public function is_taxable() {
-		return wc_tax_enabled() && 'taxable' === $this->tax_status && ! WC()->customer->get_is_vat_exempt();
+		return wc_tax_enabled() && 'taxable' === $this->tax_status && ( WC()->customer && ! WC()->customer->get_is_vat_exempt() );
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -46,7 +46,7 @@ class WC_Admin_Post_Types {
 		// Extra post data and screen elements.
 		add_action( 'edit_form_top', array( $this, 'edit_form_top' ) );
 		add_filter( 'enter_title_here', array( $this, 'enter_title_here' ), 1, 2 );
-		add_action( 'edit_form_after_title', array( $this, 'edit_form_after_title' ) );
+		add_action( 'current_screen', array( $this, 'edit_coupon_form_after_title' ) );
 		add_filter( 'default_hidden_meta_boxes', array( $this, 'hidden_meta_boxes' ), 10, 2 );
 		add_action( 'post_submitbox_misc_actions', array( $this, 'product_data_visibility' ) );
 
@@ -691,6 +691,24 @@ class WC_Admin_Post_Types {
 		}
 		return $text;
 	}
+	
+	/**
+	 * Looks at the current screen and adds an action on coupon edit screen to print coupon description.
+	 *
+	 * @since 3.5.1
+	 */
+	public function edit_coupon_form_after_title() {
+		$screen_id = false;
+		
+		if ( function_exists( 'get_current_screen' ) ) {
+			$screen    = get_current_screen();
+			$screen_id = isset( $screen, $screen->id ) ? $screen->id : '';
+		}
+		
+		if ( 'shop_coupon' == $screen_id ) {
+			add_action( 'edit_form_after_title', array( $this, 'edit_form_after_title' ) );
+		}
+	}
 
 	/**
 	 * Print coupon description textarea field.
@@ -698,11 +716,9 @@ class WC_Admin_Post_Types {
 	 * @param WP_Post $post Current post object.
 	 */
 	public function edit_form_after_title( $post ) {
-		if ( 'shop_coupon' === $post->post_type ) {
-			?>
-			<textarea id="woocommerce-coupon-description" name="excerpt" cols="5" rows="2" placeholder="<?php esc_attr_e( 'Description (optional)', 'woocommerce' ); ?>"><?php echo $post->post_excerpt; // WPCS: XSS ok. ?></textarea>
-			<?php
-		}
+		?>
+		<textarea id="woocommerce-coupon-description" name="excerpt" cols="5" rows="2" placeholder="<?php esc_attr_e( 'Description (optional)', 'woocommerce' ); ?>"><?php echo $post->post_excerpt; // WPCS: XSS ok. ?></textarea>
+		<?php
 	}
 
 	/**

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1273,6 +1273,8 @@ class WC_Countries {
 				'priority'     => 110,
 			);
 		}
+		
+		uasort( $address_fields, array( $this, 'sortByFieldPriority' ) );
 
 		/**
 		 * Important note on this filter: Changes to address fields can and will be overridden by
@@ -1282,4 +1284,15 @@ class WC_Countries {
 		 */
 		return apply_filters( 'woocommerce_' . $type . 'fields', $address_fields, $country );
 	}
+	
+	/**
+	 * @param string[] $a
+	 * @param string[] $b
+	 *
+	 * @return int
+	 */
+	private function sortByFieldPriority($a, $b) {
+		return ( isset( $a['priority'] ) ? $a['priority'] : 0  ) - ( isset( $b['priority'] ) ? $b['priority'] : 0 );
+	}
+	
 }

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1273,8 +1273,6 @@ class WC_Countries {
 				'priority'     => 110,
 			);
 		}
-		
-		uasort( $address_fields, array( $this, 'sortByFieldPriority' ) );
 
 		/**
 		 * Important note on this filter: Changes to address fields can and will be overridden by
@@ -1284,15 +1282,4 @@ class WC_Countries {
 		 */
 		return apply_filters( 'woocommerce_' . $type . 'fields', $address_fields, $country );
 	}
-	
-	/**
-	 * @param string[] $a
-	 * @param string[] $b
-	 *
-	 * @return int
-	 */
-	private function sortByFieldPriority($a, $b) {
-		return ( isset( $a['priority'] ) ? $a['priority'] : 0  ) - ( isset( $b['priority'] ) ? $b['priority'] : 0 );
-	}
-	
 }


### PR DESCRIPTION
In the actual form, the check done in the function is_taxable()  of a shipping method can only be done in the frontend, since WC()->customer must be defined.  Checking for a customer before checking the excemption would make the function also callable in the backend for different pre-calculation. If a customer is not defined, an exemption can not exists.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
