### PR TITLE
fix: Exceeding coupon limit restrictions by adding spaces to email

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1426,7 +1426,7 @@ class WC_Cart extends WC_Legacy_Cart {
 
 				// Get user and posted emails to compare.
 				$current_user = wp_get_current_user();
-				$billing_email = isset( $posted['billing_email'] ) ? $posted['billing_email'] : '';
+				$billing_email = isset( $posted['billing_email'] ) ? wc_clean( $posted['billing_email'] ) : '';
 				$check_emails  = array_unique(
 					array_filter(
 						array_map(


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?



Closes #22623 

### How to test the changes in this Pull Request:

As described in #22623 

