### PR TITLE
fix wrong variable checking

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -100,7 +100,7 @@ class WC_Regenerate_Images {
 	public static function add_uncropped_metadata( $meta_data ) {
 		$size_data = wc_get_image_size( 'woocommerce_thumbnail' );
 		if ( isset( $meta_data['sizes'], $meta_data['sizes']['woocommerce_thumbnail'] ) ) {
-			$meta_data['sizes']['woocommerce_thumbnail']['uncropped'] = empty( $size_settings['height'] );
+			$meta_data['sizes']['woocommerce_thumbnail']['uncropped'] = empty( $size_data['height'] );
 		}
 		return $meta_data;
 	}


### PR DESCRIPTION
The PR is related to "regenerate images functionality"
There is a method `add_uncropped_metadata` in `WC_Regenerate_Images` Class
There is a variable for holding image size data on the line number 101
`$size_data = wc_get_image_size( 'woocommerce_thumbnail' );`

But on the line number 103 instead of checking that variable`$size_data` used an undefined variable `$size_settings` which is always returning false.
