### PR TITLE
WIP update unit tests for PR #22443

### DIFF
--- a/tests/unit-tests/product/data.php
+++ b/tests/unit-tests/product/data.php
@@ -273,7 +273,7 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 		$image_url = $this->set_product_image( $product );
 
 		$this->assertEquals(
-			'<img width="186" height="144" src="' . $image_url . '" class="attachment-woocommerce_thumbnail size-woocommerce_thumbnail" alt="" />',
+			'<img width="186" height="144" src="' . $image_url . '" class="attachment-woocommerce_thumbnail size-woocommerce_thumbnail" alt="" sizes="100vw" />',
 			$product->get_image()
 		);
 
@@ -295,7 +295,7 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 		$image_url = $this->set_product_image( $variable_product );
 
 		$this->assertEquals(
-			'<img width="186" height="144" src="' . $image_url . '" class="attachment-woocommerce_thumbnail size-woocommerce_thumbnail" alt="" />',
+			'<img width="186" height="144" src="' . $image_url . '" class="attachment-woocommerce_thumbnail size-woocommerce_thumbnail" alt="" sizes="100vw" />',
 			$variation_1->get_image()
 		);
 
@@ -313,7 +313,7 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 	public function test_get_image_should_return_place_holder_image() {
 		$product = new WC_Product();
 		$image_url = wc_placeholder_img_src();
-		$expected_result = '<img src="' . $image_url . '" alt="Placeholder" width="300" class="woocommerce-placeholder wp-post-image" height="300" />';
+		$expected_result = '<img src="' . $image_url . '" alt="Placeholder" width="300" class="woocommerce-placeholder wp-post-image" height="300" sizes="100vw" />';
 
 		$this->assertEquals( $expected_result, $product->get_image() );
 		$this->assertEquals( $expected_result, $product->get_image( 'woocommerce_thumbnail', array(), true ) );


### PR DESCRIPTION
Unit tests are failing due to return value from `wp_get_attachment_image()`. WIP to verify unit tests pass in Travis.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
