### PR TITLE
use slug sanitization on product export category slugs

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -96,51 +96,54 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 * @return array
 	 */
 	public function get_default_column_names() {
-		return apply_filters( "woocommerce_product_export_{$this->export_type}_default_columns", array(
-			'id'                 => __( 'ID', 'woocommerce' ),
-			'type'               => __( 'Type', 'woocommerce' ),
-			'sku'                => __( 'SKU', 'woocommerce' ),
-			'name'               => __( 'Name', 'woocommerce' ),
-			'published'          => __( 'Published', 'woocommerce' ),
-			'featured'           => __( 'Is featured?', 'woocommerce' ),
-			'catalog_visibility' => __( 'Visibility in catalog', 'woocommerce' ),
-			'short_description'  => __( 'Short description', 'woocommerce' ),
-			'description'        => __( 'Description', 'woocommerce' ),
-			'date_on_sale_from'  => __( 'Date sale price starts', 'woocommerce' ),
-			'date_on_sale_to'    => __( 'Date sale price ends', 'woocommerce' ),
-			'tax_status'         => __( 'Tax status', 'woocommerce' ),
-			'tax_class'          => __( 'Tax class', 'woocommerce' ),
-			'stock_status'       => __( 'In stock?', 'woocommerce' ),
-			'stock'              => __( 'Stock', 'woocommerce' ),
-			'low_stock_amount'   => __( 'Low stock amount', 'woocommerce' ),
-			'backorders'         => __( 'Backorders allowed?', 'woocommerce' ),
-			'sold_individually'  => __( 'Sold individually?', 'woocommerce' ),
-			/* translators: %s: weight */
-			'weight'             => sprintf( __( 'Weight (%s)', 'woocommerce' ), get_option( 'woocommerce_weight_unit' ) ),
-			/* translators: %s: length */
-			'length'             => sprintf( __( 'Length (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
-			/* translators: %s: width */
-			'width'              => sprintf( __( 'Width (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
-			/* translators: %s: Height */
-			'height'             => sprintf( __( 'Height (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
-			'reviews_allowed'    => __( 'Allow customer reviews?', 'woocommerce' ),
-			'purchase_note'      => __( 'Purchase note', 'woocommerce' ),
-			'sale_price'         => __( 'Sale price', 'woocommerce' ),
-			'regular_price'      => __( 'Regular price', 'woocommerce' ),
-			'category_ids'       => __( 'Categories', 'woocommerce' ),
-			'tag_ids'            => __( 'Tags', 'woocommerce' ),
-			'shipping_class_id'  => __( 'Shipping class', 'woocommerce' ),
-			'images'             => __( 'Images', 'woocommerce' ),
-			'download_limit'     => __( 'Download limit', 'woocommerce' ),
-			'download_expiry'    => __( 'Download expiry days', 'woocommerce' ),
-			'parent_id'          => __( 'Parent', 'woocommerce' ),
-			'grouped_products'   => __( 'Grouped products', 'woocommerce' ),
-			'upsell_ids'         => __( 'Upsells', 'woocommerce' ),
-			'cross_sell_ids'     => __( 'Cross-sells', 'woocommerce' ),
-			'product_url'        => __( 'External URL', 'woocommerce' ),
-			'button_text'        => __( 'Button text', 'woocommerce' ),
-			'menu_order'         => __( 'Position', 'woocommerce' ),
-		) );
+		return apply_filters(
+			"woocommerce_product_export_{$this->export_type}_default_columns",
+			array(
+				'id'                 => __( 'ID', 'woocommerce' ),
+				'type'               => __( 'Type', 'woocommerce' ),
+				'sku'                => __( 'SKU', 'woocommerce' ),
+				'name'               => __( 'Name', 'woocommerce' ),
+				'published'          => __( 'Published', 'woocommerce' ),
+				'featured'           => __( 'Is featured?', 'woocommerce' ),
+				'catalog_visibility' => __( 'Visibility in catalog', 'woocommerce' ),
+				'short_description'  => __( 'Short description', 'woocommerce' ),
+				'description'        => __( 'Description', 'woocommerce' ),
+				'date_on_sale_from'  => __( 'Date sale price starts', 'woocommerce' ),
+				'date_on_sale_to'    => __( 'Date sale price ends', 'woocommerce' ),
+				'tax_status'         => __( 'Tax status', 'woocommerce' ),
+				'tax_class'          => __( 'Tax class', 'woocommerce' ),
+				'stock_status'       => __( 'In stock?', 'woocommerce' ),
+				'stock'              => __( 'Stock', 'woocommerce' ),
+				'low_stock_amount'   => __( 'Low stock amount', 'woocommerce' ),
+				'backorders'         => __( 'Backorders allowed?', 'woocommerce' ),
+				'sold_individually'  => __( 'Sold individually?', 'woocommerce' ),
+				/* translators: %s: weight */
+				'weight'             => sprintf( __( 'Weight (%s)', 'woocommerce' ), get_option( 'woocommerce_weight_unit' ) ),
+				/* translators: %s: length */
+				'length'             => sprintf( __( 'Length (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				/* translators: %s: width */
+				'width'              => sprintf( __( 'Width (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				/* translators: %s: Height */
+				'height'             => sprintf( __( 'Height (%s)', 'woocommerce' ), get_option( 'woocommerce_dimension_unit' ) ),
+				'reviews_allowed'    => __( 'Allow customer reviews?', 'woocommerce' ),
+				'purchase_note'      => __( 'Purchase note', 'woocommerce' ),
+				'sale_price'         => __( 'Sale price', 'woocommerce' ),
+				'regular_price'      => __( 'Regular price', 'woocommerce' ),
+				'category_ids'       => __( 'Categories', 'woocommerce' ),
+				'tag_ids'            => __( 'Tags', 'woocommerce' ),
+				'shipping_class_id'  => __( 'Shipping class', 'woocommerce' ),
+				'images'             => __( 'Images', 'woocommerce' ),
+				'download_limit'     => __( 'Download limit', 'woocommerce' ),
+				'download_expiry'    => __( 'Download expiry days', 'woocommerce' ),
+				'parent_id'          => __( 'Parent', 'woocommerce' ),
+				'grouped_products'   => __( 'Grouped products', 'woocommerce' ),
+				'upsell_ids'         => __( 'Upsells', 'woocommerce' ),
+				'cross_sell_ids'     => __( 'Cross-sells', 'woocommerce' ),
+				'product_url'        => __( 'External URL', 'woocommerce' ),
+				'button_text'        => __( 'Button text', 'woocommerce' ),
+				'menu_order'         => __( 'Position', 'woocommerce' ),
+			)
+		);
 	}
 
 	/**
@@ -182,12 +185,14 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		// If a category was selected we loop through the variations as they are not tied to a category so will be excluded by default.
 		if ( ! empty( $variable_products ) ) {
 			foreach ( $variable_products as $parent_id ) {
-				$products = wc_get_products( array(
-					'parent' => $parent_id,
-					'type'   => array( 'variation' ),
-					'return' => 'objects',
-					'limit'  => -1,
-				) );
+				$products = wc_get_products(
+					array(
+						'parent' => $parent_id,
+						'type'   => array( 'variation' ),
+						'return' => 'objects',
+						'limit'  => -1,
+					)
+				);
 
 				if ( ! $products ) {
 					continue;

--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -86,7 +86,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 * @return void
 	 */
 	public function set_product_category_to_export( $product_category_to_export ) {
-		$this->product_category_to_export = array_map( 'wc_clean', $product_category_to_export );
+		$this->product_category_to_export = array_map( 'sanitize_title_with_dashes', $product_category_to_export );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- phpcs sniff fixes for class-wc-product-csv-exporter.php are in #22298 
- use the core slug sanitizer to sanitize product category slugs submitted for export

Closes #22197 .

### How to test the changes in this Pull Request:

1. Create a product category `سشص`
2. Add the category to a product
3. Export products selecting that category
4. Exported file should contain the product

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: product export by unicode product categories.
