### PR TITLE
Fix checkout field locales on first load

### DIFF
--- a/assets/js/frontend/address-i18n.js
+++ b/assets/js/frontend/address-i18n.js
@@ -124,8 +124,8 @@ jQuery( function( $ ) {
 
 				// Sort the fields.
 				rows.sort( function( a, b ) {
-					var asort = $( a ).data( 'priority' ),
-						bsort = $( b ).data( 'priority' );
+					var asort = parseInt( $( a ).data( 'priority' ), 10 ),
+						bsort = parseInt( $( b ).data( 'priority' ), 10 );
 
 					if ( asort > bsort ) {
 						return 1;

--- a/assets/js/frontend/address-i18n.js
+++ b/assets/js/frontend/address-i18n.js
@@ -65,7 +65,8 @@ jQuery( function( $ ) {
 
 				// Placeholders.
 				if ( typeof fieldLocale.placeholder !== 'undefined' ) {
-					field.find( 'input' ).attr( 'placeholder', fieldLocale.placeholder );
+					field.find( ':input' ).attr( 'placeholder', fieldLocale.placeholder );
+					field.find( ':input' ).attr( 'data-placeholder', fieldLocale.placeholder );
 					field.find( '.select2-selection__placeholder' ).text( fieldLocale.placeholder );
 				}
 
@@ -75,7 +76,8 @@ jQuery( function( $ ) {
 					typeof fieldLocale.label !== 'undefined' &&
 					! field.find( 'label' ).length
 				) {
-					field.find( 'input' ).attr( 'placeholder', fieldLocale.label );
+					field.find( ':input' ).attr( 'placeholder', fieldLocale.label );
+					field.find( ':input' ).attr( 'data-placeholder', fieldLocale.label );
 					field.find( '.select2-selection__placeholder' ).text( fieldLocale.label );
 				}
 
@@ -94,7 +96,7 @@ jQuery( function( $ ) {
 				// Hidden fields.
 				if ( 'state' !== key ) {
 					if ( typeof fieldLocale.hidden !== 'undefined' && true === fieldLocale.hidden ) {
-						field.hide().find( 'input' ).val( '' );
+						field.hide().find( ':input' ).val( '' );
 					} else {
 						field.show();
 					}

--- a/assets/js/frontend/address-i18n.js
+++ b/assets/js/frontend/address-i18n.js
@@ -14,7 +14,11 @@ jQuery( function( $ ) {
 			field.addClass( 'validate-required' );
 
 			if ( field.find( 'label .required' ).length === 0 ) {
-				field.find( 'label' ).append( '&nbsp;<abbr class="required" title="' + wc_address_i18n_params.i18n_required_text + '">*</abbr>' );
+				field.find( 'label' ).append(
+					'&nbsp;<abbr class="required" title="' +
+					wc_address_i18n_params.i18n_required_text +
+					'">*</abbr>'
+				);
 			}
 		} else {
 			field.find( 'label .required' ).remove();
@@ -27,102 +31,113 @@ jQuery( function( $ ) {
 	}
 
 	// Handle locale
-	$( document.body ).bind( 'country_to_state_changing', function( event, country, wrapper ) {
-		var thisform = wrapper, thislocale;
+	$( document.body )
+		.bind( 'country_to_state_changing', function( event, country, wrapper ) {
+			var thisform = wrapper, thislocale;
 
-		if ( typeof locale[ country ] !== 'undefined' ) {
-			thislocale = locale[ country ];
-		} else {
-			thislocale = locale['default'];
-		}
-
-		var $postcodefield = thisform.find( '#billing_postcode_field, #shipping_postcode_field' ),
-			$cityfield     = thisform.find( '#billing_city_field, #shipping_city_field' ),
-			$statefield    = thisform.find( '#billing_state_field, #shipping_state_field' );
-
-		if ( ! $postcodefield.attr( 'data-o_class' ) ) {
-			$postcodefield.attr( 'data-o_class', $postcodefield.attr( 'class' ) );
-			$cityfield.attr( 'data-o_class', $cityfield.attr( 'class' ) );
-			$statefield.attr( 'data-o_class', $statefield.attr( 'class' ) );
-		}
-
-		var locale_fields = $.parseJSON( wc_address_i18n_params.locale_fields );
-
-		$.each( locale_fields, function( key, value ) {
-
-			var field       = thisform.find( value ),
-				fieldLocale = $.extend( true, {}, locale['default'][ key ], thislocale[ key ] );
-
-			// Labels.
-			if ( typeof fieldLocale.label !== 'undefined' ) {
-				field.find( 'label' ).html( fieldLocale.label );
-			}
-
-			// Placeholders.
-			if ( typeof fieldLocale.placeholder !== 'undefined' ) {
-				field.find( 'input' ).attr( 'placeholder', fieldLocale.placeholder );
-				field.find( '.select2-selection__placeholder' ).text( fieldLocale.placeholder );
-			}
-
-			// Use the i18n label as a placeholder if there is no label element and no i18n placeholder.
-			if ( typeof fieldLocale.placeholder === 'undefined' && typeof fieldLocale.label !== 'undefined' && ! field.find( 'label' ).length ) {
-				field.find( 'input' ).attr( 'placeholder', fieldLocale.label );
-				field.find( '.select2-selection__placeholder' ).text( fieldLocale.label );
-			}
-
-			// Required.
-			if ( typeof fieldLocale.required !== 'undefined' ) {
-				field_is_required( field, fieldLocale.required );
+			if ( typeof locale[ country ] !== 'undefined' ) {
+				thislocale = locale[ country ];
 			} else {
-				field_is_required( field, false );
+				thislocale = locale['default'];
 			}
 
-			// Priority.
-			if ( typeof fieldLocale.priority !== 'undefined' ) {
-				field.data( 'priority', fieldLocale.priority );
+			var $postcodefield = thisform.find( '#billing_postcode_field, #shipping_postcode_field' ),
+				$cityfield     = thisform.find( '#billing_city_field, #shipping_city_field' ),
+				$statefield    = thisform.find( '#billing_state_field, #shipping_state_field' );
+
+			if ( ! $postcodefield.attr( 'data-o_class' ) ) {
+				$postcodefield.attr( 'data-o_class', $postcodefield.attr( 'class' ) );
+				$cityfield.attr( 'data-o_class', $cityfield.attr( 'class' ) );
+				$statefield.attr( 'data-o_class', $statefield.attr( 'class' ) );
 			}
 
-			// Hidden fields.
-			if ( 'state' !== key ) {
-				if ( typeof fieldLocale.hidden !== 'undefined' && true === fieldLocale.hidden ) {
-					field.hide().find( 'input' ).val( '' );
+			var locale_fields = $.parseJSON( wc_address_i18n_params.locale_fields );
+
+			$.each( locale_fields, function( key, value ) {
+
+				var field       = thisform.find( value ),
+					fieldLocale = $.extend( true, {}, locale['default'][ key ], thislocale[ key ] );
+
+				// Labels.
+				if ( typeof fieldLocale.label !== 'undefined' ) {
+					field.find( 'label' ).html( fieldLocale.label );
+				}
+
+				// Placeholders.
+				if ( typeof fieldLocale.placeholder !== 'undefined' ) {
+					field.find( 'input' ).attr( 'placeholder', fieldLocale.placeholder );
+					field.find( '.select2-selection__placeholder' ).text( fieldLocale.placeholder );
+				}
+
+				// Use the i18n label as a placeholder if there is no label element and no i18n placeholder.
+				if (
+					typeof fieldLocale.placeholder === 'undefined' &&
+					typeof fieldLocale.label !== 'undefined' &&
+					! field.find( 'label' ).length
+				) {
+					field.find( 'input' ).attr( 'placeholder', fieldLocale.label );
+					field.find( '.select2-selection__placeholder' ).text( fieldLocale.label );
+				}
+
+				// Required.
+				if ( typeof fieldLocale.required !== 'undefined' ) {
+					field_is_required( field, fieldLocale.required );
 				} else {
-					field.show();
+					field_is_required( field, false );
 				}
-			}
-		});
 
-		var fieldsets = $('.woocommerce-billing-fields__field-wrapper, .woocommerce-shipping-fields__field-wrapper, .woocommerce-address-fields__field-wrapper, .woocommerce-additional-fields__field-wrapper .woocommerce-account-fields');
-
-		fieldsets.each( function( index, fieldset ) {
-			var rows    = $( fieldset ).find( '.form-row' );
-			var wrapper = rows.first().parent();
-
-			// Before sorting, ensure all fields have a priority for bW compatibility.
-			var last_priority = 0;
-
-			rows.each( function() {
-				if ( ! $( this ).data( 'priority' ) ) {
-						$( this ).data( 'priority', last_priority + 1 );
+				// Priority.
+				if ( typeof fieldLocale.priority !== 'undefined' ) {
+					field.data( 'priority', fieldLocale.priority );
 				}
-				last_priority = $( this ).data( 'priority' );
-			} );
 
-			// Sort the fields.
-			rows.sort( function( a, b ) {
-				var asort = $( a ).data( 'priority' ),
-					bsort = $( b ).data( 'priority' );
-
-				if ( asort > bsort ) {
-					return 1;
+				// Hidden fields.
+				if ( 'state' !== key ) {
+					if ( typeof fieldLocale.hidden !== 'undefined' && true === fieldLocale.hidden ) {
+						field.hide().find( 'input' ).val( '' );
+					} else {
+						field.show();
+					}
 				}
-				if ( asort < bsort ) {
-					return -1;
-				}
-				return 0;
 			});
 
-			rows.detach().appendTo( wrapper );
-		} );
-	});
+			var fieldsets = $(
+				'.woocommerce-billing-fields__field-wrapper,' +
+				'.woocommerce-shipping-fields__field-wrapper,' +
+				'.woocommerce-address-fields__field-wrapper,' +
+				'.woocommerce-additional-fields__field-wrapper .woocommerce-account-fields'
+			);
+
+			fieldsets.each( function( index, fieldset ) {
+				var rows    = $( fieldset ).find( '.form-row' );
+				var wrapper = rows.first().parent();
+
+				// Before sorting, ensure all fields have a priority for bW compatibility.
+				var last_priority = 0;
+
+				rows.each( function() {
+					if ( ! $( this ).data( 'priority' ) ) {
+							$( this ).data( 'priority', last_priority + 1 );
+					}
+					last_priority = $( this ).data( 'priority' );
+				} );
+
+				// Sort the fields.
+				rows.sort( function( a, b ) {
+					var asort = $( a ).data( 'priority' ),
+						bsort = $( b ).data( 'priority' );
+
+					if ( asort > bsort ) {
+						return 1;
+					}
+					if ( asort < bsort ) {
+						return -1;
+					}
+					return 0;
+				});
+
+				rows.detach().appendTo( wrapper );
+			});
+		})
+		.trigger( 'wc_address_i18n_ready' );
 });

--- a/assets/js/frontend/country-select.js
+++ b/assets/js/frontend/country-select.js
@@ -56,7 +56,7 @@ jQuery( function( $ ) {
 		var wc_country_select_select2 = function() {
 			$( 'select.country_select:visible, select.state_select:visible' ).each( function() {
 				var select2_args = $.extend({
-					placeholderOption: 'first',
+					placeholder: $( this ).attr( 'data-placeholder' ) || $( this ).attr( 'placeholder' ) || '',
 					width: '100%'
 				}, getEnhancedSelectFormatString() );
 

--- a/assets/js/frontend/country-select.js
+++ b/assets/js/frontend/country-select.js
@@ -99,7 +99,15 @@ jQuery( function( $ ) {
 			if ( $.isEmptyObject( states[ country ] ) ) {
 
 				$statebox.closest( 'p.form-row' ).hide().find( '.select2-container' ).remove();
-				$statebox.replaceWith( '<input type="hidden" class="hidden" name="' + input_name + '" id="' + input_id + '" value="" placeholder="' + placeholder + '" />' );
+				$statebox.replaceWith(
+					'<input type="hidden" class="hidden" name="' +
+					input_name +
+					'" id="' +
+					input_id +
+					'" value="" placeholder="' +
+					placeholder +
+					'" />'
+				);
 
 				$( document.body ).trigger( 'country_to_state_changed', [ country, $wrapper ] );
 
@@ -118,7 +126,15 @@ jQuery( function( $ ) {
 
 				if ( $statebox.is( 'input' ) ) {
 					// Change for select
-					$statebox.replaceWith( '<select name="' + input_name + '" id="' + input_id + '" class="state_select" data-placeholder="' + placeholder + '"></select>' );
+					$statebox.replaceWith(
+						'<select name="' +
+						input_name +
+						'" id="' +
+						input_id +
+						'" class="state_select" data-placeholder="' +
+						placeholder +
+						'"></select>'
+					);
 					$statebox = $wrapper.find( '#billing_state, #shipping_state, #calc_shipping_state' );
 				}
 
@@ -132,14 +148,30 @@ jQuery( function( $ ) {
 			if ( $statebox.is( 'select' ) ) {
 
 				$parent.show().find( '.select2-container' ).remove();
-				$statebox.replaceWith( '<input type="text" class="input-text" name="' + input_name + '" id="' + input_id + '" placeholder="' + placeholder + '" />' );
+				$statebox.replaceWith(
+					'<input type="text" class="input-text" name="' +
+					input_name +
+					'" id="' +
+					input_id +
+					'" placeholder="' +
+					placeholder +
+					'" />'
+				);
 
 				$( document.body ).trigger( 'country_to_state_changed', [country, $wrapper ] );
 
 			} else if ( $statebox.is( 'input[type="hidden"]' ) ) {
 
 				$parent.show().find( '.select2-container' ).remove();
-				$statebox.replaceWith( '<input type="text" class="input-text" name="' + input_name + '" id="' + input_id + '" placeholder="' + placeholder + '" />' );
+				$statebox.replaceWith(
+					'<input type="text" class="input-text" name="' +
+					input_name +
+					'" id="' +
+					input_id +
+					'" placeholder="' +
+					placeholder +
+					'" />'
+				);
 
 				$( document.body ).trigger( 'country_to_state_changed', [country, $wrapper ] );
 
@@ -148,6 +180,26 @@ jQuery( function( $ ) {
 
 		$( document.body ).trigger( 'country_to_state_changing', [country, $wrapper ] );
 
+	});
+
+	$( document.body ).on( 'wc_address_i18n_ready', function() {
+		// Init country selects with their default value once the page loads.
+		$('.woocommerce-billing-fields, .woocommerce-shipping-fields, .woocommerce-shipping-calculator').each( function() {
+			var $wrapper       = $( this ),
+				$country_input = $wrapper.find( '#billing_country, #shipping_country, #calc_shipping_country' );
+
+			if ( 0 === $country_input.length ) {
+				return;
+			}
+
+			var country = $country_input.val();
+
+			if ( 0 === country.length ) {
+				return;
+			}
+
+			$( document.body ).trigger( 'country_to_state_changing', [country, $wrapper ] );
+		});
 	});
 
 });

--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -52,7 +52,8 @@ class WC_Frontend_Scripts {
 	 */
 	public static function get_styles() {
 		return apply_filters(
-			'woocommerce_enqueue_styles', array(
+			'woocommerce_enqueue_styles',
+			array(
 				'woocommerce-layout'      => array(
 					'src'     => self::get_asset_url( 'assets/css/woocommerce-layout.css' ),
 					'deps'    => '',
@@ -221,7 +222,7 @@ class WC_Frontend_Scripts {
 			),
 			'wc-address-i18n'            => array(
 				'src'     => self::get_asset_url( 'assets/js/frontend/address-i18n' . $suffix . '.js' ),
-				'deps'    => array( 'jquery' ),
+				'deps'    => array( 'jquery', 'wc-country-select' ),
 				'version' => WC_VERSION,
 			),
 			'wc-add-payment-method'      => array(
@@ -414,7 +415,7 @@ class WC_Frontend_Scripts {
 		}
 
 		// Placeholder style.
-		wp_register_style( 'woocommerce-inline', false );
+		wp_register_style( 'woocommerce-inline', false ); // phpcs:ignore
 		wp_enqueue_style( 'woocommerce-inline' );
 
 		if ( true === wc_string_to_bool( get_option( 'woocommerce_checkout_highlight_required_fields', 'yes' ) ) ) {
@@ -473,7 +474,8 @@ class WC_Frontend_Scripts {
 					'i18n_required_rating_text' => esc_attr__( 'Please select a rating', 'woocommerce' ),
 					'review_rating_required'    => get_option( 'woocommerce_review_rating_required' ),
 					'flexslider'                => apply_filters(
-						'woocommerce_single_product_carousel_options', array(
+						'woocommerce_single_product_carousel_options',
+						array(
 							'rtl'            => is_rtl(),
 							'animation'      => 'slide',
 							'smoothHeight'   => true,
@@ -489,7 +491,8 @@ class WC_Frontend_Scripts {
 					'zoom_options'              => apply_filters( 'woocommerce_single_product_zoom_options', array() ),
 					'photoswipe_enabled'        => apply_filters( 'woocommerce_single_product_photoswipe_enabled', get_theme_support( 'wc-product-gallery-lightbox' ) ),
 					'photoswipe_options'        => apply_filters(
-						'woocommerce_single_product_photoswipe_options', array(
+						'woocommerce_single_product_photoswipe_options',
+						array(
 							'shareEl'               => false,
 							'closeOnScroll'         => false,
 							'history'               => false,

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2653,7 +2653,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				} elseif ( ! is_null( $for_country ) && is_array( $states ) ) {
 
 					$field .= '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" class="state_select ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" ' . implode( ' ', $custom_attributes ) . ' data-placeholder="' . esc_attr( $args['placeholder'] ) . '">
-						<option value="">' . esc_html__( 'Select a state&hellip;', 'woocommerce' ) . '</option>';
+						<option value="">' . esc_html__( 'Select an option&hellip;', 'woocommerce' ) . '</option>';
 
 					foreach ( $states as $ckey => $cvalue ) {
 						$field .= '<option value="' . esc_attr( $ckey ) . '" ' . selected( $value, $ckey, false ) . '>' . $cvalue . '</option>';

--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -53,7 +53,7 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 					?>
 					<span>
 						<select name="calc_shipping_state" class="state_select" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>">
-							<option value=""><?php esc_html_e( 'Select a state&hellip;', 'woocommerce' ); ?></option>
+							<option value=""><?php esc_html_e( 'Select an option&hellip;', 'woocommerce' ); ?></option>
 							<?php
 							foreach ( $states as $ckey => $cvalue ) {
 								echo '<option value="' . esc_attr( $ckey ) . '" ' . selected( $current_r, $ckey, false ) . '>' . esc_html( $cvalue ) . '</option>';

--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -52,7 +52,7 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 				} elseif ( is_array( $states ) ) {
 					?>
 					<span>
-						<select name="calc_shipping_state" class="state_select" id="calc_shipping_state" placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>">
+						<select name="calc_shipping_state" class="state_select" id="calc_shipping_state" data-placeholder="<?php esc_attr_e( 'State / County', 'woocommerce' ); ?>">
 							<option value=""><?php esc_html_e( 'Select an option&hellip;', 'woocommerce' ); ?></option>
 							<?php
 							foreach ( $states as $ckey => $cvalue ) {


### PR DESCRIPTION
Updates address-i18n and country-select.js so that on first load, the country boxes trigger a change event. This forces address-i18n to show/hide fields correctly.

To test, make your country on user profile ANGOLA. 
Go to checkout.
Confirm postcode field is hidden.

Closes #22119

Also updates priority sorting to cast to integer which fixes #22227.