### PR TITLE
Custom settings on shipping section (#13463, #13461)

### DIFF
--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -157,11 +157,18 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 			$hide_save_button = true;
 			$this->output_shipping_class_screen();
 		} else {
+			$is_shipping_method = false;
 			foreach ( $shipping_methods as $method ) {
 				if ( in_array( $current_section, array( $method->id, sanitize_title( get_class( $method ) ) ), true ) && $method->has_settings() ) {
+					$is_shipping_method = true;
 					$method->admin_options();
 				}
 			}
+			if ( !$is_shipping_method ) {
+				$settings = $this->get_settings();
+				$settings = apply_filters( 'woocommerce_get_settings_' . $this->id, $settings, $current_section );
+				WC_Admin_Settings::output_fields( $settings );
+			}			
 		}
 	}
 
@@ -183,11 +190,16 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 				break;
 			default:
 				$wc_shipping = WC_Shipping::instance();
+				$is_shipping_method = false;			
 
 				foreach ( $wc_shipping->get_shipping_methods() as $method_id => $method ) {
 					if ( in_array( $current_section, array( $method->id, sanitize_title( get_class( $method ) ) ), true ) ) {
+						$is_shipping_method = true;
 						do_action( 'woocommerce_update_options_' . $this->id . '_' . $method->id );
 					}
+				}
+				if ( !$is_shipping_method ) {
+					WC_Admin_Settings::save_fields( $this->get_settings( $current_section ) );
 				}
 				break;
 		}

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -164,7 +164,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 					$method->admin_options();
 				}
 			}
-			if ( !$is_shipping_method ) {
+			if ( ! $is_shipping_method ) {
 				$settings = $this->get_settings();
 				$settings = apply_filters( 'woocommerce_get_settings_' . $this->id, $settings, $current_section );
 				WC_Admin_Settings::output_fields( $settings );
@@ -190,7 +190,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 				break;
 			default:
 				$wc_shipping = WC_Shipping::instance();
-				$is_shipping_method = false;			
+				$is_shipping_method = false;
 
 				foreach ( $wc_shipping->get_shipping_methods() as $method_id => $method ) {
 					if ( in_array( $current_section, array( $method->id, sanitize_title( get_class( $method ) ) ), true ) ) {
@@ -198,7 +198,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 						do_action( 'woocommerce_update_options_' . $this->id . '_' . $method->id );
 					}
 				}
-				if ( !$is_shipping_method ) {
+				if ( ! $is_shipping_method ) {
 					WC_Admin_Settings::save_fields( $this->get_settings( $current_section ) );
 				}
 				break;

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -168,7 +168,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 				$settings = $this->get_settings();
 				$settings = apply_filters( 'woocommerce_get_settings_' . $this->id, $settings, $current_section );
 				WC_Admin_Settings::output_fields( $settings );
-			}			
+			}
 		}
 	}
 
@@ -189,7 +189,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 			case '':
 				break;
 			default:
-				$wc_shipping = WC_Shipping::instance();
+				$wc_shipping        = WC_Shipping::instance();
 				$is_shipping_method = false;
 
 				foreach ( $wc_shipping->get_shipping_methods() as $method_id => $method ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add a possibility for custom settings within shipping section of settings. Allows to extensions developers to add a custom setting related to shipping.

Reaction to #13463 and #13461.

### How to test the changes in this Pull Request:

1. Add a new section under Settings->Shipping which is not a Shipping class, just using following filters would be enough:

```
add_filter( 'woocommerce_get_sections_shipping', ... );
add_filter( 'woocommerce_get_settings_shipping', ... );
```
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Allow custom settings sections in the Shipping tab