### PR TITLE
Remove on-hold orders from tax reports

### DIFF
--- a/includes/admin/reports/class-wc-report-taxes-by-code.php
+++ b/includes/admin/reports/class-wc-report-taxes-by-code.php
@@ -116,6 +116,7 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 			),
 		);
 
+		// We exclude on-hold orders as they are still pending payment.
 		$tax_rows_orders = $this->get_order_report_data(
 			array(
 				'data'                => $query_data,
@@ -124,8 +125,8 @@ class WC_Report_Taxes_By_Code extends WC_Admin_Report {
 				'query_type'          => 'get_results',
 				'filter_range'        => true,
 				'order_types'         => array_merge( wc_get_order_types( 'sales-reports' ), array( 'shop_order_refund' ) ),
-				'order_status'        => array( 'completed', 'processing', 'on-hold' ),
-				'parent_order_status' => array( 'completed', 'processing', 'on-hold' ), // Partial refunds inside refunded orders should be ignored
+				'order_status'        => array( 'completed', 'processing' ),
+				'parent_order_status' => array( 'completed', 'processing' ), // Partial refunds inside refunded orders should be ignored
 			)
 		);
 

--- a/includes/admin/reports/class-wc-report-taxes-by-date.php
+++ b/includes/admin/reports/class-wc-report-taxes-by-date.php
@@ -104,6 +104,7 @@ class WC_Report_Taxes_By_Date extends WC_Admin_Report {
 			),
 		);
 
+		// We exlude on-hold orders are they are still pending payment.
 		$tax_rows_orders = $this->get_order_report_data(
 			array(
 				'data'         => $query_data,
@@ -112,7 +113,7 @@ class WC_Report_Taxes_By_Date extends WC_Admin_Report {
 				'query_type'   => 'get_results',
 				'filter_range' => true,
 				'order_types'  => wc_get_order_types( 'sales-reports' ),
-				'order_status' => array( 'completed', 'processing', 'on-hold', 'refunded' ),
+				'order_status' => array( 'completed', 'processing', 'refunded' ),
 			)
 		);
 
@@ -151,7 +152,7 @@ class WC_Report_Taxes_By_Date extends WC_Admin_Report {
 				'query_type'          => 'get_results',
 				'filter_range'        => true,
 				'order_types'         => array( 'shop_order_refund' ),
-				'parent_order_status' => array( 'completed', 'processing', 'on-hold' ), // Partial refunds inside refunded orders should be ignored.
+				'parent_order_status' => array( 'completed', 'processing' ), // Partial refunds inside refunded orders should be ignored.
 			)
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Tax reports should reflect taxes for paid orders only. This PR removes all on-hold orders from the tax reports as they are orders that are still awaiting payment.

Closes #22010 

PS: I did not fix the PHPCS errors as there are quite a lot to take care of and do not want to risk introducing a bug in this PR due to PHPCS fixes.

### How to test the changes in this Pull Request:

1. Before checking out this branch, place an order and pay with the cheque payment gateway 
2. Check the tax reports and ensure the value is included.
3. Now check out this branch and run the tax report again and make sure that the value for the specific order is not included anymore.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Remove on-hold orders from the tax reports.
