### PR TITLE
Fix missing lost password notices

### DIFF
--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -300,4 +300,5 @@ add_action( 'woocommerce_before_cart', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_checkout_form', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_account_content', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_customer_login_form', 'woocommerce_output_all_notices', 10 );
+add_action( 'woocommerce_before_lost_password_form', 'woocommerce_output_all_notices', 10 );
 add_action( 'before_woocommerce_pay', 'woocommerce_output_all_notices', 10 );

--- a/templates/myaccount/form-lost-password.php
+++ b/templates/myaccount/form-lost-password.php
@@ -12,11 +12,12 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.4.0
+ * @version 3.5.2
  */
 
 defined( 'ABSPATH' ) || exit;
 
+do_action( 'woocommerce_before_lost_password_form' );
 ?>
 
 <form method="post" class="woocommerce-ResetPassword lost_reset_password">
@@ -40,3 +41,5 @@ defined( 'ABSPATH' ) || exit;
 	<?php wp_nonce_field( 'lost_password', 'woocommerce-lost-password-nonce' ); ?>
 
 </form>
+<?php
+do_action( 'woocommerce_after_lost_password_form' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR fixes the issue with notices not displaying on the lost password form, it also introduces two new hooks for use in the form-lost-password.php template as to avoid the need to override the template for adding and removing to it.

Closes #21792 

### How to test the changes in this Pull Request:

1. Use the Twentyseventeen theme
2. Go to the lost password page and enter a username or email that does not exist on your store
3. Check that an error message is displayed when submitting the non-existant username or email.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Missing notices on lost password page.
