### PR TITLE
WC Endpoint 404s

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -16,54 +16,52 @@ defined( 'ABSPATH' ) || exit;
 function wc_template_redirect() {
 	global $wp_query, $wp;
 
+	// When default permalinks are enabled, redirect shop page to post type archive url.
 	if ( ! empty( $_GET['page_id'] ) && '' === get_option( 'permalink_structure' ) && wc_get_page_id( 'shop' ) === absint( $_GET['page_id'] ) && get_post_type_archive_link( 'product' ) ) { // WPCS: input var ok, CSRF ok.
-
-		// When default permalinks are enabled, redirect shop page to post type archive url.
 		wp_safe_redirect( get_post_type_archive_link( 'product' ) );
 		exit;
+	}
 
-	} elseif ( is_page( wc_get_page_id( 'checkout' ) ) && wc_get_page_id( 'checkout' ) !== wc_get_page_id( 'cart' ) && WC()->cart->is_empty() && empty( $wp->query_vars['order-pay'] ) && ! isset( $wp->query_vars['order-received'] ) && ! is_customize_preview() && apply_filters( 'woocommerce_checkout_redirect_empty_cart', true ) ) {
-
-		// When on the checkout with an empty cart, redirect to cart page.
+	// When on the checkout with an empty cart, redirect to cart page.
+	if ( is_page( wc_get_page_id( 'checkout' ) ) && wc_get_page_id( 'checkout' ) !== wc_get_page_id( 'cart' ) && WC()->cart->is_empty() && empty( $wp->query_vars['order-pay'] ) && ! isset( $wp->query_vars['order-received'] ) && ! is_customize_preview() && apply_filters( 'woocommerce_checkout_redirect_empty_cart', true ) ) {
 		wc_add_notice( __( 'Checkout is not available whilst your cart is empty.', 'woocommerce' ), 'notice' );
 		wp_safe_redirect( wc_get_page_permalink( 'cart' ) );
 		exit;
 
-	} elseif ( isset( $wp->query_vars['customer-logout'] ) && ! empty( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'customer-logout' ) ) { // WPCS: input var ok, CSRF ok.
+	}
 
-		// Logout.
+	// Logout.
+	if ( isset( $wp->query_vars['customer-logout'] ) && ! empty( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'customer-logout' ) ) { // WPCS: input var ok, CSRF ok.
 		wp_safe_redirect( str_replace( '&amp;', '&', wp_logout_url( wc_get_page_permalink( 'myaccount' ) ) ) );
 		exit;
+	}
 
-	} elseif ( isset( $wp->query_vars['customer-logout'] ) && 'true' === $wp->query_vars['customer-logout'] ) {
-		// Redirect to the correct logout endpoint.
+	// Redirect to the correct logout endpoint.
+	if ( isset( $wp->query_vars['customer-logout'] ) && 'true' === $wp->query_vars['customer-logout'] ) {
 		wp_safe_redirect( esc_url_raw( wc_get_account_endpoint_url( 'customer-logout' ) ) );
 		exit;
+	}
 
 	} elseif ( is_search() && is_post_type_archive( 'product' ) && apply_filters( 'woocommerce_redirect_single_search_result', true ) && 1 === absint( $wp_query->found_posts ) ) {
 
-		// Redirect to the product page if we have a single product.
+	// Redirect to the product page if we have a single product.
+	if ( is_search() && is_post_type_archive( 'product' ) && apply_filters( 'woocommerce_redirect_single_search_result', true ) && 1 === absint( $wp_query->found_posts ) ) {
 		$product = wc_get_product( $wp_query->post );
 
 		if ( $product && $product->is_visible() ) {
 			wp_safe_redirect( get_permalink( $product->get_id() ), 302 );
 			exit;
 		}
-	} elseif ( is_add_payment_method_page() ) {
+	}
 
-		// Ensure payment gateways are loaded early.
-		WC()->payment_gateways();
-
-	} elseif ( is_checkout() ) {
-
-		// Checkout pages handling
+	// Ensure gateways and shipping methods are loaded early.
+	if ( is_add_payment_method_page() || is_checkout() ) {
 		// Buffer the checkout page.
 		ob_start();
 
 		// Ensure gateways and shipping methods are loaded early.
 		WC()->payment_gateways();
 		WC()->shipping();
-
 	}
 }
 add_action( 'template_redirect', 'wc_template_redirect' );

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -42,7 +42,13 @@ function wc_template_redirect() {
 		exit;
 	}
 
-	} elseif ( is_search() && is_post_type_archive( 'product' ) && apply_filters( 'woocommerce_redirect_single_search_result', true ) && 1 === absint( $wp_query->found_posts ) ) {
+	// Trigger 404 if trying to access an endpoint on wrong page.
+	if ( is_wc_endpoint_url() && ! is_account_page() && ! is_checkout() ) {
+		$wp_query->set_404();
+		status_header( 404 );
+		include( get_query_template( '404' ) );
+		exit;
+	}
 
 	// Redirect to the product page if we have a single product.
 	if ( is_search() && is_post_type_archive( 'product' ) && apply_filters( 'woocommerce_redirect_single_search_result', true ) && 1 === absint( $wp_query->found_posts ) ) {


### PR DESCRIPTION
If we're on an endpoint URL, but we're not on checkout or account too, trigger 404.

Closes #21677

To test, try to access an account subpage outside of the account section. e.g.

/my-account/downloads = works
/sample-page/downloads = 404

> Make sure account and checkout endpoints only work under account and checkout pages