### PR TITLE
Prevent extract from polluting hook arguments

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -188,10 +188,6 @@ function wc_get_template_part( $slug, $name = '' ) {
  * @param string $default_path  Default path. (default: '').
  */
 function wc_get_template( $template_name, $args = array(), $template_path = '', $default_path = '' ) {
-	if ( ! empty( $args ) && is_array( $args ) ) {
-		extract( $args ); // @codingStandardsIgnoreLine
-	}
-
 	$located = wc_locate_template( $template_name, $template_path, $default_path );
 
 	if ( ! file_exists( $located ) ) {
@@ -203,13 +199,23 @@ function wc_get_template( $template_name, $args = array(), $template_path = '', 
 	// Allow 3rd party plugin filter template file from their plugin.
 	$located = apply_filters( 'wc_get_template', $located, $template_name, $args, $template_path, $default_path );
 
-	do_action( 'woocommerce_before_template_part', $template_name, $template_path, $located, $args );
+	$action_args = array(
+		'template_name' => $template_name,
+		'template_path' => $template_path,
+		'located'       => $located,
+		'args'          => $args,
+	);
+
+	if ( ! empty( $args ) && is_array( $args ) ) {
+		extract( $args ); // @codingStandardsIgnoreLine
+	}
+
+	do_action( 'woocommerce_before_template_part', $action_args['template_name'], $action_args['template_path'], $action_args['located'], $action_args['args'] );
 
 	include $located;
 
-	do_action( 'woocommerce_after_template_part', $template_name, $template_path, $located, $args );
+	do_action( 'woocommerce_after_template_part', $action_args['template_name'], $action_args['template_path'], $action_args['located'], $action_args['args'] );
 }
-
 
 /**
  * Like wc_get_template, but returns the HTML instead of outputting.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This is a fix for #21721. This fix avoids changing any template files.

This fix is necessary when adding single-product/review.php in custom templating systems or simply wanting to access the correct args.

### How to test the changes in this Pull Request:

1. Use the wc_get_template filter
2. Try to access the $args when filtering the single-product/review.php template
3. You can now can access the correct $args.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Prevent extract from polluting hook arguments in wc_get_template().