### PR TITLE
Fix ssl check in case shop page no longer exists

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -404,7 +404,7 @@ class WC_Admin_Notices {
 	 * @since  3.5.1
 	 */
 	protected static function is_ssl() {
-		$shop_page = 0 < wc_get_page_id( 'shop' ) ? get_permalink( wc_get_page_id( 'shop' ) ) : get_home_url();
+		$shop_page = wc_get_page_permalink( 'shop' );
 
 		return ( is_ssl() && 'https' === substr( $shop_page, 0, 5 ) );
 	}

--- a/includes/api/v2/class-wc-rest-system-status-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-v2-controller.php
@@ -989,7 +989,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 	 * @return array
 	 */
 	public function get_security_info() {
-		$check_page = 0 < wc_get_page_id( 'shop' ) ? get_permalink( wc_get_page_id( 'shop' ) ) : get_home_url();
+		$check_page = wc_get_page_permalink( 'shop' );
 		return array(
 			'secure_connection' => 'https' === substr( $check_page, 0, 5 ),
 			'hide_errors'       => ! ( defined( 'WP_DEBUG' ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG && WP_DEBUG_DISPLAY ) || 0 === intval( ini_get( 'display_errors' ) ),

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -81,7 +81,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$data        = $response->get_data();
 		$environment = (array) $data['environment'];
 
-		// Make sure all expected data is present
+		// Make sure all expected data is present.
 		$this->assertEquals( 32, count( $environment ) );
 
 		// Test some responses to make sure they match up.
@@ -468,7 +468,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 	 *
 	 * This function is called by WP_HTTP_TestCase::http_request_listner().
 	 *
-	 * @param array $request Request arguments.
+	 * @param array  $request Request arguments.
 	 * @param string $url URL of the request.
 	 *
 	 * @return array|false mocked response or false to let WP perform a regular request.

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -183,7 +183,7 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$settings = (array) $data['security'];
 
 		$this->assertEquals( 2, count( $settings ) );
-		$this->assertEquals( 'https' === substr( get_permalink( wc_get_page_id( 'shop' ) ), 0, 5 ), $settings['secure_connection'] );
+		$this->assertEquals( 'https' === substr( wc_get_page_permalink( 'shop' ), 0, 5 ), $settings['secure_connection'] );
 		$this->assertEquals( ! ( defined( 'WP_DEBUG' ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG && WP_DEBUG_DISPLAY ) || 0 === intval( ini_get( 'display_errors' ) ), $settings['hide_errors'] );
 	}
 

--- a/tests/unit-tests/api/v2/system-status.php
+++ b/tests/unit-tests/api/v2/system-status.php
@@ -78,7 +78,7 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 		$data        = $response->get_data();
 		$environment = (array) $data['environment'];
 
-		// Make sure all expected data is present
+		// Make sure all expected data is present.
 		$this->assertEquals( 32, count( $environment ) );
 
 		// Test some responses to make sure they match up.

--- a/tests/unit-tests/api/v2/system-status.php
+++ b/tests/unit-tests/api/v2/system-status.php
@@ -180,7 +180,7 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 		$settings = (array) $data['security'];
 
 		$this->assertEquals( 2, count( $settings ) );
-		$this->assertEquals( 'https' === substr( get_permalink( wc_get_page_id( 'shop' ) ), 0, 5 ), $settings['secure_connection'] );
+		$this->assertEquals( 'https' === substr( wc_get_page_permalink( 'shop' ), 0, 5 ), $settings['secure_connection'] );
 		$this->assertEquals( ! ( defined( 'WP_DEBUG' ) && defined( 'WP_DEBUG_DISPLAY' ) && WP_DEBUG && WP_DEBUG_DISPLAY ) || 0 === intval( ini_get( 'display_errors' ) ), $settings['hide_errors'] );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This pull requests fixes a case where the ssl check gives a wrong value.

Sometimes `wc_get_page_id( 'shop' )` may have a value but the page is no longer exists, and then `get_permalink( wc_get_page_id( 'shop' ) )` will return `false` and the ssl check will fail.
This pull request makes sure that `get_home_url()` will be used as a fallback in case the page doesn't exists.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix ssl check in case shop page no longer exists