### PR TITLE
"Active plugins" fix for status report

### DIFF
--- a/includes/api/v2/class-wc-rest-system-status-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-v2-controller.php
@@ -37,7 +37,8 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 	 */
 	public function register_routes() {
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base,
+			$this->namespace,
+			'/' . $this->rest_base,
 			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,

--- a/includes/api/v2/class-wc-rest-system-status-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-v2-controller.php
@@ -835,7 +835,6 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 									'changelog' => $body->sections['changelog'],
 								);
 								set_transient( md5( $plugin ) . '_version_data', $version_data, DAY_IN_SECONDS );
-								break;
 							}
 						}
 					}


### PR DESCRIPTION
### The problem
I maintain a couple of extensions sold via WooCommerce.com. When new requests arrive, they are auto-tagged with the extension being asked about, the WooCommerce version number and the extension version number. This information is pulled from the system status report submitted on the support ticket.

Recently, we've noticed a number of tickets that are not being auto-tagged correctly, and indeed a number of cases where the list of Active Plugins in the status report appears to be incorrect. Specifically, our own plugins are often missing from the list despite the fact that they're clearly active as the information they add to the status report is present. 

On further investigation, for many of these tickets, not even the core WooCommerce plugin is listed as active despite the report being generated by WooCommerce. 

I couldn't reproduce this on my local dev box, so I've been trawling through the code trying to work out ways in which this could happen. The one case I have identified is as follows:

* There is an active plugin whose URI in the plugin header contains woothemes.com, or woocommerce.com
* There is an error fetching the changelog for the plugin from the WooCommerce.com CDN (dzv365zjfbd8v.cloudfront.net) - either because it doesn't exist or some transient network issue
* The plugin slug exists as a valid plugin on wordpress.org

If the above hold true, then the plugin that matches this case will be the last plugin identified, all others will be silently dropped. You can verify this behaviour by modifying the Plugin URI of a wordpress.org plugin to woocommerce.com and generating a status report. 

The cause of this bug is an errant `break` in the code that is not inside a local loop, so unexpectedly breaks out of the outer-loop causing no further plugins to be processed. 

### Changes proposed in this Pull Request:

This change removes the errant `break` and so fixes the case identified. I'm not completely clear that this will fix the issues on the tickets we've been receiving (since I can't verify the exact cause there), but it needs fixing anyway. If anyone with knowledge of the system status report plugin code wants to take 5 minutes to see if they can spot anything else wrong that would also be useful. 

### How to test the changes in this Pull Request:

1. Find a wordpress.org plugin that is not last on the list of Active plugins
2. Modify its "Plugin URI" to https://woocommerce.com
3. Clear transients
4. Access the status report
5. Confirm that all active plugins are still present.

### Changelog entry

> Fix issues where not all active plugins were included on the system status report
