### PR TITLE
WPCS: inline PHP semicolon and spacing

### DIFF
--- a/templates/cart/cross-sells.php
+++ b/templates/cart/cross-sells.php
@@ -24,7 +24,7 @@ if ( $cross_sells ) : ?>
 
 	<div class="cross-sells">
 
-		<h2><?php _e( 'You may be interested in&hellip;', 'woocommerce' ) ?></h2>
+		<h2><?php _e( 'You may be interested in&hellip;', 'woocommerce' ); ?></h2>
 
 		<?php woocommerce_product_loop_start(); ?>
 

--- a/templates/cart/proceed-to-checkout-button.php
+++ b/templates/cart/proceed-to-checkout-button.php
@@ -23,6 +23,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 
-<a href="<?php echo esc_url( wc_get_checkout_url() );?>" class="checkout-button button alt wc-forward">
+<a href="<?php echo esc_url( wc_get_checkout_url() ); ?>" class="checkout-button button alt wc-forward">
 	<?php esc_html_e( 'Proceed to checkout', 'woocommerce' ); ?>
 </a>

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<title><?php echo get_bloginfo( 'name', 'display' ); ?></title>
 	</head>
 	<body <?php echo is_rtl() ? 'rightmargin' : 'leftmargin'; ?>="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
-		<div id="wrapper" dir="<?php echo is_rtl() ? 'rtl' : 'ltr'?>">
+		<div id="wrapper" dir="<?php echo is_rtl() ? 'rtl' : 'ltr'; ?>">
 			<table border="0" cellpadding="0" cellspacing="0" height="100%" width="100%">
 				<tr>
 					<td align="center" valign="top">

--- a/templates/global/form-login.php
+++ b/templates/global/form-login.php
@@ -46,7 +46,7 @@ if ( is_user_logged_in() ) {
 	<p class="form-row">
 		<?php wp_nonce_field( 'woocommerce-login', 'woocommerce-login-nonce' ); ?>
 		<button type="submit" class="button" name="login" value="<?php esc_attr_e( 'Login', 'woocommerce' ); ?>"><?php esc_html_e( 'Login', 'woocommerce' ); ?></button>
-		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect ) ?>" />
+		<input type="hidden" name="redirect" value="<?php echo esc_url( $redirect ); ?>" />
 		<label class="woocommerce-form__label woocommerce-form__label-for-checkbox inline">
 			<input class="woocommerce-form__input woocommerce-form__input-checkbox" name="rememberme" type="checkbox" id="rememberme" value="forever" /> <span><?php esc_html_e( 'Remember me', 'woocommerce' ); ?></span>
 		</label>

--- a/templates/myaccount/downloads.php
+++ b/templates/myaccount/downloads.php
@@ -38,7 +38,7 @@ do_action( 'woocommerce_before_account_downloads', $has_downloads ); ?>
 <?php else : ?>
 	<div class="woocommerce-Message woocommerce-Message--info woocommerce-info">
 		<a class="woocommerce-Button button" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php esc_html_e( 'Go shop', 'woocommerce' ) ?>
+			<?php esc_html_e( 'Go shop', 'woocommerce' ); ?>
 		</a>
 		<?php esc_html_e( 'No downloads available yet.', 'woocommerce' ); ?>
 	</div>

--- a/templates/myaccount/orders.php
+++ b/templates/myaccount/orders.php
@@ -98,7 +98,7 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 <?php else : ?>
 	<div class="woocommerce-message woocommerce-message--info woocommerce-Message woocommerce-Message--info woocommerce-info">
 		<a class="woocommerce-Button button" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php _e( 'Go shop', 'woocommerce' ) ?>
+			<?php _e( 'Go shop', 'woocommerce' ); ?>
 		</a>
 		<?php _e( 'No order has been made yet.', 'woocommerce' ); ?>
 	</div>

--- a/templates/myaccount/payment-methods.php
+++ b/templates/myaccount/payment-methods.php
@@ -40,7 +40,7 @@ do_action( 'woocommerce_before_account_payment_methods', $has_methods ); ?>
 		</thead>
 		<?php foreach ( $saved_methods as $type => $methods ) : ?>
 			<?php foreach ( $methods as $method ) : ?>
-				<tr class="payment-method<?php echo ! empty( $method['is_default'] ) ? ' default-payment-method' : '' ?>">
+				<tr class="payment-method<?php echo ! empty( $method['is_default'] ) ? ' default-payment-method' : ''; ?>">
 					<?php foreach ( wc_get_account_payment_methods_columns() as $column_id => $column_name ) : ?>
 						<td class="woocommerce-PaymentMethod woocommerce-PaymentMethod--<?php echo esc_attr( $column_id ); ?> payment-method-<?php echo esc_attr( $column_id ); ?>" data-title="<?php echo esc_attr( $column_name ); ?>">
 							<?php

--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -25,14 +25,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 <table class="shop_attributes">
 	<?php if ( $display_dimensions && $product->has_weight() ) : ?>
 		<tr>
-			<th><?php _e( 'Weight', 'woocommerce' ) ?></th>
+			<th><?php _e( 'Weight', 'woocommerce' ); ?></th>
 			<td class="product_weight"><?php echo esc_html( wc_format_weight( $product->get_weight() ) ); ?></td>
 		</tr>
 	<?php endif; ?>
 
 	<?php if ( $display_dimensions && $product->has_dimensions() ) : ?>
 		<tr>
-			<th><?php _e( 'Dimensions', 'woocommerce' ) ?></th>
+			<th><?php _e( 'Dimensions', 'woocommerce' ); ?></th>
 			<td class="product_dimensions"><?php echo esc_html( wc_format_dimensions( $product->get_dimensions( false ) ) ); ?></td>
 		</tr>
 	<?php endif; ?>

--- a/templates/single-product/review.php
+++ b/templates/single-product/review.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly
 }
 ?>
-<li <?php comment_class(); ?> id="li-comment-<?php comment_ID() ?>">
+<li <?php comment_class(); ?> id="li-comment-<?php comment_ID(); ?>">
 
 	<div id="comment-<?php comment_ID(); ?>" class="comment_container">
 

--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -24,7 +24,7 @@ if ( $upsells ) : ?>
 
 	<section class="up-sells upsells products">
 
-		<h2><?php esc_html_e( 'You may also like&hellip;', 'woocommerce' ) ?></h2>
+		<h2><?php esc_html_e( 'You may also like&hellip;', 'woocommerce' ); ?></h2>
 
 		<?php woocommerce_product_loop_start(); ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Added semicolons and spacing to inline PHP statements that matches WPCS. 

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
- Added semicolons and spacing to inline PHP statements that meets WPCS. 
