### PR TITLE
Log file timestamp should be UTC

### DIFF
--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -129,7 +129,7 @@ class WC_Logger implements WC_Logger_Interface {
 		}
 
 		if ( $this->should_handle( $level ) ) {
-			$timestamp = current_time( 'timestamp' );
+			$timestamp = current_time( 'timestamp', 1 );
 			$message   = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context );
 
 			foreach ( $this->handlers as $handler ) {

--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -99,10 +99,14 @@ class WC_Logger implements WC_Logger_Interface {
 	 */
 	public function add( $handle, $message, $level = WC_Log_Levels::NOTICE ) {
 		$message = apply_filters( 'woocommerce_logger_add_message', $message, $handle );
-		$this->log( $level, $message, array(
-			'source'  => $handle,
-			'_legacy' => true,
-		) );
+		$this->log(
+			$level,
+			$message,
+			array(
+				'source'  => $handle,
+				'_legacy' => true,
+			)
+		);
 		wc_do_deprecated_action( 'woocommerce_log_add', array( $handle, $message ), '3.0', 'This action has been deprecated with no alternative.' );
 		return true;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In the log files we use date( 'c', $timestamp ) to format the date/time for display, this will output the datetime in UTC, however we pass a timestamp in the local site time. This PR fixes the issue by passing the timestamp with the GMT flag set to true to the timestamp is always UTC+0;

It is also standard practice add date/time in UTC format for logs, which I think the logger meant to do due to the use of the `c` format.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21422

### How to test the changes in this Pull Request:

1. Set your site time to an offset like UTC+2
2. Create a log file entry and check that the time displayed next to the entry is the UTC time and not the local site time.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Log file date/time should be in UTC and not site timezone as per the +00:00:00 string appended to it.
