### PR TITLE
Fix Hold-stock behavior between simple products and variable products

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -310,7 +310,7 @@ function wc_get_held_stock_quantity( $product, $exclude_order_id = 0 ) {
 			AND 	posts.post_type             IN ( '" . implode( "','", wc_get_order_types() ) . "' )
 			AND 	posts.post_status           = 'wc-pending'
 			AND		posts.ID                    != %d;",
-			'variation' === get_post_type( $product->get_stock_managed_by_id() ) ? '_variation_id' : '_product_id',
+			'product_variation' === get_post_type( $product->get_stock_managed_by_id() ) ? '_variation_id' : '_product_id',
 			$product->get_stock_managed_by_id(),
 			$exclude_order_id
 		)


### PR DESCRIPTION
Fixes #22118

In the check to decide whether to search for a variation or a product, the post type check was using the wrong name. Variation post type is "product_variation".

Test instructions are inside #22118 

> Fix Hold-stock behavior between simple products and variable products