### PR TITLE
Excluded new PHPCS docblock rules.

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -39,6 +39,10 @@
 
 	<rule ref="Generic.Commenting">
 		<exclude-pattern>tests/</exclude-pattern>
+		<exclude name="Generic.Commenting.DocComment.ParamGroup"/>
+		<exclude name="Generic.Commenting.DocComment.NonParamGroup"/>
+		<exclude name="Generic.Commenting.DocComment.TagsNotGrouped"/>
+		<exclude name="Generic.Commenting.DocComment.TagValueIndent"/>
 	</rule>
 
 	<rule ref="PEAR.Functions.FunctionCallSignature.EmptyLine">


### PR DESCRIPTION
Otherwise these cause all our files to fail in PHPCS and it's easier to miss other, more important CS violations.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This should exclude new PHPCS docblock rules that cause PHPCS to throw a lot of errors on all existing WC files. This can easily lead to missing other, more important PHPCS violations when ignoring PHPCS output.

### How to test the changes in this Pull Request:

1. Run PHPCS on any WC file.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Excluded new PHPCS docblock rules.
