### PR TITLE
Only show country in formatted address on cart page

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -547,8 +547,8 @@ class WC_Countries {
 		// Handle full country name.
 		$full_country = ( isset( $this->countries[ $country ] ) ) ? $this->countries[ $country ] : $country;
 
-		// Country is not needed if the same as base.
-		if ( $country === $this->get_base_country() && ! apply_filters( 'woocommerce_formatted_address_force_country_display', true ) ) {
+		// Country is not needed if the same as base except in shipping calculator.
+		if ( $country === $this->get_base_country() && ! apply_filters( 'woocommerce_formatted_address_force_country_display', is_cart() ) ) {
 			$format = str_replace( '{country}', '', $format );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21857 .
Supersedes #21865. 

It looks like the behavior of the filter [was changed with the shipping calculator refactor](https://github.com/woocommerce/woocommerce/pull/20345/commits/243c33d9ca5fa32d117a212f6bf9dc209d8fda54) so as to always show the country in the shipping calculator.

This PR maintains that change while tweaking the filter so that it will not cause unwanted side-effects in other parts of the site/emails.

#### This is what the shipping calculator looks like with the filter off by default (the old way):

<img width="358" alt="screen shot 2018-11-15 at 9 27 10 am" src="https://user-images.githubusercontent.com/7317227/48570471-4a6c3780-e8b9-11e8-8105-aa70c54dcc6c.png">

#### This is what the shipping calculator looks like with the filter on by default or with the dynamic filter I'm proposing here:

<img width="357" alt="screen shot 2018-11-15 at 9 26 41 am" src="https://user-images.githubusercontent.com/7317227/48570467-48a27400-e8b9-11e8-87b0-0584759f980d.png">

Always showing the country in the shipping calculator will prevent confusion when a store sells to multiple countries and the customer is in the same country the store is based out of.

### How to test the changes in this Pull Request:

1. Test cart with shipping calculator shows the country.
2. Test #21857 instructions to verify emails, etc. maintain their previous behavior.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Only force show countries on Cart page to maintain backwards compatibility in other places the formatted address is displayed.
