### PR TITLE
Add woocommerce_valid_location_types filter

### DIFF
--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -334,7 +334,7 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 	 * @return boolean
 	 */
 	public function is_valid_location_type( $type ) {
-		return in_array( $type, array( 'postcode', 'state', 'country', 'continent' ), true );
+		return in_array( $type, apply_filters( 'woocommerce_valid_location_types', array( 'postcode', 'state', 'country', 'continent' ) ), true );
 	}
 
 	/**

--- a/tests/unit-tests/shipping-zones/shipping-zone.php
+++ b/tests/unit-tests/shipping-zones/shipping-zone.php
@@ -151,22 +151,35 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zone::add_location
 	 */
 	public function test_add_location() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
-		// Assert
+		// Assert.
 		$this->assertTrue( $zone->is_valid_location_type( 'state' ) );
 		$this->assertTrue( $zone->is_valid_location_type( 'country' ) );
 		$this->assertTrue( $zone->is_valid_location_type( 'continent' ) );
 		$this->assertTrue( $zone->is_valid_location_type( 'postcode' ) );
 		$this->assertFalse( $zone->is_valid_location_type( 'poop' ) );
+		add_filter( 'woocommerce_valid_location_types', array( $this, 'add_valid_zone_location' ) );
+		$this->assertTrue( $zone->is_valid_location_type( 'poop' ) );
+		remove_filter( 'woocommerce_valid_location_types', array( $this, 'add_valid_zone_location' ), 10 );
+	}
+
+	/**
+	 * Add a custom zone location.
+	 *
+	 * @param array $locations Valid zone locations.
+	 * @return array New list of valid zone locations.
+	 */
+	public function add_valid_zone_location( $locations ) {
+		return array_merge( $locations, array( 'poop' ) );
 	}
 
 	/**
 	 * Test: WC_Shipping_Zone::clear_locations
 	 */
 	public function test_clear_locations() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->clear_locations();
 
@@ -257,8 +270,13 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		$zone->set_zone_order( 1 );
 		$zone->add_location( 'GB', 'country' );
 		$zone->add_location( 'CB*', 'postcode' );
+		// Test invalid zone location.
+		$zone->add_location( '1234', 'custom_type' );
 		$zone->save();
 		$zone_id = $zone->get_id();
+
+		// Count zone locations, there should only be 2 as one is invalid.
+		$this->assertSame( 2, count( $zone->get_zone_locations() ) );
 
 		$zone_read = new WC_Shipping_Zone();
 		$zone_read->read( $zone_id );

--- a/tests/unit-tests/shipping-zones/shipping-zone.php
+++ b/tests/unit-tests/shipping-zones/shipping-zone.php
@@ -1,11 +1,18 @@
 <?php
+/**
+ * Tests for the WC_Shopping_Zones class.
+ *
+ * @package WooCommerce\Tests\Shipping_Zone
+ */
 
 /**
  * Class Shipping_Zone.
- * @package WooCommerce\Tests\Shipping_Zone
  */
 class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 
+	/**
+	 * Set up tests.
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -16,11 +23,11 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zone::get_data
 	 */
 	public function test_get_data() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$data = $zone->get_data();
 
-		// Assert
+		// Assert.
 		$this->assertTrue( is_array( $data ) );
 	}
 
@@ -28,10 +35,10 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zones::get_id
 	 */
 	public function test_get_zone_id() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
-		// Assert
+		// Assert.
 		$this->assertEquals( $zone->get_id(), 1 );
 	}
 
@@ -39,10 +46,10 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zones::get_zone_name
 	 */
 	public function test_get_zone_name() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
-		// Assert
+		// Assert.
 		$this->assertEquals( $zone->get_zone_name(), 'Local' );
 	}
 
@@ -50,10 +57,10 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zones::get_zone_order
 	 */
 	public function test_get_zone_order() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
-		// Assert
+		// Assert.
 		$this->assertEquals( $zone->get_zone_order(), 1 );
 	}
 
@@ -61,10 +68,10 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zones::get_zone_locations
 	 */
 	public function test_get_zone_locations() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
-		// Assert
+		// Assert.
 		$this->assertTrue( is_array( $zone->get_zone_locations() ) );
 		$this->assertTrue( 2 === count( $zone->get_zone_locations() ) );
 	}
@@ -73,28 +80,28 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zones::get_formatted_location
 	 */
 	public function test_get_formatted_location() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
-		// Assert
+		// Assert.
 		$this->assertEquals( $zone->get_formatted_location(), 'United Kingdom (UK), CB*' );
 
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 2 );
 
-		// Assert
+		// Assert.
 		$this->assertEquals( $zone->get_formatted_location(), 'Europe' );
 
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 3 );
 
-		// Assert
+		// Assert.
 		$this->assertEquals( $zone->get_formatted_location(), 'California' );
 
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 4 );
 
-		// Assert
+		// Assert.
 		$this->assertEquals( $zone->get_formatted_location(), 'United States (US)' );
 	}
 
@@ -102,12 +109,12 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zone::get_shipping_methods
 	 */
 	public function test_get_shipping_methods() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->add_shipping_method( 'flat_rate' );
 		$methods = $zone->get_shipping_methods();
 
-		// Assert
+		// Assert.
 		$this->assertTrue( 1 === count( $methods ) );
 		$this->assertInstanceOf( 'WC_Shipping_Method', current( $methods ) );
 	}
@@ -116,11 +123,11 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zone::set_zone_name
 	 */
 	public function test_set_zone_name() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->set_zone_name( 'I am a fish' );
 
-		// Assert
+		// Assert.
 		$this->assertEquals( $zone->get_zone_name(), 'I am a fish' );
 	}
 
@@ -128,11 +135,11 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zone::set_zone_order
 	 */
 	public function test_set_zone_order() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->set_zone_order( 100 );
 
-		// Assert
+		// Assert.
 		$this->assertEquals( $zone->get_zone_order(), 100 );
 	}
 
@@ -140,10 +147,10 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zone::is_valid_location_type
 	 */
 	public function test_is_valid_location_type() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
-		// Assert
+		// Assert.
 		$this->assertEquals( $zone->get_zone_order(), 1 );
 	}
 
@@ -183,7 +190,7 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->clear_locations();
 
-		// Assert
+		// Assert.
 		$zone_locations = $zone->get_zone_locations();
 		$this->assertTrue( empty( $zone_locations ) );
 	}
@@ -192,7 +199,7 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zone::set_locations
 	 */
 	public function test_set_locations() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->clear_locations();
 		$zone->set_locations(
@@ -208,9 +215,10 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 			)
 		);
 
-		// Assert
+		// Assert.
 		$this->assertEquals(
-			$zone->get_zone_locations(), array(
+			$zone->get_zone_locations(),
+			array(
 				0 => (object) array(
 					'code' => 'US',
 					'type' => 'country',
@@ -227,13 +235,13 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zone::save
 	 */
 	public function test_save() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->set_zone_name( 'I am a fish' );
 		$zone->save();
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
-		// Assert
+		// Assert.
 		$this->assertEquals( $zone->get_zone_name(), 'I am a fish' );
 	}
 
@@ -241,15 +249,15 @@ class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zone::add_shipping_method
 	 */
 	public function test_add_shipping_method() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 		$zone->add_shipping_method( 'flat_rate' );
 		$zone->add_shipping_method( 'free_shipping' );
 
-		// Assert
+		// Assert.
 		$methods = $zone->get_shipping_methods();
 
-		// Assert
+		// Assert.
 		$this->assertTrue( 2 === count( $methods ) );
 		$this->assertInstanceOf( 'WC_Shipping_Method', current( $methods ) );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR introduces a new woocommerce_valid_location_types filter which can be used to specify valid location types for shipping, defaults to postcode, state, country and continent.

Closes #21964 

### How to test the changes in this Pull Request:

1. Add a custom shipping zone type using the new filter woocommerce_valid_location_types
2. Call WC_Shipping_Zone::is_valid_location_type with the added type and make sure it returns true.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Introduce woocommerce_valid_location_types filter for shipping zones.
