### PR TITLE
WC_Log_Handler_File::remove - fix for MS Windows

### DIFF
--- a/includes/log-handlers/class-wc-log-handler-file.php
+++ b/includes/log-handlers/class-wc-log-handler-file.php
@@ -253,7 +253,7 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 
 		if ( isset( $logs[ $handle ] ) && $logs[ $handle ] ) {
 			$file = realpath( trailingslashit( WC_LOG_DIR ) . $logs[ $handle ] );
-			if ( 0 === stripos( $file, trailingslashit( WC_LOG_DIR ) ) && is_file( $file ) && is_writable( $file ) ) { // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_is_writable
+			if ( 0 === stripos( $file, realpath( trailingslashit( WC_LOG_DIR ) ) ) && is_file( $file ) && is_writable( $file ) ) { // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_is_writable
 				$this->close( $file ); // Close first to be certain no processes keep it alive after it is unlinked.
 				$removed = unlink( $file ); // phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink
 			}


### PR DESCRIPTION
WC_LOG_DIR is defined with Unix slashes at the end. The `realpath` has Windows slashes and therefore `stripos` never works.

Consider also fixing slashes here:
`$this->define( 'WC_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/' );`
