### PR TITLE
Introduce `woocommerce_display_product_attributes` filter and rework template file

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -111,8 +111,8 @@
 	VariationForm.prototype.onResetDisplayedVariation = function( event ) {
 		var form = event.data.variationForm;
 		form.$product.find( '.product_meta' ).find( '.sku' ).wc_reset_content();
-		form.$product.find( '.product_weight' ).wc_reset_content();
-		form.$product.find( '.product_dimensions' ).wc_reset_content();
+		form.$product.find( '.product_weight, .woocommerce-product-attributes-item--weight .woocommerce-product-attributes-item__value' ).wc_reset_content();
+		form.$product.find( '.product_dimensions, .woocommerce-product-attributes-item--dimensions .woocommerce-product-attributes-item__value' ).wc_reset_content();
 		form.$form.trigger( 'reset_image' );
 		form.$singleVariation.slideUp( 200 ).trigger( 'hide_variation' );
 	};
@@ -194,8 +194,8 @@
 	VariationForm.prototype.onFoundVariation = function( event, variation ) {
 		var form           = event.data.variationForm,
 			$sku           = form.$product.find( '.product_meta' ).find( '.sku' ),
-			$weight        = form.$product.find( '.product_weight' ),
-			$dimensions    = form.$product.find( '.product_dimensions' ),
+			$weight        = form.$product.find( '.product_weight, .woocommerce-product-attributes-item--weight .woocommerce-product-attributes-item__value' ),
+			$dimensions    = form.$product.find( '.product_dimensions, .woocommerce-product-attributes-item--dimensions .woocommerce-product-attributes-item__value' ),
 			$qty           = form.$singleVariationWrap.find( '.quantity' ),
 			purchasable    = true,
 			variation_id   = '',

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -906,13 +906,10 @@ if ( ! function_exists( 'woocommerce_content' ) ) {
 
 				<?php do_action( 'woocommerce_after_shop_loop' ); ?>
 
-			<?php else : ?>
-
-				<?php do_action( 'woocommerce_no_products_found' ); ?>
-
-			<?php
+				<?php
+			else :
+				do_action( 'woocommerce_no_products_found' );
 			endif;
-
 		}
 	}
 }
@@ -1066,7 +1063,7 @@ if ( ! function_exists( 'woocommerce_template_loop_product_title' ) ) {
 	 * Show the product title in the product loop. By default this is an H2.
 	 */
 	function woocommerce_template_loop_product_title() {
-		echo '<h2 class="woocommerce-loop-product__title">' . get_the_title() . '</h2>';
+		echo '<h2 class="woocommerce-loop-product__title">' . get_the_title() . '</h2>'; // phpcs:ignore
 	}
 }
 if ( ! function_exists( 'woocommerce_template_loop_category_title' ) ) {
@@ -1206,7 +1203,7 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 			$args = apply_filters( 'woocommerce_loop_add_to_cart_args', wp_parse_args( $args, $defaults ), $product );
 
 			if ( isset( $args['attributes']['aria-label'] ) ) {
-				$args['attributes']['aria-label'] = strip_tags( $args['attributes']['aria-label'] );
+				$args['attributes']['aria-label'] = wp_strip_all_tags( $args['attributes']['aria-label'] );
 			}
 
 			wc_get_template( 'loop/add-to-cart.php', $args );
@@ -3239,12 +3236,75 @@ if ( ! function_exists( 'woocommerce_photoswipe' ) ) {
  * @param  WC_Product $product Product Object.
  */
 function wc_display_product_attributes( $product ) {
+	$product_attributes = array();
+
+	// Display weight and dimensions before attribute list.
+	$display_dimensions = apply_filters( 'wc_product_enable_dimensions_display', $product->has_weight() || $product->has_dimensions() );
+
+	if ( $display_dimensions && $product->has_weight() ) {
+		$product_attributes['weight'] = array(
+			'label' => __( 'Weight', 'woocommerce' ),
+			'value' => wc_format_weight( $product->get_weight() ),
+		);
+	}
+
+	if ( $display_dimensions && $product->has_dimensions() ) {
+		$product_attributes['dimensions'] = array(
+			'label' => __( 'Dimensions', 'woocommerce' ),
+			'value' => wc_format_dimensions( $product->get_dimensions( false ) ),
+		);
+	}
+
+	// Add product attributes to list.
+	$attributes = array_filter( $product->get_attributes(), 'wc_attributes_array_filter_visible' );
+
+	foreach ( $attributes as $attribute ) {
+		$values = array();
+
+		if ( $attribute->is_taxonomy() ) {
+			$attribute_taxonomy = $attribute->get_taxonomy_object();
+			$attribute_values   = wc_get_product_terms( $product->get_id(), $attribute->get_name(), array( 'fields' => 'all' ) );
+
+			foreach ( $attribute_values as $attribute_value ) {
+				$value_name = esc_html( $attribute_value->name );
+
+				if ( $attribute_taxonomy->attribute_public ) {
+					$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $value_name . '</a>';
+				} else {
+					$values[] = $value_name;
+				}
+			}
+		} else {
+			$values = $attribute->get_options();
+
+			foreach ( $values as &$value ) {
+				$value = make_clickable( esc_html( $value ) );
+			}
+		}
+
+		$product_attributes[ 'attribute_' . sanitize_title_with_dashes( $attribute->get_name() ) ] = array(
+			'label' => wc_attribute_label( $attribute->get_name() ),
+			'value' => apply_filters( 'woocommerce_attribute', wpautop( wptexturize( implode( ', ', $values ) ) ), $attribute, $values ),
+		);
+	}
+
+	/**
+	 * Hook: woocommerce_display_product_attributes.
+	 *
+	 * @since 3.6.0.
+	 * @param array $product_attributes Array of atributes to display; label, value.
+	 * @param WC_Product $product Showing attributes for this product.
+	 */
+	$product_attributes = apply_filters( 'woocommerce_display_product_attributes', $product_attributes, $product );
+
 	wc_get_template(
 		'single-product/product-attributes.php',
 		array(
+			'product_attributes' => $product_attributes,
+			// Legacy params.
 			'product'            => $product,
-			'attributes'         => array_filter( $product->get_attributes(), 'wc_attributes_array_filter_visible' ),
-			'display_dimensions' => apply_filters( 'wc_product_enable_dimensions_display', $product->has_weight() || $product->has_dimensions() ),
+			'attributes'         => $attributes,
+			'display_dimensions' => $display_dimensions,
 		)
 	);
 }

--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -12,59 +12,22 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @package 	WooCommerce/Templates
- * @version     3.1.0
+ * @see https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 3.6.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
+defined( 'ABSPATH' ) || exit;
+
+if ( ! $product_attributes ) {
+	return;
 }
 ?>
-<table class="shop_attributes">
-	<?php if ( $display_dimensions && $product->has_weight() ) : ?>
-		<tr>
-			<th><?php _e( 'Weight', 'woocommerce' ); ?></th>
-			<td class="product_weight"><?php echo esc_html( wc_format_weight( $product->get_weight() ) ); ?></td>
-		</tr>
-	<?php endif; ?>
-
-	<?php if ( $display_dimensions && $product->has_dimensions() ) : ?>
-		<tr>
-			<th><?php _e( 'Dimensions', 'woocommerce' ); ?></th>
-			<td class="product_dimensions"><?php echo esc_html( wc_format_dimensions( $product->get_dimensions( false ) ) ); ?></td>
-		</tr>
-	<?php endif; ?>
-
-	<?php foreach ( $attributes as $attribute ) : ?>
-		<tr>
-			<th><?php echo wc_attribute_label( $attribute->get_name() ); ?></th>
-			<td><?php
-				$values = array();
-
-				if ( $attribute->is_taxonomy() ) {
-					$attribute_taxonomy = $attribute->get_taxonomy_object();
-					$attribute_values = wc_get_product_terms( $product->get_id(), $attribute->get_name(), array( 'fields' => 'all' ) );
-
-					foreach ( $attribute_values as $attribute_value ) {
-						$value_name = esc_html( $attribute_value->name );
-
-						if ( $attribute_taxonomy->attribute_public ) {
-							$values[] = '<a href="' . esc_url( get_term_link( $attribute_value->term_id, $attribute->get_name() ) ) . '" rel="tag">' . $value_name . '</a>';
-						} else {
-							$values[] = $value_name;
-						}
-					}
-				} else {
-					$values = $attribute->get_options();
-
-					foreach ( $values as &$value ) {
-						$value = make_clickable( esc_html( $value ) );
-					}
-				}
-
-				echo apply_filters( 'woocommerce_attribute', wpautop( wptexturize( implode( ', ', $values ) ) ), $attribute, $values );
-			?></td>
+<table class="woocommerce-product-attributes shop_attributes">
+	<?php foreach ( $product_attributes as $product_attribute_key => $product_attribute ) : ?>
+		<tr class="woocommerce-product-attributes-item woocommerce-product-attributes-item--<?php echo esc_attr( $product_attribute_key ); ?>">
+			<th class="woocommerce-product-attributes-item__label"><?php echo wp_kses_post( $product_attribute['label'] ); ?></th>
+			<td class="woocommerce-product-attributes-item__value"><?php echo wp_kses_post( $product_attribute['value'] ); ?></td>
 		</tr>
 	<?php endforeach; ?>
 </table>


### PR DESCRIPTION
Instead of inserting actions with weird names in all possible locations, this PR refactors the product-attrubutes.php template to accept an array of attributes for display. This array is ran through a new filter, `woocommerce_display_product_attributes`, to control which attributes get output.

Legacy vars are maintained so older template files do not break.

Closes #21609

To test, apply PR and visit a product with attibutes and/or weight/dimensions. You should see the attribute table on the additonal information tab.