### PR TITLE
Add dependency to WC_Product_CSV_Importer_Controller

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -17,6 +17,10 @@ if ( ! class_exists( 'WC_Product_Importer', false ) ) {
 	include_once dirname( __FILE__ ) . '/abstract-wc-product-importer.php';
 }
 
+if ( ! class_exists( 'WC_Product_CSV_Importer_Controller', false ) ) {
+	include_once WC_ABSPATH . 'includes/admin/importers/class-wc-product-csv-importer-controller.php';
+}
+
 /**
  * WC_Product_CSV_Importer Class.
  */


### PR DESCRIPTION


### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

When using the class WC_Product_CSV_Importer it gives fatal error, when using outsite of controller context, after "WC_Product_CSV_Importer_Controller" is introduced in this class.

This fixes it, and makes sure the external class exists, and is loaded.


### How to test the changes in this Pull Request:

1. Create an importer that extends the WC_Product_CSV_Importer class.
2. Run the importer. before this change, it would give fatal error. after change = success.
3.

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Added dependency to WC_Product_CSV_Importer_Controller class in WC_Product_CSV_Importer class
