### PR TITLE
[REST API] Ability to query orders from trash bin

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -217,12 +217,15 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 		$args['post_status'] = array();
 		foreach ( $statuses as $status ) {
-			if ( 'any' === $status ) {
+			if ( in_array( $status, $this->get_order_statuses(), true ) ) {
+				$args['post_status'][] = 'wc-' . $status;
+			} elseif ( 'any' === $status ) {
 				// Set status to "any" and short-circuit out.
 				$args['post_status'] = 'any';
 				break;
+			} else {
+				$args['post_status'][] = $status;
 			}
-			$args['post_status'][] = 'wc-' . $status;
 		}
 
 		return $args;
@@ -255,7 +258,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'string',
-				'enum' => array_merge( array( 'any' ), $this->get_order_statuses() ),
+				'enum' => array_merge( array( 'any', 'trash' ), $this->get_order_statuses() ),
 			),
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/api/v2/class-wc-rest-orders-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-orders-v2-controller.php
@@ -358,10 +358,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 		$args = parent::prepare_objects_query( $request );
 
 		// Set post_status.
-		if ( 'any' !== $request['status'] ) {
+		if ( in_array( $request['status'], $this->get_order_statuses(), true ) ) {
 			$args['post_status'] = 'wc-' . $request['status'];
-		} else {
+		} elseif ( 'any' === $request['status'] ) {
 			$args['post_status'] = 'any';
+		} else {
+			$args['post_status'] = $request['status'];
 		}
 
 		if ( isset( $request['customer'] ) ) {
@@ -1674,7 +1676,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 			'default'           => 'any',
 			'description'       => __( 'Limit result set to orders assigned a specific status.', 'woocommerce' ),
 			'type'              => 'string',
-			'enum'              => array_merge( array( 'any' ), $this->get_order_statuses() ),
+			'enum'              => array_merge( array( 'any', 'trash' ), $this->get_order_statuses() ),
 			'sanitize_callback' => 'sanitize_key',
 			'validate_callback' => 'rest_validate_request_arg',
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allow query orders from the trash bin.

This is not really a new feature, since we already allow query by individual orders like `/wp-json/wc/v3/orders/<TRASHED_ORDER_ID>`, but now allow use the `status` filter.

### How to test the changes in this Pull Request:

1. GET /wp-json/wc/v3/orders?status=trash

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - REST API - Ability to query trashed orders.
