### PR TITLE
 Change wp_woocommerce_sessions before dbDelta() is called

### DIFF
--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2004,11 +2004,11 @@ function wc_update_350_change_woocommerce_sessions_schema() {
 		FROM information_schema.TABLE_CONSTRAINTS
 		WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
 		AND CONSTRAINT_TYPE = 'UNIQUE'
-		AND CONSTRAINT_NAME = 'session_key'
+		AND CONSTRAINT_NAME = 'session_id'
 		AND TABLE_NAME = '{$wpdb->prefix}woocommerce_sessions'
 	" );
 
-	if ( ! $results ) {
+	if ( $results ) {
 		$wpdb->query(
 			"ALTER TABLE `{$wpdb->prefix}woocommerce_sessions` DROP KEY `session_id`, ADD UNIQUE KEY(`session_key`)"
 		);

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1999,20 +1999,9 @@ function wc_update_350_reviews_comment_type() {
 function wc_update_350_change_woocommerce_sessions_schema() {
 	global $wpdb;
 
-	$results = $wpdb->get_results( "
-		SELECT CONSTRAINT_NAME
-		FROM information_schema.TABLE_CONSTRAINTS
-		WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
-		AND CONSTRAINT_TYPE = 'UNIQUE'
-		AND CONSTRAINT_NAME = 'session_id'
-		AND TABLE_NAME = '{$wpdb->prefix}woocommerce_sessions'
-	" );
-
-	if ( $results ) {
-		$wpdb->query(
-			"ALTER TABLE `{$wpdb->prefix}woocommerce_sessions` DROP KEY `session_id`, ADD UNIQUE KEY(`session_key`)"
-		);
-	}
+	$wpdb->query(
+		"ALTER TABLE `{$wpdb->prefix}woocommerce_sessions` DROP PRIMARY KEY, DROP KEY `session_id`, ADD PRIMARY KEY(`session_id`), ADD UNIQUE KEY(`session_key`)"
+	);
 }
 
 /**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1987,24 +1987,6 @@ function wc_update_350_reviews_comment_type() {
 }
 
 /**
- * Change wp_woocommerce_sessions schema to use a bigint auto increment field
- * instead of char(32) field as the primary key. Doing this change primarily as
- * it should reduce the occurrence of deadlocks (see
- * https://github.com/woocommerce/woocommerce/issues/20912), but also because
- * it is not a good practice to use a char(32) field as the primary key of a
- * table.
- *
- * @return void
- */
-function wc_update_350_change_woocommerce_sessions_schema() {
-	global $wpdb;
-
-	$wpdb->query(
-		"ALTER TABLE `{$wpdb->prefix}woocommerce_sessions` DROP PRIMARY KEY, DROP KEY `session_id`, ADD PRIMARY KEY(`session_id`), ADD UNIQUE KEY(`session_key`)"
-	);
-}
-
-/**
  * Update DB Version.
  */
 function wc_update_350_db_version() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

On PR #21245, I added a db update routine to change wp_woocommerce_sessions primary key from session_key char(32) to session_id bigint auto_increment as dbDelta() is unable to handle primary key changes (see https://core.trac.wordpress.org/ticket/40357). But I didn't realize that dbDelta() was actually trying to add a new primary key to the table without dropping the old key first, and this was generating the following error:

```
WordPress database error Multiple primary key defined for query ALTER TABLE wp_woocommerce_sessions ADD PRIMARY KEY  (`session_id`)
```

To prevent this error from happening, this PR moves the query that changes the primary key from db update routine to WC_Install::create_tables() so that it runs before dbDelta() is called. It also reverts the commits added in #21561 as they didn't produce the desired effect (see comments starting from https://github.com/woocommerce/woocommerce/issues/21534#issuecomment-429956490).

Closes #21534 

### How to test the changes in this Pull Request:

1. Make sure your store is running a WC database <= 3.4.6 (check the value of the wp_options `woocommerce_version` and `woocommerce_db_version`) and WC codebase <= 3.4.6.
2. Switch the codebase to `master`
3. Visit a WP admin page to trigger a call to WC_Install::create_tables() and then run the database update routine
4. Check that there are no errors on debug.log and the resulting `wp_woocommerce_sessions` schema is equal to the following (`session_id` should be the primary key and `session_key` a regular unique index):

```
desc wp_woocommerce_sessions;
+----------------+---------------------+------+-----+---------+----------------+
| Field          | Type                | Null | Key | Default | Extra          |
+----------------+---------------------+------+-----+---------+----------------+
| session_id     | bigint(20) unsigned | NO   | PRI | NULL    | auto_increment |
| session_key    | char(32)            | NO   | UNI | NULL    |                |
| session_value  | longtext            | NO   |     | NULL    |                |
| session_expiry | bigint(20) unsigned | NO   |     | NULL    |                |
+----------------+---------------------+------+-----+---------+----------------+
4 rows in set (0.00 sec)
```