### PR TITLE
Don't fire duplicate actions in shipping settings

### DIFF
--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -174,8 +174,11 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		switch ( $current_section ) {
 			case 'options':
 				WC_Admin_Settings::save_fields( $this->get_settings() );
+				do_action( 'woocommerce_update_options_' . $this->id . '_options' );
 				break;
 			case 'classes':
+				do_action( 'woocommerce_update_options_' . $this->id . '_classes' );
+				break;
 			case '':
 				break;
 			default:
@@ -187,10 +190,6 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 					}
 				}
 				break;
-		}
-
-		if ( $current_section ) {
-			do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
 		}
 
 		// Increments the transient version to invalidate cache.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21484 .

The `$current_section` global is always going to be the shipping method ID `$method->id` on custom shipping method setting screens. See [where $current_section is set](https://github.com/woocommerce/woocommerce/blob/master/includes/admin/class-wc-admin-menus.php#L98) and [where the shipping method is loaded](https://github.com/woocommerce/woocommerce/blob/master/includes/admin/settings/class-wc-settings-shipping.php#L161).

This means that previously we were firing the same action twice when shipping method settings were saved. This PR refactors to make it so that only one action is fired when saving shipping method settings.

### How to test the changes in this Pull Request:

1. Add the plugin code from #21484 somewhere (remove the 2 lines with `SS_SHIPPING_WC`; not sure what those are about).
2. Try and save a shipping setting and observe that 2 of the same error are output.
3. Apply this patch.
4. Try and save a shipping setting and observe that only 1 error is output.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Fix - Don't fire two of the same action when saving shipping settings.
