### PR TITLE
Fixed padding of addresses in email template

### DIFF
--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -10,9 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @package 	WooCommerce/Templates/Emails
- * @version     3.2.1
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates/Emails
+ * @version 3.5.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,27 +20,29 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 $text_align = is_rtl() ? 'right' : 'left';
+$address    = $order->get_formatted_billing_address();
+$shipping   = $order->get_formatted_shipping_address();
 
 ?><table id="addresses" cellspacing="0" cellpadding="0" style="width: 100%; vertical-align: top; margin-bottom: 40px; padding:0;" border="0">
 	<tr>
-		<td style="text-align:<?php echo $text_align; ?>; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; border:0; padding:0;" valign="top" width="50%">
-			<h2><?php _e( 'Billing address', 'woocommerce' ); ?></h2>
+		<td style="text-align:<?php echo esc_attr( $text_align ); ?>; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; border:0; padding:0;" valign="top" width="50%">
+			<h2><?php esc_html_e( 'Billing address', 'woocommerce' ); ?></h2>
 
 			<address class="address">
-				<?php echo ( $address = $order->get_formatted_billing_address() ) ? $address : __( 'N/A', 'woocommerce' ); ?>
+				<?php echo wp_kses_post( $address ? $address : esc_html__( 'N/A', 'woocommerce' ) ); ?>
 				<?php if ( $order->get_billing_phone() ) : ?>
 					<br/><?php echo esc_html( $order->get_billing_phone() ); ?>
 				<?php endif; ?>
 				<?php if ( $order->get_billing_email() ) : ?>
-					<p><?php echo esc_html( $order->get_billing_email() ); ?></p>
+					<br/><?php echo esc_html( $order->get_billing_email() ); ?>
 				<?php endif; ?>
 			</address>
 		</td>
-		<?php if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() && ( $shipping = $order->get_formatted_shipping_address() ) ) : ?>
-			<td style="text-align:<?php echo $text_align; ?>; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; padding:0;" valign="top" width="50%">
-				<h2><?php _e( 'Shipping address', 'woocommerce' ); ?></h2>
+		<?php if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() && $shipping ) : ?>
+			<td style="text-align:<?php echo esc_attr( $text_align ); ?>; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; padding:0;" valign="top" width="50%">
+				<h2><?php esc_html_e( 'Shipping address', 'woocommerce' ); ?></h2>
 
-				<address class="address"><?php echo $shipping; ?></address>
+				<address class="address"><?php echo wp_kses_post( $shipping ); ?></address>
 			</td>
 		<?php endif; ?>
 	</tr>

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -137,7 +137,7 @@ $text_lighter_20 = wc_hex_lighter( $text, 20 );
 }
 
 .address {
-	padding: 12px 12px 0;
+	padding: 12px;
 	color: <?php echo esc_attr( $text_lighter_20 ); ?>;
 	border: 1px solid <?php echo esc_attr( $body_darker_10 ); ?>;
 }

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -20,16 +20,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Load colors.
-$bg              = get_option( 'woocommerce_email_background_color' );
-$body            = get_option( 'woocommerce_email_body_background_color' );
-$base            = get_option( 'woocommerce_email_base_color' );
-$base_text       = wc_light_or_dark( $base, '#202020', '#ffffff' );
-$text            = get_option( 'woocommerce_email_text_color' );
+$bg        = get_option( 'woocommerce_email_background_color' );
+$body      = get_option( 'woocommerce_email_body_background_color' );
+$base      = get_option( 'woocommerce_email_base_color' );
+$base_text = wc_light_or_dark( $base, '#202020', '#ffffff' );
+$text      = get_option( 'woocommerce_email_text_color' );
 
 // Pick a contrasting color for links.
-$link = wc_hex_is_light( $base ) ? $base : $base_text;
+$link_color = wc_hex_is_light( $base ) ? $base : $base_text;
+
 if ( wc_hex_is_light( $body ) ) {
-	$link = wc_hex_is_light( $base ) ? $base_text : $base;
+	$link_color = wc_hex_is_light( $base ) ? $base_text : $base;
 }
 
 $bg_darker_10    = wc_hex_darker( $bg, 10 );
@@ -190,7 +191,7 @@ h3 {
 }
 
 a {
-	color: <?php echo esc_attr( $link ); ?>;
+	color: <?php echo esc_attr( $link_color ); ?>;
 	font-weight: normal;
 	text-decoration: underline;
 }


### PR DESCRIPTION
Fixes #22036

Adds consistent padding of address elements and removes P tag which had margin.

To test, create an order or invoice yourself and check the display of addresses.