### PR TITLE
Adding new woocommerce_not_found_coupon filter

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1550,9 +1550,12 @@ class WC_Cart extends WC_Legacy_Cart {
 
 		// Prevent adding coupons by post ID.
 		if ( $the_coupon->get_code() !== $coupon_code ) {
-			$the_coupon->set_code( $coupon_code );
-			$the_coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_NOT_EXIST );
-			return false;
+			$coupon_found = apply_filters( 'woocommerce_not_found_coupon', false, $coupon_code );
+			if ( ! $coupon_found ) {			
+				$the_coupon->set_code( $coupon_code );
+				$the_coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_NOT_EXIST );
+			}
+			return $coupon_found;
 		}
 
 		// Check it can be used with cart.

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1560,8 +1560,9 @@ class WC_Cart extends WC_Legacy_Cart {
 			 *     false if it doesn't belong to any external discount and a proper error message for the user has
 			 *     already been constructed, or any other value to keep the default WooCommerce behaviour.
 			 * @param string $coupon_code Coupon code as provided by the user, after being formatted by WooCommerce
+			 * @param WC_Cart $this Cart to which the discount should be applied
 			 */
-			$external_discount_found = apply_filters( 'woocommerce_not_found_coupon', false, $coupon_code );
+			$external_discount_found = apply_filters( 'woocommerce_not_found_coupon', false, $coupon_code, $this );
 			if ( is_bool( $external_discount_found ) ) {
 				return $external_coupon_found;
 			}

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1551,21 +1551,20 @@ class WC_Cart extends WC_Legacy_Cart {
 		// No coupon exists with that coupon code
 		if ( 0 === $the_coupon->id ) {
 			/**
-			 * Filter to allow externally-defined coupon codes
+			 * Filter to allow externally-defined discount codes
 			 *
-			 * @since 4.5.x
+			 * @since 3.5.2
 			 *
-			 * @param bool|int $return Boolean that define if any external coupon code has been found or not. The
-			 *     returned value should be true if an externally-defined coupon has been found, false if no external
-			 *     coupon has been found and a proper error message has been constructed, or any other value to keep the
-			 *     default WooCommerce behaviour.
+			 * @param bool|int $return Boolean that define if any external discount code has been found or not. The
+			 *     returned value should be true if the code corresponds to an externally-defined coupon has been found,
+			 *     false if it doesn't belong to any external discount and a proper error message for the user has
+			 *     already been constructed, or any other value to keep the default WooCommerce behaviour.
 			 * @param string $coupon_code Coupon code as provided by the user, after being formatted by WooCommerce
-			 * @param WC_Coupon $the_coupon Coupon object, just created with default values, after not being found. This
-			 *     object could be used to dynamically complete the coupon properties to create virtual coupons
 			 */
-			$external_coupon_found = apply_filters( 'woocommerce_not_found_coupon', false, $coupon_code );
-			if ( $external_coupon_found === true || $external_coupon_found === false ) {
+			$external_discount_found = apply_filters( 'woocommerce_not_found_coupon', false, $coupon_code );
+			if ( is_bool( $external_discount_found ) ) {
 				return $external_coupon_found;
+			}
 		}
 
 		// Prevent adding coupons by post ID.

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1548,14 +1548,31 @@ class WC_Cart extends WC_Legacy_Cart {
 		// Get the coupon.
 		$the_coupon = new WC_Coupon( $coupon_code );
 
+		// No coupon exists with that coupon code
+		if ( 0 === $the_coupon->id ) {
+			/**
+			 * Filter to allow externally-defined coupon codes
+			 *
+			 * @since 4.5.x
+			 *
+			 * @param bool|int $return Boolean that define if any external coupon code has been found or not. The
+			 *     returned value should be true if an externally-defined coupon has been found, false if no external
+			 *     coupon has been found and a proper error message has been constructed, or any other value to keep the
+			 *     default WooCommerce behaviour.
+			 * @param string $coupon_code Coupon code as provided by the user, after being formatted by WooCommerce
+			 * @param WC_Coupon $the_coupon Coupon object, just created with default values, after not being found. This
+			 *     object could be used to dynamically complete the coupon properties to create virtual coupons
+			 */
+			$external_coupon_found = apply_filters( 'woocommerce_not_found_coupon', false, $coupon_code );
+			if ( $external_coupon_found === true || $external_coupon_found === false ) {
+				return $external_coupon_found;
+		}
+
 		// Prevent adding coupons by post ID.
 		if ( $the_coupon->get_code() !== $coupon_code ) {
-			$coupon_found = apply_filters( 'woocommerce_not_found_coupon', false, $coupon_code );
-			if ( ! $coupon_found ) {			
-				$the_coupon->set_code( $coupon_code );
-				$the_coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_NOT_EXIST );
-			}
-			return $coupon_found;
+			$the_coupon->set_code( $coupon_code );
+			$the_coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_NOT_EXIST );
+			return false;
 		}
 
 		// Check it can be used with cart.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #22022 

### How to test the changes in this Pull Request:

1. Register a filter for the new hook. For example:
```
add_filter('woocommerce_not_found_coupon', function( $result, $code ) {
	if ( ! is_bool( $result ) ) {
		if ( $code === 'externalexistingdiscount' ) {
			return true;
		}
		if ( $code === 'externalerrordiscount ) {
			wc_add_notice( 'Error in externally defined discount', 'error' );
			return false;
		}
	}
	return $result;
}, 10, 2);
```
2. If you use externalexistingdiscount as a coupon code, no error should be emitted. 
3. If you use externalerrordiscount as a coupon code, an error should be emitted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Adding new woocommerce_not_found_coupon hook to allow external plugins to recognize non-existing coupon codes as their own discount codes