### PR TITLE
User Switching support

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -231,9 +231,15 @@ class WC_Session_Handler extends WC_Session {
 	 * Destroy all session data.
 	 */
 	public function destroy_session() {
-		wc_setcookie( $this->_cookie, '', time() - YEAR_IN_SECONDS, apply_filters( 'wc_session_use_secure_cookie', false ) );
-
 		$this->delete_session( $this->_customer_id );
+		$this->forget_session();
+	}
+
+	/**
+	 * Forget all session data without destroying it.
+	 */
+	public function forget_session() {
+		wc_setcookie( $this->_cookie, '', time() - YEAR_IN_SECONDS, apply_filters( 'wc_session_use_secure_cookie', false ) );
 
 		wc_empty_cart();
 

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -90,11 +90,6 @@ class WC_Session_Handler extends WC_Session {
 		add_action( 'shutdown', array( $this, 'save_data' ), 20 );
 		add_action( 'wp_logout', array( $this, 'destroy_session' ) );
 
-		// Support for the User Switching plugin.
-		add_action( 'switch_to_user', array( $this, 'forget_session' ) );
-		add_action( 'switch_back_user', array( $this, 'forget_session' ) );
-		add_action( 'switch_off_user', array( $this, 'forget_session' ) );
-
 		if ( ! is_user_logged_in() ) {
 			add_filter( 'nonce_user_logged_out', array( $this, 'nonce_user_logged_out' ) );
 		}

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -90,6 +90,11 @@ class WC_Session_Handler extends WC_Session {
 		add_action( 'shutdown', array( $this, 'save_data' ), 20 );
 		add_action( 'wp_logout', array( $this, 'destroy_session' ) );
 
+		// Support for the User Switching plugin.
+		add_action( 'switch_to_user', array( $this, 'forget_session' ) );
+		add_action( 'switch_back_user', array( $this, 'forget_session' ) );
+		add_action( 'switch_off_user', array( $this, 'forget_session' ) );
+
 		if ( ! is_user_logged_in() ) {
 			add_filter( 'nonce_user_logged_out', array( $this, 'nonce_user_logged_out' ) );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This addresses #21989 by:

* Introducing a method for forgetting a session without also destroying it.
* Adding support for forgetting a user's session (and cart contents) when switching between users with the User Switching plugin.

Closes #21989.

### How to test the changes in this Pull Request:

1.  Log in as a store owner
2. Add some items to your cart
3. Use the User Switching plugin to switch to a customer account
4. Verify that your cart contents are those of the customer you switched to, and not those of your store owner account
5. Switch back to your store owner account
6. Verify that your cart contents are reverted to those of your store owner account

### Changelog entry

> Add support for forgetting the cart contents and user session when switching between accounts using the User Switching plugin.
