### PR TITLE
Check stock status when repopulating items in the cart from an order

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -70,7 +70,6 @@ final class WC_Cart_Session {
 
 		$update_cart_session = false; // Flag to indicate the stored cart should be updated.
 		$order_again         = false; // Flag to indicate whether this is a re-order.
-
 		$cart                = WC()->session->get( 'cart', null );
 		$merge_saved_cart    = (bool) get_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login', true );
 
@@ -121,7 +120,8 @@ final class WC_Cart_Session {
 				} else {
 					// Put session data into array. Run through filter so other plugins can load their own session data.
 					$session_data = array_merge(
-						$values, array(
+						$values,
+						array(
 							'data' => $product,
 						)
 					);
@@ -148,7 +148,7 @@ final class WC_Cart_Session {
 
 		// If this is a re-order, redirect to the cart page to get rid of the `order_again` query string.
 		if ( $order_again ) {
-			wp_redirect( wc_get_page_permalink( 'cart' ) );
+			wp_safe_redirect( wc_get_page_permalink( 'cart' ) );
 			exit;
 		}
 	}
@@ -219,7 +219,9 @@ final class WC_Cart_Session {
 	public function persistent_cart_update() {
 		if ( get_current_user_id() && apply_filters( 'woocommerce_persistent_cart_enabled', true ) ) {
 			update_user_meta(
-				get_current_user_id(), '_woocommerce_persistent_cart_' . get_current_blog_id(), array(
+				get_current_user_id(),
+				'_woocommerce_persistent_cart_' . get_current_blog_id(),
+				array(
 					'cart' => $this->get_cart_for_session(),
 				)
 			);
@@ -327,8 +329,10 @@ final class WC_Cart_Session {
 			$cart_id          = WC()->cart->generate_cart_id( $product_id, $variation_id, $variations, $cart_item_data );
 			$product_data     = wc_get_product( $variation_id ? $variation_id : $product_id );
 			$cart[ $cart_id ] = apply_filters(
-				'woocommerce_add_order_again_cart_item', array_merge(
-					$cart_item_data, array(
+				'woocommerce_add_order_again_cart_item',
+				array_merge(
+					$cart_item_data,
+					array(
 						'key'          => $cart_id,
 						'product_id'   => $product_id,
 						'variation_id' => $variation_id,
@@ -337,7 +341,8 @@ final class WC_Cart_Session {
 						'data'         => $product_data,
 						'data_hash'    => wc_get_cart_item_data_hash( $product_data ),
 					)
-				), $cart_id
+				),
+				$cart_id
 			);
 		}
 

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -312,6 +312,11 @@ final class WC_Cart_Session {
 				continue;
 			}
 
+			// Prevent reordering items specifically out of stock.
+			if ( ! $product->is_in_stock() ) {
+				continue;
+			}
+
 			foreach ( $item->get_meta_data() as $meta ) {
 				if ( taxonomy_is_product_attribute( $meta->key ) ) {
 					$term                     = get_term_by( 'slug', $meta->value, $meta->key );


### PR DESCRIPTION
Closes #22099

Adds a simple stock status check when repopulating the cart from an order.

This will not do resource intensive checks like checking pending orders and items already in cart as that would cause a slow down. But it will prevent obvious cases when an item goes out of stock.

To test:
1. Checkout order on your account with an in stock item
2. In admin, mark that product as out of stock
3. From my account page, re-order
4. The item should not add to cart.

Changelog:

> Check stock status of items when 'ordering again' from the account page.