### PR TITLE
fix:No alert for mis-matched password reset

### DIFF
--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -303,3 +303,4 @@ add_action( 'woocommerce_account_content', 'woocommerce_output_all_notices', 5 )
 add_action( 'woocommerce_before_customer_login_form', 'woocommerce_output_all_notices', 10 );
 add_action( 'woocommerce_before_lost_password_form', 'woocommerce_output_all_notices', 10 );
 add_action( 'before_woocommerce_pay', 'woocommerce_output_all_notices', 10 );
+add_action( 'woocommerce_before_reset_password_form', 'woocommerce_output_all_notices', 10 );

--- a/templates/myaccount/form-reset-password.php
+++ b/templates/myaccount/form-reset-password.php
@@ -12,11 +12,12 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.5.0
+ * @version 3.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
+do_action( 'woocommerce_before_reset_password_form' );
 ?>
 
 <form method="post" class="woocommerce-ResetPassword lost_reset_password">
@@ -47,3 +48,6 @@ defined( 'ABSPATH' ) || exit;
 	<?php wp_nonce_field( 'reset_password', 'woocommerce-reset-password-nonce' ); ?>
 
 </form>
+<?php
+do_action( 'woocommerce_after_reset_password_form' );
+

--- a/templates/myaccount/form-reset-password.php
+++ b/templates/myaccount/form-reset-password.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.6.0
+ * @version 3.5.5
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
### All Submissions:

* [X ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #22601 

### How to test the changes in this Pull Request:

1. As described in #22601 

