### PR TITLE
When only selling to one country set customer location to that country

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1079,7 +1079,8 @@ function wc_get_customer_default_location() {
 			$location = wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', get_option( 'woocommerce_default_country' ) ) );
 			break;
 		default:
-			$location = wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', '' ) );
+			$countries = WC()->countries->get_allowed_countries();
+			$location = wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', 1 === count( $countries ) ? key( $countries ) : '' ) );
 			break;
 	}
 

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1081,7 +1081,7 @@ function wc_get_customer_default_location() {
 			break;
 		default:
 			$countries = WC()->countries->get_allowed_countries();
-			$location = wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', 1 === count( $countries ) ? key( $countries ) : '' ) );
+			$location  = wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', 1 === count( $countries ) ? key( $countries ) : '' ) );
 			break;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21790 .

Previously when only selling in one country with customer base location set to 'none', the `$( '#billing_country' ).trigger( 'change' );` fired when the page first loaded would have a (likely unintended) side-effect of setting the user's location to the singular available selling country.

Removing the JS change trigger for #20640 revealed a previously hidden design flaw: when there is only one selling country and the user location is default 'none', the user cannot select a country (because there is no country dropdown) and since their default location is 'none' no state dropdown is shown for the singular selling country.

This PR addresses this flaw. If there is only one country available for selling and user default location is 'none', the singular selling country will be set as the user's country.

### How to test the changes in this Pull Request:

1. Set up a store with the following settings: Default customer location 'none' and sell to specific countries with only USA as the country.
2. Before applying this patch: Open incognito window. Add item to cart. Go to checkout. Observe State address is a text box because the user's country is `''`:
<img width="228" alt="screen shot 2018-11-20 at 12 21 41 pm" src="https://user-images.githubusercontent.com/7317227/48800667-4e37f980-ecbf-11e8-8a1f-a2e979309ea4.png">

3. Apply this patch. Open a new incognito window. Add item to cart. Go to checkout. Observe State address is a dropdown because the user's country is USA:
<img width="226" alt="screen shot 2018-11-20 at 12 22 16 pm" src="https://user-images.githubusercontent.com/7317227/48800674-5001bd00-ecbf-11e8-8d5d-df319bc24a6f.png">

4. Test the state dropdown with other checkout settings to make sure no new bugs were introduced.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Set customer's country to selling country when only selling to one country and default customer location is 'none'.