### PR TITLE
Add a filter to WC_REST_CRUD_Controller::get_collection_params method to allow developers to change params

### DIFF
--- a/includes/abstracts/abstract-wc-rest-crud-controller.php
+++ b/includes/abstracts/abstract-wc-rest-crud-controller.php
@@ -609,6 +609,19 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			);
 		}
 
-		return $params;
+		/**
+		 * Filter collection parameters for the posts controller.
+		 *
+		 * The dynamic part of the filter `$this->post_type` refers to the post
+		 * type slug for the controller.
+		 *
+		 * This filter registers the collection parameter, but does not map the
+		 * collection parameter to an internal WP_Query parameter. Use the
+		 * `rest_{$this->post_type}_query` filter to set WP_Query parameters.
+		 *
+		 * @param array        $query_params JSON Schema-formatted collection parameters.
+		 * @param WP_Post_Type $post_type    Post type object.
+		 */
+		return apply_filters( "rest_{$this->post_type}_collection_params", $params, $this->post_type );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Added a filter to `WC_REST_CRUD_Controller::get_collection_params` method to allow developers to change params in the same way as `WP_Rest_Posts_controller::get_collection_params`

### Changelog entry

> Added a filter to WC_REST_CRUD_Controller::get_collection_params method to allow developers to change params in the same way as WP_Rest_Posts_controller::get_collection_params
