### PR TITLE
Tools and status require rest API init

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -31,6 +31,15 @@ class WC_Admin_Status {
 	 * Handles output of tools.
 	 */
 	public static function status_tools() {
+		// This screen requires classes from the REST API.
+		if ( ! did_action( 'rest_api_init' ) ) {
+			WC()->api->rest_api_includes();
+		}
+
+		if ( ! class_exists( 'WC_REST_System_Status_Tools_Controller', false ) ) {
+			wp_die( 'Cannot load the REST API to access WC_REST_System_Status_Tools_Controller.' );
+		}
+
 		$tools = self::get_tools();
 
 		if ( ! empty( $_GET['action'] ) && ! empty( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( wp_unslash( $_REQUEST['_wpnonce'] ), 'debug_action' ) ) { // WPCS: input var ok, sanitization ok.

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -9,6 +9,11 @@ defined( 'ABSPATH' ) || exit;
 
 global $wpdb;
 
+// This screen requires classes from the REST API.
+if ( ! did_action( 'rest_api_init' ) ) {
+	WC()->api->rest_api_includes();
+}
+
 if ( ! class_exists( 'WC_REST_System_Status_Controller', false ) ) {
 	wp_die( 'Cannot load the REST API to access WC_REST_System_Status_Controller.' );
 }


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce/pull/22615 broke the status and tools pages which use REST API classes to get data.

I'm not sure if we should really be doing that tbh - this should really use the API rather than the classes directly...however this will restore the functionality for now.

@claudiosanches Merge once approved.