### PR TITLE
[REST API] Fixed schema stock_status on products endpoints

### DIFF
--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -567,8 +567,9 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 					'context'     => array( 'view', 'edit' ),
 				),
 				'stock_status'          => array(
-					'description' => __( 'Controls the stock status of the product: "instock", "outofstock" or "onbackorder".', 'woocommerce' ),
+					'description' => __( 'Controls the stock status of the product.', 'woocommerce' ),
 					'type'        => 'string',
+					'default'     => 'instock',
 					'enum'        => array_keys( wc_get_product_stock_status_options() ),
 					'context'     => array( 'view', 'edit' ),
 				),

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -926,8 +926,9 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 					'context'     => array( 'view', 'edit' ),
 				),
 				'stock_status'          => array(
-					'description' => __( 'Controls the stock status of the product: "instock", "outofstock" or "onbackorder".', 'woocommerce' ),
+					'description' => __( 'Controls the stock status of the product.', 'woocommerce' ),
 					'type'        => 'string',
+					'default'     => 'instock',
 					'enum'        => array_keys( wc_get_product_stock_status_options() ),
 					'context'     => array( 'view', 'edit' ),
 				),

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -1330,7 +1330,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		$data = parent::get_product_data( $product, $context );
 
 		// Replace in_stock with stock_status.
-		$pos  = array_search( 'in_stock', array_keys( $data ) );
+		$pos             = array_search( 'in_stock', array_keys( $data ), true );
 		$array_section_1 = array_slice( $data, 0, $pos, true );
 		$array_section_2 = array_slice( $data, $pos + 1, null, true );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

`stock_status` is by default `instock`, also improving the description, since we already list all available options using `enum`.

### How to test the changes in this Pull Request:

1. OPTIONS `/wp-json/wc/v3/products`
2. OPTIONS `/wp-json/wc/v3/products/<VARIABLE_PRODUCT_ID>/variations`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
