### PR TITLE
Removed non-existing WC_Product_Simple->set_date_created_gmt method

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -665,7 +665,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			$date = rest_parse_date( $request['date_created_gmt'], true );
 
 			if ( $date ) {
-				$product->set_date_created_gmt( $date );
+				$product->set_date_created( $date );
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Caused probably by copy and paste.

Closes #21660/

### How to test the changes in this Pull Request:

See #21660.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - REST API - Fixed PHP warning when trying to save `date_created_gmt` on products endpoint.
