### PR TITLE
Accessibility: Add a screen reader label for product rating star icons

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3292,7 +3292,14 @@ function wc_get_stock_html( $product ) {
  * @return string
  */
 function wc_get_rating_html( $rating, $count = 0 ) {
-	$html = 0 < $rating ? '<div class="star-rating" role="img" aria-label="Rated ' . $rating . ' out of 5">' . wc_get_star_rating_html( $rating, $count ) . '</div>' : '';
+	$html = '';
+
+	if ( 0 < $rating ) {
+		/* translators: %s: rating */
+		$label = sprintf( __( 'Rated %s out of 5', 'woocommerce' ), $rating );
+		$html  = '<div class="star-rating" role="img" aria-label="' . esc_attr( $label ) . '">' . wc_get_star_rating_html( $rating, $count ) . '</div>';
+	}
+
 	return apply_filters( 'woocommerce_product_get_rating_html', $html, $rating, $count );
 }
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3292,7 +3292,7 @@ function wc_get_stock_html( $product ) {
  * @return string
  */
 function wc_get_rating_html( $rating, $count = 0 ) {
-	$html = 0 < $rating ? '<div class="star-rating" aria-hidden="true">' . wc_get_star_rating_html( $rating, $count ) . '</div>' : '';
+	$html = 0 < $rating ? '<div class="star-rating" role="img" aria-label="Rated ' . $rating . ' out of 5">' . wc_get_star_rating_html( $rating, $count ) . '</div>' : '';
 	return apply_filters( 'woocommerce_product_get_rating_html', $html, $rating, $count );
 }
 


### PR DESCRIPTION
Fixes #22552 in a better way than #22595 – this PR adds the rating label back into the star ratings div so that screen reader users can still hear the product rating (sorry I didn't get a chance to test this before #22595 was merged).

This adds the `role="img"` to the star rating div, which flags that it's a graphic element. [From MDN:](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Roles/Role_Img)

> most screenreaders will consider the element with role="img" set on it to be to be like a black box, and not access the individual elements inside it.

This means we can use the aria-label to communicate the rating to screen reader users, without worrying about screen readers attempting to read the `:before` content.

### How to test the changes in this Pull Request:

1. View a product with a rating using a screen reader
2. Navigate to the product title, the next item should be the rating.
3. Expect: You should hear something like "Rated 4.50 out of 5"
4. Moving to the next item should be "X customer reviews"

### Changelog entry

> Fix – Read the product rating when using a screen reader