### PR TITLE
Adding action hooks before and after the Price Filter Widget input HTML

### DIFF
--- a/includes/widgets/class-wc-widget-price-filter.php
+++ b/includes/widgets/class-wc-widget-price-filter.php
@@ -92,8 +92,9 @@ class WC_Widget_Price_Filter extends WC_Widget {
 		$min_price = isset( $_GET['min_price'] ) ? wc_clean( wp_unslash( $_GET['min_price'] ) ) : apply_filters( 'woocommerce_price_filter_widget_min_amount', $min ); // WPCS: input var ok, CSRF ok.
 		$max_price = isset( $_GET['max_price'] ) ? wc_clean( wp_unslash( $_GET['max_price'] ) ) : apply_filters( 'woocommerce_price_filter_widget_max_amount', $max ); // WPCS: input var ok, CSRF ok.
 
-		echo '<form method="get" action="' . esc_url( $form_action ) . '">
-			<div class="price_slider_wrapper">
+		echo '<form method="get" action="' . esc_url( $form_action ) . '">';
+		do_action( 'woocommerce_price_filter_widget_before_input' );
+		echo '<div class="price_slider_wrapper">
 				<div class="price_slider" style="display:none;"></div>
 				<div class="price_slider_amount">
 					<input type="text" id="min_price" name="min_price" value="' . esc_attr( $min_price ) . '" data-min="' . esc_attr( apply_filters( 'woocommerce_price_filter_widget_min_amount', $min ) ) . '" placeholder="' . esc_attr__( 'Min price', 'woocommerce' ) . '" />
@@ -105,8 +106,9 @@ class WC_Widget_Price_Filter extends WC_Widget {
 					' . wc_query_string_form_fields( null, array( 'min_price', 'max_price' ), '', true ) . '
 					<div class="clear"></div>
 				</div>
-			</div>
-		</form>'; // WPCS: XSS ok.
+			</div>';
+		do_action( 'woocommerce_price_filter_widget_after_input' );
+		echo '</form>'; // WPCS: XSS ok.
 
 		$this->widget_end( $args );
 	}

--- a/includes/widgets/class-wc-widget-price-filter.php
+++ b/includes/widgets/class-wc-widget-price-filter.php
@@ -35,7 +35,9 @@ class WC_Widget_Price_Filter extends WC_Widget {
 		wp_register_script( 'wc-jquery-ui-touchpunch', WC()->plugin_url() . '/assets/js/jquery-ui-touch-punch/jquery-ui-touch-punch' . $suffix . '.js', array( 'jquery-ui-slider' ), WC_VERSION, true );
 		wp_register_script( 'wc-price-slider', WC()->plugin_url() . '/assets/js/frontend/price-slider' . $suffix . '.js', array( 'jquery-ui-slider', 'wc-jquery-ui-touchpunch', 'accounting' ), WC_VERSION, true );
 		wp_localize_script(
-			'wc-price-slider', 'woocommerce_price_slider_params', array(
+			'wc-price-slider',
+			'woocommerce_price_slider_params',
+			array(
 				'currency_format_num_decimals' => 0,
 				'currency_format_symbol'       => get_woocommerce_currency_symbol(),
 				'currency_format_decimal_sep'  => esc_attr( wc_get_price_decimal_separator() ),
@@ -92,7 +94,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 		$min_price = isset( $_GET['min_price'] ) ? wc_clean( wp_unslash( $_GET['min_price'] ) ) : apply_filters( 'woocommerce_price_filter_widget_min_amount', $min ); // WPCS: input var ok, CSRF ok.
 		$max_price = isset( $_GET['max_price'] ) ? wc_clean( wp_unslash( $_GET['max_price'] ) ) : apply_filters( 'woocommerce_price_filter_widget_max_amount', $max ); // WPCS: input var ok, CSRF ok.
 
-		echo '<form method="get" action="' . esc_url( $form_action ) . '">';
+		echo '<form method="get" action="' . esc_url( $form_action ) . '">'; // WPCS: XSS ok.
 		do_action( 'woocommerce_price_filter_widget_before_input' );
 		echo '<div class="price_slider_wrapper">
 				<div class="price_slider" style="display:none;"></div>
@@ -106,7 +108,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 					' . wc_query_string_form_fields( null, array( 'min_price', 'max_price' ), '', true ) . '
 					<div class="clear"></div>
 				</div>
-			</div>';
+			</div>'; // WPCS: XSS ok.
 		do_action( 'woocommerce_price_filter_widget_after_input' );
 		echo '</form>'; // WPCS: XSS ok.
 


### PR DESCRIPTION
Fixes #22516 

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
- Adding a new `woocommerce_price_filter_widget_before_input` action hook
- Adding a new `woocommerce_price_filter_widget_after_input` action hook

Both are inside the native `<form />` element of the Price Filter Widget. These hooks will allow adding new homemade filters inside the same `<form>` of the Price Filter Widget, so that we don't have to create and submit multiple forms to have cumulative filters.

Closes #22516
