### PR TITLE
Incorrect rounding of multiple tax rates per location

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -972,8 +972,8 @@ function wc_get_price_including_tax( $product, $args = array() ) {
 
 	if ( $product->is_taxable() ) {
 		if ( ! wc_prices_include_tax() ) {
-			$tax_rates    = WC_Tax::get_rates( $product->get_tax_class() );
-			$taxes        = WC_Tax::calc_tax( $line_price, $tax_rates, false );
+			$tax_rates = WC_Tax::get_rates( $product->get_tax_class() );
+			$taxes     = WC_Tax::calc_tax( $line_price, $tax_rates, false );
 
 			if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
 				$taxes_total = array_sum( $taxes );
@@ -1057,14 +1057,7 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 		$tax_rates      = WC_Tax::get_rates( $product->get_tax_class() );
 		$base_tax_rates = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
 		$remove_taxes   = apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ? WC_Tax::calc_tax( $line_price, $base_tax_rates, true ) : WC_Tax::calc_tax( $line_price, $tax_rates, true );
-
-		if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
-			$remove_taxes_total = array_sum( $remove_taxes );
-		} else {
-			$remove_taxes_total = array_sum( array_map( 'wc_round_tax_total', $remove_taxes ) );
-		}
-
-		$return_price = round( $line_price - $remove_taxes_total, wc_get_price_decimals() );
+		$return_price   = $line_price - array_sum( $remove_taxes ); // Unrounded since we're dealing with tax inclusive prices. Matches logic in cart-totals class. @see adjust_non_base_location_price.
 	} else {
 		$return_price = $line_price;
 	}


### PR DESCRIPTION
Fixes #21871

Product prices/subtotals were not rounding the same as in the cart. This implements the same rounding found on the cart on items, so the totals match.

See #21871  for manual test instructions.

I've added a unit test specific to case #21871 which now passes. All other tests are passing.

I have some other rounding changes I want to make to clean up somewhat which I'll be submitting separately so this fix can go live.

> Fix item subtotal rounding when multiple taxes are applied so it matches the cart.