### PR TITLE
Filter for modifying the user queries on customer reports

### DIFF
--- a/includes/admin/reports/class-wc-report-customer-list.php
+++ b/includes/admin/reports/class-wc-report-customer-list.php
@@ -278,10 +278,13 @@ class WC_Report_Customer_List extends WP_List_Table {
 		);
 
 		$query = new WP_User_Query(
-			array(
-				'exclude' => array_merge( $admin_users->get_results(), $manager_users->get_results() ),
-				'number'  => $per_page,
-				'offset'  => ( $current_page - 1 ) * $per_page,
+			apply_filters(
+				'woocommerce_admin_report_customer_list_user_query_args',
+				array(
+					'exclude' => array_merge( $admin_users->get_results(), $manager_users->get_results() ),
+					'number'  => $per_page,
+					'offset'  => ( $current_page - 1 ) * $per_page,
+				)
 			)
 		);
 

--- a/includes/admin/reports/class-wc-report-customer-list.php
+++ b/includes/admin/reports/class-wc-report-customer-list.php
@@ -1,7 +1,12 @@
 <?php
+/**
+ * Class WC_Report_Customer_List file.
+ *
+ * @package WooCommerce\Reports
+ */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 if ( ! class_exists( 'WP_List_Table' ) ) {
@@ -11,8 +16,6 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 /**
  * WC_Report_Customer_List.
  *
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce/Admin/Reports
  * @version     2.1.0
  */
@@ -36,7 +39,7 @@ class WC_Report_Customer_List extends WP_List_Table {
 	 * No items found text.
 	 */
 	public function no_items() {
-		_e( 'No customers found.', 'woocommerce' );
+		esc_html_e( 'No customers found.', 'woocommerce' );
 	}
 
 	/**
@@ -47,20 +50,20 @@ class WC_Report_Customer_List extends WP_List_Table {
 
 		echo '<div id="poststuff" class="woocommerce-reports-wide">';
 
-		if ( ! empty( $_GET['link_orders'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'link_orders' ) ) {
+		if ( ! empty( $_GET['link_orders'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'link_orders' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 			$linked = wc_update_new_customer_past_orders( absint( $_GET['link_orders'] ) );
-
-			echo '<div class="updated"><p>' . sprintf( _n( '%s previous order linked', '%s previous orders linked', $linked, 'woocommerce' ), $linked ) . '</p></div>';
+			/* translators: single or plural number of orders */
+			echo '<div class="updated"><p>' . sprintf( esc_html( _n( '%s previous order linked', '%s previous orders linked', $linked, 'woocommerce' ), $linked ) ) . '</p></div>';
 		}
 
-		if ( ! empty( $_GET['refresh'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'refresh' ) ) {
+		if ( ! empty( $_GET['refresh'] ) && wp_verify_nonce( $_REQUEST['_wpnonce'], 'refresh' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 			$user_id = absint( $_GET['refresh'] );
 			$user    = get_user_by( 'id', $user_id );
 
 			delete_user_meta( $user_id, '_money_spent' );
 			delete_user_meta( $user_id, '_order_count' );
-
-			echo '<div class="updated"><p>' . sprintf( __( 'Refreshed stats for %s', 'woocommerce' ), $user->display_name ) . '</p></div>';
+			/* translators: User display name */
+			echo '<div class="updated"><p>' . sprintf( esc_html__( 'Refreshed stats for %s', 'woocommerce' ), esc_html( $user->display_name ) ) . '</p></div>';
 		}
 
 		echo '<form method="post" id="woocommerce_customers">';
@@ -75,8 +78,8 @@ class WC_Report_Customer_List extends WP_List_Table {
 	/**
 	 * Get column value.
 	 *
-	 * @param WP_User $user
-	 * @param string  $column_name
+	 * @param WP_User $user WP User object.
+	 * @param string  $column_name Column name.
 	 * @return string
 	 */
 	public function column_default( $user, $column_name ) {
@@ -224,14 +227,13 @@ class WC_Report_Customer_List extends WP_List_Table {
 	/**
 	 * Order users by name.
 	 *
-	 * @param WP_User_Query $query
-	 *
+	 * @param WP_User_Query $query Query that gets passed through.
 	 * @return WP_User_Query
 	 */
 	public function order_by_last_name( $query ) {
 		global $wpdb;
 
-		$s = ! empty( $_REQUEST['s'] ) ? stripslashes( $_REQUEST['s'] ) : '';
+		$s = ! empty( $_REQUEST['s'] ) ? wp_unslash( $_REQUEST['s'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		$query->query_from   .= " LEFT JOIN {$wpdb->usermeta} as meta2 ON ({$wpdb->users}.ID = meta2.user_id) ";
 		$query->query_where  .= " AND meta2.meta_key = 'last_name' ";

--- a/includes/admin/reports/class-wc-report-customers.php
+++ b/includes/admin/reports/class-wc-report-customers.php
@@ -203,9 +203,12 @@ class WC_Report_Customers extends WC_Admin_Report {
 		);
 
 		$users_query = new WP_User_Query(
-			array(
-				'fields'  => array( 'user_registered' ),
-				'exclude' => array_merge( $admin_users->get_results(), $manager_users->get_results() ),
+			apply_filters(
+				'woocommerce_admin_report_customers_user_query_args',
+				array(
+					'fields'  => array( 'user_registered' ),
+					'exclude' => array_merge( $admin_users->get_results(), $manager_users->get_results() ),
+				)
 			)
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #22579 

### How to test the changes in this Pull Request:

1. Use new filters `woocommerce_admin_report_customers_user_query_args` and `woocommerce_admin_report_customer_list_user_query_args` to alter the user queries to display the customers in the report.
2. Check that the new filters are running your new queries and displaying the correct users and their relevant data.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added - woocommerce_admin_report_customer_list_user_query_args and woocommerce_admin_report_customers_user_query_args for altering the users being displayed in the customer reports.
