### PR TITLE
Do not escape wc_get_rating_html output

### DIFF
--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -11,7 +11,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.5.2
+ * @version 3.5.5
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -34,7 +34,7 @@ if ( ! is_a( $product, 'WC_Product' ) ) {
 	</a>
 
 	<?php if ( ! empty( $show_rating ) ) : ?>
-		<?php echo wp_kses_post( wc_get_rating_html( $product->get_average_rating() ) ); ?>
+		<?php echo wc_get_rating_html( $product->get_average_rating() ); // PHPCS:Ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	<?php endif; ?>
 
 	<?php echo $product->get_price_html(); ?>

--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -29,7 +29,7 @@ if ( ! is_a( $product, 'WC_Product' ) ) {
 	<?php do_action( 'woocommerce_widget_product_item_start', $args ); ?>
 
 	<a href="<?php echo esc_url( $product->get_permalink() ); ?>">
-		<?php echo $product->get_image(); ?>
+		<?php echo $product->get_image(); // PHPCS:Ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 		<span class="product-title"><?php echo wp_kses_post( $product->get_name() ); ?></span>
 	</a>
 
@@ -37,7 +37,7 @@ if ( ! is_a( $product, 'WC_Product' ) ) {
 		<?php echo wc_get_rating_html( $product->get_average_rating() ); // PHPCS:Ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 	<?php endif; ?>
 
-	<?php echo $product->get_price_html(); ?>
+	<?php echo $product->get_price_html(); // PHPCS:Ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 
 	<?php do_action( 'woocommerce_widget_product_item_end', $args ); ?>
 </li>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #22592 

### How to test the changes in this Pull Request:

1. Use the woocommerce_product_get_rating_html to add some HTML to the ratings
2. Check the ratings widget and ensure the added html is displayed correctly and not stripped.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Over escaping rating widget html
