### PR TITLE
Use array instead of string to define class for address line 2 input on checkout

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -663,7 +663,7 @@ class WC_Countries {
 			),
 			'address_2'  => array(
 				'label'        => __( 'Apartment, suite, unit etc.', 'woocommerce' ),
-				'label_class'  => 'screen-reader-text',
+				'label_class'  => array( 'screen-reader-text' ),
 				'placeholder'  => esc_attr( $address_2_placeholder ),
 				'class'        => array( 'form-row-wide', 'address-field' ),
 				'autocomplete' => 'address-line2',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Doing this to be consistent with the other instances where a class is added to one of the checkout fields and thus make it easier for third-parties to add classes to checkout fields (see #21730).

Closes #21730.

### How to test the changes in this Pull Request:

1. Make sure that the class that was added in #21193 is still present

### Changelog entry

> Fix: use array instead of string to define class for address line 2 input on checkout
