### PR TITLE
PHPCompatibility and WPCS sniff changes

### DIFF
--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -96,7 +96,7 @@ class WC_Product_CSV_Importer_Controller {
 		}
 
 		$valid_filetypes = self::get_valid_csv_filetypes();
-		$filetype = wp_check_filetype( $file, $valid_filetypes );
+		$filetype        = wp_check_filetype( $file, $valid_filetypes );
 		if ( in_array( $filetype['type'], $valid_filetypes, true ) ) {
 			return true;
 		}
@@ -111,7 +111,8 @@ class WC_Product_CSV_Importer_Controller {
 	 */
 	protected static function get_valid_csv_filetypes() {
 		return apply_filters(
-			'woocommerce_csv_product_import_valid_filetypes', array(
+			'woocommerce_csv_product_import_valid_filetypes',
+			array(
 				'csv' => 'text/csv',
 				'txt' => 'text/plain',
 			)
@@ -424,7 +425,9 @@ class WC_Product_CSV_Importer_Controller {
 		// phpcs:enable
 
 		wp_localize_script(
-			'wc-product-import', 'wc_product_import_params', array(
+			'wc-product-import',
+			'wc_product_import_params',
+			array(
 				'import_nonce'    => wp_create_nonce( 'wc-product-import' ),
 				'mapping'         => array(
 					'from' => $mapping_from,
@@ -491,7 +494,8 @@ class WC_Product_CSV_Importer_Controller {
 		 */
 		$default_columns = $this->normalize_columns_names(
 			apply_filters(
-				'woocommerce_csv_product_import_mapping_default_columns', array(
+				'woocommerce_csv_product_import_mapping_default_columns',
+				array(
 					__( 'ID', 'woocommerce' )             => 'id',
 					__( 'Type', 'woocommerce' )           => 'type',
 					__( 'SKU', 'woocommerce' )            => 'sku',

--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -148,7 +148,7 @@ class WC_Product_CSV_Importer_Controller {
 
 		$this->steps = apply_filters( 'woocommerce_product_csv_importer_steps', $default_steps );
 
-		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
 		$this->step            = isset( $_REQUEST['step'] ) ? sanitize_key( $_REQUEST['step'] ) : current( array_keys( $this->steps ) );
 		$this->file            = isset( $_REQUEST['file'] ) ? wc_clean( wp_unslash( $_REQUEST['file'] ) ) : '';
 		$this->update_existing = isset( $_REQUEST['update_existing'] ) ? (bool) $_REQUEST['update_existing'] : false;
@@ -259,7 +259,7 @@ class WC_Product_CSV_Importer_Controller {
 	 * Dispatch current step and show correct view.
 	 */
 	public function dispatch() {
-		// phpcs:ignore WordPress.CSRF.NonceVerification.NoNonceVerification
+		// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 		if ( ! empty( $_POST['save_step'] ) && ! empty( $this->steps[ $this->step ]['handler'] ) ) {
 			call_user_func( $this->steps[ $this->step ]['handler'], $this );
 		}
@@ -307,7 +307,7 @@ class WC_Product_CSV_Importer_Controller {
 	 * @return string|WP_Error
 	 */
 	public function handle_upload() {
-		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification -- Nonce already verified in WC_Product_CSV_Importer_Controller::upload_form_handler()
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification -- Nonce already verified in WC_Product_CSV_Importer_Controller::upload_form_handler()
 		$file_url = isset( $_POST['file_url'] ) ? wc_clean( wp_unslash( $_POST['file_url'] ) ) : '';
 
 		if ( empty( $file_url ) ) {
@@ -411,7 +411,7 @@ class WC_Product_CSV_Importer_Controller {
 			return;
 		}
 
-		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification -- Nonce already verified in WC_Admin_Importers::do_ajax_product_import()
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification -- Nonce already verified in WC_Admin_Importers::do_ajax_product_import()
 		if ( ! empty( $_POST['map_from'] ) && ! empty( $_POST['map_to'] ) ) {
 			$mapping_from = wc_clean( wp_unslash( $_POST['map_from'] ) );
 			$mapping_to   = wc_clean( wp_unslash( $_POST['map_to'] ) );
@@ -447,7 +447,7 @@ class WC_Product_CSV_Importer_Controller {
 	 * Done step.
 	 */
 	protected function done() {
-		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
 		$imported = isset( $_GET['products-imported'] ) ? absint( $_GET['products-imported'] ) : 0;
 		$updated  = isset( $_GET['products-updated'] ) ? absint( $_GET['products-updated'] ) : 0;
 		$failed   = isset( $_GET['products-failed'] ) ? absint( $_GET['products-failed'] ) : 0;

--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -200,7 +200,7 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 	 * @return bool False if error uploading or invalid file, true otherwise
 	 */
 	public function handle_upload() {
-		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification -- Nonce already verified in WC_Tax_Rate_Importer::dispatch()
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification -- Nonce already verified in WC_Tax_Rate_Importer::dispatch()
 		$file_url = isset( $_POST['file_url'] ) ? wc_clean( wp_unslash( $_POST['file_url'] ) ) : '';
 
 		if ( empty( $file_url ) ) {

--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -101,7 +101,7 @@ class WC_Tax_Rate_Importer extends WP_Importer {
 	 */
 	private function import_start() {
 		if ( function_exists( 'gc_enable' ) ) {
-			gc_enable(); // phpcs:ignore PHPCompatibility.PHP.NewFunctions.gc_enableFound
+			gc_enable(); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.gc_enableFound
 		}
 		wc_set_time_limit( 0 );
 		@ob_flush();

--- a/includes/class-wc-geolite-integration.php
+++ b/includes/class-wc-geolite-integration.php
@@ -55,7 +55,7 @@ class WC_Geolite_Integration {
 		$iso_code = '';
 
 		try {
-			$reader = new MaxMind\Db\Reader( $this->database ); // phpcs:ignore PHPCompatibility.PHP.NewLanguageConstructs.t_ns_separatorFound
+			$reader = new MaxMind\Db\Reader( $this->database ); // phpcs:ignore PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
 			$data   = $reader->get( $ip_address );
 
 			if ( isset( $data['country']['iso_code'] ) ) {

--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -265,7 +265,7 @@ class WC_Geolocation {
 				$dest_path = trailingslashit( $upload_dir['basedir'] ) . $database;
 
 				// Extract files with PharData. Tool built into PHP since 5.3.
-				$file      = new PharData( $tmp_database_path ); // phpcs:ignore PHPCompatibility.PHP.NewClasses.phardataFound
+				$file      = new PharData( $tmp_database_path ); // phpcs:ignore PHPCompatibility.Classes.NewClasses.phardataFound
 				$file_path = trailingslashit( $file->current()->getFileName() ) . $database;
 
 				// Extract under uploads directory.

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -85,7 +85,7 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	 */
 	public function apply_changes() {
 		if ( function_exists( 'array_replace' ) ) {
-			$this->data = array_replace( $this->data, $this->changes ); // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replaceFound
+			$this->data = array_replace( $this->data, $this->changes ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.array_replaceFound
 		} else { // PHP 5.2 compatibility.
 			foreach ( $this->changes as $key => $change ) {
 				$this->data[ $key ] = $change;

--- a/includes/export/abstract-wc-csv-exporter.php
+++ b/includes/export/abstract-wc-csv-exporter.php
@@ -171,7 +171,7 @@ abstract class WC_CSV_Exporter {
 	 */
 	public function send_headers() {
 		if ( function_exists( 'gc_enable' ) ) {
-			gc_enable(); // phpcs:ignore PHPCompatibility.PHP.NewFunctions.gc_enableFound
+			gc_enable(); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.gc_enableFound
 		}
 		if ( function_exists( 'apache_setenv' ) ) {
 			@apache_setenv( 'no-gzip', 1 ); // @codingStandardsIgnoreLine

--- a/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -205,7 +205,7 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 
 		$accounts = array();
 
-		// phpcs:disable WordPress.CSRF.NonceVerification.NoNonceVerification -- Nonce verification already handled in WC_Admin_Settings::save()
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification -- Nonce verification already handled in WC_Admin_Settings::save()
 		if ( isset( $_POST['bacs_account_name'] ) && isset( $_POST['bacs_account_number'] ) && isset( $_POST['bacs_bank_name'] )
 			 && isset( $_POST['bacs_sort_code'] ) && isset( $_POST['bacs_iban'] ) && isset( $_POST['bacs_bic'] ) ) {
 

--- a/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -306,7 +306,8 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 
 				// BACS account fields shown on the thanks page and in emails.
 				$account_fields = apply_filters(
-					'woocommerce_bacs_account_fields', array(
+					'woocommerce_bacs_account_fields',
+					array(
 						'bank_name'      => array(
 							'label' => __( 'Bank', 'woocommerce' ),
 							'value' => $bacs_account->bank_name,
@@ -327,7 +328,8 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 							'label' => __( 'BIC', 'woocommerce' ),
 							'value' => $bacs_account->bic,
 						),
-					), $order_id
+					),
+					$order_id
 				);
 
 				foreach ( $account_fields as $field_key => $field ) {
@@ -386,7 +388,8 @@ class WC_Gateway_BACS extends WC_Payment_Gateway {
 
 			// Locale information to be used - only those that are not 'Sort Code'.
 			$this->locale = apply_filters(
-				'woocommerce_get_bacs_locale', array(
+				'woocommerce_get_bacs_locale',
+				array(
 					'AU' => array(
 						'sortcode' => array(
 							'label' => __( 'BSB', 'woocommerce' ),

--- a/includes/log-handlers/class-wc-log-handler-db.php
+++ b/includes/log-handlers/class-wc-log-handler-db.php
@@ -166,7 +166,7 @@ class WC_Log_Handler_DB extends WC_Log_Handler {
 		 * @see http://php.net/manual/en/function.debug-backtrace.php#refsect1-function.debug-backtrace-parameters
 		 */
 		if ( defined( 'DEBUG_BACKTRACE_IGNORE_ARGS' ) ) {
-			$debug_backtrace_arg = DEBUG_BACKTRACE_IGNORE_ARGS; // phpcs:ignore PHPCompatibility.PHP.NewConstants.debug_backtrace_ignore_argsFound
+			$debug_backtrace_arg = DEBUG_BACKTRACE_IGNORE_ARGS; // phpcs:ignore PHPCompatibility.Constants.NewConstants.debug_backtrace_ignore_argsFound
 		} else {
 			$debug_backtrace_arg = false;
 		}

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1477,7 +1477,7 @@ function wc_get_shipping_method_count( $include_legacy = false ) {
  * @param int $limit Time limit.
  */
 function wc_set_time_limit( $limit = 0 ) {
-	if ( function_exists( 'set_time_limit' ) && false === strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) && ! ini_get( 'safe_mode' ) ) { // phpcs:ignore PHPCompatibility.PHP.DeprecatedIniDirectives.safe_modeDeprecatedRemoved
+	if ( function_exists( 'set_time_limit' ) && false === strpos( ini_get( 'disable_functions' ), 'set_time_limit' ) && ! ini_get( 'safe_mode' ) ) { // phpcs:ignore PHPCompatibility.IniDirectives.RemovedIniDirectives.safe_modeDeprecatedRemoved
 		@set_time_limit( $limit ); // @codingStandardsIgnoreLine
 	}
 }
@@ -2115,7 +2115,7 @@ function wc_decimal_to_fraction( $decimal ) {
  */
 function wc_round_discount( $value, $precision ) {
 	if ( version_compare( PHP_VERSION, '5.3.0', '>=' ) ) {
-		return round( $value, $precision, WC_DISCOUNT_ROUNDING_MODE ); // phpcs:ignore PHPCompatibility.PHP.NewFunctionParameters.round_modeFound
+		return round( $value, $precision, WC_DISCOUNT_ROUNDING_MODE ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
 	}
 
 	if ( 2 === WC_DISCOUNT_ROUNDING_MODE ) {

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -473,7 +473,8 @@ function get_woocommerce_currency_symbol( $currency = '' ) {
 	}
 
 	$symbols         = apply_filters(
-		'woocommerce_currency_symbols', array(
+		'woocommerce_currency_symbols',
+		array(
 			'AED' => '&#x62f;.&#x625;',
 			'AFN' => '&#x60b;',
 			'ALL' => 'L',
@@ -1314,7 +1315,8 @@ function wc_get_credit_card_type_label( $type ) {
 	$type = str_replace( '_', ' ', $type );
 
 	$labels = apply_filters(
-		'woocommerce_credit_card_type_labels', array(
+		'woocommerce_credit_card_type_labels',
+		array(
 			'mastercard'       => __( 'MasterCard', 'woocommerce' ),
 			'visa'             => __( 'Visa', 'woocommerce' ),
 			'discover'         => __( 'Discover', 'woocommerce' ),
@@ -1835,7 +1837,8 @@ function wc_list_pluck( $list, $callback_or_field, $index_key = null ) {
 function wc_get_permalink_structure() {
 	$saved_permalinks = (array) get_option( 'woocommerce_permalinks', array() );
 	$permalinks       = wp_parse_args(
-		array_filter( $saved_permalinks ), array(
+		array_filter( $saved_permalinks ),
+		array(
 			'product_base'           => _x( 'product', 'slug', 'woocommerce' ),
 			'category_base'          => _x( 'product-category', 'slug', 'woocommerce' ),
 			'tag_base'               => _x( 'product-tag', 'slug', 'woocommerce' ),

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -228,7 +228,7 @@ function wc_round_tax_total( $value, $precision = null ) {
 	$precision = is_null( $precision ) ? wc_get_price_decimals() : intval( $precision );
 
 	if ( version_compare( PHP_VERSION, '5.3.0', '>=' ) ) {
-		$rounded_tax = round( $value, $precision, wc_get_tax_rounding_mode() ); // phpcs:ignore PHPCompatibility.PHP.NewFunctionParameters.round_modeFound
+		$rounded_tax = round( $value, $precision, wc_get_tax_rounding_mode() ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
 	} elseif ( 2 === wc_get_tax_rounding_mode() ) {
 		$rounded_tax = wc_legacy_round_half_down( $value, $precision );
 	} else {

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -412,7 +412,8 @@ function wc_sanitize_textarea( $var ) {
 function wc_sanitize_tooltip( $var ) {
 	return htmlspecialchars(
 		wp_kses(
-			html_entity_decode( $var ), array(
+			html_entity_decode( $var ),
+			array(
 				'br'     => array(),
 				'em'     => array(),
 				'strong' => array(),
@@ -541,8 +542,10 @@ function wc_get_price_decimals() {
  */
 function wc_price( $price, $args = array() ) {
 	$args = apply_filters(
-		'wc_price_args', wp_parse_args(
-			$args, array(
+		'wc_price_args',
+		wp_parse_args(
+			$args,
+			array(
 				'ex_tax_label'       => false,
 				'currency'           => '',
 				'decimal_separator'  => wc_get_price_decimal_separator(),
@@ -1032,7 +1035,8 @@ function wc_format_product_short_description( $content ) {
 
 		return wpautop(
 			$markdown->transform(
-				$content, array(
+				$content,
+				array(
 					'unslash' => false,
 				)
 			)
@@ -1380,10 +1384,13 @@ function wc_parse_relative_date_option( $raw_value ) {
 		'years'  => __( 'Year(s)', 'woocommerce' ),
 	);
 
-	$value = wp_parse_args( (array) $raw_value, array(
-		'number' => '',
-		'unit'   => 'days',
-	) );
+	$value = wp_parse_args(
+		(array) $raw_value,
+		array(
+			'number' => '',
+			'unit'   => 'days',
+		)
+	);
 
 	$value['number'] = ! empty( $value['number'] ) ? absint( $value['number'] ) : '';
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the names of a few sniffs that changed in the most recent versions of WPCS and PHPCompatibility. It is not an exhaustive list and it is likely that we have more sniffs names to update in WooCommerce codebase.

This PR also fixes PHPCS violations in the modified files using `phpcbf` (mostly new checks introduce in the new WPCS version).