### PR TITLE
Gruntfile sass and eslint changes

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,12 +7,16 @@
 	"globals": {
 		"wp": true,
 		"wpApiSettings": true,
-		"wcSettings": true
+		"wcSettings": true,
+		"es6": true
 	},
 	"rules": {
 		"camelcase": 0,
 		"indent": 0,
 		"max-len": [ 2, { "code": 140 } ],
 		"no-console": 1
+	},
+	"parserOptions": {
+		"ecmaVersion": 6
 	}
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,6 +1,7 @@
 /* jshint node:true */
 module.exports = function( grunt ) {
 	'use strict';
+	const sass = require( 'node-sass' );
 
 	grunt.initConfig({
 
@@ -75,9 +76,13 @@ module.exports = function( grunt ) {
 					'<%= dirs.js %>/jquery-flot/jquery.flot.time.min.js': ['<%= dirs.js %>/jquery-flot/jquery.flot.time.js'],
 					'<%= dirs.js %>/jquery-payment/jquery.payment.min.js': ['<%= dirs.js %>/jquery-payment/jquery.payment.js'],
 					'<%= dirs.js %>/jquery-qrcode/jquery.qrcode.min.js': ['<%= dirs.js %>/jquery-qrcode/jquery.qrcode.js'],
-					'<%= dirs.js %>/jquery-serializejson/jquery.serializejson.min.js': ['<%= dirs.js %>/jquery-serializejson/jquery.serializejson.js'],
+					'<%= dirs.js %>/jquery-serializejson/jquery.serializejson.min.js': [
+						'<%= dirs.js %>/jquery-serializejson/jquery.serializejson.js'
+					],
 					'<%= dirs.js %>/jquery-tiptip/jquery.tipTip.min.js': ['<%= dirs.js %>/jquery-tiptip/jquery.tipTip.js'],
-					'<%= dirs.js %>/jquery-ui-touch-punch/jquery-ui-touch-punch.min.js': ['<%= dirs.js %>/jquery-ui-touch-punch/jquery-ui-touch-punch.js'],
+					'<%= dirs.js %>/jquery-ui-touch-punch/jquery-ui-touch-punch.min.js': [
+						'<%= dirs.js %>/jquery-ui-touch-punch/jquery-ui-touch-punch.js'
+					],
 					'<%= dirs.js %>/prettyPhoto/jquery.prettyPhoto.init.min.js': ['<%= dirs.js %>/prettyPhoto/jquery.prettyPhoto.init.js'],
 					'<%= dirs.js %>/prettyPhoto/jquery.prettyPhoto.min.js': ['<%= dirs.js %>/prettyPhoto/jquery.prettyPhoto.js'],
 					'<%= dirs.js %>/flexslider/jquery.flexslider.min.js': ['<%= dirs.js %>/flexslider/jquery.flexslider.js'],
@@ -112,6 +117,7 @@ module.exports = function( grunt ) {
 		sass: {
 			compile: {
 				options: {
+					implementation: sass,
 					sourceMap: 'none'
 				},
 				files: [{
@@ -260,7 +266,9 @@ module.exports = function( grunt ) {
 			contributors: {
 				command: [
 					'echo "Generating contributor list since <%= fromDate %>"',
-					'./node_modules/.bin/githubcontrib --owner woocommerce --repo woocommerce --fromDate <%= fromDate %> --authToken <%= authToken %> --cols 6 --sortBy contributions --format md --sortOrder desc --showlogin true > contributors.md'
+					'./node_modules/.bin/githubcontrib --owner woocommerce --repo woocommerce --fromDate <%= fromDate %>' +
+					' --authToken <%= authToken %> --cols 6 --sortBy contributions --format md --sortOrder desc' +
+					' --showlogin true > contributors.md'
 				].join( '&&' )
 			}
 		},
@@ -277,7 +285,8 @@ module.exports = function( grunt ) {
 						{
 							config: 'authToken',
 							type: 'input',
-							message: '(optional) Provide a personal access token. This will allow 5000 requests per hour rather than 60 - use if nothing is generated.'
+							message: '(optional) Provide a personal access token.' +
+							' This will allow 5000 requests per hour rather than 60 - use if nothing is generated.'
 						}
 					]
 				}

--- a/package.json
+++ b/package.json
@@ -54,14 +54,15 @@
     "istanbul": "1.0.0-alpha.2",
     "lint-staged": "8.1.0",
     "mocha": "5.2.0",
+    "node-sass": "4.11.0",
     "prettier": "github:automattic/calypso-prettier#c56b4251",
     "stylelint": "9.10.1",
     "stylelint-config-wordpress": "13.1.0",
     "wc-e2e-page-objects": "0.10.0"
   },
   "engines": {
-    "node": ">=8.9.3",
-    "npm": ">=5.5.1"
+    "node": ">=10.15.0",
+    "npm": ">=6.4.1"
   },
   "dependencies": {
     "github-contributors-list": "https://github.com/woocommerce/github-contributors-list/tarball/master"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue where grunt-sass now requires either the use of node-sass or dart-sass for compilation. It also enabled es6 for linting instead of the default es5 as well as introducing new minimum versions for node/npm and fixing a couple of es6 liniting issues.

### How to test the changes in this Pull Request:

1. Delete your node_modules folder.
2. Run `npm update`
3. Then run `grunt sass` en ensure it compiles new css files without any errors.
