### PR TITLE
Restore non-cart notice printing opportunity during checkout

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -86,7 +86,7 @@ class WC_Shortcode_Checkout {
 			try {
 				$order_key          = isset( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // WPCS: input var ok, CSRF ok.
 				$order              = wc_get_order( $order_id );
- 				$hold_stock_minutes = (int) get_option( 'woocommerce_hold_stock_minutes', 0 );
+				$hold_stock_minutes = (int) get_option( 'woocommerce_hold_stock_minutes', 0 );
 
 				// Order or payment link is invalid.
 				if ( ! $order || $order->get_id() !== $order_id || $order->get_order_key() !== $order_key ) {
@@ -177,7 +177,8 @@ class WC_Shortcode_Checkout {
 				}
 
 				wc_get_template(
-					'checkout/form-pay.php', array(
+					'checkout/form-pay.php',
+					array(
 						'order'              => $order,
 						'available_gateways' => $available_gateways,
 						'order_button_text'  => apply_filters( 'woocommerce_pay_order_button_text', __( 'Pay for order', 'woocommerce' ) ),

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -251,6 +251,9 @@ class WC_Shortcode_Checkout {
 	 * Show the checkout.
 	 */
 	private static function checkout() {
+		// Show non-cart errors.
+		do_action( 'woocommerce_before_checkout_form_cart_notices' );
+
 		// Check cart has contents.
 		if ( WC()->cart->is_empty() && ! is_customize_preview() && apply_filters( 'woocommerce_checkout_redirect_empty_cart', true ) ) {
 			return;

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -297,6 +297,7 @@ add_action( 'woocommerce_shortcode_before_product_cat_loop', 'woocommerce_output
 add_action( 'woocommerce_before_shop_loop', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_single_product', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_cart', 'woocommerce_output_all_notices', 10 );
+add_action( 'woocommerce_before_checkout_form_cart_notices', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_checkout_form', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_account_content', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_customer_login_form', 'woocommerce_output_all_notices', 10 );


### PR DESCRIPTION
Fixes #22048 

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Restores an opportunity to print non-cart related notices that a few extensions are relying on.

Closes #22048 .

### How to test the changes in this Pull Request:

1. Install this branch
2. Install an extension that leverages non-cart related notices, like Amazon Payments Advanced
3. Force a wc_add_notice of type error to occur during the checkout flow
4. Observe that the cart-errors template is NOT called but that the notice is displayed in the context of checkout, e.g.

<img width="830" alt="screen shot 2019-01-07 at 4 18 55 pm" src="https://user-images.githubusercontent.com/1595739/50801054-fd448a80-1297-11e9-828f-0052772b44aa.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Restores an opportunity to print non-cart related notices that a few extensions are relying on.
