### PR TITLE
Adds filter for product categories displayed by `product_categories` shortcode.

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -174,7 +174,10 @@ class WC_Shortcodes {
 			'child_of'   => $atts['parent'],
 		);
 
-		$product_categories = get_terms( 'product_cat', $args );
+		$product_categories = apply_filters(
+			'woocommerce_product_categories',
+			get_terms( 'product_cat', $args )
+		);
 
 		if ( '' !== $atts['parent'] ) {
 			$product_categories = wp_list_filter( $product_categories, array(

--- a/tests/unit-tests/shortcodes/product_categories.php
+++ b/tests/unit-tests/shortcodes/product_categories.php
@@ -1,0 +1,84 @@
+<?php
+
+/**
+ * Class WC_Shortcodes.
+ *
+ * @package WooCommerce\Tests\Shortcodes
+ */
+class WC_Test_Shortcodes extends WC_Unit_Test_Case {
+	/**
+	 * Test: WC_Shortcodes::product_categories().
+	 */
+	public function test_product_categories() {
+		// Pre
+		$categories = [
+			(object)[
+				'name' => 'out',
+				'count' => 1,
+			],
+			(object)[
+				'name' => 'empty',
+				'count' => 0,
+			],
+			(object)[
+				'name' => 'in',
+			],
+			(object)[
+				'name' => 'in',
+			],
+			(object)[
+				'name' => 'out',
+			],
+		];
+		foreach ($categories as $i => &$category) {
+			$category->term_id = $i;
+			$category->taxonomy = 'product_cat';
+			$category->slug = "{$category->name}-{$i}";
+			if (! isset($category->count)) {
+				$category->count = $i;
+			}
+		}
+		$filtered_categories = array_slice($categories, 1, -1);
+		$removed_categories = array_merge(
+			[$categories[0]],
+			array_slice($categories, -1)
+		);
+
+		// intercept `get_terms()`
+		// WP_UnitTestCase should clear out hooks
+		add_filter( 'get_terms', function( $terms, $taxonomy, $query_vars, $term_query ) use(&$categories) {
+				if ( ['product_cat'] == $taxonomy ) {
+					return $categories;
+				} else {
+					return $terms;
+				}
+			}, 10, 4 );
+
+		// create a mock for the filter so we can test if it gets called
+		$filter_prodcats = $this->getMockBuilder(stdClass::class)
+			->setMethods(['__invoke'])
+			->getMock();
+
+		$filter_prodcats->expects($this->once())
+			->method('__invoke')
+			->willReturn( $filtered_categories );
+
+		add_filter( 'woocommerce_product_categories', $filter_prodcats );
+
+		$shortcode = new WC_Shortcodes();
+
+		// In
+		$result = $shortcode->product_categories( [] );
+
+		// Post
+		$doc = new DOMDocument();
+		// generated HTML isn't valid, causing libxml to complain (about e.g. <mark> elements); since we don't care about that so much here, ignore errors
+		$doc->loadHTML($result, LIBXML_NOWARNING | LIBXML_NOERROR);
+		$xpather = new DOMXPath($doc);
+
+		$this->assertSame( 2, $xpather->query('//a[contains(@href, "product_cat=in")]')->length, "Categories included should appear in output." );
+		$this->assertSame( 0, $xpather->query('//a[contains(@href, "out")]')->length, "Categories filtered out shouldn't appear in output." );
+
+		$this->assertSame( 0, $xpather->query('//a[contains(@href, "empty")]')->length, "Empty categories shouldn't appear in output, despite not being filtered out." );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This adds a feature to allow other plugins to filter the product categories that wind up being displayed by the 'product_categories' shortcode. In short, `WC_Shortcodes::product_categories()` passes the categories retrieved with `get_terms()` through a filter named 'woocommerce_product_categories'.

This can be useful to plugins extending handling of product categories, such as category statuses (similar to post statuses) or category authorization (so that only some users can access certain categories).

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

I started to write unit tests, but this can only be done by adding runkit or APD as a requirement, which I'm hesitant to do as the consequences of this for other developers is greater than the consequences of not testing this feature.

### Changelog entry

> Adds filter for product categories displayed by `product_categories` shortcode.
