### PR TITLE
Only include the network orders widget on the main site dashboard

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -2,14 +2,12 @@
 /**
  * Admin Dashboard
  *
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce/Admin
  * @version     2.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
@@ -23,7 +21,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 		 * Hook in tabs.
 		 */
 		public function __construct() {
-			// Only hook in admin parts if the user has admin access
+			// Only hook in admin parts if the user has admin access.
 			if ( current_user_can( 'view_woocommerce_reports' ) || current_user_can( 'manage_woocommerce' ) || current_user_can( 'publish_shop_orders' ) ) {
 				// If on network admin, only load the widget that works in that context and skip the rest.
 				if ( is_multisite() && is_network_admin() ) {
@@ -110,39 +108,43 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 
 			echo '<ul class="wc_status_list">';
 
-			if ( current_user_can( 'view_woocommerce_reports' ) && ( $report_data = $this->get_sales_report_data() ) ) {
-				?>
+			if ( current_user_can( 'view_woocommerce_reports' ) ) {
+				$report_data = $this->get_sales_report_data();
+				if ( $report_data ) {
+					?>
 				<li class="sales-this-month">
-				<a href="<?php echo admin_url( 'admin.php?page=wc-reports&tab=orders&range=month' ); ?>">
-					<?php echo $reports->sales_sparkline( '', max( 7, date( 'd', current_time( 'timestamp' ) ) ) ); ?>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=orders&range=month' ) ); ?>">
+					<?php echo $reports->sales_sparkline( '', max( 7, date( 'd', current_time( 'timestamp' ) ) ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 					<?php
-						/* translators: %s: net sales */
 						printf(
-							__( '%s net sales this month', 'woocommerce' ),
+							/* translators: %s: net sales */
+							esc_html__( '%s net sales this month', 'woocommerce' ),
 							'<strong>' . wc_price( $report_data->net_sales ) . '</strong>'
-						);
-						?>
+						); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+					?>
 					</a>
 				</li>
-				<?php
-			}
-
-			if ( current_user_can( 'view_woocommerce_reports' ) && ( $top_seller = $this->get_top_seller() ) && $top_seller->qty ) {
-				?>
-				<li class="best-seller-this-month">
-				<a href="<?php echo admin_url( 'admin.php?page=wc-reports&tab=orders&report=sales_by_product&range=month&product_ids=' . $top_seller->product_id ); ?>">
-					<?php echo $reports->sales_sparkline( $top_seller->product_id, max( 7, date( 'd', current_time( 'timestamp' ) ) ), 'count' ); ?>
 					<?php
-						/* translators: 1: top seller product title 2: top seller quantity */
+				}
+
+				$top_seller = $this->get_top_seller();
+				if ( $top_seller && $top_seller->qty ) {
+					?>
+				<li class="best-seller-this-month">
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=orders&report=sales_by_product&range=month&product_ids=' . $top_seller->product_id ) ); ?>">
+					<?php echo $reports->sales_sparkline( $top_seller->product_id, max( 7, date( 'd', current_time( 'timestamp' ) ) ), 'count' ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+					<?php
 						printf(
-							__( '%1$s top seller this month (sold %2$d)', 'woocommerce' ),
+							/* translators: 1: top seller product title 2: top seller quantity */
+							esc_html__( '%1$s top seller this month (sold %2$d)', 'woocommerce' ),
 							'<strong>' . get_the_title( $top_seller->product_id ) . '</strong>',
 							$top_seller->qty
-						);
-						?>
+						); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+					?>
 					</a>
 				</li>
-				<?php
+					<?php
+				}
 			}
 
 			$this->status_widget_order_rows();
@@ -169,24 +171,24 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			}
 			?>
 			<li class="processing-orders">
-			<a href="<?php echo admin_url( 'edit.php?post_status=wc-processing&post_type=shop_order' ); ?>">
+			<a href="<?php echo esc_url( admin_url( 'edit.php?post_status=wc-processing&post_type=shop_order' ) ); ?>">
 				<?php
-					/* translators: %s: order count */
 					printf(
+						/* translators: %s: order count */
 						_n( '<strong>%s order</strong> awaiting processing', '<strong>%s orders</strong> awaiting processing', $processing_count, 'woocommerce' ),
 						$processing_count
-					);
+					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				?>
 				</a>
 			</li>
 			<li class="on-hold-orders">
-				<a href="<?php echo admin_url( 'edit.php?post_status=wc-on-hold&post_type=shop_order' ); ?>">
+				<a href="<?php echo esc_url( admin_url( 'edit.php?post_status=wc-on-hold&post_type=shop_order' ) ); ?>">
 				<?php
-					/* translators: %s: order count */
 					printf(
+						/* translators: %s: order count */
 						_n( '<strong>%s order</strong> on-hold', '<strong>%s orders</strong> on-hold', $on_hold_count, 'woocommerce' ),
 						$on_hold_count
-					);
+					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				?>
 				</a>
 			</li>
@@ -199,12 +201,13 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 		private function status_widget_stock_rows() {
 			global $wpdb;
 
-			// Get products using a query - this is too advanced for get_posts :(
+			// Get products using a query - this is too advanced for get_posts.
 			$stock          = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
 			$nostock        = absint( max( get_option( 'woocommerce_notify_no_stock_amount' ), 0 ) );
 			$transient_name = 'wc_low_stock_count';
 
-			if ( false === ( $lowinstock_count = get_transient( $transient_name ) ) ) {
+			$lowinstock_count = get_transient( $transient_name );
+			if ( false === $lowinstock_count ) {
 				$query_from       = apply_filters(
 					'woocommerce_report_low_in_stock_query_from',
 					"FROM {$wpdb->posts} as posts
@@ -223,7 +226,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 
 			$transient_name = 'wc_outofstock_count';
 
-			if ( false === ( $outofstock_count = get_transient( $transient_name ) ) ) {
+			$outofstock_count = get_transient( $transient_name );
+			if ( false === $outofstock_count ) {
 				$query_from       = apply_filters(
 					'woocommerce_report_out_of_stock_query_from',
 					"FROM {$wpdb->posts} as posts
@@ -240,24 +244,24 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			}
 			?>
 			<li class="low-in-stock">
-			<a href="<?php echo admin_url( 'admin.php?page=wc-reports&tab=stock&report=low_in_stock' ); ?>">
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=stock&report=low_in_stock' ) ); ?>">
 				<?php
-					/* translators: %s: order count */
 					printf(
+						/* translators: %s: order count */
 						_n( '<strong>%s product</strong> low in stock', '<strong>%s products</strong> low in stock', $lowinstock_count, 'woocommerce' ),
 						$lowinstock_count
-					);
+					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				?>
 				</a>
 			</li>
 			<li class="out-of-stock">
-				<a href="<?php echo admin_url( 'admin.php?page=wc-reports&tab=stock&report=out_of_stock' ); ?>">
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=stock&report=out_of_stock' ) ); ?>">
 				<?php
-					/* translators: %s: order count */
 					printf(
+						/* translators: %s: order count */
 						_n( '<strong>%s product</strong> out of stock', '<strong>%s products</strong> out of stock', $outofstock_count, 'woocommerce' ),
 						$outofstock_count
-					);
+					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 				?>
 				</a>
 			</li>
@@ -298,16 +302,16 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 					$rating = intval( get_comment_meta( $comment->comment_ID, 'rating', true ) );
 
 					/* translators: %s: rating */
-					echo '<div class="star-rating"><span style="width:' . ( $rating * 20 ) . '%">' . sprintf( __( '%s out of 5', 'woocommerce' ), $rating ) . '</span></div>';
+					echo '<div class="star-rating"><span style="width:' . esc_html( $rating * 20 ) . '%">' . sprintf( esc_html__( '%s out of 5', 'woocommerce' ), esc_html( $rating ) ) . '</span></div>';
 
 					/* translators: %s: review author */
-					echo '<h4 class="meta"><a href="' . get_permalink( $comment->ID ) . '#comment-' . absint( $comment->comment_ID ) . '">' . esc_html( apply_filters( 'woocommerce_admin_dashboard_recent_reviews', $comment->post_title, $comment ) ) . '</a> ' . sprintf( __( 'reviewed by %s', 'woocommerce' ), esc_html( $comment->comment_author ) ) . '</h4>';
+					echo '<h4 class="meta"><a href="' . esc_url( get_permalink( $comment->ID ) ) . '#comment-' . esc_html( absint( $comment->comment_ID ) ) . '">' . esc_html( apply_filters( 'woocommerce_admin_dashboard_recent_reviews', $comment->post_title, $comment ) ) . '</a> ' . sprintf( esc_html__( 'reviewed by %s', 'woocommerce' ), esc_html( $comment->comment_author ) ) . '</h4>';
 					echo '<blockquote>' . wp_kses_data( $comment->comment_content ) . '</blockquote></li>';
 
 				}
 				echo '</ul>';
 			} else {
-				echo '<p>' . __( 'There are no product reviews yet.', 'woocommerce' ) . '</p>';
+				echo '<p>' . esc_html__( 'There are no product reviews yet.', 'woocommerce' ) . '</p>';
 			}
 		}
 
@@ -326,7 +330,9 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			$blog_ids = wp_list_pluck( $blogs, 'userblog_id' );
 
 			wp_localize_script(
-				'wc-network-orders', 'woocommerce_network_orders', array(
+				'wc-network-orders',
+				'woocommerce_network_orders',
+				array(
 					'nonce'          => wp_create_nonce( 'wp_rest' ),
 					'sites'          => array_values( $blog_ids ),
 					'order_endpoint' => get_rest_url( null, 'wc/v2/orders/network' ),
@@ -357,6 +363,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 					<?php esc_html_e( 'No orders found', 'woocommerce' ); ?>
 				</p>
 			</div>
+			<?php // @codingStandardsIgnoreStart ?>
 			<script type="text/template" id="network-orders-row-template">
 				<tr>
 					<td>
@@ -374,8 +381,9 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 					</td>
 				</tr>
 			</script>
+			<?php // @codingStandardsIgnoreEnd ?>
 		</div>
-		<?php
+			<?php
 		}
 
 	}

--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -42,7 +42,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			wp_add_dashboard_widget( 'woocommerce_dashboard_status', __( 'WooCommerce Status', 'woocommerce' ), array( $this, 'status_widget' ) );
 
 			// Network Order Widget.
-			if ( is_multisite() ) {
+			if ( is_multisite() && is_main_site() ) {
 				$this->register_network_order_widget();
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Reserve the network orders widget to the main site in each network which is consistent with WP core architecture for network wide data. While this won't reduce the load of one widget, it will limit the load for network admins who have multiple dashboards open at once.
- PHP sniff fixes do not include the DB  queries as all the queries are passed through filters and should be revisited on a separate issue.

Closes #21202 .

### How to test the changes in this Pull Request:

1. As a super admin visit the dashboard of the main site & a subsite
2. Network orders should only be added to the main site dashboard
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: only include the network orders widget on the main site dashboard.
