### PR TITLE
Stop using `current_user_can` for validation roles.

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -378,11 +378,11 @@ add_filter( 'user_has_cap', 'wc_customer_has_capability', 10, 3 );
 function wc_modify_editable_roles( $roles ) {
 	if ( ! wc_current_user_has_role( 'administrator' ) ) {
 		unset( $roles['administrator'] );
-	}
 
-	if ( wc_current_user_has_role( 'shop_manager' ) ) {
-		$shop_manager_editable_roles = apply_filters( 'woocommerce_shop_manager_editable_roles', array( 'customer' ) );
-		return array_intersect_key( $roles, array_flip( $shop_manager_editable_roles ) );
+		if ( wc_current_user_has_role( 'shop_manager' ) ) {
+			$shop_manager_editable_roles = apply_filters( 'woocommerce_shop_manager_editable_roles', array( 'customer' ) );
+			return array_intersect_key( $roles, array_flip( $shop_manager_editable_roles ) );
+		}
 	}
 
 	return $roles;
@@ -409,16 +409,18 @@ function wc_modify_map_meta_cap( $caps, $cap, $user_id, $args ) {
 			if ( ! isset( $args[0] ) || $args[0] === $user_id ) {
 				break;
 			} else {
-				if ( wc_user_has_role( $args[0], 'administrator' ) && ! wc_current_user_has_role( 'administrator' ) ) {
-					$caps[] = 'do_not_allow';
-				}
-
-				// Shop managers can only edit customer info.
-				if ( wc_current_user_has_role( 'shop_manager' ) ) {
-					$userdata = get_userdata( $args[0] );
-					$shop_manager_editable_roles = apply_filters( 'woocommerce_shop_manager_editable_roles', array( 'customer' ) );
-					if ( property_exists( $userdata, 'roles' ) && ! empty( $userdata->roles ) && ! array_intersect( $userdata->roles, $shop_manager_editable_roles ) ) {
+				if ( ! wc_current_user_has_role( 'administrator' ) ) {
+					if ( wc_user_has_role( $args[0], 'administrator' ) ) {
 						$caps[] = 'do_not_allow';
+					}
+
+					// Shop managers can only edit customer info.
+					if ( wc_current_user_has_role( 'shop_manager' ) ) {
+						$userdata = get_userdata( $args[0] );
+						$shop_manager_editable_roles = apply_filters( 'woocommerce_shop_manager_editable_roles', array( 'customer' ) );
+						if ( property_exists( $userdata, 'roles' ) && ! empty( $userdata->roles ) && ! array_intersect( $userdata->roles, $shop_manager_editable_roles ) ) {
+							$caps[] = 'do_not_allow';
+						}
 					}
 				}
 			}

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -279,7 +279,7 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 /**
  * Checks if the current user has a role.
  *
- * @param string       $role The role.
+ * @param string $role The role.
  * @return bool
  */
 function wc_current_user_has_role( $role ) {
@@ -294,13 +294,15 @@ function wc_current_user_has_role( $role ) {
  * @return bool
  */
 function wc_user_has_role( $user, $role ) {
-    if ( ! is_object( $user ) )
-        $user = get_userdata( $user );
+	if ( ! is_object( $user ) ) {
+		$user = get_userdata( $user );
+	}
  
-    if ( ! $user || ! $user->exists() )
-        return false;
+	if ( ! $user || ! $user->exists() ) {
+		return false;
+	}
 
-    return in_array( $role, $user->roles, true );
+	return in_array( $role, $user->roles, true );
 }
 
 /**

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -277,6 +277,33 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 }
 
 /**
+ * Checks if the current user has a role.
+ *
+ * @param string       $role The role.
+ * @return bool
+ */
+function wc_current_user_has_role( $role ) {
+	return wc_user_has_role( wp_get_current_user(), $role );
+}
+
+/**
+ * Checks if a user has a role.
+ *
+ * @param int|\WP_User $user The user.
+ * @param string       $role The role.
+ * @return bool
+ */
+function wc_user_has_role( $user, $role ) {
+    if ( ! is_object( $user ) )
+        $user = get_userdata( $user );
+ 
+    if ( ! $user || ! $user->exists() )
+        return false;
+
+    return in_array( $role, $user->roles, true );
+}
+
+/**
  * Checks if a user has a certain capability.
  *
  * @param array $allcaps All capabilities.
@@ -349,11 +376,11 @@ add_filter( 'user_has_cap', 'wc_customer_has_capability', 10, 3 );
  * @return array
  */
 function wc_modify_editable_roles( $roles ) {
-	if ( ! current_user_can( 'administrator' ) ) {
+	if ( ! wc_current_user_has_role( 'administrator' ) ) {
 		unset( $roles['administrator'] );
 	}
 
-	if ( current_user_can( 'shop_manager' ) ) {
+	if ( wc_current_user_has_role( 'shop_manager' ) ) {
 		$shop_manager_editable_roles = apply_filters( 'woocommerce_shop_manager_editable_roles', array( 'customer' ) );
 		return array_intersect_key( $roles, array_flip( $shop_manager_editable_roles ) );
 	}
@@ -382,12 +409,12 @@ function wc_modify_map_meta_cap( $caps, $cap, $user_id, $args ) {
 			if ( ! isset( $args[0] ) || $args[0] === $user_id ) {
 				break;
 			} else {
-				if ( user_can( $args[0], 'administrator' ) && ! current_user_can( 'administrator' ) ) {
+				if ( wc_user_has_role( $args[0], 'administrator' ) && ! wc_current_user_has_role( 'administrator' ) ) {
 					$caps[] = 'do_not_allow';
 				}
 
 				// Shop managers can only edit customer info.
-				if ( current_user_can( 'shop_manager' ) ) {
+				if ( wc_current_user_has_role( 'shop_manager' ) ) {
 					$userdata = get_userdata( $args[0] );
 					$shop_manager_editable_roles = apply_filters( 'woocommerce_shop_manager_editable_roles', array( 'customer' ) );
 					if ( property_exists( $userdata, 'roles' ) && ! empty( $userdata->roles ) && ! array_intersect( $userdata->roles, $shop_manager_editable_roles ) ) {

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -297,7 +297,7 @@ function wc_user_has_role( $user, $role ) {
 	if ( ! is_object( $user ) ) {
 		$user = get_userdata( $user );
 	}
- 
+
 	if ( ! $user || ! $user->exists() ) {
 		return false;
 	}


### PR DESCRIPTION
Fixes #21568

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
  * This is a similar PR https://github.com/woocommerce/woocommerce/pull/21555 but it still uses `current_user_can()`.

### Changes proposed in this Pull Request:

See Issue below:
Closes #21568

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

New helper functions `wc_user_has_role` and `wc_current_user_has_role` to correctly check user roles.
