### PR TITLE
allow limited html in `woocommerce_rating_filter_count` filter

### DIFF
--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -121,7 +121,11 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 			$class       = in_array( $rating, $rating_filter, true ) ? 'wc-layered-nav-rating chosen' : 'wc-layered-nav-rating';
 			$link        = apply_filters( 'woocommerce_rating_filter_link', $link_ratings ? add_query_arg( 'rating_filter', $link_ratings ) : remove_query_arg( 'rating_filter' ) );
 			$rating_html = wc_get_star_rating_html( $rating );
-			$count_html  = esc_html( apply_filters( 'woocommerce_rating_filter_count', "({$count})", $count, $rating ) );
+			$count_html  = wp_kses( apply_filters( 'woocommerce_rating_filter_count', "({$count})", $count, $rating ), array(
+				'em' => array(),
+				'span' => array(),
+				'strong' => array(),
+			) );
 
 			printf( '<li class="%s"><a href="%s"><span class="star-rating">%s</span> %s</a></li>', esc_attr( $class ), esc_url( $link ), $rating_html, $count_html ); // WPCS: XSS ok.
 		}

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -121,11 +121,14 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 			$class       = in_array( $rating, $rating_filter, true ) ? 'wc-layered-nav-rating chosen' : 'wc-layered-nav-rating';
 			$link        = apply_filters( 'woocommerce_rating_filter_link', $link_ratings ? add_query_arg( 'rating_filter', $link_ratings ) : remove_query_arg( 'rating_filter' ) );
 			$rating_html = wc_get_star_rating_html( $rating );
-			$count_html  = wp_kses( apply_filters( 'woocommerce_rating_filter_count', "({$count})", $count, $rating ), array(
-				'em' => array(),
-				'span' => array(),
-				'strong' => array(),
-			) );
+			$count_html  = wp_kses(
+				apply_filters( 'woocommerce_rating_filter_count', "({$count})", $count, $rating ),
+				array(
+					'em'     => array(),
+					'span'   => array(),
+					'strong' => array(),
+				)
+			);
 
 			printf( '<li class="%s"><a href="%s"><span class="star-rating">%s</span> %s</a></li>', esc_attr( $class ), esc_url( $link ), $rating_html, $count_html ); // WPCS: XSS ok.
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Allow `em`,`span`, and `strong` to pass through the `woocommerce_rating_filter_count`. The tags are limited because the return string from the filter is output inside a `span` and a link.

Closes #21196 .

### How to test the changes in this Pull Request:

1. Add a filter to `woocommerce_rating_filter_count` and wrap the string in a `<span class="pr-test"> ... </span>`.
2. The rating filter widget output should include the added span.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Allow limited html in `woocommerce_rating_filter_count` filter.
