### PR TITLE
Added `woocommerce_paypal_force_one_line_item` filter

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -184,10 +184,16 @@ class WC_Gateway_Paypal_Request {
 	protected function get_paypal_args( $order ) {
 		WC_Gateway_Paypal::log( 'Generating payment form for order ' . $order->get_order_number() . '. Notify URL: ' . $this->notify_url );
 
+		$force_one_line_item = apply_filters( 'woocommerce_paypal_force_one_line_item', false, $order );
+
+		if ( ( wc_tax_enabled() && wc_prices_include_tax() ) || ! $this->line_items_valid( $order ) ) {
+			$force_one_line_item = true;
+		}
+
 		$paypal_args = apply_filters(
 			'woocommerce_paypal_args', array_merge(
 				$this->get_transaction_args( $order ),
-				$this->get_line_item_args( $order )
+				$this->get_line_item_args( $order, $force_one_line_item )
 			), $order
 		);
 
@@ -297,11 +303,8 @@ class WC_Gateway_Paypal_Request {
 	 * @return array
 	 */
 	protected function get_line_item_args( $order, $force_one_line_item = false ) {
-		if ( wc_tax_enabled() && wc_prices_include_tax() || ! $this->line_items_valid( $order ) ) {
-			$force_one_line_item = true;
-		}
-
 		$line_item_args = array();
+
 		if ( $force_one_line_item ) {
 			/**
 			 * Send order as a single item.


### PR DESCRIPTION
Adds a `woocommerce_paypal_force_one_line_item` filter (defaulting to false) to force PayPal gateway to send the cart as a single item if desired. 

Usage:

```
add_filter( 'woocommerce_paypal_force_one_line_item', '__return_true' );
```

Force one item logic remains unchanged - some circumstances already force it.

Closes #22568

To test,

Setup store to send line items to paypal. If you set prices excl. tax that should be enough.
Pay via PayPal sandbox - items should go across.
Add the code above.
Pay via PayPal sandbox - order should go across, no items.

> Dev - Added `woocommerce_paypal_force_one_line_item` filter to control how items are sent to PayPal.