### PR TITLE
Implement main_query parameter in get_meta_query

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -515,7 +515,7 @@ class WC_Query {
 		global $wpdb, $wp_query;
 
 		if ( isset( $wp_query->queried_object, $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy ) && is_a( $wp_query->queried_object, 'WP_Term' ) ) {
-			$search_within_terms = get_terms(
+			$search_within_terms   = get_terms(
 				array(
 					'taxonomy' => $wp_query->queried_object->taxonomy,
 					'child_of' => $wp_query->queried_object->term_id,
@@ -550,7 +550,7 @@ class WC_Query {
 		global $wpdb, $wp_query;
 
 		if ( isset( $wp_query->queried_object, $wp_query->queried_object->term_taxonomy_id, $wp_query->queried_object->taxonomy ) && is_a( $wp_query->queried_object, 'WP_Term' ) ) {
-			$search_within_terms = get_terms(
+			$search_within_terms   = get_terms(
 				array(
 					'taxonomy' => $wp_query->queried_object->taxonomy,
 					'child_of' => $wp_query->queried_object->term_id,

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -598,12 +598,10 @@ class WC_Query {
 	 * @return array
 	 */
 	public function get_meta_query( $meta_query = array(), $main_query = false ) {
-		global $wp_query;
-
 		if ( ! is_array( $meta_query ) ) {
 			$meta_query = array();
 		}
-		if ( $main_query || $wp_query === self::$product_query ) {
+		if ( $main_query ) {
 			$meta_query['price_filter'] = $this->price_filter_meta_query();
 		}
 		return array_filter( apply_filters( 'woocommerce_product_query_meta_query', $meta_query, $this ) );

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -598,10 +598,14 @@ class WC_Query {
 	 * @return array
 	 */
 	public function get_meta_query( $meta_query = array(), $main_query = false ) {
+		global $wp_query;
+
 		if ( ! is_array( $meta_query ) ) {
 			$meta_query = array();
 		}
-		$meta_query['price_filter'] = $this->price_filter_meta_query();
+		if ( $main_query || $wp_query === self::$product_query ) {
+			$meta_query['price_filter'] = $this->price_filter_meta_query();
+		}
 		return array_filter( apply_filters( 'woocommerce_product_query_meta_query', $meta_query, $this ) );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `$main_query` parameter of `WC_Query::get_meta_query` was not implemented within the function. Both the product shortcode and the Products by Rating used `get_meta_query()` with the default value of `false`. This PR adds the logic to exclude the price meta query filter when `$main_query` is `false` and the product query is not the main query.

Closes #22442 .

### How to test the changes in this Pull Request:

1. Add a product shortcode to a text widget
2. Add the products by rating widget to the sidebar
3. Add the price filter widget to the sidebar
4. Use the price filter to exclude the prices of the highest rated product and the product in the shortcode

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Restrict the price filter widget to filtering the main product query.
