### PR TITLE
Making success and notices output the same as errors

### DIFF
--- a/templates/notices/notice.php
+++ b/templates/notices/notice.php
@@ -15,20 +15,22 @@
  * @version     3.5.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
+if (!defined('ABSPATH')) {
+    exit; // Exit if accessed directly.
 }
 
-if ( ! $messages ) {
-	return;
+if (!$messages) {
+    return;
 }
 
 ?>
 
-<?php foreach ( $messages as $message ) : ?>
-	<div class="woocommerce-info">
-		<?php
-			echo wc_kses_notice( $message );
-		?>
-	</div>
-<?php endforeach; ?>
+	<ul class="woocommerce-info">
+<?php foreach ($messages as $message): ?>
+		<li>
+			<?php
+echo wc_kses_notice($message);
+?>
+		</li>
+<?php endforeach;?>
+	</ul>

--- a/templates/notices/success.php
+++ b/templates/notices/success.php
@@ -15,20 +15,22 @@
  * @version     3.5.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+if (!defined('ABSPATH')) {
+    exit;
 }
 
-if ( ! $messages ) {
-	return;
+if (!$messages) {
+    return;
 }
 
 ?>
 
-<?php foreach ( $messages as $message ) : ?>
-	<div class="woocommerce-message" role="alert">
+	<ul class="woocommerce-message" role="alert">
+<?php foreach ($messages as $message): ?>
+	<li>
 		<?php
-			echo wc_kses_notice( $message );
-		?>
-	</div>
-<?php endforeach; ?>
+echo wc_kses_notice($message);
+?>
+	</li>
+<?php endforeach;?>
+	</ul>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Outputting Success and Notice Notices as unordered lists to match Error Notices. Currently Error Outputs a `<ul>` with nested `<li>`s for the error messages, but notice and success just output `<div>`s.

Leaves the classes intact so styling should still be the same.

### How to test the changes in this Pull Request:

1. Generate Notices of all three types.
2. Output all notices

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Notice and Success Notices output will match Error Output.
