### PR TITLE
Use wp_kses_post for sanitizing product names instead of esc_html

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -19,7 +19,7 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 	</td>
 	<td class="name" data-sort-value="<?php echo esc_attr( $item->get_name() ); ?>">
 		<?php
-		echo $product_link ? '<a href="' . esc_url( $product_link ) . '" class="wc-order-item-name">' . esc_html( $item->get_name() ) . '</a>' : '<div class="wc-order-item-name">' . esc_html( $item->get_name() ) . '</div>';
+		echo $product_link ? '<a href="' . esc_url( $product_link ) . '" class="wc-order-item-name">' . wp_kses_post( $item->get_name() ) . '</a>' : '<div class="wc-order-item-name">' . wp_kses_post( $item->get_name() ) . '</div>';
 
 		if ( $product && $product->get_sku() ) {
 			echo '<div class="wc-order-item-sku"><strong>' . esc_html__( 'SKU:', 'woocommerce' ) . '</strong> ' . esc_html( $product->get_sku() ) . '</div>';

--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -30,7 +30,7 @@ if ( ! is_a( $product, 'WC_Product' ) ) {
 
 	<a href="<?php echo esc_url( $product->get_permalink() ); ?>">
 		<?php echo $product->get_image(); ?>
-		<span class="product-title"><?php echo esc_html( $product->get_name() ); ?></span>
+		<span class="product-title"><?php echo wp_kses_post( $product->get_name() ); ?></span>
 	</a>
 
 	<?php if ( ! empty( $show_rating ) ) : ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21878 .
Closes #21905 .

I think `wp_kses_post` should be the default for sanitizing product titles instead of `esc_html`, as this maintains safety while allowing HTML to be in product titles (naturally or injected with a filter).

### How to test the changes in this Pull Request:

1. Set up a product with HTML in the title.
2. Observe product title renders in widgets and order line items correctly:
<img width="995" alt="screen shot 2018-11-15 at 11 39 05 am" src="https://user-images.githubusercontent.com/7317227/48577456-12babb00-e8cc-11e8-99d9-0c562944f2b0.png">
<img width="629" alt="screen shot 2018-11-15 at 11 42 07 am" src="https://user-images.githubusercontent.com/7317227/48577457-12babb00-e8cc-11e8-8ce0-7958677d41fe.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Use `wp_kses_post` instead of `esc_html` for sanitizing product titles to allow minimal HTML in product titles.
