### PR TITLE
add gutenberg block preprocessor filter to shop page content

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -43,6 +43,7 @@ add_filter( 'woocommerce_attribute_label', 'wp_kses_post', 100 );
 /**
  * Short Description (excerpt).
  */
+add_filter( 'woocommerce_short_description', 'do_blocks', 9 );
 add_filter( 'woocommerce_short_description', 'wptexturize' );
 add_filter( 'woocommerce_short_description', 'convert_smilies' );
 add_filter( 'woocommerce_short_description', 'convert_chars' );

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -43,7 +43,7 @@ add_filter( 'woocommerce_attribute_label', 'wp_kses_post', 100 );
 /**
  * Short Description (excerpt).
  */
-if ( version_compare( $wp_version, '5.0', '>=' ) ) {
+if ( function_exists( 'do_blocks' ) ) {
 	add_filter( 'woocommerce_short_description', 'do_blocks', 9 );
 }
 add_filter( 'woocommerce_short_description', 'wptexturize' );

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -43,7 +43,9 @@ add_filter( 'woocommerce_attribute_label', 'wp_kses_post', 100 );
 /**
  * Short Description (excerpt).
  */
-add_filter( 'woocommerce_short_description', 'do_blocks', 9 );
+if ( version_compare( $wp_version, '5.0', '>=' ) ) {
+	add_filter( 'woocommerce_short_description', 'do_blocks', 9 );
+}
 add_filter( 'woocommerce_short_description', 'wptexturize' );
 add_filter( 'woocommerce_short_description', 'convert_smilies' );
 add_filter( 'woocommerce_short_description', 'convert_chars' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- add gutenberg block preprocessor filter to shop page content - copies logic from https://github.com/WordPress/WordPress/blob/master/wp-includes/default-filters.php#L184:L189

Closes #22326 .

### How to test the changes in this Pull Request:

1. Edit the shop page in gutenberg
2. add at least 1 paragraph and 1 block of any other type
3. visit the shop page
4. without PR there are extra empty paragraphs
5. view source has `<p><!-- wp:blocktype --></p>`
6. with PR the block comments are not present in the content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: remove block comments from shop page description.
