### PR TITLE
[REST API] pass missing $filter as parameter in legacy get_order_refund endpoints

### DIFF
--- a/includes/api/legacy/v2/class-wc-api-orders.php
+++ b/includes/api/legacy/v2/class-wc-api-orders.php
@@ -1492,11 +1492,12 @@ class WC_API_Orders extends WC_API_Resource {
 	 *
 	 * @param string $order_id order ID
 	 * @param int $id
-	 * @param string $fields fields to limit response to
+	 * @param string|null $fields fields to limit response to
+	 * @param array $filter
 	 *
 	 * @return array|WP_Error
 	 */
-	public function get_order_refund( $order_id, $id, $fields = null ) {
+	public function get_order_refund( $order_id, $id, $fields = null, $filter = array() ) {
 		try {
 			// Validate order ID
 			$order_id = $this->validate_request( $order_id, $this->post_type, 'read' );

--- a/includes/api/legacy/v3/class-wc-api-orders.php
+++ b/includes/api/legacy/v3/class-wc-api-orders.php
@@ -1538,10 +1538,11 @@ class WC_API_Orders extends WC_API_Resource {
 	 * @param string $order_id order ID
 	 * @param int $id
 	 * @param string|null $fields fields to limit response to
+	 * @param array $filter
 	 *
 	 * @return array|WP_Error
 	 */
-	public function get_order_refund( $order_id, $id, $fields = null ) {
+	public function get_order_refund( $order_id, $id, $fields = null, $filter = array() ) {
 		try {
 			// Validate order ID
 			$order_id = $this->validate_request( $order_id, $this->post_type, 'read' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
