### PR TITLE
Fix hardcoded db table name [Fixes #21793]

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -293,11 +293,14 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Render any custom filters and search inputs for the list table.
 	 */
 	protected function render_filters() {
-		$filters = apply_filters( 'woocommerce_products_admin_list_table_filters', array(
-			'product_category' => array( $this, 'render_products_category_filter' ),
-			'product_type'     => array( $this, 'render_products_type_filter' ),
-			'stock_status'     => array( $this, 'render_products_stock_status_filter' ),
-		) );
+		$filters = apply_filters(
+			'woocommerce_products_admin_list_table_filters',
+			array(
+				'product_category' => array( $this, 'render_products_category_filter' ),
+				'product_type'     => array( $this, 'render_products_type_filter' ),
+				'stock_status'     => array( $this, 'render_products_stock_status_filter' ),
+			)
+		);
 
 		ob_start();
 		foreach ( $filters as $filter_callback ) {
@@ -394,18 +397,24 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	protected function query_filters( $query_vars ) {
 		if ( isset( $query_vars['orderby'] ) ) {
 			if ( 'price' === $query_vars['orderby'] ) {
-				$query_vars = array_merge( $query_vars, array(
-					// phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_key
-					'meta_key' => '_price',
-					'orderby'  => 'meta_value_num',
-				) );
+				$query_vars = array_merge(
+					$query_vars,
+					array(
+						// phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_key
+						'meta_key' => '_price',
+						'orderby'  => 'meta_value_num',
+					)
+				);
 			}
 			if ( 'sku' === $query_vars['orderby'] ) {
-				$query_vars = array_merge( $query_vars, array(
-					// phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_key
-					'meta_key' => '_sku',
-					'orderby'  => 'meta_value',
-				) );
+				$query_vars = array_merge(
+					$query_vars,
+					array(
+						// phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_key
+						'meta_key' => '_sku',
+						'orderby'  => 'meta_value',
+					)
+				);
 			}
 		}
 

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -2,8 +2,8 @@
 /**
  * List tables: products.
  *
- * @package  WooCommerce/Admin
- * @version  3.3.0
+ * @package WooCommerce/Admin
+ * @version 3.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -67,6 +67,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 *
 	 * @param array   $actions Array of actions.
 	 * @param WP_Post $post Current post object.
+	 *
 	 * @return array
 	 */
 	protected function get_row_actions( $actions, $post ) {
@@ -78,6 +79,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Define which columns are sortable.
 	 *
 	 * @param array $columns Existing columns.
+	 *
 	 * @return array
 	 */
 	public function define_sortable_columns( $columns ) {
@@ -93,6 +95,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Define which columns to show on this screen.
 	 *
 	 * @param array $columns Existing columns.
+	 *
 	 * @return array
 	 */
 	public function define_columns( $columns ) {
@@ -278,6 +281,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Query vars for custom searches.
 	 *
 	 * @param mixed $public_query_vars Array of query vars.
+	 *
 	 * @return array
 	 */
 	public function add_custom_query_var( $public_query_vars ) {
@@ -384,6 +388,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Handle any custom filters.
 	 *
 	 * @param array $query_vars Query vars.
+	 *
 	 * @return array
 	 */
 	protected function query_filters( $query_vars ) {
@@ -451,8 +456,10 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	/**
 	 * Search by SKU or ID for products.
 	 *
-	 * @deprecated Logic moved to query_filters.
 	 * @param string $where Where clause SQL.
+	 *
+	 * @deprecated Logic moved to query_filters.
+	 *
 	 * @return string
 	 */
 	public function sku_search( $where ) {
@@ -462,7 +469,8 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	/**
 	 * Change views on the edit product screen.
 	 *
-	 * @param  array $views Array of views.
+	 * @param array $views Array of views.
+	 *
 	 * @return array
 	 */
 	public function product_views( $views ) {
@@ -487,6 +495,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Change the label when searching products
 	 *
 	 * @param string $query Search Query.
+	 *
 	 * @return string
 	 */
 	public function search_label( $query ) {
@@ -504,7 +513,8 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 *
 	 * @param array    $pieces   Array of SELECT statement pieces (from, where, etc).
 	 * @param WP_Query $wp_query WP_Query instance.
-	 * @return array             Array of products, including parents of variations.
+	 *
+	 * @return array Array of products, including parents of variations.
 	 */
 	public function add_variation_parents_for_shipping_class( $pieces, $wp_query ) {
 		global $wpdb;

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -2,8 +2,8 @@
 /**
  * List tables: products.
  *
- * @package WooCommerce/Admin
- * @version 3.3.0
+ * @package  WooCommerce/Admin
+ * @version  3.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -67,7 +67,6 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 *
 	 * @param array   $actions Array of actions.
 	 * @param WP_Post $post Current post object.
-	 *
 	 * @return array
 	 */
 	protected function get_row_actions( $actions, $post ) {
@@ -79,7 +78,6 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Define which columns are sortable.
 	 *
 	 * @param array $columns Existing columns.
-	 *
 	 * @return array
 	 */
 	public function define_sortable_columns( $columns ) {
@@ -95,7 +93,6 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Define which columns to show on this screen.
 	 *
 	 * @param array $columns Existing columns.
-	 *
 	 * @return array
 	 */
 	public function define_columns( $columns ) {
@@ -281,7 +278,6 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Query vars for custom searches.
 	 *
 	 * @param mixed $public_query_vars Array of query vars.
-	 *
 	 * @return array
 	 */
 	public function add_custom_query_var( $public_query_vars ) {
@@ -391,7 +387,6 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Handle any custom filters.
 	 *
 	 * @param array $query_vars Query vars.
-	 *
 	 * @return array
 	 */
 	protected function query_filters( $query_vars ) {
@@ -465,10 +460,8 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	/**
 	 * Search by SKU or ID for products.
 	 *
-	 * @param string $where Where clause SQL.
-	 *
 	 * @deprecated Logic moved to query_filters.
-	 *
+	 * @param string $where Where clause SQL.
 	 * @return string
 	 */
 	public function sku_search( $where ) {
@@ -478,8 +471,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	/**
 	 * Change views on the edit product screen.
 	 *
-	 * @param array $views Array of views.
-	 *
+	 * @param  array $views Array of views.
 	 * @return array
 	 */
 	public function product_views( $views ) {
@@ -504,7 +496,6 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * Change the label when searching products
 	 *
 	 * @param string $query Search Query.
-	 *
 	 * @return string
 	 */
 	public function search_label( $query ) {
@@ -522,8 +513,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 *
 	 * @param array    $pieces   Array of SELECT statement pieces (from, where, etc).
 	 * @param WP_Query $wp_query WP_Query instance.
-	 *
-	 * @return array Array of products, including parents of variations.
+	 * @return array             Array of products, including parents of variations.
 	 */
 	public function add_variation_parents_for_shipping_class( $pieces, $wp_query ) {
 		global $wpdb;

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -511,8 +511,8 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		if ( isset( $_GET['product_shipping_class'] ) && '0' !== $_GET['product_shipping_class'] ) { // WPCS: input var ok.
 			$replaced_where   = str_replace( ".post_type = 'product'", ".post_type = 'product_variation'", $pieces['where'] );
 			$pieces['where'] .= " OR {$wpdb->posts}.ID in (
-				SELECT {$wpdb->posts}.post_parent FROM 
-				wp_posts  LEFT JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)
+				SELECT {$wpdb->posts}.post_parent FROM
+				{$wpdb->posts} LEFT JOIN {$wpdb->term_relationships} ON ({$wpdb->posts}.ID = {$wpdb->term_relationships}.object_id)
 				WHERE 1=1 $replaced_where
 			)";
 			return $pieces;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes hardcoded db table name introduced in https://github.com/woocommerce/woocommerce/commit/ab4630111bcf2c066ca31609adc97b56e6bac4c9

Closes #21793.

### How to test the changes in this Pull Request:

1. Create a WP install using a non-standard db table prefix.
2. Install WC, create a shipping class, and assign the shipping class to a product (e.g. slug 'heavy').
3. On `master` branch, view the Products admin page and add `&product_shipping_class={shipping class slug}` to the URL. (e.g. `https://woocommerce.test/wp-admin/edit.php?post_type=product&product_shipping_class=heavy`).
4. See no products are displayed.
5. Check out this branch (`fix/21793`).
6. Refresh and see the product is now displayed correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix hardcoded db table name in product list table shipping class query
