### PR TITLE
Add PHP 7.3 to the Travis build matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,13 @@ matrix:
   - php: 7.3
 
 before_script:
-  - phpenv config-rm xdebug.ini
+  - |
+    # Remove Xdebug for a huge performance increase:
+    if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
+      phpenv config-rm xdebug.ini
+    else
+      echo "xdebug.ini does not exist"
+    fi
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION
   - bash tests/bin/travis.sh before

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ php:
   - 5.6
   - 7.0
   - 7.1
+  - 7.3
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
@@ -32,6 +33,7 @@ matrix:
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   allow_failures:
   - env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
+  - php: 7.3
 
 before_script:
   - phpenv config-rm xdebug.ini


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds PHP 7.3 to the Travis build matrix. For now, I'm adding this build to the list of builds that can fail as there are several tests failing due to changes in the new version of the language (mostly warnings when `continue` is used inside a switch statement or when an undefined variable is passed to `compact()`. Next, we need to start fixing the failing tests. PHP 7.3 is scheduled for December 13th.

To make this new Travis build work, I had to add a conditional check to the command that removes `xdebug.ini` as this file doesn't yet exist in the PHP 7.3 Travis build.

### How to test the changes in this Pull Request:

1. Check Travis to make sure all the builds were executed successfully, except the PHP 7.3 which should run but fail.