### PR TITLE
Fix sed pw

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -14,9 +14,16 @@
     $ tests/bin/install.sh <db-name> <db-user> <db-password> [db-host]
     ```
 
-Sample usage:
+The `<db-password>` will be set as given. Previously, you would have needed to escape certain characters (forward & backward slashes, and ampersand), but install.sh now escapes them when it needs to internally. You may still need to quote strings with backslashes to prevent them from being processed by the shell or other programs.
+
+Sample usages:
 
     $ tests/bin/install.sh woocommerce_tests root root
+
+    #  The actual password only has a single backslash, but it's escaped
+	#  to prevent the shell and PHP from treating it as a backspace character
+    $ tests/bin/install.sh woocommerce_tests root 'a\\b/&'
+    #  Previously, the password would have had to be passed as 'a\\\\b\/\&'
 
 **Important**: The `<db-name>` database will be created if it doesn't exist and all data will be removed during testing.
 

--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -92,7 +92,7 @@ install_test_suite() {
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		# escape the regex delim if not already escaped (i.e. if preceded by an even number of backslashes)
-		E_DB_PASS=$(echo $DB_PASS | sed -E -e 's%((^|[^\\])(\\\\)*)/%\1\\/%')
+		E_DB_PASS=$(echo $DB_PASS | sed -E -e 's%([/&\\])%\\\1%g')
 		sed $ioption "s/yourpasswordhere/${E_DB_PASS}/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
 	fi

--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -91,7 +91,9 @@ install_test_suite() {
 		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
-		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		# escape the regex delim if not already escaped (i.e. if preceded by an even number of backslashes)
+		E_DB_PASS=$(echo $DB_PASS | sed -E -e 's%((^|[^\\])(\\\\)*)/%\1\\/%')
+		sed $ioption "s/yourpasswordhere/${E_DB_PASS}/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
 	fi
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #22577 by escaping forward & backward slashes and ampersands in password.

### How to test the changes in this Pull Request:

1. Run tests/bin/install.sh with passwords containing a mix of '\\', '/' and '&'

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Changelog entry

> Fix: install script escapes metacharacters in password to prevent sed errors.
