### PR TITLE
Add $orderby and $order params to filter woocommerce_get_catalog_ordering_args

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -502,7 +502,7 @@ class WC_Query {
 				break;
 		}
 
-		return apply_filters( 'woocommerce_get_catalog_ordering_args', $args );
+		return apply_filters( 'woocommerce_get_catalog_ordering_args', $args, $orderby, $order );
 	}
 
 	/**


### PR DESCRIPTION
Filter woocommerce_get_catalog_ordering_args  has only one single argument $args, anyone filter this needs to detect the $orderby and $order value again which is already coded in the method where this filter returns. I hope adding two extra param $orderby and $order will make developer's life easier to hook this filter.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Method get_catalog_ordering_args  in class-wc-query.php , the two variables $orderby and $order already calculated and in the method return filter hook "woocommerce_get_catalog_ordering_args" only have one params $args which I think is not enough or should have more two params $orderby and $order

### How to test the changes in this Pull Request:

1. Nothing specific


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add $orderby and $order params to filter woocommerce_get_catalog_ordering_args
