### PR TITLE
Added DK (Danish ) To locale-info

### DIFF
--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -243,6 +243,26 @@ return array(
 			),
 		),
 	),
+	'DK' => array(
+		'currency_code'  => 'DKK',
+		'currency_pos'   => 'left_space',
+		'thousand_sep'   => '.',
+		'decimal_sep'    => ',',
+		'num_decimals'   => 2,
+		'weight_unit'    => 'kg',
+		'dimension_unit' => 'cm',
+		'tax_rates'      => array(
+			'' => array(
+				array(
+					'country'  => '*',
+					'state'    => '',
+					'rate'     => '25.0000',
+					'name'     => 'Moms',
+					'shipping' => true,
+				),
+			),
+		),
+	),
 	'ES' => array(
 		'currency_code'  => 'EUR',
 		'currency_pos'   => 'right',


### PR DESCRIPTION
Added danish locale-info settings.
example: DKK 12.345,67
The tax rate is called "Moms" and is 25%
The countries is set to "all", because its normal practis in Denmark, to charge Moms for everybody, including foregin countries. Some special products, like service charges, can be an exception, but then the company who sells the products must know it should not be applied. The safe way for danish companies, is to set 25% moms for everybody.

Some will argue, that the currency code could be "kr", but thats not default in WooCommerce, and the organizations who has to accept cart payment on the shops, states that if a danish shop, sells to foregin countries, the currency must be DKK

### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
Added danish locale info

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
