### PR TITLE
Check for empty height/width when determining if image regeneration should occur

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -206,7 +206,7 @@ class WC_Regenerate_Images {
 		$image_size  = wc_get_image_size( $size );
 		$ratio_match = false;
 
-		// If '' is passed to either size, we test ratios against the original file. It's uncropped.
+		// If either size is empty, we test ratios against the original file. It's uncropped.
 		if ( empty( $image_size['width'] ) || empty( $image_size['height'] ) ) {
 			$imagedata = wp_get_attachment_metadata( $attachment_id );
 

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -126,7 +126,7 @@ class WC_Regenerate_Images {
 		}
 
 		// If cropping mode has changed, regenerate the image.
-		if ( '' === $size_data['height'] && empty( $image['uncropped'] ) ) {
+		if ( empty( $size_data['height'] ) && empty( $image['uncropped'] ) ) {
 			return false;
 		}
 
@@ -207,7 +207,7 @@ class WC_Regenerate_Images {
 		$ratio_match = false;
 
 		// If '' is passed to either size, we test ratios against the original file. It's uncropped.
-		if ( '' === $image_size['width'] || '' === $image_size['height'] ) {
+		if ( empty( $image_size['width'] ) || empty( $image_size['height'] ) ) {
 			$imagedata = wp_get_attachment_metadata( $attachment_id );
 
 			if ( ! $imagedata ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Can we switch the check here to `empty()` instead of an empty string? In `/wp-includes/media.php` WP itself checks for a `0` value, not `''` - this makes it difficult to modify the values consistently when filtering `woocommerce_get_image_size_gallery_thumbnail`, for example.

### Changelog entry

> Check for empty height/width when determining if image regeneration should occur.
