### PR TITLE
Apply field priority sorting on additional filters

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -704,7 +704,11 @@ class WC_Countries {
 			unset( $fields['address_2'] );
 		}
 
-		return apply_filters( 'woocommerce_default_address_fields', $fields );
+		$default_address_fields = apply_filters( 'woocommerce_default_address_fields', $fields );
+		// Sort each of the fields based on priority.
+		uasort( $default_address_fields, 'wc_checkout_fields_uasort_comparison' );
+
+		return $default_address_fields;
 	}
 
 	/**
@@ -1280,6 +1284,10 @@ class WC_Countries {
 		 * on country selection. If you want to change things like the required status of an
 		 * address field, filter woocommerce_default_address_fields instead.
 		 */
-		return apply_filters( 'woocommerce_' . $type . 'fields', $address_fields, $country );
+		$address_fields = apply_filters( 'woocommerce_' . $type . 'fields', $address_fields, $country );
+		// Sort each of the fields based on priority.
+		uasort( $address_fields, 'wc_checkout_fields_uasort_comparison' );
+
+		return $address_fields;
 	}
 }


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In #21763 the focused was on the checkout fields whereas there are also an overlap with My Account address fields. This PR adds sorting to additional filters so it covers all the filters possible that fields can be manipulated thus ensuring that the priority stays consistent on all pages where these filters apply to.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21819 

### How to test the changes in this Pull Request:

1. Add the following custom code to your installation
```
add_filter( 'woocommerce_default_address_fields', 'custom_override_checkout_fields', 1 );
function custom_override_checkout_fields( $fields ) {
	$fields['country']['priority'] = 1;
	return $fields;
}
```
2. Go to My Account -> Edit Address and ensure the Country field is now displayed first.
3. Repeat the process but use the filter `woocommerce_billing_fields` or `woocommerce_shipping_fields` depending on the edit address page you are testing this on. Again check that the field is shown first on both the edit address and checkout pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Apply priority field sorting on additional filters to make it apply on the edit address pages as well.
