### PR TITLE
Dont default gallery variation images to gallery thumbnail size if flexslider is disabled

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -747,8 +747,7 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 		$props['thumb_src_h'] = $src[2];
 
 		// Image source.
-		$flexslider      = (bool) apply_filters( 'woocommerce_single_product_flexslider_enabled', get_theme_support( 'wc-product-gallery-slider' ) );
-		$image_size      = apply_filters( 'woocommerce_gallery_image_size', $flexslider ? 'woocommerce_single' : $gallery_thumbnail_size );
+		$image_size      = apply_filters( 'woocommerce_gallery_image_size', 'woocommerce_single' );
 		$src             = wp_get_attachment_image_src( $attachment_id, $image_size );
 		$props['src']    = $src[0];
 		$props['src_w']  = $src[1];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21646 .

In #20722 there was a behavior change introduced where if flexslider was disabled the image used for the gallery would be the 'gallery_thumbnail' size. This change causes issues on themes that are using the flexslider attribute info but with different gallery libraries (e.g. flickity).

This PR reverts that behavior and always uses the 'woocommerce_single' image size to keep behavior consistent with previous WC versions.

### How to test the changes in this Pull Request:

1. Activate Flatsome theme (@tiagonoronha let me know if you need a copy).
2. Set up a variable product with specific images for the variations.
3. Switch to the variation in the single product page. Observe image is cropped and super stretched:
<img width="878" alt="screen shot 2018-10-24 at 11 16 29 am" src="https://user-images.githubusercontent.com/7317227/47452137-4ea3aa00-d77e-11e8-9b15-fcc710bf9b12.png">

4. Apply the patch. Switch to the variation in the single product page. Observe image looks good:
<img width="859" alt="screen shot 2018-10-24 at 11 16 10 am" src="https://user-images.githubusercontent.com/7317227/47452145-519e9a80-d77e-11e8-8cbd-dd91221964ec.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Don't default gallery variation images to gallery thumbnail size if flexslider is disabled
