### PR TITLE
pass all arguments to woocommerce_order_item_display_meta_value filter

### DIFF
--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -205,7 +205,7 @@ class WC_Order_Item_Meta {
 				$formatted_meta[ $formatted_meta_key ] = array(
 					'key'   => $meta_key,
 					'label' => wc_attribute_label( $attribute_key, $this->product ),
-					'value' => apply_filters( 'woocommerce_order_item_display_meta_value', $meta_value ),
+					'value' => apply_filters( 'woocommerce_order_item_display_meta_value', $meta_value, $this->meta, $this->item ),
 				);
 			}
 		}


### PR DESCRIPTION
Fixes a fatal error in php 7.2.x (PHP Fatal error:  Uncaught ArgumentCountError: Too few arguments) when the woocommerce_order_item_display_meta_value filter is called from the get_formatted_legacy method of the WC_Order_Item_Meta class.

### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. test_display in WC_Tests_Order_Item_Meta.
2. the error is in the actual filter call, so it would be necessary to have an actual filter applied, not sure if that can be handled with a unit test. 
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Adds all 3 callback arguments to the woocommerce_order_item_display_meta_value filter called from the get_formatted_legacy method of the WC_Order_Item_Meta class.
