### PR TITLE
 Before action for order heading in checkout form template

### DIFF
--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -53,9 +53,6 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 	
 	<h3 id="order_review_heading"><?php esc_html_e( 'Your order', 'woocommerce' ); ?></h3>
 	
-	<?php do_action( 'woocommerce_checkout_after_order_review_heading' ); ?>
-	
-	
 	<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
 
 	<div id="order_review" class="woocommerce-checkout-review-order">

--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -48,9 +48,14 @@ if ( ! $checkout->is_registration_enabled() && $checkout->is_registration_requir
 		<?php do_action( 'woocommerce_checkout_after_customer_details' ); ?>
 
 	<?php endif; ?>
-
+	
+	<?php do_action( 'woocommerce_checkout_before_order_review_heading' ); ?>
+	
 	<h3 id="order_review_heading"><?php esc_html_e( 'Your order', 'woocommerce' ); ?></h3>
-
+	
+	<?php do_action( 'woocommerce_checkout_after_order_review_heading' ); ?>
+	
+	
 	<?php do_action( 'woocommerce_checkout_before_order_review' ); ?>
 
 	<div id="order_review" class="woocommerce-checkout-review-order">


### PR DESCRIPTION
To modify checkout HTML structure effectively through action.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:

1. New action added in checkout template

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev – 'woocommerce_checkout_before_order_review_heading' action added in checkout form template
