### PR TITLE
recalculate coupons after adding coupon to order

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -952,10 +952,10 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		$this->set_coupon_discount_amounts( $discounts );
-		$this->set_item_discount_amounts( $discounts );
+		$this->save();
 
 		// Recalculate totals and taxes.
-		$this->calculate_totals( true );
+		$this->recalculate_coupons();
 
 		// Record usage so counts and validation is correct.
 		$used_by = $this->get_user_id();

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -403,7 +403,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$subtotal += $item->get_subtotal();
 		}
 
-		return apply_filters( 'woocommerce_order_get_subtotal', (double) $subtotal, $this );
+		return apply_filters( 'woocommerce_order_get_subtotal', (float) $subtotal, $this );
 	}
 
 	/**
@@ -692,13 +692,16 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return string
 	 */
 	protected function type_to_group( $type ) {
-		$type_to_group = apply_filters( 'woocommerce_order_type_to_group', array(
-			'line_item' => 'line_items',
-			'tax'       => 'tax_lines',
-			'shipping'  => 'shipping_lines',
-			'fee'       => 'fee_lines',
-			'coupon'    => 'coupon_lines',
-		) );
+		$type_to_group = apply_filters(
+			'woocommerce_order_type_to_group',
+			array(
+				'line_item' => 'line_items',
+				'tax'       => 'tax_lines',
+				'shipping'  => 'shipping_lines',
+				'fee'       => 'fee_lines',
+				'coupon'    => 'coupon_lines',
+			)
+		);
 		return isset( $type_to_group[ $type ] ) ? $type_to_group[ $type ] : '';
 	}
 
@@ -1285,12 +1288,15 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$tax_based_on = 'billing';
 		}
 
-		$args = wp_parse_args( $args, array(
-			'country'  => 'billing' === $tax_based_on ? $this->get_billing_country() : $this->get_shipping_country(),
-			'state'    => 'billing' === $tax_based_on ? $this->get_billing_state() : $this->get_shipping_state(),
-			'postcode' => 'billing' === $tax_based_on ? $this->get_billing_postcode() : $this->get_shipping_postcode(),
-			'city'     => 'billing' === $tax_based_on ? $this->get_billing_city() : $this->get_shipping_city(),
-		) );
+		$args = wp_parse_args(
+			$args,
+			array(
+				'country'  => 'billing' === $tax_based_on ? $this->get_billing_country() : $this->get_shipping_country(),
+				'state'    => 'billing' === $tax_based_on ? $this->get_billing_state() : $this->get_shipping_state(),
+				'postcode' => 'billing' === $tax_based_on ? $this->get_billing_postcode() : $this->get_shipping_postcode(),
+				'city'     => 'billing' === $tax_based_on ? $this->get_billing_city() : $this->get_shipping_city(),
+			)
+		);
 
 		// Default to base.
 		if ( 'base' === $tax_based_on || empty( $args['country'] ) ) {
@@ -1619,10 +1625,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( 'excl' === $tax_display ) {
 			$ex_tax_label = $this->get_prices_include_tax() ? 1 : 0;
 
-			$subtotal = wc_price( $this->get_line_subtotal( $item ), array(
-				'ex_tax_label' => $ex_tax_label,
-				'currency'     => $this->get_currency(),
-			) );
+			$subtotal = wc_price(
+				$this->get_line_subtotal( $item ),
+				array(
+					'ex_tax_label' => $ex_tax_label,
+					'currency'     => $this->get_currency(),
+				)
+			);
 		} else {
 			$subtotal = wc_price( $this->get_line_subtotal( $item, true ), array( 'currency' => $this->get_currency() ) );
 		}

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -426,13 +426,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
 		$request->set_body_params(
 			array(
-				'line_items'   => array(
-					array(
-						'id'         => $order_item->get_id(),
-						'product_id' => $order_item->get_product_id(),
-						'subtotal'   => '35.00',
-					),
-				),
 				'coupon_lines' => array(
 					array(
 						'code' => 'fake-coupon',

--- a/tests/unit-tests/api/orders.php
+++ b/tests/unit-tests/api/orders.php
@@ -5,6 +5,10 @@
  * @package WooCommerce\Tests\API
  * @since 3.5.0
  */
+
+/**
+ * Class WC_Tests_API_Orders
+ */
 class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 	/**
@@ -121,9 +125,11 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_get_item_refund_id() {
 		wp_set_current_user( $this->user );
 		$order    = WC_Helper_Order::create_order();
-		$refund   = wc_create_refund( array(
-			'order_id' => $order->get_id(),
-		) );
+		$refund   = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+			)
+		);
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/' . $refund->get_id() ) );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -273,7 +279,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$request->set_body_params(
 			array(
 				'payment_method'       => 'bacs',
-				'payment_method_title' => '<h1>Sanitize this too <script>alert(1);</script></h1>'
+				'payment_method_title' => '<h1>Sanitize this too <script>alert(1);</script></h1>',
 			)
 		);
 		$response = $this->server->dispatch( $request );
@@ -292,7 +298,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$product = WC_Helper_Product::create_simple_product();
 
-		// non-existent customer
+		// Non-existent customer.
 		$request = new WP_REST_Request( 'POST', '/wc/v3/orders' );
 		$request->set_body_params(
 			array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Recalculate the coupon totals after validating that it applies cleanly to the order. When it is being validated it is the only coupon added to the discount so its value is distributed among the products as if it's the only coupon on the order.

Closes #22515 .

### To reproduce/test this issue

1. Create 2 products at prices $10 and $15
2. Create 2 fixed discount coupons for the same amounts
3. Create a new order and add both products
4. Add both coupons
5. Note that only half of the second coupon is applied to the $15 product without this PR
6. Remove the coupons from the order
7. Add the coupons to the order via the API 
8. Verify they were corrected added in the response and dashboard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Recalculate coupon totals after adding a coupon to an order.
