### PR TITLE
Use wp_get_upload_dir for geolite DB path

### DIFF
--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -237,7 +237,7 @@ class WC_Geolocation {
 	 * @return string
 	 */
 	public static function get_local_database_path( $deprecated = '2' ) {
-		$upload_dir = wp_upload_dir();
+		$upload_dir = wp_get_upload_dir();
 
 		return apply_filters( 'woocommerce_geolocation_local_database_path', $upload_dir['basedir'] . '/GeoLite2-Country.mmdb', $deprecated );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

By default, `wp_upload_dir` will "will create a subfolder in your Uploads folder corresponding to the queried month (or current month, if no $time argument is provided" (https://developer.wordpress.org/reference/functions/wp_upload_dir/).

This is not necessary in our case since all we want is the `basedir` value to correctly get a path to the geolite db.

We're switching to `wp_get_upload_dir`, which is a wrapper for `wp_upload_dir` that turns of the folder create behaviour. This prevents an unnecessary warning () on systems that don't allow direct writes to the `wp-content` folder.