### PR TITLE
Allow super admins and users with extra roles and admin caps to edit other users

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -353,7 +353,7 @@ function wc_modify_editable_roles( $roles ) {
 		unset( $roles['administrator'] );
 	}
 
-	if ( current_user_can( 'shop_manager' ) ) {
+	if ( current_user_can( 'shop_manager' ) && ! current_user_can( 'administrator' ) ) {
 		$shop_manager_editable_roles = apply_filters( 'woocommerce_shop_manager_editable_roles', array( 'customer' ) );
 		return array_intersect_key( $roles, array_flip( $shop_manager_editable_roles ) );
 	}
@@ -387,7 +387,7 @@ function wc_modify_map_meta_cap( $caps, $cap, $user_id, $args ) {
 				}
 
 				// Shop managers can only edit customer info.
-				if ( current_user_can( 'shop_manager' ) ) {
+				if ( current_user_can( 'shop_manager' ) && ! current_user_can( 'administrator' ) ) {
 					$userdata = get_userdata( $args[0] );
 					$shop_manager_editable_roles = apply_filters( 'woocommerce_shop_manager_editable_roles', array( 'customer' ) );
 					if ( property_exists( $userdata, 'roles' ) && ! empty( $userdata->roles ) && ! array_intersect( $userdata->roles, $shop_manager_editable_roles ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes #21546  .

For super admins and users with multiple roles `current_user_can( 'shop_manager' )` will return true, and if those users have admin capabilities we don't want to restrict their ability to edit users.

### How to test the changes in this Pull Request:

1. Set up multisite. Log in as a super admin and see that you can only edit Customers.
2. Apply this patch. Log in as a super admin and see that you can edit everyone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Allow super admins and users with extra roles and admin capabilities to edit other users.
