### PR TITLE
Custom payment sections not loading fields due to logic error.

### DIFF
--- a/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -50,7 +50,8 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 
 		if ( '' === $current_section ) {
 			$settings = apply_filters(
-				'woocommerce_payment_gateways_settings', array(
+				'woocommerce_payment_gateways_settings',
+				array(
 					array(
 						'title' => __( 'Payment methods', 'woocommerce' ),
 						'desc'  => __( 'Installed payment methods are listed below and can be sorted to control their display order on the frontend.', 'woocommerce' ),
@@ -94,10 +95,9 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 					break;
 				}
 			}
-		} else {
-			$settings = $this->get_settings();
-			WC_Admin_Settings::output_fields( $settings );
 		}
+		$settings = $this->get_settings( $current_section );
+		WC_Admin_Settings::output_fields( $settings );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes a logic error that prevents custom payment section settings to not load and display.

Closes #22696 

### How to test the changes in this Pull Request:

1. See sample code in #22696
2. Go to Settings -> Payments -> Custom Page and check that a API field is displayed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Custom payment options sections was not loading settings.
