### PR TITLE
Add a filter, woocommerce_current_user_can_edit_customer_meta_fields

### DIFF
--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -154,7 +154,7 @@ if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
 		 * @param WP_User $user
 		 */
 		public function add_customer_meta_fields( $user ) {
-			if ( ! current_user_can( 'manage_woocommerce' ) && ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', false, $user ) ) {
+			if ( ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), $user ) ) {
 				return;
 			}
 

--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -154,7 +154,7 @@ if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
 		 * @param WP_User $user
 		 */
 		public function add_customer_meta_fields( $user ) {
-			if ( ! current_user_can( 'manage_woocommerce' ) ) {
+			if ( ! current_user_can( 'manage_woocommerce' ) && ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', false, $user ) ) {
 				return;
 			}
 

--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -154,7 +154,7 @@ if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
 		 * @param WP_User $user
 		 */
 		public function add_customer_meta_fields( $user ) {
-			if ( ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), $user ) ) {
+			if ( ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), $user->ID ) ) {
 				return;
 			}
 
@@ -202,7 +202,7 @@ if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
 		 * @param int $user_id User ID of the user being saved
 		 */
 		public function save_customer_meta_fields( $user_id ) {
-			if ( ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), get_userdata( $user ) ) ) {
+			if ( ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), $user_id ) ) {
 				return;
 			}
 

--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -202,6 +202,10 @@ if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
 		 * @param int $user_id User ID of the user being saved
 		 */
 		public function save_customer_meta_fields( $user_id ) {
+			if ( ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), get_userdata( $user ) ) ) {
+				return;
+			}
+
 			$save_fields = $this->get_customer_meta_fields();
 
 			foreach ( $save_fields as $fieldset ) {


### PR DESCRIPTION
… to bypass manage_woocommerce when editing customer meta fields

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

Closes #22276

### How to test the changes in this Pull Request:

1. Create a user with edit_users permission, but not manage_woocommerce
2. Add a filter, like below:

```
class My_Plugin_WooCommerce {

    public function __construct() {
        add_filter( 'woocommerce_current_user_can_edit_customer_meta_fields', array( $this, 'shop_managers_can_edit_customer_meta_fields' ), 10, 2 );
    }

    function shop_managers_can_edit_customer_meta_fields( $current_user_can, $customer ) {

        if ( current_user_can('edit_users') ) {
            $current_user_can = true;
        }

        return $current_user_can;
    }
}
```

3. The new user should be able to view and modify customer meta.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add a filter, woocommerce_current_user_can_edit_customer_meta_fields, to bypass manage_woocommerce when editing customer meta fields
