### PR TITLE
register order auto drafts post status

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -51,7 +51,8 @@ class WC_Post_Types {
 			'product_type',
 			apply_filters( 'woocommerce_taxonomy_objects_product_type', array( 'product' ) ),
 			apply_filters(
-				'woocommerce_taxonomy_args_product_type', array(
+				'woocommerce_taxonomy_args_product_type',
+				array(
 					'hierarchical'      => false,
 					'show_ui'           => false,
 					'show_in_nav_menus' => false,
@@ -66,7 +67,8 @@ class WC_Post_Types {
 			'product_visibility',
 			apply_filters( 'woocommerce_taxonomy_objects_product_visibility', array( 'product', 'product_variation' ) ),
 			apply_filters(
-				'woocommerce_taxonomy_args_product_visibility', array(
+				'woocommerce_taxonomy_args_product_visibility',
+				array(
 					'hierarchical'      => false,
 					'show_ui'           => false,
 					'show_in_nav_menus' => false,
@@ -81,7 +83,8 @@ class WC_Post_Types {
 			'product_cat',
 			apply_filters( 'woocommerce_taxonomy_objects_product_cat', array( 'product' ) ),
 			apply_filters(
-				'woocommerce_taxonomy_args_product_cat', array(
+				'woocommerce_taxonomy_args_product_cat',
+				array(
 					'hierarchical'          => true,
 					'update_count_callback' => '_wc_term_recount',
 					'label'                 => __( 'Categories', 'woocommerce' ),
@@ -120,7 +123,8 @@ class WC_Post_Types {
 			'product_tag',
 			apply_filters( 'woocommerce_taxonomy_objects_product_tag', array( 'product' ) ),
 			apply_filters(
-				'woocommerce_taxonomy_args_product_tag', array(
+				'woocommerce_taxonomy_args_product_tag',
+				array(
 					'hierarchical'          => false,
 					'update_count_callback' => '_wc_term_recount',
 					'label'                 => __( 'Product tags', 'woocommerce' ),
@@ -160,7 +164,8 @@ class WC_Post_Types {
 			'product_shipping_class',
 			apply_filters( 'woocommerce_taxonomy_objects_product_shipping_class', array( 'product', 'product_variation' ) ),
 			apply_filters(
-				'woocommerce_taxonomy_args_product_shipping_class', array(
+				'woocommerce_taxonomy_args_product_shipping_class',
+				array(
 					'hierarchical'          => false,
 					'update_count_callback' => '_update_post_term_count',
 					'label'                 => __( 'Shipping classes', 'woocommerce' ),

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -547,6 +547,12 @@ class WC_Post_Types {
 					/* translators: %s: number of orders */
 					'label_count'               => _n_noop( 'Failed <span class="count">(%s)</span>', 'Failed <span class="count">(%s)</span>', 'woocommerce' ),
 				),
+				'wc-auto-draft'     => array(
+					'public'                    => false,
+					'exclude_from_search'       => false,
+					'show_in_admin_all_list'    => false,
+					'show_in_admin_status_list' => false,
+				),
 			)
 		);
 

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -484,6 +484,14 @@ class WC_Post_Types {
 		$order_statuses = apply_filters(
 			'woocommerce_register_shop_order_post_statuses',
 			array(
+				'wc-auto-draft'     => array(
+					'public'                    => false,
+					'exclude_from_search'       => false,
+					'show_in_admin_all_list'    => true,
+					'show_in_admin_status_list' => true,
+					/* translators: %s: number of orders */
+					'label_count'               => _n_noop( 'Draft <span class="count">(%s)</span>', 'Draft <span class="count">(%s)</span>', 'woocommerce' ),
+				),
 				'wc-pending'    => array(
 					'label'                     => _x( 'Pending payment', 'Order status', 'woocommerce' ),
 					'public'                    => false,
@@ -546,12 +554,6 @@ class WC_Post_Types {
 					'show_in_admin_status_list' => true,
 					/* translators: %s: number of orders */
 					'label_count'               => _n_noop( 'Failed <span class="count">(%s)</span>', 'Failed <span class="count">(%s)</span>', 'woocommerce' ),
-				),
-				'wc-auto-draft'     => array(
-					'public'                    => false,
-					'exclude_from_search'       => false,
-					'show_in_admin_all_list'    => false,
-					'show_in_admin_status_list' => false,
 				),
 			)
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Register the `wc-auto-draft` post status to exclude auto draft orders from the `All` count in the order list.

Closes #22261 .

### How to test the changes in this Pull Request:

1. Go to Add order screen
2. Add a product then recalculate
3. Without PR the order count on the order list is increased by 1
4. With PR the order count remains the same

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: Include auto draft orders in order list filters.
