### PR TITLE
The "for" attribute of a label for a radio input is invalid

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2723,7 +2723,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				break;
 			case 'radio':
-				$label_id = current( array_keys( $args['options'] ) );
+				$label_id .= '_' . current( array_keys( $args['options'] ) );
 
 				if ( ! empty( $args['options'] ) ) {
 					foreach ( $args['options'] as $option_key => $option_text ) {


### PR DESCRIPTION
The main label of a radio supposedly targeting the first value of the radios contains only the value instead of theId_theValue which is the id of the radio
