### PR TITLE
Fix error when rendering customer invoice email

### DIFF
--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -34,7 +34,7 @@ if ( $order->has_status( 'pending' ) ) {
 
 } else {
 	/* translators: %s Order date */
-	echo sprintf( esc_html__( 'Here are the details of your order placed on %s:', 'woocommerce' ), esc_html( wc_format_datetime( $this->object->get_date_created() ) ) ) . "\n\n";
+	echo sprintf( esc_html__( 'Here are the details of your order placed on %s:', 'woocommerce' ), esc_html( wc_format_datetime( $order->get_date_created() ) ) ) . "\n\n";
 }
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 


### PR DESCRIPTION
When sending a customer their invoice on a non-pending order, I get this error in the logs:

    PHP Fatal error: Uncaught Error: Using $this when not in object context in
    wp-content/plugins/woocommerce/templates/emails/plain/customer-invoice.php:37

    Stack trace:
    #0 wp-content/plugins/woocommerce/includes/wc-core-functions.php(208): include()
    #1 wp-content/plugins/woocommerce/includes/wc-core-functions.php(228): wc_get_template('emails/plain/cu...', Array, '', '')
    #2 wp-content/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php(165): wc_get_template_html('emails/plain/cu...', Array)
    #3 wp-content/plugins/woocommerce/includes/emails/class-wc-email.php(502): WC_Email_Customer_Invoice->get_content_plain()
    #4 wp-content/plugins/woocommerce/includes/emails/class-wc-email-customer-invoice.php(130): WC_Email->get_content()
    #5 wp-content/plugins/woocommerce/includes/class-wc-emails.php(338): WC_Email_Customer_Invoice->trigger(288402, Object(WC_Order))
    #6 wp-content/plugins/woocommerce/templates/emails/plain/customer-invoice.php on line 37
    referer: wp-admin/post.php?post=nnnnnn&action=edit

Change the "$this->object" reference to "$order" instead.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

After upgrading to WooCommerce 3.5.0, I started encountering this problem:

    PHP Fatal error: Uncaught Error: Using $this when not in object context in
    wp-content/plugins/woocommerce/templates/emails/plain/customer-invoice.php:37

(full stack trace above)

This PR proposes to fix that error.

Closes # .  <-- I didn't file a separate issue.  If you'd like to see that, I can file one.

### How to test the changes in this Pull Request:

1. Find an order that is not in "pending" state and go to its "edit" page
2. Select the "Email order / invoice details to customer" action from "Order actions" (top right) and click "Update"
3. While the desired behavior is to return to the order "edit" page and show the message "Order updated and sent", the bug causes output such as this on an otherwise blank page:

   > = Your invoice for order #NNNNNN = Hi [customer first name],

In addition, when the bug is not fixed, the above error and stack trace appear in the Apache error log.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
   This is outside my comfort zone.  If required, I could look into adding these.
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix error when rendering customer invoice email