### PR TITLE
Fix the check for GNU or BSD sed in tests/bin/install.sh

### DIFF
--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -70,10 +70,14 @@ install_wp() {
 
 install_test_suite() {
 	# portable in-place argument for both GNU sed and Mac OSX sed
-	if [[ $(uname -s) == 'Darwin' ]]; then
-		local ioption='-i .bak'
-	else
+	# Based on the fact that GNU sed understands the `--verison` argument where
+	# BSD sed does not.
+	if sed --version >/dev/null 2>&1; then
+		# GNU Sed
 		local ioption='-i'
+	else
+		# BSD Sed
+		local ioption='-i .bak'
 	fi
 
 	# set up testing suite if it doesn't yet exist


### PR DESCRIPTION
The old check worked on the assumption that all macOS users use BSD sed and everyone else uses GNU sed. In my case, where I installed GNU sed on macOS, overriding the system sed, this is not the case.

This replaced the check that used a call to `uname` with a test that will work on more systems.

The new test works on a more robust assumption that GNU sed will accept a `--version` argument where BSD sed. will return an error.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

( I installed the pre-commit hooks and there were no warnings, checked the coding standards but there are none for shell scripts, so it looks like I'm good 👍  )

### Changes proposed in this Pull Request:

Replaced the check which differentiates between GNU and BSD sed with a more robust check that calls the sed binary instead of examining the output of `uname`.

### How to test the changes in this Pull Request:

1. use a macOS system ( `[[ uname -s == 'Darwin' ]]` ) with GNU and BSD sed installed (`brew install gnu-sed --with-default-names`)
2. `alias sed='/usr/bin/sed'` and run `tests/bin/install.sh` (BSD sed) 
3. `alias sed='$(brew --prefix gnu-sed)/bin/sed'` and run `tests/bin/install.sh` (GNU sed)
4. `unalias sed` to clean up.

install.sh should work flawlessly with either version of sed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

( New tests not applicable since Travis tests using ubuntu, not macOS. )

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

More robust check to differentiate between GNU and BSD sed in tests/bin/install.sh