### PR TITLE
Update class-wc-structured-data.php. Line 214, changed wpautop to wp_…

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -210,7 +210,7 @@ class WC_Structured_Data {
 		}
 
 		$markup['image']       = wp_get_attachment_url( $product->get_image_id() );
-		$markup['description'] = wpautop( do_shortcode( $product->get_short_description() ? $product->get_short_description() : $product->get_description() ) );
+		$markup['description'] = wp_filter_nohtml_kses( do_shortcode( $product->get_short_description() ? $product->get_short_description() : $product->get_description() ) );
 		$markup['sku']         = $product->get_sku();
 
 		if ( '' !== $product->get_price() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update class-wc-structured-data.php. Line 214, changed wpautop to wp_filter_nohtml_kses.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. View Structured Data output, Product > Description. HTML should be stripped from the output.
2.
3.

### Other information:

Thus stripping html tags from the output to $markup['description']

Issue: #22565

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Update class-wc-structured-data.php. Line 214, changed wpautop to wp_filter_nohtml_kses.