### PR TITLE
Filter get_item_tax_rates in class-wc-cart-totals.php

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -485,7 +485,9 @@ final class WC_Cart_Totals {
 			return array();
 		}
 		$tax_class = $item->product->get_tax_class();
-		return isset( $this->item_tax_rates[ $tax_class ] ) ? $this->item_tax_rates[ $tax_class ] : $this->item_tax_rates[ $tax_class ] = WC_Tax::get_rates( $item->product->get_tax_class(), $this->cart->get_customer() );
+		$taxrates = isset( $this->item_tax_rates[ $tax_class ] ) ? $this->item_tax_rates[ $tax_class ] : $this->item_tax_rates[ $tax_class ] = WC_Tax::get_rates( $item->product->get_tax_class(), $this->cart->get_customer() );
+		$taxrates = apply_filters( 'woocommerce_item_tax_rates', $taxrates, $item, $this->cart );
+		return $taxrates;		
 	}
 
 	/**


### PR DESCRIPTION
Adds filter on the return value of function 'get_item_tax_rates'. This gives developers the possibility to prevent the mandatory caching of tax rates, described in https://github.com/woocommerce/woocommerce/issues/21855

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
In complex custom tax scenarios and solutions the taxable address needs to be changed dynamically, while the tax class stays the same. 
Since WooCommerce currently performs a mandatory caching of the tax rates from the tax class of the first product in the cart, this leads to incorrect results for the following products and therefore for the whole cart.
Since there is no other way available to prevent the caching in the property `item_tax_rates`, I provide this code to filter the tax rates result.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Adds filter on the return value of function 'get_item_tax_rates'. This gives developers the possibility to prevent the mandatory caching of tax rates, described in https://github.com/woocommerce/woocommerce/issues/21855