### PR TITLE
prepend dimension string in RTL languages

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -1232,10 +1232,14 @@ function wc_format_weight( $weight ) {
  * @return string
  */
 function wc_format_dimensions( $dimensions ) {
-	$dimension_string = implode( ' &times; ', array_filter( array_map( 'wc_format_localized_decimal', $dimensions ) ) );
+	$dimension_string = implode( ' x ', array_filter( array_map( 'wc_format_localized_decimal', $dimensions ) ) );
 
 	if ( ! empty( $dimension_string ) ) {
-		$dimension_string .= ' ' . get_option( 'woocommerce_dimension_unit' );
+		if ( is_rtl() ) {
+			$dimension_string = get_option( 'woocommerce_dimension_unit' ) . ' ' . $dimension_string;
+		} else {
+			$dimension_string .= ' ' . get_option( 'woocommerce_dimension_unit' );
+		}
 	} else {
 		$dimension_string = __( 'N/A', 'woocommerce' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Revert PR #21633.
Prepend dimension string when a RTL language is active.

Closes #21813.

### How to test the changes in this Pull Request:

1. Create a variable product with at least one variation.
2. View the product in a LTR language.
3. Dimension should be in the format of `10 x 10 x 10 cm`.
4. Change to a RTL language.
5. Dimension should be in the format of `cm 10 x 10 x 10`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix variation dimension string in RTL languages.
