### PR TITLE
Hide star rating icons from screen readers

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3292,7 +3292,8 @@ function wc_get_stock_html( $product ) {
  * @return string
  */
 function wc_get_rating_html( $rating, $count = 0 ) {
-	$html = 0 < $rating ? '<div class="star-rating">' . wc_get_star_rating_html( $rating, $count ) . '</div>' : '';
+	/* translators: screen reader rating value */
+	$html = 0 < $rating ? '<div class="star-rating" aria-label="' . esc_attr( sprintf( __( 'Rating: %s out of 5', 'woocommerce' ), $rating ) ) . '">' . wc_get_star_rating_html( $rating, $count ) . '</div>' : '';
 	return apply_filters( 'woocommerce_product_get_rating_html', $html, $rating, $count );
 }
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -910,7 +910,7 @@ if ( ! function_exists( 'woocommerce_content' ) ) {
 
 				<?php do_action( 'woocommerce_no_products_found' ); ?>
 
-			<?php
+				<?php
 			endif;
 
 		}
@@ -1066,7 +1066,7 @@ if ( ! function_exists( 'woocommerce_template_loop_product_title' ) ) {
 	 * Show the product title in the product loop. By default this is an H2.
 	 */
 	function woocommerce_template_loop_product_title() {
-		echo '<h2 class="woocommerce-loop-product__title">' . get_the_title() . '</h2>';
+		echo '<h2 class="woocommerce-loop-product__title">' . esc_html( get_the_title() ) . '</h2>';
 	}
 }
 if ( ! function_exists( 'woocommerce_template_loop_category_title' ) ) {

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3292,8 +3292,7 @@ function wc_get_stock_html( $product ) {
  * @return string
  */
 function wc_get_rating_html( $rating, $count = 0 ) {
-	/* translators: screen reader rating value */
-	$html = 0 < $rating ? '<div class="star-rating" aria-label="' . esc_attr( sprintf( __( 'Rating: %s out of 5', 'woocommerce' ), $rating ) ) . '">' . wc_get_star_rating_html( $rating, $count ) . '</div>' : '';
+	$html = 0 < $rating ? '<div class="star-rating" aria-hidden="true">' . wc_get_star_rating_html( $rating, $count ) . '</div>' : '';
 	return apply_filters( 'woocommerce_product_get_rating_html', $html, $rating, $count );
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #22552 

### How to test the changes in this Pull Request:

1. Use a screen reader and visit a product page with ratings
2. Tab through the page until you are at the star rating under the product title
3. Tab again and ensure it skip this as well as not making an SSSSS sound.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - SSSS sound when viewing a product page and tabbing through the star rating.
