### PR TITLE
Calculation issues on single product sales by product graph/report

### DIFF
--- a/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -85,6 +85,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 				),
 				'query_type'   => 'get_var',
 				'filter_range' => true,
+				'order_status' => array( 'completed', 'processing', 'on-hold', 'refunded' ),
 			)
 		);
 
@@ -110,6 +111,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 					),
 					'query_type'   => 'get_var',
 					'filter_range' => true,
+					'order_status' => array( 'completed', 'processing', 'on-hold', 'refunded' ),
 				)
 			)
 		);
@@ -461,6 +463,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 					'order_by'     => 'post_date ASC',
 					'query_type'   => 'get_results',
 					'filter_range' => true,
+					'order_status' => array( 'completed', 'processing', 'on-hold', 'refunded' ),
 				)
 			);
 
@@ -498,6 +501,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 					'order_by'     => 'post_date ASC',
 					'query_type'   => 'get_results',
 					'filter_range' => true,
+					'order_status' => array( 'completed', 'processing', 'on-hold', 'refunded' ),
 				)
 			);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Update the single product sales by product report and CSV Export to include refunded orders so that the report consistently shows net sales counts and amounts.

Closes #22656 .

### How to test the changes in this Pull Request:

1. Purchase the same product twice through the shop
2. Refund one of the 2 orders in the dashboard
3. Load the 7 day sales by product report
4. Click on the product in the top sellers panel
5. The graph should show 1 sold and sales amount be the price of the product for today
6. Export the CSV which should show 1 `Number of sales` and product price in `Sales amount`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix Sales by Product to consistently calculate net sales counts and amounts.
