### PR TITLE
Switch span to paragraph in user profile view

### DIFF
--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -186,8 +186,7 @@ if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
 								<?php else : ?>
 									<input type="text" name="<?php echo esc_attr( $key ); ?>" id="<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $this->get_user_meta( $user->ID, $key ) ); ?>" class="<?php echo ( ! empty( $field['class'] ) ? esc_attr( $field['class'] ) : 'regular-text' ); ?>" />
 								<?php endif; ?>
-								<br/>
-								<span class="description"><?php echo wp_kses_post( $field['description'] ); ?></span>
+								<p class="description"><?php echo wp_kses_post( $field['description'] ); ?></p>
 							</td>
 						</tr>
 					<?php endforeach; ?>


### PR DESCRIPTION
See #22559 for instrucitons.

Uses paragraph instead of span like WP does for it's descriptions.

Closes #22559

> Switch span to paragraph for descriptions in admin user profile view to correct spacing.