### PR TITLE
Add function wc_get_is_pending_statuses

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -116,7 +116,7 @@ class WC_Shortcode_Checkout {
 				}
 
 				// Ensure order items are still stocked if paying for a failed order. Pending orders do not need this check because stock is held.
-				if ( ! $order->has_status( 'pending' ) ) {
+				if ( ! $order->has_status( wc_get_is_pending_statuses() ) ) {
 					$quantities = array();
 
 					foreach ( $order->get_items() as $item_key => $item ) {

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -125,6 +125,16 @@ function wc_get_is_paid_statuses() {
 }
 
 /**
+ * Get list of statuses which are consider 'pending payment'.
+ *
+ * @since  3.5.4
+ * @return array
+ */
+function wc_get_is_pending_statuses() {
+	return apply_filters( 'woocommerce_order_is_pending_statuses', array( 'pending' ) );
+}
+
+/**
  * Get the nice name for an order status.
  *
  * @since  2.2


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR introduces a new filter, `woocommerce_valid_order_pending_statuses` and uses it in `includes/shortcodes/class-wc-shortcode-checkout.php` in place of the hard-coded `pending` status in the check for stocked items on an order on the payment page.

This allows the creation of custom statuses that mimic the existing `pending` status with respect to having held inventory and allowing checkout / payment to proceed when that held inventory reduces stock for a product to zero and the product does not allow backorders.

The existing filter `woocommerce_valid_order_statuses_for_payment` cannot be used for this use-case because it normally includes the `failed` order status which does not have held stock and should specifically not be included in the check where the new filter is introduced.

Closes #22408 .

### How to test the changes in this Pull Request:

1. Create custom status like `pending` and include it in a `add_filter` call that returns an array of pending statuses including the custom one
2. Create an order that reduces stock of a product that does not allow backorders to zero
3. Change the order status of that order to the custom `pending` status
4. Attempt to pay for the order

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Introduces new filter: `woocommerce_valid_order_pending_statuses` and uses it in `includes/shortcodes/class-wc-shortcode-checkout.php` in place of the hard-coded `pending` status in the check for stocked items on an order on the payment page.