### PR TITLE
Make get_on_sale_products not include non published parent results

### DIFF
--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -495,12 +495,22 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$future_sale_product->set_price( $future_sale_product->get_regular_price() );
 		$future_sale_product->save();
 
+		$variable_draft_product = WC_Helper_Product::create_variation_product();
+		$variable_draft_product->set_status( 'draft' );
+		$variable_draft_product->save();
+		$children = $variable_draft_product->get_children();
+		$variable_draft_product_child = wc_get_product( $children[0] );
+		$variable_draft_product_child->set_sale_price( 8 );
+		$variable_draft_product_child->save();
+
 		$sale_products    = $product_store->get_on_sale_products();
 		$sale_product_ids = wp_list_pluck( $sale_products, 'id' );
 
 		$this->assertContains( $sale_product->get_id(), $sale_product_ids );
 		$this->assertNotContains( $not_sale_product->get_id(), $sale_product_ids );
 		$this->assertNotContains( $future_sale_product->get_id(), $sale_product_ids );
+		$this->assertNotContains( $variable_draft_product->get_id(), $sale_product_ids );
+		$this->assertNotContains( $variable_draft_product_child->get_id(), $sale_product_ids );
 	}
 
 	public function test_generate_product_title() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Do not include child products of parents that do not have the published status. Variable products that were set to draft with variations on sale were still returned by the on-sale product results due to not checking on the parent product status for children.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21426

### How to test the changes in this Pull Request:

1. See #21426

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Variable products set to draft with variations on sale were included in on sale product results.
