### PR TITLE
OBW: Offer Storefront when WP 5.0 default theme is active

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -91,6 +91,7 @@ class WC_Admin_Setup_Wizard {
 	protected function is_default_theme() {
 		return wc_is_active_theme(
 			array(
+				'twentynineteen',
 				'twentyseventeen',
 				'twentysixteen',
 				'twentyfifteen',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Because the OBW's list of WP default themes hadn't been updated, Storefront was omitted from the "Recommended" step for fresh WP 5.0 installs on the basis of WooCommerce support declared for Twenty Nineteen (context: https://github.com/woocommerce/woocommerce/pull/18184, https://github.com/woocommerce/woocommerce/pull/21970).

In future, it may be helpful to refactor `is_default_theme` out to somewhere (perhaps adjacent to `wc_is_active_theme`) where it can be used in this line as well: https://github.com/woocommerce/woocommerce/blob/3c3894b676f3112db1474a9749f084011eae46d9/includes/class-woocommerce.php#L408

### How to test the changes in this Pull Request:

1. With a fresh WP 5.0.x install (or with Twenty Nineteen otherwise active), go to the OBW "Recommended" step.
2. See that "Storefront" is missing in `master`, but present in this branch.