### PR TITLE
include tax in subtotals when validating coupon minimum and maximum

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -665,10 +665,6 @@ class WC_Discounts {
 	protected function validate_coupon_minimum_amount( $coupon ) {
 		$subtotal = wc_remove_number_precision( $this->get_object_subtotal() );
 
-		if ( is_a( $this->object, 'WC_Order' ) && $this->object->get_prices_include_tax() ) {
-			$subtotal += round( $this->object->get_total_tax(), wc_get_price_decimals() );
-		}
-
 		if ( $coupon->get_minimum_amount() > 0 && apply_filters( 'woocommerce_coupon_validate_minimum_amount', $coupon->get_minimum_amount() > $subtotal, $coupon, $subtotal ) ) {
 			/* translators: %s: coupon minimum amount */
 			throw new Exception( sprintf( __( 'The minimum spend for this coupon is %s.', 'woocommerce' ), wc_price( $coupon->get_minimum_amount() ) ), 108 );
@@ -687,10 +683,6 @@ class WC_Discounts {
 	 */
 	protected function validate_coupon_maximum_amount( $coupon ) {
 		$subtotal = wc_remove_number_precision( $this->get_object_subtotal() );
-
-		if ( is_a( $this->object, 'WC_Order' ) && $this->object->get_prices_include_tax() ) {
-			$subtotal += round( $this->object->get_total_tax(), wc_get_price_decimals() );
-		}
 
 		if ( $coupon->get_maximum_amount() > 0 && apply_filters( 'woocommerce_coupon_validate_maximum_amount', $coupon->get_maximum_amount() < $subtotal, $coupon ) ) {
 			/* translators: %s: coupon maximum amount */
@@ -916,7 +908,8 @@ class WC_Discounts {
 		if ( is_a( $this->object, 'WC_Cart' ) ) {
 			return wc_add_number_precision( $this->object->get_displayed_subtotal() );
 		} elseif ( is_a( $this->object, 'WC_Order' ) ) {
-			return wc_add_number_precision( $this->object->get_subtotal() );
+			$subtotal = wc_add_number_precision( $this->object->get_subtotal() );
+			return $this->object->get_prices_include_tax() ? $subtotal + round( $this->object->get_total_tax(), wc_get_price_decimals() ) : $subtotal;
 		} else {
 			return array_sum( wp_list_pluck( $this->items, 'price' ) );
 		}

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -665,7 +665,7 @@ class WC_Discounts {
 	protected function validate_coupon_minimum_amount( $coupon ) {
 		$subtotal = wc_remove_number_precision( $this->get_object_subtotal() );
 
-		if ( $this->object->get_prices_include_tax() ) {
+		if ( is_a( $this->object, 'WC_Order' ) && $this->object->get_prices_include_tax() ) {
 			$subtotal += round( $this->object->get_total_tax(), wc_get_price_decimals() );
 		}
 
@@ -688,7 +688,7 @@ class WC_Discounts {
 	protected function validate_coupon_maximum_amount( $coupon ) {
 		$subtotal = wc_remove_number_precision( $this->get_object_subtotal() );
 
-		if ( $this->object->get_prices_include_tax() ) {
+		if ( is_a( $this->object, 'WC_Order' ) && $this->object->get_prices_include_tax() ) {
 			$subtotal += round( $this->object->get_total_tax(), wc_get_price_decimals() );
 		}
 

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -687,6 +687,11 @@ class WC_Discounts {
 	 */
 	protected function validate_coupon_maximum_amount( $coupon ) {
 		$subtotal = wc_remove_number_precision( $this->get_object_subtotal() );
+
+		if ( $this->object->get_prices_include_tax() ) {
+			$subtotal += round( $this->object->get_total_tax(), wc_get_price_decimals() );
+		}
+
 		if ( $coupon->get_maximum_amount() > 0 && apply_filters( 'woocommerce_coupon_validate_maximum_amount', $coupon->get_maximum_amount() < $subtotal, $coupon ) ) {
 			/* translators: %s: coupon maximum amount */
 			throw new Exception( sprintf( __( 'The maximum spend for this coupon is %s.', 'woocommerce' ), wc_price( $coupon->get_maximum_amount() ) ), 112 );

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -664,6 +664,11 @@ class WC_Discounts {
 	 */
 	protected function validate_coupon_minimum_amount( $coupon ) {
 		$subtotal = wc_remove_number_precision( $this->get_object_subtotal() );
+
+		if ( $this->object->get_prices_include_tax() ) {
+			$subtotal += round( $this->object->get_total_tax(), wc_get_price_decimals() );
+		}
+
 		if ( $coupon->get_minimum_amount() > 0 && apply_filters( 'woocommerce_coupon_validate_minimum_amount', $coupon->get_minimum_amount() > $subtotal, $coupon, $subtotal ) ) {
 			/* translators: %s: coupon minimum amount */
 			throw new Exception( sprintf( __( 'The minimum spend for this coupon is %s.', 'woocommerce' ), wc_price( $coupon->get_minimum_amount() ) ), 108 );

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -968,9 +968,13 @@ class WC_Discounts {
 			 */
 			$message = apply_filters( 'woocommerce_coupon_error', is_numeric( $e->getMessage() ) ? $coupon->get_coupon_error( $e->getMessage() ) : $e->getMessage(), $e->getCode(), $coupon );
 
-			return new WP_Error( 'invalid_coupon', $message, array(
-				'status' => 400,
-			) );
+			return new WP_Error(
+				'invalid_coupon',
+				$message,
+				array(
+					'status' => 400,
+				)
+			);
 		}
 		return true;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When adding a coupon in a manual order the coupon value is validated for minimum and maximum spend against the order subtotal before taxes when the store is set to tax inclusive prices. This PR adds the order tax to the order subtotal when validating the spend limits of tax inclusive coupon values. 

Closes #22245 .

### How to test the changes in this Pull Request:

1. Set the store to prices entered inclusive of tax
2. Create a 10.00 product
3. Create 2 coupons: `A` minimum spend is 9.50, `B` maximum spend is 9.50
4. Without the PR add the product to the order
5. Attempt to add each coupon
6. `A` should error, `B` should apply
7. Remove the coupon and apply PR
8. Add each coupon again
9. `A` should apply, `B` should error
10. Add the product to the cart in the shop
11. Attempt to add each coupon separately
12. Results should be the same as #9

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: include tax in subtotals when validating coupon minimum and maximum in manual order entry.
