### PR TITLE
Add WC_Admin_Taxonomies instance method

### DIFF
--- a/includes/admin/class-wc-admin-taxonomies.php
+++ b/includes/admin/class-wc-admin-taxonomies.php
@@ -5,18 +5,23 @@
  * @class    WC_Admin_Taxonomies
  * @version  2.3.10
  * @package  WooCommerce/Admin
- * @category Class
- * @author   WooThemes
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**
  * WC_Admin_Taxonomies class.
  */
 class WC_Admin_Taxonomies {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Admin_Taxonomies instance
+	 */
+	protected static $instance = false;
 
 	/**
 	 * Default category ID.
@@ -26,23 +31,33 @@ class WC_Admin_Taxonomies {
 	private $default_cat_id = 0;
 
 	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
 	 * Constructor.
 	 */
 	public function __construct() {
 		// Default category ID.
 		$this->default_cat_id = get_option( 'default_product_cat', 0 );
 
-		// Category/term ordering
+		// Category/term ordering.
 		add_action( 'create_term', array( $this, 'create_term' ), 5, 3 );
 		add_action( 'delete_term', array( $this, 'delete_term' ), 5 );
 
-		// Add form
+		// Add form.
 		add_action( 'product_cat_add_form_fields', array( $this, 'add_category_fields' ) );
 		add_action( 'product_cat_edit_form_fields', array( $this, 'edit_category_fields' ), 10 );
 		add_action( 'created_term', array( $this, 'save_category_fields' ), 10, 3 );
 		add_action( 'edit_term', array( $this, 'save_category_fields' ), 10, 3 );
 
-		// Add columns
+		// Add columns.
 		add_filter( 'manage_edit-product_cat_columns', array( $this, 'product_cat_columns' ) );
 		add_filter( 'manage_product_cat_custom_column', array( $this, 'product_cat_column' ), 10, 3 );
 
@@ -50,7 +65,7 @@ class WC_Admin_Taxonomies {
 		add_filter( 'product_cat_row_actions', array( $this, 'product_cat_row_actions' ), 10, 2 );
 		add_filter( 'admin_init', array( $this, 'handle_product_cat_row_actions' ) );
 
-		// Taxonomy page descriptions
+		// Taxonomy page descriptions.
 		add_action( 'product_cat_pre_add_form', array( $this, 'product_cat_description' ) );
 		add_action( 'after-product_cat-table', array( $this, 'product_cat_notes' ) );
 
@@ -62,19 +77,19 @@ class WC_Admin_Taxonomies {
 			}
 		}
 
-		// Maintain hierarchy of terms
+		// Maintain hierarchy of terms.
 		add_filter( 'wp_terms_checklist_args', array( $this, 'disable_checked_ontop' ) );
 
-		// Admin footer scripts for this product categories admin screen
+		// Admin footer scripts for this product categories admin screen.
 		add_action( 'admin_footer', array( $this, 'scripts_at_product_cat_screen_footer' ) );
 	}
 
 	/**
 	 * Order term when created (put in position 0).
 	 *
-	 * @param mixed  $term_id
-	 * @param mixed  $tt_id
-	 * @param string $taxonomy
+	 * @param mixed  $term_id Term ID.
+	 * @param mixed  $tt_id Term taxonomy ID.
+	 * @param string $taxonomy Taxonomy slug.
 	 */
 	public function create_term( $term_id, $tt_id = '', $taxonomy = '' ) {
 		if ( 'product_cat' != $taxonomy && ! taxonomy_is_product_attribute( $taxonomy ) ) {
@@ -89,7 +104,7 @@ class WC_Admin_Taxonomies {
 	/**
 	 * When a term is deleted, delete its meta.
 	 *
-	 * @param mixed $term_id
+	 * @param mixed $term_id Term ID.
 	 */
 	public function delete_term( $term_id ) {
 		global $wpdb;
@@ -107,21 +122,21 @@ class WC_Admin_Taxonomies {
 	public function add_category_fields() {
 		?>
 		<div class="form-field term-display-type-wrap">
-			<label for="display_type"><?php _e( 'Display type', 'woocommerce' ); ?></label>
+			<label for="display_type"><?php esc_html_e( 'Display type', 'woocommerce' ); ?></label>
 			<select id="display_type" name="display_type" class="postform">
-				<option value=""><?php _e( 'Default', 'woocommerce' ); ?></option>
-				<option value="products"><?php _e( 'Products', 'woocommerce' ); ?></option>
-				<option value="subcategories"><?php _e( 'Subcategories', 'woocommerce' ); ?></option>
-				<option value="both"><?php _e( 'Both', 'woocommerce' ); ?></option>
+				<option value=""><?php esc_html_e( 'Default', 'woocommerce' ); ?></option>
+				<option value="products"><?php esc_html_e( 'Products', 'woocommerce' ); ?></option>
+				<option value="subcategories"><?php esc_html_e( 'Subcategories', 'woocommerce' ); ?></option>
+				<option value="both"><?php esc_html_e( 'Both', 'woocommerce' ); ?></option>
 			</select>
 		</div>
 		<div class="form-field term-thumbnail-wrap">
-			<label><?php _e( 'Thumbnail', 'woocommerce' ); ?></label>
+			<label><?php esc_html_e( 'Thumbnail', 'woocommerce' ); ?></label>
 			<div id="product_cat_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( wc_placeholder_img_src() ); ?>" width="60px" height="60px" /></div>
 			<div style="line-height: 60px;">
 				<input type="hidden" id="product_cat_thumbnail_id" name="product_cat_thumbnail_id" />
-				<button type="button" class="upload_image_button button"><?php _e( 'Upload/Add image', 'woocommerce' ); ?></button>
-				<button type="button" class="remove_image_button button"><?php _e( 'Remove image', 'woocommerce' ); ?></button>
+				<button type="button" class="upload_image_button button"><?php esc_html_e( 'Upload/Add image', 'woocommerce' ); ?></button>
+				<button type="button" class="remove_image_button button"><?php esc_html_e( 'Remove image', 'woocommerce' ); ?></button>
 			</div>
 			<script type="text/javascript">
 
@@ -145,9 +160,9 @@ class WC_Admin_Taxonomies {
 
 					// Create the media frame.
 					file_frame = wp.media.frames.downloadable_file = wp.media({
-						title: '<?php _e( 'Choose an image', 'woocommerce' ); ?>',
+						title: '<?php esc_html_e( 'Choose an image', 'woocommerce' ); ?>',
 						button: {
-							text: '<?php _e( 'Use image', 'woocommerce' ); ?>'
+							text: '<?php esc_html_e( 'Use image', 'woocommerce' ); ?>'
 						},
 						multiple: false
 					});
@@ -200,7 +215,7 @@ class WC_Admin_Taxonomies {
 	/**
 	 * Edit category thumbnail field.
 	 *
-	 * @param mixed $term Term (category) being edited
+	 * @param mixed $term Term (category) being edited.
 	 */
 	public function edit_category_fields( $term ) {
 
@@ -214,24 +229,24 @@ class WC_Admin_Taxonomies {
 		}
 		?>
 		<tr class="form-field term-display-type-wrap">
-			<th scope="row" valign="top"><label><?php _e( 'Display type', 'woocommerce' ); ?></label></th>
+			<th scope="row" valign="top"><label><?php esc_html_e( 'Display type', 'woocommerce' ); ?></label></th>
 			<td>
 				<select id="display_type" name="display_type" class="postform">
-					<option value="" <?php selected( '', $display_type ); ?>><?php _e( 'Default', 'woocommerce' ); ?></option>
-					<option value="products" <?php selected( 'products', $display_type ); ?>><?php _e( 'Products', 'woocommerce' ); ?></option>
-					<option value="subcategories" <?php selected( 'subcategories', $display_type ); ?>><?php _e( 'Subcategories', 'woocommerce' ); ?></option>
-					<option value="both" <?php selected( 'both', $display_type ); ?>><?php _e( 'Both', 'woocommerce' ); ?></option>
+					<option value="" <?php selected( '', $display_type ); ?>><?php esc_html_e( 'Default', 'woocommerce' ); ?></option>
+					<option value="products" <?php selected( 'products', $display_type ); ?>><?php esc_html_e( 'Products', 'woocommerce' ); ?></option>
+					<option value="subcategories" <?php selected( 'subcategories', $display_type ); ?>><?php esc_html_e( 'Subcategories', 'woocommerce' ); ?></option>
+					<option value="both" <?php selected( 'both', $display_type ); ?>><?php esc_html_e( 'Both', 'woocommerce' ); ?></option>
 				</select>
 			</td>
 		</tr>
 		<tr class="form-field term-thumbnail-wrap">
-			<th scope="row" valign="top"><label><?php _e( 'Thumbnail', 'woocommerce' ); ?></label></th>
+			<th scope="row" valign="top"><label><?php esc_html_e( 'Thumbnail', 'woocommerce' ); ?></label></th>
 			<td>
 				<div id="product_cat_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( $image ); ?>" width="60px" height="60px" /></div>
 				<div style="line-height: 60px;">
-					<input type="hidden" id="product_cat_thumbnail_id" name="product_cat_thumbnail_id" value="<?php echo $thumbnail_id; ?>" />
-					<button type="button" class="upload_image_button button"><?php _e( 'Upload/Add image', 'woocommerce' ); ?></button>
-					<button type="button" class="remove_image_button button"><?php _e( 'Remove image', 'woocommerce' ); ?></button>
+					<input type="hidden" id="product_cat_thumbnail_id" name="product_cat_thumbnail_id" value="<?php echo esc_attr( $thumbnail_id ); ?>" />
+					<button type="button" class="upload_image_button button"><?php esc_html_e( 'Upload/Add image', 'woocommerce' ); ?></button>
+					<button type="button" class="remove_image_button button"><?php esc_html_e( 'Remove image', 'woocommerce' ); ?></button>
 				</div>
 				<script type="text/javascript">
 
@@ -255,9 +270,9 @@ class WC_Admin_Taxonomies {
 
 						// Create the media frame.
 						file_frame = wp.media.frames.downloadable_file = wp.media({
-							title: '<?php _e( 'Choose an image', 'woocommerce' ); ?>',
+							title: '<?php esc_html_e( 'Choose an image', 'woocommerce' ); ?>',
 							button: {
-								text: '<?php _e( 'Use image', 'woocommerce' ); ?>'
+								text: '<?php esc_html_e( 'Use image', 'woocommerce' ); ?>'
 							},
 							multiple: false
 						});
@@ -291,18 +306,18 @@ class WC_Admin_Taxonomies {
 	}
 
 	/**
-	 * save_category_fields function.
+	 * Save category fields
 	 *
-	 * @param mixed  $term_id Term ID being saved
-	 * @param mixed  $tt_id
-	 * @param string $taxonomy
+	 * @param mixed  $term_id Term ID being saved.
+	 * @param mixed  $tt_id Term taxonomy ID.
+	 * @param string $taxonomy Taxonomy slug.
 	 */
 	public function save_category_fields( $term_id, $tt_id = '', $taxonomy = '' ) {
-		if ( isset( $_POST['display_type'] ) && 'product_cat' === $taxonomy ) {
-			update_woocommerce_term_meta( $term_id, 'display_type', esc_attr( $_POST['display_type'] ) );
+		if ( isset( $_POST['display_type'] ) && 'product_cat' === $taxonomy ) { // WPCS: CSRF ok, input var ok.
+			update_woocommerce_term_meta( $term_id, 'display_type', esc_attr( $_POST['display_type'] ) ); // WPCS: CSRF ok, sanitization ok, input var ok.
 		}
-		if ( isset( $_POST['product_cat_thumbnail_id'] ) && 'product_cat' === $taxonomy ) {
-			update_woocommerce_term_meta( $term_id, 'thumbnail_id', absint( $_POST['product_cat_thumbnail_id'] ) );
+		if ( isset( $_POST['product_cat_thumbnail_id'] ) && 'product_cat' === $taxonomy ) { // WPCS: CSRF ok, input var ok.
+			update_woocommerce_term_meta( $term_id, 'thumbnail_id', absint( $_POST['product_cat_thumbnail_id'] ) ); // WPCS: CSRF ok, input var ok.
 		}
 	}
 
@@ -310,7 +325,10 @@ class WC_Admin_Taxonomies {
 	 * Description for product_cat page to aid users.
 	 */
 	public function product_cat_description() {
-		echo wpautop( __( 'Product categories for your store can be managed here. To change the order of categories on the front-end you can drag and drop to sort them. To see more categories listed click the "screen options" link at the top-right of this page.', 'woocommerce' ) );
+		echo wp_kses(
+			wpautop( __( 'Product categories for your store can be managed here. To change the order of categories on the front-end you can drag and drop to sort them. To see more categories listed click the "screen options" link at the top-right of this page.', 'woocommerce' ) ),
+			array( 'p' => array() )
+		);
 	}
 
 	/**
@@ -323,11 +341,11 @@ class WC_Admin_Taxonomies {
 		?>
 		<div class="form-wrap edit-term-notes">
 			<p>
-				<strong><?php _e( 'Note:', 'woocommerce' ); ?></strong><br>
+				<strong><?php esc_html_e( 'Note:', 'woocommerce' ); ?></strong><br>
 				<?php
 					printf(
 						/* translators: %s: default category */
-						__( 'Deleting a category does not delete the products in that category. Instead, products that were only assigned to the deleted category are set to the category %s.', 'woocommerce' ),
+						esc_html__( 'Deleting a category does not delete the products in that category. Instead, products that were only assigned to the deleted category are set to the category %s.', 'woocommerce' ),
 						'<strong>' . esc_html( $category_name ) . '</strong>'
 					);
 				?>
@@ -340,13 +358,16 @@ class WC_Admin_Taxonomies {
 	 * Description for shipping class page to aid users.
 	 */
 	public function product_attribute_description() {
-		echo wpautop( __( 'Attribute terms can be assigned to products and variations.<br/><br/><b>Note</b>: Deleting a term will remove it from all products and variations to which it has been assigned. Recreating a term will not automatically assign it back to products.', 'woocommerce' ) );
+		echo wp_kses(
+			wpautop( __( 'Attribute terms can be assigned to products and variations.<br/><br/><b>Note</b>: Deleting a term will remove it from all products and variations to which it has been assigned. Recreating a term will not automatically assign it back to products.', 'woocommerce' ) ),
+			array( 'p' => array() )
+		);
 	}
 
 	/**
 	 * Thumbnail column added to category admin.
 	 *
-	 * @param mixed $columns
+	 * @param mixed $columns Columns array.
 	 * @return array
 	 */
 	public function product_cat_columns( $columns ) {
@@ -392,10 +413,10 @@ class WC_Admin_Taxonomies {
 	 * Handle custom row actions.
 	 */
 	public function handle_product_cat_row_actions() {
-		if ( isset( $_GET['action'], $_GET['tag_ID'], $_GET['_wpnonce'] ) && 'make_default' === $_GET['action'] ) {
-			$make_default_id = absint( $_GET['tag_ID'] );
+		if ( isset( $_GET['action'], $_GET['tag_ID'], $_GET['_wpnonce'] ) && 'make_default' === $_GET['action'] ) { // WPCS: CSRF ok, input var ok.
+			$make_default_id = absint( $_GET['tag_ID'] ); // WPCS: Input var ok.
 
-			if ( wp_verify_nonce( $_GET['_wpnonce'], 'make_default_' . $make_default_id ) && current_user_can( 'edit_term', $make_default_id ) ) {
+			if ( wp_verify_nonce( $_GET['_wpnonce'], 'make_default_' . $make_default_id ) && current_user_can( 'edit_term', $make_default_id ) ) { // WPCS: Sanitization ok, input var ok, CSRF ok.
 				update_option( 'default_product_cat', $make_default_id );
 			}
 		}
@@ -404,9 +425,9 @@ class WC_Admin_Taxonomies {
 	/**
 	 * Thumbnail column value added to category admin.
 	 *
-	 * @param string $columns
-	 * @param string $column
-	 * @param int    $id
+	 * @param string $columns Column HTML output.
+	 * @param string $column Column name.
+	 * @param int    $id Product ID.
 	 *
 	 * @return string
 	 */
@@ -427,7 +448,7 @@ class WC_Admin_Taxonomies {
 				$image = wc_placeholder_img_src();
 			}
 
-			// Prevent esc_url from breaking spaces in urls for image embeds. Ref: https://core.trac.wordpress.org/ticket/23605
+			// Prevent esc_url from breaking spaces in urls for image embeds. Ref: https://core.trac.wordpress.org/ticket/23605 .
 			$image    = str_replace( ' ', '%20', $image );
 			$columns .= '<img src="' . esc_url( $image ) . '" alt="' . esc_attr__( 'Thumbnail', 'woocommerce' ) . '" class="wp-post-image" height="48" width="48" />';
 		}
@@ -440,7 +461,7 @@ class WC_Admin_Taxonomies {
 	/**
 	 * Maintain term hierarchy when editing a product.
 	 *
-	 * @param  array $args
+	 * @param  array $args Term checklist args.
 	 * @return array
 	 */
 	public function disable_checked_ontop( $args ) {
@@ -456,10 +477,10 @@ class WC_Admin_Taxonomies {
 	 * @return void
 	 */
 	public function scripts_at_product_cat_screen_footer() {
-		if ( ! isset( $_GET['taxonomy'] ) || 'product_cat' !== $_GET['taxonomy'] ) {
+		if ( ! isset( $_GET['taxonomy'] ) || 'product_cat' !== $_GET['taxonomy'] ) { // WPCS: CSRF ok, input var ok.
 			return;
 		}
-		// Ensure the tooltip is displayed when the image column is disabled on product categories
+		// Ensure the tooltip is displayed when the image column is disabled on product categories.
 		wc_enqueue_js("
 			(function( $ ) {
 				'use strict';
@@ -471,4 +492,4 @@ class WC_Admin_Taxonomies {
 	}
 }
 
-new WC_Admin_Taxonomies();
+$wc_admin_taxonomies = WC_Admin_Taxonomies::get_instance();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds an instance method to `WC_Admin_Taxonomies` so we can effectively remove actions enqueued in this class.

It also fixes a number of WPCS errors.

Closes #21883 

### How to test the changes in this Pull Request:

Visit the dashboard and make sure no regressions occur, specifically on the taxonomy pages - `/wp-admin/edit-tags.php?taxonomy=product_cat&post_type=product`

### Changelog entry

> Add an instance method to WC_Admin_Taxonomies
