### PR TITLE
Performance: wc_get_product_class

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -88,6 +88,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		'attributes'         => array(),
 		'default_attributes' => array(),
 		'menu_order'         => 0,
+		'post_password'      => '',
 		'virtual'            => false,
 		'downloadable'       => false,
 		'category_ids'       => array(),
@@ -547,6 +548,17 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 */
 	public function get_menu_order( $context = 'view' ) {
 		return $this->get_prop( 'menu_order', $context );
+	}
+
+	/**
+	 * Get post password.
+	 *
+	 * @since  3.6.0
+	 * @param  string $context What the value is for. Valid values are view and edit.
+	 * @return int
+	 */
+	public function get_post_password( $context = 'view' ) {
+		return $this->get_prop( 'post_password', $context );
 	}
 
 	/**
@@ -1122,6 +1134,16 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 */
 	public function set_menu_order( $menu_order ) {
 		$this->set_prop( 'menu_order', intval( $menu_order ) );
+	}
+
+	/**
+	 * Set post password.
+	 *
+	 * @since 3.6.0
+	 * @param int $post_password Post password.
+	 */
+	public function set_post_password( $post_password ) {
+		$this->set_prop( 'post_password', $post_password );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -111,6 +111,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					'comment_status' => $product->get_reviews_allowed() ? 'open' : 'closed',
 					'ping_status'    => 'closed',
 					'menu_order'     => $product->get_menu_order(),
+					'post_password'  => $product->get_post_password( 'edit' ),
 					'post_date'      => gmdate( 'Y-m-d H:i:s', $product->get_date_created( 'edit' )->getOffsetTimestamp() ),
 					'post_date_gmt'  => gmdate( 'Y-m-d H:i:s', $product->get_date_created( 'edit' )->getTimestamp() ),
 					'post_name'      => $product->get_slug( 'edit' ),
@@ -163,6 +164,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				'short_description' => $post_object->post_excerpt,
 				'parent_id'         => $post_object->post_parent,
 				'menu_order'        => $post_object->menu_order,
+				'post_password'     => $post_object->post_password,
 				'reviews_allowed'   => 'open' === $post_object->comment_status,
 			)
 		);
@@ -194,6 +196,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				'comment_status' => $product->get_reviews_allowed( 'edit' ) ? 'open' : 'closed',
 				'post_status'    => $product->get_status( 'edit' ) ? $product->get_status( 'edit' ) : 'publish',
 				'menu_order'     => $product->get_menu_order( 'edit' ),
+				'post_password'  => $product->get_post_password( 'edit' ),
 				'post_name'      => $product->get_slug( 'edit' ),
 				'post_type'      => 'product',
 			);

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -560,7 +560,7 @@ function wc_get_product_class( $class = '', $product_id = null ) {
 		$product    = $product_id;
 		$product_id = $product_id->get_id();
 	} else {
-		$product = wc_get_product( $post->ID );
+		$product = wc_get_product( $product_id );
 	}
 
 	if ( ! is_array( $class ) ) {

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -627,9 +627,10 @@ function wc_get_product_class( $class = '', $product_id = null ) {
 	// Include attributes and any extra taxonomies only if enabled via the hook - this is a performance issue.
 	if ( apply_filters( 'woocommerce_get_product_class_include_taxonomies', false ) ) {
 		$taxonomies = get_taxonomies( array( 'public' => true ) );
+		$type       = 'variation' === $product->get_type() ? 'product_variation' : 'product';
 		foreach ( (array) $taxonomies as $taxonomy ) {
-			if ( is_object_in_taxonomy( $post->post_type, $taxonomy ) && ! in_array( $taxonomy, array( 'product_cat', 'product_tag' ), true ) ) {
-				$classes = array_merge( $classes, wc_get_product_taxonomy_class( (array) get_the_terms( $post->ID, $taxonomy ), $taxonomy ) );
+			if ( is_object_in_taxonomy( $type, $taxonomy ) && ! in_array( $taxonomy, array( 'product_cat', 'product_tag' ), true ) ) {
+				$classes = array_merge( $classes, wc_get_product_taxonomy_class( (array) get_the_terms( $product->get_id(), $taxonomy ), $taxonomy ) );
 			}
 		}
 	}

--- a/templates/content-product.php
+++ b/templates/content-product.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.4.0
+ * @version 3.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -24,7 +24,7 @@ if ( empty( $product ) || ! $product->is_visible() ) {
 	return;
 }
 ?>
-<li <?php wc_product_class(); ?>>
+<li <?php wc_product_class( '', $product ); ?>>
 	<?php
 	/**
 	 * Hook: woocommerce_before_shop_loop_item.

--- a/templates/content-single-product.php
+++ b/templates/content-single-product.php
@@ -12,10 +12,12 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.4.0
+ * @version 3.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
+
+global $product;
 
 /**
  * Hook: woocommerce_before_single_product.
@@ -29,7 +31,7 @@ if ( post_password_required() ) {
 	return;
 }
 ?>
-<div id="product-<?php the_ID(); ?>" <?php wc_product_class(); ?>>
+<div id="product-<?php the_ID(); ?>" <?php wc_product_class( '', $product ); ?>>
 
 	<?php
 	/**

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -39,7 +39,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 				$post               = $post_object; // WPCS: override ok.
 				setup_postdata( $post );
 
-				echo '<tr id="product-' . esc_attr( $grouped_product_child->get_id() ) . '" class="woocommerce-grouped-product-list-item ' . esc_attr( implode( ' ', wc_get_product_class( '', $grouped_product_child->get_id() ) ) ) . '">';
+				echo '<tr id="product-' . esc_attr( $grouped_product_child->get_id() ) . '" class="woocommerce-grouped-product-list-item ' . esc_attr( implode( ' ', wc_get_product_class( '', $grouped_product_child ) ) ) . '">';
 
 				// Output columns for each product.
 				foreach ( $grouped_product_columns as $column_id ) {

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -1,10 +1,13 @@
 <?php
-
 /**
  * Test template funcitons.
  *
  * @package WooCommerce/Tests/Templates
  * @since   3.4.0
+ */
+
+/**
+ * WC_Tests_Template_Functions class.
  */
 class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 
@@ -26,52 +29,61 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$product->set_category_ids( array( $category['term_id'] ) );
 		$product->save();
 
+		$product  = wc_get_product( $product ); // Reload so status is current.
 		$expected = array(
 			'foo',
-			'post-' . $product->get_id(),
 			'product',
 			'type-product',
+			'post-' . $product->get_id(),
 			'status-publish',
-			'product_cat-some-category',
 			'first',
 			'instock',
+			'product_cat-some-category',
 			'sale',
 			'virtual',
 			'purchasable',
 			'product-type-simple',
 		);
+		$actual = array_values( wc_get_product_class( 'foo', $product ) );
 
-		$this->assertEquals( $expected, array_values( wc_get_product_class( 'foo', $product ) ) );
+		$this->assertEquals( $expected, $actual, print_r( $actual, true ) );
 
 		// All taxonomies.
 		add_filter( 'woocommerce_get_product_class_include_taxonomies', '__return_true' );
 		$expected = array(
 			'foo',
-			'post-' . $product->get_id(),
 			'product',
 			'type-product',
+			'post-' . $product->get_id(),
 			'status-publish',
-			'product_cat-some-category',
 			'instock',
+			'product_cat-some-category',
 			'sale',
 			'virtual',
 			'purchasable',
 			'product-type-simple',
 		);
+		$actual = array_values( wc_get_product_class( 'foo', $product ) );
 
-		$this->assertEquals( $expected, array_values( wc_get_product_class( 'foo', $product ) ) );
+		$this->assertEquals( $expected, $actual, print_r( $actual, true ) );
 		add_filter( 'woocommerce_get_product_class_include_taxonomies', '__return_false' );
 
 		$product->delete( true );
 		wp_delete_term( $category['term_id'], 'product_cat' );
 	}
 
+	/**
+	 * Test: test_wc_dropdown_variation_attribute_options_no_attributes.
+	 */
 	public function test_wc_dropdown_variation_attribute_options_no_attributes() {
 		$this->expectOutputString( '<select id="" class="" name="attribute_" data-attribute_name="attribute_" data-show_option_none="yes"><option value="">Choose an option</option></select>' );
 
 		wc_dropdown_variation_attribute_options();
 	}
 
+	/**
+	 * Test: test_wc_dropdown_variation_attribute_options_should_return_attributes_list.
+	 */
 	public function test_wc_dropdown_variation_attribute_options_should_return_attributes_list() {
 		$product = WC_Helper_Product::create_variation_product();
 
@@ -85,6 +97,9 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * Test: test_wc_dropdown_variation_attribute_options_should_return_attributes_list_and_selected_element.
+	 */
 	public function test_wc_dropdown_variation_attribute_options_should_return_attributes_list_and_selected_element() {
 		$product = WC_Helper_Product::create_variation_product();
 		$_REQUEST['attribute_pa_size'] = 'large';


### PR DESCRIPTION
`wc_get_product_class` and related functions were slow when profiling. This was largely due to the way in which they need to re-read the product object before outputting CSS classnames.

This PR pases the $product object around to avoid the need to re-read the product.

This PR also removes the need to lookup $post to get a post_password - I've added a getter and setter to our product class.

Finally, this PR removes the need to have 2 differnet product CSS class generation functions (one was hooked in). When using `wc_get_product_class` we don't need to filter to add more classnames, we can just do it in `wc_get_product_class`.

To test, load up PR and ensure products LI's on the shop page have classes e.g. `product type-product` and so on.