### PR TITLE
Fix: Posted variation attribute values not recognized if "+" present

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2776,7 +2776,7 @@ if ( ! function_exists( 'wc_dropdown_variation_attribute_options' ) ) {
 		// Get selected value.
 		if ( false === $args['selected'] && $args['attribute'] && $args['product'] instanceof WC_Product ) {
 			$selected_key     = 'attribute_' . sanitize_title( $args['attribute'] );
-			$args['selected'] = isset( $_REQUEST[ $selected_key ] ) ? wc_clean( urldecode( wp_unslash( $_REQUEST[ $selected_key ] ) ) ) : $args['product']->get_variation_default_attribute( $args['attribute'] ); // WPCS: input var ok, CSRF ok, sanitization ok.
+			$args['selected'] = isset( $_REQUEST[ $selected_key ] ) ? wc_clean( wp_unslash( $_REQUEST[ $selected_key ] ) ) : $args['product']->get_variation_default_attribute( $args['attribute'] ); // WPCS: input var ok, CSRF ok, sanitization ok.
 		}
 
 		$options               = $args['options'];

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -65,4 +65,39 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$product->delete( true );
 		wp_delete_term( $category['term_id'], 'product_cat' );
 	}
+
+	public function test_wc_dropdown_variation_attribute_options_no_attributes() {
+		$this->expectOutputString( '<select id="" class="" name="attribute_" data-attribute_name="attribute_" data-show_option_none="yes"><option value="">Choose an option</option></select>' );
+
+		wc_dropdown_variation_attribute_options();
+	}
+
+	public function test_wc_dropdown_variation_attribute_options_should_return_attributes_list() {
+		$product = WC_Helper_Product::create_variation_product();
+
+		$this->expectOutputString( '<select id="pa_size" class="" name="attribute_pa_size" data-attribute_name="attribute_pa_size" data-show_option_none="yes"><option value="">Choose an option</option><option value="large" >large</option><option value="small" >small</option></select>' );
+
+		wc_dropdown_variation_attribute_options(
+			array(
+				'product' => $product,
+				'attribute' => 'pa_size',
+			)
+		);
+	}
+
+	public function test_wc_dropdown_variation_attribute_options_should_return_attributes_list_and_selected_element() {
+		$product = WC_Helper_Product::create_variation_product();
+		$_REQUEST['attribute_pa_size'] = 'large';
+
+		$this->expectOutputString( '<select id="pa_size" class="" name="attribute_pa_size" data-attribute_name="attribute_pa_size" data-show_option_none="yes"><option value="">Choose an option</option><option value="large"  selected=\'selected\'>large</option><option value="small" >small</option></select>' );
+
+		wc_dropdown_variation_attribute_options(
+			array(
+				'product' => $product,
+				'attribute' => 'pa_size',
+			)
+		);
+
+		unset( $_REQUEST['attribute_pa_size'] );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes an unnecessary call to `urldecode()` that was causing the issue described in #21542. This call was added in commit 45d6c55f2ac7c4786442d1d15e2e21eb6c1fff22 as part of PR 20293. It also includes some very basic unit tests to verify the behavior of the modified function.

`urldecode()` is not necessary on the context that it was being used as PHP already decodes $_REQUEST (see section "Notes" in http://php.net/urldecode).

Closes #21542 

### How to test the changes in this Pull Request:

1. See #21542 for instructions on how to test this PR.

### Changelog

> Fix: Posted variation attribute values not recognized if "+" present