### PR TITLE
Update routine to roll back the post_author db changes.

### DIFF
--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1872,3 +1872,30 @@ function wc_update_350_reviews_comment_type() {
 function wc_update_350_db_version() {
 	WC_Install::update_db_version( '3.5.0' );
 }
+
+/**
+ * Restore the authors id to 1 as the author_id patch was rolled back in 3.5.1 https://github.com/woocommerce/woocommerce/pull/21740 and not the DB changes.
+ *
+ * @return void
+ */
+function wc_update_352_restore_order_authors_to_admin() {
+	global $wpdb;
+
+	$wpdb->query( "
+		UPDATE $wpdb->posts as post
+		LEFT JOIN $wpdb->post_meta as post_meta on post.ID = post_meta.post_id
+		SET post.post_author = 1
+		WHERE post.post_type = 'shop_order'
+		AND post_meta.meta_key = '_created_via'
+		AND post_meta.meta_value <> 'admin'
+	" );
+}
+
+/**
+ * Update DB version.
+ *
+ * @return void
+ */
+function wc_update_352_db_version() {
+	WC_Install::update_db_version( '3.5.2' );
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In #21740 the post_author changes was rolled back, but it left all the DB changes in place. This is resulting in the WP interface displaying orders as belonging to the current logged in admin when it should not. This RP rolls back the DB changes as well to ensure all orders not created via the admin is assigned the ID 1 again as per previous versions of WooCommerce.

Closes #21834 

### How to test the changes in this Pull Request:

1. Check that you have orders in the DB with different post_author IDs.
2. Check out this branch and run the DB update routine.
3. Check that orders in the DB are all assigned the ID 1, unless the order was created via wp-admin.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Rollback - post_author DB changes.
