### PR TITLE
removed variable that was not being used in test case

### DIFF
--- a/tests/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-crud-orders.php
@@ -92,7 +92,6 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	 */
 	public function test_get_prices_include_tax() {
 		$object = new WC_Order();
-		$set_to = 'USD';
 		$object->set_prices_include_tax( 1 );
 		$this->assertTrue( $object->get_prices_include_tax() );
 	}


### PR DESCRIPTION
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Super small change, simply remove a variable that is not being used in a test case. I'm learning about unit tests and was reading through some of the files and noticed this variable in a test case that is not being used.


### How to test the changes in this Pull Request:

1. Ensure that the test case for `get_prices_include_tax` pass successfully
2. Technically the automatic tests that happens upon PR should do the above right?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
Really, I don't know how big of an impact this is but its a simple fix so why not a PR for my favourite e-commerce plugin. 

* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Removed a variable in a unit test that was not being used.
