### PR TITLE
consistent logic on `woocommerce_formatted_address_force_country_display` filter name

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -548,7 +548,7 @@ class WC_Countries {
 		$full_country = ( isset( $this->countries[ $country ] ) ) ? $this->countries[ $country ] : $country;
 
 		// Country is not needed if the same as base.
-		if ( $country === $this->get_base_country() && ! apply_filters( 'woocommerce_formatted_address_force_country_display', true ) ) {
+		if ( $country === $this->get_base_country() && ! apply_filters( 'woocommerce_formatted_address_force_country_display', false ) ) {
 			$format = str_replace( '{country}', '', $format );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Change filter `woocommerce_formatted_address_force_country_display` to default to `false` to be consistent with the name of the filter. Currently you have to use `__return_false` with the filter to enable the country being omitted when the address is in the same country.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21857.

### How to test the changes in this Pull Request:

1. Add the filter `add_filter( 'woocommerce_formatted_address_force_country_display', '__return_true' );`
2. View a customer invoice in the same country as the shop
3. Country should not be included in the address

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix woocommerce_formatted_address_force_country_display filter.
