### PR TITLE
Fixed support for multiple query parameters translated to meta queries via REST API requests

### DIFF
--- a/includes/abstracts/abstract-wc-rest-controller.php
+++ b/includes/abstracts/abstract-wc-rest-controller.php
@@ -374,7 +374,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 * @return array
 	 */
 	protected function add_meta_query( $args, $meta_query ) {
-		if ( ! empty( $args['meta_query'] ) ) {
+		if ( empty( $args['meta_query'] ) ) {
 			$args['meta_query'] = array();
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

When using multiple query parameters that are translated to meta queries via REST API, only the last one was actually translated to meta query. This PR should fix the bug.

### How to test the changes in this Pull Request:

1. Create a variable product with a couple of variations with different prices and stock statuses.
2. Query the REST API with 2 query parameters translated to meta query, e.g. `min_price` and `strock_status`: https://local.wordpress.test/wp-json/wc/v3/products/1168/variations/?min_price=1&stock_status=instock
3. Either directly from the response or indirectly via SQL query, observe that master ignores `stock_status` constraint. This branch should correctly select variations respecting all the constraints.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed support for multiple query parameters translated to meta queries via REST API requests.
