### PR TITLE
Allow to filter the direct sql query to update the product stock

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1259,7 +1259,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$sql = apply_filters( 'woocommerce_update_product_stock_query', $sql, $product_id_with_stock, $stock_quantity, $operation );
 
-		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.PreparedSQL.NotPrepared
 		$wpdb->query( $sql );
 
 		wp_cache_delete( $product_id_with_stock, 'post_meta' );

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1235,36 +1235,32 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		// Update stock in DB directly.
 		switch ( $operation ) {
 			case 'increase':
-				// phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery
-				$wpdb->query(
-					$wpdb->prepare(
-						"UPDATE {$wpdb->postmeta} SET meta_value = meta_value + %f WHERE post_id = %d AND meta_key='_stock'",
-						$stock_quantity,
-						$product_id_with_stock
-					)
+				$sql = $wpdb->prepare(
+					"UPDATE {$wpdb->postmeta} SET meta_value = meta_value + %f WHERE post_id = %d AND meta_key='_stock'",
+					$stock_quantity,
+					$product_id_with_stock
 				);
 				break;
 			case 'decrease':
-				// phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery
-				$wpdb->query(
-					$wpdb->prepare(
-						"UPDATE {$wpdb->postmeta} SET meta_value = meta_value - %f WHERE post_id = %d AND meta_key='_stock'",
-						$stock_quantity,
-						$product_id_with_stock
-					)
+				$sql = $wpdb->prepare(
+					"UPDATE {$wpdb->postmeta} SET meta_value = meta_value - %f WHERE post_id = %d AND meta_key='_stock'",
+					$stock_quantity,
+					$product_id_with_stock
 				);
 				break;
 			default:
-				// phpcs:ignore WordPress.VIP.DirectDatabaseQuery.DirectQuery
-				$wpdb->query(
-					$wpdb->prepare(
-						"UPDATE {$wpdb->postmeta} SET meta_value = %f WHERE post_id = %d AND meta_key='_stock'",
-						$stock_quantity,
-						$product_id_with_stock
-					)
+				$sql = $wpdb->prepare(
+					"UPDATE {$wpdb->postmeta} SET meta_value = %f WHERE post_id = %d AND meta_key='_stock'",
+					$stock_quantity,
+					$product_id_with_stock
 				);
 				break;
 		}
+
+		$sql = apply_filters( 'woocommerce_update_product_stock_query', $sql, $product_id_with_stock, $stock_quantity, $operation );
+
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		$wpdb->query( $sql );
 
 		wp_cache_delete( $product_id_with_stock, 'post_meta' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

In a multilingual plugin like WPML and Polylang, there is one product per language. Metas such as the stock value are synchronized across products translations.

For example, when calling `wc_update_product_stock()` for a product, it is possible to synchronize the stock value by calling again `wc_update_product_stock()` for the product translation in a function hooked to the actions `woocommerce_variation_set_stock` or `woocommerce_product_set_stock`. This works well on a low traffic shop.

However a user testing his site at 20 purchases per second totally messed the stock values of his product due to a race condition between all the database queries made by this synchronization process.

My idea to solve the issue would be to replace the current database query made in `WC_Product_Data_Store_CPT::update_product_stock()` to update the stock of all product translations in one unique query.

To achieve this, I would need that WooCommerce allows to filter the queries made in `WC_Product_Data_Store_CPT::update_product_stock()` as proposed in this PR.


