### PR TITLE
Add new integration hook to get_cart_from_session method

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -30,6 +30,7 @@ final class WC_Cart_Session {
 	 *
 	 * @since 3.2.0
 	 * @throws Exception If missing WC_Cart object.
+	 *
 	 * @param WC_Cart $cart Cart object to calculate totals for.
 	 */
 	public function __construct( &$cart ) {
@@ -71,8 +72,8 @@ final class WC_Cart_Session {
 		$update_cart_session = false; // Flag to indicate the stored cart should be updated.
 		$order_again         = false; // Flag to indicate whether this is a re-order.
 
-		$cart                = WC()->session->get( 'cart', null );
-		$merge_saved_cart    = (bool) get_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login', true );
+		$cart             = WC()->session->get( 'cart', null );
+		$merge_saved_cart = (bool) get_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login', true );
 
 		// Merge saved cart with current cart.
 		if ( is_null( $cart ) || $merge_saved_cart ) {
@@ -106,35 +107,36 @@ final class WC_Cart_Session {
 
 			if ( ! empty( $product ) && $product->exists() && $values['quantity'] > 0 ) {
 
-				if(apply_filter('woocommerce_pre_remove_cart_item_from_session', false, $key, $values)) {
+				if ( apply_filter( 'woocommerce_pre_remove_cart_item_from_session', false, $key, $values ) ) {
 					$update_cart_session = true;
-					do_action('woocommerce_remove_cart_item_from_session', $key, $values);
+					do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
 
 				} else {
-					if (!$product->is_purchasable()) {
+					if ( ! $product->is_purchasable() ) {
 						$update_cart_session = true;
 						/* translators: %s: product name */
-						wc_add_notice(sprintf(__('%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce'), $product->get_name()), 'error');
-						do_action('woocommerce_remove_cart_item_from_session', $key, $values);
+						wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $product->get_name() ), 'error' );
+						do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
 
-					} elseif (!empty($values['data_hash']) && !hash_equals($values['data_hash'], wc_get_cart_item_data_hash($product))) { // phpcs:ignore PHPCompatibility.PHP.NewFunctions.hash_equalsFound
+					} elseif ( ! empty( $values['data_hash'] ) && ! hash_equals( $values['data_hash'], wc_get_cart_item_data_hash( $product ) ) ) { // phpcs:ignore PHPCompatibility.PHP.NewFunctions.hash_equalsFound
 						$update_cart_session = true;
 						/* translators: %1$s: product name. %2$s product permalink */
-						wc_add_notice(sprintf(__('%1$s has been removed from your cart because it has since been modified. You can add it back to your cart <a href="%2$s">here</a>.', 'woocommerce'), $product->get_name(), $product->get_permalink()), 'notice');
-						do_action('woocommerce_remove_cart_item_from_session', $key, $values);
+						wc_add_notice( sprintf( __( '%1$s has been removed from your cart because it has since been modified. You can add it back to your cart <a href="%2$s">here</a>.', 'woocommerce' ), $product->get_name(), $product->get_permalink() ), 'notice' );
+						do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
 
 					} else {
 						// Put session data into array. Run through filter so other plugins can load their own session data.
 						$session_data = array_merge(
-							$values, array(
+							$values,
+							array(
 								'data' => $product,
 							)
 						);
 
-						$cart_contents[$key] = apply_filters('woocommerce_get_cart_item_from_session', $session_data, $values, $key);
+						$cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', $session_data, $values, $key );
 
 						// Add to cart right away so the product is visible in woocommerce_get_cart_item_from_session hook.
-						$this->cart->set_cart_contents($cart_contents);
+						$this->cart->set_cart_contents( $cart_contents );
 					}
 				}
 			}
@@ -281,8 +283,10 @@ final class WC_Cart_Session {
 	 * Get a cart from an order, if user has permission.
 	 *
 	 * @since  3.5.0
-	 * @param int   $order_id Order ID to try to load.
+	 *
+	 * @param int $order_id Order ID to try to load.
 	 * @param array $cart Current cart array.
+	 *
 	 * @return array
 	 */
 	private function populate_cart_from_order( $order_id, $cart ) {
@@ -334,16 +338,16 @@ final class WC_Cart_Session {
 			$product_data     = wc_get_product( $variation_id ? $variation_id : $product_id );
 			$cart[ $cart_id ] = apply_filters(
 				'woocommerce_add_order_again_cart_item', array_merge(
-					$cart_item_data, array(
-						'key'          => $cart_id,
-						'product_id'   => $product_id,
-						'variation_id' => $variation_id,
-						'variation'    => $variations,
-						'quantity'     => $quantity,
-						'data'         => $product_data,
-						'data_hash'    => wc_get_cart_item_data_hash( $product_data ),
-					)
-				), $cart_id
+				$cart_item_data, array(
+					'key'          => $cart_id,
+					'product_id'   => $product_id,
+					'variation_id' => $variation_id,
+					'variation'    => $variations,
+					'quantity'     => $quantity,
+					'data'         => $product_data,
+					'data_hash'    => wc_get_cart_item_data_hash( $product_data ),
+				)
+			), $cart_id
 			);
 		}
 
@@ -356,7 +360,7 @@ final class WC_Cart_Session {
 		if ( $num_items_in_original_order > $num_items_added ) {
 			wc_add_notice(
 				sprintf(
-					/* translators: %d item count */
+				/* translators: %d item count */
 					_n(
 						'%d item from your previous order is currently unavailable and could not be added to your cart.',
 						'%d items from your previous order are currently unavailable and could not be added to your cart.',

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -106,30 +106,36 @@ final class WC_Cart_Session {
 
 			if ( ! empty( $product ) && $product->exists() && $values['quantity'] > 0 ) {
 
-				if ( ! $product->is_purchasable() ) {
+				if(apply_filter('woocommerce_pre_remove_cart_item_from_session', false, $key, $values)) {
 					$update_cart_session = true;
-					/* translators: %s: product name */
-					wc_add_notice( sprintf( __( '%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce' ), $product->get_name() ), 'error' );
-					do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
-
-				} elseif ( ! empty( $values['data_hash'] ) && ! hash_equals( $values['data_hash'], wc_get_cart_item_data_hash( $product ) ) ) { // phpcs:ignore PHPCompatibility.PHP.NewFunctions.hash_equalsFound
-					$update_cart_session = true;
-					/* translators: %1$s: product name. %2$s product permalink */
-					wc_add_notice( sprintf( __( '%1$s has been removed from your cart because it has since been modified. You can add it back to your cart <a href="%2$s">here</a>.', 'woocommerce' ), $product->get_name(), $product->get_permalink() ), 'notice' );
-					do_action( 'woocommerce_remove_cart_item_from_session', $key, $values );
+					do_action('woocommerce_remove_cart_item_from_session', $key, $values);
 
 				} else {
-					// Put session data into array. Run through filter so other plugins can load their own session data.
-					$session_data = array_merge(
-						$values, array(
-							'data' => $product,
-						)
-					);
+					if (!$product->is_purchasable()) {
+						$update_cart_session = true;
+						/* translators: %s: product name */
+						wc_add_notice(sprintf(__('%s has been removed from your cart because it can no longer be purchased. Please contact us if you need assistance.', 'woocommerce'), $product->get_name()), 'error');
+						do_action('woocommerce_remove_cart_item_from_session', $key, $values);
 
-					$cart_contents[ $key ] = apply_filters( 'woocommerce_get_cart_item_from_session', $session_data, $values, $key );
+					} elseif (!empty($values['data_hash']) && !hash_equals($values['data_hash'], wc_get_cart_item_data_hash($product))) { // phpcs:ignore PHPCompatibility.PHP.NewFunctions.hash_equalsFound
+						$update_cart_session = true;
+						/* translators: %1$s: product name. %2$s product permalink */
+						wc_add_notice(sprintf(__('%1$s has been removed from your cart because it has since been modified. You can add it back to your cart <a href="%2$s">here</a>.', 'woocommerce'), $product->get_name(), $product->get_permalink()), 'notice');
+						do_action('woocommerce_remove_cart_item_from_session', $key, $values);
 
-					// Add to cart right away so the product is visible in woocommerce_get_cart_item_from_session hook.
-					$this->cart->set_cart_contents( $cart_contents );
+					} else {
+						// Put session data into array. Run through filter so other plugins can load their own session data.
+						$session_data = array_merge(
+							$values, array(
+								'data' => $product,
+							)
+						);
+
+						$cart_contents[$key] = apply_filters('woocommerce_get_cart_item_from_session', $session_data, $values, $key);
+
+						// Add to cart right away so the product is visible in woocommerce_get_cart_item_from_session hook.
+						$this->cart->set_cart_contents($cart_contents);
+					}
 				}
 			}
 		}


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Add a new integration hook to allow removal of cart items when the cart is loaded from the session without triggering preset notices.

Current behaviour is preserved by default.

Closes #22289  .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add a new integration hook to allow removal of cart items when the cart is loaded from the session without triggering preset notices.
