### PR TITLE
Make shipping may be available text filterable

### DIFF
--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -51,7 +51,7 @@ $calculator_text          = '';
 						printf( esc_html__( 'Estimate for %s.', 'woocommerce' ) . ' ', '<strong>' . esc_html( $formatted_destination ) . '</strong>' );
 						$calculator_text = __( 'Change address', 'woocommerce' );
 					} else {
-						echo esc_html__( 'This is only an estimate. Prices will be updated during checkout.', 'woocommerce' );
+						echo wp_kses_post( apply_filters( 'woocommerce_shipping_estimate_html', __( 'This is only an estimate. Prices will be updated during checkout.', 'woocommerce' ) ) );
 					}
 					?>
 				</p>

--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -58,7 +58,7 @@ $calculator_text          = '';
 			<?php endif; ?>
 		<?php
 		elseif ( ! $has_calculated_shipping || ! $formatted_destination ) :
-			esc_html_e( 'Enter your address to view shipping options.', 'woocommerce' );
+			echo wp_kses_post( apply_filters( 'woocommerce_shipping_may_be_available_html', __( 'Enter your address to view shipping options.', 'woocommerce' ) ) );
 		elseif ( ! is_cart() ) :
 			echo wp_kses_post( apply_filters( 'woocommerce_no_shipping_available_html', __( 'There are no shipping methods available. Please ensure that your address has been entered correctly, or contact us if you need any help.', 'woocommerce' ) ) );
 		else :


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Strings in `templates/cart/cart-shipping.php` are all filterable except ~~one~~ two (on in cart, one at checkout) that are presented when there's no calculated shipping and destination available. Some plugins like Local Pickup Plus may replace this string to add some HTML toggle to switch from shipping to pickup where shipping is not available but it's the default handling of a given package.

The proposed filter follows the same pattern/format as the others found in the same template for other HTML text strings.

**Note:** You may want to update the `@version` tag of the template file if this change is accepted and the template file modified. I didn't as I am not sure which WC version this would end up targeting.

[Updated: added one more filter for the shipping estimate text in cart, same points apply]

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* `n/a` - Have you written new tests for your changes, as applicable? 
* [x] Have you successfully ran tests with your changes locally?
