### PR TITLE
Change priority of notices on the account page

### DIFF
--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -299,7 +299,7 @@ add_action( 'woocommerce_before_single_product', 'woocommerce_output_all_notices
 add_action( 'woocommerce_before_cart', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_checkout_form_cart_notices', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_checkout_form', 'woocommerce_output_all_notices', 10 );
-add_action( 'woocommerce_account_content', 'woocommerce_output_all_notices', 10 );
+add_action( 'woocommerce_account_content', 'woocommerce_output_all_notices', 5 );
 add_action( 'woocommerce_before_customer_login_form', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_lost_password_form', 'woocommerce_output_all_notices', 10 );
 add_action( 'before_woocommerce_pay', 'woocommerce_output_all_notices', 10 );


### PR DESCRIPTION
Fixes #21996

To test,

- Go to account page
- Edit address
- Remove a required field and save
- Errors appear at the top (before patch they are below the form)

> Fix position of error notices on account pages.