### PR TITLE
Remove Postal Code for Angola

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -752,6 +752,12 @@ class WC_Countries {
 							'required' => false,
 						),
 					),
+					'AO' => array(
+						'postcode' => array(
+							'required' => false,
+							'hidden'   => true,
+						),
+					),
 					'AT' => array(
 						'postcode' => array(
 							'priority' => 65,


### PR DESCRIPTION
Angola still doesn't have a postcode system in place.
References:
https://pt.wikipedia.org/wiki/C%C3%B3digo_postal#_Angola
https://en.wikipedia.org/wiki/List_of_postal_codes

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removing the Postal Code for Angolan addresses, because they still don't have them in place, although they're working on it.

Closes #21983

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Remove postal code for Angola
