### PR TITLE
For logged in customers, pull default address fields from customer object, not session object

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -37,6 +37,13 @@ class WC_Checkout {
 	protected $legacy_posted_data = array();
 
 	/**
+	 * Caches customer object. @see get_value.
+	 *
+	 * @var WC_Customer
+	 */
+	private $logged_in_customer = null;
+
+	/**
 	 * Gets the main WC_Checkout Instance.
 	 *
 	 * @since 2.1
@@ -314,13 +321,14 @@ class WC_Checkout {
 			}
 
 			$fields_prefix = array(
-				'shipping'  => true,
-				'billing'   => true,
+				'shipping' => true,
+				'billing'  => true,
 			);
+
 			$shipping_fields = array(
-				'shipping_method'   => true,
-				'shipping_total'    => true,
-				'shipping_tax'      => true,
+				'shipping_method' => true,
+				'shipping_total'  => true,
+				'shipping_tax'    => true,
 			);
 			foreach ( $data as $key => $value ) {
 				if ( is_callable( array( $order, "set_{$key}" ) ) ) {
@@ -711,7 +719,7 @@ class WC_Checkout {
 
 				if ( in_array( 'email', $format, true ) && '' !== $data[ $key ] ) {
 					$email_is_valid = is_email( $data[ $key ] );
-					$data[ $key ] = sanitize_email( $data[ $key ] );
+					$data[ $key ]   = sanitize_email( $data[ $key ] );
 
 					if ( $validate_fieldset && ! $email_is_valid ) {
 						/* translators: %s: email address */
@@ -1106,29 +1114,52 @@ class WC_Checkout {
 	}
 
 	/**
-	 * Gets the value either from the posted data, or from the users meta data.
+	 * Gets the value either from POST, or from the customer object. Sets the default values in checkout fields.
 	 *
-	 * @param string $input Input key.
-	 * @return string
+	 * @param string $input Name of the input we want to grab data for. e.g. billing_country.
+	 * @return string The default value.
 	 */
 	public function get_value( $input ) {
+		// If the form was posted, get the posted value. This will only tend to happen when JavaScript is disabled client side.
 		if ( ! empty( $_POST[ $input ] ) ) { // WPCS: input var ok, CSRF OK.
 			return wc_clean( wp_unslash( $_POST[ $input ] ) ); // WPCS: input var ok, CSRF OK.
 		}
 
+		// Allow 3rd parties to short circuit the logic and return their own default value.
 		$value = apply_filters( 'woocommerce_checkout_get_value', null, $input );
 
-		if ( null !== $value ) {
+		if ( ! is_null( $value ) ) {
 			return $value;
 		}
 
-		if ( is_callable( array( WC()->customer, "get_$input" ) ) ) {
-			$value = WC()->customer->{"get_$input"}();
-		} elseif ( WC()->customer->meta_exists( $input ) ) {
-			$value = WC()->customer->get_meta( $input, true );
+		/**
+		 * For logged in customers, pull data from their account rather than the session which may contain incomplete data.
+		 * Another reason is that WC sets shipping address to the billing address on the checkout updates unless the
+		 * "ship to another address" box is checked. @see issue #20975.
+		 */
+		$customer_object = false;
+
+		if ( is_user_logged_in() ) {
+			// Load customer object, but keep it cached to avoid reloading it multiple times.
+			if ( is_null( $this->logged_in_customer ) ) {
+				$this->logged_in_customer = new WC_Customer( get_current_user_id() );
+			}
+			$customer_object = $this->logged_in_customer;
 		}
 
-		$value = $value ? $value : null; // Empty value should return null.
+		if ( ! $customer_object ) {
+			$customer_object = WC()->customer;
+		}
+
+		if ( is_callable( array( $customer_object, "get_$input" ) ) ) {
+			$value = $customer_object->{"get_$input"}();
+		} elseif ( $customer_object->meta_exists( $input ) ) {
+			$value = $customer_object->get_meta( $input, true );
+		}
+
+		if ( '' === $value ) {
+			$value = null;
+		}
 
 		return apply_filters( 'default_checkout_' . $input, $value, $input );
 	}

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -137,7 +137,8 @@ class WC_Customer extends WC_Legacy_Customer {
 	public function delete_and_reassign( $reassign = null ) {
 		if ( $this->data_store ) {
 			$this->data_store->delete(
-				$this, array(
+				$this,
+				array(
 					'force_delete' => true,
 					'reassign'     => $reassign,
 				)
@@ -817,12 +818,16 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param string $city     City.
 	 */
 	public function set_billing_location( $country, $state = '', $postcode = '', $city = '' ) {
-		$billing             = $this->get_prop( 'billing', 'edit' );
-		$billing['country']  = $country;
-		$billing['state']    = $state;
-		$billing['postcode'] = $postcode;
-		$billing['city']     = $city;
-		$this->set_prop( 'billing', $billing );
+		$address_data = $this->get_prop( 'billing', 'edit' );
+
+		$address_data['address_1'] = '';
+		$address_data['address_2'] = '';
+		$address_data['city']      = $city;
+		$address_data['state']     = $state;
+		$address_data['postcode']  = $postcode;
+		$address_data['country']   = $country;
+
+		$this->set_prop( 'billing', $address_data );
 	}
 
 	/**
@@ -834,12 +839,16 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @param string $city     City.
 	 */
 	public function set_shipping_location( $country, $state = '', $postcode = '', $city = '' ) {
-		$shipping             = $this->get_prop( 'shipping', 'edit' );
-		$shipping['country']  = $country;
-		$shipping['state']    = $state;
-		$shipping['postcode'] = $postcode;
-		$shipping['city']     = $city;
-		$this->set_prop( 'shipping', $shipping );
+		$address_data = $this->get_prop( 'shipping', 'edit' );
+
+		$address_data['address_1'] = '';
+		$address_data['address_2'] = '';
+		$address_data['city']      = $city;
+		$address_data['state']     = $state;
+		$address_data['postcode']  = $postcode;
+		$address_data['country']   = $country;
+
+		$this->set_prop( 'shipping', $address_data );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/includes/data-stores/class-wc-customer-data-store-session.php
@@ -109,7 +109,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				if ( 'billing_' === substr( $session_key, 0, 8 ) ) {
 					$session_key = str_replace( 'billing_', '', $session_key );
 				}
-				if ( ! empty( $data[ $session_key ] ) && is_callable( array( $customer, "set_{$function_key}" ) ) ) {
+				if ( isset( $data[ $session_key ] ) && is_callable( array( $customer, "set_{$function_key}" ) ) ) {
 					$customer->{"set_{$function_key}"}( wp_unslash( $data[ $session_key ] ) );
 				}
 			}

--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -40,7 +40,7 @@ class WC_Shortcode_Cart {
 			}
 
 			if ( $address['country'] ) {
-				WC()->customer->set_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
+				WC()->customer->set_billing_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
 				WC()->customer->set_shipping_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
 			} else {
 				WC()->customer->set_billing_address_to_base();

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -86,7 +86,7 @@ class WC_Shortcode_Checkout {
 			try {
 				$order_key          = isset( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // WPCS: input var ok, CSRF ok.
 				$order              = wc_get_order( $order_id );
- 				$hold_stock_minutes = (int) get_option( 'woocommerce_hold_stock_minutes', 0 );
+				$hold_stock_minutes = (int) get_option( 'woocommerce_hold_stock_minutes', 0 );
 
 				// Order or payment link is invalid.
 				if ( ! $order || $order->get_id() !== $order_id || $order->get_order_key() !== $order_key ) {
@@ -177,7 +177,8 @@ class WC_Shortcode_Checkout {
 				}
 
 				wc_get_template(
-					'checkout/form-pay.php', array(
+					'checkout/form-pay.php',
+					array(
 						'order'              => $order,
 						'available_gateways' => $available_gateways,
 						'order_button_text'  => apply_filters( 'woocommerce_pay_order_button_text', __( 'Pay for order', 'woocommerce' ) ),


### PR DESCRIPTION
Supercedes #21639 which caused other issues.

Fixes #20975

When the checkout form is posted (manually or via ajax update) the posted fields get stored to the session. If the 'ship to different address' checkbox is unchecked, we're shipping to the billing address. So in the session, shipping now = billing address.

If you refresh the checkout page or leave/come back, you'll see session values. If you then chose to ship to a different address, rather than see the address stored to your profile, you'll actually see the billing address again.

To fix this, on first load (when populating the defaults) we can pull from the customer object rather than the session object. The side effect is that if you make changes in session and come back to checkout you'll have to make edits again, however this doesn't seem too problematic because:

a) this is for logged in users only
b) it makes sense to use stored profile addresses in most cases
c) leaving and returning should be rare - if you proceed normally your profile is updated with any changes

To test, 

1. Log in
2. Make sure your account has addresses populated
3. Go to checkout. See your stored addresses.
4. Make some edits. Fill out entire address so the ajax update triggers.
5. Leave and come back. See profile data, not the data you typed before.
6. Toggle open shipping - see your profile data too.