### PR TITLE
Reintroduce Preview button on products

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -10,11 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<?php if ( 'publish' === get_post_status() ) : ?>
-	<style type="text/css">
-		#post-preview { display:none }
-	</style>
-<?php endif; ?>
 <div class="panel-wrap product_data">
 
 	<span class="type_box hidden"> &mdash;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds the Preview Changes button back to Products. There are more people that want it back than there were people confused that it doesn't work on every product field.

See comments on https://github.com/woocommerce/woocommerce/pull/20650 or https://github.com/woocommerce/woocommerce/issues/21781 or https://github.com/woocommerce/woocommerce/issues/21723.

### How to test the changes in this Pull Request:

1. Verify Preview Changes button is present on a published product.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Reintroduce Preview Changes button on published products.