### PR TITLE
Add tests for wc_sanitize_order_id()

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -886,7 +886,7 @@ add_action( 'woocommerce_cancel_unpaid_orders', 'wc_cancel_unpaid_orders' );
  * @param int $order_id Order ID.
  */
 function wc_sanitize_order_id( $order_id ) {
-	return filter_var( $order_id, FILTER_SANITIZE_NUMBER_INT );
+	return (int) filter_var( $order_id, FILTER_SANITIZE_NUMBER_INT );
 }
 add_filter( 'woocommerce_shortcode_order_tracking_order_id', 'wc_sanitize_order_id' );
 

--- a/tests/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/unit-tests/order/class-wc-tests-order-functions.php
@@ -1272,6 +1272,18 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test wc_sanitize_order_id().
+	 *
+	 * @testWith ["123", 123]
+	 *           ["#123", 123]
+	 *           ["# 123", 123]
+	 *           ["Order #123", 123]
+	 */
+	public function test_wc_sanitize_order_id( $id, $expected ) {
+		$this->assertSame( $expected, wc_sanitize_order_id( $id ) );
+	}
+
+	/**
 	 * Test wc_get_order_note().
 	 *
 	 * @since 3.2.0

--- a/tests/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/unit-tests/order/class-wc-tests-order-functions.php
@@ -1273,14 +1273,12 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 
 	/**
 	 * Test wc_sanitize_order_id().
-	 *
-	 * @testWith ["123", 123]
-	 *           ["#123", 123]
-	 *           ["# 123", 123]
-	 *           ["Order #123", 123]
 	 */
-	public function test_wc_sanitize_order_id( $id, $expected ) {
-		$this->assertSame( $expected, wc_sanitize_order_id( $id ) );
+	public function test_wc_sanitize_order_id() {
+		$this->assertSame( 123, wc_sanitize_order_id( '123' ) );
+		$this->assertSame( 123, wc_sanitize_order_id( '#123' ) );
+		$this->assertSame( 123, wc_sanitize_order_id( '# 123' ) );
+		$this->assertSame( 123, wc_sanitize_order_id( 'Order #123' ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds four test cases (via [PHPUnit data providers](https://phpunit.de/manual/6.5/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers)) for the `wc_sanitize_order_id()` function.

While writing the tests, it was also discovered that the function was returning a *string*, not an integer as indicated by the DocBlock, so explicit type-casting was added.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Add test coverage for `wc_sanitize_order_id()`.
