### PR TITLE
Amend `absint` to `esc_html` to allow for negative numbers in menu order

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -169,7 +169,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		/* Custom inline data for woocommerce. */
 		echo '
 			<div class="hidden" id="woocommerce_inline_' . absint( $this->object->get_id() ) . '">
-				<div class="menu_order">' . absint( $this->object->get_menu_order() ) . '</div>
+				<div class="menu_order">' . esc_html( $this->object->get_menu_order() ) . '</div>
 				<div class="sku">' . esc_html( $this->object->get_sku() ) . '</div>
 				<div class="regular_price">' . esc_html( $this->object->get_regular_price() ) . '</div>
 				<div class="sale_price">' . esc_html( $this->object->get_sale_price() ) . '</div>
@@ -511,7 +511,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		if ( isset( $_GET['product_shipping_class'] ) && '0' !== $_GET['product_shipping_class'] ) { // WPCS: input var ok.
 			$replaced_where   = str_replace( ".post_type = 'product'", ".post_type = 'product_variation'", $pieces['where'] );
 			$pieces['where'] .= " OR {$wpdb->posts}.ID in (
-				SELECT {$wpdb->posts}.post_parent FROM 
+				SELECT {$wpdb->posts}.post_parent FROM
 				wp_posts  LEFT JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)
 				WHERE 1=1 $replaced_where
 			)";


### PR DESCRIPTION
`absint` only returns positive values and menu order can use both positive and negative values. Or would `intval` be better?