### PR TITLE
Make PDT validation use the same rounding as the IPN validation.

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-pdt-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-pdt-handler.php
@@ -106,7 +106,7 @@ class WC_Gateway_Paypal_PDT_Handler extends WC_Gateway_Paypal_Response {
 			update_post_meta( $order->get_id(), '_transaction_id', $transaction );
 
 			if ( 'completed' === $status ) {
-				if ( $order->get_total() !== $amount ) {
+				if ( number_format( $order->get_total(), 2, '.', '' ) !== number_format( $amount, 2, '.', '' ) ) {
 					WC_Gateway_Paypal::log( 'Payment error: Amounts do not match (amt ' . $amount . ')', 'error' );
 					/* translators: 1: Payment amount */
 					$this->payment_on_hold( $order, sprintf( __( 'Validation error: PayPal amounts do not match (amt %s).', 'woocommerce' ), $amount ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR updates the PayPal PDT order total validation to use the same rounding as which is used in the IPN validation.

Closes #21627 

### How to test the changes in this Pull Request:

1. Setup PayPal to use PDT validation
2. Checkout with an order that contains decimal in the total
3. Make payment via the PayPal sandbox and check the order is set as processing or completed depending on the type of product purchased.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Make PayPal PDT use same rounding when checking totals as IPN.