### PR TITLE
[REST API] Fixed schema for refunded_payment in order refunds endpoint

### DIFF
--- a/includes/api/v2/class-wc-rest-order-refunds-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-order-refunds-v2-controller.php
@@ -388,6 +388,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 					'description' => __( 'If the payment was refunded via the API.', 'woocommerce' ),
 					'type'        => 'boolean',
 					'context'     => array( 'view' ),
+					'readonly'    => true,
 				),
 				'meta_data'        => array(
 					'description' => __( 'Meta data.', 'woocommerce' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

`refunded_payment` is "read only".

### How to test the changes in this Pull Request:

1. OPTIONS /wp-json/wc/v3/orders/1/refunds

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->
