### PR TITLE
Check priority index before comparing

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1523,6 +1523,15 @@ function wc_shipping_zone_method_order_uasort_comparison( $a, $b ) {
  * @return int
  */
 function wc_checkout_fields_uasort_comparison( $a, $b ) {
+	/*
+	 * We are not guanranteed to get a priority
+	 * setting. So don't compare if they don't
+	 * exist.
+	 */
+	if ( ! isset( $a['priority'], $b['priority'] ) ) {
+		return 0;
+	}
+
 	return wc_uasort_comparison( $a['priority'], $b['priority'] );
 }
 

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1524,7 +1524,7 @@ function wc_shipping_zone_method_order_uasort_comparison( $a, $b ) {
  */
 function wc_checkout_fields_uasort_comparison( $a, $b ) {
 	/*
-	 * We are not guanranteed to get a priority
+	 * We are not guaranteed to get a priority
 	 * setting. So don't compare if they don't
 	 * exist.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This commit introduced an undefined index notice https://github.com/woocommerce/woocommerce/commit/c356f3d05324bf8223cf9c60959c46246dd6966d#diff-c49e4a77afbd1a753435a745896942a2

So this happened because not all checkout fields are guaranteed to have priority index. So the fix is to check if they're set before comparing to prevent this notice.

`Notice: Undefined index: priority in /srv/www/test/wp-content/plugins/woocommerce/includes/wc-core-functions.php on line 1535`

### How to test the changes in this Pull Request:

1. Add item to cart and go to checkout ( Make sure WP debug is turned on ).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix undefined index notice on checkout fields when comparing the sort order.
