### PR TITLE
don't force shop loop display mode to products when query page >1

### DIFF
--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -368,7 +368,7 @@ class WC_Breadcrumb {
 	 * Add a breadcrumb for pagination.
 	 */
 	private function paged_trail() {
-		if ( get_query_var( 'paged' ) ) {
+		if ( get_query_var( 'paged' ) && 'subcategories' !== woocommerce_get_loop_display_mode() ) {
 			/* translators: %d: page number */
 			$this->add_crumb( sprintf( __( 'Page %d', 'woocommerce' ), get_query_var( 'paged' ) ) );
 		}

--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -28,7 +28,7 @@ class WC_Breadcrumb {
 	 */
 	public function add_crumb( $name, $link = '' ) {
 		$this->crumbs[] = array(
-			strip_tags( $name ),
+			wp_strip_all_tags( $name ),
 			$link,
 		);
 	}
@@ -148,8 +148,11 @@ class WC_Breadcrumb {
 			$this->prepend_shop_page();
 
 			$terms = wc_get_product_terms(
-				$post->ID, 'product_cat', apply_filters(
-					'woocommerce_breadcrumb_product_terms_args', array(
+				$post->ID,
+				'product_cat',
+				apply_filters(
+					'woocommerce_breadcrumb_product_terms_args',
+					array(
 						'orderby' => 'parent',
 						'order'   => 'DESC',
 					)

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2211,7 +2211,7 @@ if ( ! function_exists( 'woocommerce_get_loop_display_mode' ) ) {
 	 */
 	function woocommerce_get_loop_display_mode() {
 		// Only return products when filtering things.
-		if ( 1 < wc_get_loop_prop( 'current_page' ) || wc_get_loop_prop( 'is_search' ) || wc_get_loop_prop( 'is_filtered' ) ) {
+		if ( wc_get_loop_prop( 'is_search' ) || wc_get_loop_prop( 'is_filtered' ) ) {
 			return 'products';
 		}
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -910,7 +910,7 @@ if ( ! function_exists( 'woocommerce_content' ) ) {
 
 				<?php do_action( 'woocommerce_no_products_found' ); ?>
 
-			<?php
+				<?php
 			endif;
 
 		}
@@ -1066,7 +1066,7 @@ if ( ! function_exists( 'woocommerce_template_loop_product_title' ) ) {
 	 * Show the product title in the product loop. By default this is an H2.
 	 */
 	function woocommerce_template_loop_product_title() {
-		echo '<h2 class="woocommerce-loop-product__title">' . get_the_title() . '</h2>';
+		echo '<h2 class="woocommerce-loop-product__title">' . get_the_title() . '</h2>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 }
 if ( ! function_exists( 'woocommerce_template_loop_category_title' ) ) {

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1206,7 +1206,7 @@ if ( ! function_exists( 'woocommerce_template_loop_add_to_cart' ) ) {
 			$args = apply_filters( 'woocommerce_loop_add_to_cart_args', wp_parse_args( $args, $defaults ), $product );
 
 			if ( isset( $args['attributes']['aria-label'] ) ) {
-				$args['attributes']['aria-label'] = strip_tags( $args['attributes']['aria-label'] );
+				$args['attributes']['aria-label'] = wp_strip_all_tags( $args['attributes']['aria-label'] );
 			}
 
 			wc_get_template( 'loop/add-to-cart.php', $args );

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2226,6 +2226,10 @@ if ( ! function_exists( 'woocommerce_get_loop_display_mode' ) ) {
 			$display_type = '' === $display_type ? get_option( 'woocommerce_category_archive_display', '' ) : $display_type;
 		}
 
+		if ( ( ! is_shop() || 'subcategories' !== $display_type ) && 1 < wc_get_loop_prop( 'current_page' ) ) {
+			return 'products';
+		}
+
 		// Ensure valid value.
 		if ( '' === $display_type || ! in_array( $display_type, array( 'products', 'subcategories', 'both' ), true ) ) {
 			$display_type = 'products';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Don't force shop loop display mode to products when query page >1
- Don't include the paged crumb on the shop when it's set to display subcategories

Closes #21830 .

### How to test the changes in this Pull Request:

1. Set the shop to display products on the shop page
2. Check paging on the shop & all product archive types
3. Set the shop to display subcategories on the shop page
4. Check the shop page showing categories
5. Manually add `page/2/` to the shop page URL
6. Ship page should continue to show subcategories

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Observe shop page subcategories setting when `page/N/` is added to the URL.
