### PR TITLE
Tweak tax handling when exempt of VAT and woocommerce_adjust_non_base…

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -421,7 +421,15 @@ final class WC_Cart_Totals {
 	 */
 	protected function remove_item_base_taxes( $item ) {
 		if ( $item->price_includes_tax && $item->taxable ) {
-			$base_tax_rates = WC_Tax::get_base_tax_rates( $item->product->get_tax_class( 'unfiltered' ) );
+			if ( apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ) {
+				$base_tax_rates = WC_Tax::get_base_tax_rates( $item->product->get_tax_class( 'unfiltered' ) );
+			} else {
+				/**
+				 * If we want all customers to pay the same price on this store, we should not remove base taxes from a VAT exempt user's price,
+				 * but just the relevent tax rate. See issue #20911.
+				 */
+				$base_tax_rates = $item->tax_rates;
+			}
 
 			// Work out a new base price without the shop's base tax.
 			$taxes = WC_Tax::calc_tax( $item->price, $base_tax_rates, true );


### PR DESCRIPTION
There is a test case in #20911 for this. You need to add the filter and force your user VAT exempt (you can edit the customer class temporarily).

Fixes #20911

When the user is VAT exempt we remove base taxes from the product price.

However, when the woocommerce_adjust_non_base_location filter is false (when we want to charge all users the same) removing the base tax is wrong - we want to remove the tax in their location.

This makes that change. With the test case in the issue, it makes the subtotal match the displayed item prices.