### PR TITLE
Fix: #22572-can't access settings ("The link you followed has expired")

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -98,9 +98,9 @@ class WC_Admin_Menus {
 		$current_section = empty( $_REQUEST['section'] ) ? '' : sanitize_title( wp_unslash( $_REQUEST['section'] ) ); // WPCS: input var okay, CSRF ok.
 
 		// Save settings if data has been posted.
-		if ( '' !== $current_section && apply_filters( "woocommerce_save_settings_{$current_tab}_{$current_section}", ! empty( $_POST ) ) ) { // WPCS: input var okay, CSRF ok.
+		if ( '' !== $current_section && apply_filters( "woocommerce_save_settings_{$current_tab}_{$current_section}", ! empty( $_POST['save'] ) ) ) { // WPCS: input var okay, CSRF ok.
 			WC_Admin_Settings::save();
-		} elseif ( '' === $current_section && apply_filters( "woocommerce_save_settings_{$current_tab}", ! empty( $_POST ) ) ) { // WPCS: input var okay, CSRF ok.
+		} elseif ( '' === $current_section && apply_filters( "woocommerce_save_settings_{$current_tab}", ! empty( $_POST['save'] ) ) ) { // WPCS: input var okay, CSRF ok.
 			WC_Admin_Settings::save();
 		}
 


### PR DESCRIPTION
Cause: if anything adds elements to `$_POST`, WooCommerce is triggered to try to save settings; if there's no nonce (such as when following a link to the settings page), authorization fails, resulting in the message. Soln: check for specific element ('save') in `$_POST` to determine whether to save elements, rather than testing that `$_POST` is non-empty.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #22572 by having `WC_Admin_Menus->settings_page_init()` test whether `$_POST['save']` (which should be set from the "Save changes" button) is non-empty, rather than whether all of `$_POST` is non-empty when determining whether to save settings.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

As there are no other tests for `WC_Admin_Menus->settings_page_init()` and (more importantly) it calls static methods (making unit testing difficult, if not impossible), I've not created any tests for the bug or this fix.

### Changelog entry

> Fix - Check for presence of 'save' entry in post data when determining whether to save settings. #22572

