### PR TITLE
Remove inclusive tax from sales where prices include tax

### DIFF
--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -684,7 +684,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			var main_chart;
 
 			jQuery(function(){
-				var order_data = jQuery.parseJSON( '<?php echo esc_js( $chart_data ); ?>' );
+				var order_data = jQuery.parseJSON( '<?php echo $chart_data;  // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>' );
 				var drawGraph = function( highlight ) {
 					var series = [
 						{
@@ -731,7 +731,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							<?php echo esc_js( $this->get_currency_tooltip() ); ?>
+							<?php echo $this->get_currency_tooltip();  // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Shipping amount', 'woocommerce' ) ); ?>",
@@ -741,7 +741,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol();// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>"
+							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>"
 						},
 						{
 							label: "<?php echo esc_js( __( 'Gross sales amount', 'woocommerce' ) ); ?>",
@@ -751,7 +751,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							<?php echo $this->get_currency_tooltip();// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+							<?php echo $this->get_currency_tooltip(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Net sales amount', 'woocommerce' ) ); ?>",

--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -1,16 +1,17 @@
 <?php
+/**
+ * WC_Report_Sales_By_Date
+ *
+ * @package     WooCommerce/Admin/Reports
+ * @version     2.1.0
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**
  * WC_Report_Sales_By_Date
- *
- * @author      WooThemes
- * @category    Admin
- * @package     WooCommerce/Admin/Reports
- * @version     2.1.0
  */
 class WC_Report_Sales_By_Date extends WC_Admin_Report {
 
@@ -106,7 +107,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			)
 		);
 
-		// All items from orders - even those refunded
+		// All items from orders - even those refunded.
 		$this->report_data->order_items = (array) $this->get_order_report_data(
 			array(
 				'data'         => array(
@@ -412,11 +413,11 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		$this->report_data->total_sales = wc_format_decimal( array_sum( wp_list_pluck( $this->report_data->orders, 'total_sales' ) ) - $this->report_data->total_refunds, 2 );
 		$this->report_data->net_sales   = wc_format_decimal( $this->report_data->total_sales - $this->report_data->total_shipping - max( 0, $this->report_data->total_tax ) - max( 0, $this->report_data->total_shipping_tax ), 2 );
 
-		// Calculate average based on net
+		// Calculate average based on net.
 		$this->report_data->average_sales       = wc_format_decimal( $this->report_data->net_sales / ( $this->chart_interval + 1 ), 2 );
 		$this->report_data->average_total_sales = wc_format_decimal( $this->report_data->total_sales / ( $this->chart_interval + 1 ), 2 );
 
-		// Total orders and discounts also includes those which have been refunded at some point
+		// Total orders and discounts also includes those which have been refunded at some point.
 		$this->report_data->total_coupons         = number_format( array_sum( wp_list_pluck( $this->report_data->coupons, 'discount_amount' ) ), 2, '.', '' );
 		$this->report_data->total_refunded_orders = absint( count( $this->report_data->full_refunds ) );
 
@@ -441,26 +442,26 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 
 		switch ( $this->chart_groupby ) {
 			case 'day':
-				/* translators: %s: average total sales */
 				$average_total_sales_title = sprintf(
+					/* translators: %s: average total sales */
 					__( '%s average gross daily sales', 'woocommerce' ),
 					'<strong>' . wc_price( $data->average_total_sales ) . '</strong>'
 				);
-				/* translators: %s: average sales */
 				$average_sales_title = sprintf(
+					/* translators: %s: average sales */
 					__( '%s average net daily sales', 'woocommerce' ),
 					'<strong>' . wc_price( $data->average_sales ) . '</strong>'
 				);
 				break;
 			case 'month':
 			default:
-				/* translators: %s: average total sales */
 				$average_total_sales_title = sprintf(
+					/* translators: %s: average total sales */
 					__( '%s average gross monthly sales', 'woocommerce' ),
 					'<strong>' . wc_price( $data->average_total_sales ) . '</strong>'
 				);
-				/* translators: %s: average sales */
 				$average_sales_title = sprintf(
+					/* translators: %s: average sales */
 					__( '%s average net monthly sales', 'woocommerce' ),
 					'<strong>' . wc_price( $data->average_sales ) . '</strong>'
 				);
@@ -468,8 +469,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		}
 
 		$legend[] = array(
-			/* translators: %s: total sales */
 			'title'            => sprintf(
+				/* translators: %s: total sales */
 				__( '%s gross sales in this period', 'woocommerce' ),
 				'<strong>' . wc_price( $data->total_sales ) . '</strong>'
 			),
@@ -486,8 +487,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		}
 
 		$legend[] = array(
-			/* translators: %s: net sales */
 			'title'            => sprintf(
+				/* translators: %s: net sales */
 				__( '%s net sales in this period', 'woocommerce' ),
 				'<strong>' . wc_price( $data->net_sales ) . '</strong>'
 			),
@@ -504,8 +505,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		}
 
 		$legend[] = array(
-			/* translators: %s: total orders */
 			'title'            => sprintf(
+				/* translators: %s: total orders */
 				__( '%s orders placed', 'woocommerce' ),
 				'<strong>' . $data->total_orders . '</strong>'
 			),
@@ -514,8 +515,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		);
 
 		$legend[] = array(
-			/* translators: %s: total items */
 			'title'            => sprintf(
+				/* translators: %s: total items */
 				__( '%s items purchased', 'woocommerce' ),
 				'<strong>' . $data->total_items . '</strong>'
 			),
@@ -523,8 +524,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'highlight_series' => 0,
 		);
 		$legend[] = array(
-			/* translators: 1: total refunds 2: total refunded orders 3: refunded items */
 			'title'            => sprintf(
+				/* translators: 1: total refunds 2: total refunded orders 3: refunded items */
 				_n( '%1$s refunded %2$d order (%3$d item)', '%1$s refunded %2$d orders (%3$d items)', $this->report_data->total_refunded_orders, 'woocommerce' ),
 				'<strong>' . wc_price( $data->total_refunds ) . '</strong>',
 				$this->report_data->total_refunded_orders,
@@ -534,8 +535,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'highlight_series' => 8,
 		);
 		$legend[] = array(
-			/* translators: %s: total shipping */
 			'title'            => sprintf(
+				/* translators: %s: total shipping */
 				__( '%s charged for shipping', 'woocommerce' ),
 				'<strong>' . wc_price( $data->total_shipping ) . '</strong>'
 			),
@@ -543,8 +544,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'highlight_series' => 5,
 		);
 		$legend[] = array(
-			/* translators: %s: total coupons */
 			'title'            => sprintf(
+				/* translators: %s: total coupons */
 				__( '%s worth of coupons used', 'woocommerce' ),
 				'<strong>' . wc_price( $data->total_coupons ) . '</strong>'
 			),
@@ -578,9 +579,9 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'refund_amount'    => '#e74c3c',
 		);
 
-		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( $_GET['range'] ) : '7day';
+		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( wp_unslash( $_GET['range'] ) ) : '7day'; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.NonceVerification.NoNonceVerification
 
-		if ( ! in_array( $current_range, array( 'custom', 'year', 'last_month', 'month', '7day' ) ) ) {
+		if ( ! in_array( $current_range, array( 'custom', 'year', 'last_month', 'month', '7day' ), true ) ) {
 			$current_range = '7day';
 		}
 
@@ -594,18 +595,18 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 	 * Output an export link.
 	 */
 	public function get_export_button() {
-		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( $_GET['range'] ) : '7day';
+		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( wp_unslash( $_GET['range'] ) ) : '7day'; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.NonceVerification.NoNonceVerification
 		?>
 		<a
 			href="#"
-			download="report-<?php echo esc_attr( $current_range ); ?>-<?php echo date_i18n( 'Y-m-d', current_time( 'timestamp' ) ); ?>.csv"
+			download="report-<?php echo esc_attr( $current_range ); ?>-<?php echo esc_attr( date_i18n( 'Y-m-d', current_time( 'timestamp' ) ) ); ?>.csv"
 			class="export_csv"
 			data-export="chart"
 			data-xaxes="<?php esc_attr_e( 'Date', 'woocommerce' ); ?>"
 			data-exclude_series="2"
-			data-groupby="<?php echo $this->chart_groupby; ?>"
+			data-groupby="<?php echo esc_attr( $this->chart_groupby ); ?>"
 		>
-			<?php _e( 'Export CSV', 'woocommerce' ); ?>
+			<?php esc_html_e( 'Export CSV', 'woocommerce' ); ?>
 		</a>
 		<?php
 	}
@@ -613,7 +614,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 	/**
 	 * Round our totals correctly.
 	 *
-	 * @param array|string $amount
+	 * @param array|string $amount Chart total.
 	 *
 	 * @return array|string
 	 */
@@ -631,7 +632,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 	public function get_main_chart() {
 		global $wp_locale;
 
-		// Prepare data for report
+		// Prepare data for report.
 		$data = array(
 			'order_counts'         => $this->prepare_chart_data( $this->report_data->order_counts, 'post_date', 'count', $this->chart_interval, $this->start_date, $this->chart_groupby ),
 			'order_item_counts'    => $this->prepare_chart_data( $this->report_data->order_items, 'post_date', 'order_item_count', $this->chart_interval, $this->start_date, $this->chart_groupby ),
@@ -650,7 +651,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			$data['gross_order_amounts'][ $order_amount_key ][1] -= $data['refund_amounts'][ $order_amount_key ][1];
 
 			$data['net_order_amounts'][ $order_amount_key ] = $order_amount_value;
-			// subtract the sum of the values from net order amounts
+			// Subtract the sum of the values from net order amounts.
 			$data['net_order_amounts'][ $order_amount_key ][1] -=
 				$data['refund_amounts'][ $order_amount_key ][1] +
 				$data['shipping_amounts'][ $order_amount_key ][1] +
@@ -658,11 +659,11 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 				$data['tax_amounts'][ $order_amount_key ][1];
 		}
 
-		// 3rd party filtering of report data
+		// 3rd party filtering of report data.
 		$data = apply_filters( 'woocommerce_admin_report_chart_data', $data );
 
-		// Encode in json format
-		$chart_data = json_encode(
+		// Encode in json format.
+		$chart_data = wp_json_encode(
 			array(
 				'order_counts'        => array_values( $data['order_counts'] ),
 				'order_item_counts'   => array_values( $data['order_item_counts'] ),
@@ -683,30 +684,30 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			var main_chart;
 
 			jQuery(function(){
-				var order_data = jQuery.parseJSON( '<?php echo $chart_data; ?>' );
+				var order_data = jQuery.parseJSON( '<?php echo esc_js( $chart_data ); ?>' );
 				var drawGraph = function( highlight ) {
 					var series = [
 						{
 							label: "<?php echo esc_js( __( 'Number of items sold', 'woocommerce' ) ); ?>",
 							data: order_data.order_item_counts,
-							color: '<?php echo $this->chart_colours['item_count']; ?>',
-							bars: { fillColor: '<?php echo $this->chart_colours['item_count']; ?>', fill: true, show: true, lineWidth: 0, barWidth: <?php echo $this->barwidth; ?> * 0.5, align: 'center' },
+							color: '<?php echo esc_js( $this->chart_colours['item_count'] ); ?>',
+							bars: { fillColor: '<?php echo esc_js( $this->chart_colours['item_count'] ); ?>', fill: true, show: true, lineWidth: 0, barWidth: <?php echo esc_js( $this->barwidth ); ?> * 0.5, align: 'center' },
 							shadowSize: 0,
 							hoverable: false
 						},
 						{
 							label: "<?php echo esc_js( __( 'Number of orders', 'woocommerce' ) ); ?>",
 							data: order_data.order_counts,
-							color: '<?php echo $this->chart_colours['order_count']; ?>',
-							bars: { fillColor: '<?php echo $this->chart_colours['order_count']; ?>', fill: true, show: true, lineWidth: 0, barWidth: <?php echo $this->barwidth; ?> * 0.5, align: 'center' },
+							color: '<?php echo esc_js( $this->chart_colours['order_count'] ); ?>',
+							bars: { fillColor: '<?php echo esc_js( $this->chart_colours['order_count'] ); ?>', fill: true, show: true, lineWidth: 0, barWidth: <?php echo esc_js( $this->barwidth ); ?> * 0.5, align: 'center' },
 							shadowSize: 0,
 							hoverable: false
 						},
 						{
 							label: "<?php echo esc_js( __( 'Average gross sales amount', 'woocommerce' ) ); ?>",
-							data: [ [ <?php echo min( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_total_sales; ?> ], [ <?php echo max( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_total_sales; ?> ] ],
+							data: [ [ <?php echo esc_js( min( array_keys( $data['order_amounts'] ) ) ); ?>, <?php echo esc_js( $this->report_data->average_total_sales ); ?> ], [ <?php echo esc_js( max( array_keys( $data['order_amounts'] ) ) ); ?>, <?php echo esc_js( $this->report_data->average_total_sales ); ?> ] ],
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['average']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['average'] ); ?>',
 							points: { show: false },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
@@ -714,9 +715,9 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 						},
 						{
 							label: "<?php echo esc_js( __( 'Average net sales amount', 'woocommerce' ) ); ?>",
-							data: [ [ <?php echo min( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_sales; ?> ], [ <?php echo max( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_sales; ?> ] ],
+							data: [ [ <?php echo esc_js( min( array_keys( $data['order_amounts'] ) ) ); ?>, <?php echo esc_js( $this->report_data->average_sales ); ?> ], [ <?php echo esc_js( max( array_keys( $data['order_amounts'] ) ) ); ?>, <?php echo esc_js( $this->report_data->average_sales ); ?> ] ],
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['net_average']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['net_average'] ); ?>',
 							points: { show: false },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
@@ -726,51 +727,51 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 							label: "<?php echo esc_js( __( 'Coupon amount', 'woocommerce' ) ); ?>",
 							data: order_data.coupon_amounts,
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['coupon_amount']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['coupon_amount'] ); ?>',
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							<?php echo $this->get_currency_tooltip(); ?>
+							<?php echo esc_js( $this->get_currency_tooltip() ); ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Shipping amount', 'woocommerce' ) ); ?>",
 							data: order_data.shipping_amounts,
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['shipping_amount']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['shipping_amount'] ); ?>',
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol(); ?>"
+							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol();// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>"
 						},
 						{
 							label: "<?php echo esc_js( __( 'Gross sales amount', 'woocommerce' ) ); ?>",
 							data: order_data.gross_order_amounts,
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['sales_amount']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['sales_amount'] ); ?>',
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							<?php echo $this->get_currency_tooltip(); ?>
+							<?php echo $this->get_currency_tooltip();// phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Net sales amount', 'woocommerce' ) ); ?>",
 							data: order_data.net_order_amounts,
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['net_sales_amount']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['net_sales_amount'] ); ?>',
 							points: { show: true, radius: 6, lineWidth: 4, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 5, fill: false },
 							shadowSize: 0,
-							<?php echo $this->get_currency_tooltip(); ?>
+							<?php echo $this->get_currency_tooltip(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Refund amount', 'woocommerce' ) ); ?>",
 							data: order_data.refund_amounts,
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['refund_amount']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['refund_amount'] ); ?>',
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol(); ?>"
+							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>"
 						},
 					];
 
@@ -807,9 +808,9 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 								tickColor: 'transparent',
 								mode: "time",
 								timeformat: "<?php echo ( 'day' === $this->chart_groupby ) ? '%d %b' : '%b'; ?>",
-								monthNames: <?php echo json_encode( array_values( $wp_locale->month_abbrev ) ); ?>,
+								monthNames: <?php echo wp_json_encode( array_values( $wp_locale->month_abbrev ) ); ?>,
 								tickLength: 1,
-								minTickSize: [1, "<?php echo $this->chart_groupby; ?>"],
+								minTickSize: [1, "<?php echo esc_js( $this->chart_groupby ); ?>"],
 								font: {
 									color: "#aaa"
 								}

--- a/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -37,37 +37,41 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 
 		$product = WC_Helper_Product::create_simple_product();
 		$coupon  = WC_Helper_Coupon::create_coupon();
-		$tax     = WC_Tax::_insert_tax_rate( array(
-			'tax_rate_country'  => '',
-			'tax_rate_state'    => '',
-			'tax_rate'          => '10.0000',
-			'tax_rate_name'     => 'VAT',
-			'tax_rate_priority' => '1',
-			'tax_rate_compound' => '0',
-			'tax_rate_shipping' => '1',
-			'tax_rate_order'    => '1',
-			'tax_rate_class'    => '',
-		) );
+		$tax     = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '10.0000',
+				'tax_rate_name'     => 'VAT',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '1',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			)
+		);
 
 		// A standard order.
-		$order1  = WC_Helper_Order::create_order( 0, $product->get_id() );
+		$order1 = WC_Helper_Order::create_order( 0, $product->get_id() );
 		$order1->set_status( 'completed' );
 		$order1->save();
 
 		// An order using a coupon.
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->apply_coupon( $coupon );
 		$order2->set_status( 'completed' );
 		$order2->save();
 
 		// An order that was refunded, save for shipping.
-		$order3  = WC_Helper_Order::create_order();
+		$order3 = WC_Helper_Order::create_order();
 		$order3->set_status( 'completed' );
 		$order3->save();
-		wc_create_refund( array(
-			'amount'   => 7,
-			'order_id' => $order3->get_id(),
-		) );
+		wc_create_refund(
+			array(
+				'amount'   => 7,
+				'order_id' => $order3->get_id(),
+			)
+		);
 
 		// Parameters borrowed from WC_Admin_Dashboard::get_sales_report_data().
 		$report                 = new WC_Report_Sales_By_Date();

--- a/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -92,34 +92,34 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 			$data->coupons[0]->order_item_name,
 			'There should be a single coupon applied.'
 		);
-		$this->assertEquals( $data->coupons[0]->discount_amount, $data->total_coupons );
+		$this->assertEquals( $data->coupons[0]->discount_amount, $data->total_coupons, 'Total discount amount.' );
 
 		$this->assertCount( 1, $data->refund_lines, 'There was one refund granted.' );
 		$this->assertEquals( 7, $data->partial_refunds[0]->total_refund, 'Total refunds.' );
-		$this->assertEquals( $data->partial_refunds[0]->total_refund, $data->total_refunds );
+		$this->assertEquals( $data->partial_refunds[0]->total_refund, $data->total_refunds, 'Day refunds, total refunds.' );
 
 		$this->assertEquals(
 			$order1->get_shipping_total() + $order2->get_shipping_total() + $order3->get_shipping_total(),
 			$data->orders[0]->total_shipping,
 			'Orders, total shipping.'
 		);
-		$this->assertEquals( $data->orders[0]->total_shipping, $data->total_shipping );
+		$this->assertEquals( $data->orders[0]->total_shipping, $data->total_shipping, 'Day shipping, total shipping.' );
 
 		$this->assertEquals(
 			$order1->get_shipping_tax() + $order2->get_shipping_tax() + $order3->get_shipping_tax(),
 			$data->orders[0]->total_shipping_tax,
 			'Orders, total shipping tax.'
 		);
-		$this->assertEquals( $data->orders[0]->total_shipping_tax, $data->total_shipping_tax );
+		$this->assertEquals( $data->orders[0]->total_shipping_tax, $data->total_shipping_tax, 'Day shipping tax, total shipping tax.' );
 
-		$this->assertEquals( $data->orders[0]->total_tax, $data->total_tax );
+		$this->assertEquals( $data->orders[0]->total_tax, $data->total_tax, 'Day tax, total tax.' );
 
 		$this->assertEquals(
 			$order1->get_total() + $order2->get_total() + $order3->get_total(),
 			$data->orders[0]->total_sales,
-			'Total sales.'
+			'Orders, total sales.'
 		);
-		$this->assertEquals( $data->orders[0]->total_sales - $data->total_refunds, $data->total_sales, 'Total sales.' );
+		$this->assertEquals( $data->orders[0]->total_sales - $data->total_refunds, $data->total_sales, 'Day sales, total sales.' );
 		$this->assertEquals( $data->total_sales, $data->average_total_sales, 'Average total sales.' );
 
 		$this->assertEquals(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Deduct the inclusive taxes from the order and refund totals on sales by date report. Businesses collect taxes on behalf of tax authorities. International accounting methods do not include sales taxes on gross sales.

Closes #21779 .

### How to test the changes in this Pull Request:

1. Set the shop to entered price includes tax
2. Purchase an item
3. Order report should show gross sales excluding the tax
4. Refund the order
5. Order report should show the refund excluding the tax

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: deduct the inclusive taxes from the order and refund totals on sales by date report.
