### PR TITLE
update variation guid with the id after creation

### DIFF
--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -145,6 +145,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			$product->apply_changes();
 
 			$this->update_version_and_type( $product );
+			$this->update_guid( $product );
 
 			$this->clear_caches( $product );
 
@@ -470,5 +471,27 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 
 		parent::update_post_meta( $product, $force );
+	}
+
+	/**
+	 * Update product variation guid.
+	 *
+	 * @param WC_Product_Variation $product Product variation object.
+	 *
+	 * @since 3.6.0
+	 */
+	protected function update_guid( $product ) {
+		global $wpdb;
+
+		$guid = home_url(
+			add_query_arg(
+				array(
+					'post_type' => 'product_variation',
+					'p'         => $product->get_id(),
+				),
+				''
+			)
+		);
+		$wpdb->update( $wpdb->posts, array( 'guid' => $guid ), array( 'ID' => $product->get_id() ) );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `wp_*_post` functions will not update the `guid` field after the post has been created. At the time a product variation is created, it has the default attributes of the parent product and is not uniquely identifiable. This PR uses a direct DB query to update the variation guid to include the variation ID after the post record has been created and the ID is available.

This PR does not update the guids of any existing variations.

Closes #21380 .

### How to test the changes in this Pull Request:

1. Create a new variation on any variable product
2. Look at the guid field of that variation in the DB
3. It should be in the form of `https://example.com/?post_type=product_variation&p=1234` where 1234 is the variation id.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: give product variations a unique guid.
