### PR TITLE
Exclude `paged` from price slider

### DIFF
--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -327,6 +327,11 @@ abstract class WC_Widget extends WP_Widget {
 		// Post Type Arg.
 		if ( isset( $_GET['post_type'] ) ) {
 			$link = add_query_arg( 'post_type', wc_clean( wp_unslash( $_GET['post_type'] ) ), $link );
+
+			// Prevent post type and page id when pretty permalinks are disabled.
+			if ( is_shop() ) {
+				$link = remove_query_arg( 'page_id', $link );
+			}
 		}
 
 		// Min Rating Arg.

--- a/includes/widgets/class-wc-widget-price-filter.php
+++ b/includes/widgets/class-wc-widget-price-filter.php
@@ -106,7 +106,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 					<div class="price_label" style="display:none;">
 						' . esc_html__( 'Price:', 'woocommerce' ) . ' <span class="from"></span> &mdash; <span class="to"></span>
 					</div>
-					' . wc_query_string_form_fields( null, array( 'min_price', 'max_price' ), '', true ) . '
+					' . wc_query_string_form_fields( null, array( 'min_price', 'max_price', 'paged' ), '', true ) . '
 					<div class="clear"></div>
 				</div>
 			</div>

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -110,7 +110,7 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 				continue;
 			}
 			$found = true;
-			$link  = $this->get_current_page_url();
+			$link  = remove_query_arg( 'paged', $this->get_current_page_url() );
 
 			if ( in_array( $rating, $rating_filter, true ) ) {
 				$link_ratings = implode( ',', array_diff( $rating_filter, array( $rating ) ) );
@@ -119,7 +119,7 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 			}
 
 			$class       = in_array( $rating, $rating_filter, true ) ? 'wc-layered-nav-rating chosen' : 'wc-layered-nav-rating';
-			$link        = apply_filters( 'woocommerce_rating_filter_link', $link_ratings ? add_query_arg( 'rating_filter', $link_ratings ) : remove_query_arg( 'rating_filter' ) );
+			$link        = apply_filters( 'woocommerce_rating_filter_link', $link_ratings ? add_query_arg( 'rating_filter', $link_ratings, $link ) : remove_query_arg( 'rating_filter' ) );
 			$rating_html = wc_get_star_rating_html( $rating );
 			$count_html  = wp_kses(
 				apply_filters( 'woocommerce_rating_filter_count', "({$count})", $count, $rating ),


### PR DESCRIPTION
Prevents 404s due to no products on subsequent pages after filtering.

To test,
- Go to shop page 2
- Use price filter
- Ensure it removes page from URL and go's to page 1.

Before this patch it would remain on page 2 with no products visible.

Fixes #21265 
Closes #21396

> Remove paging when filtering products by price in shop.