### PR TITLE
add is_array check to catalog ordering orderby

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -515,11 +515,13 @@ class WC_Query {
 		global $wpdb, $wp_query;
 
 		if ( isset( $wp_query->queried_object, $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy ) && is_a( $wp_query->queried_object, 'WP_Term' ) ) {
-			$search_within_terms = get_terms( array(
-				'taxonomy' => $wp_query->queried_object->taxonomy,
-				'child_of' => $wp_query->queried_object->term_id,
-				'fields'   => 'tt_ids',
-			) );
+			$search_within_terms = get_terms(
+				array(
+					'taxonomy' => $wp_query->queried_object->taxonomy,
+					'child_of' => $wp_query->queried_object->term_id,
+					'fields'   => 'tt_ids',
+				)
+			);
 			$search_within_terms[] = $wp_query->queried_object->term_taxonomy_id;
 			$args['join']         .= " INNER JOIN (
 				SELECT post_id, min( meta_value+0 ) price
@@ -548,11 +550,13 @@ class WC_Query {
 		global $wpdb, $wp_query;
 
 		if ( isset( $wp_query->queried_object, $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy ) && is_a( $wp_query->queried_object, 'WP_Term' ) ) {
-			$search_within_terms = get_terms( array(
-				'taxonomy' => $wp_query->queried_object->taxonomy,
-				'child_of' => $wp_query->queried_object->term_id,
-				'fields'   => 'tt_ids',
-			) );
+			$search_within_terms = get_terms(
+				array(
+					'taxonomy' => $wp_query->queried_object->taxonomy,
+					'child_of' => $wp_query->queried_object->term_id,
+					'fields'   => 'tt_ids',
+				)
+			);
 			$search_within_terms[] = $wp_query->queried_object->term_taxonomy_id;
 			$args['join']         .= " INNER JOIN (
 				SELECT post_id, max( meta_value+0 ) price

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -445,7 +445,7 @@ class WC_Query {
 			}
 
 			// Get order + orderby args from string.
-			$orderby_value = explode( '-', $orderby_value );
+			$orderby_value = is_array( $orderby_value ) ? $orderby_value : explode( '-', $orderby_value );
 			$orderby       = esc_attr( $orderby_value[0] );
 			$order         = ! empty( $orderby_value[1] ) ? $orderby_value[1] : $order;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add a check before exploding $order_by because `get_query_var()` can return an array.

Closes #22065 .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix error on product category when sorting by multiple fields.
