### PR TITLE
Fix/multisite session cart key

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -21,16 +21,17 @@ final class WC_Cart_Session {
 	 * Reference to cart object.
 	 *
 	 * @since 3.2.0
-	 * @var WC_Cart
+	 * @var   WC_Cart
 	 */
 	protected $cart;
 
 	/**
 	 * Sets up the items provided, and calculate totals.
 	 *
-	 * @since 3.2.0
-	 * @throws Exception If missing WC_Cart object.
 	 * @param WC_Cart $cart Cart object to calculate totals for.
+	 *
+	 * @since  3.2.0
+	 * @throws Exception If missing WC_Cart object.
 	 */
 	public function __construct( &$cart ) {
 		if ( ! is_a( $cart, 'WC_Cart' ) ) {
@@ -277,9 +278,11 @@ final class WC_Cart_Session {
 	/**
 	 * Get a cart from an order, if user has permission.
 	 *
-	 * @since  3.5.0
-	 * @param int   $order_id Order ID to try to load.
+	 * @param int $order_id Order ID to try to load.
 	 * @param array $cart Current cart array.
+	 *
+	 * @since 3.5.0
+	 *
 	 * @return array
 	 */
 	private function populate_cart_from_order( $order_id, $cart ) {

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -72,8 +72,8 @@ final class WC_Cart_Session {
 		$update_cart_session = false; // Flag to indicate the stored cart should be updated.
 		$order_again         = false; // Flag to indicate whether this is a re-order.
 
-		$cart                = WC()->session->get( 'cart', null );
-		$merge_saved_cart    = (bool) get_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login', true );
+		$cart             = WC()->session->get( 'cart', null );
+		$merge_saved_cart = (bool) get_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login', true );
 
 		// Merge saved cart with current cart.
 		if ( is_null( $cart ) || $merge_saved_cart ) {
@@ -122,7 +122,8 @@ final class WC_Cart_Session {
 				} else {
 					// Put session data into array. Run through filter so other plugins can load their own session data.
 					$session_data = array_merge(
-						$values, array(
+						$values,
+						array(
 							'data' => $product,
 						)
 					);
@@ -149,7 +150,7 @@ final class WC_Cart_Session {
 
 		// If this is a re-order, redirect to the cart page to get rid of the `order_again` query string.
 		if ( $order_again ) {
-			wp_redirect( wc_get_page_permalink( 'cart' ) );
+			wp_safe_redirect( wc_get_page_permalink( 'cart' ) );
 			exit;
 		}
 	}
@@ -221,7 +222,9 @@ final class WC_Cart_Session {
 		if ( get_current_user_id() && apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
 			$suffix = WC()->session->get_cart_key_suffix();
 			update_user_meta(
-				get_current_user_id(), '_woocommerce_persistent_cart' . $suffix, array(
+				get_current_user_id(),
+				'_woocommerce_persistent_cart' . $suffix,
+				array(
 					'cart' => $this->get_cart_for_session(),
 				)
 			);
@@ -264,7 +267,7 @@ final class WC_Cart_Session {
 		$saved_cart = array();
 
 		if ( apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
-			$suffix = WC()->session->get_cart_key_suffix();
+			$suffix          = WC()->session->get_cart_key_suffix();
 			$saved_cart_meta = get_user_meta( get_current_user_id(), '_woocommerce_persistent_cart' . $suffix, true );
 
 			if ( isset( $saved_cart_meta['cart'] ) ) {
@@ -278,7 +281,7 @@ final class WC_Cart_Session {
 	/**
 	 * Get a cart from an order, if user has permission.
 	 *
-	 * @param int $order_id Order ID to try to load.
+	 * @param int   $order_id Order ID to try to load.
 	 * @param array $cart Current cart array.
 	 *
 	 * @since 3.5.0
@@ -333,8 +336,10 @@ final class WC_Cart_Session {
 			$cart_id          = WC()->cart->generate_cart_id( $product_id, $variation_id, $variations, $cart_item_data );
 			$product_data     = wc_get_product( $variation_id ? $variation_id : $product_id );
 			$cart[ $cart_id ] = apply_filters(
-				'woocommerce_add_order_again_cart_item', array_merge(
-					$cart_item_data, array(
+				'woocommerce_add_order_again_cart_item',
+				array_merge(
+					$cart_item_data,
+					array(
 						'key'          => $cart_id,
 						'product_id'   => $product_id,
 						'variation_id' => $variation_id,
@@ -343,7 +348,8 @@ final class WC_Cart_Session {
 						'data'         => $product_data,
 						'data_hash'    => wc_get_cart_item_data_hash( $product_data ),
 					)
-				), $cart_id
+				),
+				$cart_id
 			);
 		}
 

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -218,8 +218,9 @@ final class WC_Cart_Session {
 	 */
 	public function persistent_cart_update() {
 		if ( get_current_user_id() && apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
+			$suffix = WC()->session->get_cart_key_suffix();
 			update_user_meta(
-				get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id(), array(
+				get_current_user_id(), '_woocommerce_persistent_cart' . $suffix, array(
 					'cart' => $this->get_cart_for_session(),
 				)
 			);
@@ -231,7 +232,8 @@ final class WC_Cart_Session {
 	 */
 	public function persistent_cart_destroy() {
 		if ( get_current_user_id() ) {
-			delete_user_meta( get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id() );
+			$suffix = WC()->session->get_cart_key_suffix();
+			delete_user_meta( get_current_user_id(), '_woocommerce_persistent_cart' . $suffix );
 		}
 	}
 
@@ -261,7 +263,8 @@ final class WC_Cart_Session {
 		$saved_cart = array();
 
 		if ( apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
-			$saved_cart_meta = get_user_meta( get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id(), true );
+			$suffix = WC()->session->get_cart_key_suffix();
+			$saved_cart_meta = get_user_meta( get_current_user_id(), '_woocommerce_persistent_cart' . $suffix, true );
 
 			if ( isset( $saved_cart_meta['cart'] ) ) {
 				$saved_cart = array_filter( (array) $saved_cart_meta['cart'] );

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -120,6 +120,10 @@ class WC_Install {
 		'3.5.2' => array(
 			'wc_update_352_drop_download_log_fk',
 		),
+		'3.5.4' => array(
+			'wc_update_354_rename_session_cart_keys',
+			'wc_update_354_db_version',
+		),
 	);
 
 	/**

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -96,6 +96,15 @@ class WC_Session_Handler extends WC_Session {
 	}
 
 	/**
+	 * Suffix for cart key names
+	 *
+	 * @return string value of suffix
+	 */
+	public function get_cart_key_suffix() {
+		return apply_filters( 'woocommerce_cart_key_suffix', '_' . get_current_blog_id() );
+	}
+
+	/**
 	 * Sets the session cookie on-demand (usually after adding an item to the cart).
 	 *
 	 * Since the cookie name (as of 2.1) is prepended with wp, cache systems like batcache will not cache pages when set.

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -108,7 +108,6 @@ class WC_Session_Handler extends WC_Session {
 	 * We need to suffix the cart session variable to avoid ambiguous lookup in multisite setups.
 	 *
 	 * @param string $key Key to get.
-	 * @param mixed $default used if the session variable isn't set.
 	 *
 	 * @return array|string value of session variable
 	 */
@@ -122,11 +121,11 @@ class WC_Session_Handler extends WC_Session {
 	 * Get a session variable.
 	 *
 	 * @param string $key Key to get.
-	 * @param mixed $default used if the session variable isn't set.
+	 * @param mixed  $default used if the session variable isn't set.
 	 *
 	 * @return array|string value of session variable
 	 */
-	public function get( $key, $default = NULL ) {
+	public function get( $key, $default = null ) {
 		$key = $this->maybe_suffix_cart_key( $key );
 
 		return parent::get( $key, $default );
@@ -136,7 +135,7 @@ class WC_Session_Handler extends WC_Session {
 	 * Set a session variable.
 	 *
 	 * @param string $key Key to set.
-	 * @param mixed $value Value to set.
+	 * @param mixed  $value Value to set.
 	 */
 	public function set( $key, $value ) {
 		$key = $this->maybe_suffix_cart_key( $key );

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -5,9 +5,9 @@
  *
  * From 2.5 this uses a custom table for session storage. Based on https://github.com/kloon/woocommerce-large-sessions.
  *
- * @class    WC_Session_Handler
- * @version  2.5.0
- * @package  WooCommerce/Classes
+ * @class   WC_Session_Handler
+ * @version 2.5.0
+ * @package WooCommerce/Classes
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -255,6 +255,7 @@ class WC_Session_Handler extends WC_Session {
 	 * When a user is logged out, ensure they have a unique nonce by using the customer/session ID.
 	 *
 	 * @param int $uid User ID.
+	 *
 	 * @return string
 	 */
 	public function nonce_user_logged_out( $uid ) {
@@ -279,6 +280,7 @@ class WC_Session_Handler extends WC_Session {
 	 *
 	 * @param string $customer_id Custo ID.
 	 * @param mixed  $default Default session value.
+	 *
 	 * @return string|array
 	 */
 	public function get_session( $customer_id, $default = false ) {

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -105,6 +105,46 @@ class WC_Session_Handler extends WC_Session {
 	}
 
 	/**
+	 * We need to suffix the cart session variable to avoid ambiguous lookup in multisite setups.
+	 *
+	 * @param string $key Key to get.
+	 * @param mixed $default used if the session variable isn't set.
+	 *
+	 * @return array|string value of session variable
+	 */
+	private function maybe_suffix_cart_key( $key ) {
+		$suffix = $this->get_cart_key_suffix();
+
+		return ( 'cart' === $key ) ? $key . $suffix : $key;
+	}
+
+	/**
+	 * Get a session variable.
+	 *
+	 * @param string $key Key to get.
+	 * @param mixed $default used if the session variable isn't set.
+	 *
+	 * @return array|string value of session variable
+	 */
+	public function get( $key, $default = NULL ) {
+		$key = $this->maybe_suffix_cart_key( $key );
+
+		return parent::get( $key, $default );
+	}
+
+	/**
+	 * Set a session variable.
+	 *
+	 * @param string $key Key to set.
+	 * @param mixed $value Value to set.
+	 */
+	public function set( $key, $value ) {
+		$key = $this->maybe_suffix_cart_key( $key );
+
+		parent::set( $key, $value );
+	}
+
+	/**
 	 * Sets the session cookie on-demand (usually after adding an item to the cart).
 	 *
 	 * Since the cookie name (as of 2.1) is prepended with wp, cache systems like batcache will not cache pages when set.

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -48,7 +48,8 @@ function wc_load_persistent_cart( $user_login, $user ) {
 		return;
 	}
 
-	$saved_cart = get_user_meta( $user->ID, '_woocommerce_persistent_cart_' . get_current_blog_id(), true );
+	$suffix     = WC()->session->get_cart_key_suffix();
+	$saved_cart = get_user_meta( $user->ID, '_woocommerce_persistent_cart' . $suffix, true );
 
 	if ( ! $saved_cart ) {
 		return;

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -13,8 +13,9 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Prevent password protected products being added to the cart.
  *
- * @param  bool $passed     Validation.
- * @param  int  $product_id Product ID.
+ * @param bool $passed     Validation.
+ * @param int  $product_id Product ID.
+ *
  * @return bool
  */
 function wc_protected_product_add_to_cart( $passed, $product_id ) {
@@ -41,6 +42,7 @@ function wc_empty_cart() {
  *
  * @param string  $user_login User login.
  * @param WP_User $user       User data.
+ *
  * @deprecated 2.3
  */
 function wc_load_persistent_cart( $user_login, $user ) {
@@ -67,7 +69,7 @@ function wc_load_persistent_cart( $user_login, $user ) {
  *
  * Do not use for redirects, use {@see wp_get_referer()} instead.
  *
- * @since 2.6.1
+ * @since  2.6.1
  * @return string|false Referer URL on success, false on failure.
  */
 function wc_get_raw_referer() {
@@ -141,7 +143,8 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 /**
  * Comma separate a list of item names, and replace final comma with 'and'.
  *
- * @param  array $items Cart items.
+ * @param array $items Cart items.
+ *
  * @return string
  */
 function wc_format_list_of_items( $items ) {
@@ -338,7 +341,8 @@ function wc_cart_totals_fee_html( $fee ) {
 /**
  * Get a shipping methods full label including price.
  *
- * @param  WC_Shipping_Rate $method Shipping method rate data.
+ * @param WC_Shipping_Rate $method Shipping method rate data.
+ *
  * @return string
  */
 function wc_cart_totals_shipping_method_label( $method ) {
@@ -364,8 +368,9 @@ function wc_cart_totals_shipping_method_label( $method ) {
 /**
  * Round discount.
  *
- * @param  double $value Amount to round.
- * @param  int    $precision DP to round.
+ * @param double $value Amount to round.
+ * @param int    $precision DP to round.
+ *
  * @return float
  */
 function wc_cart_round_discount( $value, $precision ) {
@@ -391,9 +396,11 @@ function wc_get_chosen_shipping_method_ids() {
 /**
  * Get chosen method for package from session.
  *
- * @since  3.2.0
- * @param  int   $key Key of package.
- * @param  array $package Package data array.
+ * @param int   $key Key of package.
+ * @param array $package Package data array.
+ *
+ * @since 3.2.0
+ *
  * @return string|bool
  */
 function wc_get_chosen_shipping_method_for_package( $key, $package ) {
@@ -427,10 +434,12 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 /**
  * Choose the default method for a package.
  *
- * @since  3.2.0
- * @param  int    $key Key of package.
- * @param  array  $package Package data array.
- * @param  string $chosen_method Chosen method id.
+ * @param int    $key Key of package.
+ * @param array  $package Package data array.
+ * @param string $chosen_method Chosen method id.
+ *
+ * @since 3.2.0
+ *
  * @return string
  */
 function wc_get_default_shipping_method_for_package( $key, $package, $chosen_method ) {
@@ -454,9 +463,11 @@ function wc_get_default_shipping_method_for_package( $key, $package, $chosen_met
 /**
  * See if the methods have changed since the last request.
  *
- * @since  3.2.0
- * @param  int   $key Key of package.
- * @param  array $package Package data array.
+ * @param int   $key Key of package.
+ * @param array $package Package data array.
+ *
+ * @since 3.2.0
+ *
  * @return bool
  */
 function wc_shipping_methods_have_changed( $key, $package ) {
@@ -477,6 +488,7 @@ function wc_shipping_methods_have_changed( $key, $package ) {
  * The woocommerce_cart_item_data_to_validate filter can be used to add custom properties.
  *
  * @param WC_Product $product Product object.
+ *
  * @return string
  */
 function wc_get_cart_item_data_hash( $product ) {

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -110,7 +110,7 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 
 	foreach ( $products as $product_id => $qty ) {
 		/* translators: %s: product name */
-		$titles[] = ( $qty > 1 ? absint( $qty ) . ' &times; ' : '' ) . apply_filters( 'woocommerce_add_to_cart_item_name_in_quotes', sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), strip_tags( get_the_title( $product_id ) ) ), $product_id );
+		$titles[] = ( $qty > 1 ? absint( $qty ) . ' &times; ' : '' ) . apply_filters( 'woocommerce_add_to_cart_item_name_in_quotes', sprintf( _x( '&ldquo;%s&rdquo;', 'Item name in quotes', 'woocommerce' ), wp_strip_all_tags( get_the_title( $product_id ) ) ), $product_id );
 		$count   += $qty;
 	}
 
@@ -207,8 +207,8 @@ function wc_cart_totals_subtotal_html() {
  * Get shipping methods.
  */
 function wc_cart_totals_shipping_html() {
-	$packages           = WC()->shipping->get_packages();
-	$first              = true;
+	$packages = WC()->shipping->get_packages();
+	$first    = true;
 
 	foreach ( $packages as $i => $package ) {
 		$chosen_method = isset( WC()->session->chosen_shipping_methods[ $i ] ) ? WC()->session->chosen_shipping_methods[ $i ] : '';
@@ -222,7 +222,8 @@ function wc_cart_totals_shipping_html() {
 		}
 
 		wc_get_template(
-			'cart/cart-shipping.php', array(
+			'cart/cart-shipping.php',
+			array(
 				'package'                  => $package,
 				'available_methods'        => $package['rates'],
 				'show_package_details'     => count( $packages ) > 1,

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1932,15 +1932,14 @@ function wc_update_354_rename_session_cart_keys() {
 			unset( $session_data['cart'] );
 			$new_data = maybe_serialize( $session_data );
 
-			// Update
 			$wpdb->query(
 				$wpdb->prepare(
-					"UPDATE $session_table
+					"UPDATE {$session_table}
 						SET session_value = %s
 						WHERE session_id = %d",
 					array(
 						$new_data,
-						$session->session_id
+						$session->session_id,
 					)
 				)
 			);

--- a/tests/unit-tests/session/class-wc-tests-session-handler.php
+++ b/tests/unit-tests/session/class-wc-tests-session-handler.php
@@ -30,9 +30,9 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $current_session_data->session_id + 1, $updated_session_data->session_id );
 		$this->assertEquals( $this->session_key, $updated_session_data->session_key );
-		$this->assertEquals( maybe_serialize( array( 'cart' => 'new cart' ) ), $updated_session_data->session_value );
+		$this->assertEquals( maybe_serialize( array( 'cart_1' => 'new cart' ) ), $updated_session_data->session_value );
 		$this->assertTrue( is_numeric( $updated_session_data->session_expiry ) );
-		$this->assertEquals( array( 'cart' => 'new cart' ), wp_cache_get( $this->cache_prefix . $this->session_key, WC_SESSION_CACHE_GROUP ) );
+		$this->assertEquals( array( 'cart_1' => 'new cart' ), wp_cache_get( $this->cache_prefix . $this->session_key, WC_SESSION_CACHE_GROUP ) );
 	}
 
 	public function test_save_data_should_replace_existing_row() {
@@ -45,19 +45,19 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $current_session_data->session_id, $updated_session_data->session_id );
 		$this->assertEquals( $this->session_key, $updated_session_data->session_key );
-		$this->assertEquals( maybe_serialize( array( 'cart' => 'new cart' ) ), $updated_session_data->session_value );
+		$this->assertEquals( maybe_serialize( array( 'cart_1' => 'new cart' ) ), $updated_session_data->session_value );
 		$this->assertTrue( is_numeric( $updated_session_data->session_expiry ) );
 	}
 
 	public function test_get_session_should_use_cache() {
 		$session = $this->handler->get_session( $this->session_key );
-		$this->assertEquals( array( 'cart' => 'fake cart' ), $session );
+		$this->assertEquals( array( 'cart_1' => 'fake cart' ), $session );
 	}
 
 	public function test_get_session_should_not_use_cache() {
 		wp_cache_delete( $this->cache_prefix . $this->session_key, WC_SESSION_CACHE_GROUP );
 		$session = $this->handler->get_session( $this->session_key );
-		$this->assertEquals( array( 'cart' => 'fake cart' ), $session );
+		$this->assertEquals( array( 'cart_1' => 'fake cart' ), $session );
 	}
 
 	public function test_get_session_should_return_default_value() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #22322 .

I saw three posibillities to fix the issue:
- ignore the cart key in the session completely (remove completely from session storage) –> that would have led to loss of cart data for users without persistent cart
- add a suffix to the session key (customer_id suffixed with blog_id) for each multisite (would be a bigger change without knowledge about side effects, but maybe also a legit fix?)
- add a suffix to the `cart` key in the serialized session data

I implemented the last option. PR includes draft for a migration too.

### How to test the changes in this Pull Request:

See issue.

### Changelog entry

> Fixes multisite carts to be correctly saved and read from the session table