### PR TITLE
Improve session table update routine

### DIFF
--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1999,9 +1999,20 @@ function wc_update_350_reviews_comment_type() {
 function wc_update_350_change_woocommerce_sessions_schema() {
 	global $wpdb;
 
-	$wpdb->query(
-		"ALTER TABLE `{$wpdb->prefix}woocommerce_sessions` DROP PRIMARY KEY, DROP KEY `session_id`, ADD PRIMARY KEY(`session_id`), ADD UNIQUE KEY(`session_key`)"
-	);
+	$results = $wpdb->get_results( "
+		SELECT CONSTRAINT_NAME
+		FROM information_schema.TABLE_CONSTRAINTS
+		WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
+		AND CONSTRAINT_TYPE = 'UNIQUE'
+		AND CONSTRAINT_NAME = 'session_id'
+		AND TABLE_NAME = '{$wpdb->prefix}woocommerce_sessions'
+	" );
+
+	if ( $results ) {
+		$wpdb->query(
+			"ALTER TABLE `{$wpdb->prefix}woocommerce_sessions` DROP KEY `session_id`, ADD UNIQUE KEY(`session_key`)"
+		);
+	}
 }
 
 /**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2004,11 +2004,11 @@ function wc_update_350_change_woocommerce_sessions_schema() {
 		FROM information_schema.TABLE_CONSTRAINTS
 		WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
 		AND CONSTRAINT_TYPE = 'UNIQUE'
-		AND CONSTRAINT_NAME = 'session_id'
+		AND CONSTRAINT_NAME = 'session_key'
 		AND TABLE_NAME = '{$wpdb->prefix}woocommerce_sessions'
 	" );
 
-	if ( $results ) {
+	if ( ! $results ) {
 		$wpdb->query(
 			"ALTER TABLE `{$wpdb->prefix}woocommerce_sessions` DROP KEY `session_id`, ADD UNIQUE KEY(`session_key`)"
 		);


### PR DESCRIPTION
… that automatically. Just drop the key if it exists and add a new unique key.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

To improve performance, reliability and to avoid deadlocks #21245 reworked the tables structure of the sessions table, with that an upgrade route was added that drops and adds a primary key without checks to see if one already exists, since DBDelta takes care of primary key creation, this PR adjusts the upgrade routine to only create a unique key for the old session_key field.

Closes #21534

### How to test the changes in this Pull Request:

1. Run the upgrade routine of 3.5 multiple times on the same database
2. There should be no mysql errors in your logs about duplicate keys.
3. See https://github.com/woocommerce/woocommerce/pull/21245#issuecomment-420194220

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->