### PR TITLE
Pay pending order, do not check stock when not managing stock

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -143,6 +143,11 @@ class WC_Shortcode_Checkout {
 								throw new Exception( sprintf( __( 'Sorry, "%s" is no longer in stock so this order cannot be paid for. We apologize for any inconvenience caused.', 'woocommerce' ), $product->get_name() ) );
 							}
 
+							// We only need to check products managing stock, with a limited stock qty.
+							if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
+								continue;
+							}
+
 							// Check stock based on all items in the cart and consider any held stock within pending orders.
 							$held_stock     = wc_get_held_stock_quantity( $product, $order->get_id() );
 							$required_stock = $quantities[ $product->get_stock_managed_by_id() ];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When you are paying for a pending order or making use of the order-pay page, stock should not be checked when your store is not managing stock or allowing backorders.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21832

### How to test the changes in this Pull Request:

1. Set up a product with 0 stock
2. Disable stock management on your store or allow backorders for the product with 0 stock
3. Place an order for the product but abandon payment
4. Go to My Account -> Orders, select the order and click the pay button
5. Continue to make payment
6. The order should be processed without any error that there is no stock.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Do not check for stock when not managing stock or have backorders enabled when paying through the order-pay page.