### PR TITLE
Lib Action Scheduler PHP 5.2 Compatible

### DIFF
--- a/includes/libraries/action-scheduler/classes/ActionScheduler_Logger.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_Logger.php
@@ -73,7 +73,7 @@ abstract class ActionScheduler_Logger {
 		$this->log( $action_id, __( 'action complete', 'action-scheduler' ) );
 	}
 
-	public function log_failed_action( $action_id, \Exception $exception ) {
+	public function log_failed_action( $action_id, Exception $exception ) {
 		$this->log( $action_id, sprintf( __( 'action failed: %s', 'action-scheduler' ), $exception->getMessage() ) );
 	}
 

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore.php
@@ -685,7 +685,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$status = $this->get_post_column( $action_id, 'post_status' );
 
 		if ( $status === null ) {
-			throw new \InvalidArgumentException( __( 'Invalid action ID. No status found.', 'action-scheduler' ) );
+			throw new InvalidArgumentException( __( 'Invalid action ID. No status found.', 'action-scheduler' ) );
 		}
 
 		return $this->get_action_status_by_post_status( $status );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes a PHP 5.2 Incompatibility due to `\` on some Exceptions classes

### How to test the changes in this Pull Request:

1. Active the plugin on Any PHP 5.2 WP
2. You shouldn't be able to see: `Warning: Unexpected character in input: '\' (ASCII=92)`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

> Avoids Warnings on Library Action Scheduler for PHP 5.2
