### PR TITLE
Use thumbnail size image for products widget instead of CSS scaling from full size

### DIFF
--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -29,7 +29,7 @@ if ( ! is_a( $product, 'WC_Product' ) ) {
 	<?php do_action( 'woocommerce_widget_product_item_start', $args ); ?>
 
 	<a href="<?php echo esc_url( $product->get_permalink() ); ?>">
-		<?php echo $product->get_image(); ?>
+		<?php echo $product->get_image('thumbnail'); ?>
 		<span class="product-title"><?php echo wp_kses_post( $product->get_name() ); ?></span>
 	</a>
 


### PR DESCRIPTION
The current version of the code scales down the maximum resolution original images using CSS, requiring browsers to load large files unnecessarily. Using the inbuilt 'thumbnail' size means that images are scaled from 150x150 to 37x37px instead.

I have implemented this on my local site which has a very low bandwidth frontpage and acheived significant bandwidth savings.

### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Change the products widget to use `thumbnail` size images instead of using CSS to scale down full size images to 37x37 px

Closes # .

### How to test the changes in this Pull Request:

1. Activate the products widget and implement the code
2. Force refresh your browser
3. Inspect the items in the browser to show that they are not resized from full high resolution

### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x ] Have you written new tests for your changes, as applicable?
* [ x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Products widget now uses smaller images to reduce bandwidth use.