### PR TITLE
Load v3 API correctly when firing webhooks

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -285,7 +285,7 @@ class WC_Webhook extends WC_Legacy_Webhook {
 	 */
 	private function get_wp_api_payload( $resource, $resource_id, $event ) {
 		$rest_api_versions = wc_get_webhook_rest_api_versions();
-		$version_suffix    = end( $rest_api_versions ) === $this->get_api_version() ? strtoupper( str_replace( 'wp_api', '', $this->get_api_version() ) ) : '';
+		$version_suffix    = end( $rest_api_versions ) !== $this->get_api_version() ? strtoupper( str_replace( 'wp_api', '', $this->get_api_version() ) ) : '';
 
 		switch ( $resource ) {
 			case 'coupon':


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes an issue where the wrong class name was generated when firing webhooks, it appended the version the API controller class name, but when using the latest version, v3 in this case, there is no version number as part of the class name.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21916.

### How to test the changes in this Pull Request:

1. Create a webhook for orders for example
2. Make sure you choose v3 API as the API version for the webhook
3. Create an order
4. Check that the logs contain no fatal error like WC_REST_Orders_V3_Controller not found
5. Check the Scheduled Actions tab under System Status and ensure the webhook fired correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fatal error when delivering webhooks using v3 API.
