### PR TITLE
Merged similar strings to reduce number of translateable strings

### DIFF
--- a/includes/abstracts/abstract-wc-rest-terms-controller.php
+++ b/includes/abstracts/abstract-wc-rest-terms-controller.php
@@ -686,7 +686,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		$params['context']['default'] = 'view';
 
 		$params['exclude'] = array(
-			'description'       => __( 'Ensure result set excludes specific ids.', 'woocommerce' ),
+			'description'       => __( 'Ensure result set excludes specific IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
 				'type' => 'integer',

--- a/includes/api/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/class-wc-rest-product-reviews-controller.php
@@ -926,7 +926,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		$params['context']['default'] = 'view';
 
 		$params['after']            = array(
-			'description' => __( 'Limit response to reviews published after a given ISO8601 compliant date.', 'woocommerce' ),
+			'description' => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'        => 'string',
 			'format'      => 'date-time',
 		);

--- a/includes/api/class-wc-rest-product-reviews-controller.php
+++ b/includes/api/class-wc-rest-product-reviews-controller.php
@@ -391,7 +391,7 @@ class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {
 		 * Do not allow a comment to be created with missing or empty comment_content. See wp_handle_comment_submission().
 		 */
 		if ( empty( $prepared_review['comment_content'] ) ) {
-			return new WP_Error( 'wc_rest_review_content_invalid', __( 'Invalid product review content.', 'woocommerce' ), array( 'status' => 400 ) );
+			return new WP_Error( 'woocommerce_rest_review_content_invalid', __( 'Invalid review content.', 'woocommerce' ), array( 'status' => 400 ) );
 		}
 
 		// Setting remaining values before wp_insert_comment so we can use wp_allow_comment().

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -662,7 +662,7 @@ class WC_Countries {
 				'priority'     => 50,
 			),
 			'address_2'  => array(
-				'label'        => __( 'Apartment, suite, or unit.', 'woocommerce' ),
+				'label'        => __( 'Apartment, suite, unit etc.', 'woocommerce' ),
 				'label_class'  => 'screen-reader-text',
 				'placeholder'  => esc_attr( $address_2_placeholder ),
 				'class'        => array( 'form-row-wide', 'address-field' ),
@@ -1012,12 +1012,12 @@ class WC_Countries {
 					),
 					'NG' => array(
 						'postcode' => array(
-							'label' => __( 'Postcode', 'woocommerce' ),
+							'label'    => __( 'Postcode', 'woocommerce' ),
 							'required' => false,
 							'hidden'   => true,
 						),
 						'state'    => array(
-							'label'    => __( 'State', 'woocommerce' ),
+							'label' => __( 'State', 'woocommerce' ),
 						),
 					),
 					'NZ' => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Just a small tweak to avoid having two similar strings, this help our translators, not having to translate something similar twice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?