### PR TITLE
Make sure WC active before running queries for MS widget

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -329,7 +329,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				'wc-network-orders', 'woocommerce_network_orders', array(
 					'nonce'          => wp_create_nonce( 'wp_rest' ),
 					'sites'          => array_values( $blog_ids ),
-					'order_endpoint' => get_rest_url( null, 'wc/v2/orders/network' ),
+					'order_endpoint' => get_rest_url( null, 'wc/v3/orders/network' ),
 				)
 			);
 			?>

--- a/includes/api/v2/class-wc-rest-network-orders-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-network-orders-v2-controller.php
@@ -31,7 +31,9 @@ class WC_REST_Network_Orders_V2_Controller extends WC_REST_Orders_V2_Controller 
 	public function register_routes() {
 		if ( is_multisite() ) {
 			register_rest_route(
-				$this->namespace, '/' . $this->rest_base . '/network', array(
+				$this->namespace,
+				'/' . $this->rest_base . '/network',
+				array(
 					array(
 						'methods'             => WP_REST_Server::READABLE,
 						'callback'            => array( $this, 'network_orders' ),
@@ -46,8 +48,6 @@ class WC_REST_Network_Orders_V2_Controller extends WC_REST_Orders_V2_Controller 
 
 	/**
 	 * Retrieves the item's schema for display / public consumption purposes.
-	 *
-	 * @access public
 	 *
 	 * @return array Public item schema data.
 	 */

--- a/includes/api/v2/class-wc-rest-network-orders-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-network-orders-v2-controller.php
@@ -118,9 +118,21 @@ class WC_REST_Network_Orders_V2_Controller extends WC_REST_Orders_V2_Controller 
 	public function network_orders( $request ) {
 		$blog_id = $request->get_param( 'blog_id' );
 		$blog_id = ! empty( $blog_id ) ? $blog_id : get_current_blog_id();
+		$active_plugins = get_blog_option( $blog_id, 'active_plugins', array() );
+		$wc_active = false;
+		foreach ( $active_plugins as $plugin ) {
+			if ( substr_compare( $plugin, '/woocommerce.php', strlen( $plugin ) - strlen( '/woocommerce.php' ), strlen( '/woocommerce.php' ) ) === 0 ) {
+				$wc_active = true;
+			}
+		}
+
+		// If WooCommerce not active for site, return an empty response.
+		if ( ! $wc_active ) {
+			$response = rest_ensure_response( array() );
+			return $response;
+		}
 
 		switch_to_blog( $blog_id );
-
 		add_filter( 'woocommerce_rest_orders_prepare_object_query', array( $this, 'network_orders_filter_args' ) );
 		$items = $this->get_items( $request );
 		remove_filter( 'woocommerce_rest_orders_prepare_object_query', array( $this, 'network_orders_filter_args' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR addresses an issue where on a network install it will try to run retrieve orders items for all sites belonging to the logged in user. If a site does not happen to have WooCommerce activated this will throw an error as the DB tables will not exist for that site.

This adds a check to make sure the WooCommerce plugin is activated before processing to run the queries.

Closes #22430 

### How to test the changes in this Pull Request:

1. Setup a network site and add WooCommerce, DO NOT NETWORK ACTIVATE.
2. Switch to one site on the network and activate WooCommerce from there.
3. Ensure you have another site assigned to your user which do not have WooCommerce active
4. Go to the Network Admin and ensure that there are no errors displayed in the error log when viewing the Network Orders widget, also ensure only the details of the single site where WC is installed is displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fatal errors when retrieving network orders for sites that do not have WooCommerce activated.
