### PR TITLE
Deprecate the 'woocommerce_loaded' action

### DIFF
--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -1012,3 +1012,23 @@ function wc_get_core_supported_themes() {
 	wc_deprecated_function( 'wc_get_core_supported_themes()', '3.3' );
 	return array( 'twentyseventeen', 'twentysixteen', 'twentyfifteen', 'twentyfourteen', 'twentythirteen', 'twentyeleven', 'twentytwelve', 'twentyten' );
 }
+
+
+/**
+ * Deprecate the 'woocommerce_loaded' action to document issues with it and discourage usage.
+ *
+ * This needs to be done on a callback to 'plugins_loaded', rather than inline when ths
+ * 'woocommerce_loaded' action is triggered, to ensure that the has_action() check accounts for
+ * all plugins. Otherwise, those plugins affected - the ones attaching callbacks to the action
+ * after the action is triggered - would not cause this notice to be displayed.
+ *
+ * @since 3.6.0
+ */
+function wc_deprecate_woocommerce_loaded() {
+
+	if ( has_action( 'woocommerce_loaded' ) ) {
+		$deprecated_notice = __( 'The woocommerce_loaded action is triggered inconsistently because the time when it is called is based on the WooCommerce plugin folder name, which can vary between sites.', 'woocommerce' );
+		wc_deprecated_hook( 'woocommerce_loaded', '3.6.0', 'plugins_loaded', $deprecated_notice );
+	}
+}
+add_filter( 'plugins_loaded', 'wc_deprecate_woocommerce_loaded' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Deprecate the `'woocommerce_loaded'` action, because it is triggered based on the WooCommerce plugin folder name, which can vary between sites, meaning it is triggered inconsistently on different installations, without warning, so can not be relied upon.

As this is a fairly major hook to deprecate, I've used `3.6.0` as the version number rather than sneaking it into `3.5.0` so late in the release cycle.

Closes #21524. Related to #13426.

### How to test the changes in this Pull Request:

1. Add the following snippet to in a plugin with a folder name that starts with a letter before `w`: `add_action( 'woocommerce_loaded', '__return_true' );`
2. Load a page
3. Check the error log to review deprecated notice

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

> Dev - Deprecate the 'woocommerce_loaded' action, because it is triggered based on the WooCommerce plugin folder name, which can vary between sites, meaning it is triggered inconsistently without warning.

