### PR TITLE
Keep count of the number of times custom coupons apply

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -519,8 +519,9 @@ class WC_Discounts {
 			$apply_quantity = max( 0, apply_filters( 'woocommerce_coupon_get_apply_quantity', $apply_quantity, $item, $coupon, $this ) );
 
 			// Run coupon calculations.
-			$discount = wc_add_number_precision( $coupon->get_discount_amount( $price_to_discount / $item->quantity, $item->object, true ) ) * $apply_quantity;
-			$discount = wc_round_discount( min( $discounted_price, $discount ), 0 );
+			$discount      = wc_add_number_precision( $coupon->get_discount_amount( $price_to_discount / $item->quantity, $item->object, true ) ) * $apply_quantity;
+			$discount      = wc_round_discount( min( $discounted_price, $discount ), 0 );
+			$applied_count = $applied_count + $apply_quantity;
 
 			// Store code and discount amount per item.
 			$this->discounts[ $coupon->get_code() ][ $item->key ] += $discount;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:
Using WooCommcerce Subscripitons with WC `master`:
1. Create a recurring product coupon for any amount (http://pic.pros.pr/ba1603b2a015)
2. Limit usage to 1 item (http://pic.pros.pr/0380eb5f7b33)
3. Go to the shop page and add multiple subscription products to the cart.
1. Go to the checkout or cart page and apply the coupon created in step 1-2.
1. On WC `master` the coupon is applied more than once http://pic.pros.pr/f3782dce8dab
1. On this branch and the discount is applied once http://pic.pros.pr/9ec9171a848e

The issue was caused by `apply_coupon_custom()` which wasn't tracking the number of time the coupon was applied. The `$applied_count` variable was declared but was never being incremented and so it never reached the coupon limit. This PR just increments the count similar to `apply_coupon_fixed_cart()`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
