### PR TITLE
Revert "Delete old ISSUE_TEMPLATE.md"

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,48 @@
+<!-- This form is for reporting bugs and issues specific to the WooCommerce plugin. This is not a support portal. If you need technical support from a human being, please submit a ticket via the helpdesk instead: https://woocommerce.com/contact-us/ -->
+
+<!-- Usage questions can also be directed to the public support forum here: https://wordpress.org/support/plugin/woocommerce, unless this is a question about a premium extension in which case you should use the helpdesk. -->
+
+<!-- If you have a feature request, submit it to: http://ideas.woocommerce.com/forums/133476-woocommerce -->
+
+<!-- If you are a developer who needs a new filter/hook raise a PR instead :) -->
+
+<!-- Please be as descriptive as possible; issues lacking the below details, or for any other reason than to report a bug, may be closed without action. -->
+
+## Prerequisites
+
+<!-- MARK COMPLETED ITEMS WITH AN [x] -->
+
+- [ ] I have searched for similar issues in both open and closed tickets and cannot find a duplicate
+- [ ] The issue still exists against the latest `master` branch of WooCommerce on Github (this is **not** the same version as on WordPress.org!)
+- [ ] I have attempted to find the simplest possible steps to reproduce the issue
+- [ ] I have included a failing test as a pull request (Optional)
+
+## Steps to reproduce the issue
+
+<!-- We need to be able to reproduce the bug in order to fix it so please be descriptive! -->
+
+1.
+2.
+3.
+
+## Expected/actual behavior
+
+When I follow those steps, I see...
+
+I was expecting to see...
+
+## Isolating the problem
+
+<!-- MARK COMPLETED ITEMS WITH AN [x] -->
+
+- [ ] This bug happens with only WooCommerce plugin active
+- [ ] This bug happens with a default WordPress theme active, or [Storefront](https://woocommerce.com/storefront/)
+- [ ] I can reproduce this bug consistently using the steps above
+
+## WordPress Environment
+
+<details>
+```
+Copy and paste the system status report from **WooCommerce > System Status** in WordPress admin here.
+```
+</details>


### PR DESCRIPTION
Reverts woocommerce/woocommerce#21468

After #21468 was merged, we saw an increase in the number of issues being created without a template. This happened because in several places we point people directly to https://github.com/woocommerce/woocommerce/issues/new instead of https://github.com/woocommerce/woocommerce/issues/new/choose. The first link uses the ISSUE_TEMPLATE.md template so let's keep this file until we figure out a better way to handle this.

cc @claudiosanches @AiratHalitov 