### PR TITLE
Decode variation html dimensions when setting dimensions html on frontend

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -215,7 +215,8 @@
 		}
 
 		if ( variation.dimensions ) {
-			$dimensions.wc_set_content( variation.dimensions_html );
+			// Decode HTML entities.
+			$dimensions.wc_set_content( $.parseHTML( variation.dimensions_html )[0].data );
 		} else {
 			$dimensions.wc_reset_content();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21813 .
Supersedes #21833 . 

### How to test the changes in this Pull Request:

1. See #21813 for instructions to reproduce.
2. Also test in RTL mode to verify dimensions look good in RTL.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Don't render undecoded HTML entities in variations dimensions.
