### PR TITLE
[REST API] Fixed duplicated entry in orders notes schema

### DIFF
--- a/includes/api/class-wc-rest-order-notes-controller.php
+++ b/includes/api/class-wc-rest-order-notes-controller.php
@@ -136,12 +136,6 @@ class WC_REST_Order_Notes_Controller extends WC_REST_Order_Notes_V2_Controller {
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'date_created'     => array(
-					'description' => __( "The date the order note was created, in the site's timezone.", 'woocommerce' ),
-					'type'        => 'date-time',
-					'context'     => array( 'view', 'edit' ),
-					'readonly'    => true,
-				),
 				'date_created_gmt' => array(
 					'description' => __( 'The date the order note was created, as GMT.', 'woocommerce' ),
 					'type'        => 'date-time',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Just fixing a duplicated item in schema.

### How to test the changes in this Pull Request:

1. OPTIONS /wp-json/wc/v3/orders/1/notes

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

