### PR TITLE
Revert parts of #20881

### DIFF
--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -11,7 +11,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.5.0
+ * @version 3.5.2
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -29,7 +29,7 @@ if ( ! is_a( $product, 'WC_Product' ) ) {
 	<?php do_action( 'woocommerce_widget_product_item_start', $args ); ?>
 
 	<a href="<?php echo esc_url( $product->get_permalink() ); ?>">
-		<?php echo wp_kses_post( $product->get_image() ); ?>
+		<?php echo $product->get_image(); ?>
 		<span class="product-title"><?php echo esc_html( $product->get_name() ); ?></span>
 	</a>
 
@@ -37,7 +37,7 @@ if ( ! is_a( $product, 'WC_Product' ) ) {
 		<?php echo wp_kses_post( wc_get_rating_html( $product->get_average_rating() ) ); ?>
 	<?php endif; ?>
 
-	<?php echo wp_kses_post( $product->get_price_html() ); ?>
+	<?php echo $product->get_price_html(); ?>
 
 	<?php do_action( 'woocommerce_widget_product_item_end', $args ); ?>
 </li>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Certain html output just should not be passed through sanitization. Things like images and prices we already control the input via the interface, but we also need to allow some flexibility to modify the output. For example passing an img element with data attributes through wp_kses_post will show the image fine, but will strip out the data attributes, which might be needed by some plugins as per #21924 

IMO there is no use to have a filter in place to modify the html and then pass it through a sanitization function on output which will just strip any modification out again.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21924 

### How to test the changes in this Pull Request:

1. Instruction to test via Rocket Lazy Load in #21924

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Overescaping image output on product widget.
