### PR TITLE
Performance: Remove external lookup of ips on localhost

### DIFF
--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -148,7 +148,7 @@ class WC_Geolocation {
 
 	/**
 	 * Get user IP Address using an external service.
-	 * This is used mainly as a fallback for users on localhost where
+	 * This can be used as a fallback for users on localhost where
 	 * get_ip_address() will be a local IP and non-geolocatable.
 	 *
 	 * @return string
@@ -215,11 +215,6 @@ class WC_Geolocation {
 					$country_code = self::geolocate_via_api( $ip_address );
 				} else {
 					$country_code = '';
-				}
-
-				if ( ! $country_code && $fallback ) {
-					// May be a local environment - find external IP.
-					return self::geolocate_ip( self::get_external_ip_address(), false, $api_fallback );
 				}
 			}
 		}

--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -191,7 +191,7 @@ class WC_Geolocation {
 	 * @param  bool   $api_fallback If true, uses geolocation APIs if the database file doesn't exist (can be slower).
 	 * @return array
 	 */
-	public static function geolocate_ip( $ip_address = '', $fallback = true, $api_fallback = true ) {
+	public static function geolocate_ip( $ip_address = '', $fallback = false, $api_fallback = true ) {
 		// Filter to allow custom geolocation of the IP address.
 		$country_code = apply_filters( 'woocommerce_geolocate_ip', false, $ip_address, $fallback, $api_fallback );
 
@@ -215,6 +215,11 @@ class WC_Geolocation {
 					$country_code = self::geolocate_via_api( $ip_address );
 				} else {
 					$country_code = '';
+				}
+
+				if ( ! $country_code && $fallback ) {
+					// May be a local environment - find external IP.
+					return self::geolocate_ip( self::get_external_ip_address(), false, $api_fallback );
 				}
 			}
 		}

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1079,7 +1079,7 @@ function wc_get_customer_default_location() {
 			$ua = strtolower( wc_get_user_agent() );
 
 			if ( ! strstr( $ua, 'bot' ) && ! strstr( $ua, 'spider' ) && ! strstr( $ua, 'crawl' ) ) {
-				$location = WC_Geolocation::geolocate_ip( '', true, false );
+				$location = WC_Geolocation::geolocate_ip( '', false, false );
 			}
 
 			// Base fallback.


### PR DESCRIPTION
Remove external lookups of IPs. This is only useful on localhost where an IP cannot be found, but it's expensive. Without this code in place, WC will fallback to the base location which is an acceptable compromise.

Left the method in place for BW compatibility.