### PR TITLE
Fix DB log handler cleanup

### DIFF
--- a/includes/log-handlers/class-wc-log-handler-db.php
+++ b/includes/log-handlers/class-wc-log-handler-db.php
@@ -146,8 +146,8 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 
 		$wpdb->query(
 			$wpdb->prepare(
-				"DELETE FROM {$wpdb->prefix}woocommerce_log WHERE timestamp < %d",
-				$timestamp
+				"DELETE FROM {$wpdb->prefix}woocommerce_log WHERE timestamp < %s",
+				date( 'Y-m-d H:i:s', $timestamp )
 			)
 		);
 	}

--- a/tests/unit-tests/log/log-handler-db.php
+++ b/tests/unit-tests/log/log-handler-db.php
@@ -6,16 +6,6 @@
  * @since 3.0.0
  */
 class WC_Tests_Log_Handler_DB extends WC_Unit_Test_Case {
-	public function setUp() {
-		parent::setUp();
-		WC_Log_Handler_DB::flush();
-	}
-
-	public function tearDown() {
-		WC_Log_Handler_DB::flush();
-		parent::tearDown();
-	}
-
 	/**
 	 * Test handle writes to database correctly.
 	 *

--- a/tests/unit-tests/log/log-handler-db.php
+++ b/tests/unit-tests/log/log-handler-db.php
@@ -25,8 +25,14 @@ class WC_Tests_Log_Handler_DB extends WC_Unit_Test_Case {
 		global $wpdb;
 
 		$handler = new WC_Log_Handler_DB( array( 'threshold' => 'debug' ) );
-		$time = time();
-		$context = array( 1, 2, 'a', 'b', 'key' => 'value' );
+		$time    = time();
+		$context = array(
+			1,
+			2,
+			'a',
+			'b',
+			'key' => 'value',
+		);
 
 		$handler->handle( $time, 'debug', 'msg_debug', array( 'source' => 'source_debug' ) );
 		$handler->handle( $time, 'info', 'msg_info', array( 'source' => 'source_info' ) );
@@ -42,69 +48,69 @@ class WC_Tests_Log_Handler_DB extends WC_Unit_Test_Case {
 		$log_entries = $wpdb->get_results( "SELECT timestamp, level, message, source, context FROM {$wpdb->prefix}woocommerce_log", ARRAY_A );
 
 		$expected_ts = date( 'Y-m-d H:i:s', $time );
-		$expected = array(
+		$expected    = array(
 			array(
 				'timestamp' => $expected_ts,
-				'level' => WC_Log_Levels::get_level_severity( 'debug' ),
-				'message' => 'msg_debug',
-				'source' => 'source_debug',
-				'context' => serialize( array( 'source' => 'source_debug' ) ),
+				'level'     => WC_Log_Levels::get_level_severity( 'debug' ),
+				'message'   => 'msg_debug',
+				'source'    => 'source_debug',
+				'context'   => serialize( array( 'source' => 'source_debug' ) ),
 			),
 			array(
 				'timestamp' => $expected_ts,
-				'level' => WC_Log_Levels::get_level_severity( 'info' ),
-				'message' => 'msg_info',
-				'source' => 'source_info',
-				'context' => serialize( array( 'source' => 'source_info' ) ),
+				'level'     => WC_Log_Levels::get_level_severity( 'info' ),
+				'message'   => 'msg_info',
+				'source'    => 'source_info',
+				'context'   => serialize( array( 'source' => 'source_info' ) ),
 			),
 			array(
 				'timestamp' => $expected_ts,
-				'level' => WC_Log_Levels::get_level_severity( 'notice' ),
-				'message' => 'msg_notice',
-				'source' => 'source_notice',
-				'context' => serialize( array( 'source' => 'source_notice' ) ),
+				'level'     => WC_Log_Levels::get_level_severity( 'notice' ),
+				'message'   => 'msg_notice',
+				'source'    => 'source_notice',
+				'context'   => serialize( array( 'source' => 'source_notice' ) ),
 			),
 			array(
 				'timestamp' => $expected_ts,
-				'level' => WC_Log_Levels::get_level_severity( 'warning' ),
-				'message' => 'msg_warning',
-				'source' => 'source_warning',
-				'context' => serialize( array( 'source' => 'source_warning' ) ),
+				'level'     => WC_Log_Levels::get_level_severity( 'warning' ),
+				'message'   => 'msg_warning',
+				'source'    => 'source_warning',
+				'context'   => serialize( array( 'source' => 'source_warning' ) ),
 			),
 			array(
 				'timestamp' => $expected_ts,
-				'level' => WC_Log_Levels::get_level_severity( 'error' ),
-				'message' => 'msg_error',
-				'source' => 'source_error',
-				'context' => serialize( array( 'source' => 'source_error' ) ),
+				'level'     => WC_Log_Levels::get_level_severity( 'error' ),
+				'message'   => 'msg_error',
+				'source'    => 'source_error',
+				'context'   => serialize( array( 'source' => 'source_error' ) ),
 			),
 			array(
 				'timestamp' => $expected_ts,
-				'level' => WC_Log_Levels::get_level_severity( 'critical' ),
-				'message' => 'msg_critical',
-				'source' => 'source_critical',
-				'context' => serialize( array( 'source' => 'source_critical' ) ),
+				'level'     => WC_Log_Levels::get_level_severity( 'critical' ),
+				'message'   => 'msg_critical',
+				'source'    => 'source_critical',
+				'context'   => serialize( array( 'source' => 'source_critical' ) ),
 			),
 			array(
 				'timestamp' => $expected_ts,
-				'level' => WC_Log_Levels::get_level_severity( 'alert' ),
-				'message' => 'msg_alert',
-				'source' => 'source_alert',
-				'context' => serialize( array( 'source' => 'source_alert' ) ),
+				'level'     => WC_Log_Levels::get_level_severity( 'alert' ),
+				'message'   => 'msg_alert',
+				'source'    => 'source_alert',
+				'context'   => serialize( array( 'source' => 'source_alert' ) ),
 			),
 			array(
 				'timestamp' => $expected_ts,
-				'level' => WC_Log_Levels::get_level_severity( 'emergency' ),
-				'message' => 'msg_emergency',
-				'source' => 'source_emergency',
-				'context' => serialize( array( 'source' => 'source_emergency' ) ),
+				'level'     => WC_Log_Levels::get_level_severity( 'emergency' ),
+				'message'   => 'msg_emergency',
+				'source'    => 'source_emergency',
+				'context'   => serialize( array( 'source' => 'source_emergency' ) ),
 			),
 			array(
 				'timestamp' => $expected_ts,
-				'level' => WC_Log_Levels::get_level_severity( 'debug' ),
-				'message' => 'context_test',
-				'source' => pathinfo( __FILE__, PATHINFO_FILENAME ),
-				'context' => serialize( $context ),
+				'level'     => WC_Log_Levels::get_level_severity( 'debug' ),
+				'message'   => 'context_test',
+				'source'    => pathinfo( __FILE__, PATHINFO_FILENAME ),
+				'context'   => serialize( $context ),
 			),
 		);
 
@@ -121,7 +127,7 @@ class WC_Tests_Log_Handler_DB extends WC_Unit_Test_Case {
 		global $wpdb;
 
 		$handler = new WC_Log_Handler_DB( array( 'threshold' => 'debug' ) );
-		$time = time();
+		$time    = time();
 
 		$handler->handle( $time, 'debug', '', array() );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21509 .

### How to test the changes in this Pull Request:

1. Set up a db log handler as described in #21509
2. Add the following code somewhere:
```
add_action( 'woocommerce_init', function(){
	$logger = wc_get_logger();
	$logger->log( 'debug', 'testing' );

	// WC_Log_Handler_DB::delete_logs_before_timestamp( time() );
});
```
3. Open up mySQL. Refresh the page to fill up the log. Uncomment out the delete to clear the log.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fix date format in `WC_Log_Handler_DB::delete_logs_before_timestamp`.