### PR TITLE
Add stock qty increase/decrease option to bulk edit

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -627,6 +627,17 @@ class WC_Admin_Post_Types {
 		$product->set_backorders( $backorders );
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
+			$change_stock = absint( $_REQUEST['change_stock'] );
+			switch ( $change_stock ) {
+				case 2:
+					$stock_amount = wc_stock_amount( $product->get_stock_quantity() + $stock_amount );
+					break;
+				case 3:
+					$stock_amount = wc_stock_amount( $product->get_stock_quantity() - $stock_amount );
+					break;
+				default:
+					break;
+			}
 			$product->set_stock_quantity( $stock_amount );
 		}
 

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -633,15 +633,15 @@ class WC_Admin_Post_Types {
 			$change_stock = absint( $_REQUEST['change_stock'] );
 			switch ( $change_stock ) {
 				case 2:
-					$stock_amount = wc_stock_amount( $product->get_stock_quantity() + $stock_amount );
+					wc_update_product_stock( $product, $stock_amount, 'increase' );
 					break;
 				case 3:
-					$stock_amount = wc_stock_amount( $product->get_stock_quantity() - $stock_amount );
+					wc_update_product_stock( $product, $stock_amount, 'decrease' );
 					break;
 				default:
+					wc_update_product_stock( $product, $stock_amount, 'set' );
 					break;
 			}
-			$product->set_stock_quantity( $stock_amount );
 		}
 
 		// Apply product type constraints to stock status.

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -132,7 +132,8 @@ class WC_Admin_Post_Types {
 			9  => sprintf(
 				/* translators: 1: date 2: product url */
 				__( 'Product scheduled for: %1$s. <a target="_blank" href="%2$s">Preview product</a>', 'woocommerce' ),
-				'<strong>' . date_i18n( __( 'M j, Y @ G:i', 'woocommerce' ), strtotime( $post->post_date ) ), esc_url( get_permalink( $post->ID ) ) . '</strong>'
+				'<strong>' . date_i18n( __( 'M j, Y @ G:i', 'woocommerce' ), strtotime( $post->post_date ) ),
+				esc_url( get_permalink( $post->ID ) ) . '</strong>'
 			),
 			/* translators: %s: product url */
 			10 => sprintf( __( 'Product draft updated. <a target="_blank" href="%s">Preview product</a>', 'woocommerce' ), esc_url( add_query_arg( 'preview', 'true', get_permalink( $post->ID ) ) ) ),
@@ -240,7 +241,8 @@ class WC_Admin_Post_Types {
 		}
 
 		$shipping_class = get_terms(
-			'product_shipping_class', array(
+			'product_shipping_class',
+			array(
 				'hide_empty' => false,
 			)
 		);
@@ -260,7 +262,8 @@ class WC_Admin_Post_Types {
 		}
 
 		$shipping_class = get_terms(
-			'product_shipping_class', array(
+			'product_shipping_class',
+			array(
 				'hide_empty' => false,
 			)
 		);

--- a/includes/admin/views/html-bulk-edit-product.php
+++ b/includes/admin/views/html-bulk-edit-product.php
@@ -257,6 +257,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 							$options = array(
 								''  => __( '— No change —', 'woocommerce' ),
 								'1' => __( 'Change to:', 'woocommerce' ),
+								'2' => __( 'Increase existing stock by:', 'woocommerce' ),
+								'3' => __( 'Decrease existing stock by:', 'woocommerce' ),
 							);
 							foreach ( $options as $key => $value ) {
 								echo '<option value="' . esc_attr( $key ) . '">' . $value . '</option>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds an increase and decrease stock by option to the bulk product edit functionality in addition to the change to already present.

Closes #22474 

PS: Did not complete the PHPCS fixes for the one file as there are quite a lot of escaping reports and do not want to change that with the fear of breaking output somewhere.

### How to test the changes in this Pull Request:

1. Bulk edit 2 or more products
2. Check the manage stock option
3. Then use the increase, decrease and change to option and ensure stock is adjusted for the selected products.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Bulk product edit increase and decrease stock by options
