### PR TITLE
Fix minor issues in WC_Webhook_Data_Store class

### DIFF
--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -146,7 +146,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 			$wpdb->prefix . 'wc_webhooks',
 			$data,
 			array(
-				'webhook_id' => $webhook->get_id( 'edit' ),
+				'webhook_id' => $webhook->get_id(),
 			)
 		); // WPCS: DB call ok.
 

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -227,7 +227,8 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 		global $wpdb;
 
 		$args = wp_parse_args(
-			$args, array(
+			$args,
+			array(
 				'limit'   => 10,
 				'offset'  => 0,
 				'order'   => 'DESC',

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -167,9 +167,8 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 	 *
 	 * @since 3.3.0
 	 * @param WC_Webhook $webhook      Webhook instance.
-	 * @param bool       $force_delete Skip trash bin forcing to delete.
 	 */
-	public function delete( &$webhook, $force_delete = false ) {
+	public function delete( &$webhook ) {
 		global $wpdb;
 
 		$wpdb->delete(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes two minor issues in WC_Webhook_Data_Store that I found while reviewing #21427:

- Removes an unused parameter from WC_Webhook_Data_Store::delete() signature
- Removes a parameter from a call to WC_Data::get_id() as this method does not take any parameters

This PR also includes PHPCS fixes for the modified file in a separate commit.

### How to test the changes in this Pull Request:

1. Review the code changes. They should not have any impact on the behavior of the code.