### PR TITLE
Revert show shipping behavior change

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1374,11 +1374,6 @@ class WC_Cart extends WC_Legacy_Cart {
 			}
 		}
 
-		// If we're on the cart page, the user has not calculated shipping, hide the area.
-		if ( is_cart() && ! $this->get_customer()->has_calculated_shipping() ) {
-			return false;
-		}
-
 		return apply_filters( 'woocommerce_cart_ready_to_calc_shipping', true );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21653 .

PR #20345 introduced [a behavior change that decided whether to show the shipping on the Cart page](https://github.com/woocommerce/woocommerce/pull/20345/files#diff-c882f570b44ec086dab59409cf40e978R1405). This change does not necessarily work in all situations, as there are times when the customer doesn't have shipping calculated but there is a matched shipping method that should be displayed.

This PR reverts the behavior to be the same as it was in previous versions of WooCommerce. The behavior change doesn't really provide any benefits to customers as far as I can tell.

### How to test the changes in this Pull Request:

1. Set up a shop with default customer location same as shop base address and a flat rate shipping method for the whole world. Open up an incognito mode window. Add a shippable product to the cart. Observe in the Cart page shipping does not show:
<img width="675" alt="screen shot 2018-10-24 at 1 19 21 pm" src="https://user-images.githubusercontent.com/7317227/47458913-abf42700-d78f-11e8-9ddd-9713fb402049.png">

But in the Checkout page it shows:
<img width="653" alt="screen shot 2018-10-24 at 1 19 34 pm" src="https://user-images.githubusercontent.com/7317227/47458916-aeef1780-d78f-11e8-90cf-75555ce1c14d.png">


2. Apply this patch. Observe shipping shows in both the Cart and Checkout pages:
<img width="661" alt="screen shot 2018-10-24 at 1 19 54 pm" src="https://user-images.githubusercontent.com/7317227/47458920-b1ea0800-d78f-11e8-88c1-bdcc24277942.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Revert WC_Cart::show_shipping behavior change when shipping hasn't been calculated for a customer.
