### PR TITLE
Add woocommerce_hold_stock_minutes check back to  calculation

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -778,7 +778,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			}
 
 			// Check stock based on all items in the cart and consider any held stock within pending orders.
-			$held_stock     = wc_get_held_stock_quantity( $product, $current_session_order_id );
+			$held_stock     = ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product, $current_session_order_id ) : 0;
 			$required_stock = $product_qty_in_cart[ $product->get_stock_managed_by_id() ];
 
 			if ( $product->get_stock_quantity() < ( $held_stock + $required_stock ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
When calculating stock held in pending orders, first verify the setting of `woocommerce_hold_stock_minutes` is greater than zero, otherwise set `$held_stock` to 0.

Closes #21796 

### How to test the changes in this Pull Request:

1. In WooCommerce > Settings > Products > Inventory enable Manage Stock and leave Hold Stock (minutes) empty.
2. Install PayPal payment gateway & configure w/ Sandbox Credentials
3. Create a simple product with stock management enabled, stock quantity of 10, and backorders disallowed.
4. Add 10 of the newly created product to your cart and enter the PayPal checkout flow to create an order with a status of wc-pending (do not complete checkout).
5. In a separate incognito browser window, add the newly created product to your cart.
6. Go to the view cart screen and verify the error message is not displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed held stock check on cart & checkout screens.
