### PR TITLE
Allow manual stock adjustment on order items

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1444,6 +1444,16 @@
 				 }
 			 }
 
+			tbody tr {
+				&.selected {
+					background: #f5ebf3;
+					td {
+						border-color: #e6cce1;
+						opacity: 0.8;
+					}
+				}
+			}
+
 			 tbody tr:last-child td {
 				 border-bottom: 1px solid #dfdfdf;
 			 }

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -254,8 +254,22 @@ jQuery( function ( $ ) {
 
 				// Bulk edit
 				.on( 'click', 'tr.item', function() {
+					if ( $( this ).find( ':focus' ).length ) {
+						return;
+					}
+
 					$( this ).toggleClass( 'selected' );
+					if ( ! $( 'div.wc-order-item-bulk-edit' ).children().length ) {
+						return;
+					}
+
+					if ( $( 'tr.item.selected').length ) {
+						$( 'div.wc-order-item-bulk-edit' ).slideDown();
+					} else {
+						$( 'div.wc-order-item-bulk-edit' ).slideUp();
+					}
 				})
+
 				// Qty
 				.on( 'change', 'input.quantity', this.quantity_changed )
 
@@ -532,6 +546,7 @@ jQuery( function ( $ ) {
 			$( this ).hide();
 			$( 'button.add-line-item' ).click();
 			$( 'button.cancel-action' ).attr( 'data-reload', true );
+			$( 'div.wc-order-item-bulk-edit' ).slideUp();
 			return false;
 		},
 

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -269,6 +269,8 @@ jQuery( function ( $ ) {
 						$( 'div.wc-order-item-bulk-edit' ).slideUp();
 					}
 				})
+				.on( 'click', 'button.bulk-increase-stock', this.bulk_actions.do_increase_stock )
+				.on( 'click', 'button.bulk-decrease-stock', this.bulk_actions.do_reduce_stock )
 
 				// Qty
 				.on( 'change', 'input.quantity', this.quantity_changed )
@@ -918,6 +920,85 @@ jQuery( function ( $ ) {
 					$row.hide();
 				}
 				return false;
+			}
+		},
+
+		bulk_actions: {
+
+			modify_stock: function( e, action ) {
+				e.preventDefault();
+				wc_meta_boxes_order_items.block();
+
+				$( '#woocommerce-order-notes' ).block({
+					message: null,
+					overlayCSS: {
+						background: '#fff',
+						opacity: 0.6
+					}
+				});
+
+				var $table = $( 'table.woocommerce_order_items' );
+				var $rows = $table.find( 'tr.selected' );
+				var quantities = {};
+				var item_ids = $.map( $rows, function( $row ) {
+					return parseInt( $( $row ).data( 'order_item_id' ), 10 );
+				});
+
+				$rows.each(function() {
+					if ( $( this ).find( 'input.quantity' ).length ) {
+						quantities[ $( this ).attr( 'data-order_item_id' ) ] = $( this ).find( 'input.quantity' ).val();
+					}
+				});
+
+				var data = {
+					order_id:       woocommerce_admin_meta_boxes.post_id,
+					order_item_ids: item_ids,
+					order_item_qty: quantities,
+					action:         action,
+					security:       woocommerce_admin_meta_boxes.order_item_nonce
+				};
+
+				$.ajax({
+					url: woocommerce_admin_meta_boxes.ajax_url,
+					data: data,
+					type: 'POST',
+					success: function( response ) {
+						wc_meta_boxes_order_items.unblock();
+
+						if ( true === response.success ) {
+							$.map( response.data, function( item ) {
+
+								// No items were updated.
+								if ( ! item.success ) {
+									window.alert( item.note );
+									return;
+								}
+
+								var order_note_data = {
+									action:    'woocommerce_add_order_note',
+									post_id:   woocommerce_admin_meta_boxes.post_id,
+									note:      item.note,
+									note_type: '',
+									security:  woocommerce_admin_meta_boxes.add_order_note_nonce
+								};
+
+								$.post( woocommerce_admin_meta_boxes.ajax_url, order_note_data, function( response ) {
+									$( 'ul.order_notes' ).prepend( response );
+								});
+							});
+						}
+
+						$( '#woocommerce-order-notes' ).unblock();
+					}
+				});
+			},
+
+			do_increase_stock: function( e ) {
+				wc_meta_boxes_order_items.bulk_actions.modify_stock( e, 'woocommerce_increase_order_item_stock' );
+			},
+
+			do_reduce_stock: function( e ) {
+				wc_meta_boxes_order_items.bulk_actions.modify_stock( e, 'woocommerce_reduce_order_item_stock' );
 			}
 		},
 

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -252,6 +252,10 @@ jQuery( function ( $ ) {
 				.on( 'change keyup', '.wc-order-refund-items #refund_amount', this.refunds.amount_changed )
 				.on( 'change', 'input.refund_order_item_qty', this.refunds.refund_quantity_changed )
 
+				// Bulk edit
+				.on( 'click', 'tr.item', function() {
+					$( this ).toggleClass( 'selected' );
+				})
 				// Qty
 				.on( 'change', 'input.quantity', this.quantity_changed )
 

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -95,6 +95,12 @@ if ( wc_tax_enabled() ) {
 		</tbody>
 	</table>
 </div>
+<div class="wc-order-data-row wc-order-item-bulk-edit" style="display:none;">
+	<?php if ( $order->allow_manual_stock_adjustment() ) : ?>
+	<button type="button" class="button bulk-decrease-stock"><?php esc_html_e( 'Reduce stock', 'woocommerce' ); ?></button>
+	<button type="button" class="button bulk-increase-stock"><?php esc_html_e( 'Increase stock', 'woocommerce' ); ?></button>
+	<?php endif; ?>
+</div>
 <div class="wc-order-data-row wc-order-totals-items wc-order-items-editable">
 	<?php
 	$coupons = $order->get_items( 'coupon' );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1940,7 +1940,7 @@ class WC_AJAX {
 					$reduced = $order_item->get_meta( '_reduced_stock', true );
 					if ( ! $reduced ) {
 						$reduced = $net_stock_change;
-					} elseif ( $net_stock_change <= 								$reduced ) {
+					} elseif ( $net_stock_change <= $reduced ) {
 					// Don't reduce if the item has already been reduced by at least this amount.
 						continue;
 					} else {

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1990,4 +1990,22 @@ class WC_Order extends WC_Abstract_Order {
 
 		return apply_filters( 'woocommerce_get_order_item_totals', $total_rows, $this, $tax_display );
 	}
+
+	/**
+	 * Determine whether manual stock adjustments are allowed.
+	 *
+	 * @since 3.5.3
+	 * @return bool True when allowed, otherwise false.
+	 */
+	public function allow_manual_stock_adjustment() {
+		if ( ! $this->is_editable() ) {
+			return false;
+		}
+
+		if ( 'yes' !== get_option( 'woocommerce_manage_stock', 'no' ) ) {
+			return false;
+		}
+
+		return apply_filters( 'woocommerce_order_allow_manual_stock_adjustment', false );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Enable selecting order item rows - #21837 
- Add manual item stock adjustment in order edit

Closes #21754 .

### How to test the changes in this Pull Request:

1. Rebuild admin.css `sass assets/css/admin.scss assets/css/admin.css`.
2. Enable the manual stock adjustment buttons `add_filter( 'woocommerce_order_allow_manual_stock_adjustment', '__return_true' );`.
3. Create a new order with at least 2 products and 2 quantities.
4. Click on a product line item on the order. 
- It should highlight.
- The `Reduce Stock` and `Increase Stock` buttons should slide down.
5. Click on it again.
- It should unhighlight.
6. Click on a product line item on the order again.
7. Click the edit pencil.
- The `Reduce Stock` and `Increase Stock` buttons should slide up.
8. Click `Cancel` or `Save`.
9. Click on a product line item on the order again.
10. Click `Reduce Stock`.
- On refresh an order note should be added indicating the product stock was reduced by the line item quantity.
11. On the same item, increase the quantity of the item and save.
12. Reduce the stock on that item again. 
- On refresh an order note should be added indicating the product stock was reduced by the net change in the line item quantity.
13. Increase the stock on that item.
- Order note indicating the full quantity reduced should be added back to stock.
14. Reduce stock on all product line items. Order notes should reflect those changes.
15. Increase stock should also calculate net adjustments and limit stock increases to the amount reduced.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

Additional note/question for reviewer: In restoring the `tbody tr.selected` CSS, I did not restore the td pointer in https://github.com/woocommerce/woocommerce/blob/3.4.7/assets/css/admin.scss#L1454:L1456. If that should be restored as well, let me know.

### Changelog entry

> Add manual item stock adjustment in order edit


