### PR TITLE
Fix WC_Action_Queue::get_next() return value

### DIFF
--- a/includes/queue/class-wc-action-queue.php
+++ b/includes/queue/class-wc-action-queue.php
@@ -127,7 +127,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 		$next_timestamp = as_next_scheduled_action( $hook, $args, $group );
 
 		if ( $next_timestamp ) {
-			return wc_string_to_datetime( $next_timestamp );
+			return new WC_DateTime( "@{$next_timestamp}", new DateTimeZone( 'UTC' ) );
 		}
 
 		return null;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix `WC_Action_Queue::get_next()` return value by passing the timestamp to `WC_DateTime` instead of `wc_string_to_datetime()`, which expects a date / time string and will operate it on it as such.

Raised in review on https://github.com/woocommerce/woocommerce/pull/22088#issuecomment-443249027

### How to test the changes in this Pull Request:

The approach for testing is to follow test instructions on #22088 so both PRs can be tested at once. :)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> * Fix - Return correct next scheduled date for items in queue by fixing date instantiation in WC_Action_Queue::get_next().