### PR TITLE
Added new filter "woocommerce_get_min_max_price_meta_query"

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -808,12 +808,12 @@ function wc_get_min_max_price_meta_query( $args ) {
 		$max = $class_max;
 	}
 
-	return array(
+	return apply_filters( 'woocommerce_get_min_max_price_meta_query', array(
 		'key'     => '_price',
 		'value'   => array( $min, $max ),
 		'compare' => 'BETWEEN',
 		'type'    => 'DECIMAL(10,' . wc_get_price_decimals() . ')',
-	);
+	), $args );
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Added new filter `woocommerce_get_min_max_price_meta_query`, to allow 3rd parties to filter the "price filter" meta query before it's used to fetch the products.

Closes #22254 .

### How to test the changes in this Pull Request:

The new filter doesn't affect the original logic. To verify that the filter is called, the following snippet can be used.
~~~
add_filter( 'woocommerce_get_min_max_price_meta_query', function($meta_query, $args) {
  return $meta_query;
}, 10, 2 );
~~~

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x ] Have you successfully ran tests with your changes locally?

### Changelog entry

> Tweak - Added new filter `woocommerce_get_min_max_price_meta_query`.
