### PR TITLE
unescape single quote in attribute value list

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -4,8 +4,6 @@
  *
  * Displays the product data box, tabbed, with several panels covering price, stock etc.
  *
- * @author   WooThemes
- * @category Admin
  * @package  WooCommerce/Admin/Meta Boxes
  * @version  3.0.0
  */
@@ -22,7 +20,7 @@ class WC_Meta_Box_Product_Data {
 	/**
 	 * Output the metabox.
 	 *
-	 * @param WP_Post $post
+	 * @param WP_Post $post Post object being edited.
 	 */
 	public static function output( $post ) {
 		global $thepostid, $product_object;
@@ -56,7 +54,8 @@ class WC_Meta_Box_Product_Data {
 	 */
 	private static function get_product_type_options() {
 		return apply_filters(
-			'product_type_options', array(
+			'product_type_options',
+			array(
 				'virtual'      => array(
 					'id'            => '_virtual',
 					'wrapper_class' => 'show_if_simple',
@@ -82,7 +81,8 @@ class WC_Meta_Box_Product_Data {
 	 */
 	private static function get_product_data_tabs() {
 		$tabs = apply_filters(
-			'woocommerce_product_data_tabs', array(
+			'woocommerce_product_data_tabs',
+			array(
 				'general'        => array(
 					'label'    => __( 'General', 'woocommerce' ),
 					'target'   => 'general_product_data',
@@ -148,7 +148,7 @@ class WC_Meta_Box_Product_Data {
 			return -1;
 		}
 
-		if ( $a['priority'] == $b['priority'] ) {
+		if ( $a['priority'] === $b['priority'] ) {
 			return 0;
 		}
 
@@ -158,7 +158,8 @@ class WC_Meta_Box_Product_Data {
 	/**
 	 * Filter callback for finding variation attributes.
 	 *
-	 * @param  WC_Product_Attribute $attribute
+	 * @param WC_Product_Attribute $attribute Attribute object.
+	 *
 	 * @return bool
 	 */
 	private static function filter_variation_attributes( $attribute ) {
@@ -183,9 +184,9 @@ class WC_Meta_Box_Product_Data {
 	/**
 	 * Prepare downloads for save.
 	 *
-	 * @param array $file_names
-	 * @param array $file_urls
-	 * @param array $file_hashes
+	 * @param array $file_names File names.
+	 * @param array $file_urls File URLs.
+	 * @param array $file_hashes File hashes.
 	 *
 	 * @return array
 	 */
@@ -193,7 +194,7 @@ class WC_Meta_Box_Product_Data {
 		$downloads = array();
 
 		if ( ! empty( $file_urls ) ) {
-			$file_url_size = sizeof( $file_urls );
+			$file_url_size = count( $file_urls );
 
 			for ( $i = 0; $i < $file_url_size; $i ++ ) {
 				if ( ! empty( $file_urls[ $i ] ) ) {
@@ -214,13 +215,13 @@ class WC_Meta_Box_Product_Data {
 	 * @return array
 	 */
 	private static function prepare_children() {
-		return isset( $_POST['grouped_products'] ) ? array_filter( array_map( 'intval', (array) $_POST['grouped_products'] ) ) : array();
+		return isset( $_POST['grouped_products'] ) ? array_filter( array_map( 'intval', (array) $_POST['grouped_products'] ) ) : array(); // phpcs:disable  WordPress.Security.NonceVerification.NoNonceVerification
 	}
 
 	/**
 	 * Prepare attributes for save.
 	 *
-	 * @param array $data
+	 * @param array $data Attribute data.
 	 *
 	 * @return array
 	 */
@@ -281,9 +282,10 @@ class WC_Meta_Box_Product_Data {
 	/**
 	 * Prepare attributes for a specific variation or defaults.
 	 *
-	 * @param  array  $all_attributes
-	 * @param  string $key_prefix
-	 * @param  int    $index
+	 * @param  array  $all_attributes All attributes for variation or default.
+	 * @param  string $key_prefix Attribute key prefix.
+	 * @param  int    $index Array index.
+	 *
 	 * @return array
 	 */
 	private static function prepare_set_attributes( $all_attributes, $key_prefix = 'attribute_', $index = null ) {
@@ -295,9 +297,9 @@ class WC_Meta_Box_Product_Data {
 					$attribute_key = sanitize_title( $attribute->get_name() );
 
 					if ( ! is_null( $index ) ) {
-						$value = isset( $_POST[ $key_prefix . $attribute_key ][ $index ] ) ? wp_unslash( $_POST[ $key_prefix . $attribute_key ][ $index ] ) : '';
+						$value = isset( $_POST[ $key_prefix . $attribute_key ][ $index ] ) ? wp_unslash( $_POST[ $key_prefix . $attribute_key ][ $index ] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 					} else {
-						$value = isset( $_POST[ $key_prefix . $attribute_key ] ) ? wp_unslash( $_POST[ $key_prefix . $attribute_key ] ) : '';
+						$value = isset( $_POST[ $key_prefix . $attribute_key ] ) ? wp_unslash( $_POST[ $key_prefix . $attribute_key ] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 					}
 
 					if ( $attribute->is_taxonomy() ) {
@@ -318,12 +320,12 @@ class WC_Meta_Box_Product_Data {
 	/**
 	 * Save meta box data.
 	 *
-	 * @param int  $post_id
-	 * @param $post
+	 * @param int     $post_id ID of product post object being saved.
+	 * @param WP_Post $post Product post object being saved.
 	 */
 	public static function save( $post_id, $post ) {
 		// Process product type first so we have the correct class to run setters.
-		$product_type = empty( $_POST['product-type'] ) ? WC_Product_Factory::get_product_type( $post_id ) : sanitize_title( stripslashes( $_POST['product-type'] ) );
+		$product_type = empty( $_POST['product-type'] ) ? WC_Product_Factory::get_product_type( $post_id ) : sanitize_title( stripslashes( $_POST['product-type'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$classname    = WC_Product_Factory::get_product_classname( $post_id, $product_type ? $product_type : 'simple' );
 		$product      = new $classname( $post_id );
 		$attributes   = self::prepare_attributes();
@@ -331,7 +333,7 @@ class WC_Meta_Box_Product_Data {
 
 		// Handle stock changes.
 		if ( isset( $_POST['_stock'] ) ) {
-			if ( isset( $_POST['_original_stock'] ) && wc_stock_amount( $product->get_stock_quantity( 'edit' ) ) !== wc_stock_amount( $_POST['_original_stock'] ) ) {
+			if ( isset( $_POST['_original_stock'] ) && wc_stock_amount( $product->get_stock_quantity( 'edit' ) ) !== wc_stock_amount( $_POST['_original_stock'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 				/* translators: 1: product ID 2: quantity in stock */
 				WC_Admin_Meta_Boxes::add_error( sprintf( __( 'The stock has not been updated because the value has changed since editing. Product %1$d has %2$d units in stock.', 'woocommerce' ), $product->get_id(), $product->get_stock_quantity( 'edit' ) ) );
 			} else {
@@ -339,6 +341,7 @@ class WC_Meta_Box_Product_Data {
 			}
 		}
 
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		$errors = $product->set_props(
 			array(
 				'sku'                => isset( $_POST['_sku'] ) ? wc_clean( wp_unslash( $_POST['_sku'] ) ) : null,
@@ -373,28 +376,31 @@ class WC_Meta_Box_Product_Data {
 					isset( $_POST['_wc_file_urls'] ) ? wp_unslash( $_POST['_wc_file_urls'] ) : array(),
 					isset( $_POST['_wc_file_hashes'] ) ? wp_unslash( $_POST['_wc_file_hashes'] ) : array()
 				),
-				'product_url'         => esc_url_raw( wp_unslash( $_POST['_product_url'] ) ),
-				'button_text'         => wc_clean( wp_unslash( $_POST['_button_text'] ) ),
-				'children'            => 'grouped' === $product_type ? self::prepare_children() : null,
-				'reviews_allowed'     => ! empty( $_POST['comment_status'] ) && 'open' === $_POST['comment_status'],
-				'attributes'          => $attributes,
-				'default_attributes'  => self::prepare_set_attributes( $attributes, 'default_attribute_' ),
+				'product_url'        => esc_url_raw( wp_unslash( $_POST['_product_url'] ) ),
+				'button_text'        => wc_clean( wp_unslash( $_POST['_button_text'] ) ),
+				'children'           => 'grouped' === $product_type ? self::prepare_children() : null,
+				'reviews_allowed'    => ! empty( $_POST['comment_status'] ) && 'open' === $_POST['comment_status'],
+				'attributes'         => $attributes,
+				'default_attributes' => self::prepare_set_attributes( $attributes, 'default_attribute_' ),
 			)
 		);
+		 // phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
 		if ( is_wp_error( $errors ) ) {
 			WC_Admin_Meta_Boxes::add_error( $errors->get_error_message() );
 		}
 
 		/**
-		 * @since 3.0.0 to set props before save.
+		 * Set props before save.
+		 *
+		 * @since 3.0.0
 		 */
 		do_action( 'woocommerce_admin_process_product_object', $product );
 
 		$product->save();
 
 		if ( $product->is_type( 'variable' ) ) {
-			$product->get_data_store()->sync_variation_names( $product, wc_clean( $_POST['original_post_title'] ), wc_clean( $_POST['post_title'] ) );
+			$product->get_data_store()->sync_variation_names( $product, wc_clean( $_POST['original_post_title'] ), wc_clean( $_POST['post_title'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 		}
 
 		do_action( 'woocommerce_process_product_meta_' . $product_type, $post_id );
@@ -403,8 +409,8 @@ class WC_Meta_Box_Product_Data {
 	/**
 	 * Save meta box data.
 	 *
-	 * @param int     $post_id
-	 * @param WP_Post $post
+	 * @param int     $post_id ID of product post object being saved.
+	 * @param WP_Post $post Product post object being saved.
 	 */
 	public static function save_variations( $post_id, $post ) {
 		if ( isset( $_POST['variable_post_id'] ) ) {
@@ -412,7 +418,7 @@ class WC_Meta_Box_Product_Data {
 			$parent->set_default_attributes( self::prepare_set_attributes( $parent->get_attributes(), 'default_attribute_' ) );
 			$parent->save();
 
-			$max_loop   = max( array_keys( $_POST['variable_post_id'] ) );
+			$max_loop   = max( array_keys( $_POST['variable_post_id'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 			$data_store = $parent->get_data_store();
 			$data_store->sort_all_product_variations( $parent->get_id() );
 
@@ -427,14 +433,15 @@ class WC_Meta_Box_Product_Data {
 
 				// Handle stock changes.
 				if ( isset( $_POST['variable_stock'], $_POST['variable_stock'][ $i ] ) ) {
-					if ( isset( $_POST['variable_original_stock'], $_POST['variable_original_stock'][ $i ] ) && wc_stock_amount( $variation->get_stock_quantity( 'edit' ) ) !== wc_stock_amount( $_POST['variable_original_stock'][ $i ] ) ) {
+					if ( isset( $_POST['variable_original_stock'], $_POST['variable_original_stock'][ $i ] ) && wc_stock_amount( $variation->get_stock_quantity( 'edit' ) ) !== wc_stock_amount( $_POST['variable_original_stock'][ $i ] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 						/* translators: 1: product ID 2: quantity in stock */
 						WC_Admin_Meta_Boxes::add_error( sprintf( __( 'The stock has not been updated because the value has changed since editing. Product %1$d has %2$d units in stock.', 'woocommerce' ), $variation->get_id(), $variation->get_stock_quantity( 'edit' ) ) );
 					} else {
-						$stock = wc_stock_amount( $_POST['variable_stock'][ $i ] );
+						$stock = wc_stock_amount( $_POST['variable_stock'][ $i ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 					}
 				}
 
+				 // phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 				$errors = $variation->set_props(
 					array(
 						'status'            => isset( $_POST['variable_enabled'][ $i ] ) ? 'publish' : 'private',
@@ -468,6 +475,7 @@ class WC_Meta_Box_Product_Data {
 						'tax_class'         => isset( $_POST['variable_tax_class'][ $i ] ) ? wc_clean( $_POST['variable_tax_class'][ $i ] ) : null,
 					)
 				);
+				 // phpcs:enable WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
 				if ( is_wp_error( $errors ) ) {
 					WC_Admin_Meta_Boxes::add_error( $errors->get_error_message() );

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -251,7 +251,7 @@ class WC_Meta_Box_Product_Data {
 					$attribute_id = wc_attribute_taxonomy_id_by_name( $attribute_name );
 				}
 
-				$options = isset( $attribute_values[ $i ] ) ? $attribute_values[ $i ] : '';
+				$options = isset( $attribute_values[ $i ] ) ? str_replace( "\'", "'", $attribute_values[ $i ] ) : '';
 
 				if ( is_array( $options ) ) {
 					// Term ids sent as array.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Supersedes #22228 - I tested a variety of characters that are normally escaped with a `\`. The only one I found being slashed in the attribute values string was the single quote. This PR targets replacing that specific case.

Closes #22147 .

### How to test the changes in this Pull Request:

1. Add `\`,`"`,`'`,`+` to an attribute value list and save. 
2. The list should display the values saved.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: allow apostrophes in product attribute values list.
