### PR TITLE
Refactor tax rounding methods for consistency

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1079,9 +1079,14 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 				// If the prices include tax, discounts should be taken off the tax inclusive prices like in the cart.
 				if ( $this->get_prices_include_tax() && wc_tax_enabled() ) {
-					$amount_tax = WC_Tax::get_tax_total( WC_Tax::calc_tax( $amount, WC_Tax::get_rates( $item->get_tax_class() ), true ) );
-					$amount    -= $amount_tax;
-					$item->set_total( max( 0, $item->get_total() - $amount ) );
+					$taxes = WC_Tax::calc_tax( $amount, WC_Tax::get_rates( $item->get_tax_class() ), true );
+
+					if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+						$taxes = array_map( 'wc_round_tax_total', $taxes );
+					}
+
+					$amount = $amount - array_sum( $taxes );
+					$item->set_total( max( 0, round( $item->get_total() - $amount, wc_get_price_decimals() ) ) );
 				} else {
 					$item->set_total( max( 0, $item->get_total() - $amount ) );
 				}

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1427,14 +1427,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->add_item( $item );
 		}
 
-		if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
-			$this->set_shipping_tax( wc_round_tax_total( array_sum( array_map( 'wc_round_tax_total', $shipping_taxes ) ) ) );
-			$this->set_cart_tax( wc_round_tax_total( array_sum( array_map( 'wc_round_tax_total', $cart_taxes ) ) ) );
-		} else {
-			$this->set_shipping_tax( wc_round_tax_total( array_sum( $shipping_taxes ) ) );
-			$this->set_cart_tax( wc_round_tax_total( array_sum( $cart_taxes ) ) );
-		}
-
+		$this->set_shipping_tax( wc_round_tax_total( array_sum( $shipping_taxes ) ) );
+		$this->set_cart_tax( wc_round_tax_total( array_sum( $cart_taxes ) ) );
 		$this->save();
 	}
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -403,7 +403,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$subtotal += $item->get_subtotal();
 		}
 
-		return apply_filters( 'woocommerce_order_get_subtotal', (double) $subtotal, $this );
+		return apply_filters( 'woocommerce_order_get_subtotal', (float) $subtotal, $this );
 	}
 
 	/**
@@ -692,13 +692,16 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	protected function type_to_group( $type ) {
-		$type_to_group = apply_filters( 'woocommerce_order_type_to_group', array(
-			'line_item' => 'line_items',
-			'tax'       => 'tax_lines',
-			'shipping'  => 'shipping_lines',
-			'fee'       => 'fee_lines',
-			'coupon'    => 'coupon_lines',
-		) );
+		$type_to_group = apply_filters(
+			'woocommerce_order_type_to_group',
+			array(
+				'line_item' => 'line_items',
+				'tax'       => 'tax_lines',
+				'shipping'  => 'shipping_lines',
+				'fee'       => 'fee_lines',
+				'coupon'    => 'coupon_lines',
+			)
+		);
 		return isset( $type_to_group[ $type ] ) ? $type_to_group[ $type ] : '';
 	}
 
@@ -1285,12 +1288,15 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$tax_based_on = 'billing';
 		}
 
-		$args = wp_parse_args( $args, array(
-			'country'  => 'billing' === $tax_based_on ? $this->get_billing_country() : $this->get_shipping_country(),
-			'state'    => 'billing' === $tax_based_on ? $this->get_billing_state() : $this->get_shipping_state(),
-			'postcode' => 'billing' === $tax_based_on ? $this->get_billing_postcode() : $this->get_shipping_postcode(),
-			'city'     => 'billing' === $tax_based_on ? $this->get_billing_city() : $this->get_shipping_city(),
-		) );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'country'  => 'billing' === $tax_based_on ? $this->get_billing_country() : $this->get_shipping_country(),
+				'state'    => 'billing' === $tax_based_on ? $this->get_billing_state() : $this->get_shipping_state(),
+				'postcode' => 'billing' === $tax_based_on ? $this->get_billing_postcode() : $this->get_shipping_postcode(),
+				'city'     => 'billing' === $tax_based_on ? $this->get_billing_city() : $this->get_shipping_city(),
+			)
+		);
 
 		// Default to base.
 		if ( 'base' === $tax_based_on || empty( $args['country'] ) ) {
@@ -1619,10 +1625,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( 'excl' === $tax_display ) {
 			$ex_tax_label = $this->get_prices_include_tax() ? 1 : 0;
 
-			$subtotal = wc_price( $this->get_line_subtotal( $item ), array(
-				'ex_tax_label' => $ex_tax_label,
-				'currency'     => $this->get_currency(),
-			) );
+			$subtotal = wc_price(
+				$this->get_line_subtotal( $item ),
+				array(
+					'ex_tax_label' => $ex_tax_label,
+					'currency'     => $this->get_currency(),
+				)
+			);
 		} else {
 			$subtotal = wc_price( $this->get_line_subtotal( $item, true ), array( 'currency' => $this->get_currency() ) );
 		}

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1124,11 +1124,22 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					$item = $this->get_item( $item_id, false );
 
 					if ( $this->get_prices_include_tax() && wc_tax_enabled() ) {
-						$amount_tax    = array_sum( WC_Tax::calc_tax( $item_discount_amount, WC_Tax::get_rates( $item->get_tax_class() ), true ) );
-						$discount_tax += $amount_tax;
-						$amount        = $amount - $amount_tax;
+						$taxes = WC_Tax::calc_tax( $item_discount_amount, WC_Tax::get_rates( $item->get_tax_class() ), true );
+
+						if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+							$taxes = array_map( 'wc_round_tax_total', $taxes );
+						}
+
+						$discount_tax += array_sum( $taxes );
+						$amount        = $amount - array_sum( $taxes );
 					} else {
-						$discount_tax += array_sum( WC_Tax::calc_tax( $item_discount_amount, WC_Tax::get_rates( $item->get_tax_class() ) ) );
+						$taxes = WC_Tax::calc_tax( $item_discount_amount, WC_Tax::get_rates( $item->get_tax_class() ) );
+
+						if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+							$taxes = array_map( 'wc_round_tax_total', $taxes );
+						}
+
+						$discount_tax += array_sum( $taxes );
 					}
 				}
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1483,14 +1483,21 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->calculate_taxes();
 		}
 
-		// Sum taxes.
+		// Sum taxes again so we can work out how much tax was discounted. This uses original values, not those possibly rounded to 2dp.
 		foreach ( $this->get_items() as $item ) {
-			$cart_subtotal_tax += $item->get_subtotal_tax();
-			$cart_total_tax    += $item->get_total_tax();
+			$taxes = $item->get_taxes();
+
+			foreach ( $taxes['total'] as $tax_rate_id => $tax ) {
+				$cart_total_tax += (float) $tax;
+			}
+
+			foreach ( $taxes['subtotal'] as $tax_rate_id => $tax ) {
+				$cart_subtotal_tax += (float) $tax;
+			}
 		}
 
 		$this->set_discount_total( $cart_subtotal - $cart_total );
-		$this->set_discount_tax( $cart_subtotal_tax - $cart_total_tax );
+		$this->set_discount_tax( wc_round_tax_total( $cart_subtotal_tax - $cart_total_tax ) );
 		$this->set_total( round( $cart_total + $fee_total + $this->get_shipping_total() + $this->get_cart_tax() + $this->get_shipping_tax(), wc_get_price_decimals() ) );
 
 		do_action( 'woocommerce_order_after_calculate_totals', $and_taxes, $this );

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -159,6 +159,7 @@ final class WC_Cart_Totals {
 			'price_includes_tax' => false,
 			'subtotal'           => 0,
 			'subtotal_tax'       => 0,
+			'subtotal_taxes'     => array(),
 			'total'              => 0,
 			'total_tax'          => 0,
 			'taxes'              => array(),
@@ -693,6 +694,8 @@ final class WC_Cart_Totals {
 	 * @since 3.2.0
 	 */
 	protected function calculate_item_subtotals() {
+		$merged_subtotal_taxes = array(); // Taxes indexed by tax rate ID for storage later.
+
 		foreach ( $this->items as $item_key => $item ) {
 			if ( $item->price_includes_tax ) {
 				if ( $this->cart->get_customer()->get_is_vat_exempt() ) {
@@ -703,24 +706,31 @@ final class WC_Cart_Totals {
 			}
 
 			$item->subtotal = $item->price;
-			$subtotal_taxes = array();
 
 			if ( $this->calculate_tax && $item->product->is_taxable() ) {
-				$subtotal_taxes     = WC_Tax::calc_tax( $item->subtotal, $item->tax_rates, $item->price_includes_tax );
-				$item->subtotal_tax = array_sum( array_map( array( $this, 'round_line_tax' ), $subtotal_taxes ) );
+				$item->subtotal_taxes = WC_Tax::calc_tax( $item->subtotal, $item->tax_rates, $item->price_includes_tax );
+				$item->subtotal_tax   = array_sum( array_map( array( $this, 'round_line_tax' ), $item->subtotal_taxes ) );
 
 				if ( $item->price_includes_tax ) {
 					// Use unrounded taxes so we can re-calculate from the orders screen accurately later.
-					$item->subtotal = $item->subtotal - array_sum( $subtotal_taxes );
+					$item->subtotal = $item->subtotal - array_sum( $item->subtotal_taxes );
+				}
+
+				foreach ( $item->subtotal_taxes as $rate_id => $rate ) {
+					if ( ! isset( $merged_subtotal_taxes[ $rate_id ] ) ) {
+						$merged_subtotal_taxes[ $rate_id ] = 0;
+					}
+					$merged_subtotal_taxes[ $rate_id ] += $this->round_line_tax( $rate );
 				}
 			}
 
-			$this->cart->cart_contents[ $item_key ]['line_tax_data']     = array( 'subtotal' => wc_remove_number_precision_deep( $subtotal_taxes ) );
+			$this->cart->cart_contents[ $item_key ]['line_tax_data']     = array( 'subtotal' => wc_remove_number_precision_deep( $item->subtotal_taxes ) );
 			$this->cart->cart_contents[ $item_key ]['line_subtotal']     = wc_remove_number_precision( $item->subtotal );
 			$this->cart->cart_contents[ $item_key ]['line_subtotal_tax'] = wc_remove_number_precision( $item->subtotal_tax );
 		}
+
 		$this->set_total( 'items_subtotal', array_sum( array_map( 'round', array_values( wp_list_pluck( $this->items, 'subtotal' ) ) ) ) );
-		$this->set_total( 'items_subtotal_tax', array_sum( array_values( wp_list_pluck( $this->items, 'subtotal_tax' ) ) ) );
+		$this->set_total( 'items_subtotal_tax', array_sum( $this->round_merged_taxes( $merged_subtotal_taxes ) ) );
 
 		$this->cart->set_subtotal( $this->get_total( 'items_subtotal' ) );
 		$this->cart->set_subtotal_tax( $this->get_total( 'items_subtotal_tax' ) );

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -869,7 +869,7 @@ class WC_Cart extends WC_Legacy_Cart {
 				$tax_totals[ $code ]->is_compound      = WC_Tax::is_compound( $key );
 				$tax_totals[ $code ]->label            = WC_Tax::get_rate_label( $key );
 				$tax_totals[ $code ]->amount          += wc_round_tax_total( $tax );
-				$tax_totals[ $code ]->formatted_amount = wc_price( wc_round_tax_total( $tax_totals[ $code ]->amount ) );
+				$tax_totals[ $code ]->formatted_amount = wc_price( $tax_totals[ $code ]->amount );
 			}
 		}
 
@@ -1916,10 +1916,10 @@ class WC_Cart extends WC_Legacy_Cart {
 			if ( ! $compound && WC_Tax::is_compound( $key ) ) {
 				continue;
 			}
-			$total += $tax;
+			$total += wc_round_tax_total( $tax );
 		}
 		if ( $display ) {
-			$total = wc_round_tax_total( $total );
+			$total = wc_format_decimal( $total, wc_get_price_decimals() );
 		}
 		return apply_filters( 'woocommerce_cart_taxes_total', $total, $compound, $display, $this );
 	}

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1425,7 +1425,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			if ( $coupon->is_valid() ) {
 
 				// Get user and posted emails to compare.
-				$current_user = wp_get_current_user();
+				$current_user  = wp_get_current_user();
 				$billing_email = isset( $posted['billing_email'] ) ? $posted['billing_email'] : '';
 				$check_emails  = array_unique(
 					array_filter(

--- a/includes/class-wc-order-item-fee.php
+++ b/includes/class-wc-order-item-fee.php
@@ -180,7 +180,12 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 			$tax_data['total'] = array_map( 'wc_format_decimal', $raw_tax_data['total'] );
 		}
 		$this->set_prop( 'taxes', $tax_data );
-		$this->set_total_tax( array_sum( $tax_data['total'] ) );
+
+		if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+			$this->set_total_tax( array_sum( $tax_data['total'] ) );
+		} else {
+			$this->set_total_tax( array_sum( array_map( 'wc_round_tax_total', $tax_data['total'] ) ) );
+		}
 	}
 
 	/*

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -160,8 +160,14 @@ class WC_Order_Item_Product extends WC_Order_Item {
 			}
 		}
 		$this->set_prop( 'taxes', $tax_data );
-		$this->set_total_tax( array_sum( $tax_data['total'] ) );
-		$this->set_subtotal_tax( array_sum( $tax_data['subtotal'] ) );
+
+		if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+			$this->set_total_tax( array_sum( $tax_data['total'] ) );
+			$this->set_subtotal_tax( array_sum( $tax_data['subtotal'] ) );
+		} else {
+			$this->set_total_tax( array_sum( array_map( 'wc_round_tax_total', $tax_data['total'] ) ) );
+			$this->set_subtotal_tax( array_sum( array_map( 'wc_round_tax_total', $tax_data['subtotal'] ) ) );
+		}
 	}
 
 	/**
@@ -347,7 +353,8 @@ class WC_Order_Item_Product extends WC_Order_Item {
 				'order'         => $order->get_order_key(),
 				'email'         => rawurlencode( $order->get_billing_email() ),
 				'key'           => $download_id,
-			), trailingslashit( home_url() )
+			),
+			trailingslashit( home_url() )
 		) : '';
 	}
 
@@ -386,7 +393,8 @@ class WC_Order_Item_Product extends WC_Order_Item {
 							'order'         => $order->get_order_key(),
 							'uid'           => $email_hash,
 							'key'           => $download_id,
-						), trailingslashit( home_url() )
+						),
+						trailingslashit( home_url() )
 					);
 				}
 			}

--- a/includes/class-wc-order-item-shipping.php
+++ b/includes/class-wc-order-item-shipping.php
@@ -142,7 +142,12 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 			$tax_data['total'] = array_map( 'wc_format_decimal', $raw_tax_data );
 		}
 		$this->set_prop( 'taxes', $tax_data );
-		$this->set_total_tax( array_sum( $tax_data['total'] ) );
+
+		if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+			$this->set_total_tax( array_sum( $tax_data['total'] ) );
+		} else {
+			$this->set_total_tax( array_sum( array_map( 'wc_round_tax_total', $tax_data['total'] ) ) );
+		}
 	}
 
 	/**

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -1,17 +1,16 @@
 <?php
+/**
+ * Tax calculation and rate finding class.
+ *
+ * @package WooCommerce/Classes
+ */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Performs tax calculations and loads tax rates
  *
- * @class 		WC_Tax
- * @version		2.2.0
- * @package		WooCommerce/Classes
- * @category	Class
- * @author 		WooThemes
+ * @class WC_Tax
  */
 class WC_Tax {
 
@@ -31,8 +30,6 @@ class WC_Tax {
 
 	/**
 	 * Load options.
-	 *
-	 * @access public
 	 */
 	public static function init() {
 		self::$precision         = wc_get_rounding_precision();
@@ -42,8 +39,9 @@ class WC_Tax {
 
 	/**
 	 * When the woocommerce_tax_classes option is changed, remove any orphan rates.
-	 * @param  string $old_value
-	 * @param  string $value
+	 *
+	 * @param  string $old_value Old rates value.
+	 * @param  string $value New rates value.
 	 */
 	public static function maybe_remove_tax_class_rates( $old_value, $value ) {
 		$old     = array_filter( array_map( 'trim', explode( "\n", $old_value ) ) );
@@ -83,9 +81,9 @@ class WC_Tax {
 	/**
 	 * Calculate the shipping tax using a passed array of rates.
 	 *
-	 * @param   float		Price
-	 * @param	array		Taxation Rate
-	 * @return  array
+	 * @param float $price Shipping cost.
+	 * @param array $rates Taxation Rate.
+	 * @return array
 	 */
 	public static function calc_shipping_tax( $price, $rates ) {
 		$taxes = self::calc_exclusive_tax( $price, $rates );
@@ -102,8 +100,7 @@ class WC_Tax {
 	 * }
 	 * add_filter( 'woocommerce_tax_round', 'euro_5cent_rounding' );
 	 *
-	 * @param float|int $in
-	 *
+	 * @param float|int $in Value to round.
 	 * @return float
 	 */
 	public static function round( $in ) {
@@ -209,25 +206,31 @@ class WC_Tax {
 	/**
 	 * Searches for all matching country/state/postcode tax rates.
 	 *
-	 * @param array $args
+	 * @param array $args Args that determine the rate to find.
 	 * @return array
 	 */
 	public static function find_rates( $args = array() ) {
-		$args = wp_parse_args( $args, array(
-			'country'   => '',
-			'state'     => '',
-			'city'      => '',
-			'postcode'  => '',
-			'tax_class' => '',
-		) );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'country'   => '',
+				'state'     => '',
+				'city'      => '',
+				'postcode'  => '',
+				'tax_class' => '',
+			)
+		);
 
-		extract( $args, EXTR_SKIP );
+		$country   = $args['country'];
+		$state     = $args['state'];
+		$city      = $args['city'];
+		$postcode  = wc_normalize_postcode( wc_clean( $args['postcode'] ) );
+		$tax_class = $args['tax_class'];
 
 		if ( ! $country ) {
 			return array();
 		}
 
-		$postcode          = wc_normalize_postcode( wc_clean( $postcode ) );
 		$cache_key         = WC_Cache_Helper::get_cache_prefix( 'taxes' ) . 'wc_tax_rates_' . md5( sprintf( '%s+%s+%s+%s+%s', $country, $state, $city, $postcode, $tax_class ) );
 		$matched_tax_rates = wp_cache_get( $cache_key, 'taxes' );
 
@@ -242,7 +245,7 @@ class WC_Tax {
 	/**
 	 * Searches for all matching country/state/postcode tax rates.
 	 *
-	 * @param array $args
+	 * @param array $args Args that determine the rate to find.
 	 * @return array
 	 */
 	public static function find_shipping_rates( $args = array() ) {
@@ -262,12 +265,12 @@ class WC_Tax {
 
 	/**
 	 * Does the sort comparison. Compares (in this order):
-	 * 	- Priority
-	 *  - Country
-	 *  - State
-	 *  - Number of postcodes
-	 *  - Number of cities
-	 *  - ID
+	 * - Priority
+	 * - Country
+	 * - State
+	 * - Number of postcodes
+	 * - Number of cities
+	 * - ID
 	 *
 	 * @param object $rate1 First rate to compare.
 	 * @param object $rate2 Second rate to compare.
@@ -275,7 +278,7 @@ class WC_Tax {
 	 */
 	private static function sort_rates_callback( $rate1, $rate2 ) {
 		if ( $rate1->tax_rate_priority !== $rate2->tax_rate_priority ) {
-			return $rate1->tax_rate_priority < $rate2->tax_rate_priority ? -1 : 1; // ASC
+			return $rate1->tax_rate_priority < $rate2->tax_rate_priority ? -1 : 1; // ASC.
 		}
 
 		if ( $rate1->tax_rate_country !== $rate2->tax_rate_country ) {
@@ -361,10 +364,10 @@ class WC_Tax {
 		/**
 		 * Location matching criteria - ORed
 		 * Needs to match:
-		 * 	- rates with no postcodes and cities
-		 * 	- rates with a matching postcode and city
-		 * 	- rates with matching postcode, no city
-		 * 	- rates with matching city, no postcode
+		 * - rates with no postcodes and cities
+		 * - rates with a matching postcode and city
+		 * - rates with matching postcode, no city
+		 * - rates with matching city, no postcode
 		 */
 		$locations_criteria   = array();
 		$locations_criteria[] = 'locations.location_type IS NULL';
@@ -387,17 +390,24 @@ class WC_Tax {
 				AND sub.tax_rate_id = tax_rates.tax_rate_id
 			)
 		";
+
 		$criteria[] = '( ( ' . implode( ' ) OR ( ', $locations_criteria ) . ' ) )';
 
-		$found_rates = $wpdb->get_results( "
+		$criteria_string = implode( ' AND ', $criteria );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$found_rates = $wpdb->get_results(
+			"
 			SELECT tax_rates.*, COUNT( locations.location_id ) as postcode_count, COUNT( locations2.location_id ) as city_count
 			FROM {$wpdb->prefix}woocommerce_tax_rates as tax_rates
 			LEFT OUTER JOIN {$wpdb->prefix}woocommerce_tax_rate_locations as locations ON tax_rates.tax_rate_id = locations.tax_rate_id
 			LEFT OUTER JOIN {$wpdb->prefix}woocommerce_tax_rate_locations as locations2 ON tax_rates.tax_rate_id = locations2.tax_rate_id
-			WHERE 1=1 AND " . implode( ' AND ', $criteria ) . "
+			WHERE 1=1 AND {$criteria_string}
 			GROUP BY tax_rates.tax_rate_id
 			ORDER BY tax_rates.tax_rate_priority
-		" );
+			"
+		);
+		// phpcs:enable
 
 		$found_rates       = self::sort_rates( $found_rates );
 		$matched_tax_rates = array();
@@ -426,14 +436,14 @@ class WC_Tax {
 	 *
 	 * Used by get_rates(), get_shipping_rates().
 	 *
-	 * @param  $tax_class string Optional, passed to the filter for advanced tax setups.
+	 * @param  string $tax_class string Optional, passed to the filter for advanced tax setups.
 	 * @param  object $customer Override the customer object to get their location.
 	 * @return array
 	 */
 	public static function get_tax_location( $tax_class = '', $customer = null ) {
 		$location = array();
 
-		if ( is_null( $customer ) && ! empty( WC()->customer ) ) {
+		if ( is_null( $customer ) && WC()->customer ) {
 			$customer = WC()->customer;
 		}
 
@@ -463,16 +473,18 @@ class WC_Tax {
 		$location          = self::get_tax_location( $tax_class, $customer );
 		$matched_tax_rates = array();
 
-		if ( sizeof( $location ) === 4 ) {
+		if ( count( $location ) === 4 ) {
 			list( $country, $state, $postcode, $city ) = $location;
 
-			$matched_tax_rates = self::find_rates( array(
-				'country' 	=> $country,
-				'state' 	=> $state,
-				'postcode' 	=> $postcode,
-				'city' 		=> $city,
-				'tax_class' => $tax_class,
-			) );
+			$matched_tax_rates = self::find_rates(
+				array(
+					'country'   => $country,
+					'state'     => $state,
+					'postcode'  => $postcode,
+					'city'      => $city,
+					'tax_class' => $tax_class,
+				)
+			);
 		}
 
 		return apply_filters( 'woocommerce_matched_rates', $matched_tax_rates, $tax_class );
@@ -481,25 +493,31 @@ class WC_Tax {
 	/**
 	 * Get's an array of matching rates for the shop's base country.
 	 *
-	 * @param   string	Tax Class
-	 * @return  array
+	 * @param string $tax_class Tax Class.
+	 * @return array
 	 */
 	public static function get_base_tax_rates( $tax_class = '' ) {
-		return apply_filters( 'woocommerce_base_tax_rates', self::find_rates( array(
-			'country' 	=> WC()->countries->get_base_country(),
-			'state' 	=> WC()->countries->get_base_state(),
-			'postcode' 	=> WC()->countries->get_base_postcode(),
-			'city' 		=> WC()->countries->get_base_city(),
-			'tax_class' => $tax_class,
-		) ), $tax_class );
+		return apply_filters(
+			'woocommerce_base_tax_rates',
+			self::find_rates(
+				array(
+					'country'   => WC()->countries->get_base_country(),
+					'state'     => WC()->countries->get_base_state(),
+					'postcode'  => WC()->countries->get_base_postcode(),
+					'city'      => WC()->countries->get_base_city(),
+					'tax_class' => $tax_class,
+				)
+			),
+			$tax_class
+		);
 	}
 
 	/**
 	 * Alias for get_base_tax_rates().
 	 *
 	 * @deprecated 2.3
-	 * @param   string	Tax Class
-	 * @return  array
+	 * @param string $tax_class Tax Class.
+	 * @return array
 	 */
 	public static function get_shop_base_rate( $tax_class = '' ) {
 		return self::get_base_tax_rates( $tax_class );
@@ -513,7 +531,7 @@ class WC_Tax {
 	 * @return mixed
 	 */
 	public static function get_shipping_tax_rates( $tax_class = null, $customer = null ) {
-		// See if we have an explicitly set shipping tax class
+		// See if we have an explicitly set shipping tax class.
 		$shipping_tax_class = get_option( 'woocommerce_shipping_tax_class' );
 
 		if ( 'inherit' !== $shipping_tax_class ) {
@@ -523,22 +541,24 @@ class WC_Tax {
 		$location          = self::get_tax_location( $tax_class, $customer );
 		$matched_tax_rates = array();
 
-		if ( sizeof( $location ) === 4 ) {
+		if ( 4 === count( $location ) ) {
 			list( $country, $state, $postcode, $city ) = $location;
 
 			if ( ! is_null( $tax_class ) ) {
-				// This will be per item shipping
-				$matched_tax_rates = self::find_shipping_rates( array(
-					'country' 	=> $country,
-					'state' 	=> $state,
-					'postcode' 	=> $postcode,
-					'city' 		=> $city,
-					'tax_class' => $tax_class,
-				) );
+				// This will be per item shipping.
+				$matched_tax_rates = self::find_shipping_rates(
+					array(
+						'country'   => $country,
+						'state'     => $state,
+						'postcode'  => $postcode,
+						'city'      => $city,
+						'tax_class' => $tax_class,
+					)
+				);
 
 			} elseif ( WC()->cart->get_cart() ) {
 
-				// This will be per order shipping - loop through the order and find the highest tax class rate
+				// This will be per order shipping - loop through the order and find the highest tax class rate.
 				$cart_tax_classes = WC()->cart->get_cart_item_tax_classes_for_shipping();
 
 				// No tax classes = no taxable items.
@@ -547,42 +567,47 @@ class WC_Tax {
 				}
 
 				// If multiple classes are found, use the first one found unless a standard rate item is found. This will be the first listed in the 'additional tax class' section.
-				if ( sizeof( $cart_tax_classes ) > 1 && ! in_array( '', $cart_tax_classes ) ) {
+				if ( count( $cart_tax_classes ) > 1 && ! in_array( '', $cart_tax_classes, true ) ) {
 					$tax_classes = self::get_tax_class_slugs();
 
 					foreach ( $tax_classes as $tax_class ) {
-						if ( in_array( $tax_class, $cart_tax_classes ) ) {
-							$matched_tax_rates = self::find_shipping_rates( array(
-								'country' 	=> $country,
-								'state' 	=> $state,
-								'postcode' 	=> $postcode,
-								'city' 		=> $city,
-								'tax_class' => $tax_class,
-							) );
+						if ( in_array( $tax_class, $cart_tax_classes, true ) ) {
+							$matched_tax_rates = self::find_shipping_rates(
+								array(
+									'country'   => $country,
+									'state'     => $state,
+									'postcode'  => $postcode,
+									'city'      => $city,
+									'tax_class' => $tax_class,
+								)
+							);
 							break;
 						}
 					}
-
-				// If a single tax class is found, use it
-				} elseif ( sizeof( $cart_tax_classes ) == 1 ) {
-					$matched_tax_rates = self::find_shipping_rates( array(
-						'country' 	=> $country,
-						'state' 	=> $state,
-						'postcode' 	=> $postcode,
-						'city' 		=> $city,
-						'tax_class' => $cart_tax_classes[0],
-					) );
+				} elseif ( 1 === count( $cart_tax_classes ) ) {
+					// If a single tax class is found, use it.
+					$matched_tax_rates = self::find_shipping_rates(
+						array(
+							'country'   => $country,
+							'state'     => $state,
+							'postcode'  => $postcode,
+							'city'      => $city,
+							'tax_class' => $cart_tax_classes[0],
+						)
+					);
 				}
 			}
 
-			// Get standard rate if no taxes were found
-			if ( ! sizeof( $matched_tax_rates ) ) {
-				$matched_tax_rates = self::find_shipping_rates( array(
-					'country' 	=> $country,
-					'state' 	=> $state,
-					'postcode' 	=> $postcode,
-					'city' 		=> $city,
-				) );
+			// Get standard rate if no taxes were found.
+			if ( ! count( $matched_tax_rates ) ) {
+				$matched_tax_rates = self::find_shipping_rates(
+					array(
+						'country'  => $country,
+						'state'    => $state,
+						'postcode' => $postcode,
+						'city'     => $city,
+					)
+				);
 			}
 		}
 
@@ -592,18 +617,18 @@ class WC_Tax {
 	/**
 	 * Return true/false depending on if a rate is a compound rate.
 	 *
-	 * @param mixed $key_or_rate Tax rate ID, or the db row itself in object format
+	 * @param mixed $key_or_rate Tax rate ID, or the db row itself in object format.
 	 * @return  bool
 	 */
 	public static function is_compound( $key_or_rate ) {
 		global $wpdb;
 
 		if ( is_object( $key_or_rate ) ) {
-			$key       = $key_or_rate->tax_rate_id;
-			$compound  = $key_or_rate->tax_rate_compound;
+			$key      = $key_or_rate->tax_rate_id;
+			$compound = $key_or_rate->tax_rate_compound;
 		} else {
-			$key 	   = $key_or_rate;
-			$compound  = (bool) $wpdb->get_var( $wpdb->prepare( "SELECT tax_rate_compound FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_id = %s", $key ) );
+			$key      = $key_or_rate;
+			$compound = (bool) $wpdb->get_var( $wpdb->prepare( "SELECT tax_rate_compound FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_id = %s", $key ) );
 		}
 
 		return (bool) apply_filters( 'woocommerce_rate_compound', $compound, $key );
@@ -612,7 +637,7 @@ class WC_Tax {
 	/**
 	 * Return a given rates label.
 	 *
-	 * @param mixed $key_or_rate Tax rate ID, or the db row itself in object format
+	 * @param mixed $key_or_rate Tax rate ID, or the db row itself in object format.
 	 * @return  string
 	 */
 	public static function get_rate_label( $key_or_rate ) {
@@ -636,7 +661,7 @@ class WC_Tax {
 	/**
 	 * Return a given rates percent.
 	 *
-	 * @param mixed $key_or_rate Tax rate ID, or the db row itself in object format
+	 * @param mixed $key_or_rate Tax rate ID, or the db row itself in object format.
 	 * @return  string
 	 */
 	public static function get_rate_percent( $key_or_rate ) {
@@ -656,8 +681,7 @@ class WC_Tax {
 	/**
 	 * Get a rates code. Code is made up of COUNTRY-STATE-NAME-Priority. E.g GB-VAT-1, US-AL-TAX-1.
 	 *
-	 * @access public
-	 * @param mixed $key_or_rate Tax rate ID, or the db row itself in object format
+	 * @param mixed $key_or_rate Tax rate ID, or the db row itself in object format.
 	 * @return string
 	 */
 	public static function get_rate_code( $key_or_rate ) {
@@ -674,11 +698,11 @@ class WC_Tax {
 		$code_string = '';
 
 		if ( null !== $rate ) {
-			$code   = array();
-			$code[] = $rate->tax_rate_country;
-			$code[] = $rate->tax_rate_state;
-			$code[] = $rate->tax_rate_name ? $rate->tax_rate_name : 'TAX';
-			$code[] = absint( $rate->tax_rate_priority );
+			$code        = array();
+			$code[]      = $rate->tax_rate_country;
+			$code[]      = $rate->tax_rate_state;
+			$code[]      = $rate->tax_rate_name ? $rate->tax_rate_name : 'TAX';
+			$code[]      = absint( $rate->tax_rate_priority );
 			$code_string = strtoupper( implode( '-', array_filter( $code ) ) );
 		}
 
@@ -686,9 +710,9 @@ class WC_Tax {
 	}
 
 	/**
-	 * Round tax lines and return the sum.
+	 * Round tax lines and return the sum. Note this rounds to precision, not store currency decimals.
 	 *
-	 * @param   array
+	 * @param   array $taxes Array of taxes to round.
 	 * @return  float
 	 */
 	public static function get_tax_total( $taxes ) {
@@ -725,8 +749,9 @@ class WC_Tax {
 	}
 
 	/**
-	 * format the city.
-	 * @param  string $city
+	 * Format the city.
+	 *
+	 * @param  string $city Value to format.
 	 * @return string
 	 */
 	private static function format_tax_rate_city( $city ) {
@@ -734,8 +759,9 @@ class WC_Tax {
 	}
 
 	/**
-	 * format the state.
-	 * @param  string $state
+	 * Format the state.
+	 *
+	 * @param  string $state Value to format.
 	 * @return string
 	 */
 	private static function format_tax_rate_state( $state ) {
@@ -744,8 +770,9 @@ class WC_Tax {
 	}
 
 	/**
-	 * format the country.
-	 * @param  string $country
+	 * Format the country.
+	 *
+	 * @param  string $country Value to format.
 	 * @return string
 	 */
 	private static function format_tax_rate_country( $country ) {
@@ -754,8 +781,9 @@ class WC_Tax {
 	}
 
 	/**
-	 * format the tax rate name.
-	 * @param  string $name
+	 * Format the tax rate name.
+	 *
+	 * @param  string $name Value to format.
 	 * @return string
 	 */
 	private static function format_tax_rate_name( $name ) {
@@ -763,17 +791,19 @@ class WC_Tax {
 	}
 
 	/**
-	 * format the rate.
-	 * @param  double $rate
+	 * Format the rate.
+	 *
+	 * @param  float $rate Value to format.
 	 * @return string
 	 */
 	private static function format_tax_rate( $rate ) {
-		return number_format( (double) $rate, 4, '.', '' );
+		return number_format( (float) $rate, 4, '.', '' );
 	}
 
 	/**
-	 * format the priority.
-	 * @param  string $priority
+	 * Format the priority.
+	 *
+	 * @param  string $priority Value to format.
 	 * @return int
 	 */
 	private static function format_tax_rate_priority( $priority ) {
@@ -781,14 +811,15 @@ class WC_Tax {
 	}
 
 	/**
-	 * format the class.
-	 * @param  string $class
+	 * Format the class.
+	 *
+	 * @param  string $class Value to format.
 	 * @return string
 	 */
 	public static function format_tax_rate_class( $class ) {
 		$class   = sanitize_title( $class );
 		$classes = self::get_tax_class_slugs();
-		if ( ! in_array( $class, $classes ) ) {
+		if ( ! in_array( $class, $classes, true ) ) {
 			$class = '';
 		}
 		return ( 'standard' === $class ) ? '' : $class;
@@ -796,7 +827,8 @@ class WC_Tax {
 
 	/**
 	 * Prepare and format tax rate for DB insertion.
-	 * @param  array $tax_rate
+	 *
+	 * @param  array $tax_rate Tax rate to format.
 	 * @return array
 	 */
 	private static function prepare_tax_rate( $tax_rate ) {
@@ -818,10 +850,8 @@ class WC_Tax {
 	 * Internal use only.
 	 *
 	 * @since 2.3.0
-	 * @access private
 	 *
-	 * @param  array $tax_rate
-	 *
+	 * @param  array $tax_rate Tax rate to insert.
 	 * @return int tax rate id
 	 */
 	public static function _insert_tax_rate( $tax_rate ) {
@@ -842,21 +872,25 @@ class WC_Tax {
 	 * Internal use only.
 	 *
 	 * @since 2.5.0
-	 * @access private
 	 *
-	 * @param int $tax_rate_id
-	 * @param string $output_type
-	 *
+	 * @param int    $tax_rate_id Tax rate ID.
+	 * @param string $output_type Type of output.
 	 * @return array|object
 	 */
 	public static function _get_tax_rate( $tax_rate_id, $output_type = ARRAY_A ) {
 		global $wpdb;
 
-		return $wpdb->get_row( $wpdb->prepare( "
-			SELECT *
-			FROM {$wpdb->prefix}woocommerce_tax_rates
-			WHERE tax_rate_id = %d
-		", $tax_rate_id ), $output_type );
+		return $wpdb->get_row(
+			$wpdb->prepare(
+				"
+					SELECT *
+					FROM {$wpdb->prefix}woocommerce_tax_rates
+					WHERE tax_rate_id = %d
+				",
+				$tax_rate_id
+			),
+			$output_type
+		);
 	}
 
 	/**
@@ -865,10 +899,9 @@ class WC_Tax {
 	 * Internal use only.
 	 *
 	 * @since 2.3.0
-	 * @access private
 	 *
-	 * @param int $tax_rate_id
-	 * @param array $tax_rate
+	 * @param int   $tax_rate_id Tax rate to update.
+	 * @param array $tax_rate Tax rate values.
 	 */
 	public static function _update_tax_rate( $tax_rate_id, $tax_rate ) {
 		global $wpdb;
@@ -876,7 +909,7 @@ class WC_Tax {
 		$tax_rate_id = absint( $tax_rate_id );
 
 		$wpdb->update(
-			$wpdb->prefix . "woocommerce_tax_rates",
+			$wpdb->prefix . 'woocommerce_tax_rates',
 			self::prepare_tax_rate( $tax_rate ),
 			array(
 				'tax_rate_id' => $tax_rate_id,
@@ -894,9 +927,7 @@ class WC_Tax {
 	 * Internal use only.
 	 *
 	 * @since 2.3.0
-	 * @access private
-	 *
-	 * @param  int $tax_rate_id
+	 * @param  int $tax_rate_id Tax rate to delete.
 	 */
 	public static function _delete_tax_rate( $tax_rate_id ) {
 		global $wpdb;
@@ -915,10 +946,9 @@ class WC_Tax {
 	 * Internal use only.
 	 *
 	 * @since 2.3.0
-	 * @access private
 	 *
-	 * @param  int $tax_rate_id
-	 * @param  string $postcodes String of postcodes separated by ; characters
+	 * @param int    $tax_rate_id Tax rate to update.
+	 * @param string $postcodes String of postcodes separated by ; characters.
 	 */
 	public static function _update_tax_rate_postcodes( $tax_rate_id, $postcodes ) {
 		if ( ! is_array( $postcodes ) ) {
@@ -928,7 +958,7 @@ class WC_Tax {
 		foreach ( $postcodes as $key => $postcode ) {
 			$postcodes[ $key ] = strtoupper( trim( str_replace( chr( 226 ) . chr( 128 ) . chr( 166 ), '...', $postcode ) ) );
 		}
-		self::_update_tax_rate_locations( $tax_rate_id, array_diff( array_filter( $postcodes ), array( '*' ) ), 'postcode' );
+		self::update_tax_rate_locations( $tax_rate_id, array_diff( array_filter( $postcodes ), array( '*' ) ), 'postcode' );
 	}
 
 	/**
@@ -937,10 +967,9 @@ class WC_Tax {
 	 * Internal use only.
 	 *
 	 * @since 2.3.0
-	 * @access private
 	 *
-	 * @param  int $tax_rate_id
-	 * @param  string $cities
+	 * @param int    $tax_rate_id Tax rate to update.
+	 * @param string $cities Cities to set.
 	 */
 	public static function _update_tax_rate_cities( $tax_rate_id, $cities ) {
 		if ( ! is_array( $cities ) ) {
@@ -948,7 +977,7 @@ class WC_Tax {
 		}
 		$cities = array_filter( array_diff( array_map( array( __CLASS__, 'format_tax_rate_city' ), $cities ), array( '*' ) ) );
 
-		self::_update_tax_rate_locations( $tax_rate_id, $cities, 'city' );
+		self::update_tax_rate_locations( $tax_rate_id, $cities, 'city' );
 	}
 
 	/**
@@ -957,30 +986,28 @@ class WC_Tax {
 	 * Internal use only.
 	 *
 	 * @since 2.3.0
-	 * @access private
 	 *
-	 * @param int $tax_rate_id
-	 * @param array $values
-	 * @param string $type
+	 * @param int    $tax_rate_id Tax rate ID to update.
+	 * @param array  $values Values to set.
+	 * @param string $type Location type.
 	 */
-	private static function _update_tax_rate_locations( $tax_rate_id, $values, $type ) {
+	private static function update_tax_rate_locations( $tax_rate_id, $values, $type ) {
 		global $wpdb;
 
 		$tax_rate_id = absint( $tax_rate_id );
 
 		$wpdb->query(
-			$wpdb->prepare( "
-				DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE tax_rate_id = %d AND location_type = %s;
-				", $tax_rate_id, $type
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE tax_rate_id = %d AND location_type = %s;",
+				$tax_rate_id,
+				$type
 			)
 		);
 
-		if ( sizeof( $values ) > 0 ) {
+		if ( count( $values ) > 0 ) {
 			$sql = "( '" . implode( "', $tax_rate_id, '" . esc_sql( $type ) . "' ),( '", array_map( 'esc_sql', $values ) ) . "', $tax_rate_id, '" . esc_sql( $type ) . "' )";
 
-			$wpdb->query( "
-				INSERT INTO {$wpdb->prefix}woocommerce_tax_rate_locations ( location_code, tax_rate_id, location_type ) VALUES $sql;
-				" );
+			$wpdb->query( "INSERT INTO {$wpdb->prefix}woocommerce_tax_rate_locations ( location_code, tax_rate_id, location_type ) VALUES $sql;" ); // @codingStandardsIgnoreLine.
 		}
 
 		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
@@ -989,7 +1016,7 @@ class WC_Tax {
 	/**
 	 * Used by admin settings page.
 	 *
-	 * @param string $tax_class
+	 * @param string $tax_class Tax class slug.
 	 *
 	 * @return array|null|object
 	 */

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -150,6 +150,13 @@ class WC_Tax {
 			$taxes[ $key ] += $tax_amount;
 		}
 
+		/**
+		 * Round all taxes to precision (4DP) before passing them back. Note, this is not the same rounding
+		 * as in the cart calculation class which, depending on settings, will round to 2DP when calculating
+		 * final totals. Also unlike that class, this rounds .5 up for all cases.
+		 */
+		$taxes = array_map( array( __CLASS__, 'round' ), $taxes );
+
 		return $taxes;
 	}
 
@@ -199,6 +206,13 @@ class WC_Tax {
 				$pre_compound_total = array_sum( $taxes );
 			}
 		}
+
+		/**
+		 * Round all taxes to precision (4DP) before passing them back. Note, this is not the same rounding
+		 * as in the cart calculation class which, depending on settings, will round to 2DP when calculating
+		 * final totals. Also unlike that class, this rounds .5 up for all cases.
+		 */
+		$taxes = array_map( array( __CLASS__, 'round' ), $taxes );
 
 		return $taxes;
 	}
@@ -710,13 +724,13 @@ class WC_Tax {
 	}
 
 	/**
-	 * Round tax lines and return the sum. Note this rounds to precision, not store currency decimals.
+	 * Sums a set of taxes to form a single total. Values are pre-rounded to precision from 3.6.0.
 	 *
-	 * @param   array $taxes Array of taxes to round.
-	 * @return  float
+	 * @param  array $taxes Array of taxes.
+	 * @return float
 	 */
 	public static function get_tax_total( $taxes ) {
-		return array_sum( array_map( array( __CLASS__, 'round' ), $taxes ) );
+		return array_sum( $taxes );
 	}
 
 	/**

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -972,8 +972,8 @@ function wc_get_price_including_tax( $product, $args = array() ) {
 
 	if ( $product->is_taxable() ) {
 		if ( ! wc_prices_include_tax() ) {
-			$tax_rates    = WC_Tax::get_rates( $product->get_tax_class() );
-			$taxes        = WC_Tax::calc_tax( $line_price, $tax_rates, false );
+			$tax_rates = WC_Tax::get_rates( $product->get_tax_class() );
+			$taxes     = WC_Tax::calc_tax( $line_price, $tax_rates, false );
 
 			if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
 				$taxes_total = array_sum( $taxes );

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -972,8 +972,8 @@ function wc_get_price_including_tax( $product, $args = array() ) {
 
 	if ( $product->is_taxable() ) {
 		if ( ! wc_prices_include_tax() ) {
-			$tax_rates    = WC_Tax::get_rates( $product->get_tax_class() );
-			$taxes        = WC_Tax::calc_tax( $line_price, $tax_rates, false );
+			$tax_rates = WC_Tax::get_rates( $product->get_tax_class() );
+			$taxes     = WC_Tax::calc_tax( $line_price, $tax_rates, false );
 
 			if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
 				$taxes_total = array_sum( $taxes );
@@ -1057,14 +1057,7 @@ function wc_get_price_excluding_tax( $product, $args = array() ) {
 		$tax_rates      = WC_Tax::get_rates( $product->get_tax_class() );
 		$base_tax_rates = WC_Tax::get_base_tax_rates( $product->get_tax_class( 'unfiltered' ) );
 		$remove_taxes   = apply_filters( 'woocommerce_adjust_non_base_location_prices', true ) ? WC_Tax::calc_tax( $line_price, $base_tax_rates, true ) : WC_Tax::calc_tax( $line_price, $tax_rates, true );
-
-		if ( 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
-			$remove_taxes_total = array_sum( $remove_taxes );
-		} else {
-			$remove_taxes_total = array_sum( array_map( 'wc_round_tax_total', $remove_taxes ) );
-		}
-
-		$return_price = round( $line_price - $remove_taxes_total, wc_get_price_decimals() );
+		$return_price   = $line_price - array_sum( $remove_taxes ); // Unrounded since we're dealing with tax inclusive prices. Matches logic in cart-totals class. @see adjust_non_base_location_price.
 	} else {
 		$return_price = $line_price;
 	}


### PR DESCRIPTION
This is a follow up to #22416 (#22416 is merged into this branch) which further updates rounding across the tax class and cart totals class for consistency and to support the 'round at subtotal' option.

- Unit tests are passing
- #22416 is fixed
- PHPCS fixes made in commit https://github.com/woocommerce/woocommerce/commit/11d14b30a48baf0e566b49fd92cc62d201ae6b17

General idea in this PR:

- Taxes are rounded to precision (4dp) after calculation to avoid needing to do it manually later. This is where some of the inconsistency arose.
- When rounding at subtotal, only array sums are performed. Rounding is done later.
- When not rounding at subtotal, taxes are rounded per line to the store DP setting.
- Some classes were ignoring the setting.

@claudiulodro Any more detail I can add?