### PR TITLE
Add a fallback to cURL version check in system status

### DIFF
--- a/includes/api/v2/class-wc-rest-system-status-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-v2-controller.php
@@ -572,6 +572,8 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		if ( function_exists( 'curl_version' ) ) {
 			$curl_version = curl_version();
 			$curl_version = $curl_version['version'] . ', ' . $curl_version['ssl_version'];
+		} elseif ( extension_loaded( 'curl' ) ) {
+			$curl_version = __( 'cURL installed but unable to retrieve version.', 'woocommerce' );
 		}
 
 		// WP memory limit.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a fallback check to see if the cURL is extension is loaded when the curl_version check fails. Some hosts disable function as a security measure of sort as to not divulge the version of cURL the site is running.

Closes #22406 

### How to test the changes in this Pull Request:

1. Open your php.ini file and look for the disable_functions section
2. Add `curl_version` to the list, save and then reload PHP
3. Check that you get a message stating `cURL installed but unable to retrieve version.`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

