### PR TITLE
Display notices in order pay page.

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -79,6 +79,8 @@ class WC_Shortcode_Checkout {
 
 		do_action( 'before_woocommerce_pay' );
 
+		wc_print_notices();
+
 		$order_id = absint( $order_id );
 
 		// Pay for existing order.

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -79,8 +79,6 @@ class WC_Shortcode_Checkout {
 
 		do_action( 'before_woocommerce_pay' );
 
-		wc_print_notices();
-
 		$order_id = absint( $order_id );
 
 		// Pay for existing order.

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -300,3 +300,4 @@ add_action( 'woocommerce_before_cart', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_checkout_form', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_account_content', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_customer_login_form', 'woocommerce_output_all_notices', 10 );
+add_action( 'before_woocommerce_pay', 'woocommerce_output_all_notices', 10 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

We are not display notices in order pay page, this should fix the issue and display any of the messages that checkout or a payment gateway may throw.

Closes #21798.

### How to test the changes in this Pull Request:

Details in #21798.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed notices in order pay page.