### PR TITLE
Added more types of input to styling in admin/variations.

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -4797,8 +4797,20 @@
 		 float: right;
 	 }
 
-	 input[type=text],
-	 input[type=number],
+	 input[type="text"],
+	 input[type="number"],
+	 input[type="password"],
+	 input[type="color"],
+	 input[type="date"],
+	 input[type="datetime"],
+	 input[type="datetime-local"],
+	 input[type="email"],
+	 input[type="month"],
+	 input[type="search"],
+	 input[type="tel"],
+	 input[type="time"],
+	 input[type="url"],
+	 input[type="week"],
 	 select,
 	 textarea {
 		 width: 100%;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #22395  .

### How to test the changes in this Pull Request:

1. Either add a new input type to admin/variations panel or change input type of existing fields to one of previously not supported ones, e.g. `date`, `month`
2. Observe incorrect styling before the change, after the change, the styling is corresponding.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Additional CSS support for more input types on variations panel in admin.
