### PR TITLE
Ensure wp_list_pluck() gets a array and not possibly null

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -744,7 +744,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 						continue;
 
 					} elseif ( $attribute->is_taxonomy() ) {
-						wp_set_object_terms( $product->get_id(), wp_list_pluck( $attribute->get_terms(), 'term_id' ), $attribute->get_name() );
+						wp_set_object_terms( $product->get_id(), wp_list_pluck( (array) $attribute->get_terms(), 'term_id' ), $attribute->get_name() );
 					} else {
 						$value = wc_implode_text_attributes( $attribute->get_options() );
 					}


### PR DESCRIPTION
`WC_Product_Attribute::get_terms()` has the possibility of returning null even when is is checked as `is_taxonomy()`. 

Just a additional cast to ensure an array is provided to `wp_list_pluck()`.

The following error could be displayed in such exception case;
```
PHP Warning:  Invalid argument supplied for foreach() in /public_html/wp-includes/class-wp-list-util.php on line 148
PHP Stack trace:
PHP   1. {main}() /public_html/index.php:0
PHP   2. require() /public_html/index.php:17
PHP   3. wp() /public_html/wp-blog-header.php:16
PHP   4. WP->main() /public_html/wp-includes/functions.php:960
PHP   5. WP->parse_request() /public_html/wp-includes/class-wp.php:713
PHP   6. do_action_ref_array() /public_html/wp-includes/class-wp.php:373
PHP   7. WP_Hook->do_action() /public_html/wp-includes/plugin.php:515
PHP   8. WP_Hook->apply_filters() /public_html/wp-includes/class-wp-hook.php:310
PHP   9. rest_api_loaded() /public_html/wp-includes/class-wp-hook.php:286
PHP  10. WP_REST_Server->serve_request() /public_html/wp-includes/rest-api.php:266
PHP  11. WP_REST_Server->dispatch() /public_html/wp-includes/rest-api/class-wp-rest-server.php:321
PHP  12. WC_REST_Products_Controller->update_item() /public_html/wp-includes/rest-api/class-wp-rest-server.php:936
PHP  13. WC_REST_Products_Controller->save_object() /public_html/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-rest-crud-controller.php:238
PHP  14. WC_Product_Variable->save() /public_html/wp-content/plugins/woocommerce/includes/abstracts/abstract-wc-rest-crud-controller.php:169
PHP  15. WC_Data_Store->update() /public_html/wp-content/plugins/woocommerce/includes/class-wc-product-variable.php:445
PHP  16. WC_Product_Variable_Data_Store_CPT->update() /public_html/wp-content/plugins/woocommerce/includes/class-wc-data-store.php:176
PHP  17. WC_Product_Variable_Data_Store_CPT->update_attributes() /public_html/wp-content/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php:242
PHP  18. wp_list_pluck() /public_html/wp-content/plugins/woocommerce/includes/data-stores/class-wc-product-data-store-cpt.php:744
PHP  19. WP_List_Util->pluck() /public_html/wp-includes/functions.php:3662
```