### PR TITLE
Performance: caching of template loader, product type, and layered nav widget

### DIFF
--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -354,6 +354,8 @@ abstract class WC_Widget extends WP_Widget {
 			}
 		}
 
+		wp_cache_set( $cache_key, $link, 'woocommerce' );
+
 		return apply_filters( 'woocommerce_widget_get_current_page_url', $link, $this );
 	}
 

--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -289,11 +289,11 @@ abstract class WC_Widget extends WP_Widget {
 	 * @since  3.3.0
 	 */
 	protected function get_current_page_url() {
-		$cache_key    = 'woocommerce_widget_get_current_page_url';
-		$cached_value = (string) wp_cache_get( $cache_key, 'woocommerce' );
+		$cache_key   = 'widget_current_page_url';
+		$cache_value = wp_cache_get( $cache_key, 'woocommerce' );
 
-		if ( $cached_value ) {
-			return apply_filters( 'woocommerce_widget_get_current_page_url', $cached_value, $this );
+		if ( $cache_value ) {
+			return apply_filters( 'woocommerce_widget_get_current_page_url', $cache_value, $this );
 		}
 
 		if ( defined( 'SHOP_IS_ON_FRONT' ) ) {

--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -289,6 +289,13 @@ abstract class WC_Widget extends WP_Widget {
 	 * @since  3.3.0
 	 */
 	protected function get_current_page_url() {
+		$cache_key    = 'woocommerce_widget_get_current_page_url';
+		$cached_value = (string) wp_cache_get( $cache_key, 'woocommerce' );
+
+		if ( $cached_value ) {
+			return apply_filters( 'woocommerce_widget_get_current_page_url', $cached_value, $this );
+		}
+
 		if ( defined( 'SHOP_IS_ON_FRONT' ) ) {
 			$link = home_url();
 		} elseif ( is_shop() ) {

--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -289,13 +289,6 @@ abstract class WC_Widget extends WP_Widget {
 	 * @since  3.3.0
 	 */
 	protected function get_current_page_url() {
-		$cache_key   = 'widget_current_page_url';
-		$cache_value = wp_cache_get( $cache_key, 'woocommerce' );
-
-		if ( $cache_value ) {
-			return apply_filters( 'woocommerce_widget_get_current_page_url', $cache_value, $this );
-		}
-
 		if ( defined( 'SHOP_IS_ON_FRONT' ) ) {
 			$link = home_url();
 		} elseif ( is_shop() ) {
@@ -353,8 +346,6 @@ abstract class WC_Widget extends WP_Widget {
 				}
 			}
 		}
-
-		wp_cache_set( $cache_key, $link, 'woocommerce' );
 
 		return apply_filters( 'woocommerce_widget_get_current_page_url', $link, $this );
 	}

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -721,13 +721,13 @@ class WC_Tax {
 	 * @return array Array of class slugs ("reduced-rate", "zero-rate", etc).
 	 */
 	public static function get_tax_class_slugs() {
-		$cache_key = 'tax_class_slugs';
-		$slugs     = wp_cache_get( $cache_key, 'woocommerce' );
+		$cache_key = WC_Cache_Helper::get_cache_prefix( 'taxes' ) . '-slugs';
+		$slugs     = wp_cache_get( $cache_key, 'taxes' );
 
 		if ( ! $slugs ) {
 			$slugs = array_filter( array_map( 'sanitize_title', self::get_tax_classes() ) );
 
-			wp_cache_set( $cache_key, $slugs, 'woocommerce' );
+			wp_cache_set( $cache_key, $slugs, 'taxes' );
 		}
 
 		return $slugs;

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -721,7 +721,16 @@ class WC_Tax {
 	 * @return array Array of class slugs ("reduced-rate", "zero-rate", etc).
 	 */
 	public static function get_tax_class_slugs() {
-		return array_filter( array_map( 'sanitize_title', self::get_tax_classes() ) );
+		$cache_key = 'tax_class_slugs';
+		$slugs     = wp_cache_get( $cache_key, 'woocommerce' );
+
+		if ( ! $slugs ) {
+			$slugs = array_filter( array_map( 'sanitize_title', self::get_tax_classes() ) );
+
+			wp_cache_set( $cache_key, $slugs, 'woocommerce' );
+		}
+
+		return $slugs;
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1503,7 +1503,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @return bool|string
 	 */
 	public function get_product_type( $product_id ) {
-		$cache_key    = WC_Cache_Helper::get_cache_prefix( 'product_' . $product->get_id() ) . '_type_' . $product_id;
+		$cache_key    = WC_Cache_Helper::get_cache_prefix( 'product_' . $product_id ) . '_type_' . $product_id;
 		$product_type = wp_cache_get( $cache_key, 'products' );
 
 		if ( $product_type ) {

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1503,15 +1503,27 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @return bool|string
 	 */
 	public function get_product_type( $product_id ) {
-		$post_type = get_post_type( $product_id );
-		if ( 'product_variation' === $post_type ) {
-			return 'variation';
-		} elseif ( 'product' === $post_type ) {
-			$terms = get_the_terms( $product_id, 'product_type' );
-			return ! empty( $terms ) ? sanitize_title( current( $terms )->name ) : 'simple';
-		} else {
-			return false;
+		$cache_key    = WC_Cache_Helper::get_cache_prefix( 'product_' . $product->get_id() ) . '_type_' . $product_id;
+		$product_type = wp_cache_get( $cache_key, 'products' );
+
+		if ( $product_type ) {
+			return $product_type;
 		}
+
+		$post_type = get_post_type( $product_id );
+
+		if ( 'product_variation' === $post_type ) {
+			$product_type = 'variation';
+		} elseif ( 'product' === $post_type ) {
+			$terms        = get_the_terms( $product_id, 'product_type' );
+			$product_type = ! empty( $terms ) ? sanitize_title( current( $terms )->name ) : 'simple';
+		} else {
+			$product_type = false;
+		}
+
+		wp_cache_set( $cache_key, $product_type, 'products' );
+
+		return $product_type;
 	}
 
 	/**

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -678,6 +678,16 @@ function wc_delete_attribute( $id ) {
  * @return string
  */
 function wc_attribute_taxonomy_slug( $attribute_name ) {
+	$cache_key   = 'slug-' . $attribute_name;
+	$cache_value = wp_cache_get( $cache_key, 'woocommerce-attributes' );
+
+	if ( $cache_value ) {
+		return $cache_value;
+	}
+
 	$attribute_name = wc_sanitize_taxonomy_name( $attribute_name );
-	return 0 === strpos( $attribute_name, 'pa_' ) ? substr( $attribute_name, 3 ) : $attribute_name;
+	$attribute_slug = 0 === strpos( $attribute_name, 'pa_' ) ? substr( $attribute_name, 3 ) : $attribute_name;
+	wp_cache_set( $cache_key, $attribute_slug, 'woocommerce-attributes' );
+
+	return $attribute_slug;
 }

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -159,19 +159,28 @@ function wc_update_order( $args ) {
 function wc_get_template_part( $slug, $name = '' ) {
 	$template = '';
 
-	// Look in yourtheme/slug-name.php and yourtheme/woocommerce/slug-name.php.
-	if ( $name && ! WC_TEMPLATE_DEBUG_MODE ) {
-		$template = locate_template( array( "{$slug}-{$name}.php", WC()->template_path() . "{$slug}-{$name}.php" ) );
+	if ( $name ) {
+		$template = WC_TEMPLATE_DEBUG_MODE ? '' : locate_template(
+			array(
+				"{$slug}-{$name}.php",
+				WC()->template_path() . "{$slug}-{$name}.php",
+			)
+		);
+
+		if ( ! $template ) {
+			$fallback = WC()->plugin_path() . "/templates/{$slug}-{$name}.php";
+			$template = file_exists( $fallback ) ? $fallback : '';
+		}
 	}
 
-	// Get default slug-name.php.
-	if ( ! $template && $name && file_exists( WC()->plugin_path() . "/templates/{$slug}-{$name}.php" ) ) {
-		$template = WC()->plugin_path() . "/templates/{$slug}-{$name}.php";
-	}
-
-	// If template file doesn't exist, look in yourtheme/slug.php and yourtheme/woocommerce/slug.php.
-	if ( ! $template && ! WC_TEMPLATE_DEBUG_MODE ) {
-		$template = locate_template( array( "{$slug}.php", WC()->template_path() . "{$slug}.php" ) );
+	if ( ! $template ) {
+		// If template file doesn't exist, look in yourtheme/slug.php and yourtheme/woocommerce/slug.php.
+		$template = WC_TEMPLATE_DEBUG_MODE ? '' : locate_template(
+			array(
+				"{$slug}.php",
+				WC()->template_path() . "{$slug}.php",
+			)
+		);
 	}
 
 	// Allow 3rd party plugins to filter template file from their plugin.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -203,12 +203,15 @@ function wc_get_template( $template_name, $args = array(), $template_path = '', 
 	$located = wc_locate_template( $template_name, $template_path, $default_path );
 
 	// Allow 3rd party plugin filter template file from their plugin.
-	$located = apply_filters( 'wc_get_template', $located, $template_name, $args, $template_path, $default_path );
+	$filter_located = apply_filters( 'wc_get_template', $located, $template_name, $args, $template_path, $default_path );
 
-	if ( ! file_exists( $located ) ) {
-		/* translators: %s template */
-		wc_doing_it_wrong( __FUNCTION__, sprintf( __( '%s does not exist.', 'woocommerce' ), '<code>' . $located . '</code>' ), '2.1' );
-		return;
+	if ( $filter_located !== $located ) {
+		if ( ! file_exists( $filter_located ) ) {
+			/* translators: %s template */
+			wc_doing_it_wrong( __FUNCTION__, sprintf( __( '%s does not exist.', 'woocommerce' ), '<code>' . $located . '</code>' ), '2.1' );
+			return;
+		}
+		$located = $filter_located;
 	}
 
 	$action_args = array(

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -398,6 +398,8 @@ function wc_reset_product_grid_settings() {
 	if ( ! empty( $product_grid['default_columns'] ) ) {
 		update_option( 'woocommerce_catalog_columns', absint( $product_grid['default_columns'] ) );
 	}
+
+	wp_cache_flush(); // Flush any caches which could impact settings or templates.
 }
 add_action( 'after_switch_theme', 'wc_reset_product_grid_settings' );
 

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -458,8 +458,8 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			}
 
 			if ( $count > 0 || $option_is_set ) {
-				$link      = esc_url( apply_filters( 'woocommerce_layered_nav_link', $link, $term, $taxonomy ) );
-				$term_html = '<a rel="nofollow" href="' . $link . '">' . esc_html( $term->name ) . '</a>';
+				$link      = apply_filters( 'woocommerce_layered_nav_link', $link, $term, $taxonomy );
+				$term_html = '<a rel="nofollow" href="' . esc_url( $link ) . '">' . esc_html( $term->name ) . '</a>';
 			} else {
 				$link      = false;
 				$term_html = '<span>' . esc_html( $term->name ) . '</span>';
@@ -468,7 +468,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			$term_html .= ' ' . apply_filters( 'woocommerce_layered_nav_count', '<span class="count">(' . absint( $count ) . ')</span>', $count, $term );
 
 			echo '<li class="woocommerce-widget-layered-nav-list__item wc-layered-nav-term ' . ( $option_is_set ? 'woocommerce-widget-layered-nav-list__item--chosen chosen' : '' ) . '">';
-			echo wp_kses_post( apply_filters( 'woocommerce_layered_nav_term_html', $term_html, $term, $link, $count ) );
+			echo apply_filters( 'woocommerce_layered_nav_term_html', $term_html, $term, $link, $count ); // WPCS: XSS ok.
 			echo '</li>';
 		}
 

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -405,6 +405,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		$term_counts        = $this->get_filtered_term_product_counts( wp_list_pluck( $terms, 'term_id' ), $taxonomy, $query_type );
 		$_chosen_attributes = WC_Query::get_layered_nav_chosen_attributes();
 		$found              = false;
+		$base_link          = $this->get_current_page_url();
 
 		foreach ( $terms as $term ) {
 			$current_values = isset( $_chosen_attributes[ $taxonomy ]['terms'] ) ? $_chosen_attributes[ $taxonomy ]['terms'] : array();
@@ -431,7 +432,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 				$current_filter[] = $term->slug;
 			}
 
-			$link = remove_query_arg( $filter_name, $this->get_current_page_url() );
+			$link = remove_query_arg( $filter_name, $base_link );
 
 			// Add current filters to URL.
 			foreach ( $current_filter as $key => $value ) {

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -99,6 +99,7 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 
 		$found         = false;
 		$rating_filter = isset( $_GET['rating_filter'] ) ? array_filter( array_map( 'absint', explode( ',', wp_unslash( $_GET['rating_filter'] ) ) ) ) : array(); // WPCS: input var ok, CSRF ok, sanitization ok.
+		$base_link     = $this->get_current_page_url();
 
 		$this->widget_start( $args, $instance );
 
@@ -110,7 +111,7 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 				continue;
 			}
 			$found = true;
-			$link  = $this->get_current_page_url();
+			$link  = $base_link;
 
 			if ( in_array( $rating, $rating_filter, true ) ) {
 				$link_ratings = implode( ',', array_diff( $rating_filter, array( $rating ) ) );


### PR DESCRIPTION
This PR introduces some extra caching to improve performnace and repetitive calls to the same functions.

- `get_tax_class_slugs` - Caches the return value to avoid name lookup and sanitization.
- `get_product_type` - Caches the type to avoid reading the terms multiple times.
- `wc_attribute_taxonomy_slug` - Caches the return value to avoid name lookup and sanitization.
- `wc_get_template_part`  and `wc_get_template` -  These functions look for template files within the theme and core. Without caching, it repeats hundreds of `file_exists` checks which are not neccessary. Templates do not change.

Rather than WP cache for `get_current_page_url`, I reverted that and improved the widgets instead. It doesn't change per page, but should not persist.