### PR TITLE
Add text/plain mime type to csv importer

### DIFF
--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -114,6 +114,7 @@ class WC_Product_CSV_Importer_Controller {
 			'woocommerce_csv_product_import_valid_filetypes',
 			array(
 				'csv' => 'text/csv',
+				'csv' => 'text/plain',
 				'txt' => 'text/plain',
 			)
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Since WP 5.0.1 there is now strict mime type checking, however csv files have in most cases text/plain mime types and not text/csv. This PR adds text/plain as an acceptable mime type for csv imports.

This is a workaround for the WP 5.0.1 bug. See https://core.trac.wordpress.org/ticket/45615

Closes #22208 

### How to test the changes in this Pull Request:
1. Try uploading the sample product file, it should work without issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Allow text/plain mime type for CSV uploads.