### PR TITLE
Validate multisite super admins before filtering editable roles & mapping capabilities

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -403,6 +403,9 @@ add_filter( 'editable_roles', 'wc_modify_editable_roles' );
  * @return array
  */
 function wc_modify_map_meta_cap( $caps, $cap, $user_id, $args ) {
+	if ( is_multisite() && is_super_admin() ) {
+		return $caps;
+	}
 	switch ( $cap ) {
 		case 'edit_user':
 		case 'remove_user':

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -420,10 +420,8 @@ function wc_modify_map_meta_cap( $caps, $cap, $user_id, $args ) {
 				if ( ! wc_current_user_has_role( 'administrator' ) ) {
 					if ( wc_user_has_role( $args[0], 'administrator' ) ) {
 						$caps[] = 'do_not_allow';
-					}
-
-					// Shop managers can only edit customer info.
-					if ( wc_current_user_has_role( 'shop_manager' ) ) {
+					} elseif ( wc_current_user_has_role( 'shop_manager' ) ) {
+						// Shop managers can only edit customer info.
 						$userdata = get_userdata( $args[0] );
 						$shop_manager_editable_roles = apply_filters( 'woocommerce_shop_manager_editable_roles', array( 'customer' ) );
 						if ( property_exists( $userdata, 'roles' ) && ! empty( $userdata->roles ) && ! array_intersect( $userdata->roles, $shop_manager_editable_roles ) ) {

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -378,6 +378,9 @@ add_filter( 'user_has_cap', 'wc_customer_has_capability', 10, 3 );
  * @return array
  */
 function wc_modify_editable_roles( $roles ) {
+	if ( is_multisite() && is_super_admin() ) {
+		return $roles;
+	}
 	if ( ! wc_current_user_has_role( 'administrator' ) ) {
 		unset( $roles['administrator'] );
 


### PR DESCRIPTION
PR relates to discussion in #21569 

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

For network super admins these filters should not apply.
Just `is_super_admin()` isn't enough since this function returns true on single site installations when users have the `delete_users` capability and that still needs to be filtered for other roles than administrators. That is why it first checks `is_multisite()` and then `is_super_admin()`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

See #21569 
