### PR TITLE
Fix get_cart_from_session infinite loop

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -61,6 +61,7 @@ final class WC_Cart_Session {
 	 * @since 3.2.0
 	 */
 	public function get_cart_from_session() {
+		do_action( 'woocommerce_load_cart_from_session' );
 		$this->cart->set_totals( WC()->session->get( 'cart_totals', null ) );
 		$this->cart->set_applied_coupons( WC()->session->get( 'applied_coupons', array() ) );
 		$this->cart->set_coupon_discount_totals( WC()->session->get( 'coupon_discount_totals', array() ) );

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -603,7 +603,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		if ( ! did_action( 'wp_loaded' ) ) {
 			wc_doing_it_wrong( __FUNCTION__, __( 'Get cart should not be called before the wp_loaded action.', 'woocommerce' ), '2.3' );
 		}
-		if ( ! did_action( 'woocommerce_cart_loaded_from_session' ) && ! isset( $_GET['order_again'] ) ) {
+		if ( ! did_action( 'woocommerce_load_cart_from_session' ) ) {
 			$this->session->get_cart_from_session();
 		}
 		return array_filter( $this->get_cart_contents() );

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -603,7 +603,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		if ( ! did_action( 'wp_loaded' ) ) {
 			wc_doing_it_wrong( __FUNCTION__, __( 'Get cart should not be called before the wp_loaded action.', 'woocommerce' ), '2.3' );
 		}
-		if ( ! did_action( 'woocommerce_cart_loaded_from_session' ) ) {
+		if ( ! did_action( 'woocommerce_cart_loaded_from_session' ) && ! isset( $_GET['order_again'] ) ) {
 			$this->session->get_cart_from_session();
 		}
 		return array_filter( $this->get_cart_contents() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When you use any of the hooks in `WC_Cart_Session::get_cart_from_session` and call `WC()->cart->get_cart()` it will go into an infinite loop as `get_cart` also calls `WC_Cart_Session::get_cart_from_session`

This PR adds a hook right at the top of the get_cart_from_session function and then when calling get_cart checks if the hook has not been executed yet before calling get_cart_from_session again.

Closes #21746 

### How to test the changes in this Pull Request:

1. See #21746 for code example to test
2. Use that code example and click the order again button on an order in your account
3. The cart page should load with the item and not display a 500 error page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Infinite loop when using a hook inside get_cart_from_session and calling get_cart in that hook.
