### PR TITLE
Prepare WooCommerce for PHP 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,8 +35,6 @@ matrix:
   allow_failures:
   - php: 7.1
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
-  - php: 7.3
-    env: WP_VERSION=5.0-beta5 WP_MULTISITE=0
 
 before_script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,6 @@ php:
   - 5.6
   - 7.0
   - 7.1
-  - 7.3
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
@@ -31,9 +30,13 @@ matrix:
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1 RUN_E2E=1
   - php: 7.1
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
-  allow_failures:
-  - env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   - php: 7.3
+    env: WP_VERSION=5.0-beta5 WP_MULTISITE=0
+  allow_failures:
+  - php: 7.1
+    env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
+  - php: 7.3
+    env: WP_VERSION=5.0-beta5 WP_MULTISITE=0
 
 before_script:
   - |

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -129,7 +129,7 @@ class WC_Admin_Report {
 					$get_key = "order_items.{$key}";
 					break;
 				default:
-					continue;
+					break;
 			}
 
 			if ( $value['function'] ) {

--- a/includes/libraries/class-emogrifier.php
+++ b/includes/libraries/class-emogrifier.php
@@ -162,15 +162,15 @@ class Emogrifier
         // type and attribute exact value
         '/(\\w)\\[(\\w+)\\=[\'"]?([\\w\\s]+)[\'"]?\\]/' => '\\1[@\\2="\\3"]',
         // type and attribute value with ~ (one word within a whitespace-separated list of words)
-        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\~\\=[\\s]*[\'"]?([\\w-_\\/]+)[\'"]?\\]/'
+        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\~\\=[\\s]*[\'"]?([\\w\\-_\\/]+)[\'"]?\\]/'
         => '\\1[contains(concat(" ", @\\2, " "), concat(" ", "\\3", " "))]',
         // type and attribute value with | (either exact value match or prefix followed by a hyphen)
-        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\|\\=[\\s]*[\'"]?([\\w-_\\s\\/]+)[\'"]?\\]/'
+        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\|\\=[\\s]*[\'"]?([\\w\\-_\\s\\/]+)[\'"]?\\]/'
         => '\\1[@\\2="\\3" or starts-with(@\\2, concat("\\3", "-"))]',
         // type and attribute value with ^ (prefix match)
-        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\^\\=[\\s]*[\'"]?([\\w-_\\/]+)[\'"]?\\]/' => '\\1[starts-with(@\\2, "\\3")]',
+        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\^\\=[\\s]*[\'"]?([\\w\\-_\\/]+)[\'"]?\\]/' => '\\1[starts-with(@\\2, "\\3")]',
         // type and attribute value with * (substring match)
-        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\*\\=[\\s]*[\'"]?([\\w-_\\s\\/:;]+)[\'"]?\\]/' => '\\1[contains(@\\2, "\\3")]',
+        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\*\\=[\\s]*[\'"]?([\\w\\-_\\s\\/:;]+)[\'"]?\\]/' => '\\1[contains(@\\2, "\\3")]',
         // adjacent sibling
         '/\\s+\\+\\s+/' => '/following-sibling::*[1]/self::',
         // child
@@ -185,7 +185,7 @@ class Emogrifier
         // The following matcher will break things if it is placed before the adjacent matcher.
         // So one of the matchers matches either too much or not enough.
         // type and attribute value with $ (suffix match)
-        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\$\\=[\\s]*[\'"]?([\\w-_\\s\\/]+)[\'"]?\\]/'
+        '/([\\w\\*]+)\\[(\\w+)[\\s]*\\$\\=[\\s]*[\'"]?([\\w\\-_\\s\\/]+)[\'"]?\\]/'
         => '\\1[substring(@\\2, string-length(@\\2) - string-length("\\3") + 1) = "\\3"]',
     ];
 

--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -24,7 +24,7 @@ download() {
     fi
 }
 
-if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)?(^-) ]]; then
 	WP_TESTS_TAG="tags/$WP_VERSION"
 elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
 	WP_TESTS_TAG="trunk"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes a few adjustments to WooCommerce code to prepare it for PHP 7.3. To have an idea of the required changes, I checked [PHP 7.3 upgrade document](https://github.com/php/php-src/blob/PHP-7.3/UPGRADING) and [WordPress and PHP 7.3 post](https://make.wordpress.org/core/2018/10/15/wordpress-and-php-7-3/).

To find code that needed to be changed in WooCommerce, I used a combination of running PHPCS using only the PHPCompatibility standard, which has sniffs to detect some of the PHP 7.3 changes but not all of them ([here](https://github.com/PHPCompatibility/PHPCompatibility/issues?utf8=%E2%9C%93&q=is%3Aissue+PHP+7.3) is a list of what is already supported and what they still plan to support), and running our unit tests using PHP 7.3 and WP 5.0 beta5. There is a chance that there is still some code that we need to update if it is not covered by our unit tests and not catched by one of the PHPCompatibility PHP 7.3 sniffs.

Here is a list of the changes:

- Escape hyphens in Emogrifier regular expressions to make them compatible with PCRE2 and avoid a warning. For more information see d29ead0.
- Replace `continue` with `break` inside a `switch` statement to avoid a warning. For more information see a9e5320.
- Adjusted Travis PHP 7.3 build job to use WP 5.0-beta5 (commits 68abf96 and 8b85eee). This was necessary because when running the tests with the latest WP release, WC tests were flooded with PHP 7.3 warnings caused by WP code and that are already fixed in the WP upcoming release. My initial plan was to use WP nightly but that didn't work as nightly is still build from trunk and WP 5.0 development is being done on another branch. Once WP 5.0 is released, we can switch back to running the build job using the latest WP version.
- Removed Travis PHP 7.3 build job from the list of jobs that are allowed to fail.

Thanks to @desrosj and @jrfnl for their help.

### How to test the changes in this Pull Request:

1. Verify the Travis build
2. Review and test code changes in Emogrifier, admin report and `tests/bin/install.sh`

### Changelog entry

> Prepare WooCommerce for PHP 7.3