### PR TITLE
allow export and display of attribute labels containing html special characters

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -173,7 +173,7 @@ class WC_Admin_Attributes {
 				echo '<div id="woocommerce_errors" class="error"><p>' . esc_html__( 'Error: non-existing attribute ID.', 'woocommerce' ) . '</p></div>';
 			} else {
 				$att_type    = $attribute_to_edit->attribute_type;
-				$att_label   = $attribute_to_edit->attribute_label;
+				$att_label   = format_to_edit( $attribute_to_edit->attribute_label );
 				$att_name    = $attribute_to_edit->attribute_name;
 				$att_orderby = $attribute_to_edit->attribute_orderby;
 				$att_public  = $attribute_to_edit->attribute_public;

--- a/includes/export/abstract-wc-csv-exporter.php
+++ b/includes/export/abstract-wc-csv-exporter.php
@@ -379,7 +379,6 @@ abstract class WC_CSV_Exporter {
 		}
 
 		$use_mb = function_exists( 'mb_convert_encoding' );
-		$data   = (string) urldecode( $data );
 
 		if ( $use_mb ) {
 			$encoding = mb_detect_encoding( $data, 'UTF-8, ISO-8859-1', true );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Export attribute names containing html special characters without decoding,
Allow editing attribute names containing html special characters.

## Current Code
| Editor Entry | DB Value | Editor Display | Product Display | Exported CSV Field | Imported DB Field |
| ------------ | --------- | ------------- | ---------------- | -------------------- | ------------------ |
| `&quot;A3+&quot;` | `&quot;A3+&quot;` | `"A3+"` | `"A3+"` | `"""A3 """` | `"A3 "` |

## PR Applied
| Editor Entry | DB Value | Editor Display | Product Display | Exported CSV Field | Imported DB Field |
| ------------ | --------- | ------------- | ---------------- | -------------------- | ------------------ |
| `&quot;A3+&quot;` | `&quot;A3+&quot;` | `&quot;A3+&quot;` | `"A3+"` | `"&quot;A3+&quot;"` | `&quot;A3+&quot;` |

Closes #21457 .

### How to test the changes in this Pull Request:

1. Enter an attribute name with one or more html special characters
2. Save & Export
3. Review export file
4. Delete the attribute
5. Import the exported CSV

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix export and edit of attribute labels with html encoded special characters.
