### PR TITLE
Make webhook scheduled actions unique

### DIFF
--- a/includes/wc-webhook-functions.php
+++ b/includes/wc-webhook-functions.php
@@ -20,11 +20,17 @@ function wc_webhook_process_delivery( $webhook, $arg ) {
 	// so as to avoid delays or failures in delivery from affecting the
 	// user who triggered it.
 	if ( apply_filters( 'woocommerce_webhook_deliver_async', true, $webhook, $arg ) ) {
-		// Deliver in background.
-		WC()->queue()->add( 'woocommerce_deliver_webhook_async', array(
+		$queue_args = array(
 			'webhook_id' => $webhook->get_id(),
 			'arg'        => $arg,
-		), 'woocommerce-webhooks' );
+		);
+
+		$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_deliver_webhook_async', $queue_args, 'woocommerce-webhooks' );
+
+		// Make webhooks unique - only schedule one webhook every 10 minutes to maintain backward compatibility with WP Cron behaviour seen in WC < 3.5.0.
+		if ( is_null( $next_scheduled_date ) || $next_scheduled_date->getTimestamp() >= ( 600 + gmdate( 'U' ) ) ) {
+			WC()->queue()->add( 'woocommerce_deliver_webhook_async', $queue_args, 'woocommerce-webhooks' );
+		}
 	} else {
 		// Deliver immediately.
 		$webhook->deliver( $arg );


### PR DESCRIPTION
Fixes #22087

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This patch changes how webhooks are scheduled to maintain backward compatibility with a uniqueness requirement present when they were scheduled in WP Cron (with WC < 3.5.0). Specifically, identical webhooks will not be scheduled within 10 minutes of each other.

I've enforced this constraint within `wc_webhook_process_delivery()` instead of in a new method like `add_unique()` in `WC_Queue_Interface` and `WC_Action_Queue` because that would be a breaking change - anything extending `WC_Queue_Interface` would need to implement that new method.

Closes #22087.

### How to test the changes in this Pull Request:

0. Disable Action Scheduler's queue runner by installing [this plugin](https://github.com/Prospress/action-scheduler-disable-default-runner)
1. Create a webhook for order updates
2. Update an order multiple times in the same request, or within concurrent requests
3. View the duplicate webhooks on the **Tools > Scheduled Actions** screen

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

### Changelog entry

```
* Fix - Do not schedule duplicate webhooks within 10 minutes of each other to maintain previous behaviour.
```
