### PR TITLE
Fix locale for São Tomé and Príncipe

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1175,6 +1175,15 @@ class WC_Countries {
 							'required' => false,
 						),
 					),
+					'ST' => array(
+						'postcode' => array(
+							'required' => false,
+							'hidden'   => true,
+						),
+						'state'    => array(
+							'label' => __( 'District', 'woocommerce' ),
+						),
+					),
 					'VN' => array(
 						'state'     => array(
 							'required' => false,


### PR DESCRIPTION
Remove Postal Code for São Tomé and Príncipe, because they still don't have it in place. Also the stat field should have "District" as label.

Reference:
https://pt.wikipedia.org/wiki/C%C3%B3digo_postal#_S%C3%A3o_Tom%C3%A9_e_Pr%C3%ADncipe

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removing the Postal Code for São Tomé and Príncipe addresses, because they still don't have them in place. Also, the "state" is known as "Distrito" (or "District" in English).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Remove Postal Code and fix District for São Tomé and Príncipe
