### PR TITLE
fix: attribute name is not save properly in database with this Ελληνικά language.

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -753,6 +753,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 						$value = wc_implode_text_attributes( $attribute->get_options() );
 					}
 
+					// Encode attribute key name.
+					$attribute_key = urldecode($attribute_key);
+					
 					// Store in format WC uses in meta.
 					$meta_values[ $attribute_key ] = array(
 						'name'         => $attribute->get_name(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Currently, the attribute name `pa_περιοχή` doesn't save properly with `Ελληνικά language` but this PR will resolve this bug.

Closes #22263 .

### How to test the changes in this Pull Request:

1. Go to Settings -> Site Language -> Ελληνικά and Save it
2. Go to Attributes -> Add new attribute -> Περιοχή (This is attribute's name)
3. Go to Products -> Edit Product OR Add Product -> Product data -> Attributes -> Add this attribute "Περιοχή" and select Attribute value and save it

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

fix: attribute name is not save properly in database with this Ελληνικά language.
