### PR TITLE
Add a new Travis job to run WC unit tests using WordPress nightly

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,9 @@ matrix:
   - name: "Unit tests code coverage"
     php: 7.1
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
+  - name: "WooCommerce unit tests using WordPress nightly"
+    php: 7.3
+    env: WP_VERSION=nightly WP_MULTISITE=0
   allow_failures:
   - php: 7.1
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Doing this to help us find problems in the upcoming versions of WordPress and hopefully address them before the final WP release. Having this new Travis job might help us prevent issues like #22271 that we learned about only after WP 5.0.2 was released.

### How to test the changes in this Pull Request:

1. Check that the new Travis build job works and that it uses the nightly WordPress build. The best way that I know to do that is to check which version of WP the install.sh downloaded: https://travis-ci.org/woocommerce/woocommerce/jobs/480326381#L526