### PR TITLE
Avoid treating HTTP 301 and 302 Codes as Failures

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -442,7 +442,7 @@ class WC_Webhook extends WC_Legacy_Webhook {
 		);
 
 		// Track failures.
-		// Check for a success, which is a 2xx, 301 or 302 Response Code
+		// Check for a success, which is a 2xx, 301 or 302 Response Code.
 		if ( intval( $response_code ) >= 200 && intval( $response_code ) < 303 ) {
 			$this->set_failure_count( 0 );
 			$this->save();

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -442,7 +442,8 @@ class WC_Webhook extends WC_Legacy_Webhook {
 		);
 
 		// Track failures.
-		if ( intval( $response_code ) >= 200 && intval( $response_code ) < 300 ) {
+		// Check for a success, which is a 2xx, 301 or 302 Response Code
+		if ( intval( $response_code ) >= 200 && intval( $response_code ) < 303 ) {
 			$this->set_failure_count( 0 );
 			$this->save();
 		} else {


### PR DESCRIPTION
As per:

https://github.com/woocommerce/woocommerce/issues/21490

Change the definition of a Webhook Delivery Failure to exclude HTTP/301 and HTTP/302 responses. This allows webhook handlers (such as Google Apps Script) to avoid breaching failure limits and disabling webhooks.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
