### PR TITLE
[REST API] Fixed schema for product's downloads

### DIFF
--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -514,10 +514,9 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 						'type'       => 'object',
 						'properties' => array(
 							'id'   => array(
-								'description' => __( 'File MD5 hash.', 'woocommerce' ),
+								'description' => __( 'File ID.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
 							),
 							'name' => array(
 								'description' => __( 'File name.', 'woocommerce' ),

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -862,10 +862,9 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 						'type'       => 'object',
 						'properties' => array(
 							'id'   => array(
-								'description' => __( 'File MD5 hash.', 'woocommerce' ),
+								'description' => __( 'File ID.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
 							),
 							'name' => array(
 								'description' => __( 'File name.', 'woocommerce' ),

--- a/includes/api/v1/class-wc-rest-products-controller.php
+++ b/includes/api/v1/class-wc-rest-products-controller.php
@@ -1882,10 +1882,9 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 						'type'       => 'object',
 						'properties' => array(
 							'id' => array(
-								'description' => __( 'File MD5 hash.', 'woocommerce' ),
+								'description' => __( 'File ID.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
 							),
 							'name' => array(
 								'description' => __( 'File name.', 'woocommerce' ),
@@ -2360,10 +2359,9 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 									'type'       => 'object',
 									'properties' => array(
 										'id' => array(
-											'description' => __( 'File MD5 hash.', 'woocommerce' ),
+											'description' => __( 'File ID.', 'woocommerce' ),
 											'type'        => 'string',
 											'context'     => array( 'view', 'edit' ),
-											'readonly'    => true,
 										),
 										'name' => array(
 											'description' => __( 'File name.', 'woocommerce' ),

--- a/includes/api/v2/class-wc-rest-product-variations-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-variations-v2-controller.php
@@ -762,10 +762,9 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 						'type'       => 'object',
 						'properties' => array(
 							'id'   => array(
-								'description' => __( 'File MD5 hash.', 'woocommerce' ),
+								'description' => __( 'File ID.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
 							),
 							'name' => array(
 								'description' => __( 'File name.', 'woocommerce' ),

--- a/includes/api/v2/class-wc-rest-products-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-products-v2-controller.php
@@ -1606,10 +1606,9 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 						'type'       => 'object',
 						'properties' => array(
 							'id'   => array(
-								'description' => __( 'File MD5 hash.', 'woocommerce' ),
+								'description' => __( 'File ID.', 'woocommerce' ),
 								'type'        => 'string',
 								'context'     => array( 'view', 'edit' ),
-								'readonly'    => true,
 							),
 							'name' => array(
 								'description' => __( 'File name.', 'woocommerce' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Download ID are generated with wp_generate_uuid4() for while now.
Also we allow users to manipulate it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->