### PR TITLE
Tracks: add Woo identity

### DIFF
--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -64,6 +64,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 		'syntax_highlighting',
 		'_order_count',
 		'_money_spent',
+		'_woo_tracks_anon_id',
 	);
 
 	/**

--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -64,7 +64,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 		'syntax_highlighting',
 		'_order_count',
 		'_money_spent',
-		'_woo_tracks_anon_id',
+		'_woocommerce_tracks_anon_id',
 	);
 
 	/**

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -109,7 +109,7 @@ class WC_Tracks_Client {
 		}
 
 		// Start with a previously set cookie.
-		$anon_id = isset( $_COOKIE['tk_ai'] ) ? wp_unslash( $_COOKIE['tk_ai'] ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$anon_id = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		// If there is no cookie, apply a saved id.
 		if ( ! $anon_id ) {

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -99,10 +99,10 @@ class WC_Tracks_Client {
 	 * @return array Identity properties.
 	 */
 	public static function get_identity( $user_id ) {
-		$jetpack_lib_file = trailingslashit( WP_PLUGIN_DIR ) . 'jetpack/_inc/lib/tracks/client.php';
+		$jetpack_lib = trailingslashit( WP_PLUGIN_DIR ) . 'jetpack/_inc/lib/tracks/client.php';
 
-		if ( class_exists( 'Jetpack' ) && file_exists( $jetpack_lib_file ) ) {
-			include_once $jetpack_lib_file;
+		if ( class_exists( 'Jetpack' ) && file_exists( $jetpack_lib ) ) {
+			include_once $jetpack_lib;
 
 			if ( function_exists( 'jetpack_tracks_get_identity' ) ) {
 				return jetpack_tracks_get_identity( $user_id );
@@ -120,6 +120,7 @@ class WC_Tracks_Client {
 		// If an id is still not found, create one and save it.
 		if ( ! $anon_id ) {
 			$anon_id = self::get_anon_id();
+
 			update_user_meta( $user_id, '_woocommerce_tracks_anon_id', $anon_id );
 		}
 
@@ -145,7 +146,7 @@ class WC_Tracks_Client {
 
 			// Did the browser send us a cookie?
 			if ( isset( $_COOKIE['tk_ai'] ) ) {
-					$anon_id = sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) );
+				$anon_id = sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) );
 			} else {
 
 				$binary = '';

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -99,9 +99,10 @@ class WC_Tracks_Client {
 	 * @return array Identity properties.
 	 */
 	public static function get_identity( $user_id ) {
-		if ( class_exists( 'Jetpack' ) ) {
+		$jetpack_lib_file = trailingslashit( WP_PLUGIN_DIR ) . 'jetpack/_inc/lib/tracks/client.php';
 
-			include_once trailingslashit( WP_PLUGIN_DIR ) . 'jetpack/_inc/lib/tracks/client.php';
+		if ( file_exists( $jetpack_lib_file ) ) {
+			include_once $jetpack_lib_file;
 
 			if ( function_exists( 'jetpack_tracks_get_identity' ) ) {
 				return jetpack_tracks_get_identity( $user_id );

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -101,7 +101,7 @@ class WC_Tracks_Client {
 	public static function get_identity( $user_id ) {
 		$jetpack_lib_file = trailingslashit( WP_PLUGIN_DIR ) . 'jetpack/_inc/lib/tracks/client.php';
 
-		if ( file_exists( $jetpack_lib_file ) ) {
+		if ( class_exists( 'Jetpack' ) && file_exists( $jetpack_lib_file ) ) {
 			include_once $jetpack_lib_file;
 
 			if ( function_exists( 'jetpack_tracks_get_identity' ) ) {

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -109,7 +109,7 @@ class WC_Tracks_Client {
 		}
 
 		// Start with a previously set cookie.
-		$anon_id = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$anon_id = isset( $_COOKIE['tk_ai'] ) ? sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) ) : false;
 
 		// If there is no cookie, apply a saved id.
 		if ( ! $anon_id ) {

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -93,9 +93,48 @@ class WC_Tracks_Client {
 	}
 
 	/**
+	 * Get a user's identity to send to Tracks. If Jetpack exists, default to its implementation.
+	 *
+	 * @param int $user_id User id.
+	 * @return array Identity properties.
+	 */
+	public static function get_identity( $user_id ) {
+		if ( class_exists( 'Jetpack' ) ) {
+
+			include_once trailingslashit( WP_PLUGIN_DIR ) . 'jetpack/_inc/lib/tracks/client.php';
+
+			if ( function_exists( 'jetpack_tracks_get_identity' ) ) {
+				return jetpack_tracks_get_identity( $user_id );
+			}
+		}
+
+		// Start with a previously set cookie.
+		$anon_id = isset( $_COOKIE['tk_ai'] ) ? wp_unslash( $_COOKIE['tk_ai'] ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		// If there is no cookie, apply a saved id.
+		if ( ! $anon_id ) {
+			$anon_id = get_user_meta( $user_id, '_woocommerce_tracks_anon_id', true );
+		}
+
+		// If an id is still not found, create one and save it.
+		if ( ! $anon_id ) {
+			$anon_id = self::get_anon_id();
+			update_user_meta( $user_id, '_woocommerce_tracks_anon_id', $anon_id );
+		}
+
+		if ( ! isset( $_COOKIE['tk_ai'] ) ) {
+			wc_setcookie( 'tk_ai', $anon_id );
+		}
+
+		return array(
+			'_ut' => 'anon',
+			'_ui' => $anon_id,
+		);
+	}
+
+	/**
 	 * Grabs the user's anon id from cookies, or generates and sets a new one
 	 *
-	 * @todo: Determine the best way to identify sites/users with/without Jetpack connection.
 	 * @return string An anon id for the user
 	 */
 	public static function get_anon_id() {
@@ -104,25 +143,26 @@ class WC_Tracks_Client {
 		if ( ! isset( $anon_id ) ) {
 
 			// Did the browser send us a cookie?
-			if ( isset( $_COOKIE['tk_ai'] ) && preg_match( '#^[A-Za-z0-9+/=]{24}$#', wp_unslash( $_COOKIE['tk_ai'] ) ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				$anon_id = wp_unslash( $_COOKIE['tk_ai'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			if ( isset( $_COOKIE['tk_ai'] ) ) {
+					$anon_id = sanitize_text_field( wp_unslash( $_COOKIE['tk_ai'] ) );
 			} else {
 
 				$binary = '';
 
-				// Generate a new anonId and try to save it in the browser's cookies
+				// Generate a new anonId and try to save it in the browser's cookies.
 				// Note that base64-encoding an 18 character string generates a 24-character anon id.
 				for ( $i = 0; $i < 18; ++$i ) {
 					$binary .= chr( wp_rand( 0, 255 ) );
 				}
 
-				$anon_id = 'jetpack:' . base64_encode( $binary );
+				$anon_id = 'woo:' . base64_encode( $binary );
 
-				if ( ! headers_sent()
-					&& ! ( defined( 'REST_REQUEST' ) && REST_REQUEST )
-					&& ! ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
+				// Don't set cookie on API requests.
+				if (
+					! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) &&
+					! ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
 				) {
-					setcookie( 'tk_ai', $anon_id );
+					wc_setcookie( 'tk_ai', $anon_id );
 				}
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Adds a Woo based identification for a user. Uses a Jetpack id if available, otherwise creates a Woo specific id.

### How to test the changes in this Pull Request:

1. Disable Jetpack.
1. Add this line to code that runs after `init`. 
```php
print_r( WC_Tracks_Client::get_identity( wp_get_current_user()->ID ) );
```
Here is a good spot
  https://github.com/woocommerce/woocommerce/blob/078057e9b2bbb362be3eddab4009aa116e4e3a1a/includes/tracks/class-wc-site-tracking.php#L58

3. Delete the `tk_ai` cookie from your browser.
3. Refresh the page and see a property `anon [_ui]` printed to the page with an anonymous woo flavored id along with a matching `tk_ai` cookie.
4. Delete the `tk_ai` cookie once again an refresh. Notice the cookie re-appear with the same id.
5. Acitvate Jetpack and see a new Jetpack id associated with the cookie and printed output. *
6. Deactivate Jetpack and see a Jetpack id remain in the cookie and output. **

`*` Jetpack writes over the existing `tk_ai` cookie on activation, even when that cookie was established by a previous connection to Jetpack. This seems like a bug to track separately. 

`**` Jetpack also re-writes the existing `tk_ai` cookie on deactivation. This is possibly a bug related to the one described directly above.