### PR TITLE
Add new pre query filter to WC_Product_Data_Store_CPT::search_products()

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1392,6 +1392,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	public function search_products( $term, $type = '', $include_variations = false, $all_statuses = false, $limit = null ) {
 		global $wpdb;
 
+		$custom_results = apply_filters( 'woocommerce_product_pre_search_products', false, $term, $type, $include_variations, $all_statuses, $limit );
+
+		if ( is_array( $custom_results ) ) {
+			return $custom_results;
+		}
+
 		$post_types    = $include_variations ? array( 'product', 'product_variation' ) : array( 'product' );
 		$post_statuses = current_user_can( 'edit_private_products' ) ? array( 'private', 'publish' ) : array( 'publish' );
 		$type_join     = '';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a filter to WC_Product_Data_Store_CPT::search_products() to let third-party code define custom ways to search for products. This is similar to an another pre query filter that was added to WC_Customer_Data_Store::search_customers() in PR #16631.

Closes #22089

### How to test the changes in this Pull Request:

1. Test that searching for products in the admin still works
2. Test that it is possible to use the new filter to run a custom query and return products

### Changelog entry

> Add new pre query filter to WC_Product_Data_Store_CPT::search_products()
