### PR TITLE
Rename wc() to WC() for consistency

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -651,7 +651,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 			// Sanity check: bail out if this is actually not a status, or is not a registered status.
 			if ( isset( $order_statuses[ 'wc-' . $new_status ] ) ) {
 				// Initialize payment gateways in case order has hooked status transition actions.
-				wc()->payment_gateways();
+				WC()->payment_gateways();
 
 				foreach ( $ids as $id ) {
 					$order = wc_get_order( $id );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -486,7 +486,7 @@ class WC_AJAX {
 
 			if ( wc_is_order_status( 'wc-' . $status ) && $order ) {
 				// Initialize payment gateways in case order has hooked status transition actions.
-				wc()->payment_gateways();
+				WC()->payment_gateways();
 
 				$order->update_status( $status, '', true );
 				do_action( 'woocommerce_order_edit_status', $order->get_id(), $status );

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -95,10 +95,10 @@ class WC_Shipping {
 	public function __get( $name ) {
 		// Grab from cart for backwards compatibility with versions prior to 3.2.
 		if ( 'shipping_total' === $name ) {
-			return wc()->cart->get_shipping_total();
+			return WC()->cart->get_shipping_total();
 		}
 		if ( 'shipping_taxes' === $name ) {
-			return wc()->cart->get_shipping_taxes();
+			return WC()->cart->get_shipping_taxes();
 		}
 	}
 

--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -443,7 +443,7 @@ class WC_Template_Loader {
 			$args      = self::get_current_shop_view_args();
 			$shortcode = new WC_Shortcode_Products(
 				array_merge(
-					wc()->query->get_catalog_ordering_args(),
+					WC()->query->get_catalog_ordering_args(),
 					array(
 						'page'     => $args->page,
 						'columns'  => $args->columns,
@@ -457,12 +457,12 @@ class WC_Template_Loader {
 			'products' );
 
 			// Allow queries to run e.g. layered nav.
-			add_action( 'pre_get_posts', array( wc()->query, 'product_query' ) );
+			add_action( 'pre_get_posts', array( WC()->query, 'product_query' ) );
 
 			$content = $content . $shortcode->get_content();
 
 			// Remove actions and self to avoid nested calls.
-			remove_action( 'pre_get_posts', array( wc()->query, 'product_query' ) );
+			remove_action( 'pre_get_posts', array( WC()->query, 'product_query' ) );
 			WC()->query->remove_ordering_args();
 		}
 

--- a/includes/widgets/class-wc-widget-price-filter.php
+++ b/includes/widgets/class-wc-widget-price-filter.php
@@ -66,7 +66,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 			return;
 		}
 
-		if ( ! wc()->query->get_main_query()->post_count ) {
+		if ( ! WC()->query->get_main_query()->post_count ) {
 			return;
 		}
 
@@ -119,7 +119,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 	protected function get_filtered_price() {
 		global $wpdb;
 
-		$args       = wc()->query->get_main_query()->query_vars;
+		$args       = WC()->query->get_main_query()->query_vars;
 		$tax_query  = isset( $args['tax_query'] ) ? $args['tax_query'] : array();
 		$meta_query = isset( $args['meta_query'] ) ? $args['meta_query'] : array();
 

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -91,7 +91,7 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 			return;
 		}
 
-		if ( ! wc()->query->get_main_query()->post_count ) {
+		if ( ! WC()->query->get_main_query()->post_count ) {
 			return;
 		}
 

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -34,9 +34,9 @@ if ( ! class_exists( 'WooCommerce' ) ) {
  * @since  2.1
  * @return WooCommerce
  */
-function wc() {
+function WC() {
 	return WooCommerce::instance();
 }
 
 // Global for backwards compatibility.
-$GLOBALS['woocommerce'] = wc();
+$GLOBALS['woocommerce'] = WC();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This pull request renames the function wc() to upper-case WC().
The reason is consistency, as the function name is wc() but mostly used in the upper case form WC() across woocommerce code.

* This change won't break BC as php functions are case-insensitive.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Rename wc() to WC() for consistency
