### PR TITLE
Restore empty schema support for register_rest_field

### DIFF
--- a/includes/abstracts/abstract-wc-rest-controller.php
+++ b/includes/abstracts/abstract-wc-rest-controller.php
@@ -203,10 +203,12 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 				}
 
 				$_item = new WP_REST_Request( 'DELETE' );
-				$_item->set_query_params( array(
-					'id'    => $id,
-					'force' => true,
-				) );
+				$_item->set_query_params(
+					array(
+						'id'    => $id,
+						'force' => true,
+					)
+				);
 				$_response = $this->delete_item( $_item );
 
 				if ( is_wp_error( $_response ) ) {
@@ -350,7 +352,8 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	 */
 	public function validate_setting_textarea_field( $value, $setting ) {
 		$value = is_null( $value ) ? '' : $value;
-		return wp_kses( trim( stripslashes( $value ) ),
+		return wp_kses(
+			trim( stripslashes( $value ) ),
 			array_merge(
 				array(
 					'iframe' => array(

--- a/includes/abstracts/abstract-wc-rest-controller.php
+++ b/includes/abstracts/abstract-wc-rest-controller.php
@@ -436,6 +436,16 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	public function get_fields_for_response( $request ) {
 		$schema = $this->get_item_schema();
 		$fields = isset( $schema['properties'] ) ? array_keys( $schema['properties'] ) : array();
+
+		$additional_fields = $this->get_additional_fields();
+		foreach ( $additional_fields as $field_name => $field_options ) {
+			// For back-compat, include any field with an empty schema
+			// because it won't be present in $this->get_item_schema().
+			if ( is_null( $field_options['schema'] ) ) {
+				$fields[] = $field_name;
+			}
+		}
+
 		if ( ! isset( $request['_fields'] ) ) {
 			return $fields;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Since WP 5.0 a change was made to empty schemas, there was a backward compatible change added to support adding empty schemas but since WC overrides the WP_REST_controller class this changes was not carried over to WooCommerce. This PR updates the overridden method to include the backward compatible code from WP core.

Closes #22201 

### How to test the changes in this Pull Request:

1. See #22201 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Allow empty schema again when registering a custom field for the API.