### PR TITLE
Add 3rd param on `woocommerce_product_option_terms` action to use custom attribute types on product attribute create

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -59,7 +59,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 								<?php
 							}
 
-							do_action( 'woocommerce_product_option_terms', $attribute_taxonomy, $i );
+							do_action( 'woocommerce_product_option_terms', $attribute_taxonomy, $i, $attribute );
 						} else {
 							/* translators: %s: WC_DELIMITER */
 							?>


### PR DESCRIPTION
Add `$attribute` to get more info about custom attribute types

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Just add extra product attribute type, with `product_attributes_type_selector` filter. Like: color
2. Now create new product attributes with that attribute type.
3. Create a variable product, and add attributes from those type, definitely value field will blank, and woocommerce have `woocommerce_product_option_terms` action to take care about it, but without 3rd param `$attribute` you cannot make it selected after ajax return. Value field will blank. You cannot get selected product attribute value on ajax return.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
