### PR TITLE
Fix Angolan "State" label to "Province"

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -757,6 +757,9 @@ class WC_Countries {
 							'required' => false,
 							'hidden'   => true,
 						),
+						'state' => array(
+							'label' => __( 'Province', 'woocommerce' ),
+						),
 					),
 					'AT' => array(
 						'postcode' => array(


### PR DESCRIPTION
In Angola "states" are called "Províncias" (or "Provinces" in English)

(Sorry that I didn't make this change on PR #21984)

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix Angolan "State" label to "Province"

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Fix Angolan "State" label to "Province"
