### PR TITLE
Allow native WC_Ajax to pass cart_item_data

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -381,6 +381,7 @@ class WC_AJAX {
 		$product_status    = get_post_status( $product_id );
 		$variation_id      = 0;
 		$variation         = array();
+		$cart_item_data    = empty( $_POST['cart_item_data'] ) ? array() : wc_clean( $_POST['cart_item_data'] );
 
 		if ( $product && 'variation' === $product->get_type() ) {
 			$variation_id = $product_id;
@@ -388,7 +389,7 @@ class WC_AJAX {
 			$variation    = $product->get_variation_attributes();
 		}
 
-		if ( $passed_validation && false !== WC()->cart->add_to_cart( $product_id, $quantity, $variation_id, $variation ) && 'publish' === $product_status ) {
+		if ( $passed_validation && false !== WC()->cart->add_to_cart( $product_id, $quantity, $variation_id, $variation, $cart_item_data ) && 'publish' === $product_status ) {
 
 			do_action( 'woocommerce_ajax_added_to_cart', $product_id );
 


### PR DESCRIPTION
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Allow native `WC_Ajax` class to pass `cart_item_data` such as product addons :)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Allow AJAX cart to pass cart item data which may be added by other plugins.
