### PR TITLE
Add WP 5.0 checks to Wootenberg notices

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -368,8 +368,7 @@ class WC_Admin_Notices {
 	 * @todo  Remove this notice and associated code once the feature plugin has been merged into core.
 	 */
 	public static function add_wootenberg_feature_plugin_notice() {
-		global $wp_version;
-		if ( ( is_plugin_active( 'gutenberg/gutenberg.php' ) || version_compare( $wp_version, '5.0', '>=' ) ) && ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) {
+		if ( ( is_plugin_active( 'gutenberg/gutenberg.php' ) || version_compare( get_bloginfo( 'version' ), '5.0', '>=' ) ) && ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) {
 			self::add_notice( 'wootenberg' );
 		}
 	}
@@ -381,8 +380,7 @@ class WC_Admin_Notices {
 	 * @todo  Remove this notice and associated code once the feature plugin has been merged into core.
 	 */
 	public static function add_wootenberg_feature_plugin_notice_on_gutenberg_activate() {
-		global $wp_version;
-		if ( ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) && version_compare( $wp_version, '5.0', '<' ) ) {
+		if ( ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) && version_compare( get_bloginfo( 'version' ), '5.0', '<' ) ) {
 			self::add_notice( 'wootenberg' );
 		}
 	}

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -118,7 +118,8 @@ class WC_Admin_Notices {
 	/**
 	 * See if a notice is being shown.
 	 *
-	 * @param  string $name Notice name.
+	 * @param string $name Notice name.
+	 *
 	 * @return boolean
 	 */
 	public static function has_notice( $name ) {
@@ -364,10 +365,11 @@ class WC_Admin_Notices {
 	 * If Gutenberg is active, tell people about the Products block feature plugin.
 	 *
 	 * @since 3.4.3
-	 * @todo Remove this notice and associated code once the feature plugin has been merged into core.
+	 * @todo  Remove this notice and associated code once the feature plugin has been merged into core.
 	 */
 	public static function add_wootenberg_feature_plugin_notice() {
-		if ( is_plugin_active( 'gutenberg/gutenberg.php' ) && ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) {
+		global $wp_version;
+		if ( ( is_plugin_active( 'gutenberg/gutenberg.php' ) || version_compare( $wp_version, '5.0', '>=' ) ) && ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) {
 			self::add_notice( 'wootenberg' );
 		}
 	}
@@ -376,10 +378,11 @@ class WC_Admin_Notices {
 	 * Tell people about the Products block feature plugin when they activate Gutenberg.
 	 *
 	 * @since 3.4.3
-	 * @todo Remove this notice and associated code once the feature plugin has been merged into core.
+	 * @todo  Remove this notice and associated code once the feature plugin has been merged into core.
 	 */
 	public static function add_wootenberg_feature_plugin_notice_on_gutenberg_activate() {
-		if ( ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) {
+		global $wp_version;
+		if ( ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) && version_compare( $wp_version, '5.0', '<' ) ) {
 			self::add_notice( 'wootenberg' );
 		}
 	}
@@ -400,7 +403,7 @@ class WC_Admin_Notices {
 	 * Determine if the store is running SSL.
 	 *
 	 * @return bool Flag SSL enabled.
-	 * @since 3.5.1
+	 * @since  3.5.1
 	 */
 	protected static function is_ssl() {
 		$shop_page = 0 < wc_get_page_id( 'shop' ) ? get_permalink( wc_get_page_id( 'shop' ) ) : get_home_url();

--- a/includes/admin/views/html-notice-wootenberg.php
+++ b/includes/admin/views/html-notice-wootenberg.php
@@ -12,11 +12,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'wootenberg' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 
 	<p>
-		<?php echo wp_kses_post( __( "We noticed you're experimenting with Gutenberg: Try the WooCommerce Gutenberg Products Block for a powerful new way to feature products in posts.", 'woocommerce' ) ); ?>
+		<?php echo wp_kses_post( __( "We noticed you have the block editor available: Try the WooCommerce Products Block for a powerful new way to feature products in posts.", 'woocommerce' ) ); ?>
 	</p>
 	<?php if ( file_exists( WP_PLUGIN_DIR . '/woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) && ! is_plugin_active( 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) && current_user_can( 'activate_plugin', 'woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ) : ?>
 		<p>
-			<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php&plugin_status=active' ), 'activate-plugin_woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Activate the Gutenberg Products Block', 'woocommerce' ); ?></a>
+			<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php&plugin_status=active' ), 'activate-plugin_woo-gutenberg-products-block/woocommerce-gutenberg-products-block.php' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Activate the Products Block', 'woocommerce' ); ?></a>
 		</p>
 	<?php else : ?>
 		<?php
@@ -27,7 +27,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		}
 		?>
 		<p>
-			<a href="<?php echo esc_url( $url ); ?>" class="button button-primary"><?php esc_html_e( 'Install the WooCommerce Gutenberg Products Block', 'woocommerce' ); ?></a>
+			<a href="<?php echo esc_url( $url ); ?>" class="button button-primary"><?php esc_html_e( 'Install the WooCommerce Products Block', 'woocommerce' ); ?></a>
 		</p>
 	<?php endif; ?>
 </div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR introduces additional checks to the Wootenberg notices to check the WP version as well since the Gutenberg plugin is not needed since WP 5.0.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21915 

### How to test the changes in this Pull Request:

1. Uninstall Gutenberg and Update to WP 5.0 instead
2. Check that the notice to install the products blocks feature plugin is still showing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Include WP 5.0 check when before displaying Product Blocks notice.