### PR TITLE
Add novalidate to order review form

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -24,6 +24,7 @@ jQuery( function( $ ) {
 
 			if ( $( document.body ).hasClass( 'woocommerce-order-pay' ) ) {
 				this.$order_review.on( 'click', 'input[name="payment_method"]', this.payment_method_selected );
+				this.$order_review.attr( 'novalidate', 'novalidate' );
 			}
 
 			// Prevent HTML5 validation which can conflict.


### PR DESCRIPTION
Fixes #21858

Matches logic for checkout form.

To test, create a pending order, go to the account page, pay, then inspect the form to confirm novalidate is present.

> Add novalidate attribute to payment form to prevent hidden fields preventing submission.