### PR TITLE
Update external/affiliate URL placeholder from http to https

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				'id'          => '_product_url',
 				'value'       => is_callable( array( $product_object, 'get_product_url' ) ) ? $product_object->get_product_url( 'edit' ) : '',
 				'label'       => __( 'Product URL', 'woocommerce' ),
-				'placeholder' => 'http://',
+				'placeholder' => 'https://',
 				'description' => __( 'Enter the external URL to the product.', 'woocommerce' ),
 			)
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Changed external/affiliate product URL field's placeholder from http:// to https:// to reflect web preference for https.

### How to test the changes in this Pull Request:

1. Create new product
2. Set type to external/affiliate
3. Verify that URL placeholder text shows https:// instead of http://

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Updated external/affiliate product placeholder from http:// to https://
