### PR TITLE
Trigger a country select change on initial load

### DIFF
--- a/assets/js/frontend/address-i18n.js
+++ b/assets/js/frontend/address-i18n.js
@@ -1,132 +1,131 @@
 /*global wc_address_i18n_params */
 jQuery( function( $ ) {
 
-		// wc_address_i18n_params is required to continue, ensure the object exists
-		if ( typeof wc_address_i18n_params === 'undefined' ) {
-			return false;
+	// wc_address_i18n_params is required to continue, ensure the object exists
+	if ( typeof wc_address_i18n_params === 'undefined' ) {
+		return false;
+	}
+
+	var locale_json = wc_address_i18n_params.locale.replace( /&quot;/g, '"' ), locale = $.parseJSON( locale_json );
+
+	function field_is_required( field, is_required ) {
+		if ( is_required ) {
+			field.find( 'label .optional' ).remove();
+			field.addClass( 'validate-required' );
+
+			if ( field.find( 'label .required' ).length === 0 ) {
+				field.find( 'label' ).append( '&nbsp;<abbr class="required" title="' + wc_address_i18n_params.i18n_required_text + '">*</abbr>' );
+			}
+		} else {
+			field.find( 'label .required' ).remove();
+			field.removeClass( 'validate-required' );
+
+			if ( field.find( 'label .optional' ).length === 0 ) {
+				field.find( 'label' ).append( '&nbsp;<span class="optional">(' + wc_address_i18n_params.i18n_optional_text + ')</span>' );
+			}
+		}
+	}
+
+	// Handle locale
+	$( document.body ).bind( 'country_to_state_changing', function( event, country, wrapper ) {
+		var thisform = wrapper, thislocale;
+
+		if ( typeof locale[ country ] !== 'undefined' ) {
+			thislocale = locale[ country ];
+		} else {
+			thislocale = locale['default'];
 		}
 
-		var locale_json = wc_address_i18n_params.locale.replace( /&quot;/g, '"' ),
-			locale = $.parseJSON( locale_json );
+		var $postcodefield = thisform.find( '#billing_postcode_field, #shipping_postcode_field' ),
+			$cityfield     = thisform.find( '#billing_city_field, #shipping_city_field' ),
+			$statefield    = thisform.find( '#billing_state_field, #shipping_state_field' );
 
-			function field_is_required( field, is_required ) {
-				if ( is_required ) {
-					field.find( 'label .optional' ).remove();
-					field.addClass( 'validate-required' );
+		if ( ! $postcodefield.attr( 'data-o_class' ) ) {
+			$postcodefield.attr( 'data-o_class', $postcodefield.attr( 'class' ) );
+			$cityfield.attr( 'data-o_class', $cityfield.attr( 'class' ) );
+			$statefield.attr( 'data-o_class', $statefield.attr( 'class' ) );
+		}
 
-					if ( field.find( 'label .required' ).length === 0 ) {
-						field.find( 'label' ).append( '&nbsp;<abbr class="required" title="' + wc_address_i18n_params.i18n_required_text + '">*</abbr>' );
-					}
-				} else {
-					field.find( 'label .required' ).remove();
-					field.removeClass( 'validate-required' );
+		var locale_fields = $.parseJSON( wc_address_i18n_params.locale_fields );
 
-					if ( field.find( 'label .optional' ).length === 0 ) {
-						field.find( 'label' ).append( '&nbsp;<span class="optional">(' + wc_address_i18n_params.i18n_optional_text + ')</span>' );
-					}
-				}
+		$.each( locale_fields, function( key, value ) {
+
+			var field       = thisform.find( value ),
+				fieldLocale = $.extend( true, {}, locale['default'][ key ], thislocale[ key ] );
+
+			// Labels.
+			if ( typeof fieldLocale.label !== 'undefined' ) {
+				field.find( 'label' ).html( fieldLocale.label );
 			}
 
-		$( document.body )
+			// Placeholders.
+			if ( typeof fieldLocale.placeholder !== 'undefined' ) {
+				field.find( 'input' ).attr( 'placeholder', fieldLocale.placeholder );
+				field.find( '.select2-selection__placeholder' ).text( fieldLocale.placeholder );
+			}
 
-			// Handle locale
-			.bind( 'country_to_state_changing', function( event, country, wrapper ) {
+			// Use the i18n label as a placeholder if there is no label element and no i18n placeholder.
+			if ( typeof fieldLocale.placeholder === 'undefined' && typeof fieldLocale.label !== 'undefined' && ! field.find( 'label' ).length ) {
+				field.find( 'input' ).attr( 'placeholder', fieldLocale.label );
+				field.find( '.select2-selection__placeholder' ).text( fieldLocale.label );
+			}
 
-				var thisform = wrapper, thislocale;
+			// Required.
+			if ( typeof fieldLocale.required !== 'undefined' ) {
+				field_is_required( field, fieldLocale.required );
+			} else {
+				field_is_required( field, false );
+			}
 
-				if ( typeof locale[ country ] !== 'undefined' ) {
-					thislocale = locale[ country ];
+			// Priority.
+			if ( typeof fieldLocale.priority !== 'undefined' ) {
+				field.data( 'priority', fieldLocale.priority );
+			}
+
+			// Hidden fields.
+			if ( 'state' !== key ) {
+				if ( typeof fieldLocale.hidden !== 'undefined' && true === fieldLocale.hidden ) {
+					field.hide().find( 'input' ).val( '' );
 				} else {
-					thislocale = locale['default'];
+					field.show();
 				}
+			}
+		});
 
-				var $postcodefield = thisform.find( '#billing_postcode_field, #shipping_postcode_field' ),
-					$cityfield     = thisform.find( '#billing_city_field, #shipping_city_field' ),
-					$statefield    = thisform.find( '#billing_state_field, #shipping_state_field' );
+		var fieldsets = $('.woocommerce-billing-fields__field-wrapper, .woocommerce-shipping-fields__field-wrapper, .woocommerce-address-fields__field-wrapper, .woocommerce-additional-fields__field-wrapper .woocommerce-account-fields');
 
-				if ( ! $postcodefield.attr( 'data-o_class' ) ) {
-					$postcodefield.attr( 'data-o_class', $postcodefield.attr( 'class' ) );
-					$cityfield.attr( 'data-o_class', $cityfield.attr( 'class' ) );
-					$statefield.attr( 'data-o_class', $statefield.attr( 'class' ) );
+		fieldsets.each( function( index, fieldset ) {
+			var rows    = $( fieldset ).find( '.form-row' );
+			var wrapper = rows.first().parent();
+
+			// Before sorting, ensure all fields have a priority for bW compatibility.
+			var last_priority = 0;
+
+			rows.each( function() {
+				if ( ! $( this ).data( 'priority' ) ) {
+						$( this ).data( 'priority', last_priority + 1 );
 				}
+				last_priority = $( this ).data( 'priority' );
+			} );
 
-				var locale_fields = $.parseJSON( wc_address_i18n_params.locale_fields );
+			// Sort the fields.
+			rows.sort( function( a, b ) {
+				var asort = $( a ).data( 'priority' ),
+					bsort = $( b ).data( 'priority' );
 
-				$.each( locale_fields, function( key, value ) {
-
-					var field       = thisform.find( value ),
-						fieldLocale = $.extend( true, {}, locale['default'][ key ], thislocale[ key ] );
-
-					// Labels.
-					if ( typeof fieldLocale.label !== 'undefined' ) {
-						field.find( 'label' ).html( fieldLocale.label );
-					}
-
-					// Placeholders.
-					if ( typeof fieldLocale.placeholder !== 'undefined' ) {
-						field.find( 'input' ).attr( 'placeholder', fieldLocale.placeholder );
-						field.find( '.select2-selection__placeholder' ).text( fieldLocale.placeholder );
-					}
-
-					// Use the i18n label as a placeholder if there is no label element and no i18n placeholder.
-					if ( typeof fieldLocale.placeholder === 'undefined' && typeof fieldLocale.label !== 'undefined' && ! field.find( 'label' ).length ) {
-						field.find( 'input' ).attr( 'placeholder', fieldLocale.label );
-						field.find( '.select2-selection__placeholder' ).text( fieldLocale.label );
-					}
-
-					// Required.
-					if ( typeof fieldLocale.required !== 'undefined' ) {
-						field_is_required( field, fieldLocale.required );
-					} else {
-						field_is_required( field, false );
-					}
-
-					// Priority.
-					if ( typeof fieldLocale.priority !== 'undefined' ) {
-						field.data( 'priority', fieldLocale.priority );
-					}
-
-					// Hidden fields.
-					if ( 'state' !== key ) {
-						if ( typeof fieldLocale.hidden !== 'undefined' && true === fieldLocale.hidden ) {
-							field.hide().find( 'input' ).val( '' );
-						} else {
-							field.show();
-						}
-					}
-				});
-
-				var fieldsets = $('.woocommerce-billing-fields__field-wrapper, .woocommerce-shipping-fields__field-wrapper, .woocommerce-address-fields__field-wrapper, .woocommerce-additional-fields__field-wrapper .woocommerce-account-fields');
-
-				fieldsets.each( function( index, fieldset ) {
-					var rows    = $( fieldset ).find( '.form-row' );
-					var wrapper = rows.first().parent();
-
-					// Before sorting, ensure all fields have a priority for bW compatibility.
-					var last_priority = 0;
-
-					rows.each( function() {
-						if ( ! $( this ).data( 'priority' ) ) {
-							 $( this ).data( 'priority', last_priority + 1 );
-						}
-						last_priority = $( this ).data( 'priority' );
-					} );
-
-					// Sort the fields.
-					rows.sort( function( a, b ) {
-						var asort = $( a ).data( 'priority' ),
-							bsort = $( b ).data( 'priority' );
-
-						if ( asort > bsort ) {
-							return 1;
-						}
-						if ( asort < bsort ) {
-							return -1;
-						}
-						return 0;
-					});
-
-					rows.detach().appendTo( wrapper );
-				} );
+				if ( asort > bsort ) {
+					return 1;
+				}
+				if ( asort < bsort ) {
+					return -1;
+				}
+				return 0;
 			});
+
+			rows.detach().appendTo( wrapper );
+		} );
 	});
+
+	// Make sure the locales are loaded on first page load.
+	$( '#billing_country' ).trigger( 'change' );
+});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes an issue where the address-i18n.js was not firing on initial page loads due to it only being tied to the country on change event causing priority and other local info to be missing.

To remedy this I simply trigger an onchange event on page load to ensure it fires and apply the correct locale info.

Closes #21642 

### How to test the changes in this Pull Request:

1. Add the following code to your theme's functions.php file
```
add_filter("woocommerce_checkout_fields", "custom_override_checkout_fields", 1 );
function custom_override_checkout_fields($fields) {
	$fields['billing']['billing_email']['priority'] = 1;
	return $fields;
}
```
2. Add something to cart and load the checkout page.
3. Ensure the email field is displayed right at the top.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Address locale info was not being applied on checkout on initial page load.
