### PR TITLE
Remove possibe superfluous wp_attachment_is_image() filter.

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1257,10 +1257,6 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	public function set_gallery_image_ids( $image_ids ) {
 		$image_ids = wp_parse_id_list( $image_ids );
 
-		if ( $this->get_object_read() ) {
-			$image_ids = array_filter( $image_ids, 'wp_attachment_is_image' );
-		}
-
 		$this->set_prop( 'gallery_image_ids', $image_ids );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Not sure you'll go for this, but want to raise it anyway, if anything just to raise the discussion.

The reason to remove this is that this function uses get_post() under
the hood which always assumes the attachment is on the same site, where
as if you're using a plugin such as
https://github.com/humanmade/network-media-library it might not be.

I'm not sure if there's any adverse affects of not doing this filtering,
from my testing, it still seems to work in the same way.

Alternatively, we could introduce some hooks in here so that end users can hook into to switch/restore the blog if using network-media-library.

### How to test the changes in this Pull Request:

1. On a multi site install with network-media-library installed.
2. Attempt to add a gallery image on a product on a site that isn't the main site.
3. Before this change it wouldn't save
4. After this change it will save.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Remove `wp_attachment_is_image()` check for gallery image to allow gallery images to work with network media library plugin.
