### PR TITLE
Fix fatal in plain text customer invoice email.

### DIFF
--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -27,14 +27,14 @@ echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billi
 if ( $order->has_status( 'pending' ) ) {
 	echo sprintf(
 		/* translators: %1$s Site title, %2$s Order pay link */
-		__( 'An order has been created for you on %1$s. Your invoice is below, with a link to make payment when you’re ready: %2$s', 'woocommerce' ),
+		esc_html__( 'An order has been created for you on %1$s. Your invoice is below, with a link to make payment when you’re ready: %2$s', 'woocommerce' ),
 		esc_html( get_bloginfo( 'name', 'display' ) ),
 		esc_url( $order->get_checkout_payment_url() )
 	) . "\n\n";
 
 } else {
 	/* translators: %s Order date */
-	echo sprintf( esc_html__( 'Here are the details of your order placed on %s:', 'woocommerce' ), esc_html( wc_format_datetime( $this->object->get_date_created() ) ) ) . "\n\n";
+	echo sprintf( esc_html__( 'Here are the details of your order placed on %s:', 'woocommerce' ), esc_html( wc_format_datetime( $order->get_date_created() ) ) ) . "\n\n";
 }
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes a fatal error caused by using the wrong variable name when sending the customer invoice plain text email.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21863 

### How to test the changes in this Pull Request:

1. Set your store to use plain text emails for the customer invoice.
2. Open an order and select the option to send the invoice to the customer
3. Check that a plain text email is sent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Error when sending plain text customer invoice.
