### PR TITLE
Improve shipping zone continents [Fixes #22130]

### DIFF
--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -76,7 +76,8 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 
 		if ( '' === $current_section ) {
 			$settings = apply_filters(
-				'woocommerce_shipping_settings', array(
+				'woocommerce_shipping_settings',
+				array(
 
 					array(
 						'title' => __( 'Shipping options', 'woocommerce' ),
@@ -247,7 +248,9 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		}
 
 		wp_localize_script(
-			'wc-shipping-zone-methods', 'shippingZoneMethodsLocalizeScript', array(
+			'wc-shipping-zone-methods',
+			'shippingZoneMethodsLocalizeScript',
+			array(
 				'methods'                 => $zone->get_shipping_methods( false, 'json' ),
 				'zone_name'               => $zone->get_zone_name(),
 				'zone_id'                 => $zone->get_id(),
@@ -277,7 +280,9 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		$method_count      = wc_get_shipping_method_count();
 
 		wp_localize_script(
-			'wc-shipping-zones', 'shippingZonesLocalizeScript', array(
+			'wc-shipping-zones',
+			'shippingZonesLocalizeScript',
+			array(
 				'zones'                   => WC_Shipping_Zones::get_zones( 'json' ),
 				'default_zone'            => array(
 					'zone_id'    => 0,
@@ -336,7 +341,9 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 	protected function output_shipping_class_screen() {
 		$wc_shipping = WC_Shipping::instance();
 		wp_localize_script(
-			'wc-shipping-classes', 'shippingClassesLocalizeScript', array(
+			'wc-shipping-classes',
+			'shippingClassesLocalizeScript',
+			array(
 				'classes'                   => $wc_shipping->get_shipping_classes(),
 				'default_shipping_class'    => array(
 					'term_id'     => 0,
@@ -354,7 +361,8 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 
 		// Extendable columns to show on the shipping classes screen.
 		$shipping_class_columns = apply_filters(
-			'woocommerce_shipping_classes_columns', array(
+			'woocommerce_shipping_classes_columns',
+			array(
 				'wc-shipping-class-name'        => __( 'Shipping class', 'woocommerce' ),
 				'wc-shipping-class-slug'        => __( 'Slug', 'woocommerce' ),
 				'wc-shipping-class-description' => __( 'Description', 'woocommerce' ),

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -229,10 +229,10 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 			wp_die( esc_html__( 'Zone does not exist!', 'woocommerce' ) );
 		}
 
-		$allowed_countries = WC()->countries->get_allowed_countries();
-		$wc_shipping       = WC_Shipping::instance();
-		$shipping_methods  = $wc_shipping->get_shipping_methods();
-		$continents        = WC()->countries->get_continents();
+		$allowed_countries    = WC()->countries->get_allowed_countries();
+		$wc_shipping          = WC_Shipping::instance();
+		$shipping_methods     = $wc_shipping->get_shipping_methods();
+		$shipping_continents  = WC()->countries->get_shipping_continents();
 
 		// Prepare locations.
 		$locations = array();

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -231,8 +231,6 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 		}
 
 		$allowed_countries    = WC()->countries->get_allowed_countries();
-		$wc_shipping          = WC_Shipping::instance();
-		$shipping_methods     = $wc_shipping->get_shipping_methods();
 		$shipping_continents  = WC()->countries->get_shipping_continents();
 
 		// Prepare locations.
@@ -275,9 +273,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 	 * Show zones
 	 */
 	protected function zones_screen() {
-		$allowed_countries = WC()->countries->get_allowed_countries();
-		$continents        = WC()->countries->get_continents();
-		$method_count      = wc_get_shipping_method_count();
+		$method_count = wc_get_shipping_method_count();
 
 		wp_localize_script(
 			'wc-shipping-zones',

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -230,7 +230,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 			wp_die( esc_html__( 'Zone does not exist!', 'woocommerce' ) );
 		}
 
-		$allowed_countries    = WC()->countries->get_allowed_countries();
+		$allowed_countries    = WC()->countries->get_shipping_countries();
 		$shipping_continents  = WC()->countries->get_shipping_continents();
 
 		// Prepare locations.

--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -41,7 +41,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<td class="forminp">
 					<select multiple="multiple" data-attribute="zone_locations" id="zone_locations" name="zone_locations" data-placeholder="<?php esc_html_e( 'Select regions within this zone', 'woocommerce' ); ?>" class="wc-shipping-zone-region-select chosen_select">
 						<?php
-						foreach ( $continents as $continent_code => $continent ) {
+						foreach ( $shipping_continents as $continent_code => $continent ) {
 							echo '<option value="continent:' . esc_attr( $continent_code ) . '"' . wc_selected( "continent:$continent_code", $locations ) . ' alt="">' . esc_html( $continent['name'] ) . '</option>';
 
 							$countries = array_intersect( array_keys( $allowed_countries ), $continent['countries'] );

--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -49,7 +49,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 							foreach ( $countries as $country_code ) {
 								echo '<option value="country:' . esc_attr( $country_code ) . '"' . wc_selected( "country:$country_code", $locations ) . ' alt="' . esc_attr( $continent['name'] ) . '">' . esc_html( '&nbsp;&nbsp; ' . $allowed_countries[ $country_code ] ) . '</option>';
 
-								if ( $states = WC()->countries->get_states( $country_code ) ) {
+								$states = WC()->countries->get_states( $country_code );
+
+								if ( $states ) {
 									foreach ( $states as $state_code => $state_name ) {
 										echo '<option value="state:' . esc_attr( $country_code . ':' . $state_code ) . '"' . wc_selected( "state:$country_code:$state_code", $locations ) . ' alt="' . esc_attr( $continent['name'] . ' ' . $allowed_countries[ $country_code ] ) . '">' . esc_html( '&nbsp;&nbsp;&nbsp;&nbsp; ' . $state_name ) . '</option>';
 									}
@@ -138,8 +140,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<header class="wc-backbone-modal-header">
 					<h1>
 						<?php
-						/* translators: %s: shipping method title */
 						printf(
+							/* translators: %s: shipping method title */
 							esc_html__( '%s Settings', 'woocommerce' ),
 							'{{{ data.method.method_title }}}'
 						);

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -74,7 +74,7 @@ class WC_Countries {
 	 * Get continent code for a country code.
 	 *
 	 * @since 2.6.0
-	 * @param string $cc Continent code.
+	 * @param string $cc Country code.
 	 * @return string
 	 */
 	public function get_continent_code_for_country( $cc ) {
@@ -252,7 +252,7 @@ class WC_Countries {
 	}
 
 	/**
-	 * Get the allowed countries for the store.
+	 * Get countries that the store sells to.
 	 *
 	 * @return array
 	 */
@@ -289,7 +289,7 @@ class WC_Countries {
 	}
 
 	/**
-	 * Get the countries you ship to.
+	 * Get countries that the store ships to.
 	 *
 	 * @return array
 	 */

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -91,6 +91,26 @@ class WC_Countries {
 	}
 
 	/**
+	 * Get continents that the store ships to.
+	 *
+	 * @return array
+	 */
+	public function get_shipping_continents() {
+		$continents             = $this->get_continents();
+		$shipping_countries     = $this->get_shipping_countries();
+		$shipping_country_codes = array_keys( $shipping_countries );
+		$shipping_continents    = array();
+
+		foreach ( $continents as $continent_code => $continent ) {
+			if ( count( array_intersect( $continent['countries'], $shipping_country_codes ) ) ) {
+				$shipping_continents[ $continent_code ] = $continent;
+			}
+		}
+
+		return $shipping_continents;
+	}
+
+	/**
 	 * Load the states.
 	 */
 	public function load_country_states() {

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -93,6 +93,7 @@ class WC_Countries {
 	/**
 	 * Get continents that the store ships to.
 	 *
+	 * @since 3.6.0
 	 * @return array
 	 */
 	public function get_shipping_continents() {

--- a/tests/unit-tests/countries/countries.php
+++ b/tests/unit-tests/countries/countries.php
@@ -18,6 +18,27 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test get_shipping_continents.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_shipping_continents() {
+		$countries = new WC_Countries();
+		$all_continents = $countries->get_continents();
+
+		update_option( 'woocommerce_ship_to_countries', 'all' );
+		$this->assertSame( $all_continents, $countries->get_shipping_continents() );
+
+		update_option( 'woocommerce_ship_to_countries', 'specific' );
+		update_option( 'woocommerce_specific_ship_to_countries', array( 'CA', 'JP' ) );
+		$expected = array(
+			'AS' => $all_continents['AS'],
+			'NA' => $all_continents['NA'],
+		);
+		$this->assertSame( $expected, $countries->get_shipping_continents() );
+	}
+
+	/**
 	 * Test get_allowed_countries.
 	 *
 	 * @since 3.1

--- a/tests/unit-tests/countries/countries.php
+++ b/tests/unit-tests/countries/countries.php
@@ -1,8 +1,12 @@
 <?php
+/**
+ * Unit tests for the WP_Countries class.
+ *
+ * @package WooCommerce\Tests\Countries
+ */
 
 /**
- * Class WC_Countries.
- * @package WooCommerce\Tests\Countries
+ * WC_Countries tests.
  */
 class WC_Tests_Countries extends WC_Unit_Test_Case {
 
@@ -12,7 +16,7 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_getters() {
-		$countries = new WC_Countries;
+		$countries = new WC_Countries();
 		$this->assertEquals( $countries->get_countries(), $countries->countries );
 		$this->assertEquals( $countries->get_states(), $countries->states );
 	}
@@ -44,11 +48,14 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_get_allowed_countries() {
-		$countries = new WC_Countries;
+		$countries = new WC_Countries();
 
 		update_option( 'woocommerce_allowed_countries', 'specific' );
 		update_option( 'woocommerce_specific_allowed_countries', array( 'RO', 'SI' ) );
-		$expected = array( 'RO' => 'Romania', 'SI' => 'Slovenia' );
+		$expected = array(
+			'RO' => 'Romania',
+			'SI' => 'Slovenia',
+		);
 		$this->assertEquals( $expected, $countries->get_allowed_countries() );
 
 		update_option( 'woocommerce_allowed_countries', 'all' );
@@ -67,7 +74,7 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_get_shipping_countries() {
-		$countries = new WC_Countries;
+		$countries = new WC_Countries();
 
 		update_option( 'woocommerce_ship_to_countries', '' );
 		$this->assertEquals( $countries->get_allowed_countries(), $countries->get_shipping_countries() );
@@ -81,7 +88,10 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 
 		update_option( 'woocommerce_ship_to_countries', 'specific' );
 		update_option( 'woocommerce_specific_ship_to_countries', array( 'RO', 'SI' ) );
-		$expected = array( 'RO' => 'Romania', 'SI' => 'Slovenia' );
+		$expected = array(
+			'RO' => 'Romania',
+			'SI' => 'Slovenia',
+		);
 		$this->assertEquals( $expected, $countries->get_shipping_countries() );
 	}
 
@@ -91,7 +101,7 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_get_allowed_country_states() {
-		$countries = new WC_Countries;
+		$countries = new WC_Countries();
 
 		update_option( 'woocommerce_allowed_countries', 'all' );
 		$this->assertEquals( $countries->get_states(), $countries->get_allowed_country_states() );
@@ -112,7 +122,7 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_get_shipping_country_states() {
-		$countries = new WC_Countries;
+		$countries = new WC_Countries();
 
 		update_option( 'woocommerce_ship_to_countries', '' );
 		$this->assertEquals( $countries->get_allowed_country_states(), $countries->get_shipping_country_states() );
@@ -136,7 +146,7 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_shipping_to_prefix() {
-		$countries = new WC_Countries;
+		$countries = new WC_Countries();
 
 		$this->assertEquals( 'to', $countries->shipping_to_prefix( 'RO' ) );
 		$this->assertEquals( 'to the', $countries->shipping_to_prefix( 'US' ) );
@@ -148,7 +158,7 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_estimated_for_prefix() {
-		$countries = new WC_Countries;
+		$countries = new WC_Countries();
 
 		$this->assertEquals( 'the ', $countries->estimated_for_prefix( 'GB' ) );
 		$this->assertEquals( '', $countries->estimated_for_prefix( 'RO' ) );
@@ -160,7 +170,7 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_tax_or_vat() {
-		$countries = new WC_Countries;
+		$countries = new WC_Countries();
 
 		update_option( 'woocommerce_default_country', 'CZ' );
 		$this->assertEquals( 'VAT', $countries->tax_or_vat() );
@@ -178,7 +188,7 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_get_country_locale() {
-		$countries = new WC_Countries;
+		$countries = new WC_Countries();
 		update_option( 'woocommerce_allowed_countries', 'specific' );
 		update_option( 'woocommerce_specific_allowed_countries', array( 'RO', 'SI' ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
This PR updates shipping zones to only show available shipping continents when selecting a shipping zone region.

I added one new method, `WC_Countries->get_shipping_continents()`. The shipping zone method screen now uses this instead of showing all continents in the 'Zone regions' input.

Closes #22130 

### How to test the changes in this Pull Request:

1. See #22130.
2. Check out this branch and notice that only continents with allowed shipping countries are shown in the 'Zone regions' field of a shipping zone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Only show available shipping continents when selecting shipping zone region