### PR TITLE
Sort terms by parent and work back from bottommost term

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -228,13 +228,14 @@ function wc_product_post_type_link( $permalink, $post ) {
 	$terms = get_the_terms( $post->ID, 'product_cat' );
 
 	if ( ! empty( $terms ) ) {
-		if ( function_exists( 'wp_list_sort' ) ) {
-			$terms = wp_list_sort( $terms, 'term_id', 'ASC' );
-		} else {
-			usort( $terms, '_usort_terms_by_ID' );
-		}
+		$terms           = wp_list_sort(
+			$terms,
+			array(
+				'parent'  => 'DESC',
+				'term_id' => 'ASC',
+			)
+		);
 		$category_object = apply_filters( 'wc_product_post_type_link_product_cat', $terms[0], $terms, $post );
-		$category_object = get_term( $category_object, 'product_cat' );
 		$product_cat     = $category_object->slug;
 
 		if ( $category_object->parent ) {
@@ -818,12 +819,16 @@ function wc_get_min_max_price_meta_query( $args ) {
 		$max = $class_max;
 	}
 
-	return apply_filters( 'woocommerce_get_min_max_price_meta_query', array(
-		'key'     => '_price',
-		'value'   => array( $min, $max ),
-		'compare' => 'BETWEEN',
-		'type'    => 'DECIMAL(10,' . wc_get_price_decimals() . ')',
-	), $args );
+	return apply_filters(
+		'woocommerce_get_min_max_price_meta_query',
+		array(
+			'key'     => '_price',
+			'value'   => array( $min, $max ),
+			'compare' => 'BETWEEN',
+			'type'    => 'DECIMAL(10,' . wc_get_price_decimals() . ')',
+		),
+		$args
+	);
 }
 
 /**


### PR DESCRIPTION
Fixes the issue described in #21299 by sorting terms by parent ID.

Remove the extra get_term call because we already have a term object.

Since we support 4.7+, also removed function exists for wp_list_sort function.

To test create 2 categories. I used MUSIC and DECOR.

1. Set Decor parent to Music. 
2. Assign both terms to product.
3. See URL is /music/decor/product-name
4. Set Music parent to decor.
5. See URL is /decor/music/product-name

> Show full category hierarchy in product URLs when term IDs are not sequencial.