### PR TITLE
Send webhooks for partial refund creation

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -865,6 +865,7 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			'order.updated'    => array(
 				'woocommerce_process_shop_order_meta',
 				'woocommerce_update_order',
+				'woocommerce_order_refunded',
 			),
 			'order.deleted'    => array(
 				'wp_trash_post',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add the `woocommerce_order_refunded` hook to the `order.updated` topic.

Closes #22072

**Note that** I did consider a separate `order.refunded` topic for this PR. However, as an API consumer, I think that (a) I expect `order.updated` to tell me when a refund happens, as I care more about the current state of the order than whether the status changed, and (b) I don't expect to have to subscribe to a new topic to get notified of partial and full refunds; I shouldn't care about the difference as a consumer, and only care about checking the `order->refunds` object.

There is a valid use case for, "what if I _only_ want to know about refund events? Shouldn't I be able to subscribe to a webhook for this?" I think this should be possible; however, I think that deserves a separate PR to add refund topics that mirror order topics, such as `refund.created`, `refund.deleted`, etc., which sounds like it might better be a candidate for a minor release in a separate PR.

### How to test the changes in this Pull Request:

1. Follow the QA steps outlined in #22072 and note that a partial refund will now fire the `order.updated` webhook.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Fix - Ensure partial refunds fire order.updated webhooks #22072
