### PR TITLE
convert newlines to/from \n on export/import

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -2,8 +2,8 @@
 /**
  * Handles product CSV export.
  *
- * @package  WooCommerce/Export
- * @version  3.1.0
+ * @package WooCommerce/Export
+ * @version 3.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -61,8 +61,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Should meta be exported?
 	 *
-	 * @since 3.1.0
 	 * @param bool $enable_meta_export Should meta be exported.
+	 *
+	 * @since 3.1.0
 	 */
 	public function enable_meta_export( $enable_meta_export ) {
 		$this->enable_meta_export = (bool) $enable_meta_export;
@@ -71,8 +72,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Product types to export.
 	 *
-	 * @since 3.1.0
 	 * @param array $product_types_to_export List of types to export.
+	 *
+	 * @since 3.1.0
 	 */
 	public function set_product_types_to_export( $product_types_to_export ) {
 		$this->product_types_to_export = array_map( 'wc_clean', $product_types_to_export );
@@ -81,8 +83,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Product category to export
 	 *
-	 * @since 3.5.0
 	 * @param string $product_category_to_export Product category slug to export, empty string exports all.
+	 *
+	 * @since  3.5.0
 	 * @return void
 	 */
 	public function set_product_category_to_export( $product_category_to_export ) {
@@ -92,7 +95,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Return an array of columns to export.
 	 *
-	 * @since 3.1.0
+	 * @since  3.1.0
 	 * @return array
 	 */
 	public function get_default_column_names() {
@@ -204,6 +207,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 * Take a product and generate row data from it for export.
 	 *
 	 * @param WC_Product $product WC_Product object.
+	 *
 	 * @return array
 	 */
 	protected function generate_row_data( $product ) {
@@ -243,8 +247,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get published value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return int
 	 */
 	protected function get_column_value_published( $product ) {
@@ -263,6 +268,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 * Get formatted sale price.
 	 *
 	 * @param WC_Product $product Product being exported.
+	 *
 	 * @return string
 	 */
 	protected function get_column_value_sale_price( $product ) {
@@ -273,6 +279,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 * Get formatted regular price.
 	 *
 	 * @param WC_Product $product Product being exported.
+	 *
 	 * @return string
 	 */
 	protected function get_column_value_regular_price( $product ) {
@@ -282,8 +289,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get product_cat value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_category_ids( $product ) {
@@ -294,8 +302,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get product_tag value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_tag_ids( $product ) {
@@ -306,8 +315,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get product_shipping_class value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_shipping_class_id( $product ) {
@@ -318,8 +328,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get images value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_images( $product ) {
@@ -340,8 +351,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Prepare linked products for export.
 	 *
-	 * @since 3.1.0
 	 * @param int[] $linked_products Array of linked product ids.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function prepare_linked_products_for_export( $linked_products ) {
@@ -361,8 +373,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get cross_sell_ids value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_cross_sell_ids( $product ) {
@@ -372,8 +385,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get upsell_ids value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_upsell_ids( $product ) {
@@ -383,8 +397,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get parent_id value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_parent_id( $product ) {
@@ -402,8 +417,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get grouped_products value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_grouped_products( $product ) {
@@ -427,8 +443,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get download_limit value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_download_limit( $product ) {
@@ -438,8 +455,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get download_expiry value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_download_expiry( $product ) {
@@ -449,8 +467,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get stock value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_stock( $product ) {
@@ -469,8 +488,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get stock status value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_stock_status( $product ) {
@@ -486,8 +506,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get backorders.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_backorders( $product ) {
@@ -505,7 +526,8 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 * Get low stock amount value.
 	 *
 	 * @param WC_Product $product Product being exported.
-	 * @since 3.5.0
+	 *
+	 * @since  3.5.0
 	 * @return int|string Empty string if value not set
 	 */
 	protected function get_column_value_low_stock_amount( $product ) {
@@ -515,8 +537,9 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Get type value.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
+	 *
+	 * @since  3.1.0
 	 * @return string
 	 */
 	protected function get_column_value_type( $product ) {
@@ -537,9 +560,10 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Export downloads.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @param array      $row     Row being exported.
+	 *
+	 * @since 3.1.0
 	 */
 	protected function prepare_downloads_for_export( $product, &$row ) {
 		if ( $product->is_downloadable() && $this->is_column_exporting( 'downloads' ) ) {
@@ -563,9 +587,10 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Export attributes data.
 	 *
+	 * @param WC_Product $product Product being exported.
+	 * @param array      $row     Row being exported.
+	 *
 	 * @since 3.1.0
-	 * @param  WC_Product $product Product being exported.
-	 * @param  array      $row     Row being exported.
 	 */
 	protected function prepare_attributes_for_export( $product, &$row ) {
 		if ( $this->is_column_exporting( 'attributes' ) ) {
@@ -639,9 +664,10 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	/**
 	 * Export meta data.
 	 *
-	 * @since 3.1.0
 	 * @param WC_Product $product Product being exported.
 	 * @param array      $row Row data.
+	 *
+	 * @since 3.1.0
 	 */
 	protected function prepare_meta_for_export( $product, &$row ) {
 		if ( $this->enable_meta_export ) {

--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -235,6 +235,10 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 				$value = $product->{"get_{$column_id}"}( 'edit' );
 			}
 
+			if ( 'description' == $column_id || 'short_description' == $column_id ) {
+				$value = $this->filter_description_field( $value );
+			}
+
 			$row[ $column_id ] = $value;
 		}
 
@@ -557,6 +561,20 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		return $this->implode_values( $types );
 	}
 
+	/**
+	 * Filter description field for export.
+	 * Convert newlines to '\n'.
+	 *
+	 * @param string $description Product description text to filter.
+	 *
+	 * @since  3.5.4
+	 * @return string
+	 */
+	protected function filter_description_field( $description ) {
+		$description = str_replace( '\n', "\\\\n", $description );
+		$description = str_replace( "\n", '\n', $description );
+		return $description;
+	}
 	/**
 	 * Export downloads.
 	 *

--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -99,51 +99,54 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 * @return array
 	 */
 	public function get_default_column_names() {
-		return apply_filters( "woocommerce_product_export_{$this->export_type}_default_columns", array(
-			'id'                 => __( 'ID', 'woocommerce' ),
-			'type'               => __( 'Type', 'woocommerce' ),
-			'sku'                => __( 'SKU', 'woocommerce' ),
-			'name'               => __( 'Name', 'woocommerce' ),
-			'published'          => __( 'Published', 'woocommerce' ),
-			'featured'           => __( 'Is featured?', 'woocommerce' ),
-			'catalog_visibility' => __( 'Visibility in catalog', 'woocommerce' ),
-			'short_description'  => __( 'Short description', 'woocommerce' ),
-			'description'        => __( 'Description', 'woocommerce' ),
-			'date_on_sale_from'  => __( 'Date sale price starts', 'woocommerce' ),
-			'date_on_sale_to'    => __( 'Date sale price ends', 'woocommerce' ),
-			'tax_status'         => __( 'Tax status', 'woocommerce' ),
-			'tax_class'          => __( 'Tax class', 'woocommerce' ),
-			'stock_status'       => __( 'In stock?', 'woocommerce' ),
-			'stock'              => __( 'Stock', 'woocommerce' ),
-			'low_stock_amount'   => __( 'Low stock amount', 'woocommerce' ),
-			'backorders'         => __( 'Backorders allowed?', 'woocommerce' ),
-			'sold_individually'  => __( 'Sold individually?', 'woocommerce' ),
-			/* translators: %s: weight */
-			'weight'             => sprintf( __( 'Weight (%s)', 'woocommerce' ), get_option( 'woocommerce_weight_unit' ) ),
-			/* translators: %s: length */
-			'length'             => sprintf( __( 'Length (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
-			/* translators: %s: width */
-			'width'              => sprintf( __( 'Width (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
-			/* translators: %s: Height */
-			'height'             => sprintf( __( 'Height (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
-			'reviews_allowed'    => __( 'Allow customer reviews?', 'woocommerce' ),
-			'purchase_note'      => __( 'Purchase note', 'woocommerce' ),
-			'sale_price'         => __( 'Sale price', 'woocommerce' ),
-			'regular_price'      => __( 'Regular price', 'woocommerce' ),
-			'category_ids'       => __( 'Categories', 'woocommerce' ),
-			'tag_ids'            => __( 'Tags', 'woocommerce' ),
-			'shipping_class_id'  => __( 'Shipping class', 'woocommerce' ),
-			'images'             => __( 'Images', 'woocommerce' ),
-			'download_limit'     => __( 'Download limit', 'woocommerce' ),
-			'download_expiry'    => __( 'Download expiry days', 'woocommerce' ),
-			'parent_id'          => __( 'Parent', 'woocommerce' ),
-			'grouped_products'   => __( 'Grouped products', 'woocommerce' ),
-			'upsell_ids'         => __( 'Upsells', 'woocommerce' ),
-			'cross_sell_ids'     => __( 'Cross-sells', 'woocommerce' ),
-			'product_url'        => __( 'External URL', 'woocommerce' ),
-			'button_text'        => __( 'Button text', 'woocommerce' ),
-			'menu_order'         => __( 'Position', 'woocommerce' ),
-		) );
+		return apply_filters(
+			"woocommerce_product_export_{$this->export_type}_default_columns",
+			array(
+				'id'                 => __( 'ID', 'woocommerce' ),
+				'type'               => __( 'Type', 'woocommerce' ),
+				'sku'                => __( 'SKU', 'woocommerce' ),
+				'name'               => __( 'Name', 'woocommerce' ),
+				'published'          => __( 'Published', 'woocommerce' ),
+				'featured'           => __( 'Is featured?', 'woocommerce' ),
+				'catalog_visibility' => __( 'Visibility in catalog', 'woocommerce' ),
+				'short_description'  => __( 'Short description', 'woocommerce' ),
+				'description'        => __( 'Description', 'woocommerce' ),
+				'date_on_sale_from'  => __( 'Date sale price starts', 'woocommerce' ),
+				'date_on_sale_to'    => __( 'Date sale price ends', 'woocommerce' ),
+				'tax_status'         => __( 'Tax status', 'woocommerce' ),
+				'tax_class'          => __( 'Tax class', 'woocommerce' ),
+				'stock_status'       => __( 'In stock?', 'woocommerce' ),
+				'stock'              => __( 'Stock', 'woocommerce' ),
+				'low_stock_amount'   => __( 'Low stock amount', 'woocommerce' ),
+				'backorders'         => __( 'Backorders allowed?', 'woocommerce' ),
+				'sold_individually'  => __( 'Sold individually?', 'woocommerce' ),
+				/* translators: %s: weight */
+				'weight'             => sprintf( __( 'Weight (%s)', 'woocommerce' ), get_option( 'woocommerce_weight_unit' ) ),
+				/* translators: %s: length */
+				'length'             => sprintf( __( 'Length (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				/* translators: %s: width */
+				'width'              => sprintf( __( 'Width (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				/* translators: %s: Height */
+				'height'             => sprintf( __( 'Height (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				'reviews_allowed'    => __( 'Allow customer reviews?', 'woocommerce' ),
+				'purchase_note'      => __( 'Purchase note', 'woocommerce' ),
+				'sale_price'         => __( 'Sale price', 'woocommerce' ),
+				'regular_price'      => __( 'Regular price', 'woocommerce' ),
+				'category_ids'       => __( 'Categories', 'woocommerce' ),
+				'tag_ids'            => __( 'Tags', 'woocommerce' ),
+				'shipping_class_id'  => __( 'Shipping class', 'woocommerce' ),
+				'images'             => __( 'Images', 'woocommerce' ),
+				'download_limit'     => __( 'Download limit', 'woocommerce' ),
+				'download_expiry'    => __( 'Download expiry days', 'woocommerce' ),
+				'parent_id'          => __( 'Parent', 'woocommerce' ),
+				'grouped_products'   => __( 'Grouped products', 'woocommerce' ),
+				'upsell_ids'         => __( 'Upsells', 'woocommerce' ),
+				'cross_sell_ids'     => __( 'Cross-sells', 'woocommerce' ),
+				'product_url'        => __( 'External URL', 'woocommerce' ),
+				'button_text'        => __( 'Button text', 'woocommerce' ),
+				'menu_order'         => __( 'Position', 'woocommerce' ),
+			)
+		);
 	}
 
 	/**
@@ -185,12 +188,14 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		// If a category was selected we loop through the variations as they are not tied to a category so will be excluded by default.
 		if ( ! empty( $variable_products ) ) {
 			foreach ( $variable_products as $parent_id ) {
-				$products = wc_get_products( array(
-					'parent' => $parent_id,
-					'type'   => array( 'variation' ),
-					'return' => 'objects',
-					'limit'  => -1,
-				) );
+				$products = wc_get_products(
+					array(
+						'parent' => $parent_id,
+						'type'   => array( 'variation' ),
+						'return' => 'objects',
+						'limit'  => -1,
+					)
+				);
 
 				if ( ! $products ) {
 					continue;
@@ -235,7 +240,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 				$value = $product->{"get_{$column_id}"}( 'edit' );
 			}
 
-			if ( 'description' == $column_id || 'short_description' == $column_id ) {
+			if ( 'description' === $column_id || 'short_description' === $column_id ) {
 				$value = $this->filter_description_field( $value );
 			}
 

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -64,7 +64,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 */
 	protected function read_file() {
 		if ( ! WC_Product_CSV_Importer_Controller::is_file_valid_csv( $this->file ) ) {
-			wp_die( __( 'Invalid file type. The importer supports CSV and TXT file formats.', 'woocommerce' ) );
+			wp_die( esc_html__( 'Invalid file type. The importer supports CSV and TXT file formats.', 'woocommerce' ) );
 		}
 
 		$handle = fopen( $this->file, 'r' ); // @codingStandardsIgnoreLine.
@@ -947,27 +947,39 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			}
 
 			if ( $id_exists && ! $update_existing ) {
-				$data['skipped'][] = new WP_Error( 'woocommerce_product_importer_error', __( 'A product with this ID already exists.', 'woocommerce' ), array(
-					'id'  => $id,
-					'row' => $this->get_row_id( $parsed_data ),
-				) );
+				$data['skipped'][] = new WP_Error(
+					'woocommerce_product_importer_error',
+					esc_html__( 'A product with this ID already exists.', 'woocommerce' ),
+					array(
+						'id'  => $id,
+						'row' => $this->get_row_id( $parsed_data ),
+					)
+				);
 				continue;
 			}
 
 			if ( $sku_exists && ! $update_existing ) {
-				$data['skipped'][] = new WP_Error( 'woocommerce_product_importer_error', __( 'A product with this SKU already exists.', 'woocommerce' ), array(
-					'sku' => $sku,
-					'row' => $this->get_row_id( $parsed_data ),
-				) );
+				$data['skipped'][] = new WP_Error(
+					'woocommerce_product_importer_error',
+					esc_html__( 'A product with this SKU already exists.', 'woocommerce' ),
+					array(
+						'sku' => $sku,
+						'row' => $this->get_row_id( $parsed_data ),
+					)
+				);
 				continue;
 			}
 
 			if ( $update_existing && ( $id || $sku ) && ! $id_exists && ! $sku_exists ) {
-				$data['skipped'][] = new WP_Error( 'woocommerce_product_importer_error', __( 'No matching product exists to update.', 'woocommerce' ), array(
-					'id'  => $id,
-					'sku' => $sku,
-					'row' => $this->get_row_id( $parsed_data ),
-				) );
+				$data['skipped'][] = new WP_Error(
+					'woocommerce_product_importer_error',
+					esc_html__( 'No matching product exists to update.', 'woocommerce' ),
+					array(
+						'id'  => $id,
+						'sku' => $sku,
+						'row' => $this->get_row_id( $parsed_data ),
+					)
+				);
 				continue;
 			}
 

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -2,8 +2,8 @@
 /**
  * WooCommerce Product CSV importer
  *
- * @package  WooCommerce/Import
- * @version  3.1.0
+ * @package WooCommerce/Import
+ * @version 3.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -111,7 +111,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Remove UTF-8 BOM signature.
 	 *
-	 * @param  string $string String to handle.
+	 * @param string $string String to handle.
+	 *
 	 * @return string
 	 */
 	protected function remove_utf8_bom( $string ) {
@@ -144,7 +145,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * If mapping to a SKU and the product ID does not exist, a temporary object
 	 * will be created so it can be updated later.
 	 *
-	 * @param  string $value Field value.
+	 * @param string $value Field value.
+	 *
 	 * @return int|string
 	 */
 	public function parse_relative_field( $value ) {
@@ -213,7 +215,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * If we're not doing an update, create a placeholder product so mapping works
 	 * for rows following this one.
 	 *
-	 * @param  string $value Field value.
+	 * @param string $value Field value.
+	 *
 	 * @return int
 	 */
 	public function parse_id_field( $value ) {
@@ -263,6 +266,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Parse relative comma-delineated field and return product ID.
 	 *
 	 * @param string $value Field value.
+	 *
 	 * @return array
 	 */
 	public function parse_relative_comma_field( $value ) {
@@ -277,6 +281,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Parse a comma-delineated field from a CSV.
 	 *
 	 * @param string $value Field value.
+	 *
 	 * @return array
 	 */
 	public function parse_comma_field( $value ) {
@@ -291,6 +296,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Parse a field that is generally '1' or '0' but can be something else.
 	 *
 	 * @param string $value Field value.
+	 *
 	 * @return bool|string
 	 */
 	public function parse_bool_field( $value ) {
@@ -310,6 +316,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Parse a float value field.
 	 *
 	 * @param string $value Field value.
+	 *
 	 * @return float|string
 	 */
 	public function parse_float_field( $value ) {
@@ -327,6 +334,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Parse the stock qty field.
 	 *
 	 * @param string $value Field value.
+	 *
 	 * @return float|string
 	 */
 	public function parse_stock_quantity_field( $value ) {
@@ -345,6 +353,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Categories are separated by commas and subcategories are "parent > subcategory".
 	 *
 	 * @param string $value Field value.
+	 *
 	 * @return array of arrays with "parent" and "name" keys.
 	 */
 	public function parse_categories_field( $value ) {
@@ -395,7 +404,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Parse a tag field from a CSV.
 	 *
-	 * @param  string $value Field value.
+	 * @param string $value Field value.
+	 *
 	 * @return array
 	 */
 	public function parse_tags_field( $value ) {
@@ -424,7 +434,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Parse a shipping class field from a CSV.
 	 *
-	 * @param  string $value Field value.
+	 * @param string $value Field value.
+	 *
 	 * @return int
 	 */
 	public function parse_shipping_class_field( $value ) {
@@ -448,7 +459,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Parse images list from a CSV. Images can be filenames or URLs.
 	 *
-	 * @param  string $value Field value.
+	 * @param string $value Field value.
+	 *
 	 * @return array
 	 */
 	public function parse_images_field( $value ) {
@@ -473,7 +485,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Parse dates from a CSV.
 	 * Dates requires the format YYYY-MM-DD and time is optional.
 	 *
-	 * @param  string $value Field value.
+	 * @param string $value Field value.
+	 *
 	 * @return string|null
 	 */
 	public function parse_date_field( $value ) {
@@ -492,7 +505,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Parse backorders from a CSV.
 	 *
-	 * @param  string $value Field value.
+	 * @param string $value Field value.
+	 *
 	 * @return string
 	 */
 	public function parse_backorders_field( $value ) {
@@ -517,7 +531,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * By default is applied wc_clean() to all not listed fields
 	 * in self::get_formating_callback(), use this method to skip any formating.
 	 *
-	 * @param  string $value Field value.
+	 * @param string $value Field value.
+	 *
 	 * @return string
 	 */
 	public function parse_skip_field( $value ) {
@@ -530,6 +545,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Allow shortcodes if present, othersiwe esc_url the value.
 	 *
 	 * @param string $value Field value.
+	 *
 	 * @return string
 	 */
 	public function parse_download_file_field( $value ) {
@@ -545,6 +561,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Parse an int value field
 	 *
 	 * @param int $value field value.
+	 *
 	 * @return int
 	 */
 	public function parse_int_field( $value ) {
@@ -640,8 +657,9 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Check if strings starts with determined word.
 	 *
-	 * @param  string $haystack Complete sentence.
-	 * @param  string $needle   Excerpt.
+	 * @param string $haystack Complete sentence.
+	 * @param string $needle   Excerpt.
+	 *
 	 * @return bool
 	 */
 	protected function starts_with( $haystack, $needle ) {
@@ -651,7 +669,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Expand special and internal data into the correct formats for the product CRUD.
 	 *
-	 * @param  array $data Data to import.
+	 * @param array $data Data to import.
+	 *
 	 * @return array
 	 */
 	protected function expand_data( $data ) {
@@ -847,7 +866,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	/**
 	 * Get a string to identify the row from parsed data.
 	 *
-	 * @param  array $parsed_data Parsed data.
+	 * @param array $parsed_data Parsed data.
+	 *
 	 * @return string
 	 */
 	protected function get_row_id( $parsed_data ) {

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -572,6 +572,22 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	}
 
 	/**
+	 * Parse a description value field
+	 *
+	 * @param string $description field value.
+	 *
+	 * @return string
+	 */
+	public function parse_description_field( $description ) {
+		$parts = explode( "\\\\n", $description );
+		foreach ( $parts as $key => $part ) {
+			$parts[ $key ] = str_replace( '\n', "\n", $part );
+		}
+
+		return implode( '\\\n', $parts );
+	}
+
+	/**
 	 * Get formatting callback.
 	 *
 	 * @return array
@@ -590,8 +606,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			'date_on_sale_from' => array( $this, 'parse_date_field' ),
 			'date_on_sale_to'   => array( $this, 'parse_date_field' ),
 			'name'              => array( $this, 'parse_skip_field' ),
-			'short_description' => array( $this, 'parse_skip_field' ),
-			'description'       => array( $this, 'parse_skip_field' ),
+			'short_description' => array( $this, 'parse_description_field' ),
+			'description'       => array( $this, 'parse_description_field' ),
 			'manage_stock'      => array( $this, 'parse_bool_field' ),
 			'low_stock_amount'  => array( $this, 'parse_stock_quantity_field' ),
 			'backorders'        => array( $this, 'parse_backorders_field' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Convert 
- string literal `\n` to `\\n` and newlines to a `\n` string literal on export
- `\n` to a newline and string literal `\\n` to `\n` on import. 

Closes #22280 .

### How to test the changes in this Pull Request:

1. Edit a product description using the text editor tab
2. Add blank lines to the middle of the description
3. Add at least one \n to the product description
4. Export products
5. Import the export file
6. Product description should be the same as before exported.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix import & export of newline characters in product description fields.
