### PR TITLE
Prevent deleting default product category via REST API

### DIFF
--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -533,6 +533,14 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		}
 
 		$term = get_term( (int) $request['id'], $taxonomy );
+		// Get default category id.
+		$default_category_id = absint( get_option( 'default_product_cat', 0 ) );
+
+		// Prevent deleting the default product category
+		if ( $default_category_id === $term ) {
+			return new WP_Error( 'woocommerce_rest_default_product_cat_cannot_delete', __( 'Default product category cannot be deleted.', 'woocommerce' ), array( 'status' => 500 ) );
+		}
+
 		$request->set_param( 'context', 'edit' );
 		$response = $this->prepare_item_for_response( $term, $request );
 

--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -536,7 +536,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		// Get default category id.
 		$default_category_id = absint( get_option( 'default_product_cat', 0 ) );
 
-		// Prevent deleting the default product category
+		// Prevent deleting the default product category.
 		if ( $default_category_id === $term ) {
 			return new WP_Error( 'woocommerce_rest_default_product_cat_cannot_delete', __( 'Default product category cannot be deleted.', 'woocommerce' ), array( 'status' => 500 ) );
 		}

--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -537,8 +537,8 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		$default_category_id = absint( get_option( 'default_product_cat', 0 ) );
 
 		// Prevent deleting the default product category.
-		if ( $default_category_id === $term ) {
-			return new WP_Error( 'woocommerce_rest_default_product_cat_cannot_delete', __( 'Default product category cannot be deleted.', 'woocommerce' ), array( 'status' => 500 ) );
+		if ( $default_category_id === (int) $request['id'] ) {
+			return new WP_Error( 'woocommerce_rest_cannot_delete', __( 'Default product category cannot be deleted.', 'woocommerce' ), array( 'status' => 500 ) );
 		}
 
 		$request->set_param( 'context', 'edit' );


### PR DESCRIPTION
Prevent deleting the default product category. Added additional checking is the category is the default category or not.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21652 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Prevent deleting the default product category.
