### PR TITLE
make default state option in shipping calculator consistent with ajax version

### DIFF
--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.5.0
+ * @version 3.5.4
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -53,7 +53,7 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 					?>
 					<span>
 						<select name="calc_shipping_state" class="state_select" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>">
-							<option value=""><?php esc_html_e( 'Select a state&hellip;', 'woocommerce' ); ?></option>
+							<option value=""><?php esc_html_e( 'Select an option&hellip;', 'woocommerce' ); ?></option>
 							<?php
 							foreach ( $states as $ckey => $cvalue ) {
 								echo '<option value="' . esc_attr( $ckey ) . '" ' . selected( $current_r, $ckey, false ) . '>' . esc_html( $cvalue ) . '</option>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Update the shipping calculator state default option to be consistent with the default option generated via ajax when the country is changed.

Closes #22040 .

### How to test the changes in this Pull Request:

1. Click change address in the cart
2. The default state option should be `Choose an option...`
3. Change the address country
4. Default state option should retain the same text

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Make default state option in shipping calculator consistently `Choose an option...`
