### PR TITLE
Line 27 - replacing a typo in the comment

### DIFF
--- a/templates/emails/admin-cancelled-order.php
+++ b/templates/emails/admin-cancelled-order.php
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 */
 do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 
-<?php /* translators: %1$s: Customer full name. %2$s: Order numer */ ?>
+<?php /* translators: %1$s: Customer full name. %2$s: Order number */ ?>
 <p><?php printf( esc_html__( 'Alas. Just to let you know &mdash; %1$s has cancelled order #%2$s:', 'woocommerce' ), esc_html( $order->get_formatted_billing_full_name() ), esc_html( $order->get_order_number() ) ); ?></p>
 
 <?php


### PR DESCRIPTION
Line 27 - there's currently a typo, `numer`, changing that to `number`

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Line 27 - there's currently a typo, `numer`, changing that to `number`


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Line 27 - there's currently a typo, `numer`, changing that to `number`