### PR TITLE
Dont kses cart thumbnails

### DIFF
--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -64,9 +64,9 @@ do_action( 'woocommerce_before_cart' ); ?>
 						$thumbnail = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
 
 						if ( ! $product_permalink ) {
-							echo wp_kses_post( $thumbnail );
+							echo $thumbnail; // PHPCS: XSS ok.
 						} else {
-							printf( '<a href="%s">%s</a>', esc_url( $product_permalink ), wp_kses_post( $thumbnail ) );
+							printf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $thumbnail ); // PHPCS: XSS ok.
 						}
 						?>
 						</td>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21505.

This change removes the calls to `wp_kses_post` when rendering cart images. The calls are not necessary since WP has already sanitized the images. This changes the behavior to [match the mini-cart](https://github.com/woocommerce/woocommerce/blob/master/templates/cart/mini-cart.php#L54-L57).

### How to test the changes in this Pull Request:

1. Examine cart images before the patch. Observe srscet is missing:
<img width="1314" alt="screen shot 2018-10-15 at 2 10 37 pm" src="https://user-images.githubusercontent.com/7317227/46978973-1c5ec200-d085-11e8-9b68-9160536527f1.png">

2. Examine cart images after the patch. Observe srscet is present:
<img width="1315" alt="screen shot 2018-10-15 at 2 11 18 pm" src="https://user-images.githubusercontent.com/7317227/46978975-1e288580-d085-11e8-948b-5a6f489329f6.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Don't double-sanitize cart images.