### PR TITLE
Fix updating settings via the API

### DIFF
--- a/includes/api/class-wc-rest-settings-controller.php
+++ b/includes/api/class-wc-rest-settings-controller.php
@@ -61,7 +61,7 @@ class WC_REST_Settings_Controller extends WC_REST_Settings_V2_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function update_item( $request ) {
-		$options_controller = new WC_REST_Dev_Setting_Options_Controller();
+		$options_controller = new WC_REST_Setting_Options_Controller();
 		$response           = $options_controller->update_item( $request );
 
 		return $response;


### PR DESCRIPTION
WC_REST_Settings_Controller makes a call to `WC_REST_Dev_Setting_Options_Controller` in `update_item`. This leads to a fatal error when trying to update/POST to a settings endpoint.

`PHP Fatal error:  Uncaught Error: Class 'WC_REST_Dev_Setting_Options_Controller' not found in includes/api/class-wc-rest-settings-controller.php:64`

### How to test the changes in this Pull Request:

1. Fire up Postman and make a request to POST `/wp-json/wc/v3/settings/batch` with a JSON body of `{"update":[{"group_id":"general","id":"woocommerce_store_postcode","value":"11112"}]}`.
2. Verify that the request succeeds. You should get an array of `update` options, one of which should contain your new zip code.
