### PR TITLE
Use `get` instead of `load` on cart page

### DIFF
--- a/assets/js/frontend/add-to-cart.js
+++ b/assets/js/frontend/add-to-cart.js
@@ -119,15 +119,13 @@ jQuery( function( $ ) {
 	AddToCartHandler.prototype.updateCartPage = function() {
 		var page = window.location.toString().replace( 'add-to-cart', 'added-to-cart' );
 
-		$( '.shop_table.cart' ).load( page + ' .shop_table.cart:eq(0) > *', function() {
-			$( '.shop_table.cart' ).stop( true ).css( 'opacity', '1' ).unblock();
+		$.get( page, function( data ) {
+			$( '.shop_table.cart:eq(0)' ).replaceWith( $( data ).find( '.shop_table.cart:eq(0)' ) );
+			$( '.cart_totals:eq(0)' ).replaceWith( $( data ).find( '.cart_totals:eq(0)' ) );
+			$( '.cart_totals, .shop_table.cart' ).stop( true ).css( 'opacity', '1' ).unblock();
 			$( document.body ).trigger( 'cart_page_refreshed' );
-		});
-
-		$( '.cart_totals' ).load( page + ' .cart_totals:eq(0) > *', function() {
-			$( '.cart_totals' ).stop( true ).css( 'opacity', '1' ).unblock();
 			$( document.body ).trigger( 'cart_totals_refreshed' );
-		});
+		} );
 	};
 
 	/**


### PR DESCRIPTION
Replaces 2 `load` calls on the cart page to the same URL with a single `get` call which injects both sets of content.

To test,

1. Go to cart page with a cart
2. Run this in the console:

```
jQuery( document.body ).trigger('added_to_cart');
```

You should see 1 ajax request in the network tab, and both the cart table and totals should be updated.

Closes #22260

> Performance * Reduce requests during cart update events.