### PR TITLE
Checkout fields priority refactor

### DIFF
--- a/assets/js/frontend/address-i18n.js
+++ b/assets/js/frontend/address-i18n.js
@@ -125,7 +125,4 @@ jQuery( function( $ ) {
 			rows.detach().appendTo( wrapper );
 		} );
 	});
-
-	// Make sure the locales are loaded on first page load.
-	$( '#billing_country' ).trigger( 'change' );
 });

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -238,8 +238,12 @@ class WC_Checkout {
 				'placeholder' => esc_attr__( 'Password', 'woocommerce' ),
 			);
 		}
-
 		$this->fields = apply_filters( 'woocommerce_checkout_fields', $this->fields );
+
+		foreach ( $this->fields as $field_type => $fields ) {
+			// Sort each of the checkout field sections based on priority.
+			uasort( $this->fields[ $field_type ], 'wc_checkout_fields_uasort_comparison' );
+		}
 
 		return $fieldset ? $this->fields[ $fieldset ] : $this->fields;
 	}

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1499,10 +1499,7 @@ function wc_nocache_headers() {
  * @return int
  */
 function wc_product_attribute_uasort_comparison( $a, $b ) {
-	if ( $a['position'] === $b['position'] ) {
-		return 0;
-	}
-	return ( $a['position'] < $b['position'] ) ? -1 : 1;
+	return wc_uasort_comparison( $a['position'], $b['position'] );
 }
 
 /**

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1515,6 +1515,18 @@ function wc_shipping_zone_method_order_uasort_comparison( $a, $b ) {
 }
 
 /**
+ * User to sort checkout fields based on priority with uasort.
+ *
+ * @since 3.5.1
+ * @param array $a First field to compare.
+ * @param array $b Second field to compare.
+ * @return int
+ */
+function wc_checkout_fields_uasort_comparison( $a, $b ) {
+	return wc_uasort_comparison( $a['priority'], $b['priority'] );
+}
+
+/**
  * User to sort two values with ausort.
  *
  * @since 3.5.1

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1514,15 +1514,13 @@ function wc_product_attribute_uasort_comparison( $a, $b ) {
  * @return int
  */
 function wc_shipping_zone_method_order_uasort_comparison( $a, $b ) {
-	if ( $a->method_order === $b->method_order ) {
-		return 0;
-	}
-	return ( $a->method_order < $b->method_order ) ? -1 : 1;
+	return wc_uasort_comparison( $a->method_order, $b->method_order );
 }
 
 /**
  * User to sort two values with ausort.
  *
+ * @since 3.5.1
  * @param int $a First value to compare.
  * @param int $b Second value to compare.
  * @return int

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1521,6 +1521,20 @@ function wc_shipping_zone_method_order_uasort_comparison( $a, $b ) {
 }
 
 /**
+ * User to sort two values with ausort.
+ *
+ * @param int $a First value to compare.
+ * @param int $b Second value to compare.
+ * @return int
+ */
+function wc_uasort_comparison( $a, $b ) {
+	if ( $a === $b ) {
+		return 0;
+	}
+	return ( $a < $b ) ? -1 : 1;
+}
+
+/**
  * Get rounding mode for internal tax calculations.
  *
  * @since 3.2.4

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -849,4 +849,25 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		$_SERVER['HTTP_USER_AGENT'] = $example_user_agent;
 		$this->assertEquals( $example_user_agent, wc_get_user_agent() );
 	}
+
+	/**
+	 * Test the wc_checkout_fields_uasort_comparison function.
+	 *
+	 * @return void
+	 */
+	public function test_wc_checkout_fields_uasort_comparison() {
+		$fields = array(
+			'billing_first_name' => array(
+				'priority' => 10,
+			),
+			'billing_last_name' => array(
+				'priority' => 20,
+			),
+			'billing_email' => array(
+				'priority' => 1,
+			),
+		);
+		uasort( $fields, 'wc_checkout_fields_uasort_comparison' );
+		$this->assertSame( 0, array_search( 'billing_email', array_keys( $fields ) ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In #20640 it was reported that the trigger to mimic a country select was causing issue, it was then removed which broke the field priority on intial page load. #21733 added back an onselect trigger without knowing it will cause #20640 to happen again.

This PR removes the onselect trigger again and goes with another approach by sorting via PHP, thanks @pierrebuet for the suggestion and idea based on the code you provided. I reworked Pierre's code a bit as it was not working on all the filters you can use to change the checkout fields and also refactored the other uasort methods we have by introducing a new wc_uasort_comparison method which can be reused.

Closes #21642

### How to test the changes in this Pull Request:

1. Use either the `woocommerce_checkout_fields` or `the woocommerce_default_address_fields` or any of the other filters you can use to alter the checkout fields and changes the priority of one of the fields to 1 so it should show right at the top of the checkout page.
2. Load the checkout page and ensure the field is displayed at the correct place based on the priority set.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Checkout field priority was not applying on initial page load.
