### PR TITLE
Update Lodash indexBy use with keyBy

### DIFF
--- a/assets/js/admin/settings-views-html-settings-tax.js
+++ b/assets/js/admin/settings-views-html-settings-tax.js
@@ -24,7 +24,7 @@
 			WCTaxTableModelConstructor = Backbone.Model.extend({
 				changes: {},
 				setRateAttribute: function( rateID, attribute, value ) {
-					var rates   = _.indexBy( this.get( 'rates' ), 'tax_rate_id' ),
+					var rates   = _.keyBy( this.get( 'rates' ), 'tax_rate_id' ),
 						changes = {};
 
 					if ( rates[ rateID ][ attribute ] !== value ) {
@@ -207,7 +207,7 @@
 				onAddNewRow: function( event ) {
 					var view    = event.data.view,
 						model   = view.model,
-						rates   = _.indexBy( model.get( 'rates' ), 'tax_rate_id' ),
+						rates   = _.keyBy( model.get( 'rates' ), 'tax_rate_id' ),
 						changes = {},
 						size    = _.size( rates ),
 						newRow  = _.extend( {}, data.default_rate, {
@@ -258,7 +258,7 @@
 				onDeleteRow: function( event ) {
 					var view    = event.data.view,
 						model   = view.model,
-						rates   = _.indexBy( model.get( 'rates' ), 'tax_rate_id' ),
+						rates   = _.keyBy( model.get( 'rates' ), 'tax_rate_id' ),
 						changes = {},
 						$current, current_id;
 

--- a/assets/js/admin/wc-shipping-classes.js
+++ b/assets/js/admin/wc-shipping-classes.js
@@ -83,7 +83,7 @@
 					$( this.el ).unblock();
 				},
 				render: function() {
-					var classes       = _.indexBy( this.model.get( 'classes' ), 'term_id' ),
+					var classes       = _.keyBy( this.model.get( 'classes' ), 'term_id' ),
 						view        = this;
 
 					this.$el.empty();
@@ -142,7 +142,7 @@
 
 					var view    = event.data.view,
 						model   = view.model,
-						classes   = _.indexBy( model.get( 'classes' ), 'term_id' ),
+						classes   = _.keyBy( model.get( 'classes' ), 'term_id' ),
 						changes = {},
 						size    = _.size( classes ),
 						newRow  = _.extend( {}, data.default_shipping_class, {
@@ -167,7 +167,7 @@
 				onDeleteRow: function( event ) {
 					var view    = event.data.view,
 						model   = view.model,
-						classes = _.indexBy( model.get( 'classes' ), 'term_id' ),
+						classes = _.keyBy( model.get( 'classes' ), 'term_id' ),
 						changes = {},
 						term_id = $( this ).closest('tr').data('id');
 
@@ -187,7 +187,7 @@
 						model   = view.model,
 						row     = $( this ).closest('tr'),
 						term_id = $( this ).closest('tr').data('id'),
-						classes = _.indexBy( model.get( 'classes' ), 'term_id' );
+						classes = _.keyBy( model.get( 'classes' ), 'term_id' );
 
 					event.preventDefault();
 					model.discardChanges( term_id );
@@ -221,7 +221,7 @@
 						term_id   = $target.closest( 'tr' ).data( 'id' ),
 						attribute = $target.data( 'attribute' ),
 						value     = $target.val(),
-						classes   = _.indexBy( model.get( 'classes' ), 'term_id' ),
+						classes   = _.keyBy( model.get( 'classes' ), 'term_id' ),
 						changes = {};
 
 					if ( ! classes[ term_id ] || classes[ term_id ][ attribute ] !== value ) {

--- a/assets/js/admin/wc-shipping-zone-methods.js
+++ b/assets/js/admin/wc-shipping-zone-methods.js
@@ -108,7 +108,7 @@
 					$( this.el ).unblock();
 				},
 				render: function() {
-					var methods     = _.indexBy( this.model.get( 'methods' ), 'instance_id' ),
+					var methods     = _.keyBy( this.model.get( 'methods' ), 'instance_id' ),
 						zone_name   = this.model.get( 'zone_name' ),
 						view        = this;
 
@@ -166,7 +166,7 @@
 				onDeleteRow: function( event ) {
 					var view    = event.data.view,
 						model   = view.model,
-						methods   = _.indexBy( model.get( 'methods' ), 'instance_id' ),
+						methods   = _.keyBy( model.get( 'methods' ), 'instance_id' ),
 						changes = {},
 						instance_id = $( this ).closest('tr').data('id');
 
@@ -183,7 +183,7 @@
 					var view        = event.data.view,
 						$target     = $( event.target ),
 						model       = view.model,
-						methods     = _.indexBy( model.get( 'methods' ), 'instance_id' ),
+						methods     = _.keyBy( model.get( 'methods' ), 'instance_id' ),
 						instance_id = $target.closest( 'tr' ).data( 'id' ),
 						enabled     = $target.closest( 'tr' ).data( 'enabled' ) === 'yes' ? 'no' : 'yes',
 						changes     = {};
@@ -217,7 +217,7 @@
 						instance_id   = $target.closest( 'tr' ).data( 'id' ),
 						attribute = $target.data( 'attribute' ),
 						value     = $target.val(),
-						methods   = _.indexBy( model.get( 'methods' ), 'instance_id' ),
+						methods   = _.keyBy( model.get( 'methods' ), 'instance_id' ),
 						changes = {};
 
 					if ( methods[ instance_id ][ attribute ] !== value ) {
@@ -231,7 +231,7 @@
 				updateModelOnSort: function( event ) {
 					var view         = event.data.view,
 						model        = view.model,
-						methods        = _.indexBy( model.get( 'methods' ), 'instance_id' ),
+						methods        = _.keyBy( model.get( 'methods' ), 'instance_id' ),
 						changes      = {};
 
 					_.each( methods, function( method ) {
@@ -252,7 +252,7 @@
 				onConfigureShippingMethod: function( event ) {
 					var instance_id = $( this ).closest( 'tr' ).data( 'id' ),
 						model       = event.data.view.model,
-						methods     = _.indexBy( model.get( 'methods' ), 'instance_id' ),
+						methods     = _.keyBy( model.get( 'methods' ), 'instance_id' ),
 						method      = methods[ instance_id ];
 
 					// Only load modal if supported

--- a/assets/js/admin/wc-shipping-zones.js
+++ b/assets/js/admin/wc-shipping-zones.js
@@ -23,7 +23,7 @@
 				discardChanges: function( id ) {
 					var changes      = this.changes || {},
 						set_position = null,
-						zones        = _.indexBy( this.get( 'zones' ), 'zone_id' );
+						zones        = _.keyBy( this.get( 'zones' ), 'zone_id' );
 
 					// Find current set position if it has moved since last save
 					if ( changes[ id ] && changes[ id ].zone_order !== undefined ) {
@@ -94,7 +94,7 @@
 					$( this.el ).unblock();
 				},
 				render: function() {
-					var zones = _.indexBy( this.model.get( 'zones' ), 'zone_id' ),
+					var zones = _.keyBy( this.model.get( 'zones' ), 'zone_id' ),
 						view  = this;
 
 					view.$el.empty();
@@ -170,7 +170,7 @@
 				onDeleteRow: function( event ) {
 					var view    = event.data.view,
 						model   = view.model,
-						zones   = _.indexBy( model.get( 'zones' ), 'zone_id' ),
+						zones   = _.keyBy( model.get( 'zones' ), 'zone_id' ),
 						changes = {},
 						row     = $( this ).closest('tr'),
 						zone_id = row.data('id');
@@ -209,7 +209,7 @@
 						zone_id   = $target.closest( 'tr' ).data( 'id' ),
 						attribute = $target.data( 'attribute' ),
 						value     = $target.val(),
-						zones   = _.indexBy( model.get( 'zones' ), 'zone_id' ),
+						zones   = _.keyBy( model.get( 'zones' ), 'zone_id' ),
 						changes = {};
 
 					if ( ! zones[ zone_id ] || zones[ zone_id ][ attribute ] !== value ) {
@@ -222,7 +222,7 @@
 				updateModelOnSort: function( event ) {
 					var view    = event.data.view,
 						model   = view.model,
-						zones   = _.indexBy( model.get( 'zones' ), 'zone_id' ),
+						zones   = _.keyBy( model.get( 'zones' ), 'zone_id' ),
 						rows    = $( 'tbody.wc-shipping-zone-rows tr' ),
 						changes = {};
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR replaces the use of all _.indexBy use with _.keyBy instead. Lodash has deprecated and replaced indexBy with keyBy since 4.0 https://github.com/lodash/lodash/wiki/Changelog#v400

Closes #21978 

### How to test the changes in this Pull Request:

1. Ensure that all JS functionality of the tax settings, shipping zones, shipping zone methods and shipping classes function as it should.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Lodash indexBy usage update with keyBy.
