### PR TITLE
feat($templates): filterable notices wrapper

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3359,10 +3359,24 @@ function wc_get_cart_undo_url( $cart_item_key ) {
  *
  * @since 3.5.0
  */
-function woocommerce_output_all_notices() {
+function woocommerce_output_all_notices($return = false) {
+	if (wc_notice_count() === 0) {
+		return;
+	}
+
+	ob_start();
+
 	echo '<div class="woocommerce-notices-wrapper">';
 	wc_print_notices();
 	echo '</div>';
+
+	$notices = apply_filters('woocommerce_output_all_notices', ob_get_clean());
+
+	if ($return) {
+		return $notices;
+	}
+
+	echo $notices;
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces `woocommerce_output_all_notices` filter for customizing `woocommerce_output_all_notices()`'s output.

Closes #21671 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* introduces `woocommerce_output_all_notices` filter
