### PR TITLE
OBW: Fix ShipStation plugin info so install works

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1080,10 +1080,11 @@ class WC_Admin_Setup_Wizard {
 
 		if ( $setup_shipstation ) {
 			$this->install_plugin(
-				'woocommerce-shipstation',
+				'woocommerce-shipstation-integration',
 				array(
 					'name'      => __( 'ShipStation', 'woocommerce' ),
-					'repo-slug' => 'woocommerce-shipstation',
+					'repo-slug' => 'woocommerce-shipstation-integration',
+					'file'      => 'woocommerce-shipstation.php',
 				)
 			);
 		}


### PR DESCRIPTION
This PR updates the ShipStation plugin info passed to `install_plugin` to use the plugin's WP.org information. Currently the ShipStation plugin is not successfully installed after being selected in the OBW, and this PR fixes that.

The plugin slug is `woocommerce-shipstation-integration`: https://wordpress.org/plugins/woocommerce-shipstation-integration

And the plugin's filename is `woocommerce-shipstation.php`, not `woocommerce-shipstation-integration.php`, which is why the `file` key is needed.