### PR TITLE
add out of stock criteria to tax_query array instead of replacing it

### DIFF
--- a/includes/widgets/class-wc-widget-products.php
+++ b/includes/widgets/class-wc-widget-products.php
@@ -83,8 +83,9 @@ class WC_Widget_Products extends WC_Widget {
 	/**
 	 * Query the products and return them.
 	 *
-	 * @param  array $args     Arguments.
-	 * @param  array $instance Widget instance.
+	 * @param array $args     Arguments.
+	 * @param array $instance Widget instance.
+	 *
 	 * @return WP_Query
 	 */
 	public function get_products( $args, $instance ) {
@@ -173,10 +174,10 @@ class WC_Widget_Products extends WC_Widget {
 	/**
 	 * Output widget.
 	 *
-	 * @see WP_Widget
-	 *
 	 * @param array $args     Arguments.
 	 * @param array $instance Widget instance.
+	 *
+	 * @see WP_Widget
 	 */
 	public function widget( $args, $instance ) {
 		if ( $this->get_cached_widget( $args ) ) {

--- a/includes/widgets/class-wc-widget-products.php
+++ b/includes/widgets/class-wc-widget-products.php
@@ -127,7 +127,7 @@ class WC_Widget_Products extends WC_Widget {
 		}
 
 		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
-			$query_args['tax_query'] = array(
+			$query_args['tax_query'][] = array(
 				array(
 					'taxonomy' => 'product_visibility',
 					'field'    => 'term_taxonomy_id',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add the taxonomy query for hide out of stock items instead eliminating the tax query parameter from the query.

Closes #22129  .

### How to test the changes in this Pull Request:

1. Edit a product and set visibility to hidden & give the product a sale price.
2. Add the product widget to a sidebar & choose on sale products with show hidden products unchecked.
3. The product should not show in the widget.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix Product widget showing hidden products when hide out of stock was enabled.
