### PR TITLE
Fix/21779 redux

### DIFF
--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -1,16 +1,17 @@
 <?php
+/**
+ * WC_Report_Sales_By_Date
+ *
+ * @package     WooCommerce/Admin/Reports
+ * @version     2.1.0
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**
  * WC_Report_Sales_By_Date
- *
- * @author      WooThemes
- * @category    Admin
- * @package     WooCommerce/Admin/Reports
- * @version     2.1.0
  */
 class WC_Report_Sales_By_Date extends WC_Admin_Report {
 
@@ -106,7 +107,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			)
 		);
 
-		// All items from orders - even those refunded
+		// All items from orders - even those refunded.
 		$this->report_data->order_items = (array) $this->get_order_report_data(
 			array(
 				'data'         => array(
@@ -412,11 +413,11 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		$this->report_data->total_sales = wc_format_decimal( array_sum( wp_list_pluck( $this->report_data->orders, 'total_sales' ) ) - $this->report_data->total_refunds, 2 );
 		$this->report_data->net_sales   = wc_format_decimal( $this->report_data->total_sales - $this->report_data->total_shipping - max( 0, $this->report_data->total_tax ) - max( 0, $this->report_data->total_shipping_tax ), 2 );
 
-		// Calculate average based on net
+		// Calculate average based on net.
 		$this->report_data->average_sales       = wc_format_decimal( $this->report_data->net_sales / ( $this->chart_interval + 1 ), 2 );
 		$this->report_data->average_total_sales = wc_format_decimal( $this->report_data->total_sales / ( $this->chart_interval + 1 ), 2 );
 
-		// Total orders and discounts also includes those which have been refunded at some point
+		// Total orders and discounts also includes those which have been refunded at some point.
 		$this->report_data->total_coupons         = number_format( array_sum( wp_list_pluck( $this->report_data->coupons, 'discount_amount' ) ), 2, '.', '' );
 		$this->report_data->total_refunded_orders = absint( count( $this->report_data->full_refunds ) );
 
@@ -441,26 +442,26 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 
 		switch ( $this->chart_groupby ) {
 			case 'day':
-				/* translators: %s: average total sales */
 				$average_total_sales_title = sprintf(
+					/* translators: %s: average total sales */
 					__( '%s average gross daily sales', 'woocommerce' ),
 					'<strong>' . wc_price( $data->average_total_sales ) . '</strong>'
 				);
-				/* translators: %s: average sales */
 				$average_sales_title = sprintf(
+					/* translators: %s: average sales */
 					__( '%s average net daily sales', 'woocommerce' ),
 					'<strong>' . wc_price( $data->average_sales ) . '</strong>'
 				);
 				break;
 			case 'month':
 			default:
-				/* translators: %s: average total sales */
 				$average_total_sales_title = sprintf(
+					/* translators: %s: average total sales */
 					__( '%s average gross monthly sales', 'woocommerce' ),
 					'<strong>' . wc_price( $data->average_total_sales ) . '</strong>'
 				);
-				/* translators: %s: average sales */
 				$average_sales_title = sprintf(
+					/* translators: %s: average sales */
 					__( '%s average net monthly sales', 'woocommerce' ),
 					'<strong>' . wc_price( $data->average_sales ) . '</strong>'
 				);
@@ -468,8 +469,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		}
 
 		$legend[] = array(
-			/* translators: %s: total sales */
 			'title'            => sprintf(
+				/* translators: %s: total sales */
 				__( '%s gross sales in this period', 'woocommerce' ),
 				'<strong>' . wc_price( $data->total_sales ) . '</strong>'
 			),
@@ -486,8 +487,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		}
 
 		$legend[] = array(
-			/* translators: %s: net sales */
 			'title'            => sprintf(
+				/* translators: %s: net sales */
 				__( '%s net sales in this period', 'woocommerce' ),
 				'<strong>' . wc_price( $data->net_sales ) . '</strong>'
 			),
@@ -504,8 +505,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		}
 
 		$legend[] = array(
-			/* translators: %s: total orders */
 			'title'            => sprintf(
+				/* translators: %s: total orders */
 				__( '%s orders placed', 'woocommerce' ),
 				'<strong>' . $data->total_orders . '</strong>'
 			),
@@ -514,8 +515,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		);
 
 		$legend[] = array(
-			/* translators: %s: total items */
 			'title'            => sprintf(
+				/* translators: %s: total items */
 				__( '%s items purchased', 'woocommerce' ),
 				'<strong>' . $data->total_items . '</strong>'
 			),
@@ -523,8 +524,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'highlight_series' => 0,
 		);
 		$legend[] = array(
-			/* translators: 1: total refunds 2: total refunded orders 3: refunded items */
 			'title'            => sprintf(
+				/* translators: 1: total refunds 2: total refunded orders 3: refunded items */
 				_n( '%1$s refunded %2$d order (%3$d item)', '%1$s refunded %2$d orders (%3$d items)', $this->report_data->total_refunded_orders, 'woocommerce' ),
 				'<strong>' . wc_price( $data->total_refunds ) . '</strong>',
 				$this->report_data->total_refunded_orders,
@@ -534,8 +535,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'highlight_series' => 8,
 		);
 		$legend[] = array(
-			/* translators: %s: total shipping */
 			'title'            => sprintf(
+				/* translators: %s: total shipping */
 				__( '%s charged for shipping', 'woocommerce' ),
 				'<strong>' . wc_price( $data->total_shipping ) . '</strong>'
 			),
@@ -543,8 +544,8 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'highlight_series' => 5,
 		);
 		$legend[] = array(
-			/* translators: %s: total coupons */
 			'title'            => sprintf(
+				/* translators: %s: total coupons */
 				__( '%s worth of coupons used', 'woocommerce' ),
 				'<strong>' . wc_price( $data->total_coupons ) . '</strong>'
 			),
@@ -578,9 +579,9 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'refund_amount'    => '#e74c3c',
 		);
 
-		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( $_GET['range'] ) : '7day';
+		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( wp_unslash( $_GET['range'] ) ) : '7day'; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.NonceVerification.NoNonceVerification
 
-		if ( ! in_array( $current_range, array( 'custom', 'year', 'last_month', 'month', '7day' ) ) ) {
+		if ( ! in_array( $current_range, array( 'custom', 'year', 'last_month', 'month', '7day' ), true ) ) {
 			$current_range = '7day';
 		}
 
@@ -594,18 +595,18 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 	 * Output an export link.
 	 */
 	public function get_export_button() {
-		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( $_GET['range'] ) : '7day';
+		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( wp_unslash( $_GET['range'] ) ) : '7day'; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.NonceVerification.NoNonceVerification
 		?>
 		<a
 			href="#"
-			download="report-<?php echo esc_attr( $current_range ); ?>-<?php echo date_i18n( 'Y-m-d', current_time( 'timestamp' ) ); ?>.csv"
+			download="report-<?php echo esc_attr( $current_range ); ?>-<?php echo esc_attr( date_i18n( 'Y-m-d', current_time( 'timestamp' ) ) ); ?>.csv"
 			class="export_csv"
 			data-export="chart"
 			data-xaxes="<?php esc_attr_e( 'Date', 'woocommerce' ); ?>"
 			data-exclude_series="2"
-			data-groupby="<?php echo $this->chart_groupby; ?>"
+			data-groupby="<?php echo esc_attr( $this->chart_groupby ); ?>"
 		>
-			<?php _e( 'Export CSV', 'woocommerce' ); ?>
+			<?php esc_html_e( 'Export CSV', 'woocommerce' ); ?>
 		</a>
 		<?php
 	}
@@ -613,7 +614,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 	/**
 	 * Round our totals correctly.
 	 *
-	 * @param array|string $amount
+	 * @param array|string $amount Chart total.
 	 *
 	 * @return array|string
 	 */
@@ -631,7 +632,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 	public function get_main_chart() {
 		global $wp_locale;
 
-		// Prepare data for report
+		// Prepare data for report.
 		$data = array(
 			'order_counts'         => $this->prepare_chart_data( $this->report_data->order_counts, 'post_date', 'count', $this->chart_interval, $this->start_date, $this->chart_groupby ),
 			'order_item_counts'    => $this->prepare_chart_data( $this->report_data->order_items, 'post_date', 'order_item_count', $this->chart_interval, $this->start_date, $this->chart_groupby ),
@@ -650,7 +651,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			$data['gross_order_amounts'][ $order_amount_key ][1] -= $data['refund_amounts'][ $order_amount_key ][1];
 
 			$data['net_order_amounts'][ $order_amount_key ] = $order_amount_value;
-			// subtract the sum of the values from net order amounts
+			// Subtract the sum of the values from net order amounts.
 			$data['net_order_amounts'][ $order_amount_key ][1] -=
 				$data['refund_amounts'][ $order_amount_key ][1] +
 				$data['shipping_amounts'][ $order_amount_key ][1] +
@@ -658,11 +659,11 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 				$data['tax_amounts'][ $order_amount_key ][1];
 		}
 
-		// 3rd party filtering of report data
+		// 3rd party filtering of report data.
 		$data = apply_filters( 'woocommerce_admin_report_chart_data', $data );
 
-		// Encode in json format
-		$chart_data = json_encode(
+		// Encode in json format.
+		$chart_data = wp_json_encode(
 			array(
 				'order_counts'        => array_values( $data['order_counts'] ),
 				'order_item_counts'   => array_values( $data['order_item_counts'] ),
@@ -683,30 +684,30 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			var main_chart;
 
 			jQuery(function(){
-				var order_data = jQuery.parseJSON( '<?php echo $chart_data; ?>' );
+				var order_data = jQuery.parseJSON( '<?php echo $chart_data;  // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>' );
 				var drawGraph = function( highlight ) {
 					var series = [
 						{
 							label: "<?php echo esc_js( __( 'Number of items sold', 'woocommerce' ) ); ?>",
 							data: order_data.order_item_counts,
-							color: '<?php echo $this->chart_colours['item_count']; ?>',
-							bars: { fillColor: '<?php echo $this->chart_colours['item_count']; ?>', fill: true, show: true, lineWidth: 0, barWidth: <?php echo $this->barwidth; ?> * 0.5, align: 'center' },
+							color: '<?php echo esc_js( $this->chart_colours['item_count'] ); ?>',
+							bars: { fillColor: '<?php echo esc_js( $this->chart_colours['item_count'] ); ?>', fill: true, show: true, lineWidth: 0, barWidth: <?php echo esc_js( $this->barwidth ); ?> * 0.5, align: 'center' },
 							shadowSize: 0,
 							hoverable: false
 						},
 						{
 							label: "<?php echo esc_js( __( 'Number of orders', 'woocommerce' ) ); ?>",
 							data: order_data.order_counts,
-							color: '<?php echo $this->chart_colours['order_count']; ?>',
-							bars: { fillColor: '<?php echo $this->chart_colours['order_count']; ?>', fill: true, show: true, lineWidth: 0, barWidth: <?php echo $this->barwidth; ?> * 0.5, align: 'center' },
+							color: '<?php echo esc_js( $this->chart_colours['order_count'] ); ?>',
+							bars: { fillColor: '<?php echo esc_js( $this->chart_colours['order_count'] ); ?>', fill: true, show: true, lineWidth: 0, barWidth: <?php echo esc_js( $this->barwidth ); ?> * 0.5, align: 'center' },
 							shadowSize: 0,
 							hoverable: false
 						},
 						{
 							label: "<?php echo esc_js( __( 'Average gross sales amount', 'woocommerce' ) ); ?>",
-							data: [ [ <?php echo min( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_total_sales; ?> ], [ <?php echo max( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_total_sales; ?> ] ],
+							data: [ [ <?php echo esc_js( min( array_keys( $data['order_amounts'] ) ) ); ?>, <?php echo esc_js( $this->report_data->average_total_sales ); ?> ], [ <?php echo esc_js( max( array_keys( $data['order_amounts'] ) ) ); ?>, <?php echo esc_js( $this->report_data->average_total_sales ); ?> ] ],
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['average']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['average'] ); ?>',
 							points: { show: false },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
@@ -714,9 +715,9 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 						},
 						{
 							label: "<?php echo esc_js( __( 'Average net sales amount', 'woocommerce' ) ); ?>",
-							data: [ [ <?php echo min( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_sales; ?> ], [ <?php echo max( array_keys( $data['order_amounts'] ) ); ?>, <?php echo $this->report_data->average_sales; ?> ] ],
+							data: [ [ <?php echo esc_js( min( array_keys( $data['order_amounts'] ) ) ); ?>, <?php echo esc_js( $this->report_data->average_sales ); ?> ], [ <?php echo esc_js( max( array_keys( $data['order_amounts'] ) ) ); ?>, <?php echo esc_js( $this->report_data->average_sales ); ?> ] ],
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['net_average']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['net_average'] ); ?>',
 							points: { show: false },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
@@ -726,51 +727,51 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 							label: "<?php echo esc_js( __( 'Coupon amount', 'woocommerce' ) ); ?>",
 							data: order_data.coupon_amounts,
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['coupon_amount']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['coupon_amount'] ); ?>',
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							<?php echo $this->get_currency_tooltip(); ?>
+							<?php echo $this->get_currency_tooltip();  // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Shipping amount', 'woocommerce' ) ); ?>",
 							data: order_data.shipping_amounts,
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['shipping_amount']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['shipping_amount'] ); ?>',
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol(); ?>"
+							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>"
 						},
 						{
 							label: "<?php echo esc_js( __( 'Gross sales amount', 'woocommerce' ) ); ?>",
 							data: order_data.gross_order_amounts,
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['sales_amount']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['sales_amount'] ); ?>',
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							<?php echo $this->get_currency_tooltip(); ?>
+							<?php echo $this->get_currency_tooltip(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Net sales amount', 'woocommerce' ) ); ?>",
 							data: order_data.net_order_amounts,
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['net_sales_amount']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['net_sales_amount'] ); ?>',
 							points: { show: true, radius: 6, lineWidth: 4, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 5, fill: false },
 							shadowSize: 0,
-							<?php echo $this->get_currency_tooltip(); ?>
+							<?php echo $this->get_currency_tooltip(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
 						},
 						{
 							label: "<?php echo esc_js( __( 'Refund amount', 'woocommerce' ) ); ?>",
 							data: order_data.refund_amounts,
 							yaxis: 2,
-							color: '<?php echo $this->chart_colours['refund_amount']; ?>',
+							color: '<?php echo esc_js( $this->chart_colours['refund_amount'] ); ?>',
 							points: { show: true, radius: 5, lineWidth: 2, fillColor: '#fff', fill: true },
 							lines: { show: true, lineWidth: 2, fill: false },
 							shadowSize: 0,
-							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol(); ?>"
+							prepend_tooltip: "<?php echo get_woocommerce_currency_symbol(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>"
 						},
 					];
 
@@ -807,9 +808,9 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 								tickColor: 'transparent',
 								mode: "time",
 								timeformat: "<?php echo ( 'day' === $this->chart_groupby ) ? '%d %b' : '%b'; ?>",
-								monthNames: <?php echo json_encode( array_values( $wp_locale->month_abbrev ) ); ?>,
+								monthNames: <?php echo wp_json_encode( array_values( $wp_locale->month_abbrev ) ); ?>,
 								tickLength: 1,
-								minTickSize: [1, "<?php echo $this->chart_groupby; ?>"],
+								minTickSize: [1, "<?php echo esc_js( $this->chart_groupby ); ?>"],
 								font: {
 									color: "#aaa"
 								}

--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -250,6 +250,10 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			)
 		);
 
+		foreach ( $this->report_data->full_refunds as $key => $order ) {
+			$this->report_data->full_refunds[ $key ]->net_refund = $order->total_refund - ( $order->total_shipping + $order->total_tax + $order->total_shipping_tax );
+		}
+
 		/**
 		 * Partial refunds. This includes line items, shipping and taxes. Not grouped by date.
 		 */
@@ -315,6 +319,10 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 				'parent_order_status' => array( 'completed', 'processing', 'on-hold' ),
 			)
 		);
+
+		foreach ( $this->report_data->partial_refunds as $key => $order ) {
+			$this->report_data->partial_refunds[ $key ]->net_refund = $order->total_refund - ( $order->total_shipping + $order->total_tax + $order->total_shipping_tax );
+		}
 
 		/**
 		 * Refund lines - all partial refunds on all order types so we can plot full AND partial refunds on the chart.
@@ -390,9 +398,9 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		$this->report_data->total_shipping_tax_refunded = 0;
 		$this->report_data->total_refunds               = 0;
 
-		$refunded_orders = array_merge( $this->report_data->partial_refunds, $this->report_data->full_refunds );
+		$this->report_data->refunded_orders = array_merge( $this->report_data->partial_refunds, $this->report_data->full_refunds );
 
-		foreach ( $refunded_orders as $key => $value ) {
+		foreach ( $this->report_data->refunded_orders as $key => $value ) {
 			$this->report_data->total_tax_refunded          += floatval( $value->total_tax < 0 ? $value->total_tax * -1 : $value->total_tax );
 			$this->report_data->total_refunds               += floatval( $value->total_refund );
 			$this->report_data->total_shipping_tax_refunded += floatval( $value->total_shipping_tax < 0 ? $value->total_shipping_tax * -1 : $value->total_shipping_tax );
@@ -640,6 +648,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			'coupon_amounts'       => $this->prepare_chart_data( $this->report_data->coupons, 'post_date', 'discount_amount', $this->chart_interval, $this->start_date, $this->chart_groupby ),
 			'shipping_amounts'     => $this->prepare_chart_data( $this->report_data->orders, 'post_date', 'total_shipping', $this->chart_interval, $this->start_date, $this->chart_groupby ),
 			'refund_amounts'       => $this->prepare_chart_data( $this->report_data->refund_lines, 'post_date', 'total_refund', $this->chart_interval, $this->start_date, $this->chart_groupby ),
+			'net_refund_amounts'   => $this->prepare_chart_data( $this->report_data->refunded_orders, 'post_date', 'net_refund', $this->chart_interval, $this->start_date, $this->chart_groupby ),
 			'shipping_tax_amounts' => $this->prepare_chart_data( $this->report_data->orders, 'post_date', 'total_shipping_tax', $this->chart_interval, $this->start_date, $this->chart_groupby ),
 			'tax_amounts'          => $this->prepare_chart_data( $this->report_data->orders, 'post_date', 'total_tax', $this->chart_interval, $this->start_date, $this->chart_groupby ),
 			'net_order_amounts'    => array(),
@@ -653,7 +662,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			$data['net_order_amounts'][ $order_amount_key ] = $order_amount_value;
 			// Subtract the sum of the values from net order amounts.
 			$data['net_order_amounts'][ $order_amount_key ][1] -=
-				$data['refund_amounts'][ $order_amount_key ][1] +
+				$data['net_refund_amounts'][ $order_amount_key ][1] +
 				$data['shipping_amounts'][ $order_amount_key ][1] +
 				$data['shipping_tax_amounts'][ $order_amount_key ][1] +
 				$data['tax_amounts'][ $order_amount_key ][1];

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -500,6 +500,7 @@ function wc_create_refund( $args = array() ) {
 		$refund->set_amount( $args['amount'] );
 		$refund->set_parent_id( absint( $args['order_id'] ) );
 		$refund->set_refunded_by( get_current_user_id() ? get_current_user_id() : 1 );
+		$refund->set_prices_include_tax( $order->get_prices_include_tax() );
 
 		if ( ! is_null( $args['reason'] ) ) {
 			$refund->set_reason( $args['reason'] );

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -294,7 +294,6 @@ function wc_register_order_type( $type, $args = array() ) {
 /**
  * Return the count of processing orders.
  *
- * @access public
  * @return int
  */
 function wc_processing_order_count() {
@@ -907,13 +906,15 @@ function wc_get_order_note( $data ) {
 	}
 
 	return (object) apply_filters(
-		'woocommerce_get_order_note', array(
+		'woocommerce_get_order_note',
+		array(
 			'id'            => (int) $data->comment_ID,
 			'date_created'  => wc_string_to_datetime( $data->comment_date ),
 			'content'       => $data->comment_content,
 			'customer_note' => (bool) get_comment_meta( $data->comment_ID, 'is_customer_note', true ),
 			'added_by'      => __( 'WooCommerce', 'woocommerce' ) === $data->comment_author ? 'system' : $data->comment_author,
-		), $data
+		),
+		$data
 	);
 }
 

--- a/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -123,7 +123,11 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 			$data->orders[0]->total_sales,
 			'Orders, total sales.'
 		);
-		$this->assertEquals( $data->orders[0]->total_sales - $data->total_refunds, $data->total_sales, 'Day sales, total sales.' );
+		$this->assertEquals(
+			$data->orders[0]->total_sales - $data->total_refunds,
+			$data->total_sales,
+			'Day sales, total sales.'
+		);
 		$this->assertEquals( $data->total_sales, $data->average_total_sales, 'Average total sales.' );
 
 		$this->assertEquals(

--- a/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -96,34 +96,34 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 			$data->coupons[0]->order_item_name,
 			'There should be a single coupon applied.'
 		);
-		$this->assertEquals( $data->coupons[0]->discount_amount, $data->total_coupons );
+		$this->assertEquals( $data->coupons[0]->discount_amount, $data->total_coupons, 'Total discount amount.' );
 
 		$this->assertCount( 1, $data->refund_lines, 'There was one refund granted.' );
 		$this->assertEquals( 7, $data->partial_refunds[0]->total_refund, 'Total refunds.' );
-		$this->assertEquals( $data->partial_refunds[0]->total_refund, $data->total_refunds );
+		$this->assertEquals( $data->partial_refunds[0]->total_refund, $data->total_refunds, 'Day refunds, total refunds.' );
 
 		$this->assertEquals(
 			$order1->get_shipping_total() + $order2->get_shipping_total() + $order3->get_shipping_total(),
 			$data->orders[0]->total_shipping,
 			'Orders, total shipping.'
 		);
-		$this->assertEquals( $data->orders[0]->total_shipping, $data->total_shipping );
+		$this->assertEquals( $data->orders[0]->total_shipping, $data->total_shipping, 'Day shipping, total shipping.' );
 
 		$this->assertEquals(
 			$order1->get_shipping_tax() + $order2->get_shipping_tax() + $order3->get_shipping_tax(),
 			$data->orders[0]->total_shipping_tax,
 			'Orders, total shipping tax.'
 		);
-		$this->assertEquals( $data->orders[0]->total_shipping_tax, $data->total_shipping_tax );
+		$this->assertEquals( $data->orders[0]->total_shipping_tax, $data->total_shipping_tax, 'Day shipping tax, total shipping tax.' );
 
-		$this->assertEquals( $data->orders[0]->total_tax, $data->total_tax );
+		$this->assertEquals( $data->orders[0]->total_tax, $data->total_tax, 'Day tax, total tax.' );
 
 		$this->assertEquals(
 			$order1->get_total() + $order2->get_total() + $order3->get_total(),
 			$data->orders[0]->total_sales,
-			'Total sales.'
+			'Orders, total sales.'
 		);
-		$this->assertEquals( $data->orders[0]->total_sales - $data->total_refunds, $data->total_sales, 'Total sales.' );
+		$this->assertEquals( $data->orders[0]->total_sales - $data->total_refunds, $data->total_sales, 'Day sales, total sales.' );
 		$this->assertEquals( $data->total_sales, $data->average_total_sales, 'Average total sales.' );
 
 		$this->assertEquals(

--- a/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-report-sales-by-date.php
@@ -37,37 +37,41 @@ class WC_Tests_Report_Sales_By_Date extends WC_Unit_Test_Case {
 
 		$product = WC_Helper_Product::create_simple_product();
 		$coupon  = WC_Helper_Coupon::create_coupon();
-		$tax     = WC_Tax::_insert_tax_rate( array(
-			'tax_rate_country'  => '',
-			'tax_rate_state'    => '',
-			'tax_rate'          => '10.0000',
-			'tax_rate_name'     => 'VAT',
-			'tax_rate_priority' => '1',
-			'tax_rate_compound' => '0',
-			'tax_rate_shipping' => '1',
-			'tax_rate_order'    => '1',
-			'tax_rate_class'    => '',
-		) );
+		$tax     = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '10.0000',
+				'tax_rate_name'     => 'VAT',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '1',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			)
+		);
 
 		// A standard order.
-		$order1  = WC_Helper_Order::create_order( 0, $product->get_id() );
+		$order1 = WC_Helper_Order::create_order( 0, $product->get_id() );
 		$order1->set_status( 'completed' );
 		$order1->save();
 
 		// An order using a coupon.
-		$order2  = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
 		$order2->apply_coupon( $coupon );
 		$order2->set_status( 'completed' );
 		$order2->save();
 
 		// An order that was refunded, save for shipping.
-		$order3  = WC_Helper_Order::create_order();
+		$order3 = WC_Helper_Order::create_order();
 		$order3->set_status( 'completed' );
 		$order3->save();
-		wc_create_refund( array(
-			'amount'   => 7,
-			'order_id' => $order3->get_id(),
-		) );
+		wc_create_refund(
+			array(
+				'amount'   => 7,
+				'order_id' => $order3->get_id(),
+			)
+		);
 
 		// Parameters borrowed from WC_Admin_Dashboard::get_sales_report_data().
 		$report                 = new WC_Report_Sales_By_Date();


### PR DESCRIPTION
Supersedes: #22451 
Closes #21779 .

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I created 8 orders over 3 days to troubleshoot the issue. I found that the tax inclusive pricing mentioned in the issue is not a factor. I used the following SQL to retrieve the data on the orders:

```
SELECT 
	MAX( IF( m.meta_key = '_prices_include_tax', m.meta_value, NULL ) ) AS taxinc,
	m.post_id AS `order`,
	MAX( r.meta_value ) AS refund,
	MAX( IF( m.meta_key = '_order_total', m.meta_value, NULL ) ) AS total,
	MAX( IF( m.meta_key = '_order_tax', m.meta_value, NULL ) ) AS tax,
	MAX( IF( m.meta_key = '_cart_discount', m.meta_value, NULL ) ) AS disc,
	MAX( IF( m.meta_key = '_cart_discount_tax', m.meta_value, NULL ) ) AS disctax,
	MAX( IF( m.meta_key = '_order_shipping', m.meta_value, NULL ) ) AS ship,
	MAX( IF( m.meta_key = '_order_shipping_tax', m.meta_value, NULL ) ) AS shiptax
FROM 
	wp_postmeta m,
	wp_posts p LEFT JOIN (
		SELECT
			psub.ID,
			psub.post_parent,
			msub.meta_value
		FROM
			wp_posts psub,
			wp_postmeta msub
		WHERE
			psub.ID = msub.post_id
			AND psub.post_type = 'shop_order_refund'
			AND msub.meta_key = '_refund_amount'
	) r ON r.post_parent = p.ID
WHERE 
	p.post_status IN ('wc-refunded', 'wc-processing') 
	AND p.post_type = 'shop_order'
	AND p.ID = m.post_id
GROUP BY
	m.post_id
HAVING
	tax > 0;
```

The result set is

```
taxinc	order	refund	total	tax	disc	disctax	ship	shiptax
yes	11	NULL	49.00	5.09	0.87	0.13	10.00	0
yes	12	60.00	60.00	6.52	0	0	10.00	0
no	13	NULL	67.50	7.5	0	0	10.00	0
no	14	NULL	54.85	5.85	1	0.15	10.00	0
no	15	7.00	56.00	6	0	0	10.00	0
yes	21	1000.00	1000.00	130.43	0	0	0.00	0
yes	22	1000.00	1000.00	130.43	0	0	0.00	0
no	31	1160.00	1160.00	150	0	0	10.00	0
```
Day 1 - 11-15
Day 2 - 21-22
Day 3 - 31

Report screen 
<img width="235" alt="screen shot 2019-01-21 at 3 52 57 pm" src="https://user-images.githubusercontent.com/343847/51496013-b32dcf80-1d94-11e9-91d1-46d0bd0eaf1f.png">

Export file without PR 
```
"Date","Number of items sold","Number of orders","Average net sales amount","Coupon amount","Shipping amount","Gross sales amount","Net sales amount","Refund amount"
"2019-1-18","22","5","38.98","1.87","50.00","220.35","139.39","67.00"
"2019-1-19","2","2","0","0.00","0.00","0.00","-260.86","2000.00"
"2019-1-20","0","0","0","0.00","0.00","0.00","0.00","0.00"
"2019-1-21","1","1","38.98","0.00","10.00","0.00","-160.00","1160.00"
```

Export file with PR

```
"Date","Number of items sold","Number of orders","Average net sales amount","Coupon amount","Shipping amount","Gross sales amount","Net sales amount","Refund amount"
"2019-1-18","22","5","38.98","1.87","50.00","220.35","155.91","67.00"
"2019-1-19","2","2","0","0.00","0.00","0.00","0.00","2000.00"
"2019-1-20","0","0","0","0.00","0.00","0.00","0.00","0.00"
"2019-1-21","1","1","38.98","0.00","10.00","0.00","0.00","1160.00"
```

In the current code, refunded shipping, taxes, and shipping taxes are included in both the refunded amounts and their respective total amounts. As a result the daily net sales calculated for the CSV export has those values deducted twice.

This PR calculates a net refund for refund order to have shipping, taxes, and shipping taxes only deducted once.

### How to test the changes in this Pull Request:

1. Create a mix of orders with tax inclusive/exclusive pricing
2. Do partial and full refunds on some of the orders
3. Load the sales by date report
4. Export the CSV
5. Values in the CSV should match the onscreen values.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: deduct correct refunded amounts in calculated net daily sales export CSV.
