### PR TITLE
Fix incorrect return type documentation for product factory `get_product()`.

### DIFF
--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -20,7 +20,7 @@ class WC_Product_Factory {
 	 *
 	 * @param mixed $product_id WC_Product|WP_Post|int|bool $product Product instance, post instance, numeric or false to use global $post.
 	 * @param array $deprecated Previously used to pass arguments to the factory, e.g. to force a type.
-	 * @return WC_Product|bool Product object or null if the product cannot be loaded.
+	 * @return WC_Product|bool Product object or false if the product cannot be loaded.
 	 */
 	public function get_product( $product_id = false, $deprecated = array() ) {
 		$product_id = $this->get_product_id( $product_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `WC_Product_Factory::get_product()` method returns `false` if the product cannot be loaded, but the documentation states `null`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

> Fix incorrect return type documentation for product factory `get_product()` method.