### PR TITLE
Setup wizard: remove mention of live shipping rates from “activate” step

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1072,6 +1072,8 @@ class WC_Admin_Setup_Wizard {
 		$setup_wcs_labels  = isset( $_POST['setup_woocommerce_services'] ) && 'yes' === $_POST['setup_woocommerce_services'];
 		$setup_shipstation = isset( $_POST['setup_shipstation'] ) && 'yes' === $_POST['setup_shipstation'];
 
+		update_option( 'woocommerce_setup_shipping_labels', $setup_wcs_labels );
+
 		if ( $setup_wcs_labels ) {
 			$this->install_woocommerce_services();
 		}
@@ -1989,10 +1991,10 @@ class WC_Admin_Setup_Wizard {
 		$ppec_enabled    = is_array( $ppec_settings )
 			&& isset( $ppec_settings['reroute_requests'] ) && 'yes' === $ppec_settings['reroute_requests']
 			&& isset( $ppec_settings['enabled'] ) && 'yes' === $ppec_settings['enabled'];
-		$features['payment'] = $stripe_enabled || $ppec_enabled;
 
-		$features['taxes']  = (bool) get_option( 'woocommerce_setup_automated_taxes', false );
-		$features['labels'] = ( 'US' === WC()->countries->get_base_country() );
+		$features['payment'] = $stripe_enabled || $ppec_enabled;
+		$features['taxes']   = (bool) get_option( 'woocommerce_setup_automated_taxes', false );
+		$features['labels']  = (bool) get_option( 'woocommerce_setup_shipping_labels', false );
 
 		return $features;
 	}

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1991,31 +1991,28 @@ class WC_Admin_Setup_Wizard {
 			&& isset( $ppec_settings['enabled'] ) && 'yes' === $ppec_settings['enabled'];
 		$features['payment'] = $stripe_enabled || $ppec_enabled;
 
-		$features['taxes'] = (bool) get_option( 'woocommerce_setup_automated_taxes', false );
-
-		$domestic_rates  = (bool) get_option( 'woocommerce_setup_domestic_live_rates_zone', false );
-		$intl_rates      = (bool) get_option( 'woocommerce_setup_intl_live_rates_zone', false );
-		$features['rates'] = $domestic_rates || $intl_rates;
+		$features['taxes']  = (bool) get_option( 'woocommerce_setup_automated_taxes', false );
+		$features['labels'] = ( 'US' === WC()->countries->get_base_country() );
 
 		return $features;
 	}
 
 	protected function wc_setup_activate_get_feature_list_str() {
 		$features = $this->wc_setup_activate_get_feature_list();
-		if ( $features['payment'] && $features['taxes'] && $features['rates'] ) {
-			return __( 'payment setup, automated taxes, live rates and discounted shipping labels', 'woocommerce' );
+		if ( $features['payment'] && $features['taxes'] && $features['labels'] ) {
+			return __( 'payment setup, automated taxes and discounted shipping labels', 'woocommerce' );
 		} else if ( $features['payment'] && $features['taxes'] ) {
 			return __( 'payment setup and automated taxes', 'woocommerce' );
-		} else if ( $features['payment'] && $features['rates'] ) {
-			return __( 'payment setup, live rates and discounted shipping labels', 'woocommerce' );
+		} else if ( $features['payment'] && $features['labels'] ) {
+			return __( 'payment setup and discounted shipping labels', 'woocommerce' );
 		} else if ( $features['payment'] ) {
 			return __( 'payment setup', 'woocommerce' );
-		} else if ( $features['taxes'] && $features['rates'] ) {
-			return __( 'automated taxes, live rates and discounted shipping labels', 'woocommerce' );
+		} else if ( $features['taxes'] && $features['labels'] ) {
+			return __( 'automated taxes and discounted shipping labels', 'woocommerce' );
 		} else if ( $features['taxes'] ) {
 			return __( 'automated taxes', 'woocommerce' );
-		} else if ( $features['rates'] ) {
-			return __( 'live rates and discounted shipping labels', 'woocommerce' );
+		} else if ( $features['labels'] ) {
+			return __( 'discounted shipping labels', 'woocommerce' );
 		}
 		return false;
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Continuation of the work started in https://github.com/woocommerce/woocommerce/pull/21234 - I missed the mentions of live rates on the "activate" step.

### How to test the changes in this Pull Request:

1. Visit the setup wizard
2. Set store location to USA
3. Verify that on the "activate" step, "discounted shipping labels" are mentioned, but not "live rates"

<img width="755" alt="screen shot 2018-10-24 at 8 57 47 am" src="https://user-images.githubusercontent.com/63922/47432247-bb617900-d76b-11e8-8e6b-3ce8982193cb.png">
