### PR TITLE
Better `@id` generation for product structured data

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -195,15 +195,16 @@ class WC_Structured_Data {
 		$shop_name = get_bloginfo( 'name' );
 		$shop_url  = home_url();
 		$currency  = get_woocommerce_currency();
+		$permalink = get_permalink( $product->get_id() );
 
 		$markup = array(
 			'@type' => 'Product',
-			'@id'   => get_permalink( $product->get_id() ),
+			'@id'   => $permalink . '#product', // Append '#product' to differentiate between this @id and the @id generated for the Breadcrumblist.
 			'name'  => $product->get_name(),
 		);
 
 		if ( apply_filters( 'woocommerce_structured_data_product_limit', is_product_taxonomy() || is_shop() ) ) {
-			$markup['url'] = $markup['@id'];
+			$markup['url'] = $permalink;
 
 			$this->set_data( apply_filters( 'woocommerce_structured_data_product_limited', $markup, $product ) );
 			return;
@@ -250,7 +251,7 @@ class WC_Structured_Data {
 			$markup_offer += array(
 				'priceCurrency' => $currency,
 				'availability'  => 'https://schema.org/' . ( $product->is_in_stock() ? 'InStock' : 'OutOfStock' ),
-				'url'           => $markup['@id'],
+				'url'           => $permalink,
 				'seller'        => array(
 					'@type' => 'Organization',
 					'name'  => $shop_name,
@@ -329,12 +330,6 @@ class WC_Structured_Data {
 		$markup['itemListElement'] = array();
 
 		foreach ( $crumbs as $key => $crumb ) {
-			// Don't add the current page to the breadcrumb list on product pages,
-			// otherwise Google will not recognize both the BreadcrumbList and Product structured data.
-			if ( is_product() && count( $crumbs ) - 1 === $key ) {
-				continue;
-			}
-
 			$markup['itemListElement'][ $key ] = array(
 				'@type'    => 'ListItem',
 				'position' => $key + 1,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Fixes #22440 .

Implements @jono-alderson's recommendations for generating the product structured data in a way that won't cause issues with Yoast:
- Revert the change introduced in #22344 so we include the product URL as the `@id` for the element in the Breadcrumblist.
- Append #product to the `@id` of the Product structured data, so the `@id` for the Product structured data will be e.g. `http://example.com/product/foo#product`.

### How to test the changes in this Pull Request:

1. Paste the source code from a single product page [into the Structured Data tester tool](https://search.google.com/structured-data/testing-tool/u/0/) and verify everything looks good. You should see both BreadcrumbList and Product structured data.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Refactor `@id` generation for product structured data to prevent plugin conflicts.
