### PR TITLE
Get widget instance setting defaults so it shows in customiser before save

### DIFF
--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -129,7 +129,15 @@ abstract class WC_Widget extends WP_Widget {
 	 * @return string
 	 */
 	protected function get_instance_title( $instance ) {
-		return isset( $instance['title'] ) ? $instance['title'] : '';
+		if ( isset( $instance['title'] ) ) {
+			return $instance['title'];
+		}
+
+		if ( isset( $this->settings, $this->settings['title'], $this->settings['title']['std'] ) ) {
+			return $this->settings['title']['std'];
+		}
+
+		return '';
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -123,6 +123,16 @@ abstract class WC_Widget extends WP_Widget {
 	}
 
 	/**
+	 * Get this widgets title.
+	 *
+	 * @param array $instance Array of instance options.
+	 * @return string
+	 */
+	protected function get_instance_title( $instance ) {
+		return isset( $instance['title'] ) ? $instance['title'] : '';
+	}
+
+	/**
 	 * Output the html at the start of a widget.
 	 *
 	 * @param array $args Arguments.
@@ -131,7 +141,9 @@ abstract class WC_Widget extends WP_Widget {
 	public function widget_start( $args, $instance ) {
 		echo $args['before_widget']; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 
-		if ( $title = apply_filters( 'widget_title', empty( $instance['title'] ) ? '' : $instance['title'], $instance, $this->id_base ) ) { // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found, WordPress.CodeAnalysis.AssignmentInCondition.Found
+		$title = apply_filters( 'widget_title', $this->get_instance_title( $instance ), $instance, $this->id_base );
+
+		if ( $title ) {
 			echo $args['before_title'] . $title . $args['after_title']; // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
 		}
 	}
@@ -225,7 +237,7 @@ abstract class WC_Widget extends WP_Widget {
 				case 'text':
 					?>
 					<p>
-						<label for="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>"><?php echo $setting['label']; ?></label><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+						<label for="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>"><?php echo wp_kses_post( $setting['label'] ); ?></label><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 						<input class="widefat <?php echo esc_attr( $class ); ?>" id="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( $key ) ); ?>" type="text" value="<?php echo esc_attr( $value ); ?>" />
 					</p>
 					<?php

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -56,6 +56,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 	 */
 	public function init_settings() {
 		$attribute_array      = array();
+		$std_attribute        = '';
 		$attribute_taxonomies = wc_get_attribute_taxonomies();
 
 		if ( ! empty( $attribute_taxonomies ) ) {
@@ -64,6 +65,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 					$attribute_array[ $tax->attribute_name ] = $tax->attribute_name;
 				}
 			}
+			$std_attribute = current( $attribute_array );
 		}
 
 		$this->settings = array(
@@ -74,7 +76,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			),
 			'attribute'    => array(
 				'type'    => 'select',
-				'std'     => '',
+				'std'     => $std_attribute,
 				'label'   => __( 'Attribute', 'woocommerce' ),
 				'options' => $attribute_array,
 			),
@@ -100,6 +102,60 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 	}
 
 	/**
+	 * Get this widgets title.
+	 *
+	 * @param array $instance Array of instance options.
+	 * @return string
+	 */
+	protected function get_instance_title( $instance ) {
+		return isset( $instance['title'] ) ? $instance['title'] : __( 'Filter by', 'woocommerce' );
+	}
+
+	/**
+	 * Get this widgets taxonomy.
+	 *
+	 * @param array $instance Array of instance options.
+	 * @return string
+	 */
+	protected function get_instance_taxonomy( $instance ) {
+		if ( isset( $instance['attribute'] ) ) {
+			return wc_attribute_taxonomy_name( $instance['attribute'] );
+		}
+
+		$attribute_taxonomies = wc_get_attribute_taxonomies();
+
+		if ( ! empty( $attribute_taxonomies ) ) {
+			foreach ( $attribute_taxonomies as $tax ) {
+				if ( taxonomy_exists( wc_attribute_taxonomy_name( $tax->attribute_name ) ) ) {
+					return wc_attribute_taxonomy_name( $tax->attribute_name );
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Get this widgets query type.
+	 *
+	 * @param array $instance Array of instance options.
+	 * @return string
+	 */
+	protected function get_instance_query_type( $instance ) {
+		return isset( $instance['query_type'] ) ? $instance['query_type'] : 'and';
+	}
+
+	/**
+	 * Get this widgets display type.
+	 *
+	 * @param array $instance Array of instance options.
+	 * @return string
+	 */
+	protected function get_instance_display_type( $instance ) {
+		return isset( $instance['display_type'] ) ? $instance['display_type'] : 'list';
+	}
+
+	/**
 	 * Output widget.
 	 *
 	 * @see WP_Widget
@@ -113,9 +169,9 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		}
 
 		$_chosen_attributes = WC_Query::get_layered_nav_chosen_attributes();
-		$taxonomy           = isset( $instance['attribute'] ) ? wc_attribute_taxonomy_name( $instance['attribute'] ) : $this->settings['attribute']['std'];
-		$query_type         = isset( $instance['query_type'] ) ? $instance['query_type'] : $this->settings['query_type']['std'];
-		$display_type       = isset( $instance['display_type'] ) ? $instance['display_type'] : $this->settings['display_type']['std'];
+		$taxonomy           = $this->get_instance_taxonomy( $instance );
+		$query_type         = $this->get_instance_query_type( $instance );
+		$display_type       = $this->get_instance_display_type( $instance );
 
 		if ( ! taxonomy_exists( $taxonomy ) ) {
 			return;
@@ -368,7 +424,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		$query             = implode( ' ', $query );
 
 		// We have a query - let's see if cached results of this query already exist.
-		$query_hash    = md5( $query );
+		$query_hash = md5( $query );
 
 		// Maybe store a transient of the count values.
 		$cache = apply_filters( 'woocommerce_layered_nav_count_maybe_cache', true );

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -102,16 +102,6 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 	}
 
 	/**
-	 * Get this widgets title.
-	 *
-	 * @param array $instance Array of instance options.
-	 * @return string
-	 */
-	protected function get_instance_title( $instance ) {
-		return isset( $instance['title'] ) ? $instance['title'] : __( 'Filter by', 'woocommerce' );
-	}
-
-	/**
 	 * Get this widgets taxonomy.
 	 *
 	 * @param array $instance Array of instance options.


### PR DESCRIPTION
Widgets were not showing in the customiser/sidebar after being added due to having no settings yet. 

1. Go to shop page
2. Customiser
3. Add filter by product widget to sidebar. You won't see it.
4. Save or change options. Now you can see it.

To fix this, this PR adds some methods to return either the instance's setting, or a valid default. Retest and you'll now see the widget right away on your shop page.

This is not a major bug so I'd suggest leaving for 3.6.

Closes #20710