### PR TITLE
Tweaks to unsupported theme handling and hidden preview button handling

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -9,9 +9,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<style type="text/css">
-	#post-preview { display:none }
-</style>
+
+<?php if ( 'publish' === get_post_status() ): ?>
+	<style type="text/css">
+		#post-preview { display:none }
+	</style>
+<?php endif; ?>
 <div class="panel-wrap product_data">
 
 	<span class="type_box hidden"> &mdash;

--- a/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<?php if ( 'publish' === get_post_status() ): ?>
+<?php if ( 'publish' === get_post_status() ) : ?>
 	<style type="text/css">
 		#post-preview { display:none }
 	</style>

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -475,7 +475,7 @@ class WC_Shortcodes {
 		$args = array(
 			'posts_per_page'      => 1,
 			'post_type'           => 'product',
-			'post_status'         => 'publish',
+			'post_status'         => ( ! empty( $atts['status'] ) ) ? $atts['status'] : 'publish',
 			'ignore_sticky_posts' => 1,
 			'no_found_rows'       => 1,
 		);

--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -493,7 +493,7 @@ class WC_Template_Loader {
 		remove_filter( 'the_content', array( __CLASS__, 'unsupported_theme_product_content_filter' ) );
 
 		if ( is_product() ) {
-			$content = do_shortcode( '[product_page id="' . get_the_ID() . '" show_title=0]' );
+			$content = do_shortcode( '[product_page id="' . get_the_ID() . '" show_title=0 status="any"]' );
 		}
 
 		self::$in_content_filter = false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21571 .

This PR introduces 2 changes:
1. Only hide the preview button on published products. In #20650 we changed it so that the preview button is hidden because the "preview changes" feature is not hooked up to a lot of stuff. This made it difficult to preview draft products, and draft product previews *are* hooked up to everything so the change is not needed there.
2. Adds a new `status` field to the `product_page` shortcode for defining supported product statuses. Previously the shortcode only worked on 'publish' status products. 

### How to test the changes in this Pull Request:

1. Use an unsupported theme (e.g. Bassist).
2. Preview a 'draft' status product. Verify it renders correctly in the preview and the preview button is present.
3. Go to a published product and verify the Preview Changes button is not present.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Show draft products in previews on unsupported themes.
