### PR TITLE
Option "Used for variations" should not appear for non-variable product types

### DIFF
--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -466,6 +466,9 @@ jQuery( function( $ ) {
 				$( '.product_attributes' ).html( response.data.html );
 				$( '.product_attributes' ).unblock();
 
+				// Hide the 'Used for variations' checkbox if not viewing a variable product
+				show_and_hide_panels();
+
 				// Make sure the dropdown is not disabled for empty value attributes.
 				var nr_elements = original_data.length / 6;
 				for ( var i = 0; i < nr_elements; i++ ) {

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -1,7 +1,8 @@
 /*global woocommerce_admin_meta_boxes */
 jQuery( function( $ ) {
 
-	// Scroll to first checked category - https://github.com/scribu/wp-category-checklist-tree/blob/d1c3c1f449e1144542efa17dde84a9f52ade1739/category-checklist-tree.php
+	// Scroll to first checked category
+	// https://github.com/scribu/wp-category-checklist-tree/blob/d1c3c1f449e1144542efa17dde84a9f52ade1739/category-checklist-tree.php
 	$( function() {
 		$( '[id$="-all"] > ul.categorychecklist' ).each( function() {
 			var $list = $( this );
@@ -422,7 +423,8 @@ jQuery( function( $ ) {
 					window.alert( response.error );
 				} else if ( response.slug ) {
 					// Success.
-					$wrapper.find( 'select.attribute_values' ).append( '<option value="' + response.term_id + '" selected="selected">' + response.name + '</option>' );
+					$wrapper.find( 'select.attribute_values' )
+						.append( '<option value="' + response.term_id + '" selected="selected">' + response.name + '</option>' );
 					$wrapper.find( 'select.attribute_values' ).change();
 				}
 
@@ -468,7 +470,8 @@ jQuery( function( $ ) {
 				var nr_elements = original_data.length / 6;
 				for ( var i = 0; i < nr_elements; i++ ) {
 					if ( typeof( original_data ) !== 'undefined' && original_data[ i * 6 + 2 ].value === '' ) {
-						$( 'select.attribute_taxonomy' ).find( 'option[value="' + original_data[ i * 6 ].value + '"]' ).removeAttr( 'disabled' );
+						$( 'select.attribute_taxonomy' )
+							.find( 'option[value="' + original_data[ i * 6 ].value + '"]' ).removeAttr( 'disabled' );
 					}
 				}
 
@@ -607,7 +610,11 @@ jQuery( function( $ ) {
 					attachment_ids   = attachment_ids ? attachment_ids + ',' + attachment.id : attachment.id;
 					var attachment_image = attachment.sizes && attachment.sizes.thumbnail ? attachment.sizes.thumbnail.url : attachment.url;
 
-					$product_images.append( '<li class="image" data-attachment_id="' + attachment.id + '"><img src="' + attachment_image + '" /><ul class="actions"><li><a href="#" class="delete" title="' + $el.data('delete') + '">' + $el.data('text') + '</a></li></ul></li>' );
+					$product_images.append(
+						'<li class="image" data-attachment_id="' + attachment.id + '"><img src="' + attachment_image +
+						'" /><ul class="actions"><li><a href="#" class="delete" title="' + $el.data('delete') + '">' +
+						$el.data('text') + '</a></li></ul></li>'
+					);
 				}
 			});
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When editing product attributes, the checkbox 'Used for variations' should only be displayed when editing a variable product. The code has checks in place to control the display of this checkbox when adding an attribute or when loading the product attributes, but it was missing a check when saving product attributes which is added in this PR.

I opted to use the function `show_and_hide_panels()` instead of manually hiding the checkbox to avoid code duplication. As far as I could test, there are no unwanted side effects due to calling this function in this context.

This PR also includes a separte commit that fixes eslint errors (four instances of lines that exceed the maximum length). I'm not too familiar with JS coding standards so please let me know if there are better ways to split long lines.

Closes #22499.

### How to test the changes in this Pull Request:

1. See #22499 for testing instructions

### Changelog entry

> Fix: option "Used for variations" should show only for variable products when saving attributes