### PR TITLE
Change get_name() return type from int to string

### DIFF
--- a/includes/class-wc-product-attribute.php
+++ b/includes/class-wc-product-attribute.php
@@ -211,7 +211,7 @@ class WC_Product_Attribute implements ArrayAccess {
 	/**
 	 * Get name.
 	 *
-	 * @return int
+	 * @return string
 	 */
 	public function get_name() {
 		return $this->data['name'];


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Change return type of get_name() method of WC_product_attribute class from int to string.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### Changelog entry

> Change return type of get_name() method of WC_product_attribute class from int to string.
