### PR TITLE
Fix: WC_Product::get_image() should use $attr parameter

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1822,10 +1822,10 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 */
 	public function get_image( $size = 'woocommerce_thumbnail', $attr = array(), $placeholder = true ) {
 		if ( $this->get_image_id() ) {
-			$image = wp_get_attachment_image( $this->get_image_id(), $size );
+			$image = wp_get_attachment_image( $this->get_image_id(), $size, false, $attr );
 		} elseif ( $this->get_parent_id() ) {
 			$parent_product = wc_get_product( $this->get_parent_id() );
-			$image          = $parent_product->get_image();
+			$image          = $parent_product->get_image( $size, $attr, $placeholder );
 		} elseif ( $placeholder ) {
 			$image = wc_placeholder_img( $size );
 		} else {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes an issue that was introduced when WC_Product::get_image() was refactored in 64b589f, and that was making this method ignore what was passed in the $attr parameter. It also includes unit tests for the WC_Product::get_image() to protect against problems like this one in the future.

Closes #21578.

### How to test the changes in this Pull Request:

1. Check the string returned by WC_Product::get_image() before and after the changes proposed in this PR. Nothing should change when this method is called without any parameters or when `$size` and/or `$placeholder` are passed.
2. Check the string returned by WC_Product::get_image() when `$attr` is used, for example, to set a custom class. Before this change, the custom class will be ignored, and after this change, it should override all the other classes. Code example:

```
$product->get_image( 'woocommerce_thumbnail', array( 'class' => 'custom-class' ) )
```

cc @ktmn in case you are available to test if this PR fixes the issue for you

