### PR TITLE
Add statuses filter on wc_clear_cart_after_payment

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -184,7 +184,7 @@ function wc_clear_cart_after_payment() {
 
 		if ( $order && $order->get_id() > 0 ) {
 			// If the order has not failed, or is not pending, the order must have gone through.
-			if ( ! $order->has_status( array( 'failed', 'pending', 'cancelled' ) ) ) {
+			if ( ! $order->has_status( apply_filters( 'woocommerce_valid_order_statuses_for_clear_cart_after_payment_exemption', array( 'failed', 'pending', 'cancelled' ) ) ) ) {
 				WC()->cart->empty_cart();
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request: 

I propose applying a filter to allow developers to have use other statuses when using order_awaiting_payment in session

### Changelog entry

> woocommerce_valid_order_statuses_for_clear_cart_after_payment_exemption  filter added and applied to allow exempt statuses to be passed when clearing cart via wc_clear_cart_after_payment function


