### PR TITLE
Allow plugins to filter located template location before failing

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -194,14 +194,14 @@ function wc_get_template( $template_name, $args = array(), $template_path = '', 
 
 	$located = wc_locate_template( $template_name, $template_path, $default_path );
 
+	// Allow 3rd party plugin filter template file from their plugin.
+	$located = apply_filters( 'wc_get_template', $located, $template_name, $args, $template_path, $default_path );
+
 	if ( ! file_exists( $located ) ) {
 		/* translators: %s template */
 		wc_doing_it_wrong( __FUNCTION__, sprintf( __( '%s does not exist.', 'woocommerce' ), '<code>' . $located . '</code>' ), '2.1' );
 		return;
 	}
-
-	// Allow 3rd party plugin filter template file from their plugin.
-	$located = apply_filters( 'wc_get_template', $located, $template_name, $args, $template_path, $default_path );
 
 	do_action( 'woocommerce_before_template_part', $template_name, $template_path, $located, $args );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently, you can add a new notice type using the `woocommerce_notice_types` filter. 

To output a notice added with a custom type, WooCommerce will automatically look for a corresponding notice template by calling `wc_get_template( "notices/{$notice_type}.php"` (https://github.com/woocommerce/woocommerce/blob/master/includes/wc-notice-functions.php#L139). 

However, if that template doesn't exist in WooCommerce core, then this will fail due to the checks at https://github.com/woocommerce/woocommerce/blob/master/includes/wc-core-functions.php#L199

It looks like there is a filter already in place that would allow plugins to register a template location for their custom template, but it is only called if the above test succeeds (e.g. there is an existing template in WooCommerce or the theme). 

That means that the following code will fail:

```php
add_filter( 'woocommerce_notice_types', function ($types) {
    $types[] = 'my-notice-type';
    return $types;
} );

add_filter( 'wc_get_template', function ( $located, $template_name, $args, $template_path, $default_path ) {
    if ( $template_name === 'notices/my-notice-type.php' && ! file_exists( $located ) ) {
        $located = dirname(__DIR__) . '/templates/my-notice-type.php';
    }
    return $located;
} );
```

Moving the filter before the `file_exists()` check resolves things so that plugin code can supply its own template file if none is found in WooCommerce. 

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Moves existing filter.

### Changelog entry

> Move `wc_get_template` filter to allow plugins to register locations for template files that do not exist in WooCommerce core.



