### PR TITLE
notify script plugins that the cart was emptied

### DIFF
--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -97,7 +97,7 @@ jQuery( function( $ ) {
 			}
 
 			// Notify plugins that the cart was emptied.
-			$( document.body ).trigger( 'updated_cart_emptied' );
+			$( document.body ).trigger( 'wc_cart_emptied' );
 		} else {
 			// If the checkout is also displayed on this page, trigger update event.
 			if ( $( '.woocommerce-checkout' ).length ) {

--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -95,6 +95,9 @@ jQuery( function( $ ) {
 			if ( $notices.length > 0 ) {
 				show_notice( $notices );
 			}
+
+			// Notify plugins that the cart was emptied.
+			$( document.body ).trigger( 'updated_cart_emptied' );
 		} else {
 			// If the checkout is also displayed on this page, trigger update event.
 			if ( $( '.woocommerce-checkout' ).length ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Script plugins relying on the `updated_cart_totals` event get a notification when products are removed from the cart except when the cart is emptied. It looks like the reasoning for this was that the cart elements are no longer present. Adding the `updated_cart_totals` event when the cart is emptied could create compatibility issues with scripts attached to the event that are expecting the cart content to be present.

This PR adds a new trigger `updated_cart_emptied` that can be used by plugins to monitor for the empty cart event.

Closes #22453 .

### How to test the changes in this Pull Request:

1. Add multiple items to the cart
2. Add listeners to `updated_cart_totals` and `updated_cart_emptied`.
3. Remove the items from the cart & verify the triggers are called as described above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add a trigger `updated_cart_emptied` for the empty cart event..
