### PR TITLE
Use correct comment_type when populating Recent Reviews widget.

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -275,7 +275,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				"FROM {$wpdb->comments} comments
 				LEFT JOIN {$wpdb->posts} posts ON (comments.comment_post_ID = posts.ID)
 				WHERE comments.comment_approved = '1'
-				AND comments.comment_type = ''
+				AND comments.comment_type = 'review'
 				AND posts.post_password = ''
 				AND posts.post_type = 'product'
 				AND comments.comment_parent = 0


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21654 

### How to test the changes in this Pull Request:

1. Ensure you have product reviews, if not add some
2. Go to wp-admin and view the Recent Reviews widget
3. Your reviews should show there

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Recent Reviews widget was not using the correct comment_type
