### PR TITLE
Alternative to #21525. Launching plugin on plugins_loaded 

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -113,6 +113,8 @@ final class WooCommerce {
 	public static function instance() {
 		if ( is_null( self::$_instance ) ) {
 			self::$_instance = new self();
+			// Global for backwards compatibility.
+			$GLOBALS['woocommerce'] = self::$_instance;
 		}
 		return self::$_instance;
 	}

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -38,5 +38,6 @@ function wc() {
 	return WooCommerce::instance();
 }
 
-// Global for backwards compatibility.
-$GLOBALS['woocommerce'] = wc();
+// Launch the plugin.
+add_action( 'plugins_loaded', 'wc', 0 );
+


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Per @kloon suggestion [here](https://github.com/woocommerce/woocommerce/issues/21524#issuecomment-429222206). Launching WooCommerce on `plugins_loaded` causes `woocommerce_loaded` hook to fire consistently, in which case it no longer needs to be deprecated.

Closes #21524.

### How to test the changes in this Pull Request:

1. Add the following `zzz-woocommerce-extension.php plugin` to `wp-content/plugins/zzz-woocommerce-extension/zzz-woocommerce-extension.php` :
```
<?php
/*
 * Plugin Name: ZZZ WooCommerce Extension
 * Description: WooCommerce extension activation test.
 * Version: 1.0
 * Author: Kathy Darling
 * Author URI: http://kathyisawesome.com
 *
 * License: GNU General Public License v3.0
 * License URI: http://www.gnu.org/licenses/gpl-3.0.html
 *
 */

/**
 * Should only run if WooCommerce is active.
 */
function zzz_test_new_hook() {
    if( defined( 'WC_VERSION' ) ) {
        error_log( 'WooCommerce is active and the version is ' . WC_VERSION . ' and this hook is ' . current_action() );
    } else {
        error_log( 'WooCommerce is NOT active and this hook is ' . current_action() );
    }
}
add_action( 'woocommerce_loaded', 'zzz_test_new_hook' );
```
2. Enable WP_DEBUG_LOG.
3. Activate the plugin, for a sub-site in a network.
4. Check the error log, which should show the error log, whereas before this change it would not show _anything_

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Launch plugin on plugins_loaded hook to make woocommerce_loaded hook fire consistently.
