### PR TITLE
fix `0` value attribute permalink, property in REST api

### DIFF
--- a/includes/api/v2/class-wc-rest-products-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-products-v2-controller.php
@@ -524,7 +524,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 			foreach ( $product->get_variation_attributes() as $attribute_name => $attribute ) {
 				$name = str_replace( 'attribute_', '', $attribute_name );
 
-				if ( ! $attribute ) {
+				if ( empty( $attribute ) && '0' !== $attribute ) {
 					continue;
 				}
 

--- a/includes/api/v2/class-wc-rest-products-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-products-v2-controller.php
@@ -58,7 +58,8 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 */
 	public function register_routes() {
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base, array(
+			$this->namespace, '/' . $this->rest_base, // @codingStandardsIgnoreLine.
+			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
@@ -76,7 +77,8 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 		);
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', array(
+			$this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', // @codingStandardsIgnoreLine.
+			array(
 				'args'   => array(
 					'id' => array(
 						'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
@@ -118,7 +120,8 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 		);
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/batch', array(
+			$this->namespace, '/' . $this->rest_base . '/batch', // @codingStandardsIgnoreLine.
+			array(
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'batch_items' ),
@@ -133,8 +136,9 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Get object.
 	 *
+	 * @param int $id Object ID.
+	 *
 	 * @since  3.0.0
-	 * @param  int $id Object ID.
 	 * @return WC_Data
 	 */
 	protected function get_object( $id ) {
@@ -144,9 +148,10 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Prepare a single product output for response.
 	 *
+	 * @param WC_Data         $object  Object data.
+	 * @param WP_REST_Request $request Request object.
+	 *
 	 * @since  3.0.0
-	 * @param  WC_Data         $object  Object data.
-	 * @param  WP_REST_Request $request Request object.
 	 * @return WP_REST_Response
 	 */
 	public function prepare_object_for_response( $object, $request ) {
@@ -184,8 +189,9 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Prepare objects query.
 	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 *
 	 * @since  3.0.0
-	 * @param  WP_REST_Request $request Full details about the request.
 	 * @return array
 	 */
 	protected function prepare_objects_query( $request ) {
@@ -317,6 +323,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 * Get the downloads for a product or product variation.
 	 *
 	 * @param WC_Product|WC_Product_Variation $product Product instance.
+	 *
 	 * @return array
 	 */
 	protected function get_downloads( $product ) {
@@ -340,6 +347,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 *
 	 * @param WC_Product $product  Product instance.
 	 * @param string     $taxonomy Taxonomy slug.
+	 *
 	 * @return array
 	 */
 	protected function get_taxonomy_terms( $product, $taxonomy = 'cat' ) {
@@ -360,6 +368,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 * Get the images for a product or product variation.
 	 *
 	 * @param WC_Product|WC_Product_Variation $product Product instance.
+	 *
 	 * @return array
 	 */
 	protected function get_images( $product ) {
@@ -420,10 +429,10 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Get attribute taxonomy label.
 	 *
-	 * @deprecated 3.0.0
+	 * @param string $name Taxonomy name.
 	 *
-	 * @param  string $name Taxonomy name.
-	 * @return string
+	 * @deprecated 3.0.0
+	 * @return     string
 	 */
 	protected function get_attribute_taxonomy_label( $name ) {
 		$tax    = get_taxonomy( $name );
@@ -435,9 +444,10 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Get product attribute taxonomy name.
 	 *
+	 * @param string     $slug    Taxonomy name.
+	 * @param WC_Product $product Product data.
+	 *
 	 * @since  3.0.0
-	 * @param  string     $slug    Taxonomy name.
-	 * @param  WC_Product $product Product data.
 	 * @return string
 	 */
 	protected function get_attribute_taxonomy_name( $slug, $product ) {
@@ -463,6 +473,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 * Get default attributes.
 	 *
 	 * @param WC_Product $product Product instance.
+	 *
 	 * @return array
 	 */
 	protected function get_default_attributes( $product ) {
@@ -494,6 +505,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 *
 	 * @param int   $product_id Product ID.
 	 * @param array $attribute  Attribute data.
+	 *
 	 * @return array
 	 */
 	protected function get_attribute_options( $product_id, $attribute ) {
@@ -514,6 +526,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 * Get the attributes for a product or product variation.
 	 *
 	 * @param WC_Product|WC_Product_Variation $product Product instance.
+	 *
 	 * @return array
 	 */
 	protected function get_attributes( $product ) {
@@ -566,6 +579,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 * @param WC_Product $product Product instance.
 	 * @param string     $context Request context.
 	 *                            Options: 'view' and 'edit'.
+	 *
 	 * @return array
 	 */
 	protected function get_product_data( $product, $context = 'view' ) {
@@ -649,21 +663,22 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 *
 	 * @param WC_Data         $object  Object data.
 	 * @param WP_REST_Request $request Request object.
+	 *
 	 * @return array                   Links for the given post.
 	 */
 	protected function prepare_links( $object, $request ) {
 		$links = array(
 			'self'       => array(
-				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $object->get_id() ) ),
+				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $object->get_id() ) ),  // @codingStandardsIgnoreLine.
 			),
 			'collection' => array(
-				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),
+				'href' => rest_url( sprintf( '/%s/%s', $this->namespace, $this->rest_base ) ),  // @codingStandardsIgnoreLine.
 			),
 		);
 
 		if ( $object->get_parent_id() ) {
 			$links['up'] = array(
-				'href' => rest_url( sprintf( '/%s/products/%d', $this->namespace, $object->get_parent_id() ) ),
+				'href' => rest_url( sprintf( '/%s/products/%d', $this->namespace, $object->get_parent_id() ) ),  // @codingStandardsIgnoreLine.
 			);
 		}
 
@@ -673,8 +688,9 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Prepare a single product for create or update.
 	 *
-	 * @param  WP_REST_Request $request Request object.
-	 * @param  bool            $creating If is creating a new object.
+	 * @param WP_REST_Request $request Request object.
+	 * @param bool            $creating If is creating a new object.
+	 *
 	 * @return WP_Error|WC_Data
 	 */
 	protected function prepare_object_for_database( $request, $creating = false ) {
@@ -1055,9 +1071,10 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Set product images.
 	 *
-	 * @throws WC_REST_Exception REST API exceptions.
 	 * @param WC_Product $product Product instance.
 	 * @param array      $images  Images data.
+	 *
+	 * @throws WC_REST_Exception REST API exceptions.
 	 * @return WC_Product
 	 */
 	protected function set_product_images( $product, $images ) {
@@ -1136,6 +1153,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 *
 	 * @param WC_Product $product Product instance.
 	 * @param array      $data    Shipping data.
+	 *
 	 * @return WC_Product
 	 */
 	protected function save_product_shipping_data( $product, $data ) {
@@ -1181,7 +1199,8 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 *
 	 * @param WC_Product $product    Product instance.
 	 * @param array      $downloads  Downloads data.
-	 * @param int        $deprecated Deprecated since 3.0.
+	 * @param int        $deprecated Deprecated since 3.0
+	 *
 	 * @return WC_Product
 	 */
 	protected function save_downloadable_files( $product, $downloads, $deprecated = 0 ) {
@@ -1212,6 +1231,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 * @param WC_Product $product  Product instance.
 	 * @param array      $terms    Terms data.
 	 * @param string     $taxonomy Taxonomy name.
+	 *
 	 * @return WC_Product
 	 */
 	protected function save_taxonomy_terms( $product, $terms, $taxonomy = 'cat' ) {
@@ -1229,10 +1249,10 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	/**
 	 * Save default attributes.
 	 *
-	 * @since 3.0.0
-	 *
 	 * @param WC_Product      $product Product instance.
 	 * @param WP_REST_Request $request Request data.
+	 *
+	 * @since  3.0.0
 	 * @return WC_Product
 	 */
 	protected function save_default_attributes( $product, $request ) {
@@ -1301,6 +1321,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 * Delete a single item.
 	 *
 	 * @param WP_REST_Request $request Full details about the request.
+	 *
 	 * @return WP_REST_Response|WP_Error
 	 */
 	public function delete_item( $request ) {

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -167,7 +167,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 			$data = $this->get_variation_attributes();
 		}
 
-		$data = array_filter( $data );
+		$data = array_filter( $data, 'wc_array_filter_default_attributes' );
 
 		if ( empty( $data ) ) {
 			return $url;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix attribute value checks for `"0"` value attributes on attribute permalink calculation and variation `attributes` property.

Closes #21743 .

### How to test the changes in this Pull Request:

1. Create a new variable product with an attribute of `Size` => `00 | 0 | 2` & use the attribute for variations.
2. Create variations from all attributes.
3. Request to product variations in the REST api (v3).
4. `"0"` variation permalink should include `?attribute_size=0`
5. `"0"` variation attributes property should be populated

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix `0` value attribute permalink calculation, property population in REST api.
