### PR TITLE
When selling to a single country and using geolocation, force user location to the selling country

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1071,6 +1071,12 @@ function wc_get_customer_default_location() {
 				$location = WC_Geolocation::geolocate_ip( '', true, false );
 			}
 
+			// When selling to only one country, force customer location to that country.
+			$countries = WC()->countries->get_allowed_countries();
+			if ( 1 === count( $countries ) ) {
+				$location  = wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', key( $countries ) ) );
+			}
+
 			// Base fallback.
 			if ( empty( $location['country'] ) ) {
 				$location = wc_format_country_state_string( apply_filters( 'woocommerce_customer_default_location', get_option( 'woocommerce_default_country' ) ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
If a store is set to sell to only a single country and geolocation is enabled, this change forces the customer location  to the selling country (even if geolocated outside the country) to enable the State/Province input to work on checkout.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #22120

### How to test the changes in this Pull Request:

See #22120. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> When selling to a single country and using geolocation, force user location to the selling country
