### PR TITLE
Add a test for handling errors during order status transitions

### DIFF
--- a/tests/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-crud-orders.php
@@ -945,6 +945,28 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test: status_transition
+	 */
+	public function test_status_transition_handles_transition_errors() {
+		$object = new WC_Order();
+		$object->save();
+
+		add_filter( 'woocommerce_order_status_on-hold', array( $this, 'throwAnException' ) );
+		$object->update_status( 'on-hold' );
+		remove_filter( 'woocommerce_order_status_on-hold', array( $this, 'throwAnException' ) );
+
+		$note = current(
+			wc_get_order_notes(
+				array(
+					'order_id' => $object->get_id(),
+				)
+			)
+		);
+
+		$this->assertContains( __( 'Error during status transition.', 'woocommerce' ), $note->content );
+	}
+
+	/**
 	 * Test: get_billing_first_name
 	 */
 	public function test_get_billing_first_name() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a test for `WC_Order::status_transition()`, ensuring that a note is added to the order when an error has occurred.

### Changelog entry

> Add a test for handling errors during order status transitions