### PR TITLE
Update database tools option

### DIFF
--- a/includes/api/v2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-tools-v2-controller.php
@@ -191,13 +191,13 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 				'button' => __( 'Regenerate', 'woocommerce' ),
 				'desc'   => __( 'This will regenerate all shop thumbnails to match your theme and/or image settings.', 'woocommerce' ),
 			),
-			'db_upgrade_routine'                 => array(
-				'name'   => __( 'Upgrade database', 'woocommerce' ),
-				'button' => __( 'Upgrade database', 'woocommerce' ),
+			'db_update_routine'                  => array(
+				'name'   => __( 'Update database', 'woocommerce' ),
+				'button' => __( 'Update database', 'woocommerce' ),
 				'desc'   => sprintf(
 					'<strong class="red">%1$s</strong> %2$s',
 					__( 'Note:', 'woocommerce' ),
-					__( 'This tool will upgrade your WooCommerce database to the latest version. Please ensure you make sufficient backups before proceeding.', 'woocommerce' )
+					__( 'This tool will update your WooCommerce database to the latest version. Please ensure you make sufficient backups before proceeding.', 'woocommerce' )
 				),
 			)
 		);
@@ -545,7 +545,7 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 				$message = __( 'Thumbnail regeneration has been scheduled to run in the background.', 'woocommerce' );
 				break;
 
-			case 'db_upgrade_routine':
+			case 'db_update_routine':
 				$blog_id = get_current_blog_id();
 				// Used to fire an action added in WP_Background_Process::_construct() that calls WP_Background_Process::handle_cron_healthcheck().
 				// This method will make sure the database updates are executed even if cron is disabled. Nothing will happen if the updates are already running.

--- a/includes/api/v2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-tools-v2-controller.php
@@ -191,6 +191,15 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 				'button' => __( 'Regenerate', 'woocommerce' ),
 				'desc'   => __( 'This will regenerate all shop thumbnails to match your theme and/or image settings.', 'woocommerce' ),
 			),
+			'db_upgrade_routine'                 => array(
+				'name'   => __( 'Upgrade database', 'woocommerce' ),
+				'button' => __( 'Upgrade database', 'woocommerce' ),
+				'desc'   => sprintf(
+					'<strong class="red">%1$s</strong> %2$s',
+					__( 'Note:', 'woocommerce' ),
+					__( 'This tool will upgrade your WooCommerce database to the latest version. Please ensure you make sufficient backups before proceeding.', 'woocommerce' )
+				),
+			)
 		);
 
 		// Jetpack does the image resizing heavy lifting so you don't have to.
@@ -534,6 +543,14 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 			case 'regenerate_thumbnails':
 				WC_Regenerate_Images::queue_image_regeneration();
 				$message = __( 'Thumbnail regeneration has been scheduled to run in the background.', 'woocommerce' );
+				break;
+
+			case 'db_upgrade_routine':
+				$blog_id = get_current_blog_id();
+				// Used to fire an action added in WP_Background_Process::_construct() that calls WP_Background_Process::handle_cron_healthcheck().
+				// This method will make sure the database updates are executed even if cron is disabled. Nothing will happen if the updates are already running.
+				do_action( 'wp_' . $blog_id . '_wc_updater_cron' );
+				$message = __( 'Database upgrade routine has been scheduled to run in the background.', 'woocommerce' );
 				break;
 
 			default:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR adds a new button to the tools page to allow upgrading the database from there. Why is this needed? Since 3.5 we now sign the upgrade notice link with a nonce and some hosts and plugins can hide these notices leaving you with no way to update the DB.

Closes #21902

### How to test the changes in this Pull Request:

1. Change your woocommerce_db_version to something like 3.4 in wp_options
2. Load the WooCommerce tools page and click the Update database option.
3. Check that the DB has been updated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - New Database update tool option
