### PR TITLE
allow-filtering-on-wiget-get_current_page_url

### DIFF
--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -347,7 +347,7 @@ abstract class WC_Widget extends WP_Widget {
 			}
 		}
 
-		return $link;
+		return apply_filters( 'woocommerce_widget_get_current_page_url', $link, $this )
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -347,7 +347,7 @@ abstract class WC_Widget extends WP_Widget {
 			}
 		}
 
-		return apply_filters( 'woocommerce_widget_get_current_page_url', $link, $this )
+		return apply_filters( 'woocommerce_widget_get_current_page_url', $link, $this );
 	}
 
 	/**


### PR DESCRIPTION

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allow for filtering on get_current_page_url() in widgets, to make it possible to extend the parameteres, and keep them.

If building some functionality, where wee work with the parameters in the url, they will be removed, when using the links produced by wc_widget - for example the layered nav, or the price range.

With the filter, we kan add out custom parameter, to the url generated by these widgets.

Closes # .

### How to test the changes in this Pull Request:

1. Use the layered nav filter, or any other widgets, that uses get_current_page_url() from wc_widget
2. Hook into the filter, to change the url parameters.
3. See how the url's changed.

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
