### PR TITLE
WC Refund class older name 'WC_Refund' somehow left over in the funct…

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -73,7 +73,7 @@ function wc_get_orders( $args ) {
  *
  * @param  mixed $the_order Post object or post ID of the order.
  *
- * @return bool|WC_Order|WC_Refund
+ * @return bool|WC_Order|WC_Order_Refund
  */
 function wc_get_order( $the_order = false ) {
 	if ( ! did_action( 'woocommerce_after_register_post_type' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Found WC Refund class older name 'WC_Refund' in the 'wc_get_order' function docblock.
The Class name is changed already to WC_Order_Refund.
So, just a typo correction.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?


### Changelog entry

> WC Refund class older name 'WC_Refund' left over in the function docblock. Corrected to WC_Order_Refund.
