### PR TITLE
Fix: copy customer ID for orders placed manually via wp-admin

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -118,6 +118,10 @@ class WC_Install {
 			'wc_update_350_reviews_comment_type',
 			'wc_update_350_db_version',
 		),
+		'3.5.1' => array(
+			'wc_update_351_manual_orders_customer_id',
+			'wc_update_351_db_version',
+		),
 	);
 
 	/**

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -20,7 +20,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '3.5.0';
+	public $version = '3.5.1';
 
 	/**
 	 * The single instance of the class.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a new database update routine to copy the customer ID for orders placed manually via wp-admin from the `_customer_user` postmeta to the `post_author` field in `wp_posts`. This is necessary due to a bug in wc_update_350_order_customer_id() that made this function skip copying data for manually placed orders via wp-admin in some cases. The bug only affected stores that executed the database updated routine via the wp-admin interface and not stores that executed the update routine via the WP-CLI command.

This new update routine gets all the IDs of the orders that were placed manually via wp-admin using the postmeta `_created_via` and then executes another query to get the customer ID for those orders using the postmeta `_customer_user`. Finally, it executes an update query to change the post_author value for each of the manually placed orders. This strategy should work well for most stores but it will be slow for stores with a significant number of manually placed orders.

It is also important to note that this update routine will run for every store, but it only needs to run for stores that updated the database to 3.5 using the wp-admin interface. I couldn't think of a way to skip this update routine for stores that updated the database to 3.5 using the WP-CLI command.

Closes #21656 

### How to test the changes in this Pull Request:

1. Check that the update routine is not altering anything other than what is needed
2. See #21656 for instructions on how to reproduce the problem and run the 3.5.1 update routine to confirm that this PR fixes it.

### Changelog entry

> Fix: copy customer ID for orders placed manually via wp-admin to fix issue caused by a bug in the 3.5 update routine
