### PR TITLE
Do not include strong tags as part of translation string on subscriptions disconnect message

### DIFF
--- a/includes/admin/helper/views/html-oauth-start.php
+++ b/includes/admin/helper/views/html-oauth-start.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit();
 				<img src="<?php echo esc_url( WC()->plugin_url() . '/assets/images/woocommerce_logo.png' ); ?>" alt="WooCommerce" style="width:180px;">
 
 				<?php if ( ! empty( $_GET['wc-helper-status'] ) && 'helper-disconnected' === $_GET['wc-helper-status'] ) : ?>
-					<p><?php esc_html_e( '<strong>Sorry to see you go</strong>. Feel free to reconnect again using the button below.', 'woocommerce' ); ?></p>
+					<p><?php _e( '<strong>Sorry to see you go</strong>. Feel free to reconnect again using the button below.', 'woocommerce' ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput ?>
 				<?php endif; ?>
 
 				<h2><?php esc_html_e( 'Manage your subscriptions, get important product notifications, and updates, all from the convenience of your WooCommerce dashboard', 'woocommerce' ); ?></h2>

--- a/includes/admin/helper/views/html-oauth-start.php
+++ b/includes/admin/helper/views/html-oauth-start.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit();
 				<img src="<?php echo esc_url( WC()->plugin_url() . '/assets/images/woocommerce_logo.png' ); ?>" alt="WooCommerce" style="width:180px;">
 
 				<?php if ( ! empty( $_GET['wc-helper-status'] ) && 'helper-disconnected' === $_GET['wc-helper-status'] ) : ?>
-					<p><?php _e( '<strong>Sorry to see you go</strong>. Feel free to reconnect again using the button below.', 'woocommerce' ); ?></p><?php // phpcs:ignore WordPress.XSS.EscapeOutput ?>
+					<p><strong><?php esc_html_e( 'Sorry to see you go.', 'woocommerce' ) . '</strong>' . esc_html_e( 'Feel free to reconnect again using the button below.', 'woocommerce' ); ?></p>
 				<?php endif; ?>
 
 				<h2><?php esc_html_e( 'Manage your subscriptions, get important product notifications, and updates, all from the convenience of your WooCommerce dashboard', 'woocommerce' ); ?></h2>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Do not make the helper disconnect message include the strong tags as part of the translation string.

Closes #21684 

### How to test the changes in this Pull Request:

1. Go the the subscriptions page in wp-admin
2. Make sure you have an account connected to woocommerce.com
3. Disconnect the account
4. You should see a message starting with: **Sorry to see you go.** 
5. Make sure that message is bold and does not output the tags <strong>Sorry to see you go.</strong>

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Make bold text when disconnecting from woocommerce.com bold again, and not just output the html tags.
