### PR TITLE
Use shipping countries for zone region select [Fixes #21527]

### DIFF
--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -76,7 +76,8 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 
 		if ( '' === $current_section ) {
 			$settings = apply_filters(
-				'woocommerce_shipping_settings', array(
+				'woocommerce_shipping_settings',
+				array(
 
 					array(
 						'title' => __( 'Shipping options', 'woocommerce' ),
@@ -248,7 +249,9 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		}
 
 		wp_localize_script(
-			'wc-shipping-zone-methods', 'shippingZoneMethodsLocalizeScript', array(
+			'wc-shipping-zone-methods',
+			'shippingZoneMethodsLocalizeScript',
+			array(
 				'methods'                 => $zone->get_shipping_methods( false, 'json' ),
 				'zone_name'               => $zone->get_zone_name(),
 				'zone_id'                 => $zone->get_id(),
@@ -278,7 +281,9 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		$method_count      = wc_get_shipping_method_count();
 
 		wp_localize_script(
-			'wc-shipping-zones', 'shippingZonesLocalizeScript', array(
+			'wc-shipping-zones',
+			'shippingZonesLocalizeScript',
+			array(
 				'zones'                   => WC_Shipping_Zones::get_zones( 'json' ),
 				'default_zone'            => array(
 					'zone_id'    => 0,
@@ -337,7 +342,9 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 	protected function output_shipping_class_screen() {
 		$wc_shipping = WC_Shipping::instance();
 		wp_localize_script(
-			'wc-shipping-classes', 'shippingClassesLocalizeScript', array(
+			'wc-shipping-classes',
+			'shippingClassesLocalizeScript',
+			array(
 				'classes'                   => $wc_shipping->get_shipping_classes(),
 				'default_shipping_class'    => array(
 					'term_id'     => 0,
@@ -355,7 +362,8 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 
 		// Extendable columns to show on the shipping classes screen.
 		$shipping_class_columns = apply_filters(
-			'woocommerce_shipping_classes_columns', array(
+			'woocommerce_shipping_classes_columns',
+			array(
 				'wc-shipping-class-name'        => __( 'Shipping class', 'woocommerce' ),
 				'wc-shipping-class-slug'        => __( 'Slug', 'woocommerce' ),
 				'wc-shipping-class-description' => __( 'Description', 'woocommerce' ),

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -230,11 +230,11 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 			wp_die( esc_html__( 'Zone does not exist!', 'woocommerce' ) );
 		}
 
-		$allowed_countries = WC()->countries->get_allowed_countries();
+		$allowed_countries  = WC()->countries->get_allowed_countries();
 		$shipping_countries = WC()->countries->get_shipping_countries();
-		$wc_shipping       = WC_Shipping::instance();
-		$shipping_methods  = $wc_shipping->get_shipping_methods();
-		$continents        = WC()->countries->get_continents();
+		$wc_shipping        = WC_Shipping::instance();
+		$shipping_methods   = $wc_shipping->get_shipping_methods();
+		$continents         = WC()->countries->get_continents();
 
 		// Prepare locations.
 		$locations = array();

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -230,6 +230,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		}
 
 		$allowed_countries = WC()->countries->get_allowed_countries();
+		$shipping_countries = WC()->countries->get_shipping_countries();
 		$wc_shipping       = WC_Shipping::instance();
 		$shipping_methods  = $wc_shipping->get_shipping_methods();
 		$continents        = WC()->countries->get_continents();

--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -49,7 +49,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 							foreach ( $countries as $country_code ) {
 								echo '<option value="country:' . esc_attr( $country_code ) . '"' . wc_selected( "country:$country_code", $locations ) . ' alt="' . esc_attr( $continent['name'] ) . '">' . esc_html( '&nbsp;&nbsp; ' . $shipping_countries[ $country_code ] ) . '</option>';
 
-								if ( $states = WC()->countries->get_states( $country_code ) ) {
+								$states = WC()->countries->get_states( $country_code );
+								if ( $states ) {
 									foreach ( $states as $state_code => $state_name ) {
 										echo '<option value="state:' . esc_attr( $country_code . ':' . $state_code ) . '"' . wc_selected( "state:$country_code:$state_code", $locations ) . ' alt="' . esc_attr( $continent['name'] . ' ' . $shipping_countries[ $country_code ] ) . '">' . esc_html( '&nbsp;&nbsp;&nbsp;&nbsp; ' . $state_name ) . '</option>';
 									}
@@ -138,8 +139,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<header class="wc-backbone-modal-header">
 					<h1>
 						<?php
-						/* translators: %s: shipping method title */
 						printf(
+							/* translators: %s: shipping method title */
 							esc_html__( '%s Settings', 'woocommerce' ),
 							'{{{ data.method.method_title }}}'
 						);

--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -44,14 +44,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 						foreach ( $continents as $continent_code => $continent ) {
 							echo '<option value="continent:' . esc_attr( $continent_code ) . '"' . wc_selected( "continent:$continent_code", $locations ) . ' alt="">' . esc_html( $continent['name'] ) . '</option>';
 
-							$countries = array_intersect( array_keys( $allowed_countries ), $continent['countries'] );
+							$countries = array_intersect( array_keys( $shipping_countries ), $continent['countries'] );
 
 							foreach ( $countries as $country_code ) {
-								echo '<option value="country:' . esc_attr( $country_code ) . '"' . wc_selected( "country:$country_code", $locations ) . ' alt="' . esc_attr( $continent['name'] ) . '">' . esc_html( '&nbsp;&nbsp; ' . $allowed_countries[ $country_code ] ) . '</option>';
+								echo '<option value="country:' . esc_attr( $country_code ) . '"' . wc_selected( "country:$country_code", $locations ) . ' alt="' . esc_attr( $continent['name'] ) . '">' . esc_html( '&nbsp;&nbsp; ' . $shipping_countries[ $country_code ] ) . '</option>';
 
 								if ( $states = WC()->countries->get_states( $country_code ) ) {
 									foreach ( $states as $state_code => $state_name ) {
-										echo '<option value="state:' . esc_attr( $country_code . ':' . $state_code ) . '"' . wc_selected( "state:$country_code:$state_code", $locations ) . ' alt="' . esc_attr( $continent['name'] . ' ' . $allowed_countries[ $country_code ] ) . '">' . esc_html( '&nbsp;&nbsp;&nbsp;&nbsp; ' . $state_name ) . '</option>';
+										echo '<option value="state:' . esc_attr( $country_code . ':' . $state_code ) . '"' . wc_selected( "state:$country_code:$state_code", $locations ) . ' alt="' . esc_attr( $continent['name'] . ' ' . $shipping_countries[ $country_code ] ) . '">' . esc_html( '&nbsp;&nbsp;&nbsp;&nbsp; ' . $state_name ) . '</option>';
 									}
 								}
 							}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR sets available options for shipping zone region to the _shipping_ countries set in WC Settings > General, instead of the _selling_ countries.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21527 .

### How to test the changes in this Pull Request:

See #21527.

1. On `master` branch: In WC Settings > General, set up options like this:

<img width="670" alt="screen shot 2018-12-04 at 3 47 33 pm" src="https://user-images.githubusercontent.com/1883584/49471857-f1b6fd00-f7db-11e8-8128-3cc1d84ab721.png">

2. Go to Settings > Shipping > Add Shipping Zone
3. In the 'Zone Regions' dropdown, see that only US regions are available.
4. Check out this branch. Refresh and see that US and Canada regions are available.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Use shipping countries instead of selling countries for shipping zone region option
