### PR TITLE
Properly align order item meta in RTL emails

### DIFF
--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -56,9 +56,12 @@ foreach ( $items as $item_id => $item ) :
 		// allow other plugins to add additional product information here.
 		do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, $plain_text );
 
-		wc_display_item_meta( $item, array(
-			'label_before' => '<strong class="wc-item-meta-label" style="float: left; margin-right: .25em; clear: both">',
-		) );
+		wc_display_item_meta(
+			$item,
+			array(
+				'label_before' => '<strong class="wc-item-meta-label" style="float: left; margin-right: .25em; clear: both">',
+			)
+		);
 
 		// allow other plugins to add additional product information here.
 		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -17,7 +17,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
-$text_align = is_rtl() ? 'right' : 'left';
+$text_align  = is_rtl() ? 'right' : 'left';
+$margin_side = is_rtl() ? 'left' : 'right';
 
 foreach ( $items as $item_id => $item ) :
 	$product       = $item->get_product();
@@ -59,7 +60,7 @@ foreach ( $items as $item_id => $item ) :
 		wc_display_item_meta(
 			$item,
 			array(
-				'label_before' => '<strong class="wc-item-meta-label" style="float: left; margin-right: .25em; clear: both">',
+				'label_before' => '<strong class="wc-item-meta-label" style="float: ' . esc_attr( $text_align ) . '; margin-' . esc_attr( $margin_side ) . ': .25em; clear: both">',
 			)
 		);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Since commit
4082222#diff-30dd34631dd7461f75c05ded270e9ee4R60, order item meta is not aligned properly in order e-mails when using a RTL language. This PR fixes this problem by using the is_rtl() function to determine the float side for the element that contains the order item meta information. It also includes PHPCS fixes for the modified file in a separate commit.

cc @claudiulodro 

Closes #22296.

### How to test the changes in this Pull Request:

1. See issue #22296 for instructions on how to test.

### Changelog entry

> Fix order item meta alignment in order emails when using an RTL language