### PR TITLE
Change footer wording for WooCommerce emails

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -133,7 +133,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'css'         => 'width:300px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),
 					'type'        => 'textarea',
-					'default'     => '{site_title}<br/>Powered by <a href="https://woocommerce.com/">WooCommerce</a>',
+					'default'     => '{site_title}<br/>Built with <a href="https://woocommerce.com/">WooCommerce</a>',
 					'autoload'    => false,
 					'desc_tip'    => true,
 				),


### PR DESCRIPTION
Change WooCommerce emails footer from `Powered by WooCommerce` to `Built with WooCommerce` according to the following discussion - p6q7sZ-5ig-p2

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Place a test order
2. Check the footer of the emails received, I tested it with On-hold/Processed/Completed emails and store owner emails:

![http://cld.wthms.co/ZSUzJP](http://cld.wthms.co/ZSUzJP+) 
Full Size: http://cld.wthms.co/ZSUzJP

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Change WooCommerce emails footer from `Powered by WooCommerce` to `Built with WooCommerce`
