### PR TITLE
Support for Dutch postcodes

### DIFF
--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -92,6 +92,9 @@ class WC_Validation {
 			case 'SK':
 				$valid = (bool) preg_match( '/^([0-9]{3})(\s?)([0-9]{2})$/', $postcode );
 				break;
+			case 'NL':
+				$valid = (bool) preg_match( '/^[1-9][0-9]{3}\s(?!SA|SD|SS)[A-Z]{2}$/', $postcode );
+				break;
 
 			default:
 				$valid = true;

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -933,6 +933,9 @@ function wc_format_postcode( $postcode, $country ) {
 		case 'US':
 			$postcode = rtrim( substr_replace( $postcode, '-', 5, 0 ), '-' );
 			break;
+		case 'NL':
+			$postcode = substr_replace( $postcode, ' ', 4, 0 );
+			break;
 	}
 
 	return apply_filters( 'woocommerce_format_postcode', $postcode, $country );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?



### Changes proposed in this Pull Request:

This pull request adds support for validation and formatting of Dutch postcodes during checkout.
Dutch postcode have four digits followed by two uppercase letters. The digits and letters are separated by a space. The letter combinations SA, SD an SS are not used.

### How to test the changes in this Pull Request:

1.  Start the checkout
2. Choose The Netherlands as billing or shipping address
3. Try to complete the order with an incorrect postcode ( e.g. 12345 CA, 1234 SS or 1234 A ) and check that this is blocked by validation.
4. Complete the order with a correct postcode ( e.g. 4321 AB)

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Localization - Dutch postcode validation.
