### PR TITLE
Fixes #21363 Recommends using assertSame rather than assertEquals

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -44,7 +44,7 @@ A text code coverage summary can be displayed using the `--coverage-text` option
 * Use the test coverage HTML report (under `tmp/coverage/index.html`) to examine which lines your tests are covering and aim for 100% coverage
 * For code that cannot be tested (e.g. they require a certain PHP version), you can exclude them from coverage using a comment: `// @codeCoverageIgnoreStart` and `// @codeCoverageIgnoreEnd`. For example, see [`wc_round_tax_total()`](https://github.com/woocommerce/woocommerce/blob/35f83867736713955fa2c4f463a024578bb88795/includes/wc-formatting-functions.php#L208-L219)
 * In addition to covering each line of a method/function, make sure to test common input and edge cases.
-* Prefer `assertsEquals()` where possible as it tests both type & equality
+* Prefer `assertSame()` where possible as it tests both type & equality
 * Remember that only methods prefixed with `test` will be run so use helper methods liberally to keep test methods small and reduce code duplication. If there is a common helper method used in multiple test files, consider adding it to the `WC_Unit_Test_Case` class so it can be shared by all test cases
 * Filters persist between test cases so be sure to remove them in your test method or in the `tearDown()` method.
 * Use data providers where possible. Be sure that their name is like `data_provider_function_to_test` (i.e. the data provider for `test_is_postcode` would be `data_provider_test_is_postcode`). Read more about data providers [here](https://phpunit.de/manual/current/en/writing-tests-for-phpunit.html#writing-tests-for-phpunit.data-providers).


### PR DESCRIPTION
### All Submissions:

* [ X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #21363 .

### Changelog entry

Readme should recommend using assertSame rather than assertEquals since it tests both type and equality.
