### PR TITLE
Fix PayPal UTF characters in product names

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -91,12 +91,15 @@ class WC_Gateway_Paypal_Request {
 	 * @return string
 	 */
 	protected function limit_length( $string, $limit = 127 ) {
-		// As the output is to be used in http_build_query which applies URL encoding, the string needs to be
-		// cut as if it was URL-encoded, but returned non-encoded (it will be encoded by http_build_query later).
-		$url_encoded_str = rawurlencode( $string );
-
-		if ( strlen( $url_encoded_str ) > $limit ) {
-			$string = rawurldecode( substr( $url_encoded_str, 0, $limit - 3 ) . '...' );
+		$str_limit = $limit - 3;
+		if ( function_exists( 'mb_strimwidth' ) ) {
+			if ( mb_strlen( $string ) > $limit ) {
+				$string = mb_strimwidth( $string, 0, $str_limit ) . '...';
+			}
+		} else {
+			if ( strlen( $string ) > $limit ) {
+				$string = substr( $string, 0, $str_limit ) . '...';
+			}
 		}
 		return $string;
 	}

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -167,10 +167,12 @@ class WC_Gateway_Paypal_Request {
 		}
 
 		return apply_filters(
-			'woocommerce_paypal_args', array_merge(
+			'woocommerce_paypal_args',
+			array_merge(
 				$this->get_transaction_args( $order ),
 				$this->get_line_item_args( $order, true )
-			), $order
+			),
+			$order
 		);
 
 	}
@@ -185,10 +187,12 @@ class WC_Gateway_Paypal_Request {
 		WC_Gateway_Paypal::log( 'Generating payment form for order ' . $order->get_order_number() . '. Notify URL: ' . $this->notify_url );
 
 		$paypal_args = apply_filters(
-			'woocommerce_paypal_args', array_merge(
+			'woocommerce_paypal_args',
+			array_merge(
 				$this->get_transaction_args( $order ),
 				$this->get_line_item_args( $order )
-			), $order
+			),
+			$order
 		);
 
 		return $this->fix_request_length( $order, $paypal_args );
@@ -339,9 +343,10 @@ class WC_Gateway_Paypal_Request {
 
 		foreach ( $order->get_items() as $item ) {
 			$item_name = $item->get_name();
-			$item_meta = strip_tags(
+			$item_meta = wp_strip_all_tags(
 				wc_display_item_meta(
-					$item, array(
+					$item,
+					array(
 						'before'    => '',
 						'separator' => ', ',
 						'after'     => '',
@@ -370,9 +375,10 @@ class WC_Gateway_Paypal_Request {
 	 */
 	protected function get_order_item_name( $order, $item ) {
 		$item_name = $item->get_name();
-		$item_meta = strip_tags(
+		$item_meta = wp_strip_all_tags(
 			wc_display_item_meta(
-				$item, array(
+				$item,
+				array(
 					'before'    => '',
 					'separator' => ', ',
 					'after'     => '',
@@ -444,12 +450,12 @@ class WC_Gateway_Paypal_Request {
 		// Products.
 		foreach ( $order->get_items( array( 'line_item', 'fee' ) ) as $item ) {
 			if ( 'fee' === $item['type'] ) {
-				$item_line_total   = $this->number_format( $item['line_total'], $order );
+				$item_line_total = $this->number_format( $item['line_total'], $order );
 				$this->add_line_item( $item->get_name(), 1, $item_line_total );
 			} else {
-				$product           = $item->get_product();
-				$sku               = $product ? $product->get_sku() : '';
-				$item_line_total   = $this->number_format( $order->get_item_subtotal( $item, false ), $order );
+				$product         = $item->get_product();
+				$sku             = $product ? $product->get_sku() : '';
+				$item_line_total = $this->number_format( $order->get_item_subtotal( $item, false ), $order );
 				$this->add_line_item( $this->get_order_item_name( $order, $item ), $item->get_quantity(), $item_line_total, $sku );
 			}
 		}
@@ -467,12 +473,17 @@ class WC_Gateway_Paypal_Request {
 		$index = ( count( $this->line_items ) / 4 ) + 1;
 
 		$item = apply_filters(
-			'woocommerce_paypal_line_item', array(
+			'woocommerce_paypal_line_item',
+			array(
 				'item_name'   => html_entity_decode( wc_trim_string( $item_name ? $item_name : __( 'Item', 'woocommerce' ), 127 ), ENT_NOQUOTES, 'UTF-8' ),
 				'quantity'    => (int) $quantity,
 				'amount'      => wc_float_to_string( (float) $amount ),
 				'item_number' => $item_number,
-			), $item_name, $quantity, $amount, $item_number
+			),
+			$item_name,
+			$quantity,
+			$amount,
+			$item_number
 		);
 
 		$this->line_items[ 'item_name_' . $index ]   = $this->limit_length( $item['item_name'], 127 );

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -4,6 +4,10 @@
  *
  * @package WooCommerce\Tests\Gateways\Paypal
  */
+
+/**
+ * Class WC_Tests_Paypal_Gateway_Request.
+ */
 class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 
 	/**
@@ -96,7 +100,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	 * @param array $product_prices Array of prices to use for created products. Leave empty for default prices.
 	 * @param bool  $calc_order_totals Whether the WC_Order::calculate_totals() should be triggered when creating order.
 	 * @return string
-	 * @throws WC_Data_Exception
+	 * @throws WC_Data_Exception Exception on failure.
 	 */
 	protected function get_request_url( $product_count, $testmode, $product_prices = array(), $calc_order_totals = true ) {
 		// Create products.
@@ -179,7 +183,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	 *
 	 * @param  bool $shipping_tax_included Whether the shipping tax should be included or not.
 	 * @param  bool $testmode              Whether to use Paypal sandbox.
-	 * @throws WC_Data_Exception
+	 * @throws WC_Data_Exception Exception on failure.
 	 */
 	protected function check_large_order( $shipping_tax_included, $testmode ) {
 		$request_url = $this->get_request_url( 30, $testmode );
@@ -198,7 +202,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		$query_array  = array();
 		parse_str( $query_string, $query_array );
 		foreach ( $fields_limited_to_127_chars as $field_name ) {
-			$this->assertLessThanOrEqual( 127, strlen( $query_array[ $field_name ] ) );
+			$this->assertLessThanOrEqual( 127, mb_strlen( $query_array[ $field_name ] ) );
 		}
 
 		// Check that there is actually only one item for order with URL length > limit.
@@ -230,7 +234,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	 * @param bool  $testmode Whether to use Paypal sandbox.
 	 * @param array $product_prices Array of prices to use for created products. Leave empty for default prices.
 	 * @param bool  $calc_order_totals Whether the WC_Order::calculate_totals() should be triggered when creating order.
-	 * @throws WC_Data_Exception
+	 * @throws WC_Data_Exception Exception on failure.
 	 */
 	protected function check_small_order( $product_count, $shipping_tax_included, $testmode, $product_prices = array(), $calc_order_totals = true ) {
 		$request_url = $this->get_request_url( $product_count, $testmode, $product_prices, $calc_order_totals );
@@ -258,8 +262,8 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 			$this->assertTrue( array_key_exists( 'cmd', $query_array ) );
 			$this->assertEquals( '_cart', $query_array['cmd'] );
 
-			$this->assertLessThanOrEqual( 127, strlen( $query_array[ 'item_name_' . $i ] ) );
-			$this->assertLessThanOrEqual( 127, strlen( $query_array[ 'item_number_' . $i ] ) );
+			$this->assertLessThanOrEqual( 127, mb_strlen( $query_array[ 'item_name_' . $i ] ) );
+			$this->assertLessThanOrEqual( 127, mb_strlen( $query_array[ 'item_number_' . $i ] ) );
 
 		}
 
@@ -272,7 +276,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	 * will return false.
 	 *
 	 * @param bool $testmode Whether PayPal request should point to sandbox or live production.
-	 * @throws WC_Data_Exception
+	 * @throws WC_Data_Exception Exception on failure.
 	 */
 	protected function check_negative_amount( $testmode ) {
 		$shipping_tax_included = true;
@@ -286,7 +290,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	 * will return false.
 	 *
 	 * @param bool $testmode Whether PayPal request should point to sandbox or live production.
-	 * @throws WC_Data_Exception
+	 * @throws WC_Data_Exception Exception on failure.
 	 */
 	protected function check_totals_mismatch( $testmode ) {
 		// totals mismatch forces tax inclusion and single line item.
@@ -298,7 +302,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 	 * Test for request_url() method.
 	 *
 	 * @group timeout
-	 * @throws WC_Data_Exception
+	 * @throws WC_Data_Exception Exception on failure.
 	 */
 	public function test_request_url() {
 		// User set up.


### PR DESCRIPTION
For whatever reason (I couldn't work it out exactly) url decoding and encoding breaks UTF-8 characters. When we truncate strings to send to PayPal, this is performed causing invalid display on the PayPal side.

We can avoid the urldecode/encode by limiting strings with mb_ functions which are character encoding aware. This PR implements that.

Fixes #21463

To test, create a product with a long name containing unicode chars e.g. `Шампунь для увлажнения и питания волос Шампунь для увлажнения и питания волос`

On PayPal, after this patch, you'll see a correct truncated version.

String will appear less than 127 in length because of the mb_ functions. This is expected behavior,

> Fix PayPal item name encoding.


