### PR TITLE
Make wc_download_log FK use table prefix

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -117,6 +117,9 @@ class WC_Install {
 			'wc_update_350_reviews_comment_type',
 			'wc_update_350_db_version',
 		),
+		'3.5.2' => array(
+			'wc_update_352_drop_download_log_fk',
+		)
 	);
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -597,19 +597,18 @@ class WC_Install {
 
 		// Add constraint to download logs if the columns matches.
 		if ( ! empty( $download_permissions_column_type ) && ! empty( $download_log_column_type ) && $download_permissions_column_type === $download_log_column_type ) {
-			$constraint_prefix = ! is_multisite() || ( is_main_site() && is_main_network() ) ? 'fk_' . $wpdb->prefix : str_replace( $wpdb->base_prefix, 'fk_', $wpdb->prefix );
 			$fk_result = $wpdb->get_row( "
 				SELECT COUNT(*) AS fk_count
 				FROM information_schema.TABLE_CONSTRAINTS
 				WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
-				AND CONSTRAINT_NAME = '{$constraint_prefix}wc_download_log_permission_id'
+				AND CONSTRAINT_NAME = 'fk_{$wpdb->prefix}wc_download_log_permission_id'
 				AND CONSTRAINT_TYPE = 'FOREIGN KEY'
 				AND TABLE_NAME = '{$wpdb->prefix}wc_download_log'
 			" ); // WPCS: unprepared SQL ok.
 			if ( 0 === (int) $fk_result->fk_count ) {
 				$wpdb->query( "
 					ALTER TABLE `{$wpdb->prefix}wc_download_log`
-					ADD CONSTRAINT `{$constraint_prefix}wc_download_log_permission_id`
+					ADD CONSTRAINT `fk_{$wpdb->prefix}wc_download_log_permission_id`
 					FOREIGN KEY (`permission_id`)
 					REFERENCES `{$wpdb->prefix}woocommerce_downloadable_product_permissions` (`permission_id`) ON DELETE CASCADE;
 				" ); // WPCS: unprepared SQL ok.

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -593,7 +593,7 @@ class WC_Install {
 
 		// Add constraint to download logs if the columns matches.
 		if ( ! empty( $download_permissions_column_type ) && ! empty( $download_log_column_type ) && $download_permissions_column_type === $download_log_column_type ) {
-			$constraint_prefix = ! is_multisite() || ( is_main_site() && is_main_network() ) ? 'fk_' : str_replace( $wpdb->base_prefix, 'fk_', $wpdb->prefix );
+			$constraint_prefix = ! is_multisite() || ( is_main_site() && is_main_network() ) ? 'fk_' . $wpdb->prefix : str_replace( $wpdb->base_prefix, 'fk_', $wpdb->prefix );
 			$fk_result = $wpdb->get_row( "
 				SELECT COUNT(*) AS fk_count
 				FROM information_schema.TABLE_CONSTRAINTS

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -250,7 +250,7 @@ class WC_Install {
 	/**
 	 * Is this a brand new WC install?
 	 *
-	 * @since 3.2.0
+	 * @since  3.2.0
 	 * @return boolean
 	 */
 	private static function is_new_install() {
@@ -260,7 +260,7 @@ class WC_Install {
 	/**
 	 * Is a DB update needed?
 	 *
-	 * @since 3.2.0
+	 * @since  3.2.0
 	 * @return boolean
 	 */
 	private static function needs_db_update() {
@@ -357,7 +357,8 @@ class WC_Install {
 	/**
 	 * Add more cron schedules.
 	 *
-	 * @param  array $schedules List of WP scheduled cron jobs.
+	 * @param array $schedules List of WP scheduled cron jobs.
+	 *
 	 * @return array
 	 */
 	public static function cron_schedules( $schedules ) {
@@ -899,7 +900,8 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 	/**
 	 * Uninstall tables when MU blog is deleted.
 	 *
-	 * @param  array $tables List of tables that will be deleted by WP.
+	 * @param array $tables List of tables that will be deleted by WP.
+	 *
 	 * @return string[]
 	 */
 	public static function wpmu_drop_tables( $tables ) {
@@ -1169,8 +1171,9 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 	/**
 	 * Show action links on the plugin screen.
 	 *
-	 * @param   mixed $links Plugin Action links.
-	 * @return  array
+	 * @param mixed $links Plugin Action links.
+	 *
+	 * @return array
 	 */
 	public static function plugin_action_links( $links ) {
 		$action_links = array(
@@ -1183,9 +1186,10 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 	/**
 	 * Show row meta on the plugin screen.
 	 *
-	 * @param   mixed $links Plugin Row Meta.
-	 * @param   mixed $file  Plugin Base file.
-	 * @return  array
+	 * @param mixed $links Plugin Row Meta.
+	 * @param mixed $file  Plugin Base file.
+	 *
+	 * @return array
 	 */
 	public static function plugin_row_meta( $links, $file ) {
 		if ( WC_PLUGIN_BASENAME === $file ) {
@@ -1220,8 +1224,9 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 	 *
 	 * @param string $plugin_to_install_id Plugin ID.
 	 * @param array  $plugin_to_install Plugin information.
+	 *
 	 * @throws Exception If unable to proceed with plugin installation.
-	 * @since 2.6.0
+	 * @since  2.6.0
 	 */
 	public static function background_installer( $plugin_to_install_id, $plugin_to_install ) {
 		// Explicitly clear the event.
@@ -1375,8 +1380,9 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 	 * Install a theme from .org in the background via a cron job (used by installer - opt in).
 	 *
 	 * @param string $theme_slug Theme slug.
+	 *
 	 * @throws Exception If unable to proceed with theme installation.
-	 * @since 3.1.0
+	 * @since  3.1.0
 	 */
 	public static function theme_background_installer( $theme_slug ) {
 		// Explicitly clear the event.

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1872,3 +1872,25 @@ function wc_update_350_reviews_comment_type() {
 function wc_update_350_db_version() {
 	WC_Install::update_db_version( '3.5.0' );
 }
+
+/**
+ * Drop the fk_wc_download_log_permission_id FK as we use a new one with the table and blog prefix for MS compatability.
+ *
+ * @return void
+ */
+function wc_update_352_drop_download_log_fk() {
+	global $wpdb;
+	$results = $wpdb->get_results( "
+		SELECT CONSTRAINT_NAME
+		FROM information_schema.TABLE_CONSTRAINTS
+		WHERE CONSTRAINT_SCHEMA = '{$wpdb->dbname}'
+		AND CONSTRAINT_NAME = 'fk_wc_download_log_permission_id'
+		AND CONSTRAINT_TYPE = 'FOREIGN KEY'
+		AND TABLE_NAME = '{$wpdb->prefix}wc_download_log'
+	" );
+
+	// We only need to drop the old key as WC_Install::create_tables() takes care of creating the new FK.
+	if ( $results ) {
+		$wpdb->query( "ALTER TABLE {$wpdb->prefix}wc_download_log DROP FOREIGN KEY fk_wc_download_log_permission_id" ); // phpcs:ignore WordPress.WP.PreparedSQL.NotPrepared
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR addresses an issue where if you have multiple single sites sharing the same DB you run into issue creating the download_log FK as FKs need to be unique in the DB. All this PR does is drop the old FK and then make it so that WC_Install::create_tables now create a new FK which uses the table prefix as part of the FK name.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21937 

### How to test the changes in this Pull Request:

1. Install 2 WC stores on the same DB, ensure they both have different table prefix names
2. Check the DB there should be no fk_wc_download_log_permission_id FK but rather 2 that follows the fk_{$wpdb->prefix}wc_download_log_permission_id format.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Allow WP sites sharing the same DB to create unique wc_download_log_permission_id foreign keys for each install.
