### PR TITLE
Fix for: WooCommerce Tax Rates (CSV) import does not work when entered path to file #21826

### DIFF
--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -201,7 +201,7 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 	 */
 	public function handle_upload() {
 		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification -- Nonce already verified in WC_Tax_Rate_Importer::dispatch()
-		$file_url = isset( $_POST['file_url'] ) ? esc_url_raw( wp_unslash( $_POST['file_url'] ) ) : '';
+		$file_url = isset( $_POST['file_url'] ) ? wc_clean( wp_unslash( $_POST['file_url'] ) ) : '';
 
 		if ( empty( $file_url ) ) {
 			$file = wp_import_handle_upload();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is a proposed solution for the issue which I have described here: https://github.com/woocommerce/woocommerce/issues/21826

It changes the escaping for `$file_url` in the function `handle_upload()`. Changing it in this way will properly process the CSV data and it doesn't output an error as it currently does. 

Closes #21826 .

### How to test the changes in this Pull Request:

1. Login admin section /wp-admin. 
2. Go to: Tools > Import > Under `WooCommerce tax rates (CSV)` click on “Run Importer”.
3. Enter a path at the section `OR enter path to file:` and click `Upload file and import`. I have used the by default enclosed shipped example at `wp-content/plugins/woocommerce/sample-data/sample_tax_rates.csv`. 
4. Now you’ll see the ouput `Import complete - imported 5 tax rates. | All done! View tax rates`.  

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Tax rates CSV upload is now using correct escaping for url of the file when entering . 