### PR TITLE
Fix arialabelledby attribute for quantity selectors

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1580,14 +1580,15 @@ if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 		}
 
 		$defaults = array(
-			'input_id'    => uniqid( 'quantity_' ),
-			'input_name'  => 'quantity',
-			'input_value' => '1',
-			'max_value'   => apply_filters( 'woocommerce_quantity_input_max', -1, $product ),
-			'min_value'   => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
-			'step'        => apply_filters( 'woocommerce_quantity_input_step', 1, $product ),
-			'pattern'     => apply_filters( 'woocommerce_quantity_input_pattern', has_filter( 'woocommerce_stock_amount', 'intval' ) ? '[0-9]*' : '' ),
-			'inputmode'   => apply_filters( 'woocommerce_quantity_input_inputmode', has_filter( 'woocommerce_stock_amount', 'intval' ) ? 'numeric' : '' ),
+			'input_id'     => uniqid( 'quantity_' ),
+			'input_name'   => 'quantity',
+			'input_value'  => '1',
+			'max_value'    => apply_filters( 'woocommerce_quantity_input_max', -1, $product ),
+			'min_value'    => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
+			'step'         => apply_filters( 'woocommerce_quantity_input_step', 1, $product ),
+			'pattern'      => apply_filters( 'woocommerce_quantity_input_pattern', has_filter( 'woocommerce_stock_amount', 'intval' ) ? '[0-9]*' : '' ),
+			'inputmode'    => apply_filters( 'woocommerce_quantity_input_inputmode', has_filter( 'woocommerce_stock_amount', 'intval' ) ? 'numeric' : '' ),
+			'product_name' => $product->get_title(),
 		);
 
 		$args = apply_filters( 'woocommerce_quantity_input_args', wp_parse_args( $args, $defaults ), $product );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
We have code to add a arialabelledby attribute to quantity selectors but we never passed the product_name in the arguments which the template relied on. This PR adds product_name to the passed arguments.
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21990

### How to test the changes in this Pull Request:

1. View a product page and inspect the quantity selector, ensure arialabelledby attribute is populated with the product name followed by the word quantity.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Aria-Labelledby attribute for quantity selectors.