### PR TITLE
[REST API] Fixes and improvements to product reviews schema and params

### DIFF
--- a/includes/api/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/class-wc-rest-product-reviews-controller.php
@@ -926,26 +926,6 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 			'type'        => 'string',
 			'format'      => 'date-time',
 		);
-		$params['reviewer']         = array(
-			'description' => __( 'Limit result set to reviews assigned to specific user IDs.', 'woocommerce' ),
-			'type'        => 'array',
-			'items'       => array(
-				'type' => 'integer',
-			),
-		);
-		$params['reviewer_exclude'] = array(
-			'description' => __( 'Ensure result set excludes reviews assigned to specific user IDs.', 'woocommerce' ),
-			'type'        => 'array',
-			'items'       => array(
-				'type' => 'integer',
-			),
-		);
-		$params['reviewer_email']   = array(
-			'default'     => null,
-			'description' => __( 'Limit result set to that from a specific author email.', 'woocommerce' ),
-			'format'      => 'email',
-			'type'        => 'string',
-		);
 		$params['before']           = array(
 			'description' => __( 'Limit response to reviews published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'        => 'string',
@@ -991,6 +971,26 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 				'include',
 				'product',
 			),
+		);
+		$params['reviewer']         = array(
+			'description' => __( 'Limit result set to reviews assigned to specific user IDs.', 'woocommerce' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'integer',
+			),
+		);
+		$params['reviewer_exclude'] = array(
+			'description' => __( 'Ensure result set excludes reviews assigned to specific user IDs.', 'woocommerce' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'integer',
+			),
+		);
+		$params['reviewer_email']   = array(
+			'default'     => null,
+			'description' => __( 'Limit result set to that from a specific author email.', 'woocommerce' ),
+			'format'      => 'email',
+			'type'        => 'string',
 		);
 		$params['product']          = array(
 			'default'     => array(),

--- a/includes/api/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/class-wc-rest-product-reviews-controller.php
@@ -743,7 +743,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		}
 
 		if ( isset( $request['review'] ) ) {
-			$prepared_review['comment_content'] = wp_filter_post_kses( $request['review'] );
+			$prepared_review['comment_content'] = $request['review'];
 		}
 
 		if ( isset( $request['product_id'] ) ) {
@@ -865,12 +865,16 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 				'reviewer_email'   => array(
 					'description' => __( 'Reviewer email.', 'woocommerce' ),
 					'type'        => 'string',
+					'format'      => 'email',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'review'           => array(
 					'description' => __( 'The content of the review.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
+					'arg_options' => array(
+						'sanitize_callback' => 'wp_filter_post_kses',
+					),
 				),
 				'rating'           => array(
 					'description' => __( 'Review rating (0 to 5).', 'woocommerce' ),

--- a/includes/api/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/class-wc-rest-product-reviews-controller.php
@@ -743,7 +743,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		}
 
 		if ( isset( $request['review'] ) ) {
-			$prepared_review['comment_content'] = $request['review'];
+			$prepared_review['comment_content'] = wp_filter_post_kses( $request['review'] );
 		}
 
 		if ( isset( $request['product_id'] ) ) {
@@ -847,11 +847,11 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 				),
 				'product_id'       => array(
 					'description' => __( 'Unique identifier for the product that the review belongs to.', 'woocommerce' ),
-					'type'        => 'string',
+					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'status'           => array(
-					'description' => __( 'Status of the review', 'woocommerce' ),
+					'description' => __( 'Status of the review.', 'woocommerce' ),
 					'type'        => 'string',
 					'default'     => 'approved',
 					'enum'        => array( 'approved', 'hold', 'spam', 'unspam', 'trash', 'untrash' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Just a few tweaks to product reviews schema and collection params.

### How to test the changes in this Pull Request:

1. OPTIONS `/wp-json/wc/v3/products/reviews`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->