### PR TITLE
Filter out buttons from edit order row click

### DIFF
--- a/assets/js/admin/wc-orders.js
+++ b/assets/js/admin/wc-orders.js
@@ -18,7 +18,7 @@ jQuery( function( $ ) {
 	 * Click a row.
 	 */
 	WCOrdersTable.prototype.onRowClick = function( e ) {
-		if ( $( e.target ).filter( 'a, a *, .no-link, .no-link *' ).length ) {
+		if ( $( e.target ).filter( 'a, a *, .no-link, .no-link *, button, button *' ).length ) {
 			return true;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When you view the edit orders page you can click anywhere on a row to load the edit order page, if you happen to have a custom column with a button this will also load the edit order page instead of performing the button action. You can add .no-link to the button class to bypass this, but a better solution would be to also filter out buttons from the onRowClick event.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21955

### How to test the changes in this Pull Request:

1. Add a button anywhere on the orders list view page in wp-admin
2. Check that when clicking the button it does not load the edit order page for the specific row, it should perform the button action.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Filter out buttons from the onRowClick event on the Orders list view page.
