### PR TITLE
Performance: rest api includes

### DIFF
--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -45,6 +45,9 @@ class WC_API extends WC_Legacy_API {
 	 * @since 2.6.0
 	 */
 	private function rest_api_init() {
+		// Authentication needs to run early to handle basic auth.
+		include_once dirname( __FILE__ ) . '/api/class-wc-rest-authentication.php';
+
 		add_action( 'rest_api_init', array( $this, 'rest_api_includes' ), 5 );
 		add_action( 'rest_api_init', array( $this, 'register_rest_routes' ), 10 );
 	}
@@ -123,9 +126,6 @@ class WC_API extends WC_Legacy_API {
 	public function rest_api_includes() {
 		// Exception handler.
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-exception.php';
-
-		// Authentication.
-		include_once dirname( __FILE__ ) . '/api/class-wc-rest-authentication.php';
 
 		// Abstract controllers.
 		include_once dirname( __FILE__ ) . '/abstracts/abstract-wc-rest-controller.php';


### PR DESCRIPTION
This PR defers the inclusion of REST API includes so they are only loaded during REST API requests, and not on all pages, using the `rest_api_init` hook.

Note: The auth class needs to be loaded on all, since this code runs before `rest_api_init` is fired. Without this, basic auth fails. 

To test this, check the following APIs.

1. WP Rest API e.g. https://local.wordpress.test/wp-json/wc/v3/products
2. Auth endpoint e.g. http://local.wordpress.test/wc-auth/v1/authorize?app_name=My%20App%20Name&scope=read_write&user_id=123&return_url=http://app.com/return-page&callback_url=https://app.com/callback-endpoint
3. Legacy API e.g. https://local.wordpress.test/wc-api/v3/products

cc @claudiosanches 
