### PR TITLE
Replaced deprecated edit_form_after_title  with edit_form_after_editor

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -132,7 +132,8 @@ class WC_Admin_Post_Types {
 			9  => sprintf(
 				/* translators: 1: date 2: product url */
 				__( 'Product scheduled for: %1$s. <a target="_blank" href="%2$s">Preview product</a>', 'woocommerce' ),
-				'<strong>' . date_i18n( __( 'M j, Y @ G:i', 'woocommerce' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post->ID ) ) . '</strong>'
+				'<strong>' . date_i18n( __( 'M j, Y @ G:i', 'woocommerce' ), strtotime( $post->post_date ) ),
+				esc_url( get_permalink( $post->ID ) ) . '</strong>'
 			),
 			/* translators: %s: product url */
 			10 => sprintf( __( 'Product draft updated. <a target="_blank" href="%s">Preview product</a>', 'woocommerce' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post->ID ) ) ) ),
@@ -240,7 +241,8 @@ class WC_Admin_Post_Types {
 		}
 
 		$shipping_class = get_terms(
-			'product_shipping_class', array(
+			'product_shipping_class',
+			array(
 				'hide_empty' => false,
 			)
 		);
@@ -260,7 +262,8 @@ class WC_Admin_Post_Types {
 		}
 
 		$shipping_class = get_terms(
-			'product_shipping_class', array(
+			'product_shipping_class',
+			array(
 				'hide_empty' => false,
 			)
 		);

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -46,7 +46,7 @@ class WC_Admin_Post_Types {
 		// Extra post data and screen elements.
 		add_action( 'edit_form_top', array( $this, 'edit_form_top' ) );
 		add_filter( 'enter_title_here', array( $this, 'enter_title_here' ), 1, 2 );
-		add_action( 'edit_form_after_title', array( $this, 'edit_form_after_title' ) );
+		add_action( 'edit_form_after_editor', array( $this, 'edit_form_after_title' ) );
 		add_filter( 'default_hidden_meta_boxes', array( $this, 'hidden_meta_boxes' ), 10, 2 );
 		add_action( 'post_submitbox_misc_actions', array( $this, 'product_data_visibility' ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

For coupons we use `edit_form_after_title` to display the coupon's description field, but this started to throw warnings when trying to edit any post/page with blocks editor, see;

> PHP Notice:  edit_form_after_title is <strong>deprecated</strong> since version 5.0.0! Use block_editor_meta_box_hidden_fields instead. Thisaction is still supported in the classic editor, but is deprecated in the block editor. in wp-includes/functions.php on line 4112

Note that `block_editor_meta_box_hidden_fields` is not an option for us here, since we don't use block editor on coupons, still we hook there and check for coupons:

https://github.com/woocommerce/woocommerce/blob/8b7ccf84ecdeee83e7701b2841171aa60a11bb15/includes/admin/class-wc-admin-post-types.php#L695-L706

Still since we are hooking into it very early, we are getting this deprecated message, so I replaced with `edit_form_after_editor` that make it work like before and without any deprecated warning.

There's also another deprecated notice in my logs, but comes from WordPress, already tested it with all plugins deactivated, this is the warning:

> PHP Notice:  edit_form_advanced is <strong>deprecated</strong> since version 5.0.0! Use block_editor_meta_box_hidden_fields instead. This action is still supported in the classic editor, but is deprecated in the block editor. in wp-includes/functions.php on line 4112

### How to test the changes in this Pull Request:

1. Enable WP debug mode
2. Try edit/create a post/page with blocks editor and WP 5 RC3
3. See the PHP notices
4. Apply this patch and try edit/create again with blocks editor
5. No more notices about `edit_form_after_title`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Changed deprecated `edit_form_after_title` to `edit_form_after_editor`.
