### PR TITLE
Refine new order-again logic

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -341,7 +341,7 @@ final class WC_Cart_Session {
 			);
 		}
 
-		do_action( 'woocommerce_ordered_again', $order->get_id() );
+		do_action( 'woocommerce_ordered_again', $order->get_id(), $cart );
 
 		$num_items_in_cart           = count( $cart );
 		$num_items_in_original_order = count( $order_items );

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -341,7 +341,7 @@ final class WC_Cart_Session {
 			);
 		}
 
-		do_action( 'woocommerce_ordered_again', $order->get_id(), $cart );
+		do_action( 'woocommerce_ordered_again', $order->get_id(), $order_items, $cart );
 
 		$num_items_in_cart           = count( $cart );
 		$num_items_in_original_order = count( $order_items );

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -327,7 +327,7 @@ final class WC_Cart_Session {
 			$cart_id          = WC()->cart->generate_cart_id( $product_id, $variation_id, $variations, $cart_item_data );
 			$product_data     = wc_get_product( $variation_id ? $variation_id : $product_id );
 			$cart[ $cart_id ] = apply_filters(
-				'woocommerce_add_cart_item', array_merge(
+				'woocommerce_add_order_again_cart_item', array_merge(
 					$cart_item_data, array(
 						'key'          => $cart_id,
 						'product_id'   => $product_id,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

1. Rename `woocommerce_add_cart_item` to `woocommerce_add_order_again_cart_item`

* Session data is not loaded yet, so any code hooking into filters/actions like `woocommerce_add_cart_item` is likely to trigger errors if it attempts to work with cart contents.

* `WC_Cart::add_to_cart` is designed to catch exceptions in order to allow third-party code to generate failure notices from code/callbacks hooked into those filters/actions. The new order-again logic runs in a completely different context and shouldn't attempt to re-use hooks from `WC_Cart::add_to_cart`.

2. Pass the local `$cart` (and `$order_items`) variable into the `woocommerce_ordered_again` action here, as it's no longer possible to access anything through `WC_Cart::get_cart`.

@rrennick do you have any tests that cover these parts of WCS -- https://github.com/Prospress/woocommerce-subscriptions/blob/master/includes/class-wcs-cart-renewal.php#L323 ? Just want to make sure we will not be breaking anything here.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21845 .


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Use dedicated `woocommerce_add_order_again_cart_item` to filter cart item data when ordering again. Prevents issues with applying `woocommerce_add_cart_item` out of context.