### PR TITLE
Add support for sanitizing arrays used when saving order item data

### DIFF
--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -208,7 +208,7 @@ function wc_save_order_items( $order_id, $items ) {
 			$item_data = array();
 
 			foreach ( $data_keys as $key => $default ) {
-				$item_data[ $key ] = isset( $items[ $key ][ $item_id ] ) ? wc_clean( wp_unslash( $items[ $key ][ $item_id ] ) ) : $default;
+				$item_data[ $key ] = isset( $items[ $key ][ $item_id ] ) ? wc_check_invalid_utf8( wp_unslash( $items[ $key ][ $item_id ] ) ) : $default;
 			}
 
 			if ( '0' === $item_data['order_item_qty'] ) {

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -208,7 +208,7 @@ function wc_save_order_items( $order_id, $items ) {
 			$item_data = array();
 
 			foreach ( $data_keys as $key => $default ) {
-				$item_data[ $key ] = isset( $items[ $key ][ $item_id ] ) ? wp_check_invalid_utf8( wp_unslash( $items[ $key ][ $item_id ] ) ) : $default;
+				$item_data[ $key ] = isset( $items[ $key ][ $item_id ] ) ? wc_clean( wp_unslash( $items[ $key ][ $item_id ] ) ) : $default;
 			}
 
 			if ( '0' === $item_data['order_item_qty'] ) {

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -378,6 +378,20 @@ function wc_clean( $var ) {
 }
 
 /**
+ * wp_check_invalid_utf8 with recursive array support.
+ *
+ * @param string|array $var Data to sanitize.
+ * @return string|array
+ */
+function wc_check_invalid_utf8( $var ) {
+	if ( is_array( $var ) ) {
+		return array_map( 'wc_check_invalid_utf8', $var );
+	} else {
+		return wp_check_invalid_utf8( $var );
+	}
+}
+
+/**
  * Run wc_clean over posted textarea but maintain line breaks.
  *
  * @since  3.0.0


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21497 .

When saving existing orders on the admin screen, the tax information for orders was getting removed. This was because`wp_check_invalid_utf8` does not support arrays in the recursive way that `wc_clean` does. 

Examining the results of the function when saving taxes before applying this patch and you will see:
```
Notice: Array to string conversion in /srv/www/woodev/wp-includes/formatting.php on line 1045

array(7) { ["line_tax"]=> string(5) "Array"...
```

This PR introduces a new `wc_check_invalid_utf8` function which adds support for arrays recursively.

### How to test the changes in this Pull Request:

1. Before applying this patch, go to an existing order with taxes and save the order with the "Update" button. Observe that taxes disappear after saving.
2. Apply the patch. Go to an existing order with taxes and save the order with the "Update" button. Observe the taxes do not disappear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?