### PR TITLE
use `name` for POST/PUT category image name for consistency

### DIFF
--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -181,7 +181,7 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 							'format'      => 'uri',
 							'context'     => array( 'view', 'edit' ),
 						),
-						'name'             => array(
+						'name'              => array(
 							'description' => __( 'Image name.', 'woocommerce' ),
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
@@ -254,10 +254,12 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 
 				// Set the image title.
 				if ( ! empty( $request['image']['name'] ) ) {
-					wp_update_post( array(
-						'ID'         => $image_id,
-						'post_title' => wc_clean( $request['image']['name'] ),
-					) );
+					wp_update_post(
+						array(
+							'ID'         => $image_id,
+							'post_title' => wc_clean( $request['image']['name'] ),
+						)
+					);
 				}
 			} else {
 				delete_woocommerce_term_meta( $id, 'thumbnail_id' );

--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -209,4 +209,61 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 
 		return $this->add_additional_fields_schema( $schema );
 	}
+
+	/**
+	 * Update term meta fields.
+	 *
+	 * @param WP_Term         $term    Term object.
+	 * @param WP_REST_Request $request Request instance.
+	 * @return bool|WP_Error
+	 *
+	 * @since 3.5.5
+	 */
+	protected function update_term_meta_fields( $term, $request ) {
+		$id = (int) $term->term_id;
+
+		if ( isset( $request['display'] ) ) {
+			update_woocommerce_term_meta( $id, 'display_type', 'default' === $request['display'] ? '' : $request['display'] );
+		}
+
+		if ( isset( $request['menu_order'] ) ) {
+			update_woocommerce_term_meta( $id, 'order', $request['menu_order'] );
+		}
+
+		if ( isset( $request['image'] ) ) {
+			if ( empty( $request['image']['id'] ) && ! empty( $request['image']['src'] ) ) {
+				$upload = wc_rest_upload_image_from_url( esc_url_raw( $request['image']['src'] ) );
+
+				if ( is_wp_error( $upload ) ) {
+					return $upload;
+				}
+
+				$image_id = wc_rest_set_uploaded_image_as_attachment( $upload );
+			} else {
+				$image_id = isset( $request['image']['id'] ) ? absint( $request['image']['id'] ) : 0;
+			}
+
+			// Check if image_id is a valid image attachment before updating the term meta.
+			if ( $image_id && wp_attachment_is_image( $image_id ) ) {
+				update_woocommerce_term_meta( $id, 'thumbnail_id', $image_id );
+
+				// Set the image alt.
+				if ( ! empty( $request['image']['alt'] ) ) {
+					update_post_meta( $image_id, '_wp_attachment_image_alt', wc_clean( $request['image']['alt'] ) );
+				}
+
+				// Set the image title.
+				if ( ! empty( $request['image']['name'] ) ) {
+					wp_update_post( array(
+						'ID'         => $image_id,
+						'post_title' => wc_clean( $request['image']['name'] ),
+					) );
+				}
+			} else {
+				delete_woocommerce_term_meta( $id, 'thumbnail_id' );
+			}
+		}
+
+		return true;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In the V3 version of the API the image name (title in the media library) field is output as the `name`. Updating via PUT/POST (for existing media) uses the `title` field. Images attached to products use `name`. This PR updates PUT/POST to use `name`.

Closes #22449 .

### How to test the changes in this Pull Request:

1. Without the PR PUT 
URL: `/wp-json/wc/v3/products/categories/(category-id)`
Payload: `{"id":(category-id),"image":{"id":(attachment-id),"name":"Updated Title"}}`
2. The response should have `name` as the original image title from the media library
3. Repeat with the PR
4. The response should have `name` as `Updated Title` from the media library
5. Visit the media library & the image title should be `Updated Title`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix category image `name` field to be used for API POST/PUT.
