### PR TITLE
Do not output non secure notice when called via CLI

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -89,7 +89,7 @@ class WC_Admin_Notices {
 			WC_Admin_Notices::add_notice( 'simplify_commerce' );
 		}
 
-		if ( ! is_ssl() || 'https' !== substr( $shop_page, 0, 5 ) ) {
+		if ( ! isset( $_SERVER['REQUEST_SCHEME'] ) && ( ! is_ssl() || 'https' !== substr( $shop_page, 0, 5 ) ) ) {
 			WC_Admin_Notices::add_notice( 'no_secure_connection' );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The non secure notice relies on is_ssl and also the shop page URL which gives false reasing when you call a WP file like wp-cron.php from command line. This PR ensures that the Server var REQUEST_SCHEME is set before continuing the tests. On CLI and other non web protocals you can call PHP scripts from this variable will not be set.

Closes #21621.

### How to test the changes in this Pull Request:

1. Run wp-cron.php from command line
2. Ensure that no message is displayed about your store not using a secure connection.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Do not display store not using a secure connection when running wp-cron.php from command line.
