### PR TITLE
Bail if getimagesize fails in filter_image_sizes_to_only_missing_thumbnails

### DIFF
--- a/includes/class-wc-regenerate-images-request.php
+++ b/includes/class-wc-regenerate-images-request.php
@@ -101,8 +101,12 @@ class WC_Regenerate_Images_Request extends WC_Background_Process {
 
 		$log = wc_get_logger();
 
-		// translators: %s: ID of the attachment.
-		$log->info( sprintf( __( 'Regenerating images for attachment ID: %s', 'woocommerce' ), $this->attachment_id ),
+		$log->info(
+			sprintf(
+				// translators: %s: ID of the attachment.
+				__( 'Regenerating images for attachment ID: %s', 'woocommerce' ),
+				$this->attachment_id
+			),
 			array(
 				'source' => 'wc-image-regeneration',
 			)
@@ -248,7 +252,8 @@ class WC_Regenerate_Images_Request extends WC_Background_Process {
 	protected function complete() {
 		parent::complete();
 		$log = wc_get_logger();
-		$log->info( __( 'Completed product image regeneration job.', 'woocommerce' ),
+		$log->info(
+			__( 'Completed product image regeneration job.', 'woocommerce' ),
 			array(
 				'source' => 'wc-image-regeneration',
 			)

--- a/includes/class-wc-regenerate-images-request.php
+++ b/includes/class-wc-regenerate-images-request.php
@@ -202,7 +202,11 @@ class WC_Regenerate_Images_Request extends WC_Background_Process {
 				$size_data['crop'] = false;
 			}
 
-			list( $orig_w, $orig_h ) = getimagesize( $fullsizepath );
+			$image_sizes = getimagesize( $fullsizepath );
+			if ( false === $image_sizes ) {
+				continue;
+			}
+			list( $orig_w, $orig_h ) = $image_sizes;
 
 			$dimensions = image_resize_dimensions( $orig_w, $orig_h, $size_data['width'], $size_data['height'], $size_data['crop'] );
 
@@ -222,6 +226,7 @@ class WC_Regenerate_Images_Request extends WC_Background_Process {
 				unset( $sizes[ $size ] );
 			}
 		}
+
 		return $sizes;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes an issue when you use media plugins that offloads media to an external service and also remove the media items from the local library. All it does it bails and returns the orignal sizes when the getimagesize function fails causing no errors.

Closes #21761

### How to test the changes in this Pull Request:

1. Install WP Offload Media plugin
2. Set it up to offload images to S3 and also check the option to remove files from the local server
3. Change the image settings via the customizer and ensure that no errors are throw or broken images are displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Issue where images offloaded to external servers caused errors and broken images when changing aspect ratios.
