### PR TITLE
Revert PR #17895

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -774,7 +774,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		if ( ! empty( $_GET['_customer_user'] ) ) { // WPCS: input var ok.
 			$customer_id = (int) $_GET['_customer_user'];  // WPCS: input var ok, sanitization ok.
 
-			if ( version_compare( get_option( 'woocommerce_db_version' ), '3.4.0', '>=' ) ) {
+			if ( version_compare( get_option( 'woocommerce_db_version' ), '3.3.0', '>=' ) ) {
 				$query_vars['author'] = $customer_id;
 			} else {
 				// @codingStandardsIgnoreStart

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -772,21 +772,15 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 
 		// Filter the orders by the posted customer.
 		if ( ! empty( $_GET['_customer_user'] ) ) { // WPCS: input var ok.
-			$customer_id = (int) $_GET['_customer_user'];  // WPCS: input var ok, sanitization ok.
-
-			if ( version_compare( get_option( 'woocommerce_db_version' ), '3.3.0', '>=' ) ) {
-				$query_vars['author'] = $customer_id;
-			} else {
-				// @codingStandardsIgnoreStart
-				$query_vars['meta_query'] = array(
-					array(
-						'key'     => '_customer_user',
-						'value'   => $customer_id,
-						'compare' => '=',
-					),
-				);
-				// @codingStandardsIgnoreEnd
-			}
+			// @codingStandardsIgnoreStart
+			$query_vars['meta_query'] = array(
+				array(
+					'key'   => '_customer_user',
+					'value' => (int) $_GET['_customer_user'], // WPCS: input var ok, sanitization ok.
+					'compare' => '=',
+				),
+			);
+			// @codingStandardsIgnoreEnd
 		}
 
 		// Sorting.

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -774,8 +774,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		if ( ! empty( $_GET['_customer_user'] ) ) { // WPCS: input var ok.
 			$customer_id = (int) $_GET['_customer_user'];  // WPCS: input var ok, sanitization ok.
 
-			// On WC 3.5.0 the ID of the user that placed the order was moved from the post meta _customer_user to the post_author field in the wp_posts table.
-			if ( version_compare( get_option( 'woocommerce_db_version' ), '3.5.0', '>=' ) ) {
+			if ( version_compare( get_option( 'woocommerce_db_version' ), '3.4.0', '>=' ) ) {
 				$query_vars['author'] = $customer_id;
 			} else {
 				// @codingStandardsIgnoreStart

--- a/includes/admin/reports/class-wc-report-customers.php
+++ b/includes/admin/reports/class-wc-report-customers.php
@@ -69,56 +69,46 @@ class WC_Report_Customers extends WC_Admin_Report {
 	 * Output customers vs guests chart.
 	 */
 	public function customers_vs_guests() {
-		$customer_args = array(
-			'data'         => array(
-				'ID' => array(
-					'type'     => 'post_data',
-					'function' => 'COUNT',
-					'name'     => 'total_orders',
+
+		$customer_order_totals = $this->get_order_report_data(
+			array(
+				'data'         => array(
+					'ID' => array(
+						'type'     => 'post_data',
+						'function' => 'COUNT',
+						'name'     => 'total_orders',
+					),
 				),
-			),
-			'filter_range' => true,
+				'where_meta'   => array(
+					array(
+						'meta_key'   => '_customer_user',
+						'meta_value' => '0',
+						'operator'   => '>',
+					),
+				),
+				'filter_range' => true,
+			)
 		);
-		$guest_args    = $customer_args;
 
-		// On WC 3.5.0 the ID of the user that placed the order was moved from the post meta _customer_user to the post_author field in the wp_posts table.
-		if ( version_compare( get_option( 'woocommerce_db_version' ), '3.5.0', '>=' ) ) {
-			$customer_args['where'] = array(
-				array(
-					'key'      => 'post_author',
-					'value'    => '0',
-					'operator' => '>',
+		$guest_order_totals = $this->get_order_report_data(
+			array(
+				'data'         => array(
+					'ID' => array(
+						'type'     => 'post_data',
+						'function' => 'COUNT',
+						'name'     => 'total_orders',
+					),
 				),
-			);
-
-			$guest_args['where'] = array(
-				array(
-					'key'      => 'post_author',
-					'value'    => '0',
-					'operator' => '=',
+				'where_meta'   => array(
+					array(
+						'meta_key'   => '_customer_user',
+						'meta_value' => '0',
+						'operator'   => '=',
+					),
 				),
-			);
-		} else {
-			$customer_args['where_meta'] = array(
-				array(
-					'meta_key'   => '_customer_user',
-					'meta_value' => '0',
-					'operator'   => '>',
-				),
-			);
-
-			$guest_args['where_meta'] = array(
-				array(
-					'meta_key'   => '_customer_user',
-					'meta_value' => '0',
-					'operator'   => '=',
-				),
-			);
-		}
-
-		$customer_order_totals = $this->get_order_report_data( $customer_args );
-		$guest_order_totals = $this->get_order_report_data( $guest_args );
-
+				'filter_range' => true,
+			)
+		);
 		?>
 		<div class="chart-container">
 			<div class="chart-placeholder customers_vs_guests pie-chart" style="height:200px"></div>
@@ -256,63 +246,61 @@ class WC_Report_Customers extends WC_Admin_Report {
 	public function get_main_chart() {
 		global $wp_locale;
 
-		$customer_args = array(
-			'data'         => array(
-				'ID'        => array(
-					'type'     => 'post_data',
-					'function' => 'COUNT',
-					'name'     => 'total_orders',
+		$customer_orders = $this->get_order_report_data(
+			array(
+				'data'         => array(
+					'ID'        => array(
+						'type'     => 'post_data',
+						'function' => 'COUNT',
+						'name'     => 'total_orders',
+					),
+					'post_date' => array(
+						'type'     => 'post_data',
+						'function' => '',
+						'name'     => 'post_date',
+					),
 				),
-				'post_date' => array(
-					'type'     => 'post_data',
-					'function' => '',
-					'name'     => 'post_date',
+				'where_meta'   => array(
+					array(
+						'meta_key'   => '_customer_user',
+						'meta_value' => '0',
+						'operator'   => '>',
+					),
 				),
-			),
-			'group_by'     => $this->group_by_query,
-			'order_by'     => 'post_date ASC',
-			'query_type'   => 'get_results',
-			'filter_range' => true,
+				'group_by'     => $this->group_by_query,
+				'order_by'     => 'post_date ASC',
+				'query_type'   => 'get_results',
+				'filter_range' => true,
+			)
 		);
-		$guest_args    = $customer_args;
 
-		// On WC 3.5.0 the ID of the user that placed the order was moved from the post meta _customer_user to the post_author field in the wp_posts table.
-		if ( version_compare( get_option( 'woocommerce_db_version' ), '3.5.0', '>=' ) ) {
-			$customer_args['where'] = array(
-				array(
-					'key'      => 'post_author',
-					'value'    => '0',
-					'operator' => '>',
+		$guest_orders = $this->get_order_report_data(
+			array(
+				'data'         => array(
+					'ID'        => array(
+						'type'     => 'post_data',
+						'function' => 'COUNT',
+						'name'     => 'total_orders',
+					),
+					'post_date' => array(
+						'type'     => 'post_data',
+						'function' => '',
+						'name'     => 'post_date',
+					),
 				),
-			);
-
-			$guest_args['where'] = array(
-				array(
-					'key'      => 'post_author',
-					'value'    => '0',
-					'operator' => '=',
+				'where_meta'   => array(
+					array(
+						'meta_key'   => '_customer_user',
+						'meta_value' => '0',
+						'operator'   => '=',
+					),
 				),
-			);
-		} else {
-			$customer_args['where_meta'] = array(
-				array(
-					'meta_key'   => '_customer_user',
-					'meta_value' => '0',
-					'operator'   => '>',
-				),
-			);
-
-			$guest_args['where_meta'] = array(
-				array(
-					'meta_key'   => '_customer_user',
-					'meta_value' => '0',
-					'operator'   => '=',
-				),
-			);
-		}
-
-		$customer_orders = $this->get_order_report_data( $customer_args );
-		$guest_orders = $this->get_order_report_data( $guest_args );
+				'group_by'     => $this->group_by_query,
+				'order_by'     => 'post_date ASC',
+				'query_type'   => 'get_results',
+				'filter_range' => true,
+			)
+		);
 
 		$signups         = $this->prepare_chart_data( $this->customers, 'user_registered', '', $this->chart_interval, $this->start_date, $this->chart_groupby );
 		$customer_orders = $this->prepare_chart_data( $customer_orders, 'post_date', 'total_orders', $this->chart_interval, $this->start_date, $this->chart_groupby );

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -404,20 +404,15 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 		}
 
 		if ( isset( $request['customer'] ) ) {
-			// On WC 3.5.0 the ID of the user that placed the order was moved from the post meta _customer_user to the post_author field in the wp_posts table.
-			if ( version_compare( get_option( 'woocommerce_db_version' ), '3.5.0', '>=' ) ) {
-				$args['author'] = $request['customer'];
-			} else {
-				if ( ! empty( $args['meta_query'] ) ) {
-					$args['meta_query'] = array(); // WPCS: slow query ok.
-				}
-
-				$args['meta_query'][] = array(
-					'key'   => '_customer_user',
-					'value' => $request['customer'],
-					'type'  => 'NUMERIC',
-				);
+			if ( ! empty( $args['meta_query'] ) ) {
+				$args['meta_query'] = array();
 			}
+
+			$args['meta_query'][] = array(
+				'key'   => '_customer_user',
+				'value' => $request['customer'],
+				'type'  => 'NUMERIC',
+			);
 		}
 
 		// Search by product.

--- a/includes/api/v2/class-wc-rest-orders-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-orders-v2-controller.php
@@ -367,20 +367,15 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 		}
 
 		if ( isset( $request['customer'] ) ) {
-			// On WC 3.5.0 the ID of the user that placed the order was moved from the post meta _customer_user to the post_author field in the wp_posts table.
-			if ( version_compare( get_option( 'woocommerce_db_version' ), '3.5.0', '>=' ) ) {
-				$args['author'] = $request['customer'];
-			} else {
-				if ( ! empty( $args['meta_query'] ) ) {
-					$args['meta_query'] = array(); // WPCS: slow query ok.
-				}
-
-				$args['meta_query'][] = array(
-					'key'   => '_customer_user',
-					'value' => $request['customer'],
-					'type'  => 'NUMERIC',
-				);
+			if ( ! empty( $args['meta_query'] ) ) {
+				$args['meta_query'] = array(); // WPCS: slow query ok.
 			}
+
+			$args['meta_query'][] = array(
+				'key'   => '_customer_user',
+				'value' => $request['customer'],
+				'type'  => 'NUMERIC',
+			);
 		}
 
 		// Search by product.

--- a/includes/class-wc-background-updater.php
+++ b/includes/class-wc-background-updater.php
@@ -99,6 +99,7 @@ class WC_Background_Updater extends WC_Background_Process {
 		wc_maybe_define_constant( 'WC_UPDATING', true );
 
 		$logger = wc_get_logger();
+		$result = null;
 
 		include_once dirname( __FILE__ ) . '/wc-update-functions.php';
 
@@ -113,8 +114,6 @@ class WC_Background_Updater extends WC_Background_Process {
 			} else {
 				$logger->info( sprintf( 'Finished running %s callback', $callback ), array( 'source' => 'wc_db_updates' ) );
 			}
-		} else {
-			$logger->notice( sprintf( 'Could not find %s callback', $callback ), array( 'source' => 'wc_db_updates' ) );
 		}
 
 		return $result ? $callback : false;

--- a/includes/class-wc-background-updater.php
+++ b/includes/class-wc-background-updater.php
@@ -99,7 +99,6 @@ class WC_Background_Updater extends WC_Background_Process {
 		wc_maybe_define_constant( 'WC_UPDATING', true );
 
 		$logger = wc_get_logger();
-		$result = null;
 
 		include_once dirname( __FILE__ ) . '/wc-update-functions.php';
 
@@ -114,6 +113,8 @@ class WC_Background_Updater extends WC_Background_Process {
 			} else {
 				$logger->info( sprintf( 'Finished running %s callback', $callback ), array( 'source' => 'wc_db_updates' ) );
 			}
+		} else {
+			$logger->notice( sprintf( 'Could not find %s callback', $callback ), array( 'source' => 'wc_db_updates' ) );
 		}
 
 		return $result ? $callback : false;
@@ -137,7 +138,7 @@ class WC_Background_Updater extends WC_Background_Process {
 	 *
 	 * @return bool
 	 */
-	public function is_batch_limit_exceeded() {
-		return $this->batch_limit_exceeded();
+	public function is_memory_exceeded() {
+		return $this->memory_exceeded();
 	}
 }

--- a/includes/class-wc-background-updater.php
+++ b/includes/class-wc-background-updater.php
@@ -137,7 +137,7 @@ class WC_Background_Updater extends WC_Background_Process {
 	 *
 	 * @return bool
 	 */
-	public function is_memory_exceeded() {
-		return $this->memory_exceeded();
+	public function is_batch_limit_exceeded() {
+		return $this->batch_limit_exceeded();
 	}
 }

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -95,12 +95,12 @@ class WC_Install {
 			'wc_update_330_webhooks',
 			'wc_update_330_product_stock_status',
 			'wc_update_330_set_default_product_cat',
+			'wc_update_330_order_customer_id',
 			'wc_update_330_clear_transients',
 			'wc_update_330_set_paypal_sandbox_credentials',
 			'wc_update_330_db_version',
 		),
 		'3.4.0' => array(
-			'wc_update_340_order_customer_id',
 			'wc_update_340_states',
 			'wc_update_340_state',
 			'wc_update_340_last_active',

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -95,7 +95,6 @@ class WC_Install {
 			'wc_update_330_webhooks',
 			'wc_update_330_product_stock_status',
 			'wc_update_330_set_default_product_cat',
-			'wc_update_330_order_customer_id',
 			'wc_update_330_clear_transients',
 			'wc_update_330_set_paypal_sandbox_credentials',
 			'wc_update_330_db_version',

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -100,6 +100,7 @@ class WC_Install {
 			'wc_update_330_db_version',
 		),
 		'3.4.0' => array(
+			'wc_update_340_order_customer_id',
 			'wc_update_340_states',
 			'wc_update_340_state',
 			'wc_update_340_last_active',
@@ -114,7 +115,6 @@ class WC_Install {
 			'wc_update_344_db_version',
 		),
 		'3.5.0' => array(
-			'wc_update_350_order_customer_id',
 			'wc_update_350_reviews_comment_type',
 			'wc_update_350_db_version',
 		),

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -67,7 +67,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					'post_type'     => $order->get_type( 'edit' ),
 					'post_status'   => 'wc-' . ( $order->get_status( 'edit' ) ? $order->get_status( 'edit' ) : apply_filters( 'woocommerce_default_order_status', 'pending' ) ),
 					'ping_status'   => 'closed',
-					'post_author'   => is_callable( array( $order, 'get_customer_id' ) ) ? $order->get_customer_id() : 1,
+					'post_author'   => 1,
 					'post_title'    => $this->get_post_title(),
 					'post_password' => uniqid( 'order_' ),
 					'post_parent'   => $order->get_parent_id( 'edit' ),
@@ -139,7 +139,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		$changes = $order->get_changes();
 
 		// Only update the post when the post data changes.
-		if ( array_intersect( array( 'date_created', 'date_modified', 'status', 'parent_id', 'post_excerpt', 'customer_id' ), array_keys( $changes ) ) ) {
+		if ( array_intersect( array( 'date_created', 'date_modified', 'status', 'parent_id', 'post_excerpt' ), array_keys( $changes ) ) ) {
 			$post_data = array(
 				'post_date'         => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getOffsetTimestamp() ),
 				'post_date_gmt'     => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
@@ -148,7 +148,6 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				'post_excerpt'      => $this->get_post_excerpt( $order ),
 				'post_modified'     => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $order->get_date_modified( 'edit' )->getOffsetTimestamp() ) : current_time( 'mysql' ),
 				'post_modified_gmt' => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $order->get_date_modified( 'edit' )->getTimestamp() ) : current_time( 'mysql', 1 ),
-				'post_author'       => is_callable( array( $order, 'get_customer_id' ) ) ? $order->get_customer_id() : 1,
 			);
 
 			/**
@@ -166,25 +165,10 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				wp_update_post( array_merge( array( 'ID' => $order->get_id() ), $post_data ) );
 			}
 			$order->read_meta_data( true ); // Refresh internal meta data, in case things were hooked into `save_post` or another WP hook.
-
-			// If customer changed, update any downloadable permissions.
-			if ( in_array( 'customer_id', $changes ) ) {
-				$this->update_downloadable_permissions( $order );
-			}
 		}
 		$this->update_post_meta( $order );
 		$order->apply_changes();
 		$this->clear_caches( $order );
-	}
-
-	/**
-	 * Update downloadable permissions for a given order.
-	 *
-	 * @param WC_Order $order Order object.
-	 */
-	protected function update_downloadable_permissions( $order ) {
-		$data_store = WC_Data_Store::load( 'customer-download' );
-		$data_store->update_user_by_order_id( $order->get_id(), $order->get_customer_id(), $order->get_billing_email() );
 	}
 
 	/**

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -67,7 +67,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					'post_type'     => $order->get_type( 'edit' ),
 					'post_status'   => 'wc-' . ( $order->get_status( 'edit' ) ? $order->get_status( 'edit' ) : apply_filters( 'woocommerce_default_order_status', 'pending' ) ),
 					'ping_status'   => 'closed',
-					'post_author'   => is_callable( array( $order, 'get_customer_id' ) ) ? $order->get_customer_id() : 0,
+					'post_author'   => is_callable( array( $order, 'get_customer_id' ) ) ? $order->get_customer_id() : 1,
 					'post_title'    => $this->get_post_title(),
 					'post_password' => uniqid( 'order_' ),
 					'post_parent'   => $order->get_parent_id( 'edit' ),
@@ -148,7 +148,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 				'post_excerpt'      => $this->get_post_excerpt( $order ),
 				'post_modified'     => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $order->get_date_modified( 'edit' )->getOffsetTimestamp() ) : current_time( 'mysql' ),
 				'post_modified_gmt' => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $order->get_date_modified( 'edit' )->getTimestamp() ) : current_time( 'mysql', 1 ),
-				'post_author'       => is_callable( array( $order, 'get_customer_id' ) ) ? $order->get_customer_id() : 0,
+				'post_author'       => is_callable( array( $order, 'get_customer_id' ) ) ? $order->get_customer_id() : 1,
 			);
 
 			/**

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -107,17 +107,10 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			$date_paid = get_post_meta( $id, '_paid_date', true );
 		}
 
-		// Make sure post_author is used only after WC 3.3.0 DB upgrade routine is executed.
-		if ( version_compare( get_option( 'woocommerce_db_version' ), '3.3.0', '>=' ) ) {
-			$customer_id = $post_object->post_author;
-		} else {
-			$customer_id = get_post_meta( $id, '_customer_user', true );
-		}
-
 		$order->set_props(
 			array(
 				'order_key'            => get_post_meta( $id, '_order_key', true ),
-				'customer_id'          => $customer_id,
+				'customer_id'          => $post_object->post_author,
 				'billing_first_name'   => get_post_meta( $id, '_billing_first_name', true ),
 				'billing_last_name'    => get_post_meta( $id, '_billing_last_name', true ),
 				'billing_company'      => get_post_meta( $id, '_billing_company', true ),

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -651,11 +651,6 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			'page'           => 'paged',
 		);
 
-		// On WC 3.5.0 the ID of the user that placed the order was moved from the post meta _customer_user to the post_author field in the wp_posts table.
-		if ( version_compare( get_option( 'woocommerce_db_version' ), '3.5.0', '>=' ) ) {
-			$key_mapping['customer_id'] = 'author';
-		}
-
 		foreach ( $key_mapping as $query_key => $db_key ) {
 			if ( isset( $query_vars[ $query_key ] ) ) {
 				$query_vars[ $db_key ] = $query_vars[ $query_key ];

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -107,8 +107,8 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			$date_paid = get_post_meta( $id, '_paid_date', true );
 		}
 
-		// On WC 3.5.0 the ID of the user that placed the order was moved from the post meta _customer_user to the post_author field in the wp_posts table.
-		if ( version_compare( get_option( 'woocommerce_db_version' ), '3.5.0', '>=' ) ) {
+		// Make sure post_author is used only after WC 3.4.0 DB upgrade routine is executed.
+		if ( version_compare( get_option( 'woocommerce_db_version' ), '3.4.0', '>=' ) ) {
 			$customer_id = $post_object->post_author;
 		} else {
 			$customer_id = get_post_meta( $id, '_customer_user', true );

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -110,7 +110,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		$order->set_props(
 			array(
 				'order_key'            => get_post_meta( $id, '_order_key', true ),
-				'customer_id'          => $post_object->post_author,
+				'customer_id'          => get_post_meta( $id, '_customer_user', true ),
 				'billing_first_name'   => get_post_meta( $id, '_billing_first_name', true ),
 				'billing_last_name'    => get_post_meta( $id, '_billing_last_name', true ),
 				'billing_company'      => get_post_meta( $id, '_billing_company', true ),
@@ -258,9 +258,10 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			update_post_meta( $id, '_shipping_address_index', implode( ' ', $order->get_address( 'shipping' ) ) );
 		}
 
-		// If customer email changed, update any downloadable permissions.
-		if ( in_array( 'billing_email', $updated_props ) ) {
-			$this->update_downloadable_permissions( $order );
+		// If customer changed, update any downloadable permissions.
+		if ( in_array( 'customer_user', $updated_props ) || in_array( 'billing_email', $updated_props ) ) {
+			$data_store = WC_Data_Store::load( 'customer-download' );
+			$data_store->update_user_by_order_id( $id, $order->get_customer_id(), $order->get_billing_email() );
 		}
 
 		// Mark user account as active.

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -259,7 +259,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		}
 
 		// If customer changed, update any downloadable permissions.
-		if ( in_array( 'customer_user', $updated_props ) || in_array( 'billing_email', $updated_props ) ) {
+		if ( in_array( 'customer_id', $updated_props ) || in_array( 'billing_email', $updated_props ) ) {
 			$data_store = WC_Data_Store::load( 'customer-download' );
 			$data_store->update_user_by_order_id( $id, $order->get_customer_id(), $order->get_billing_email() );
 		}

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -107,8 +107,8 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			$date_paid = get_post_meta( $id, '_paid_date', true );
 		}
 
-		// Make sure post_author is used only after WC 3.4.0 DB upgrade routine is executed.
-		if ( version_compare( get_option( 'woocommerce_db_version' ), '3.4.0', '>=' ) ) {
+		// Make sure post_author is used only after WC 3.3.0 DB upgrade routine is executed.
+		if ( version_compare( get_option( 'woocommerce_db_version' ), '3.3.0', '>=' ) ) {
 			$customer_id = $post_object->post_author;
 		} else {
 			$customer_id = get_post_meta( $id, '_customer_user', true );

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1858,114 +1858,85 @@ function wc_update_344_db_version() {
 /**
  * Copy order customer_id from post meta to post_author and set post_author to 0 for refunds.
  *
- * Two different strategies are used to copy data depending if the update is being executed from
- * the command line or not. If `wp wc update` is used to update the database, this function
- * copies data in a single go that is faster but uses more resources. If the databse update was
- * triggered from the wp-admin, this function copies data in batches which is slower but uses
- * few resources and thus is less likely to fail on smaller servers.
- *
- * @param WC_Background_Updater|false $updater Background updater instance or false if function is called from `wp wc update` WP-CLI command.
+ * @param WC_Background_Updater $updater Background updater instance.
  */
-function wc_update_350_order_customer_id( $updater = false ) {
+function wc_update_350_order_customer_id( $updater ) {
 	global $wpdb;
 
 	$post_types              = (array) apply_filters( 'woocommerce_update_350_order_customer_id_post_types', array( 'shop_order' ) );
 	$post_types_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
+	$admin_orders_sql        = '';
 
-	if ( defined( 'WP_CLI' ) && WP_CLI ) {
-		// If running the update from the command-line, copy data in a single go which is faster but uses more resources.
-		$wpdb->query(
-			'CREATE TEMPORARY TABLE customers_map (post_id BIGINT(20), customer_id BIGINT(20), PRIMARY KEY(post_id))'
-		);
-
-		$wpdb->query(
-			"INSERT IGNORE INTO customers_map (SELECT post_id, meta_value FROM {$wpdb->prefix}postmeta WHERE meta_key = '_customer_user')"
-		);
-
-		$wpdb->query( 'SET sql_safe_updates=1' );
-
-		$wpdb->query(
-			$wpdb->prepare(
-				"UPDATE {$wpdb->prefix}posts JOIN customers_map ON {$wpdb->prefix}posts.ID = customers_map.post_id SET {$wpdb->prefix}posts.post_author = customers_map.customer_id WHERE post_type IN ({$post_types_placeholders})",  // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-				$post_types
-			)
-		);
-
-		$wpdb->update( $wpdb->posts, array( 'post_author' => 0 ), array( 'post_type' => 'shop_order_refund' ) );
-	} else {
-		// If running the update from the wp-admin, copy data in batches being careful not to use more memory than allowed and respecting PHP time limit.
-		$admin_orders_sql = '';
-
-		// Get the list of orders that we don't want to change as they belong to user ID 1.
-		$admin_orders = $wpdb->get_col(
-			$wpdb->prepare(
-				"SELECT ID FROM wp_posts p
-				INNER JOIN wp_postmeta pm ON p.ID = pm.post_id
-				WHERE post_type IN ({$post_types_placeholders}) AND meta_key = '_customer_user' AND meta_value = 1", // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-				$post_types
-			)
-		);
-
-		if ( ! empty( $admin_orders ) ) {
-			$admin_orders_sql .= ' AND ID NOT IN (' . implode( ', ', $admin_orders ) . ') ';
-		}
-
-		// Query to get a batch of orders IDs to change.
-		$query = $wpdb->prepare(
-			// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
-			"SELECT ID FROM {$wpdb->posts}
-	        WHERE post_author = 1 AND post_type IN ({$post_types_placeholders}) $admin_orders_sql
-			LIMIT 1000",
+	// Get the list of orders that we don't want to change as they belong to user ID 1.
+	$admin_orders = $wpdb->get_col(
+		$wpdb->prepare(
+			"SELECT ID FROM wp_posts p
+			INNER JOIN wp_postmeta pm ON p.ID = pm.post_id
+			WHERE post_type IN ({$post_types_placeholders}) AND meta_key = '_customer_user' AND meta_value = 1", // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$post_types
-			// phpcs:enable
-		);
+		)
+	);
 
-		while ( true ) {
-			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-			$orders_to_update = $wpdb->get_col( $query );
+	if ( ! empty( $admin_orders ) ) {
+		$admin_orders_sql .= ' AND ID NOT IN (' . implode( ', ', $admin_orders ) . ') ';
+	}
 
-			// Exit loop if no more orders to update.
-			if ( ! $orders_to_update ) {
-				break;
-			}
+	// Query to get a batch of orders IDs to change.
+	$query = $wpdb->prepare(
+		// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
+		"SELECT ID FROM {$wpdb->posts}
+ 		WHERE post_author = 1 AND post_type IN ({$post_types_placeholders}) $admin_orders_sql
+		LIMIT 1000",
+		$post_types
+		// phpcs:enable
+	);
 
-			$orders_meta_data = $wpdb->get_results(
-				// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-				"SELECT post_id, meta_value as customer_id FROM {$wpdb->postmeta} WHERE meta_key = '_customer_user' AND post_id IN (" . implode( ', ', $orders_to_update ) . ')'
-			);
+	while ( true ) {
+		// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+		$orders_to_update = $wpdb->get_col( $query );
 
-			// Exit loop if no _customer_user metas exist for the list of orders to update.
-			if ( ! $orders_meta_data ) {
-				break;
-			}
-
-			// Update post_author for a batch of orders.
-			foreach ( $orders_meta_data as $order_meta ) {
-				// Stop update execution and re-enqueue it if near memory and timeout limits.
-				if ( $updater instanceof WC_Background_Updater && $updater->is_batch_limit_exceeded() ) {
-					return -1;
-				}
-
-				$wpdb->update( $wpdb->posts, array( 'post_author' => $order_meta->customer_id ), array( 'ID' => $order_meta->post_id ) );
-			}
+		// Exit loop if no more orders to update.
+		if ( ! $orders_to_update ) {
+			break;
 		}
 
-		// Set post_author to 0 instead of 1 on all shop_order_refunds.
-		while ( true ) {
+		$orders_meta_data = $wpdb->get_results(
+			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+			"SELECT post_id, meta_value as customer_id FROM {$wpdb->postmeta} WHERE meta_key = '_customer_user' AND post_id IN (" . implode( ', ', $orders_to_update ) . ')'
+		);
+
+		// Exit loop if no _customer_user metas exist for the list of orders to update.
+		if ( ! $orders_meta_data ) {
+			break;
+		}
+
+		// Update post_author for a batch of orders.
+		foreach ( $orders_meta_data as $order_meta ) {
 			// Stop update execution and re-enqueue it if near memory and timeout limits.
-			if ( $updater instanceof WC_Background_Updater && $updater->is_batch_limit_exceeded() ) {
+			if ( $updater->is_batch_limit_exceeded() ) {
 				return -1;
 			}
 
-			$updated_rows = $wpdb->query( "UPDATE {$wpdb->posts} SET post_author = 0 WHERE post_type = 'shop_order_refund' LIMIT 1000" );
+			$wpdb->update( $wpdb->posts, array( 'post_author' => $order_meta->customer_id ), array( 'ID' => $order_meta->post_id ) );
 
-			if ( ! $updated_rows ) {
-				break;
-			}
+			wp_cache_delete( $order_meta->post_id, 'posts' );
+			wp_cache_delete( $order_meta->post_id, 'post_meta' );
 		}
 	}
 
-	wp_cache_flush();
+	// Set post_author to 0 instead of 1 to all shop_order_refunds.
+	while ( true ) {
+		// Stop update execution and re-enqueue it if near memory and timeout limits.
+		if ( $updater->is_batch_limit_exceeded() ) {
+			return -1;
+		}
+
+		$updated_rows = $wpdb->query( "UPDATE {$wpdb->posts} SET post_author = 0 WHERE post_type = 'shop_order_refund' LIMIT 1000" );
+
+		if ( ! $updated_rows ) {
+			break;
+		}
+	}
 }
 
 /**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1566,7 +1566,7 @@ function wc_update_330_set_default_product_cat() {
 /**
  * Copy order customer_id from post meta to post_author and set post_author to 0 for refunds.
  */
-function wc_update_340_order_customer_id() {
+function wc_update_330_order_customer_id() {
 	global $wpdb;
 
 	$orders_to_update = $wpdb->get_results(

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1857,86 +1857,27 @@ function wc_update_344_db_version() {
 
 /**
  * Copy order customer_id from post meta to post_author and set post_author to 0 for refunds.
- *
- * @param WC_Background_Updater $updater Background updater instance.
  */
-function wc_update_340_order_customer_id( $updater ) {
+function wc_update_340_order_customer_id() {
 	global $wpdb;
 
-	$post_types              = (array) apply_filters( 'woocommerce_update_340_order_customer_id_post_types', array( 'shop_order' ) );
-	$post_types_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
-	$admin_orders_sql        = '';
+	$post_types = (array) apply_filters( 'woocommerce_update_340_order_customer_id_post_types', array( 'shop_order' ) );
+	$query_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
 
-	// Get the list of orders that we don't want to change as they belong to user ID 1.
-	$admin_orders = $wpdb->get_col(
+	$orders_to_update = $wpdb->get_results(
 		$wpdb->prepare(
-			"SELECT ID FROM wp_posts p
-			INNER JOIN wp_postmeta pm ON p.ID = pm.post_id
-			WHERE post_type IN ({$post_types_placeholders}) AND meta_key = '_customer_user' AND meta_value = 1", // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+			"SELECT post_id, meta_value AS customer_id FROM {$wpdb->postmeta} pm
+			LEFT JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+			WHERE meta_key = '_customer_user' AND p.post_type IN ({$query_placeholders})", // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
 			$post_types
 		)
 	);
 
-	if ( ! empty( $admin_orders ) ) {
-		$admin_orders_sql .= ' AND ID NOT IN (' . implode( ', ', $admin_orders ) . ') ';
+	foreach ( $orders_to_update as $order ) {
+		$wpdb->update( $wpdb->posts, array( 'post_author' => $order->customer_id ), array( 'ID' => $order->post_id ) );
 	}
 
-	// Query to get a batch of orders IDs to change.
-	$query = $wpdb->prepare(
-		// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
-		"SELECT ID FROM {$wpdb->posts}
- 		WHERE post_author = 1 AND post_type IN ({$post_types_placeholders}) $admin_orders_sql
-		LIMIT 1000",
-		$post_types
-		// phpcs:enable
-	);
-
-	while ( true ) {
-		// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-		$orders_to_update = $wpdb->get_col( $query );
-
-		// Exit loop if no more orders to update.
-		if ( ! $orders_to_update ) {
-			break;
-		}
-
-		$orders_meta_data = $wpdb->get_results(
-			// phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-			"SELECT post_id, meta_value as customer_id FROM {$wpdb->postmeta} WHERE meta_key = '_customer_user' AND post_id IN (" . implode( ', ', $orders_to_update ) . ')'
-		);
-
-		// Exit loop if no _customer_user metas exist for the list of orders to update.
-		if ( ! $orders_meta_data ) {
-			break;
-		}
-
-		// Update post_author for a batch of orders.
-		foreach ( $orders_meta_data as $order_meta ) {
-			// Stop update execution and re-enqueue it if near memory and timeout limits.
-			if ( $updater->is_batch_limit_exceeded() ) {
-				return -1;
-			}
-
-			$wpdb->update( $wpdb->posts, array( 'post_author' => $order_meta->customer_id ), array( 'ID' => $order_meta->post_id ) );
-
-			wp_cache_delete( $order_meta->post_id, 'posts' );
-			wp_cache_delete( $order_meta->post_id, 'post_meta' );
-		}
-	}
-
-	// Set post_author to 0 instead of 1 to all shop_order_refunds.
-	while ( true ) {
-		// Stop update execution and re-enqueue it if near memory and timeout limits.
-		if ( $updater->is_batch_limit_exceeded() ) {
-			return -1;
-		}
-
-		$updated_rows = $wpdb->query( "UPDATE {$wpdb->posts} SET post_author = 0 WHERE post_type = 'shop_order_refund' LIMIT 1000" );
-
-		if ( ! $updated_rows ) {
-			break;
-		}
-	}
+	$wpdb->update( $wpdb->posts, array( 'post_author' => 0 ), array( 'post_type' => 'shop_order_refund' ) );
 }
 
 /**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1865,7 +1865,6 @@ function wc_update_344_db_version() {
  * few resources and thus is less likely to fail on smaller servers.
  *
  * @param WC_Background_Updater|false $updater Background updater instance or false if function is called from `wp wc update` WP-CLI command.
- * @return true|void Return true if near memory limit and needs to restart. Return void if update completed.
  */
 function wc_update_350_order_customer_id( $updater = false ) {
 	global $wpdb;

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1564,21 +1564,6 @@ function wc_update_330_set_default_product_cat() {
 }
 
 /**
- * Copy order customer_id from post meta to post_author.
- */
-function wc_update_330_order_customer_id() {
-	global $wpdb;
-
-	$orders_to_update = $wpdb->get_results(
-		"SELECT post_id, meta_value AS customer_id FROM {$wpdb->postmeta} pm LEFT JOIN {$wpdb->posts} p ON p.ID = pm.post_id WHERE meta_key = '_customer_user' AND p.post_type = 'shop_order'"
-	);
-
-	foreach ( $orders_to_update as $order ) {
-		$wpdb->update( $wpdb->posts, array( 'post_author' => $order->customer_id ), array( 'ID' => $order->post_id ) );
-	}
-}
-
-/**
  * Update product stock status to use the new onbackorder status.
  */
 function wc_update_330_product_stock_status() {

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1564,6 +1564,31 @@ function wc_update_330_set_default_product_cat() {
 }
 
 /**
+ * Copy order customer_id from post meta to post_author and set post_author to 0 for refunds.
+ */
+function wc_update_340_order_customer_id() {
+	global $wpdb;
+
+	$post_types = (array) apply_filters( 'woocommerce_update_340_order_customer_id_post_types', array( 'shop_order' ) );
+	$query_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
+
+	$orders_to_update = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT post_id, meta_value AS customer_id FROM {$wpdb->postmeta} pm
+			LEFT JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+			WHERE meta_key = '_customer_user' AND p.post_type IN ({$query_placeholders})", // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+			$post_types
+		)
+	);
+
+	foreach ( $orders_to_update as $order ) {
+		$wpdb->update( $wpdb->posts, array( 'post_author' => $order->customer_id ), array( 'ID' => $order->post_id ) );
+	}
+
+	$wpdb->update( $wpdb->posts, array( 'post_author' => 0 ), array( 'post_type' => 'shop_order_refund' ) );
+}
+
+/**
  * Update product stock status to use the new onbackorder status.
  */
 function wc_update_330_product_stock_status() {
@@ -1853,31 +1878,6 @@ function wc_update_344_recreate_roles() {
  */
 function wc_update_344_db_version() {
 	WC_Install::update_db_version( '3.4.4' );
-}
-
-/**
- * Copy order customer_id from post meta to post_author and set post_author to 0 for refunds.
- */
-function wc_update_340_order_customer_id() {
-	global $wpdb;
-
-	$post_types = (array) apply_filters( 'woocommerce_update_340_order_customer_id_post_types', array( 'shop_order' ) );
-	$query_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
-
-	$orders_to_update = $wpdb->get_results(
-		$wpdb->prepare(
-			"SELECT post_id, meta_value AS customer_id FROM {$wpdb->postmeta} pm
-			LEFT JOIN {$wpdb->posts} p ON p.ID = pm.post_id
-			WHERE meta_key = '_customer_user' AND p.post_type IN ({$query_placeholders})", // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-			$post_types
-		)
-	);
-
-	foreach ( $orders_to_update as $order ) {
-		$wpdb->update( $wpdb->posts, array( 'post_author' => $order->customer_id ), array( 'ID' => $order->post_id ) );
-	}
-
-	$wpdb->update( $wpdb->posts, array( 'post_author' => 0 ), array( 'post_type' => 'shop_order_refund' ) );
 }
 
 /**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1895,22 +1895,16 @@ function wc_update_350_order_customer_id( $updater = false ) {
 	} else {
 		// If running the update from the wp-admin, copy data in batches being careful not to use more memory than allowed.
 		$admin_orders_sql = '';
-		$admin_orders     = get_transient( 'wc_update_350_admin_orders' );
 
-		if ( false === $admin_orders ) {
-			// Get the list of orders that we don't want to change as they belong to user ID 1.
-			$admin_orders = $wpdb->get_col(
-				$wpdb->prepare(
-					"SELECT ID FROM {$wpdb->prefix}posts p
-					INNER JOIN {$wpdb->prefix}postmeta pm ON p.ID = pm.post_id
-					WHERE post_type IN ({$post_types_placeholders}) AND meta_key = '_customer_user' AND meta_value = 1", // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-					$post_types
-				)
-			);
-
-			// Cache the list of orders placed by the user ID 1 as to large stores this query can be slow.
-			set_transient( 'wc_update_350_admin_orders', $admin_orders, DAY_IN_SECONDS );
-		}
+		// Get the list of orders that we don't want to change as they belong to user ID 1.
+		$admin_orders = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM wp_posts p
+				INNER JOIN wp_postmeta pm ON p.ID = pm.post_id
+				WHERE post_type IN ({$post_types_placeholders}) AND meta_key = '_customer_user' AND meta_value = 1", // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+				$post_types
+			)
+		);
 
 		if ( ! empty( $admin_orders ) ) {
 			$admin_orders_sql .= ' AND ID NOT IN (' . implode( ', ', $admin_orders ) . ') ';

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1564,7 +1564,7 @@ function wc_update_330_set_default_product_cat() {
 }
 
 /**
- * Copy order customer_id from post meta to post_author and set post_author to 0 for refunds.
+ * Copy order customer_id from post meta to post_author.
  */
 function wc_update_330_order_customer_id() {
 	global $wpdb;
@@ -1576,8 +1576,6 @@ function wc_update_330_order_customer_id() {
 	foreach ( $orders_to_update as $order ) {
 		$wpdb->update( $wpdb->posts, array( 'post_author' => $order->customer_id ), array( 'ID' => $order->post_id ) );
 	}
-
-	$wpdb->update( $wpdb->posts, array( 'post_author' => 0 ), array( 'post_type' => 'shop_order_refund' ) );
 }
 
 /**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1920,7 +1920,7 @@ function wc_update_350_order_customer_id( $updater = false ) {
 		$query = $wpdb->prepare(
 			// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared
 			"SELECT ID FROM {$wpdb->posts}
-			WHERE post_author = 1 AND post_type IN ({$post_types_placeholders}) $admin_orders_sql
+	        WHERE post_author = 1 AND post_type IN ({$post_types_placeholders}) $admin_orders_sql
 			LIMIT 1000",
 			$post_types
 			// phpcs:enable

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1569,16 +1569,8 @@ function wc_update_330_set_default_product_cat() {
 function wc_update_340_order_customer_id() {
 	global $wpdb;
 
-	$post_types = (array) apply_filters( 'woocommerce_update_340_order_customer_id_post_types', array( 'shop_order' ) );
-	$query_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
-
 	$orders_to_update = $wpdb->get_results(
-		$wpdb->prepare(
-			"SELECT post_id, meta_value AS customer_id FROM {$wpdb->postmeta} pm
-			LEFT JOIN {$wpdb->posts} p ON p.ID = pm.post_id
-			WHERE meta_key = '_customer_user' AND p.post_type IN ({$query_placeholders})", // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
-			$post_types
-		)
+		"SELECT post_id, meta_value AS customer_id FROM {$wpdb->postmeta} pm LEFT JOIN {$wpdb->posts} p ON p.ID = pm.post_id WHERE meta_key = '_customer_user' AND p.post_type = 'shop_order'"
 	);
 
 	foreach ( $orders_to_update as $order ) {

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1860,10 +1860,10 @@ function wc_update_344_db_version() {
  *
  * @param WC_Background_Updater $updater Background updater instance.
  */
-function wc_update_350_order_customer_id( $updater ) {
+function wc_update_340_order_customer_id( $updater ) {
 	global $wpdb;
 
-	$post_types              = (array) apply_filters( 'woocommerce_update_350_order_customer_id_post_types', array( 'shop_order' ) );
+	$post_types              = (array) apply_filters( 'woocommerce_update_340_order_customer_id_post_types', array( 'shop_order' ) );
 	$post_types_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
 	$admin_orders_sql        = '';
 

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -545,7 +545,7 @@ function wc_get_customer_order_count( $user_id ) {
 }
 
 /**
- * Reset customer ID on orders when a user is deleted.
+ * Reset _customer_user on orders when a user is deleted.
  *
  * @param int $user_id User ID.
  */
@@ -558,21 +558,6 @@ function wc_reset_order_customer_id_on_deleted_user( $user_id ) {
 			'meta_value' => $user_id,
 		)
 	); // WPCS: slow query ok.
-
-	$post_types              = (array) apply_filters( 'woocommerce_reset_order_customer_id_post_types', array( 'shop_order' ) );
-	$post_types_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
-
-	// Since WC 3.5, the customer ID is stored both in the _customer_user postmeta and in the post_author field.
-	// In future versions of WC, the plan is to use only post_author and stop using _customer_user, but for now
-	// we have to update both places.
-	$wpdb->query(
-		// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
-		$wpdb->prepare(
-			"UPDATE {$wpdb->posts} SET `post_author` = 0 WHERE post_type IN ({$post_types_placeholders}) AND post_author = {$user_id}",
-			$post_types
-		)
-		// phpcs:enable
-	);
 }
 
 add_action( 'deleted_user', 'wc_reset_order_customer_id_on_deleted_user' );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -219,14 +219,10 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 	$result         = get_transient( $transient_name );
 
 	if ( false === $result ) {
-		$customer_data = array();
+		$customer_data = array( $user_id );
 
 		if ( $user_id ) {
 			$user = get_user_by( 'id', $user_id );
-
-			if ( version_compare( get_option( 'woocommerce_db_version' ), '3.5.0', '<' ) ) {
-				$customer_data[] = $user_id;
-			}
 
 			if ( isset( $user->user_email ) ) {
 				$customer_data[] = $user->user_email;
@@ -244,31 +240,19 @@ function wc_customer_bought_product( $customer_email, $user_id, $product_id ) {
 			return false;
 		}
 
-		if ( version_compare( get_option( 'woocommerce_db_version' ), '3.5.0', '>=' ) && $user_id ) {
-			// Since WC 3.5 wp_posts.post_author is used to store the ID of the customer who placed an order.
-			$query = "SELECT im.meta_value FROM {$wpdb->posts} AS p
-				INNER JOIN {$wpdb->postmeta} AS pm ON p.ID = pm.post_id
-				INNER JOIN {$wpdb->prefix}woocommerce_order_items AS i ON p.ID = i.order_id
-				INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS im ON i.order_item_id = im.order_item_id
-				WHERE p.post_status IN ( 'wc-" . implode( "','wc-", $statuses ) . "' )
-				AND p.post_author = {$user_id}
-				AND pm.meta_key = '_billing_email'
-				AND im.meta_key IN ( '_product_id', '_variation_id' )
-				AND im.meta_value != 0
-				AND pm.meta_value IN ( '" . implode( "','", $customer_data ) . "' )";
-		} else {
-			$query = "SELECT im.meta_value FROM {$wpdb->posts} AS p
-				INNER JOIN {$wpdb->postmeta} AS pm ON p.ID = pm.post_id
-				INNER JOIN {$wpdb->prefix}woocommerce_order_items AS i ON p.ID = i.order_id
-				INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS im ON i.order_item_id = im.order_item_id
-				WHERE p.post_status IN ( 'wc-" . implode( "','wc-", $statuses ) . "' )
-				AND pm.meta_key IN ( '_billing_email', '_customer_user' )
-				AND im.meta_key IN ( '_product_id', '_variation_id' )
-				AND im.meta_value != 0
-				AND pm.meta_value IN ( '" . implode( "','", $customer_data ) . "' )";
-		}
-
-		$result = $wpdb->get_col( $query ); // WPCS: unprepared SQL ok.
+		$result = $wpdb->get_col(
+			"
+			SELECT im.meta_value FROM {$wpdb->posts} AS p
+			INNER JOIN {$wpdb->postmeta} AS pm ON p.ID = pm.post_id
+			INNER JOIN {$wpdb->prefix}woocommerce_order_items AS i ON p.ID = i.order_id
+			INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS im ON i.order_item_id = im.order_item_id
+			WHERE p.post_status IN ( 'wc-" . implode( "','wc-", $statuses ) . "' )
+			AND pm.meta_key IN ( '_billing_email', '_customer_user' )
+			AND im.meta_key IN ( '_product_id', '_variation_id' )
+			AND im.meta_value != 0
+			AND pm.meta_value IN ( '" . implode( "','", $customer_data ) . "' )
+		"
+		); // WPCS: unprepared SQL ok.
 		$result = array_map( 'absint', $result );
 
 		set_transient( $transient_name, $result, DAY_IN_SECONDS * 30 );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -577,7 +577,6 @@ function wc_reset_order_customer_id_on_deleted_user( $user_id ) {
 
 	$post_types              = (array) apply_filters( 'woocommerce_reset_order_customer_id_post_types', array( 'shop_order' ) );
 	$post_types_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
-	$query_args              = array_merge( $post_types, array( $user_id ) );
 
 	// Since WC 3.5, the customer ID is stored both in the _customer_user postmeta and in the post_author field.
 	// In future versions of WC, the plan is to use only post_author and stop using _customer_user, but for now
@@ -585,8 +584,8 @@ function wc_reset_order_customer_id_on_deleted_user( $user_id ) {
 	$wpdb->query(
 		// phpcs:disable WordPress.WP.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 		$wpdb->prepare(
-			"UPDATE {$wpdb->posts} SET `post_author` = 0 WHERE post_type IN ({$post_types_placeholders}) AND post_author = %d",
-			$query_args
+			"UPDATE {$wpdb->posts} SET `post_author` = 0 WHERE post_type IN ({$post_types_placeholders}) AND post_author = {$user_id}",
+			$post_types
 		)
 		// phpcs:enable
 	);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR reverts #17895 which was introduced in WC 3.5 to use post_author instead of `_customer_user` post meta to store customer ID for orders. After talking to @claudiulodro, we decided to revert the changes for WC 3.5.1 and reconsider #17895 for 3.6. This decision was made due to the bugs that were introduced by #17895 and that we didn't catch before the release (#21656, #21687 and #21737). All the issues seem fixable, but we are opting to err on the side of caution instead of rushing to create fixes that could introduce more problems. Reverting is the safest and fastest option that we have now.

#17895 copied data from `_customer_user` postmeta to the field `post_autor` of the table `wp_posts` and changed WooCommerce to populate both `customer_user` and `post_author` when a order is created or updated. So, this PR simply revert the code changes to make WooCommerce get the customer ID for orders in the old way. For now, we are not touching the data that was copied to `post_author` and this shouldn't be a problem as WooCommerce doesn't use this field for orders.

It was not possible to revert #17895 automatically, so I had to revert each commit manually. I decided to keep the changes introduced in `includes/class-wc-background-updater.php` (https://github.com/woocommerce/woocommerce/pull/17895/files#diff-3809cc9b6218b1f645071ed0351b2edc) as they could be useful for future database update routines.

Closes #21656, #21687, #21737 and #21741.
Supersedes #21673 and #21695

### How to test the changes in this Pull Request:

1. Check that code changes were properly reverted
2. Check that the issue in #21737 was fixed
3. Test that the functionality altered in this PR still works: customer reports, filter orders by customer in the admin interface, filter orders by customer in the REST API, saving customer ID when placing an order or manually created it via wp-admin, saving customer ID when updating an order, get customer last order (https://github.com/woocommerce/woocommerce/compare/revert/17895?expand=1#diff-d6dba1e5e24baa6d5d15671305dd1994R325), `wc_reset_order_customer_id_on_deleted_user()` and `wc_customer_bought_product()`.
4. Make sure that orders that were created after the WC 3.5 have the correct customer after updating to 3.5.1.

### Changelog entry

> Revert PR to use post_author instead of the post meta '_customer_user' to store customer ID for orders
