### PR TITLE
Sort countries using new ascii comparison function

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -50,7 +50,7 @@ class WC_Countries {
 		if ( empty( $this->countries ) ) {
 			$this->countries = apply_filters( 'woocommerce_countries', include WC()->plugin_path() . '/i18n/countries.php' );
 			if ( apply_filters( 'woocommerce_sort_countries', true ) ) {
-				asort( $this->countries );
+				uasort( $this->countries, 'wc_ascii_uasort_comparison' );
 			}
 		}
 

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1565,7 +1565,7 @@ function wc_ascii_uasort_comparison( $a, $b ) {
 		$a = iconv( 'UTF-8', 'ASCII//TRANSLIT', $a );
 		$b = iconv( 'UTF-8', 'ASCII//TRANSLIT', $b );
 	}
-	return strcmp( $aconv, $bconv );
+	return strcmp( $a, $b );
 }
 
 /**

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1554,6 +1554,19 @@ function wc_uasort_comparison( $a, $b ) {
 }
 
 /**
+ * Sort values based on ascii, usefull for special chars in strings.
+ *
+ * @param string $a First value.
+ * @param string $b Second value.
+ * @return int
+ */
+function wc_ascii_uasort_comparison( $a, $b ) {
+	$aconv = iconv( 'UTF-8', 'ASCII//TRANSLIT', $a );
+	$bconv = iconv( 'UTF-8', 'ASCII//TRANSLIT', $b );
+	return strcmp( $aconv, $bconv );
+}
+
+/**
  * Get rounding mode for internal tax calculations.
  *
  * @since 3.2.4

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1561,8 +1561,10 @@ function wc_uasort_comparison( $a, $b ) {
  * @return int
  */
 function wc_ascii_uasort_comparison( $a, $b ) {
-	$aconv = iconv( 'UTF-8', 'ASCII//TRANSLIT', $a );
-	$bconv = iconv( 'UTF-8', 'ASCII//TRANSLIT', $b );
+	if ( function_exists( 'iconv' ) ) {
+		$a = iconv( 'UTF-8', 'ASCII//TRANSLIT', $a );
+		$b = iconv( 'UTF-8', 'ASCII//TRANSLIT', $b );
+	}
 	return strcmp( $aconv, $bconv );
 }
 

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -870,4 +870,26 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		uasort( $fields, 'wc_checkout_fields_uasort_comparison' );
 		$this->assertSame( 0, array_search( 'billing_email', array_keys( $fields ) ) );
 	}
+
+	/**
+	 * Test wc_ascii_uasort_comparison function
+	 *
+	 * @return void
+	 */
+	public function test_wc_ascii_uasort_comparison() {
+		$unsorted_values = array(
+			'Benin',
+			'Bélgica',
+		);
+
+		// First test a normal asort which does not work right for accented characters.
+		$sorted_values = $unsorted_values;
+		asort( $sorted_values );
+		$this->assertSame( array( 'Benin', 'Bélgica' ), $sorted_values );
+
+		$sorted_values = $unsorted_values;
+		// Now test the new wc_ascii_uasort_comparison function which sorts the strings correctly.
+		uasort( $sorted_values, 'wc_ascii_uasort_comparison' );
+		$this->assertSame( array( 'Bélgica', 'Benin' ), $sorted_values );
+	}
 }

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -885,11 +885,11 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		// First test a normal asort which does not work right for accented characters.
 		$sorted_values = $unsorted_values;
 		asort( $sorted_values );
-		$this->assertSame( array( 'Benin', 'Bélgica' ), $sorted_values );
+		$this->assertSame( array( 'Benin', 'Bélgica' ), array_values( $sorted_values ) );
 
 		$sorted_values = $unsorted_values;
 		// Now test the new wc_ascii_uasort_comparison function which sorts the strings correctly.
 		uasort( $sorted_values, 'wc_ascii_uasort_comparison' );
-		$this->assertSame( array( 'Bélgica', 'Benin' ), $sorted_values );
+		$this->assertSame( array( 'Bélgica', 'Benin' ), array_values( $sorted_values ) );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces a new uasort function called wc_ascii_uasort_comparison, this function converts strings to ascii before comparing it, this fixes issues where if your site was in a language that uses accents it would not order the countries correctly.

Closes #21175

### How to test the changes in this Pull Request:

1. Switch your WordPress site to Spanish
2. Follow [this guide](https://docs.woocommerce.com/document/woocommerce-localization/) and download the Spanish WooCommerce translation
3. Go to any page where countries are displayed, ie checkout, and ensure the orders of accented countries are correctly sorted alphabetically.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix country sorting for stores which use a language that uses a lot of accented characters, ie Spanish.
