### PR TITLE
Don't include product in single product breadcrumb structured data

### DIFF
--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -148,8 +148,11 @@ class WC_Breadcrumb {
 			$this->prepend_shop_page();
 
 			$terms = wc_get_product_terms(
-				$post->ID, 'product_cat', apply_filters(
-					'woocommerce_breadcrumb_product_terms_args', array(
+				$post->ID,
+				'product_cat',
+				apply_filters(
+					'woocommerce_breadcrumb_product_terms_args',
+					array(
 						'orderby' => 'parent',
 						'order'   => 'DESC',
 					)

--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -164,6 +164,8 @@ class WC_Breadcrumb {
 				$this->term_ancestors( $main_term->term_id, 'product_cat' );
 				$this->add_crumb( $main_term->name, get_term_link( $main_term ) );
 			}
+
+			return;
 		} elseif ( 'post' !== get_post_type( $post ) ) {
 			$post_type = get_post_type_object( get_post_type( $post ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prior to 3.3.0, the breadcrumb structured data had a validation error on the product item of the breadcrumb (resulting in it being ignored). The current breadcrumb adds the URL to the single product which fixes that error. However, because the single product URL is included in the breadcrumb the structured data about the product is ignored. This PR removes the single product item from the breadcrumb data fixing both the original issue and the current one.

Closes #22024 .

### How to test the changes in this Pull Request:

1. View the source of a single product page
2. Copy the structured data script from the footer of the source
3. Validate using the SD testing tool - https://search.google.com/structured-data/testing-tool

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix breadcrumb structured data on single product page.
