### PR TITLE
Strip hash from URL that prevents reload on refunds

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -750,7 +750,7 @@ jQuery( function ( $ ) {
 					$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
 						if ( true === response.success ) {
 							// Redirect to same page for show the refunded status
-							window.location.href = window.location.href;
+							window.location.href = window.location.href.split('#')[0];
 						} else {
 							window.alert( response.data.error );
 							wc_meta_boxes_order_items.reload_items();

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -750,7 +750,7 @@ jQuery( function ( $ ) {
 					$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
 						if ( true === response.success ) {
 							// Redirect to same page for show the refunded status
-							window.location.href = window.location.href.split('#')[0];
+							window.location.reload();
 						} else {
 							window.alert( response.data.error );
 							wc_meta_boxes_order_items.reload_items();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Strip the `#` from `window.location.href` so that refunds can be processed and reloaded when a hash is appended to URL.  This is necessary for plugins that make use of the React Router (e.g., WC Admin).

Closes #22115 

### How to test the changes in this Pull Request:

1.  Install and activate [WC Admin](https://github.com/woocommerce/wc-admin/releases)
2.  Visit any order page in the dashboard.
3.  Refund any amount to that order.
4.  Note the page correctly refreshing after the refund has processed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Strip hash from URL when reload refunds in the dashboard
