### PR TITLE
apply_filters_deprecated to avoid conflict with wp profile

### DIFF
--- a/includes/class-wc-deprecated-filter-hooks.php
+++ b/includes/class-wc-deprecated-filter-hooks.php
@@ -56,21 +56,8 @@ class WC_Deprecated_Filter_Hooks extends WC_Deprecated_Hooks {
 		'default_checkout_billing_postcode'          => 'default_checkout_postcode',
 		'woocommerce_system_status_environment_rows' => 'woocommerce_debug_posting',
 		'woocommerce_credit_card_type_labels'        => 'wocommerce_credit_card_type_labels',
-		'woocommerce_get_script_data'                => array(
-			'woocommerce_params',
-			'wc_geolocation_params',
-			'wc_single_product_params',
-			'wc_checkout_params',
-			'wc_address_i18n_params',
-			'wc_cart_params',
-			'wc_cart_fragments_params',
-			'wc_add_to_cart_params',
-			'wc_add_to_cart_variation_params',
-			'wc_country_select_params',
-			'wc_password_strength_meter_params',
-		),
-		'woocommerce_settings_tabs_advanced' => 'woocommerce_settings_tabs_api',
-		'woocommerce_settings_advanced'      => 'woocommerce_settings_api',
+		'woocommerce_settings_tabs_advanced'         => 'woocommerce_settings_tabs_api',
+		'woocommerce_settings_advanced'              => 'woocommerce_settings_api',
 	);
 
 	/**

--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -591,6 +591,8 @@ class WC_Frontend_Scripts {
 				$params = false;
 		}
 
+		$params = apply_filters_deprecated( $handle . '_params', array( $params ), '3.0.0', 'woocommerce_get_script_data' );
+
 		return apply_filters( 'woocommerce_get_script_data', $params, $handle );
 	}
 


### PR DESCRIPTION
This is a small change to avoid deprecated notices appearing when running the CLI `wp profile` command. Simply moves the deprecation handling inline.

This is also part of https://github.com/woocommerce/woocommerce/issues/22598 :)