### PR TITLE
Hide ratings when reviews are disabled

### DIFF
--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -225,7 +225,7 @@ abstract class WC_Widget extends WP_Widget {
 				case 'text':
 					?>
 					<p>
-						<label for="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>"><?php echo $setting['label']; ?></label><?php // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+						<label for="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>"><?php echo $setting['label']; /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></label>
 						<input class="widefat <?php echo esc_attr( $class ); ?>" id="<?php echo esc_attr( $this->get_field_id( $key ) ); ?>" name="<?php echo esc_attr( $this->get_field_name( $key ) ); ?>" type="text" value="<?php echo esc_attr( $value ); ?>" />
 					</p>
 					<?php

--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -146,7 +146,7 @@ class WC_Comments {
 	 */
 	public static function check_comment_rating( $comment_data ) {
 		// If posting a comment (not trackback etc) and not logged in.
-		if ( ! is_admin() && isset( $_POST['comment_post_ID'], $_POST['rating'], $comment_data['comment_type'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) && empty( $_POST['rating'] ) && '' === $comment_data['comment_type'] && 'yes' === get_option( 'woocommerce_enable_review_rating' ) && 'yes' === get_option( 'woocommerce_review_rating_required' ) ) { // WPCS: input var ok, CSRF ok.
+		if ( ! is_admin() && isset( $_POST['comment_post_ID'], $_POST['rating'], $comment_data['comment_type'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) && empty( $_POST['rating'] ) && '' === $comment_data['comment_type'] && wc_review_ratings_enabled() && wc_review_ratings_required() ) { // WPCS: input var ok, CSRF ok.
 			wp_die( esc_html__( 'Please rate the product.', 'woocommerce' ) );
 			exit;
 		}

--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -240,7 +240,8 @@ class WC_Comments {
 					FROM {$wpdb->comments}
 					WHERE comment_type NOT IN ('order_note', 'webhook_delivery')
 					GROUP BY comment_approved
-				", ARRAY_A
+					",
+					ARRAY_A
 				);
 
 				$approved = array(
@@ -327,7 +328,8 @@ class WC_Comments {
 				AND comment_post_ID = %d
 				AND comment_approved = '1'
 				AND meta_value > 0
-			", $product->get_id()
+					",
+					$product->get_id()
 				)
 			);
 			$average = number_format( $ratings / $count, 2, '.', '' );
@@ -360,7 +362,8 @@ class WC_Comments {
 			WHERE comment_parent = 0
 			AND comment_post_ID = %d
 			AND comment_approved = '1'
-		", $product->get_id()
+				",
+				$product->get_id()
 			)
 		);
 
@@ -393,7 +396,8 @@ class WC_Comments {
 			AND comment_approved = '1'
 			AND meta_value > 0
 			GROUP BY meta_value
-		", $product->get_id()
+				",
+				$product->get_id()
 			)
 		);
 

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -137,7 +137,8 @@ class WC_Customer extends WC_Legacy_Customer {
 	public function delete_and_reassign( $reassign = null ) {
 		if ( $this->data_store ) {
 			$this->data_store->delete(
-				$this, array(
+				$this,
+				array(
 					'force_delete' => true,
 					'reassign'     => $reassign,
 				)

--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -471,7 +471,7 @@ class WC_Frontend_Scripts {
 			case 'wc-single-product':
 				$params = array(
 					'i18n_required_rating_text' => esc_attr__( 'Please select a rating', 'woocommerce' ),
-					'review_rating_required'    => get_option( 'woocommerce_review_rating_required' ),
+					'review_rating_required'    => wc_review_ratings_required() ? 'yes' : 'no',
 					'flexslider'                => apply_filters(
 						'woocommerce_single_product_carousel_options', array(
 							'rtl'            => is_rtl(),

--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -52,7 +52,8 @@ class WC_Frontend_Scripts {
 	 */
 	public static function get_styles() {
 		return apply_filters(
-			'woocommerce_enqueue_styles', array(
+			'woocommerce_enqueue_styles',
+			array(
 				'woocommerce-layout'      => array(
 					'src'     => self::get_asset_url( 'assets/css/woocommerce-layout.css' ),
 					'deps'    => '',
@@ -414,7 +415,7 @@ class WC_Frontend_Scripts {
 		}
 
 		// Placeholder style.
-		wp_register_style( 'woocommerce-inline', false );
+		wp_register_style( 'woocommerce-inline', false ); // phpcs:ignore
 		wp_enqueue_style( 'woocommerce-inline' );
 
 		if ( true === wc_string_to_bool( get_option( 'woocommerce_checkout_highlight_required_fields', 'yes' ) ) ) {
@@ -473,7 +474,8 @@ class WC_Frontend_Scripts {
 					'i18n_required_rating_text' => esc_attr__( 'Please select a rating', 'woocommerce' ),
 					'review_rating_required'    => wc_review_ratings_required() ? 'yes' : 'no',
 					'flexslider'                => apply_filters(
-						'woocommerce_single_product_carousel_options', array(
+						'woocommerce_single_product_carousel_options',
+						array(
 							'rtl'            => is_rtl(),
 							'animation'      => 'slide',
 							'smoothHeight'   => true,
@@ -489,7 +491,8 @@ class WC_Frontend_Scripts {
 					'zoom_options'              => apply_filters( 'woocommerce_single_product_zoom_options', array() ),
 					'photoswipe_enabled'        => apply_filters( 'woocommerce_single_product_photoswipe_enabled', get_theme_support( 'wc-product-gallery-lightbox' ) ),
 					'photoswipe_options'        => apply_filters(
-						'woocommerce_single_product_photoswipe_options', array(
+						'woocommerce_single_product_photoswipe_options',
+						array(
 							'shareEl'               => false,
 							'closeOnScroll'         => false,
 							'history'               => false,

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -51,7 +51,8 @@ class WC_Post_Types {
 			'product_type',
 			apply_filters( 'woocommerce_taxonomy_objects_product_type', array( 'product' ) ),
 			apply_filters(
-				'woocommerce_taxonomy_args_product_type', array(
+				'woocommerce_taxonomy_args_product_type',
+				array(
 					'hierarchical'      => false,
 					'show_ui'           => false,
 					'show_in_nav_menus' => false,
@@ -66,7 +67,8 @@ class WC_Post_Types {
 			'product_visibility',
 			apply_filters( 'woocommerce_taxonomy_objects_product_visibility', array( 'product', 'product_variation' ) ),
 			apply_filters(
-				'woocommerce_taxonomy_args_product_visibility', array(
+				'woocommerce_taxonomy_args_product_visibility',
+				array(
 					'hierarchical'      => false,
 					'show_ui'           => false,
 					'show_in_nav_menus' => false,
@@ -81,7 +83,8 @@ class WC_Post_Types {
 			'product_cat',
 			apply_filters( 'woocommerce_taxonomy_objects_product_cat', array( 'product' ) ),
 			apply_filters(
-				'woocommerce_taxonomy_args_product_cat', array(
+				'woocommerce_taxonomy_args_product_cat',
+				array(
 					'hierarchical'          => true,
 					'update_count_callback' => '_wc_term_recount',
 					'label'                 => __( 'Categories', 'woocommerce' ),
@@ -120,7 +123,8 @@ class WC_Post_Types {
 			'product_tag',
 			apply_filters( 'woocommerce_taxonomy_objects_product_tag', array( 'product' ) ),
 			apply_filters(
-				'woocommerce_taxonomy_args_product_tag', array(
+				'woocommerce_taxonomy_args_product_tag',
+				array(
 					'hierarchical'          => false,
 					'update_count_callback' => '_wc_term_recount',
 					'label'                 => __( 'Product tags', 'woocommerce' ),
@@ -160,7 +164,8 @@ class WC_Post_Types {
 			'product_shipping_class',
 			apply_filters( 'woocommerce_taxonomy_objects_product_shipping_class', array( 'product', 'product_variation' ) ),
 			apply_filters(
-				'woocommerce_taxonomy_args_product_shipping_class', array(
+				'woocommerce_taxonomy_args_product_shipping_class',
+				array(
 					'hierarchical'          => false,
 					'update_count_callback' => '_update_post_term_count',
 					'label'                 => __( 'Shipping classes', 'woocommerce' ),

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -261,7 +261,7 @@ class WC_Structured_Data {
 			$markup['offers'] = array( apply_filters( 'woocommerce_structured_data_product_offer', $markup_offer, $product ) );
 		}
 
-		if ( $product->get_review_count() && 'yes' === get_option( 'woocommerce_enable_review_rating' ) ) {
+		if ( $product->get_review_count() && wc_review_ratings_enabled() ) {
 			$markup['aggregateRating'] = array(
 				'@type'       => 'AggregateRating',
 				'ratingValue' => $product->get_average_rating(),

--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -422,7 +422,7 @@ function wc_post_content_has_shortcode( $tag = '' ) {
 /**
  * Check if reviews are enabled.
  *
- * @since 3.5.4
+ * @since 3.6.0
  * @return bool
  */
 function wc_reviews_enabled() {
@@ -432,7 +432,7 @@ function wc_reviews_enabled() {
 /**
  * Check if reviews ratings are enabled.
  *
- * @since 3.5.4
+ * @since 3.6.0
  * @return bool
  */
 function wc_review_ratings_enabled() {
@@ -442,7 +442,7 @@ function wc_review_ratings_enabled() {
 /**
  * Check if review ratings are required.
  *
- * @since 3.5.4
+ * @since 3.6.0
  * @return bool
  */
 function wc_review_ratings_required() {

--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -418,3 +418,33 @@ function wc_post_content_has_shortcode( $tag = '' ) {
 
 	return is_singular() && is_a( $post, 'WP_Post' ) && has_shortcode( $post->post_content, $tag );
 }
+
+/**
+ * Check if reviews are enabled.
+ *
+ * @since 3.5.4
+ * @return bool
+ */
+function wc_reviews_enabled() {
+	return 'yes' === get_option( 'woocommerce_enable_reviews' );
+}
+
+/**
+ * Check if reviews ratings are enabled.
+ *
+ * @since 3.5.4
+ * @return bool
+ */
+function wc_review_ratings_enabled() {
+	return wc_reviews_enabled() && 'yes' === get_option( 'woocommerce_enable_review_rating' );
+}
+
+/**
+ * Check if review ratings are required.
+ *
+ * @since 3.5.4
+ * @return bool
+ */
+function wc_review_ratings_required() {
+	return 'yes' === get_option( 'woocommerce_review_rating_required' );
+}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1324,7 +1324,7 @@ if ( ! function_exists( 'woocommerce_catalog_ordering' ) ) {
 			unset( $catalog_orderby_options['menu_order'] );
 		}
 
-		if ( 'no' === get_option( 'woocommerce_enable_review_rating' ) ) {
+		if ( ! wc_review_ratings_enabled() ) {
 			unset( $catalog_orderby_options['rating'] );
 		}
 

--- a/templates/loop/rating.php
+++ b/templates/loop/rating.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.0.0
+ * @version 3.5.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/loop/rating.php
+++ b/templates/loop/rating.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.5.4
+ * @version 3.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/loop/rating.php
+++ b/templates/loop/rating.php
@@ -10,9 +10,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @package 	WooCommerce/Templates
- * @version     3.0.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.0.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -25,4 +25,4 @@ if ( 'no' === get_option( 'woocommerce_enable_review_rating' ) || 'no' === get_o
 	return;
 }
 
-echo wc_get_rating_html( $product->get_average_rating() );
+echo wc_get_rating_html( $product->get_average_rating() ); // WordPress.XSS.EscapeOutput.OutputNotEscaped.

--- a/templates/loop/rating.php
+++ b/templates/loop/rating.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $product;
 
-if ( 'no' === get_option( 'woocommerce_enable_review_rating' ) || 'no' === get_option( 'woocommerce_enable_reviews' ) ) {
+if ( ! wc_review_ratings_enabled() ) {
 	return;
 }
 

--- a/templates/loop/rating.php
+++ b/templates/loop/rating.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 global $product;
 
-if ( get_option( 'woocommerce_enable_review_rating' ) === 'no' ) {
+if ( 'no' === get_option( 'woocommerce_enable_review_rating' ) || 'no' === get_option( 'woocommerce_enable_reviews' ) ) {
 	return;
 }
 

--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.5.4
+ * @version 3.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.0
+ * @version 3.5.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -31,7 +31,7 @@ if ( ! comments_open() ) {
 		<h2 class="woocommerce-Reviews-title">
 			<?php
 			$count = $product->get_review_count();
-			if ( $count && get_option( 'woocommerce_enable_review_rating' ) === 'yes' ) {
+			if ( $count && wc_review_ratings_enabled() ) {
 				/* translators: 1: reviews count 2: product name */
 				$reviews_title = sprintf( esc_html( _n( '%1$s review for %2$s', '%1$s reviews for %2$s', $count, 'woocommerce' ) ), esc_html( $count ), '<span>' . get_the_title() . '</span>' );
 				echo apply_filters( 'woocommerce_reviews_title', $reviews_title, $count, $product ); // WPCS: XSS ok.
@@ -98,7 +98,7 @@ if ( ! comments_open() ) {
 					$comment_form['must_log_in'] = '<p class="must-log-in">' . sprintf( esc_html__( 'You must be %slogged in%S to post a review.', 'woocommerce' ), '<a href="' . esc_url( $account_page_url ) . '">', '</a>' ) . '</p>';
 				}
 
-				if ( get_option( 'woocommerce_enable_review_rating' ) === 'yes' ) {
+				if ( wc_review_ratings_enabled() ) {
 					$comment_form['comment_field'] = '<div class="comment-form-rating"><label for="rating">' . esc_html__( 'Your rating', 'woocommerce' ) . '</label><select name="rating" id="rating" required>
 						<option value="">' . esc_html__( 'Rate&hellip;', 'woocommerce' ) . '</option>
 						<option value="5">' . esc_html__( 'Perfect', 'woocommerce' ) . '</option>

--- a/templates/single-product/rating.php
+++ b/templates/single-product/rating.php
@@ -12,16 +12,16 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.1.0
+ * @version 3.5.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 global $product;
 
-if ( 'no' === get_option( 'woocommerce_enable_review_rating' ) ) {
+if ( ! wc_review_ratings_enabled() ) {
 	return;
 }
 
@@ -32,7 +32,7 @@ $average      = $product->get_average_rating();
 if ( $rating_count > 0 ) : ?>
 
 	<div class="woocommerce-product-rating">
-		<?php echo wc_get_rating_html( $average, $rating_count ); ?>
+		<?php echo wc_get_rating_html( $average, $rating_count ); // ?>
 		<?php if ( comments_open() ) : ?><a href="#reviews" class="woocommerce-review-link" rel="nofollow">(<?php printf( _n( '%s customer review', '%s customer reviews', $review_count, 'woocommerce' ), '<span class="count">' . esc_html( $review_count ) . '</span>' ); ?>)</a><?php endif ?>
 	</div>
 

--- a/templates/single-product/rating.php
+++ b/templates/single-product/rating.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.5.4
+ * @version 3.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/single-product/rating.php
+++ b/templates/single-product/rating.php
@@ -32,8 +32,12 @@ $average      = $product->get_average_rating();
 if ( $rating_count > 0 ) : ?>
 
 	<div class="woocommerce-product-rating">
-		<?php echo wc_get_rating_html( $average, $rating_count ); // ?>
-		<?php if ( comments_open() ) : ?><a href="#reviews" class="woocommerce-review-link" rel="nofollow">(<?php printf( _n( '%s customer review', '%s customer reviews', $review_count, 'woocommerce' ), '<span class="count">' . esc_html( $review_count ) . '</span>' ); ?>)</a><?php endif ?>
+		<?php echo wc_get_rating_html( $average, $rating_count ); // WPCS: XSS ok. ?>
+		<?php if ( comments_open() ) : ?>
+			<?php //phpcs:disable ?>
+			<a href="#reviews" class="woocommerce-review-link" rel="nofollow">(<?php printf( _n( '%s customer review', '%s customer reviews', $review_count, 'woocommerce' ), '<span class="count">' . esc_html( $review_count ) . '</span>' ); ?>)</a>
+			<?php // phpcs:enable ?>
+		<?php endif ?>
 	</div>
 
 <?php endif; ?>

--- a/templates/single-product/review-rating.php
+++ b/templates/single-product/review-rating.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.1.0
+ * @version 3.5.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,6 +22,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 global $comment;
 $rating = intval( get_comment_meta( $comment->comment_ID, 'rating', true ) );
 
-if ( $rating && 'yes' === get_option( 'woocommerce_enable_review_rating' ) ) {
+if ( $rating && wc_review_ratings_enabled() ) {
 	echo wc_get_rating_html( $rating );
 }

--- a/templates/single-product/review-rating.php
+++ b/templates/single-product/review-rating.php
@@ -16,12 +16,12 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 global $comment;
 $rating = intval( get_comment_meta( $comment->comment_ID, 'rating', true ) );
 
 if ( $rating && wc_review_ratings_enabled() ) {
-	echo wc_get_rating_html( $rating );
+	echo wc_get_rating_html( $rating ); // WPCS: XSS ok.
 }

--- a/templates/single-product/review-rating.php
+++ b/templates/single-product/review-rating.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.5.4
+ * @version 3.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Ratings forms part of the review system, this PR fixes an issue where if you disable reviews it will still show the ratings. Since ratings are part of reviews and the settings are hidden when you disable reviews the ratings should also not be disabled as reviews when you disable reviews.

Closes #22470 

### How to test the changes in this Pull Request:

1. Enable ratings and enable reviews and save settings
2. Create a rating for a product
3. Disable just the reviews setting and save
4. Check the shop page for the product and ensure no star ratings are displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Hide ratings on the shop page when reviews are disabled.
