### PR TITLE
Load REST API endpoints before generate webhook payload

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -290,6 +290,11 @@ class WC_Webhook extends WC_Legacy_Webhook {
 		$rest_api_versions = wc_get_webhook_rest_api_versions();
 		$version_suffix    = end( $rest_api_versions ) !== $this->get_api_version() ? strtoupper( str_replace( 'wp_api', '', $this->get_api_version() ) ) : '';
 
+		// Load REST API endpoints to generate payload.
+		if ( ! did_action( 'rest_api_init' ) ) {
+			WC()->api->rest_api_includes();
+		}
+
 		switch ( $resource ) {
 			case 'coupon':
 			case 'customer':


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since https://github.com/woocommerce/woocommerce/pull/22615 we started to load REST API classes only inside `rest_api_init`, and this make webhooks stop work, this PR should fix it.


### How to test the changes in this Pull Request:

1. Try trigger any webhook (created, updated, and deleted events)
2. See PHP fatal error logged in `wp-admin/admin.php?page=wc-status&tab=action-scheduler`
3. Apply this patch and try trigger again, now gets delivered without any PHP error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
