### PR TITLE
Prevent multiple cookie sets per request

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -253,18 +253,34 @@ final class WC_Cart_Session {
 	}
 
 	/**
-	 * Set cart hash cookie and items in cart.
+	 * Set cart hash cookie and items in cart if not already set.
 	 *
 	 * @param bool $set Should cookies be set (true) or unset.
 	 */
 	private function set_cart_cookies( $set = true ) {
 		if ( $set ) {
-			wc_setcookie( 'woocommerce_items_in_cart', 1 );
-			wc_setcookie( 'woocommerce_cart_hash', WC()->cart->get_cart_hash() );
-		} elseif ( isset( $_COOKIE['woocommerce_items_in_cart'] ) ) { // WPCS: input var ok.
-			wc_setcookie( 'woocommerce_items_in_cart', 0, time() - HOUR_IN_SECONDS );
-			wc_setcookie( 'woocommerce_cart_hash', '', time() - HOUR_IN_SECONDS );
+			$setcookies = array(
+				'woocommerce_items_in_cart' => '1',
+				'woocommerce_cart_hash'     => WC()->cart->get_cart_hash(),
+			);
+			foreach ( $setcookies as $name => $value ) {
+				if ( ! isset( $_COOKIE[ $name ] ) || $_COOKIE[ $name ] !== $value ) {
+					wc_setcookie( $name, $value );
+				}
+			}
+		} else {
+			$unsetcookies = array(
+				'woocommerce_items_in_cart',
+				'woocommerce_cart_hash',
+			);
+			foreach ( $unsetcookies as $name ) {
+				if ( isset( $_COOKIE[ $name ] ) ) {
+					wc_setcookie( $name, 0, time() - HOUR_IN_SECONDS );
+					unset( $_COOKIE[ $name ] );
+				}
+			}
 		}
+
 		do_action( 'woocommerce_set_cart_cookies', $set );
 	}
 

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -47,13 +47,19 @@ final class WC_Cart_Session {
 	public function init() {
 		add_action( 'wp_loaded', array( $this, 'get_cart_from_session' ) );
 		add_action( 'woocommerce_cart_emptied', array( $this, 'destroy_cart_session' ) );
-		add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 );
-		add_action( 'woocommerce_add_to_cart', array( $this, 'maybe_set_cart_cookies' ) );
 		add_action( 'woocommerce_after_calculate_totals', array( $this, 'set_session' ) );
 		add_action( 'woocommerce_cart_loaded_from_session', array( $this, 'set_session' ) );
 		add_action( 'woocommerce_removed_coupon', array( $this, 'set_session' ) );
-		add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 );
 		add_action( 'woocommerce_cart_updated', array( $this, 'persistent_cart_update' ) );
+
+		// Cookie events - cart cookies need to be set before headers are sent.
+		if ( function_exists( 'header_register_callback' ) ) {
+			header_register_callback( array( $this, 'maybe_set_cart_cookies' ) ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.header_register_callbackFound
+		} else {
+			add_action( 'woocommerce_add_to_cart', array( $this, 'maybe_set_cart_cookies' ) );
+			add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 );
+			add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 );
+		}
 	}
 
 	/**

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -111,7 +111,9 @@ class WC_Session_Handler extends WC_Session {
 			$cookie_value      = $this->_customer_id . '||' . $this->_session_expiration . '||' . $this->_session_expiring . '||' . $cookie_hash;
 			$this->_has_cookie = true;
 
-			wc_setcookie( $this->_cookie, $cookie_value, $this->_session_expiration, apply_filters( 'wc_session_use_secure_cookie', false ) );
+			if ( ! isset( $_COOKIE[ $this->_cookie ] ) || $_COOKIE[ $this->_cookie ] !== $cookie_value ) {
+				wc_setcookie( $this->_cookie, $cookie_value, $this->_session_expiration, apply_filters( 'wc_session_use_secure_cookie', false ) );
+			}
 		}
 	}
 


### PR DESCRIPTION
@kloon I think you'd best review this one.

Fixes #21101

SHAs c88a921 and d004150 add some simple logic to avoid calling `wc_setcookie` if the cookie already exists with the same value. For session, this is not a problem that will cause expiry because the cookie value changes if the expiration date needs to increase. These changes make it so calling `maybe_set_cookie` multiple times won't cause same value cookies to be set.

On top of this, I found a PHP 5.4+ feature `header_register_callback` which fires before headers get set. By using this, we can avoid guessing where we may need to set cookies before headers are sent. 
Thats in ac29fea

To test,

- Add to cart and check network insepector. Headers tab should only list changed cookies. e.g. if you have a cart, and add another product to cart, you'll see 1 woocommerce_cart_hash cookie being set.

> Prevent multiple headers being sent for the same cookies.

