### PR TITLE
Fixes #22443 tests

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -317,7 +317,7 @@ function wc_placeholder_img( $size = 'woocommerce_thumbnail' ) {
 	$dimensions        = wc_get_image_size( $size );
 	$placeholder_image = get_option( 'woocommerce_placeholder_image', 0 );
 
-	if ( ! empty( $placeholder_image ) && is_numeric( $placeholder_image ) ) {
+	if ( ! empty( $placeholder_image ) && is_numeric( $placeholder_image ) && wp_attachment_is_image( $placeholder_image ) ) {
 		$image_html = wp_get_attachment_image(
 			$placeholder_image,
 			$size,

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -317,7 +317,7 @@ function wc_placeholder_img( $size = 'woocommerce_thumbnail' ) {
 	$dimensions        = wc_get_image_size( $size );
 	$placeholder_image = get_option( 'woocommerce_placeholder_image', 0 );
 
-	if ( ! empty( $placeholder_image ) && is_numeric( $placeholder_image ) && wp_attachment_is_image( $placeholder_image ) ) {
+	if ( wp_attachment_is_image( $placeholder_image ) ) {
 		$image_html = wp_get_attachment_image(
 			$placeholder_image,
 			$size,

--- a/tests/unit-tests/product/data.php
+++ b/tests/unit-tests/product/data.php
@@ -80,7 +80,8 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 		}
 		$this->assertCount( 1, $product->get_attributes() );
 		$this->assertContains(
-			current( $product->get_attributes() )->get_data(), array(
+			current( $product->get_attributes() )->get_data(),
+			array(
 				'attribute_id' => 0,
 				'name'         => 'Test Attribute',
 				'options'      => array( 'Fish', 'Fingers' ),
@@ -268,6 +269,9 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 		$this->assertEquals( '<span class="woocommerce-Price-amount amount"><span class="woocommerce-Price-currencySymbol">&pound;</span>50.00</span>', $product->get_price_html() );
 	}
 
+	/**
+	 * Test: test_get_image_should_return_product_image.
+	 */
 	public function test_get_image_should_return_product_image() {
 		$product = new WC_Product();
 		$image_url = $this->set_product_image( $product );
@@ -288,6 +292,9 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * Test: test_get_image_should_return_parent_product_image.
+	 */
 	public function test_get_image_should_return_parent_product_image() {
 		$variable_product = WC_Helper_Product::create_variation_product();
 		$variations = $variable_product->get_children();
@@ -299,7 +306,7 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 			$variation_1->get_image()
 		);
 
-		$this->assertEquals(
+		$this->assertContains(
 			'<img width="186" height="144" src="' . $image_url . '" class="attachment-single size-single" alt="" />',
 			$variation_1->get_image( 'single' )
 		);
@@ -310,15 +317,18 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 		);
 	}
 
+	/**
+	 * Test: test_get_image_should_return_place_holder_image.
+	 */
 	public function test_get_image_should_return_place_holder_image() {
 		$product = new WC_Product();
-		$image_url = wc_placeholder_img_src();
-		$expected_result = '<img src="' . $image_url . '" alt="Placeholder" width="300" class="woocommerce-placeholder wp-post-image" height="300" />';
 
-		$this->assertEquals( $expected_result, $product->get_image() );
-		$this->assertEquals( $expected_result, $product->get_image( 'woocommerce_thumbnail', array(), true ) );
+		$this->assertContains( $product->get_image(), wc_placeholder_img_src() );
 	}
 
+	/**
+	 * Test: test_get_image_should_return_empty_string.
+	 */
 	public function test_get_image_should_return_empty_string() {
 		$product = new WC_Product();
 		$this->assertEquals( '', $product->get_image( 'woocommerce_thumbnail', array(), false ) );

--- a/tests/unit-tests/product/data.php
+++ b/tests/unit-tests/product/data.php
@@ -323,7 +323,7 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 	public function test_get_image_should_return_place_holder_image() {
 		$product = new WC_Product();
 
-		$this->assertContains( $product->get_image(), wc_placeholder_img_src() );
+		$this->assertContains( wc_placeholder_img_src(), $product->get_image() );
 	}
 
 	/**


### PR DESCRIPTION
The change for placeholders caused some of the strings in our tests to mismatch. This fixes it by checking only a part of the string.

There is an additonal check to make sure placeholder image is actually an image, since it seems the unit tests installer does not create a valid attachment. 

cc @rrennick @claudiosanches 