### PR TITLE
fix-22267

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -379,7 +379,7 @@ class WC_Discounts {
 				}
 			}
 
-			$discount       = wc_round_discount( min( $discounted_price, $discount ), 0 );
+			$discount       = wc_round_discount( max( $discounted_price, $discount ), 0 );
 			$cart_total     = $cart_total + $price_to_discount;
 			$total_discount = $total_discount + $discount;
 			$applied_count  = $applied_count + $apply_quantity;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->
<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> "100% coupon on product with a price with three decimal places doesn't discount full amount" Issue Solved and now "100% coupon on product with a price with three decimal places discounts perfectly full amount".
