### PR TITLE
Add hold stock minutes check to order pay shortcode also

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -84,8 +84,9 @@ class WC_Shortcode_Checkout {
 		// Pay for existing order.
 		if ( isset( $_GET['pay_for_order'], $_GET['key'] ) && $order_id ) { // WPCS: input var ok, CSRF ok.
 			try {
-				$order_key = isset( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // WPCS: input var ok, CSRF ok.
-				$order     = wc_get_order( $order_id );
+				$order_key          = isset( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // WPCS: input var ok, CSRF ok.
+				$order              = wc_get_order( $order_id );
+ 				$hold_stock_minutes = (int) get_option( 'woocommerce_hold_stock_minutes', 0 );
 
 				// Order or payment link is invalid.
 				if ( ! $order || $order->get_id() !== $order_id || $order->get_order_key() !== $order_key ) {
@@ -149,7 +150,7 @@ class WC_Shortcode_Checkout {
 							}
 
 							// Check stock based on all items in the cart and consider any held stock within pending orders.
-							$held_stock     = wc_get_held_stock_quantity( $product, $order->get_id() );
+							$held_stock     = ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product, $order->get_id() ) : 0;
 							$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
 
 							if ( $product->get_stock_quantity() < ( $held_stock + $required_stock ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/pull/21797#issuecomment-441030753.

Adds the check from #21797 to the `order_pay` shortcode also.

### How to test the changes in this Pull Request:

1. Test same as #21797

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Only check held stock when held stock time is set.