### PR TITLE
Fix for images with no metadata

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -346,6 +346,11 @@ class WC_Regenerate_Images {
 		}
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
+		
+		//Fix for images with no metadata
+		if(!is_array($metadata)){
+		$metadata = array();
+		}
 
 		// We only want to regen a specific image size.
 		add_filter( 'intermediate_image_sizes', array( __CLASS__, 'adjust_intermediate_image_sizes' ) );

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -348,9 +348,9 @@ class WC_Regenerate_Images {
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 		
 		//Fix for images with no metadata
-		if(!is_array($metadata)){
+		if( !is_array( $metadata ) ){ 
 		$metadata = array();
-		}
+		} 
 
 		// We only want to regen a specific image size.
 		add_filter( 'intermediate_image_sizes', array( __CLASS__, 'adjust_intermediate_image_sizes' ) );

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -347,10 +347,10 @@ class WC_Regenerate_Images {
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
 		
-		//Fix for images with no metadata
-		if( !is_array( $metadata ) ){ 
-		$metadata = array();
-		} 
+		// Fix for images with no metadata.
+		if ( ! is_array( $metadata ) ) {
+			$metadata = array();
+		}
 
 		// We only want to regen a specific image size.
 		add_filter( 'intermediate_image_sizes', array( __CLASS__, 'adjust_intermediate_image_sizes' ) );

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -346,7 +346,7 @@ class WC_Regenerate_Images {
 		}
 
 		$metadata = wp_get_attachment_metadata( $attachment_id );
-		
+
 		// Fix for images with no metadata.
 		if ( ! is_array( $metadata ) ) {
 			$metadata = array();


### PR DESCRIPTION
Fix for error when images have no metadata or their metadata is removed.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

**Error from Logs:**
`[25-Jan-2019 12:19:08 UTC] PHP Warning:  Illegal string offset 'sizes' in /home/xxxxxxx/public_html/staging/wp-content/plugins/woocommerce/includes/class-wc-regenerate-images.php on line 365
[25-Jan-2019 12:19:08 UTC] PHP Fatal error:  Uncaught Error: Cannot use string offset as an array in /home/xxxxxxx/public_html/staging/wp-content/plugins/woocommerce/includes/class-wc-regenerate-images.php:365
Stack trace:
#0 /home/xxxxxxx/public_html/staging/wp-content/plugins/woocommerce/includes/class-wc-regenerate-images.php(228): WC_Regenerate_Images::resize_and_return_image('10913', Array, 'woocommerce_thu...', false)
#1 /home/xxxxxxx/public_html/staging/wp-includes/class-wp-hook.php(286): WC_Regenerate_Images::maybe_resize_image(Array, '10913', 'woocommerce_thu...', false)
#2 /home/xxxxxxx/public_html/staging/wp-includes/plugin.php(203): WP_Hook->apply_filters(Array, Array)
#3 /home/xxxxxxx/public_html/staging/wp-includes/media.php(851): apply_filters('wp_get_attachme...', Array, '10913', 'woocommerce_thu...', false)
#4 /home/xxxxxxx/public_html/staging/wp-includes/media.php(873): wp_get_attachment_image_src('10913', 'woocommerce_thu...', false)
#5 /home/xxxxxxx/public_html/staging/wp-content/plugins/woocommerce/includes/abstracts/abstract in /home/xxxxxxx/public_html/staging/wp-content/plugins/woocommerce/includes/class-wc-regenerate-images.php on line 365
`

Cause: Images with blank metdata or images optimized by Remush.it Plugin

### How to test the changes in this Pull Request:

1. Install Resmush.it Image Optimizer Plugin
2. Enable option to remove metadata in Settings
3. Upload new image and let it be optimized
4. On website open any listing where more then 1 Product are added.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix for images with no metadata.