### PR TITLE
Fix some memory limit values not correctly converting to bytes

### DIFF
--- a/includes/abstracts/class-wc-background-process.php
+++ b/includes/abstracts/class-wc-background-process.php
@@ -146,10 +146,10 @@ abstract class WC_Background_Process extends WP_Background_Process {
 
 		if ( ! $memory_limit || -1 === intval( $memory_limit ) ) {
 			// Unlimited, set to 32GB.
-			$memory_limit = '32000M';
+			$memory_limit = '32G';
 		}
 
-		return intval( $memory_limit ) * 1024 * 1024;
+		return wp_convert_hr_to_bytes( $memory_limit );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR sends the output of [`WC_Background_Process::get_memory_limit()`](https://github.com/woocommerce/woocommerce/blob/74693979db82198284a10e2610378a26a6a54939/includes/abstracts/class-wc-background-process.php#L134-L153) through the WP core function [`wp_convert_hr_to_bytes()`](https://github.com/WordPress/WordPress/blob/da7a80d67fea29c2badfc538bfc01c8a585f0cbe/wp-includes/load.php#L1075-L1101), which correctly converts all possible values of php.ini's `memory_limit` to bytes.

The current implementation always assumes the value retrieved from the ini is in Megabytes, but the ini values can actually be written in shorthand for G, M, K, or just plain bytes. The `wp_convert_hr_to_bytes()` function converts all of these values to bytes and was moved into `load.php` in 4.6.

I was alerted to this issue because the WC 3.5.0-rc.1 database update was continually failing on my local install [at this point](https://github.com/woocommerce/woocommerce/blob/74693979db82198284a10e2610378a26a6a54939/includes/wc-update-functions.php#L1952). This was due to my local ini defining a memory_limit of `2G` which was being interpreted as `2M` and always showing out of memory.

I also updated the default 'unlimited' memory value to more correctly represent 32G.

### How to test the changes in this Pull Request:

1. (On `master`): Set `memory_limit` in php.ini to a `G` shorthand, I have mine set at `2G`.
2. Dump the value of `WC_Background_Process::get_memory_limit()` - observe an incorrect byte value.
3. Checkout this code and repeat, the byte value should match the value defined in the ini.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Correctly handle shorthand values for memory_limit in php.ini