### PR TITLE
Centralized term image url function & added filter

### DIFF
--- a/includes/admin/class-wc-admin-taxonomies.php
+++ b/includes/admin/class-wc-admin-taxonomies.php
@@ -221,7 +221,7 @@ class WC_Admin_Taxonomies {
 		<tr class="form-field term-thumbnail-wrap">
 			<th scope="row" valign="top"><label><?php _e( 'Thumbnail', 'woocommerce' ); ?></label></th>
 			<td>
-				<div id="product_cat_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( wc_get_term_thumbnail_url( $term, $thumbnail_id, 'thumb', true ) ); ?>" width="60px" height="60px" /></div>
+				<div id="product_cat_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( wc_get_term_src_url( $term, $thumbnail_id, 'thumb', true ) ); ?>" width="60px" height="60px" /></div>
 				<div style="line-height: 60px;">
 					<input type="hidden" id="product_cat_thumbnail_id" name="product_cat_thumbnail_id" value="<?php echo $thumbnail_id; ?>" />
 					<button type="button" class="upload_image_button button"><?php _e( 'Upload/Add image', 'woocommerce' ); ?></button>

--- a/includes/admin/class-wc-admin-taxonomies.php
+++ b/includes/admin/class-wc-admin-taxonomies.php
@@ -221,7 +221,7 @@ class WC_Admin_Taxonomies {
 		<tr class="form-field term-thumbnail-wrap">
 			<th scope="row" valign="top"><label><?php _e( 'Thumbnail', 'woocommerce' ); ?></label></th>
 			<td>
-				<div id="product_cat_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( wc_get_term_src_url( $term, $thumbnail_id, 'thumb', true ) ); ?>" width="60px" height="60px" /></div>
+				<div id="product_cat_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( wc_get_term_image_url( $term, $thumbnail_id, 'thumb', true ) ); ?>" width="60px" height="60px" /></div>
 				<div style="line-height: 60px;">
 					<input type="hidden" id="product_cat_thumbnail_id" name="product_cat_thumbnail_id" value="<?php echo $thumbnail_id; ?>" />
 					<button type="button" class="upload_image_button button"><?php _e( 'Upload/Add image', 'woocommerce' ); ?></button>

--- a/includes/admin/class-wc-admin-taxonomies.php
+++ b/includes/admin/class-wc-admin-taxonomies.php
@@ -206,12 +206,6 @@ class WC_Admin_Taxonomies {
 
 		$display_type = get_woocommerce_term_meta( $term->term_id, 'display_type', true );
 		$thumbnail_id = absint( get_woocommerce_term_meta( $term->term_id, 'thumbnail_id', true ) );
-
-		if ( $thumbnail_id ) {
-			$image = wp_get_attachment_thumb_url( $thumbnail_id );
-		} else {
-			$image = wc_placeholder_img_src();
-		}
 		?>
 		<tr class="form-field term-display-type-wrap">
 			<th scope="row" valign="top"><label><?php _e( 'Display type', 'woocommerce' ); ?></label></th>
@@ -227,7 +221,7 @@ class WC_Admin_Taxonomies {
 		<tr class="form-field term-thumbnail-wrap">
 			<th scope="row" valign="top"><label><?php _e( 'Thumbnail', 'woocommerce' ); ?></label></th>
 			<td>
-				<div id="product_cat_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( $image ); ?>" width="60px" height="60px" /></div>
+				<div id="product_cat_thumbnail" style="float: left; margin-right: 10px;"><img src="<?php echo esc_url( wc_get_term_thumbnail_url( $term, $thumbnail_id, 'thumb', true ) ); ?>" width="60px" height="60px" /></div>
 				<div style="line-height: 60px;">
 					<input type="hidden" id="product_cat_thumbnail_id" name="product_cat_thumbnail_id" value="<?php echo $thumbnail_id; ?>" />
 					<button type="button" class="upload_image_button button"><?php _e( 'Upload/Add image', 'woocommerce' ); ?></button>

--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -62,10 +62,13 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 				'date_created_gmt'  => wc_rest_prepare_date_response( $attachment->post_date_gmt ),
 				'date_modified'     => wc_rest_prepare_date_response( $attachment->post_modified ),
 				'date_modified_gmt' => wc_rest_prepare_date_response( $attachment->post_modified_gmt ),
-				'src'               => wp_get_attachment_url( $image_id ),
+				'src'               => wc_get_term_thumbnail_url($item, $image_id, false, false),
 				'name'              => get_the_title( $attachment ),
 				'alt'               => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
+		}
+		else{
+			$data['image_src'] = wc_get_term_thumbnail_url($item, false, false, false);
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -62,13 +62,13 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 				'date_created_gmt'  => wc_rest_prepare_date_response( $attachment->post_date_gmt ),
 				'date_modified'     => wc_rest_prepare_date_response( $attachment->post_modified ),
 				'date_modified_gmt' => wc_rest_prepare_date_response( $attachment->post_modified_gmt ),
-				'src'               => wc_get_term_thumbnail_url($item, $image_id, false, false),
+				'src'               => wc_get_term_thumbnail_url( $item, $image_id, false, false ),
 				'name'              => get_the_title( $attachment ),
 				'alt'               => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
 		}
 		else{
-			$data['image_src'] = wc_get_term_thumbnail_url($item, false, false, false);
+			$data['image_src'] = wc_get_term_thumbnail_url( $item, false, false, false );
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -53,6 +53,7 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 
 		// Get category image.
 		$image_id = get_woocommerce_term_meta( $item->term_id, 'thumbnail_id' );
+		
 		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 
@@ -62,13 +63,13 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 				'date_created_gmt'  => wc_rest_prepare_date_response( $attachment->post_date_gmt ),
 				'date_modified'     => wc_rest_prepare_date_response( $attachment->post_modified ),
 				'date_modified_gmt' => wc_rest_prepare_date_response( $attachment->post_modified_gmt ),
-				'src'               => wc_get_term_src_url( $item, $image_id, false, false ),
+				'src'               => wc_get_term_image_url( $item, $image_id, false, false ),
 				'name'              => get_the_title( $attachment ),
 				'alt'               => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
 		}
 		else{
-			$data['image_src'] = wc_get_term_src_url( $item, false, false, false );
+			$data['image_src'] = wc_get_term_image_url( $item, false, false, false );
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -67,8 +67,7 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 				'name'              => get_the_title( $attachment ),
 				'alt'               => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
-		}
-		else{
+		} else {
 			$data['image_src'] = wc_get_term_image_url( $item, false, false, false );
 		}
 

--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -62,13 +62,13 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 				'date_created_gmt'  => wc_rest_prepare_date_response( $attachment->post_date_gmt ),
 				'date_modified'     => wc_rest_prepare_date_response( $attachment->post_modified ),
 				'date_modified_gmt' => wc_rest_prepare_date_response( $attachment->post_modified_gmt ),
-				'src'               => wc_get_term_thumbnail_url( $item, $image_id, false, false ),
+				'src'               => wc_get_term_src_url( $item, $image_id, false, false ),
 				'name'              => get_the_title( $attachment ),
 				'alt'               => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
 		}
 		else{
-			$data['image_src'] = wc_get_term_thumbnail_url( $item, false, false, false );
+			$data['image_src'] = wc_get_term_src_url( $item, false, false, false );
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/includes/api/v1/class-wc-rest-product-categories-controller.php
+++ b/includes/api/v1/class-wc-rest-product-categories-controller.php
@@ -71,6 +71,7 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 
 		// Get category image.
 		$image_id = get_woocommerce_term_meta( $item->term_id, 'thumbnail_id' );
+		
 		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 
@@ -78,13 +79,13 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 				'id'            => (int) $image_id,
 				'date_created'  => wc_rest_prepare_date_response( $attachment->post_date_gmt ),
 				'date_modified' => wc_rest_prepare_date_response( $attachment->post_modified_gmt ),
-				'src'           => wc_get_term_src_url( $item, $image_id, false, false ),
+				'src'           => wc_get_term_image_url( $item, $image_id, false, false ),
 				'title'         => get_the_title( $attachment ),
 				'alt'           => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
 		}
 		else{
-			$data['image_src'] = wc_get_term_src_url( $item, false, false, false );
+			$data['image_src'] = wc_get_term_image_url( $item, false, false, false );
 		}
 		
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/includes/api/v1/class-wc-rest-product-categories-controller.php
+++ b/includes/api/v1/class-wc-rest-product-categories-controller.php
@@ -83,8 +83,7 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 				'title'         => get_the_title( $attachment ),
 				'alt'           => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
-		}
-		else{
+		} else {
 			$data['image_src'] = wc_get_term_image_url( $item, false, false, false );
 		}
 		

--- a/includes/api/v1/class-wc-rest-product-categories-controller.php
+++ b/includes/api/v1/class-wc-rest-product-categories-controller.php
@@ -78,12 +78,15 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 				'id'            => (int) $image_id,
 				'date_created'  => wc_rest_prepare_date_response( $attachment->post_date_gmt ),
 				'date_modified' => wc_rest_prepare_date_response( $attachment->post_modified_gmt ),
-				'src'           => wp_get_attachment_url( $image_id ),
+				'src'           => wc_get_term_thumbnail_url($item, $image_id, false, false),
 				'title'         => get_the_title( $attachment ),
 				'alt'           => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
 		}
-
+		else{
+			$data['image_src'] = wc_get_term_thumbnail_url($item, false, false, false);
+		}
+		
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );
 		$data    = $this->filter_response_by_context( $data, $context );

--- a/includes/api/v1/class-wc-rest-product-categories-controller.php
+++ b/includes/api/v1/class-wc-rest-product-categories-controller.php
@@ -78,13 +78,13 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 				'id'            => (int) $image_id,
 				'date_created'  => wc_rest_prepare_date_response( $attachment->post_date_gmt ),
 				'date_modified' => wc_rest_prepare_date_response( $attachment->post_modified_gmt ),
-				'src'           => wc_get_term_thumbnail_url( $item, $image_id, false, false ),
+				'src'           => wc_get_term_src_url( $item, $image_id, false, false ),
 				'title'         => get_the_title( $attachment ),
 				'alt'           => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
 		}
 		else{
-			$data['image_src'] = wc_get_term_thumbnail_url( $item, false, false, false );
+			$data['image_src'] = wc_get_term_src_url( $item, false, false, false );
 		}
 		
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/includes/api/v1/class-wc-rest-product-categories-controller.php
+++ b/includes/api/v1/class-wc-rest-product-categories-controller.php
@@ -78,13 +78,13 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 				'id'            => (int) $image_id,
 				'date_created'  => wc_rest_prepare_date_response( $attachment->post_date_gmt ),
 				'date_modified' => wc_rest_prepare_date_response( $attachment->post_modified_gmt ),
-				'src'           => wc_get_term_thumbnail_url($item, $image_id, false, false),
+				'src'           => wc_get_term_thumbnail_url( $item, $image_id, false, false ),
 				'title'         => get_the_title( $attachment ),
 				'alt'           => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
 		}
 		else{
-			$data['image_src'] = wc_get_term_thumbnail_url($item, false, false, false);
+			$data['image_src'] = wc_get_term_thumbnail_url( $item, false, false, false );
 		}
 		
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
@@ -62,10 +62,13 @@ class WC_REST_Product_Categories_V2_Controller extends WC_REST_Product_Categorie
 				'date_created_gmt'  => wc_rest_prepare_date_response( $attachment->post_date_gmt ),
 				'date_modified'     => wc_rest_prepare_date_response( $attachment->post_modified ),
 				'date_modified_gmt' => wc_rest_prepare_date_response( $attachment->post_modified_gmt ),
-				'src'               => wp_get_attachment_url( $image_id ),
+				'src'               => wc_get_term_thumbnail_url( $item, $image_id, false, false ),
 				'title'             => get_the_title( $attachment ),
 				'alt'               => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
+		}
+		else{
+			$data['image_src'] = wc_get_term_thumbnail_url( $item, false, false, false );
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
@@ -53,6 +53,7 @@ class WC_REST_Product_Categories_V2_Controller extends WC_REST_Product_Categorie
 
 		// Get category image.
 		$image_id = get_woocommerce_term_meta( $item->term_id, 'thumbnail_id' );
+		
 		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 
@@ -62,13 +63,13 @@ class WC_REST_Product_Categories_V2_Controller extends WC_REST_Product_Categorie
 				'date_created_gmt'  => wc_rest_prepare_date_response( $attachment->post_date_gmt ),
 				'date_modified'     => wc_rest_prepare_date_response( $attachment->post_modified ),
 				'date_modified_gmt' => wc_rest_prepare_date_response( $attachment->post_modified_gmt ),
-				'src'               => wc_get_term_src_url( $item, $image_id, false, false ),
+				'src'               => wc_get_term_image_url( $item, $image_id, false, false ),
 				'title'             => get_the_title( $attachment ),
 				'alt'               => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
 		}
 		else{
-			$data['image_src'] = wc_get_term_src_url( $item, false, false, false );
+			$data['image_src'] = wc_get_term_image_url( $item, false, false, false );
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
@@ -67,8 +67,7 @@ class WC_REST_Product_Categories_V2_Controller extends WC_REST_Product_Categorie
 				'title'             => get_the_title( $attachment ),
 				'alt'               => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
-		}
-		else{
+		} else {
 			$data['image_src'] = wc_get_term_image_url( $item, false, false, false );
 		}
 

--- a/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
@@ -62,13 +62,13 @@ class WC_REST_Product_Categories_V2_Controller extends WC_REST_Product_Categorie
 				'date_created_gmt'  => wc_rest_prepare_date_response( $attachment->post_date_gmt ),
 				'date_modified'     => wc_rest_prepare_date_response( $attachment->post_modified ),
 				'date_modified_gmt' => wc_rest_prepare_date_response( $attachment->post_modified_gmt ),
-				'src'               => wc_get_term_thumbnail_url( $item, $image_id, false, false ),
+				'src'               => wc_get_term_src_url( $item, $image_id, false, false ),
 				'title'             => get_the_title( $attachment ),
 				'alt'               => get_post_meta( $image_id, '_wp_attachment_image_alt', true ),
 			);
 		}
 		else{
-			$data['image_src'] = wc_get_term_thumbnail_url( $item, false, false, false );
+			$data['image_src'] = wc_get_term_src_url( $item, false, false, false );
 		}
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2453,10 +2453,12 @@ if ( ! function_exists( 'woocommerce_subcategory_thumbnail' ) ) {
 
 			// Add responsive image markup if available.
 			if ( $image_srcset && $image_sizes ) {
-				echo '<img src="' . esc_url( $image ) . '" alt="' . esc_attr( $category->name ) . '" width="' . esc_attr( $dimensions['width'] ) . '" height="' . esc_attr( $dimensions['height'] ) . '" srcset="' . esc_attr( $image_srcset ) . '" sizes="' . esc_attr( $image_sizes ) . '" />';
+				$output = '<img src="' . esc_url( $image ) . '" alt="' . esc_attr( $category->name ) . '" width="' . esc_attr( $dimensions['width'] ) . '" height="' . esc_attr( $dimensions['height'] ) . '" srcset="' . esc_attr( $image_srcset ) . '" sizes="' . esc_attr( $image_sizes ) . '" />';
 			} else {
-				echo '<img src="' . esc_url( $image ) . '" alt="' . esc_attr( $category->name ) . '" width="' . esc_attr( $dimensions['width'] ) . '" height="' . esc_attr( $dimensions['height'] ) . '" />';
+				$output = '<img src="' . esc_url( $image ) . '" alt="' . esc_attr( $category->name ) . '" width="' . esc_attr( $dimensions['width'] ) . '" height="' . esc_attr( $dimensions['height'] ) . '" />';
 			}
+			
+			echo apply_filters( 'woocommerce_subcategory_thumbnail', $output, $category, $thumbnail_id, $dimensions );
 		}
 	}
 }

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -791,3 +791,34 @@ function wc_get_product_visibility_term_ids() {
 		)
 	);
 }
+
+/**
+ * Get a thumbnail image for term.
+ *
+ * The returned variable is filtered by woocommerce_get_term_thumbnail_url filter to
+ * allow 3rd party customisation.
+ *
+ * @param array|int $term Term object of the target term, or term ID.
+ * @return string Final image url.
+ */
+function wc_get_term_thumbnail_url( $term, $image_id = false, $size = false, $placeholder_image = false ) {
+	
+	$term_id = is_numeric($term) ? $term : $term->term_id;
+	$image_url = '';
+	
+	// Get term image id.
+	if ( ! $image_id )
+		$image_id = (int) get_woocommerce_term_meta( $term_id, 'thumbnail_id' );
+	
+	// If image exists, get it
+	if ( $image_id ) {
+		$image_url = wp_get_attachment_url( $image_id );
+	}
+	
+	// If placeholder image is needed
+	if ( empty( $image_url ) && $placeholder_image ) {
+		$image_url = wc_placeholder_img_src();
+	}
+	
+	return apply_filters( 'woocommerce_get_term_thumbnail_url', $image_url, $term_id );
+}

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -812,7 +812,7 @@ function wc_get_term_thumbnail_url( $term, $image_id = false, $size = false, $pl
 	
 	// If image exists, get it
 	if ( $image_id ) {
-		$image_url = wp_get_attachment_url( $image_id );
+		$image_url = $size == 'thumb' ? wp_get_attachment_thumb_url($image_id) : wp_get_attachment_url( $image_id );
 	}
 	
 	// If placeholder image is needed

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -801,7 +801,7 @@ function wc_get_product_visibility_term_ids() {
  * @param array|int $term Term object of the target term, or term ID.
  * @return string Final image url.
  */
-function wc_get_term_thumbnail_url( $term, $image_id = false, $size = false, $placeholder_image = false ) {
+function wc_get_term_src_url( $term, $image_id = false, $size = false, $placeholder_image = false ) {
 	
 	$term_id = is_numeric($term) ? $term : $term->term_id;
 	$image_url = '';
@@ -820,5 +820,5 @@ function wc_get_term_thumbnail_url( $term, $image_id = false, $size = false, $pl
 		$image_url = wc_placeholder_img_src();
 	}
 	
-	return apply_filters( 'woocommerce_get_term_thumbnail_url', $image_url, $term_id );
+	return apply_filters( 'woocommerce_get_term_src_url', $image_url, $term_id );
 }

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -820,5 +820,5 @@ function wc_get_term_src_url( $term, $image_id = false, $size = false, $placehol
 		$image_url = wc_placeholder_img_src();
 	}
 	
-	return apply_filters( 'woocommerce_get_term_src_url', $image_url, $term_id );
+	return apply_filters( 'woocommerce_get_term_src_url', $image_url, $term_id, $size, $placeholder_image );
 }

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -812,7 +812,7 @@ function wc_get_term_thumbnail_url( $term, $image_id = false, $size = false, $pl
 	
 	// If image exists, get it
 	if ( $image_id ) {
-		$image_url = $size == 'thumb' ? wp_get_attachment_thumb_url($image_id) : wp_get_attachment_url( $image_id );
+		$image_url = $size == 'thumb' ? wp_get_attachment_thumb_url( $image_id ) : wp_get_attachment_url( $image_id );
 	}
 	
 	// If placeholder image is needed

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -801,7 +801,7 @@ function wc_get_product_visibility_term_ids() {
  * @param array|int $term Term object of the target term, or term ID.
  * @return string Final image url.
  */
-function wc_get_term_src_url( $term, $image_id = false, $size = false, $placeholder_image = false ) {
+function wc_get_term_image_url( $term, $image_id = false, $size = false, $placeholder_image = false ) {
 	
 	$term_id = is_numeric($term) ? $term : $term->term_id;
 	$image_url = '';
@@ -820,5 +820,5 @@ function wc_get_term_src_url( $term, $image_id = false, $size = false, $placehol
 		$image_url = wc_placeholder_img_src();
 	}
 	
-	return apply_filters( 'woocommerce_get_term_src_url', $image_url, $term_id, $size, $placeholder_image );
+	return apply_filters( 'woocommerce_get_term_image_url', $image_url, $term_id, $size, $placeholder_image );
 }

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -806,9 +806,10 @@ function wc_get_term_image_url( $term, $image_id = false, $size = false, $placeh
 	$term_id = is_numeric($term) ? $term : $term->term_id;
 	$image_url = '';
 	
-	// Get term image id.
-	if ( ! $image_id )
+	// Get term image id, if ID was not explicitly passed
+	if ( ! $image_id ) {
 		$image_id = (int) get_woocommerce_term_meta( $term_id, 'thumbnail_id' );
+	}
 	
 	// If image exists, get it
 	if ( $image_id ) {


### PR DESCRIPTION
### All Submissions:

* [ x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. For example, we can now add a hook to change the term images.
```
add_filter( 'woocommerce_get_term_src_url', 'example_func', 10, 5);
function example_func($image_url, $term_id, $size, $placeholder_image ) {
	...
	if ( condition ) 
		$image_url =  'https://i.vimeocdn.com/portrait/25122243_300x300';
	...
	return $image_url ;
}
```

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x ] Have you written new tests for your changes, as applicable?
* [x ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

1. I've Added a global function to get term thumbnail urls, so we can use this function, instead of repeated code for getting the image of term. This also has an essential hook for 3rd party customizations, which lacks current WC version for term images, because in some cases, developers (like me) use custom images for taxonomies (not uploaded inside standard WP uploader, like manual directories or CDN-ed files) to serve custom urls instead of native thumbnail urls.

2. Replaced all manually-repeated code in other places, with this function.

Now, many developers (including my firm) will have an useful way to change term images.