### PR TITLE
Fix uncaught error in email template

### DIFF
--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -34,7 +34,7 @@ if ( $order->has_status( 'pending' ) ) {
 
 } else {
 	/* translators: %s Order date */
-	echo sprintf( esc_html__( 'Here are the details of your order placed on %s:', 'woocommerce' ), esc_html( wc_format_datetime( $this->object->get_date_created() ) ) ) . "\n\n";
+	echo sprintf( esc_html__( 'Here are the details of your order placed on %s:', 'woocommerce' ), esc_html( wc_format_datetime( $order->get_date_created() ) ) ) . "\n\n";
 }
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 


### PR DESCRIPTION
Fixes Uncaught Error: Using $this when not in object context 

See https://wordpress.org/support/topic/invoice-sending-error/

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Go to wp-admin > WooCommerce > Settings > Emails > Customer invoice
2. Change email type to 'plain text'. Press save
3. Go to any order page
4. Click Order Actions > Send Invoice
5. Should not fail

WC 3.5.1 without this fix will fail in step 5.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

- FIX Fatal error when sending customer invoice from admin
