### PR TITLE
[REST API] Fixed orderby slug

### DIFF
--- a/includes/abstracts/abstract-wc-rest-posts-controller.php
+++ b/includes/abstracts/abstract-wc-rest-posts-controller.php
@@ -530,6 +530,8 @@ abstract class WC_REST_Posts_Controller extends WC_REST_Controller {
 			$query_args['orderby'] = 'post__in';
 		} elseif ( 'id' === $query_args['orderby'] ) {
 			$query_args['orderby'] = 'ID'; // ID must be capitalized.
+		} elseif ( 'slug' === $query_args['orderby'] ) {
+			$query_args['orderby'] = 'name';
 		}
 
 		return $query_args;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This allow order results by slugs on REST API.

### How to test the changes in this Pull Request:

1. Try query products sorting by slug
2. Apply this patch
3. Check try sort again by slug

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - REST API - Fixed support to order results by slugs.