### PR TITLE
use multisite blog prefix in `fk_wc_download_log_permission_id` constraint name

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -593,21 +593,22 @@ class WC_Install {
 
 		// Add constraint to download logs if the columns matches.
 		if ( ! empty( $download_permissions_column_type ) && ! empty( $download_log_column_type ) && $download_permissions_column_type === $download_log_column_type ) {
+			$constraint_prefix = ! is_multisite() || ( is_main_site() && is_main_network() ) ? 'fk_' : str_replace( $wpdb->base_prefix, 'fk_', $wpdb->prefix );
 			$fk_result = $wpdb->get_row( "
 				SELECT COUNT(*) AS fk_count
 				FROM information_schema.TABLE_CONSTRAINTS
 				WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
-				AND CONSTRAINT_NAME = 'fk_wc_download_log_permission_id'
+				AND CONSTRAINT_NAME = '{$constraint_prefix}wc_download_log_permission_id'
 				AND CONSTRAINT_TYPE = 'FOREIGN KEY'
 				AND TABLE_NAME = '{$wpdb->prefix}wc_download_log'
-			" );
+			" ); // WPCS: unprepared SQL ok.
 			if ( 0 === (int) $fk_result->fk_count ) {
 				$wpdb->query( "
 					ALTER TABLE `{$wpdb->prefix}wc_download_log`
-					ADD CONSTRAINT `fk_wc_download_log_permission_id`
+					ADD CONSTRAINT `{$constraint_prefix}wc_download_log_permission_id`
 					FOREIGN KEY (`permission_id`)
 					REFERENCES `{$wpdb->prefix}woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE;
-				" );
+				" ); // WPCS: unprepared SQL ok.
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Use string replacement of `fk_` for `$table_prefix` in multisite for generating the `wc_download_log_permission_id` constraint when the site is not the main/original site of the install.

Output from MySQL `SHOW TABLE CREATE` for the main site and a subsite with this change

```shell
Table	Create Table
wp_wc_download_log	CREATE TABLE `wp_wc_download_log` (\n  `download_log_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `timestamp` datetime NOT NULL,\n  `permission_id` bigint(20) unsigned NOT NULL,\n  `user_id` bigint(20) unsigned DEFAULT NULL,\n  `user_ip_address` varchar(100) COLLATE utf8mb4_unicode_520_ci DEFAULT '',\n  PRIMARY KEY (`download_log_id`),\n  KEY `permission_id` (`permission_id`),\n  KEY `timestamp` (`timestamp`),\n  CONSTRAINT `fk_wc_download_log_permission_id` FOREIGN KEY (`permission_id`) REFERENCES `wp_woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci

Table	Create Table
wp_2_wc_download_log	CREATE TABLE `wp_2_wc_download_log` (\n  `download_log_id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,\n  `timestamp` datetime NOT NULL,\n  `permission_id` bigint(20) unsigned NOT NULL,\n  `user_id` bigint(20) unsigned DEFAULT NULL,\n  `user_ip_address` varchar(100) COLLATE utf8mb4_unicode_520_ci DEFAULT '',\n  PRIMARY KEY (`download_log_id`),\n  KEY `permission_id` (`permission_id`),\n  KEY `timestamp` (`timestamp`),\n  CONSTRAINT `fk_2_wc_download_log_permission_id` FOREIGN KEY (`permission_id`) REFERENCES `wp_2_woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE\n) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_520_ci
```

Closes #21775 .

### How to test the changes in this Pull Request:

1. Enable multisite.
2. Create a subsite.
3. Activate WooCommerce on the subsite.
4. MySQL `SHOW CREATE TABLE {subsite wc_download_log}` should have the foreign key added. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix `wc_download_log_permission_id` constraint creation on multisite subsites.
