### PR TITLE
Add notice hash to store notice cookie

### DIFF
--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -14,18 +14,21 @@ jQuery( function( $ ) {
 		}
 	});
 
-	// Set a cookie and hide the store notice when the dismiss button is clicked
-	$( '.woocommerce-store-notice__dismiss-link' ).click( function() {
-		Cookies.set( 'store_notice', 'hidden', { path: '/' } );
-		$( '.woocommerce-store-notice' ).hide();
-	});
+	var noticeID   = $( '.woocommerce-store-notice' ).data( 'notice-id' ) || '',
+		cookieName = 'store_notice' + noticeID;
 
 	// Check the value of that cookie and show/hide the notice accordingly
-	if ( 'hidden' === Cookies.get( 'store_notice' ) ) {
+	if ( 'hidden' === Cookies.get( cookieName ) ) {
 		$( '.woocommerce-store-notice' ).hide();
 	} else {
 		$( '.woocommerce-store-notice' ).show();
 	}
+
+	// Set a cookie and hide the store notice when the dismiss button is clicked
+	$( '.woocommerce-store-notice__dismiss-link' ).click( function() {
+		Cookies.set( cookieName, 'hidden', { path: '/' } );
+		$( '.woocommerce-store-notice' ).hide();
+	});
 
 	// Make form field descriptions toggle on focus.
 	$( document.body ).on( 'click', function() {

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -963,7 +963,9 @@ if ( ! function_exists( 'woocommerce_demo_store' ) ) {
 			$notice = __( 'This is a demo store for testing purposes &mdash; no orders shall be fulfilled.', 'woocommerce' );
 		}
 
-		echo apply_filters( 'woocommerce_demo_store', '<p class="woocommerce-store-notice demo_store">' . wp_kses_post( $notice ) . ' <a href="#" class="woocommerce-store-notice__dismiss-link">' . esc_html__( 'Dismiss', 'woocommerce' ) . '</a></p>', $notice ); // WPCS: XSS ok.
+		$notice_id = md5( $notice );
+
+		echo apply_filters( 'woocommerce_demo_store', '<p class="woocommerce-store-notice demo_store" data-notice-id="' . esc_attr( $notice_id ) . '" style="display:none;">' . wp_kses_post( $notice ) . ' <a href="#" class="woocommerce-store-notice__dismiss-link">' . esc_html__( 'Dismiss', 'woocommerce' ) . '</a></p>', $notice ); // WPCS: XSS ok.
 	}
 }
 


### PR DESCRIPTION
Closes #21963

Makes the store notice cookie name dependent on the store notice text using md5. If the hash changes (notice text changes), the notice is made visible due to a new cookie name.

To test,

1. Add a store notice via customiser. Dismiss it.
2. Change store notice text.
3. Notice is visible again

> Store notice is visible again if the notice text is changed.