### PR TITLE
Fix attribute apostrophe saving, and usage in variations

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -352,11 +352,19 @@
 								}
 
 								if ( attr_val ) {
-									// Decode entities and add slashes.
+									// Decode entities.
 									attr_val = $( '<div/>' ).html( attr_val ).text();
 
-									// Attach.
-									new_attr_select.find( 'option[value="' + form.addSlashes( attr_val ) + '"]' ).addClass( 'attached ' + variation_active );
+									// Attach to matching options by value. This is done to compare
+									// TEXT values rather than any HTML entities.
+									new_attr_select.find( 'option' ).each( function( index, el ) {
+										var option_value = $( this ).val();
+
+										if ( attr_val === option_value ) {
+											$( this ).addClass( 'attached ' + variation_active );
+											return false; // break.
+										}
+									});
 								} else {
 									// Attach all apart from placeholder.
 									new_attr_select.find( 'option:gt(0)' ).addClass( 'attached ' + variation_active );
@@ -371,8 +379,21 @@
 			attached_options_count = new_attr_select.find( 'option.attached' ).length;
 
 			// Check if current selection is in attached options.
-			if ( selected_attr_val && ( attached_options_count === 0 || new_attr_select.find( 'option.attached.enabled[value="' + form.addSlashes( selected_attr_val ) + '"]' ).length === 0 ) ) {
-				selected_attr_val_valid = false;
+			if ( selected_attr_val ) {
+				if ( 0 === attached_options_count ) {
+					selected_attr_val_valid = false;
+				} else {
+					selected_attr_val_valid = false;
+
+					new_attr_select.find( 'option.attached.enabled' ).each( function( index, el ) {
+						var option_value = $( this ).val();
+
+						if ( selected_attr_val === option_value ) {
+							selected_attr_val_valid = true;
+							return false; // break.
+						}
+					});
+				}
 			}
 
 			// Detach the placeholder if:

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -228,7 +228,7 @@ class WC_Meta_Box_Product_Data {
 		$attributes = array();
 
 		if ( ! $data ) {
-			$data = $_POST;
+			$data = stripslashes_deep( $_POST );
 		}
 
 		if ( isset( $data['attribute_names'], $data['attribute_values'] ) ) {

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -615,7 +615,7 @@ class WC_AJAX {
 		$response = array();
 
 		try {
-			parse_str( $_POST['data'], $data );
+			parse_str( wp_unslash( $_POST['data'] ), $data );
 
 			$attributes   = WC_Meta_Box_Product_Data::prepare_attributes( $data );
 			$product_id   = absint( $_POST['post_id'] );

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -764,7 +764,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					);
 				}
 			}
-			update_post_meta( $product->get_id(), '_product_attributes', $meta_values );
+			// Note, we use wp_slash to add extra level of escaping. See https://codex.wordpress.org/Function_Reference/update_post_meta#Workaround.
+			update_post_meta( $product->get_id(), '_product_attributes', wp_slash( $meta_values ) );
 		}
 	}
 

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -427,7 +427,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			$attributes             = $product->get_attributes();
 			$updated_attribute_keys = array();
 			foreach ( $attributes as $key => $value ) {
-				update_post_meta( $product->get_id(), 'attribute_' . $key, $value );
+				update_post_meta( $product->get_id(), 'attribute_' . $key, wp_slash( $value ) );
 				$updated_attribute_keys[] = 'attribute_' . $key;
 			}
 

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -94,10 +94,11 @@ function wc_attribute_taxonomy_name_by_id( $attribute_id ) {
 	$attribute_name = $wpdb->get_var(
 		$wpdb->prepare(
 			"
-		SELECT attribute_name
-		FROM {$wpdb->prefix}woocommerce_attribute_taxonomies
-		WHERE attribute_id = %d
-	", $attribute_id
+			SELECT attribute_name
+			FROM {$wpdb->prefix}woocommerce_attribute_taxonomies
+			WHERE attribute_id = %d
+			",
+			$attribute_id
 		)
 	);
 
@@ -201,7 +202,8 @@ function wc_get_attribute_taxonomy_names() {
  */
 function wc_get_attribute_types() {
 	return (array) apply_filters(
-		'product_attributes_type_selector', array(
+		'product_attributes_type_selector',
+		array(
 			'select' => __( 'Select', 'woocommerce' ),
 		)
 	);
@@ -382,10 +384,11 @@ function wc_get_attribute( $id ) {
 	$data = $wpdb->get_row(
 		$wpdb->prepare(
 			"
-		SELECT *
-		FROM {$wpdb->prefix}woocommerce_attribute_taxonomies
-		WHERE attribute_id = %d
-	 ", $id
+			SELECT *
+			FROM {$wpdb->prefix}woocommerce_attribute_taxonomies
+			WHERE attribute_id = %d
+			",
+			$id
 		)
 	);
 
@@ -543,7 +546,8 @@ function wc_create_attribute( $args ) {
 					"SELECT post_id, meta_value FROM {$wpdb->postmeta} WHERE meta_key = '_product_attributes' AND meta_value LIKE %s",
 					'%' . $wpdb->esc_like( $old_taxonomy_name ) . '%'
 				),
-			ARRAY_A );
+				ARRAY_A
+			);
 			foreach ( $metadatas as $metadata ) {
 				$product_id        = $metadata['post_id'];
 				$unserialized_data = maybe_unserialize( $metadata['meta_value'] );
@@ -554,7 +558,7 @@ function wc_create_attribute( $args ) {
 				$unserialized_data[ $new_taxonomy_name ] = $unserialized_data[ $old_taxonomy_name ];
 				unset( $unserialized_data[ $old_taxonomy_name ] );
 				$unserialized_data[ $new_taxonomy_name ]['name'] = $new_taxonomy_name;
-				update_post_meta( $product_id, '_product_attributes', $unserialized_data );
+				update_post_meta( $product_id, '_product_attributes', wp_slash( $unserialized_data ) );
 			}
 
 			// Update variations which use this taxonomy.
@@ -600,7 +604,8 @@ function wc_update_attribute( $id, $args ) {
 				SELECT attribute_name
 				FROM {$wpdb->prefix}woocommerce_attribute_taxonomies
 				WHERE attribute_id = %d
-			", $args['id']
+			",
+			$args['id']
 		)
 	);
 
@@ -620,10 +625,11 @@ function wc_delete_attribute( $id ) {
 	$name = $wpdb->get_var(
 		$wpdb->prepare(
 			"
-		SELECT attribute_name
-		FROM {$wpdb->prefix}woocommerce_attribute_taxonomies
-		WHERE attribute_id = %d
-	", $id
+			SELECT attribute_name
+			FROM {$wpdb->prefix}woocommerce_attribute_taxonomies
+			WHERE attribute_id = %d
+			",
+			$id
 		)
 	);
 


### PR DESCRIPTION
Supercedes #22361 
Closes #22147

Found out that the quotes needed `wp_unslash` when posted, and also to preserve slashes, `wp_slash` was needed on the meta value [because of this behaviour in WordPress core](https://codex.wordpress.org/Function_Reference/update_post_meta#Workaround).

After getting an attribute and value saving called `test'ing"\s` I found that there was a related issue on the frontend variation form whereby the values were not shown in the attribute dropdown. This appears to be due to trying to match an escaped version of that string to the actual value (the attribute dropdown uses `esc_attr` which turns `"` to `&quot` etc).

To fix this I had to remove the value matcher and use a loop instead so text versions are compared (without entities). This is now also fixed.

## How to test the changes in this Pull Request:

1. Add `\,",',+` to an attribute value list and save.
2. The list should display the values saved.
3. Refreshing the page, the value should remain.
4. Adding the attribute value to a variation should save.
5. Frontend form should allow you to add that new variation to the cart.

Thanks @rrennick for working on this prior.

> Fix: allow apostrophes in product attribute values list to save, and be used by variations.

Propose punting this to 3.6.0 for more testing since it was a little more in-depth than hoped. Should also run through automated tests.