### PR TITLE
Prevent selected payment method description box from sliding up

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -77,10 +77,12 @@ jQuery( function( $ ) {
 				$payment_methods.eq(0).prop( 'checked', true );
 			}
 
-			if ( $payment_methods.length > 1 ) {
+			// Get name of new selected method.
+			var checkedPaymentMethod = $payment_methods.filter( ':checked' ).eq(0).prop( 'id' );
 
+			if ( $payment_methods.length > 1 ) {
 				// Hide open descriptions.
-				$( 'div.payment_box' ).filter( ':visible' ).slideUp( 0 );
+				$( 'div.payment_box:not(".' + checkedPaymentMethod + '")' ).filter( ':visible' ).slideUp( 0 );
 			}
 
 			// Trigger click event for selected method


### PR DESCRIPTION
Closes #21770

To test, go to checkout with multiple payment methods and choose shipping/edit address. The payment box below each payment method should not slide up/down if already selected.

> Prevevent payment method descriptions sliding up/down if selected after ajax updates.