### PR TITLE
Use WP latest instead of 5.0-beta3 to run the PHP 7.3 Travis build job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ php:
   - 7.0
   - 7.1
   - 7.2
+  - 7.3
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
@@ -36,8 +37,6 @@ matrix:
   - name: "Unit tests code coverage"
     php: 7.1
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
-  - php: 7.3
-    env: WP_VERSION=5.0-beta5 WP_MULTISITE=0
   allow_failures:
   - php: 7.1
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Now that WP 5.0 has been released, we don't need to use 5.0-beta3 anymore to run the PHP 7.3 Travis build job.

### How to test the changes in this Pull Request:

1. Make sure the Travis builds succeed.