### PR TITLE
Simplified path check for CSV importer to cause less issues

### DIFF
--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -91,7 +91,7 @@ class WC_Product_CSV_Importer_Controller {
 	 * @return bool
 	 */
 	public static function is_file_valid_csv( $file, $check_path = true ) {
-		if ( $check_path && apply_filters( 'woocommerce_product_csv_importer_check_import_file_path', true ) && 0 !== stripos( $file, ABSPATH ) ) {
+		if ( $check_path && apply_filters( 'woocommerce_product_csv_importer_check_import_file_path', true ) && false !== stripos( $file, '://' ) ) {
 			return false;
 		}
 

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -27,16 +27,6 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 		$bootstrap = WC_Unit_Tests_Bootstrap::instance();
 		require_once $bootstrap->plugin_dir . '/includes/import/class-wc-product-csv-importer.php';
 		require_once $bootstrap->plugin_dir . '/includes/admin/importers/class-wc-product-csv-importer-controller.php';
-
-		add_filter( 'woocommerce_product_csv_importer_check_import_file_path', '__return_false' );
-	}
-
-	/**
-	 * Remove filters.
-	 */
-	public function tearDown() {
-		parent::tearDown();
-		remove_filter( 'woocommerce_product_csv_importer_check_import_file_path', '__return_false' );
 	}
 
 	/**
@@ -623,5 +613,15 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 		}
 
 		return $mocked_response;
+	}
+
+	/**
+	 * Test WC_Product_CSV_Importer_Controller::is_file_valid_csv.
+	 */
+	public function test_is_file_valid_csv() {
+		$this->assertTrue( WC_Product_CSV_Importer_Controller::is_file_valid_csv( 'C:/wamp64/www/test.local/wp-content/uploads/2018/10/products_all_gg-1.csv' ) );
+		$this->assertTrue( WC_Product_CSV_Importer_Controller::is_file_valid_csv( '/srv/www/woodev/wp-content/uploads/2018/10/1098488_single.csv' ) );
+		$this->assertFalse( WC_Product_CSV_Importer_Controller::is_file_valid_csv( '/srv/www/woodev/wp-content/uploads/2018/10/img.jpg' ) );
+		$this->assertFalse( WC_Product_CSV_Importer_Controller::is_file_valid_csv( 'file:///srv/www/woodev/wp-content/uploads/2018/10/1098488_single.csv' ) );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21548 .

The check for ABSPATH worked well on linux environments but not on Windows environments or many types of server setups that don't have the file uploads somewhere in ABSPATH. This change simplifies the check and just checks for the existence of a protocol. This should allow uploads located anywhere in the server's filesystem and prevent uploads from outside the server or with a PHP protocol. (See unit tests)

### How to test the changes in this Pull Request:

1. Upload valid CSV and verify it works.
2. Try and force WC to accept an invalid CSV by modifying the hidden `file` variable on the importer mappings screen. Observe it fails.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Only check for protocols instead of full path in the CSV importer to prevent invalid CSV false positives.
