### PR TITLE
Archive breadcrubs should use plural name not singular

### DIFF
--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -240,7 +240,7 @@ class WC_Breadcrumb {
 
 		if ( ! $_name ) {
 			$product_post_type = get_post_type_object( 'product' );
-			$_name             = $product_post_type->labels->singular_name;
+			$_name             = $product_post_type->labels->name;
 		}
 
 		$this->add_crumb( $_name, get_post_type_archive_link( 'product' ) );
@@ -253,7 +253,7 @@ class WC_Breadcrumb {
 		$post_type = get_post_type_object( get_post_type() );
 
 		if ( $post_type ) {
-			$this->add_crumb( $post_type->labels->singular_name, get_post_type_archive_link( get_post_type() ) );
+			$this->add_crumb( $post_type->labels->name, get_post_type_archive_link( get_post_type() ) );
 		}
 	}
 

--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -148,8 +148,11 @@ class WC_Breadcrumb {
 			$this->prepend_shop_page();
 
 			$terms = wc_get_product_terms(
-				$post->ID, 'product_cat', apply_filters(
-					'woocommerce_breadcrumb_product_terms_args', array(
+				$post->ID,
+				'product_cat',
+				apply_filters(
+					'woocommerce_breadcrumb_product_terms_args',
+					array(
 						'orderby' => 'parent',
 						'order'   => 'DESC',
 					)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue where the breadcrumb generation code was using the singular name for custom post type archives, ie it would display something like `Home > Course` for a custom post type called Courses. This change ensures that it uses the name and not singular name property when building the breadcrumb for archive pages using custom post types.

Closes #22699 

### How to test the changes in this Pull Request:

1. Register a new custom post type as per https://codex.wordpress.org/Function_Reference/register_post_type
2. Visit the archive page for that post type and ensure it uses the plural word.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Breadcrumbs on custom post types was using the singular name instead of plural.
