### PR TITLE
 Fixed REST API authentication when using 3rd party auth methods 

### DIFF
--- a/includes/api/class-wc-rest-authentication.php
+++ b/includes/api/class-wc-rest-authentication.php
@@ -140,15 +140,15 @@ class WC_REST_Authentication {
 		$consumer_secret   = '';
 
 		// If the $_GET parameters are present, use those first.
-		if ( ! empty( $_GET['consumer_key'] ) && ! empty( $_GET['consumer_secret'] ) ) {
-			$consumer_key    = $_GET['consumer_key']; // WPCS: sanitization ok.
-			$consumer_secret = $_GET['consumer_secret']; // WPCS: sanitization ok.
+		if ( ! empty( $_GET['consumer_key'] ) && ! empty( $_GET['consumer_secret'] ) ) { // WPCS: CSRF ok.
+			$consumer_key    = $_GET['consumer_key']; // WPCS: CSRF ok, sanitization ok.
+			$consumer_secret = $_GET['consumer_secret']; // WPCS: CSRF ok, sanitization ok.
 		}
 
 		// If the above is not present, we will do full basic auth.
 		if ( ! $consumer_key && ! empty( $_SERVER['PHP_AUTH_USER'] ) && ! empty( $_SERVER['PHP_AUTH_PW'] ) ) {
-			$consumer_key    = $_SERVER['PHP_AUTH_USER']; // WPCS: sanitization ok.
-			$consumer_secret = $_SERVER['PHP_AUTH_PW']; // WPCS: sanitization ok.
+			$consumer_key    = $_SERVER['PHP_AUTH_USER']; // WPCS: CSRF ok, sanitization ok.
+			$consumer_secret = $_SERVER['PHP_AUTH_PW']; // WPCS: CSRF ok, sanitization ok.
 		}
 
 		// Stop if don't have any key.
@@ -353,7 +353,7 @@ class WC_REST_Authentication {
 	 */
 	private function check_oauth_signature( $user, $params ) {
 		$http_method  = isset( $_SERVER['REQUEST_METHOD'] ) ? strtoupper( $_SERVER['REQUEST_METHOD'] ) : ''; // WPCS: sanitization ok.
-		$request_path = isset( $_SERVER['REQUEST_URI'] ) ? parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) : ''; // WPCS: sanitization ok.
+		$request_path = isset( $_SERVER['REQUEST_URI'] ) ? wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ) : ''; // WPCS: sanitization ok.
 		$wp_base      = get_home_url( null, '/', 'relative' );
 		if ( substr( $request_path, 0, strlen( $wp_base ) ) === $wp_base ) {
 			$request_path = substr( $request_path, strlen( $wp_base ) );
@@ -468,7 +468,7 @@ class WC_REST_Authentication {
 			$used_nonces = array();
 		}
 
-		if ( in_array( $nonce, $used_nonces ) ) {
+		if ( in_array( $nonce, $used_nonces, true ) ) {
 			return new WP_Error( 'woocommerce_rest_authentication_error', __( 'Invalid nonce - nonce has already been used.', 'woocommerce' ), array( 'status' => 401 ) );
 		}
 
@@ -510,7 +510,8 @@ class WC_REST_Authentication {
 			SELECT key_id, user_id, permissions, consumer_key, consumer_secret, nonces
 			FROM {$wpdb->prefix}woocommerce_api_keys
 			WHERE consumer_key = %s
-		", $consumer_key
+		",
+				$consumer_key
 			)
 		);
 

--- a/includes/api/class-wc-rest-authentication.php
+++ b/includes/api/class-wc-rest-authentication.php
@@ -39,7 +39,7 @@ class WC_REST_Authentication {
 	 */
 	public function __construct() {
 		add_filter( 'determine_current_user', array( $this, 'authenticate' ), 15 );
-		add_filter( 'rest_authentication_errors', array( $this, 'check_authentication_error' ) );
+		add_filter( 'rest_authentication_errors', array( $this, 'check_authentication_error' ), 15 );
 		add_filter( 'rest_post_dispatch', array( $this, 'send_unauthorized_headers' ), 50 );
 		add_filter( 'rest_pre_dispatch', array( $this, 'check_user_permissions' ), 10, 3 );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes support for 3rd party authentication methods.

Currently we are filtering `rest_authentication_errors` too early, stopping plugins like `rest-api-oauth1` to stop work, so changing our priority in the filter will allow 3rd party methods authenticate without problem, and then fallback to WooCommerce authentication methods.

Also fixed a few minor coding standards issues.

Closes #21789.

### How to test the changes in this Pull Request:

1. `wp plugin install rest-api-oauth1`.
2. `wp plugin activate rest-api-oauth1`.
3. `wp oauth1 add --name="Test app"`.
4. Copy "Consumer Key" and "Consumer Secret".
5. Do a POST request to `/oauth1/request` on Postman or Insonia, change to use oAuth1, and then set "Consumer Key" and "Consumer Secret", and "Signature Method" as HMAC-SHA1 (on postman maybe you need to click to update first).
6. Copy your `oauth_token` and `auth_token_secret`,
7. Open on your browser: `/oauth1/authorize?oauth_token=<your_auth_token_here>`.
8. Pass through the authorization process and copy your `oauth_verifier` at the end.
9. Go back to Postman or Insonia, and do a request to `/oauth1/access?oauth_verifier=<your_oauth_verifier_here>`, also set OAuth1 and fill "Consumer Key" and "Consumer Secret" again with the information provided by step 4, and then fill "Token" and "Token Secret" with data from step 6.
10. Now we have our final `oauth_token` and `auth_token_secret`, copy this as well.
11. Finally able to do requests, so try a GET request to `/wp-json/wc/v3/products`, do not forget to use the "Token" and "Token Secret" from step 10... Requesting this endpoint should return an error: `woocommerce_rest_authentication_error`.
12. Apply this patch and try again, now should work without any problem.
13. Also you may want to try doing Basic Auth and oAuth 1 using WooCommerce REST API keys to make sure that everything is still working.

Yeah, one line of code fix this bug, but a long process to test :smile: 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Fixed REST API 3rd party authentication support.
