### PR TITLE
round variation percentage price adjustments to decimal setting

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2242,7 +2242,7 @@ class WC_AJAX {
 
 			if ( '%' === substr( $value, -1 ) ) {
 				$percent      = wc_format_decimal( substr( $value, 0, -1 ) );
-				$field_value += ( ( $field_value / 100 ) * $percent ) * "{$operator}1";
+				$field_value += round( ( $field_value / 100 ) * $percent, wc_get_price_decimals() ) * "{$operator}1";
 			} else {
 				$field_value += $value * "{$operator}1";
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Round variation percentage price adjustments in bulk edit action to decimal places set in setting pricing settings.

Closes #22450 .

### How to test the changes in this Pull Request:

1. Add a variable product with multiple variations priced with decimals
2. Set one variation to have 3 decimal places
3. Set decimal place setting to 2
4. Use the Increase or Decrease all variation prices
5. Increase prices by 2%
6. Check prices to see that no decimal places were added to the prices
7. The variation from #2 should retain the same value in the third decimal place

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Limit bulk variation percentage price adjustment to decimal places in pricing settings.
