### PR TITLE
Check for _reduced_stock meta when restocking refunded items

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -689,17 +689,23 @@ function wc_restock_refunded_items( $order, $refunded_line_items ) {
 		if ( ! isset( $refunded_line_items[ $item_id ], $refunded_line_items[ $item_id ]['qty'] ) ) {
 			continue;
 		}
-		$product = $item->get_product();
+		$product            = $item->get_product();
+		$item_stock_reduced = $item->get_meta( '_reduced_stock', true );
 
-		if ( $product && $product->managing_stock() ) {
-			$old_stock = $product->get_stock_quantity();
-			$new_stock = wc_update_product_stock( $product, $refunded_line_items[ $item_id ]['qty'], 'increase' );
-
-			/* translators: 1: product ID 2: old stock level 3: new stock level */
-			$order->add_order_note( sprintf( __( 'Item #%1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $product->get_id(), $old_stock, $new_stock ) );
-
-			do_action( 'woocommerce_restock_refunded_item', $product->get_id(), $old_stock, $new_stock, $order, $product );
+		if ( ! $item_stock_reduced || ! $product || ! $product->managing_stock() ) {
+			continue;
 		}
+
+		$old_stock = $product->get_stock_quantity();
+		$new_stock = wc_update_product_stock( $product, $refunded_line_items[ $item_id ]['qty'], 'increase' );
+
+		/* translators: 1: product ID 2: old stock level 3: new stock level */
+		$order->add_order_note( sprintf( __( 'Item #%1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $product->get_id(), $old_stock, $new_stock ) );
+
+		$item->delete_meta_data( '_reduced_stock' );
+		$item->save();
+
+		do_action( 'woocommerce_restock_refunded_item', $product->get_id(), $old_stock, $new_stock, $order, $product );
 	}
 }
 

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -691,18 +691,27 @@ function wc_restock_refunded_items( $order, $refunded_line_items ) {
 		}
 		$product            = $item->get_product();
 		$item_stock_reduced = $item->get_meta( '_reduced_stock', true );
+		$qty_to_refund      = $refunded_line_items[ $item_id ]['qty'];
 
-		if ( ! $item_stock_reduced || ! $product || ! $product->managing_stock() ) {
+		if ( ! $item_stock_reduced || ! $qty_to_refund || ! $product || ! $product->managing_stock() ) {
 			continue;
 		}
 
 		$old_stock = $product->get_stock_quantity();
-		$new_stock = wc_update_product_stock( $product, $refunded_line_items[ $item_id ]['qty'], 'increase' );
+		$new_stock = wc_update_product_stock( $product, $qty_to_refund, 'increase' );
+
+		// Update _reduced_stock meta to track changes.
+		$item_stock_reduced = $item_stock_reduced - $qty_to_refund;
+
+		if ( 0 < $item_stock_reduced ) {
+			$item->update_meta_data( '_reduced_stock', $item_stock_reduced );
+		} else {
+			$item->delete_meta_data( '_reduced_stock' );
+		}
 
 		/* translators: 1: product ID 2: old stock level 3: new stock level */
 		$order->add_order_note( sprintf( __( 'Item #%1$s stock increased from %2$s to %3$s.', 'woocommerce' ), $product->get_id(), $old_stock, $new_stock ) );
 
-		$item->delete_meta_data( '_reduced_stock' );
 		$item->save();
 
 		do_action( 'woocommerce_restock_refunded_item', $product->get_id(), $old_stock, $new_stock, $order, $product );


### PR DESCRIPTION
Fixes #22489

When restocking items after performing a refund it was not setting correct meta values for each item. Refunded items are tracked using meta on the item named `_reduced_stock`.

This PR checks if that meta exists before restocking the item, and deletes it after doing the restock action.

To test,

- Order an item that is stock managed
- Mark order complete. Stock is reduced.
- Refund the line item. Stock is restored.
- Cancel the order. No stock is changed.

> Fix - Set correct item meta after restocking items with refunds.