### PR TITLE
Products shortcode allow numeric term slug matching

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -288,7 +288,13 @@ class WC_Shortcode_Products {
 
 			if ( $terms && is_numeric( $terms[0] ) ) {
 				$terms = array_map( 'absint', $terms );
-				$field = 'term_id';
+				$query_args['tax_query']['relation'] = 'OR';
+				$query_args['tax_query'][] = array(
+					'taxonomy' => $taxonomy,
+					'terms'    => $terms,
+					'field'    => 'term_id',
+					'operator' => $this->attributes['terms_operator'],
+				);
 			}
 
 			// If no terms were specified get all products that are in the attribute taxonomy.
@@ -299,9 +305,15 @@ class WC_Shortcode_Products {
 						'fields'   => 'ids',
 					)
 				);
-				$field = 'term_id';
+				$query_args['tax_query'][] = array(
+					'taxonomy' => $taxonomy,
+					'terms'    => $terms,
+					'field'    => 'term_id',
+					'operator' => $this->attributes['terms_operator'],
+				);
 			}
 
+			// We always need to search based on the slug as well, this is to accommodate numeric slugs.
 			$query_args['tax_query'][] = array(
 				'taxonomy' => $taxonomy,
 				'terms'    => $terms,
@@ -324,9 +336,22 @@ class WC_Shortcode_Products {
 
 			if ( is_numeric( $categories[0] ) ) {
 				$categories = array_map( 'absint', $categories );
-				$field      = 'term_id';
+				$query_args['tax_query']['relation'] = 'OR';
+				$query_args['tax_query'][] = array(
+					'taxonomy'         => 'product_cat',
+					'terms'            => $categories,
+					'field'            => 'term_id',
+					'operator'         => $this->attributes['cat_operator'],
+
+					/*
+					 * When cat_operator is AND, the children categories should be excluded,
+					 * as only products belonging to all the children categories would be selected.
+					 */
+					'include_children' => 'AND' === $this->attributes['cat_operator'] ? false : true,
+				);
 			}
 
+			// We always need to search based on the slug as well, this is to accommodate numeric slugs.
 			$query_args['tax_query'][] = array(
 				'taxonomy'         => 'product_cat',
 				'terms'            => $categories,

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -287,14 +287,15 @@ class WC_Shortcode_Products {
 			$field    = 'slug';
 
 			if ( $terms && is_numeric( $terms[0] ) ) {
+				$field = 'term_id';
 				$terms = array_map( 'absint', $terms );
-				$query_args['tax_query']['relation'] = 'OR';
-				$query_args['tax_query'][] = array(
-					'taxonomy' => $taxonomy,
-					'terms'    => $terms,
-					'field'    => 'term_id',
-					'operator' => $this->attributes['terms_operator'],
-				);
+				// Check numeric slugs.
+				foreach ( $terms as $term ) {
+					$the_term = get_term_by( 'slug', $term, $taxonomy );
+					if ( false !== $the_term ) {
+						$terms[] = $the_term->term_id;
+					}
+				}
 			}
 
 			// If no terms were specified get all products that are in the attribute taxonomy.
@@ -305,12 +306,7 @@ class WC_Shortcode_Products {
 						'fields'   => 'ids',
 					)
 				);
-				$query_args['tax_query'][] = array(
-					'taxonomy' => $taxonomy,
-					'terms'    => $terms,
-					'field'    => 'term_id',
-					'operator' => $this->attributes['terms_operator'],
-				);
+				$field = 'term_id';
 			}
 
 			// We always need to search based on the slug as well, this is to accommodate numeric slugs.
@@ -335,23 +331,17 @@ class WC_Shortcode_Products {
 			$field      = 'slug';
 
 			if ( is_numeric( $categories[0] ) ) {
+				$field = 'term_id';
 				$categories = array_map( 'absint', $categories );
-				$query_args['tax_query']['relation'] = 'OR';
-				$query_args['tax_query'][] = array(
-					'taxonomy'         => 'product_cat',
-					'terms'            => $categories,
-					'field'            => 'term_id',
-					'operator'         => $this->attributes['cat_operator'],
-
-					/*
-					 * When cat_operator is AND, the children categories should be excluded,
-					 * as only products belonging to all the children categories would be selected.
-					 */
-					'include_children' => 'AND' === $this->attributes['cat_operator'] ? false : true,
-				);
+				// Check numeric slugs.
+				foreach ( $categories as $cat ) {
+					$the_cat = get_term_by( 'slug', $cat, 'product_cat' );
+					if ( false !== $the_cat ) {
+						$categories[] = $the_cat->term_id;
+					}
+				}
 			}
 
-			// We always need to search based on the slug as well, this is to accommodate numeric slugs.
 			$query_args['tax_query'][] = array(
 				'taxonomy'         => 'product_cat',
 				'terms'            => $categories,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds functionality that allows you to match products with numeric slugs the way it used to work before #19204 was merged.

Closes #21552

### How to test the changes in this Pull Request:

1. Create an attribute and assign a term with a numeric value and slug to it.
2. Assign the attribute to a product and select the term with the the numeric slug as a value.
3. Use the [products] shortcode with the attribute and term properties to look up the term via the numeric slug.
4. Product should show up where it currently does not.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Product shortcode numeric term slug matching.
