### PR TITLE
Set order vat exempt status to that of customer on checkout.

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -336,7 +336,7 @@ class WC_Checkout {
 			$order->set_created_via( 'checkout' );
 			$order->set_cart_hash( $cart_hash );
 			$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) );
-			$order->set_meta( 'is_vat_exempt', WC()->cart->get_customer()->get_is_vat_exempt() );
+			$order->add_meta_data( 'is_vat_exempt', WC()->cart->get_customer()->get_is_vat_exempt() );
 			$order->set_currency( get_woocommerce_currency() );
 			$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
 			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -336,6 +336,7 @@ class WC_Checkout {
 			$order->set_created_via( 'checkout' );
 			$order->set_cart_hash( $cart_hash );
 			$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) );
+			$order->set_meta( 'is_vat_exempt', WC()->cart->get_customer()->get_is_vat_exempt() );
 			$order->set_currency( get_woocommerce_currency() );
 			$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
 			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -336,7 +336,8 @@ class WC_Checkout {
 			$order->set_created_via( 'checkout' );
 			$order->set_cart_hash( $cart_hash );
 			$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) );
-			$order->add_meta_data( 'is_vat_exempt', WC()->cart->get_customer()->get_is_vat_exempt() );
+			$order_vat_exempt = WC()->cart->get_customer()->get_is_vat_exempt() ? 'yes' : 'no';
+			$order->add_meta_data( 'is_vat_exempt', $order_vat_exempt );
 			$order->set_currency( get_woocommerce_currency() );
 			$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
 			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue where when a customer that is VAT exempt places an order the totals are VAT exempt, but when the $order->calculate_totals method is called taxes are added back to the order. What the PR does is on checkout only, it will set the order is_vat_exempt meta value to that of the customer which will result in calculate_totals skipping the taxes when called again after placing the initial order.

Closes #22456 

### How to test the changes in this Pull Request:

1. See #22456 for sample code on how to test.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Customer VAT exempt status now carries through to order when placed via checkout.
