### PR TITLE
Remove the stock data type on low stock threshold input which can be empty

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-inventory.php
+++ b/includes/admin/meta-boxes/views/html-product-data-inventory.php
@@ -71,19 +71,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 				)
 			);
 
-			woocommerce_wp_text_input( array(
-				'id'                => '_low_stock_amount',
-				'value'             => $product_object->get_low_stock_amount( 'edit' ),
-				'placeholder'       => get_option( 'woocommerce_notify_low_stock_amount' ),
-				'label'             => __( 'Low stock threshold', 'woocommerce' ),
-				'desc_tip'          => true,
-				'description'       => __( 'When product stock reaches this amount you will be notified by email', 'woocommerce' ),
-				'type'              => 'number',
-				'custom_attributes' => array(
-					'step' => 'any',
-				),
-				'data_type'         => 'stock',
-			) );
+			woocommerce_wp_text_input(
+				array(
+					'id'                => '_low_stock_amount',
+					'value'             => $product_object->get_low_stock_amount( 'edit' ),
+					'placeholder'       => get_option( 'woocommerce_notify_low_stock_amount' ),
+					'label'             => __( 'Low stock threshold', 'woocommerce' ),
+					'desc_tip'          => true,
+					'description'       => __( 'When product stock reaches this amount you will be notified by email', 'woocommerce' ),
+					'type'              => 'number',
+					'custom_attributes' => array(
+						'step' => 'any',
+					),
+				)
+			);
 
 			do_action( 'woocommerce_product_options_stock_fields' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Remove the stock input data type which forces empty values to `0` from the low stock thresh hold input field.

Closes #22075 .

### How to test the changes in this Pull Request:

1. Set a low stock threshold in the WC settings.
2. Create a new product & save.
3. Check the inventory tab to see that the store wide low stock setting is showing as the placeholder in the product inventory tab.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix allow products to use default low stock threshold.
