### PR TITLE
Unescape imported escaped CSV formulas in product attributes

### DIFF
--- a/includes/export/abstract-wc-csv-exporter.php
+++ b/includes/export/abstract-wc-csv-exporter.php
@@ -354,7 +354,7 @@ abstract class WC_CSV_Exporter {
 		$active_content_triggers = array( '=', '+', '-', '@' );
 
 		if ( in_array( mb_substr( $data, 0, 1 ), $active_content_triggers, true ) ) {
-			$data = "'" . $data . "'";
+			$data = "'" . $data;
 		}
 
 		return $data;

--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -765,21 +765,21 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	}
 
 	/**
-	 * The exporter prepends a ' to fields that start with a - which causes
-	 * issues with negative numbers. This removes the ' if the input is still a valid
-	 * number after removal.
+	 * The exporter prepends a ' to escape fields that start with =, +, - or @.
+	 * Remove the prepended ' character preceding those characters.
 	 *
-	 * @since 3.3.0
-	 * @param string $value A numeric string that may or may not have ' prepended.
+	 * @since 3.5.2
+	 * @param  string $value A string that may or may not have been escaped with '.
 	 * @return string
 	 */
-	protected function unescape_negative_number( $value ) {
-		if ( 0 === strpos( $value, "'-" ) ) {
-			$unescaped = trim( $value, "'" );
-			if ( is_numeric( $unescaped ) ) {
-				return $unescaped;
-			}
+	protected function unescape_data( $value ) {
+		$active_content_triggers = array( "'=", "'+", "'-", "'@" );
+
+		if ( in_array( mb_substr( $value, 0, 2 ), $active_content_triggers, true ) ) {
+			$value = mb_substr( $value, 1 );
 		}
+
 		return $value;
 	}
+
 }

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -284,6 +284,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			return array();
 		}
 
+		$value = $this->unescape_data( $value );
 		return array_map( 'wc_clean', $this->explode_values( $value ) );
 	}
 
@@ -318,7 +319,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		}
 
 		// Remove the ' prepended to fields that start with - if needed.
-		$value = $this->unescape_negative_number( $value );
+		$value = $this->unescape_data( $value );
 
 		return floatval( $value );
 	}
@@ -335,7 +336,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		}
 
 		// Remove the ' prepended to fields that start with - if needed.
-		$value = $this->unescape_negative_number( $value );
+		$value = $this->unescape_data( $value );
 
 		return wc_stock_amount( $value );
 	}
@@ -403,6 +404,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			return array();
 		}
 
+		$value = $this->unescape_data( $value );
 		$names = $this->explode_values( $value );
 		$tags  = array();
 
@@ -549,7 +551,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 */
 	public function parse_int_field( $value ) {
 		// Remove the ' prepended to fields that start with - if needed.
-		$value = $this->unescape_negative_number( $value );
+		$value = $this->unescape_data( $value );
 
 		return intval( $value );
 	}

--- a/tests/unit-tests/exporter/product.php
+++ b/tests/unit-tests/exporter/product.php
@@ -24,16 +24,16 @@ class WC_Tests_Product_CSV_Exporter extends WC_Unit_Test_Case {
 		$exporter = new WC_Product_CSV_Exporter();
 
 		$data = "=cmd|' /C calc'!A0";
-		$this->assertEquals( "'=cmd|' /C calc'!A0'", $exporter->escape_data( $data ) );
+		$this->assertEquals( "'=cmd|' /C calc'!A0", $exporter->escape_data( $data ) );
 
 		$data = "+cmd|' /C calc'!A0";
-		$this->assertEquals( "'+cmd|' /C calc'!A0'", $exporter->escape_data( $data ) );
+		$this->assertEquals( "'+cmd|' /C calc'!A0", $exporter->escape_data( $data ) );
 
 		$data = "-cmd|' /C calc'!A0";
-		$this->assertEquals( "'-cmd|' /C calc'!A0'", $exporter->escape_data( $data ) );
+		$this->assertEquals( "'-cmd|' /C calc'!A0", $exporter->escape_data( $data ) );
 
 		$data = "@cmd|' /C calc'!A0";
-		$this->assertEquals( "'@cmd|' /C calc'!A0'", $exporter->escape_data( $data ) );
+		$this->assertEquals( "'@cmd|' /C calc'!A0", $exporter->escape_data( $data ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prepend with a `'` to escape when exporting in a CSV context rather than wrap the string in `'`.
Update the CSV import functionality to remove the prepended `'` when it is used as an escape character.

Closes #21935 .

### How to test the changes in this Pull Request:

1. Go to Product Attributes.
2. Add an attribute.
3. Add a term to the attribute where the name begins with a `+`.
4. Edit a variable product.
5. Add the attribute to the product & select the term beginning with the `+`.
6. Export variable products.
7. Delete the term beginning with the `+`.
8. Import the CSV you exported.
9. Imported term should have the same name as before exported.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Unescape imported CSV formulas in product attributes.
