### PR TITLE
Multisite - Load customer data for logged in users regardless of being member of sub-site

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -346,7 +346,7 @@ class WC_Admin_Menus {
 		}
 
 		// Show only when the user is a member of this site, or they're a super admin.
-		if ( ! is_user_member_of_blog() && ! is_super_admin() ) {
+		if ( ! is_super_admin() ) {
 			return;
 		}
 

--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -346,7 +346,7 @@ class WC_Admin_Menus {
 		}
 
 		// Show only when the user is a member of this site, or they're a super admin.
-		if ( ! is_super_admin() ) {
+		if ( ! is_user_member_of_blog() && ! is_super_admin() ) {
 			return;
 		}
 

--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -162,7 +162,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 				// Make sure customer is part of blog.
 				if ( is_multisite() && ! is_user_member_of_blog( $request['customer_id'] ) ) {
-					throw new WC_REST_Exception( 'woocommerce_rest_invalid_customer_id_network', __( 'Customer ID does not belong to this site.', 'woocommerce' ), 400 );
+					add_user_to_blog( get_current_blog_id(), $request['customer_id'], 'customer' );
 				}
 			}
 

--- a/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
+++ b/includes/api/legacy/class-wc-rest-legacy-orders-controller.php
@@ -251,7 +251,7 @@ class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {
 
 			// Make sure customer is part of blog.
 			if ( is_multisite() && ! is_user_member_of_blog( $request['customer_id'] ) ) {
-				throw new WC_REST_Exception( 'woocommerce_rest_invalid_customer_id_network',__( 'Customer ID does not belong to this site.', 'woocommerce' ), 400 );
+				add_user_to_blog( get_current_blog_id(), $request['customer_id'], 'customer' );
 			}
 
 			$order = $this->prepare_item_for_database( $request );

--- a/includes/api/v1/class-wc-rest-orders-controller.php
+++ b/includes/api/v1/class-wc-rest-orders-controller.php
@@ -536,7 +536,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 
 			// Make sure customer is part of blog.
 			if ( is_multisite() && ! is_user_member_of_blog( $request['customer_id'] ) ) {
-				throw new WC_REST_Exception( 'woocommerce_rest_invalid_customer_id_network',__( 'Customer ID does not belong to this site.', 'woocommerce' ), 400 );
+				add_user_to_blog( get_current_blog_id(), $request['customer_id'], 'customer' );
 			}
 
 			$order = $this->prepare_item_for_database( $request );

--- a/includes/api/v2/class-wc-rest-orders-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-orders-v2-controller.php
@@ -58,7 +58,9 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 	 */
 	public function register_routes() {
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base, array(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
 				array(
 					'methods'             => WP_REST_Server::READABLE,
 					'callback'            => array( $this, 'get_items' ),
@@ -76,7 +78,9 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 		);
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', array(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
 				'args'   => array(
 					'id' => array(
 						'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
@@ -114,7 +118,9 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 		);
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/batch', array(
+			$this->namespace,
+			'/' . $this->rest_base . '/batch',
+			array(
 				array(
 					'methods'             => WP_REST_Server::EDITABLE,
 					'callback'            => array( $this, 'batch_items' ),
@@ -382,12 +388,11 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 		if ( ! empty( $request['product'] ) ) {
 			$order_ids = $wpdb->get_col(
 				$wpdb->prepare(
-					"
-				SELECT order_id
-				FROM {$wpdb->prefix}woocommerce_order_items
-				WHERE order_item_id IN ( SELECT order_item_id FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE meta_key = '_product_id' AND meta_value = %d )
-				AND order_item_type = 'line_item'
-			 ", $request['product']
+					"SELECT order_id
+					FROM {$wpdb->prefix}woocommerce_order_items
+					WHERE order_item_id IN ( SELECT order_item_id FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE meta_key = '_product_id' AND meta_value = %d )
+					AND order_item_type = 'line_item'",
+					$request['product']
 				)
 			);
 

--- a/includes/api/v2/class-wc-rest-orders-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-orders-v2-controller.php
@@ -529,7 +529,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 
 				// Make sure customer is part of blog.
 				if ( is_multisite() && ! is_user_member_of_blog( $request['customer_id'] ) ) {
-					throw new WC_REST_Exception( 'woocommerce_rest_invalid_customer_id_network', __( 'Customer ID does not belong to this site.', 'woocommerce' ), 400 );
+					add_user_to_blog( get_current_blog_id(), $request['customer_id'], 'customer' );
 				}
 			}
 

--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -149,11 +149,6 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 			throw new Exception( __( 'Invalid customer.', 'woocommerce' ) );
 		}
 
-		// Only users on this site should be read.
-		if ( is_multisite() && ! is_user_member_of_blog( $customer->get_id() ) ) {
-			throw new Exception( __( 'Invalid customer.', 'woocommerce' ) );
-		}
-
 		$customer_id = $customer->get_id();
 
 		// Load meta but exclude deprecated props.


### PR DESCRIPTION
This is an attempted fix of #21580

Before this patch, if you're logged in, but not a member of a site, WordPress still treats you as a logged in users in some circumstances:

- is_user_logged_in is true
- user has an ID
- admin bar shows (if WC is off)

Additonally, if you login or checkout, WooCommerce will add you as a user on a site automatically.

Therefore, I don't understand why we'd want to limit customer data being loaded if you're logged in, regardless of site.

I also see no reason why API calls cannot add you to a site automatically like checkout does.

I've made those tweaks in this PR. If you repeat the test instructions in #21580 you'll see your address on the account page on other networked sites, and won't see a fatal error.