### PR TITLE
Make easy to register new REST API versions into webhooks

### DIFF
--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -119,7 +119,8 @@ class WC_Admin_Webhooks {
 		}
 
 		// API version.
-		$webhook->set_api_version( ! empty( $_POST['webhook_api_version'] ) ? sanitize_text_field( wp_unslash( $_POST['webhook_api_version'] ) ) : 'wp_api_v2' ); // WPCS: input var okay, CSRF ok.
+		$rest_api_versions = wc_get_webhook_rest_api_versions();
+		$webhook->set_api_version( ! empty( $_POST['webhook_api_version'] ) ? sanitize_text_field( wp_unslash( $_POST['webhook_api_version'] ) ) : end( $rest_api_versions ) ); // WPCS: input var okay, CSRF ok.
 
 		$webhook->save();
 

--- a/includes/admin/settings/views/html-webhooks-edit.php
+++ b/includes/admin/settings/views/html-webhooks-edit.php
@@ -136,8 +136,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 				</th>
 				<td class="forminp">
 					<select name="webhook_api_version" id="webhook_api_version">
-						<option value="wp_api_v2" <?php selected( 'wp_api_v2', $webhook->get_api_version(), true ); ?>><?php esc_html_e( 'WP REST API Integration v2', 'woocommerce' ); ?></option>
-						<option value="wp_api_v1" <?php selected( 'wp_api_v1', $webhook->get_api_version(), true ); ?>><?php esc_html_e( 'WP REST API Integration v1', 'woocommerce' ); ?></option>
+						<?php foreach ( array_reverse( wc_get_webhook_rest_api_versions() ) as $version ) : ?>
+							<option value="<?php echo esc_attr( $version ); ?>" <?php selected( $version, $webhook->get_api_version(), true ); ?>>
+								<?php
+									/* translators: %d: rest api version number */
+									echo esc_html( sprintf( __( 'WP REST API Integration v%d', 'woocommerce' ), str_replace( 'wp_api_v', '', $version ) ) );
+								?>
+							</option>
+						<?php endforeach; ?>
 						<option value="legacy_v3" <?php selected( 'legacy_v3', $webhook->get_api_version(), true ); ?>><?php esc_html_e( 'Legacy API v3 (deprecated)', 'woocommerce' ); ?></option>
 					</select>
 				</td>

--- a/includes/api/class-wc-rest-webhooks-controller.php
+++ b/includes/api/class-wc-rest-webhooks-controller.php
@@ -24,4 +24,14 @@ class WC_REST_Webhooks_Controller extends WC_REST_Webhooks_V2_Controller {
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Get the default REST API version.
+	 *
+	 * @since  3.0.0
+	 * @return string
+	 */
+	protected function get_default_api_version() {
+		return 'wp_api_v3';
+	}
 }

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -280,7 +280,8 @@ class WC_Webhook extends WC_Legacy_Webhook {
 	 * @return array
 	 */
 	private function get_wp_api_payload( $resource, $resource_id, $event ) {
-		$version_suffix = 'wp_api_v1' === $this->get_api_version() ? '_V1' : '';
+		$rest_api_versions = wc_get_webhook_rest_api_versions();
+		$version_suffix    = end( $rest_api_versions ) === $this->get_api_version() ? strtoupper( str_replace( 'wp_api', '', $this->get_api_version() ) ) : '';
 
 		switch ( $resource ) {
 			case 'coupon':
@@ -340,7 +341,7 @@ class WC_Webhook extends WC_Legacy_Webhook {
 				'id' => $resource_id,
 			);
 		} else {
-			if ( in_array( $this->get_api_version(), array( 'wp_api_v1', 'wp_api_v2' ), true ) ) {
+			if ( in_array( $this->get_api_version(), wc_get_webhook_rest_api_versions(), true ) ) {
 				$payload = $this->get_wp_api_payload( $resource, $resource_id, $event );
 			} else {
 				$payload = $this->get_legacy_api_payload( $resource, $resource_id, $event );

--- a/includes/wc-webhook-functions.php
+++ b/includes/wc-webhook-functions.php
@@ -21,7 +21,10 @@ function wc_webhook_process_delivery( $webhook, $arg ) {
 	// user who triggered it.
 	if ( apply_filters( 'woocommerce_webhook_deliver_async', true, $webhook, $arg ) ) {
 		// Deliver in background.
-		WC()->queue()->add( 'woocommerce_deliver_webhook_async', array( 'webhook_id' => $webhook->get_id(), 'arg' => $arg ), 'woocommerce-webhooks' );
+		WC()->queue()->add( 'woocommerce_deliver_webhook_async', array(
+			'webhook_id' => $webhook->get_id(),
+			'arg'        => $arg,
+		), 'woocommerce-webhooks' );
 	} else {
 		// Deliver immediately.
 		$webhook->deliver( $arg );
@@ -123,4 +126,18 @@ function wc_get_webhook( $id ) {
 	$webhook = new WC_Webhook( $id );
 
 	return 0 !== $webhook->get_id() ? $webhook : null;
+}
+
+/**
+ * Get webhoook REST API versions.
+ *
+ * @since 3.5.1
+ * @return array
+ */
+function wc_get_webhook_rest_api_versions() {
+	return array(
+		'wp_api_v1',
+		'wp_api_v2',
+		'wp_api_v3',
+	);
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Now we just need to update in one place when inserting new REST API versions.

Closes #21697

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Fix list of available REST API versions when editing a webhook.
