### PR TITLE
Make sure PHPUnit tests runs when using PHP 7.2+ in the Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,7 +44,7 @@ before_script:
     else
       echo "xdebug.ini does not exist"
     fi
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - export PATH="$HOME/.config/composer/vendor/bin:$PATH"
   - bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION
   - bash tests/bin/travis.sh before
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Due to a recent change in the Travis environment, WooCommerce unit tests stopped working with the following error (see for example https://travis-ci.org/woocommerce/woocommerce/jobs/463470674#L876) in the PHP 7.2 and 7.3 build jobs:

```
Fatal error: Class PHPUnit_Util_Test may not inherit from final class (PHPUnit\Util\Test) in /tmp/wordpress-tests-lib/includes/phpunit6-compat.php on line 18
```

This error is happening because Travis started ignoring the PHPUnit version that we install manually via Composer ([tests/bin/travis.sh#L6](https://github.com/woocommerce/woocommerce/blob/f7bc3fb85195df8f96c70d2846b0104ee224fef2/tests/bin/travis.sh#L6)) and started using the PHPUnit version that is shipped with each of its PHP docker images. This means that for the docker images running PHP 7.2 and 7.3, PHPUnit 7 is used, but the WordPress unit test framework is not compatible with PHPUnit 7 (see WordPress core ticket https://core.trac.wordpress.org/ticket/43218) and produces the error above. I believe that this is happening because Travis changed the directory where it installs composer global packages from `$HOME/.composer/` to `$HOME/.config/composer/` (https://github.com/travis-ci/travis-ci/issues/7289#issuecomment-427333966) and we add `$HOME/.composer/vendor/bin:$PATH` to the `$PATH`. So this commit simply updates the path in the line where we add it to the `$PATH`.

I tried to use `composer exec` instead of updating `$PATH`, but that didn't work for PHP 5.2.

### How to test the changes in this Pull Request:

1. Make sure all Travis build jobs pass
