### PR TITLE
Product structured data tweak to show both BreadcrumbList and Product structured data.

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -329,6 +329,12 @@ class WC_Structured_Data {
 		$markup['itemListElement'] = array();
 
 		foreach ( $crumbs as $key => $crumb ) {
+			// Don't add the current page to the breadcrumb list on product pages,
+			// otherwise Google will not recognize both the BreadcrumbList and Product structured data.
+			if ( is_product() && count( $crumbs ) - 1 === $key ) {
+				continue;
+			}
+
 			$markup['itemListElement'][ $key ] = array(
 				'@type'    => 'ListItem',
 				'position' => $key + 1,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
### Changes proposed in this Pull Request:

Closes #22024 .
Supersedes #22045. 

Don't include the current page on single product page structured data breadcrumbs. Google will recognize both the breadcrumblist and product structured data if we do it this way (the current page will not show in the breadcrumblist structured data, though. Only in the product structured data)

### How to test the changes in this Pull Request:

1. https://search.google.com/structured-data/testing-tool/u/0/ with the source code from single product pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak/Fix - Don't include product in BreadcrumbList structured data so Google will recognize stand-alone Product structured data.
