### PR TITLE
Added order object to the preview modal hooks

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -349,7 +349,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 							</button>
 						</header>
 						<article>
-							<?php do_action( 'woocommerce_admin_order_preview_start' ); ?>
+							<?php do_action( 'woocommerce_admin_order_preview_start', $this->object ); ?>
 
 							<div class="wc-order-preview-addresses">
 								<div class="wc-order-preview-address">
@@ -397,7 +397,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 
 							{{{ data.item_html }}}
 
-							<?php do_action( 'woocommerce_admin_order_preview_end' ); ?>
+							<?php do_action( 'woocommerce_admin_order_preview_end', $this->object ); ?>
 						</article>
 						<footer>
 							<div class="inner">


### PR DESCRIPTION
The hooks ( 'woocommerce_admin_order_preview_start' and 'woocommerce_admin_order_preview_end' )
are useless whitout the order information ($this->object);

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
