### PR TITLE
Fix typo revivew

### DIFF
--- a/includes/api/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/class-wc-rest-product-reviews-controller.php
@@ -554,7 +554,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 			}
 
 			if ( isset( $prepared_args['comment_content'] ) && empty( $prepared_args['comment_content'] ) ) {
-				return new WP_Error( 'woocommerce_rest_review_content_invalid', __( 'Invalid revivew content.', 'woocommerce' ), array( 'status' => 400 ) );
+				return new WP_Error( 'woocommerce_rest_review_content_invalid', __( 'Invalid review content.', 'woocommerce' ), array( 'status' => 400 ) );
 			}
 
 			$prepared_args['comment_ID'] = $id;


### PR DESCRIPTION
Fixes a typo in a translatable text:

```
Invalid revivew content.
```
should be:
```
Invalid review content.
```
