### PR TITLE
Fix: make sure sql_safe_updates is disabled before running db update

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -118,6 +118,10 @@ class WC_Install {
 			'wc_update_350_reviews_comment_type',
 			'wc_update_350_db_version',
 		),
+		'3.5.1' => array(
+			'wc_update_351_rerun_order_customer_id',
+			'wc_update_351_db_version',
+		),
 	);
 
 	/**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1992,3 +1992,27 @@ function wc_update_350_reviews_comment_type() {
 function wc_update_350_db_version() {
 	WC_Install::update_db_version( '3.5.0' );
 }
+
+/**
+ * There is a bug in the WC 3.5 wc_update_350_order_customer_id() update routine that
+ * makes it fail, but report success if the filter woocommerce_update_350_order_customer_id_post_types
+ * is used to add more post types and if the routine is triggered via WP-CLI
+ * (see https://github.com/woocommerce/woocommerce/issues/21687). It was caused by wrongly setting
+ * sql_safe_updates to true. Now we set this MySQL option to false, but we need to run
+ * wc_update_350_order_customer_id() again to migrate the data that wasn't migrated in the WC 3.5 update.
+ *
+ * @param WC_Background_Updater|false $updater Background updater instance or false if function is called from `wp wc update` WP-CLI command.
+ * @return true|void Return true if near memory limit and needs to restart. Return void if update completed.
+ */
+function wc_update_351_rerun_order_customer_id( $updater = false ) {
+	if ( has_filter( 'woocommerce_update_350_order_customer_id_post_types' ) ) {
+		return wc_update_350_order_customer_id( $updater );
+	}
+}
+
+/**
+ * Update DB Version.
+ */
+function wc_update_351_db_version() {
+	WC_Install::update_db_version( '3.5.1' );
+}

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1883,7 +1883,7 @@ function wc_update_350_order_customer_id( $updater = false ) {
 			"INSERT IGNORE INTO customers_map (SELECT post_id, meta_value FROM {$wpdb->prefix}postmeta WHERE meta_key = '_customer_user')"
 		);
 
-		$wpdb->query( 'SET sql_safe_updates=1' );
+		$wpdb->query( 'SET sql_safe_updates=0' );
 
 		$wpdb->query(
 			$wpdb->prepare(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the query that is executed before migrating customer IDs from _customer_user postmeta to post_author when the database update is triggered via WP-CLI from `SET sql_safe_updates=1` to `SET sql_safe_updates=0`.

Enabling sql_safe_updates was added by mistake in wc_update_350_order_customer_id() while I was testing if we needed to disable it before running the update query that runs right after it. My conclusion was that we didn't need to disable sql_safe_updates as I could run the update query even with this option enabled, so there was actually no need to include anything, but anyway the query to enable it was included accidentally. It turns out my testing was wrong and, in some scenarios (see #21687), the query will fail if sql_safe_updates is enabled. It is still not clear to me why in some situations the update query fails when sql_safe_updates is on, and in some it works.

This change is only to avoid potential problems for users still running WC <= 3.4 and updating to WC 3.5.1. Once we understand what is causing the error described in #21687, we might need to take some action to find a solution for affected users that are already running 3.5.

Closes #21687

### How to test the changes in this Pull Request:

Running WC <= 3.4.7 database, run the update routine using the WP-CLI command `wp wc update` and make sure all `_customer_user` entries were properly copied to the `post_author` field in `wp_posts`.

### Changelog entry

> Fix: make sure sql_safe_updates is disabled before running database update to copy `_customer_user` postmeta