### PR TITLE
fix: No warning-notification when trying to pay from the customer pay…

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -114,6 +114,11 @@ class WC_Shortcode_Checkout {
 					throw new Exception( sprintf( __( 'This order&rsquo;s status is &ldquo;%s&rdquo;&mdash;it cannot be paid for. Please contact us if you need assistance.', 'woocommerce' ), wc_get_order_status_name( $order->get_status() ) ) );
 				}
 
+				// Terms.
+				if ( ! empty( $_POST['terms-field'] ) && empty( $_POST['terms'] ) ) {
+					throw new Exception( __( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce' ) );
+				}
+
 				// Ensure order items are still stocked if paying for a failed order. Pending orders do not need this check because stock is held.
 				if ( ! $order->has_status( 'pending' ) ) {
 					$quantities = array();


### PR DESCRIPTION
…ments

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

I was able to reproduce issue and found that `class-wc-shortcode-checkout.php`  `order_pay` function to validate the conditions in that I did not see terms and condition was validating. I had add the conditions. would you please check for the same and let me know if any changes required.

Closes #21798

### How to test the changes in this Pull Request:
1.Add a product to cart and checkout with PayPal standard
2.When redirected to PayPal, cancel the payment and open the order from WooCommerce >> Orders
3.Click the customer payment page link and visit the customer payments page
4.Try to pay without checking the terms & conditions check box


### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

