### PR TITLE
Use $product->get_image_id() instead of has_post_thumbnail()

### DIFF
--- a/includes/api/class-wc-rest-product-variations-controller.php
+++ b/includes/api/class-wc-rest-product-variations-controller.php
@@ -314,7 +314,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	 * @return array
 	 */
 	protected function get_image( $variation ) {
-		if ( ! has_post_thumbnail( $variation->get_id() ) ) {
+		if ( ! $variation->get_image_id() ) {
 			return;
 		}
 

--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -36,7 +36,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		$attachment_ids = array();
 
 		// Add featured image.
-		if ( has_post_thumbnail( $product->get_id() ) ) {
+		if ( $product->get_image_id() ) {
 			$attachment_ids[] = $product->get_image_id();
 		}
 

--- a/includes/api/v1/class-wc-rest-products-controller.php
+++ b/includes/api/v1/class-wc-rest-products-controller.php
@@ -273,7 +273,7 @@ class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {
 		$attachment_ids = array();
 
 		// Add featured image.
-		if ( has_post_thumbnail( $product->get_id() ) ) {
+		if ( $product->get_image_id() ) {
 			$attachment_ids[] = $product->get_image_id();
 		}
 

--- a/includes/api/v2/class-wc-rest-products-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-products-v2-controller.php
@@ -367,7 +367,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 		$attachment_ids = array();
 
 		// Add featured image.
-		if ( has_post_thumbnail( $product->get_id() ) ) {
+		if ( $product->get_image_id() ) {
 			$attachment_ids[] = $product->get_image_id();
 		}
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -603,7 +603,7 @@ function wc_get_product_class( $class = '', $product_id = null ) {
 	}
 
 	// Post thumbnails.
-	if ( current_theme_supports( 'post-thumbnails' ) && has_post_thumbnail( $post->ID ) && ! is_attachment( $post ) && ! $post_password_required ) {
+	if ( current_theme_supports( 'post-thumbnails' ) && $product->get_image_id() && ! is_attachment( $post ) && ! $post_password_required ) {
 		$classes[] = 'has-post-thumbnail';
 	}
 

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.5.0
+ * @version 3.5.1
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -28,7 +28,7 @@ $columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 
 $post_thumbnail_id = $product->get_image_id();
 $wrapper_classes   = apply_filters( 'woocommerce_single_product_image_gallery_classes', array(
 	'woocommerce-product-gallery',
-	'woocommerce-product-gallery--' . ( has_post_thumbnail() ? 'with-images' : 'without-images' ),
+	'woocommerce-product-gallery--' . ( $product->get_image_id() ? 'with-images' : 'without-images' ),
 	'woocommerce-product-gallery--columns-' . absint( $columns ),
 	'images',
 ) );
@@ -36,7 +36,7 @@ $wrapper_classes   = apply_filters( 'woocommerce_single_product_image_gallery_cl
 <div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>" style="opacity: 0; transition: opacity .25s ease-in-out;">
 	<figure class="woocommerce-product-gallery__wrapper">
 		<?php
-		if ( has_post_thumbnail() ) {
+		if ( $product->get_image_id() ) {
 			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
 		} else {
 			$html  = '<div class="woocommerce-product-gallery__image--placeholder">';

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -11,7 +11,6 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @author  WooThemes
  * @package WooCommerce/Templates
  * @version 3.5.0
  */
@@ -38,14 +37,14 @@ $wrapper_classes   = apply_filters( 'woocommerce_single_product_image_gallery_cl
 	<figure class="woocommerce-product-gallery__wrapper">
 		<?php
 		if ( has_post_thumbnail() ) {
-			$html  = wc_get_gallery_image_html( $post_thumbnail_id, true );
+			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
 		} else {
 			$html  = '<div class="woocommerce-product-gallery__image--placeholder">';
 			$html .= sprintf( '<img src="%s" alt="%s" class="wp-post-image" />', esc_url( wc_placeholder_img_src( 'woocommerce_single' ) ), esc_html__( 'Awaiting product image', 'woocommerce' ) );
 			$html .= '</div>';
 		}
 
-		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', $html, $post_thumbnail_id );
+		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', $html, $post_thumbnail_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 
 		do_action( 'woocommerce_product_thumbnails' );
 		?>

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -10,9 +10,8 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @author 		WooThemes
- * @package 	WooCommerce/Templates
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @package     WooCommerce/Templates
  * @version     3.3.2
  */
 
@@ -29,6 +28,6 @@ $attachment_ids = $product->get_gallery_image_ids();
 
 if ( $attachment_ids && has_post_thumbnail() ) {
 	foreach ( $attachment_ids as $attachment_id ) {
-		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id  ), $attachment_id );
+		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id ), $attachment_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 	}
 }

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce/Templates
- * @version     3.3.2
+ * @version     3.5.1
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -26,7 +26,7 @@ global $product;
 
 $attachment_ids = $product->get_gallery_image_ids();
 
-if ( $attachment_ids && has_post_thumbnail() ) {
+if ( $attachment_ids && $product->get_image_id() ) {
 	foreach ( $attachment_ids as $attachment_id ) {
 		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id ), $attachment_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR replaces all instances where has_post_thumbnail() was used with $product->get_image_id(). This is a continuation of 64b589f and is needed to support the custom product tables plugin as has_post_thumbnail() relies on a post meta.

This PR also includes a separate commit to fix PHPCS violations in the modified files.

Closes https://github.com/woocommerce/woocommerce-product-tables-feature-plugin/issues/124

### How to test the changes in this Pull Request:

This PR changes two product single templates, one product related function and a WC API method in three different versions of the API. So it is necessary to test product images in the following contexts (it is a good idea to test a product with an image and another one without an image):

1. Get a product using v1, v2 and v3 of the WC API and check what is returned related to images.
2. Open product single page and check that the featured image and any other product images are displayed and that the page has the class `has-post-thumbnail` if the product has at least one image.

### Changelog entry

> Use $product->get_image_id() instead of has_post_thumbnail() to support the custom product tables plugin
