### PR TITLE
include refunded orders in top sellers, earners in sales by product report

### DIFF
--- a/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -12,8 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * WC_Report_Sales_By_Product
  *
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce/Admin/Reports
  * @version     2.1.0
  */
@@ -44,11 +42,13 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 	 * Constructor.
 	 */
 	public function __construct() {
+		// @codingStandardsIgnoreStart
 		if ( isset( $_GET['product_ids'] ) && is_array( $_GET['product_ids'] ) ) {
 			$this->product_ids = array_filter( array_map( 'absint', $_GET['product_ids'] ) );
 		} elseif ( isset( $_GET['product_ids'] ) ) {
 			$this->product_ids = array_filter( array( absint( $_GET['product_ids'] ) ) );
 		}
+		// @codingStandardsIgnoreEnd
 	}
 
 	/**
@@ -78,8 +78,8 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 					'relation' => 'OR',
 					array(
 						'type'       => 'order_item_meta',
-						'meta_key'   => array( '_product_id', '_variation_id' ),
-						'meta_value' => $this->product_ids,
+						'meta_key'   => array( '_product_id', '_variation_id' ), // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_key
+						'meta_value' => $this->product_ids, // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_value
 						'operator'   => 'IN',
 					),
 				),
@@ -103,8 +103,8 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 						'relation' => 'OR',
 						array(
 							'type'       => 'order_item_meta',
-							'meta_key'   => array( '_product_id', '_variation_id' ),
-							'meta_value' => $this->product_ids,
+							'meta_key'   => array( '_product_id', '_variation_id' ), // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_key
+							'meta_value' => $this->product_ids, // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_value
 							'operator'   => 'IN',
 						),
 					),
@@ -148,9 +148,9 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 			'item_count'   => '#d4d9dc',
 		);
 
-		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( wp_unslash( $_GET['range'] ) ) : '7day';
+		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( wp_unslash( $_GET['range'] ) ) : '7day'; //phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 
-		if ( ! in_array( $current_range, array( 'custom', 'year', 'last_month', 'month', '7day' ) ) ) {
+		if ( ! in_array( $current_range, array( 'custom', 'year', 'last_month', 'month', '7day' ), true ) ) {
 			$current_range = '7day';
 		}
 
@@ -297,8 +297,8 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 						'where_meta'   => array(
 							array(
 								'type'       => 'order_item_meta',
-								'meta_key'   => '_line_subtotal',
-								'meta_value' => '0',
+								'meta_key'   => '_line_subtotal', // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_key
+								'meta_value' => '0', // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_value
 								'operator'   => '=',
 							),
 						),
@@ -398,7 +398,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 	 */
 	public function get_export_button() {
 
-		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( wp_unslash( $_GET['range'] ) ) : '7day';
+		$current_range = ! empty( $_GET['range'] ) ? sanitize_text_field( wp_unslash( $_GET['range'] ) ) : '7day'; //phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 		?>
 		<a
 			href="#"
@@ -452,8 +452,8 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 						'relation' => 'OR',
 						array(
 							'type'       => 'order_item_meta',
-							'meta_key'   => array( '_product_id', '_variation_id' ),
-							'meta_value' => $this->product_ids,
+							'meta_key'   => array( '_product_id', '_variation_id' ), // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_key
+							'meta_value' => $this->product_ids, // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_value
 							'operator'   => 'IN',
 						),
 					),
@@ -489,8 +489,8 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 						'relation' => 'OR',
 						array(
 							'type'       => 'order_item_meta',
-							'meta_key'   => array( '_product_id', '_variation_id' ),
-							'meta_value' => $this->product_ids,
+							'meta_key'   => array( '_product_id', '_variation_id' ), // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_key
+							'meta_value' => $this->product_ids, // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_value
 							'operator'   => 'IN',
 						),
 					),
@@ -506,7 +506,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 			$order_item_amounts = $this->prepare_chart_data( $order_item_amounts, 'post_date', 'order_item_amount', $this->chart_interval, $this->start_date, $this->chart_groupby );
 
 			// Encode in json format.
-			$chart_data = json_encode(
+			$chart_data = wp_json_encode(
 				array(
 					'order_item_counts'  => array_values( $order_item_counts ),
 					'order_item_amounts' => array_values( $order_item_amounts ),

--- a/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -254,6 +254,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 						'limit'        => 12,
 						'query_type'   => 'get_results',
 						'filter_range' => true,
+						'order_status' => array( 'completed', 'processing', 'on-hold', 'refunded' ),
 					)
 				);
 
@@ -350,6 +351,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 						'limit'        => 12,
 						'query_type'   => 'get_results',
 						'filter_range' => true,
+						'order_status' => array( 'completed', 'processing', 'on-hold', 'refunded' ),
 					)
 				);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Refunds but not the refunded orders are included in the top sellers & earners totals in the sales by product report. This PR adds the refunded orders to both totals so that over the range of purchase to refund the net balance of a refunded order is 0.

Closes #22561 .

### How to test the changes in this Pull Request:

1. Purchase a product through the cart
2. Log into the dashboard and refund the order
3. Without the PR the sellers/earners show a negative 1/product price
4. With PR they show 0/0

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Include refunded orders in top sellers, earners sales by product.
