### PR TITLE
Fix orders list in the admin

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -802,7 +802,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		}
 
 		// Status.
-		if ( ! isset( $query_vars['post_status'] ) ) {
+		if ( empty( $query_vars['post_status'] ) ) {
 			$post_statuses = wc_get_order_statuses();
 
 			foreach ( $post_statuses as $status => $value ) {

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -422,7 +422,8 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	 */
 	public static function get_order_preview_item_html( $order ) {
 		$hidden_order_itemmeta = apply_filters(
-			'woocommerce_hidden_order_itemmeta', array(
+			'woocommerce_hidden_order_itemmeta',
+			array(
 				'_qty',
 				'_tax_class',
 				'_product_id',
@@ -439,12 +440,14 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 
 		$line_items = apply_filters( 'woocommerce_admin_order_preview_line_items', $order->get_items(), $order );
 		$columns    = apply_filters(
-			'woocommerce_admin_order_preview_line_item_columns', array(
+			'woocommerce_admin_order_preview_line_item_columns',
+			array(
 				'product'  => __( 'Product', 'woocommerce' ),
 				'quantity' => __( 'Quantity', 'woocommerce' ),
 				'tax'      => __( 'Tax', 'woocommerce' ),
 				'total'    => __( 'Total', 'woocommerce' ),
-			), $order
+			),
+			$order
 		);
 
 		if ( ! wc_tax_enabled() ) {
@@ -602,11 +605,12 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		$shipping_address = $order->get_formatted_shipping_address();
 
 		return apply_filters(
-			'woocommerce_admin_order_preview_get_order_details', array(
+			'woocommerce_admin_order_preview_get_order_details',
+			array(
 				'data'                       => $order->get_data(),
 				'order_number'               => $order->get_order_number(),
-				'item_html'                  => WC_Admin_List_Table_Orders::get_order_preview_item_html( $order ),
-				'actions_html'               => WC_Admin_List_Table_Orders::get_order_preview_actions_html( $order ),
+				'item_html'                  => self::get_order_preview_item_html( $order ),
+				'actions_html'               => self::get_order_preview_actions_html( $order ),
 				'ship_to_billing'            => wc_ship_to_billing_address_only(),
 				'needs_shipping'             => $order->needs_shipping_address(),
 				'formatted_billing_address'  => $billing_address ? $billing_address : __( 'N/A', 'woocommerce' ),
@@ -616,7 +620,8 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 				'shipping_via'               => $order->get_shipping_method(),
 				'status'                     => $order->get_status(),
 				'status_name'                => wc_get_order_status_name( $order->get_status() ),
-			), $order
+			),
+			$order
 		);
 	}
 
@@ -669,7 +674,8 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 					'bulk_action' => $report_action,
 					'changed'     => $changed,
 					'ids'         => join( ',', $ids ),
-				), $redirect_to
+				),
+				$redirect_to
 			);
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

WP 5.0.2, which was released yesterday, sets `$query_vars['post_status']` to an empty string instead of leaving it unset (https://core.trac.wordpress.org/ticket/45719 and https://core.trac.wordpress.org/changeset/44185). This change broke the WC orders list in the admin when listing orders of all post statuses as we were checking if `$query_vars['post_status']` was not set to add all order statuses to this variable ([includes/admin/list-tables/class-wc-admin-list-table-orders.php#L799](https://github.com/woocommerce/woocommerce/blob/125eaaf241aabc9d8c1bd77503c3e04da6082419/includes/admin/list-tables/class-wc-admin-list-table-orders.php#L799)).

To workaround this problem, this commit introduces a change that verifies if `$query_vars['post_status']` is empty instead of verifying if it is not set.

This PR also includes a separate commit to fix PHPCS violations in the modified file. I won't cherry-pick this commit when preparing the WC 3.5.3 release.

Closes #22271.

### How to test the changes in this Pull Request:

1. Confirm that this change restores the orders list in the admin (see #22271 for a description of the problem) when running WP 5.0.2
2. Confirm that the orders list in the admin still works when running WP <= 5.0.1

### Changelog entry

> Fix orders list in the admin after a change introduced in WordPress 5.0.2
