### PR TITLE
Fix save logic by moving setter into loop grabbing the value

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -149,11 +149,18 @@ class WC_Form_Handler {
 				}
 			}
 
-			// Set prop in customer object.
-			if ( is_callable( array( $customer, "set_$key" ) ) ) {
-				$customer->{"set_$key"}( $value );
-			} else {
-				$customer->update_meta_data( $key, $value );
+			try {
+				// Set prop in customer object.
+				if ( is_callable( array( $customer, "set_$key" ) ) ) {
+					$customer->{"set_$key"}( $value );
+				} else {
+					$customer->update_meta_data( $key, $value );
+				}
+			} catch ( WC_Data_Exception $e ) {
+				// Set notices. Ignore invalid billing email, since is already validated.
+				if ( 'customer_invalid_billing_email' !== $e->getErrorCode() ) {
+					wc_add_notice( $e->getMessage(), 'error' );
+				}
 			}
 		}
 

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -81,6 +81,12 @@ class WC_Form_Handler {
 			return;
 		}
 
+		$customer = new WC_Customer( $user_id );
+
+		if ( ! $customer ) {
+			return;
+		}
+
 		$load_address = isset( $wp->query_vars['edit-address'] ) ? wc_edit_address_i18n( sanitize_title( $wp->query_vars['edit-address'] ), true ) : 'billing';
 
 		if ( ! isset( $_POST[ $load_address . '_country' ] ) ) {
@@ -111,8 +117,7 @@ class WC_Form_Handler {
 			}
 
 			if ( ! empty( $value ) ) {
-
-				// Validation rules.
+				// Validation and formatting rules.
 				if ( ! empty( $field['validate'] ) && is_array( $field['validate'] ) ) {
 					foreach ( $field['validate'] as $rule ) {
 						switch ( $rule ) {
@@ -143,36 +148,39 @@ class WC_Form_Handler {
 					}
 				}
 			}
-		}
 
-		do_action( 'woocommerce_after_save_address_validation', $user_id, $load_address, $address );
-
-		if ( 0 === wc_notice_count( 'error' ) ) {
-
-			$customer = new WC_Customer( $user_id );
-
-			if ( $customer ) {
-				foreach ( $address as $key => $field ) {
-					if ( is_callable( array( $customer, "set_$key" ) ) ) {
-						$customer->{"set_$key"}( $value );
-					} else {
-						$customer->update_meta_data( $key, $value );
-					}
-
-					if ( WC()->customer && is_callable( array( WC()->customer, "set_$key" ) ) ) {
-						WC()->customer->{"set_$key"}( $value );
-					}
-				}
-				$customer->save();
+			// Set prop in customer object.
+			if ( is_callable( array( $customer, "set_$key" ) ) ) {
+				$customer->{"set_$key"}( $value );
+			} else {
+				$customer->update_meta_data( $key, $value );
 			}
-
-			wc_add_notice( __( 'Address changed successfully.', 'woocommerce' ) );
-
-			do_action( 'woocommerce_customer_save_address', $user_id, $load_address );
-
-			wp_safe_redirect( wc_get_endpoint_url( 'edit-address', '', wc_get_page_permalink( 'myaccount' ) ) );
-			exit;
 		}
+
+		/**
+		 * Hook: woocommerce_after_save_address_validation.
+		 *
+		 * Allow developers to add custom validation logic and throw an error to prevent save.
+		 *
+		 * @param int         $user_id User ID being saved.
+		 * @param string      $load_address Type of address e.g. billing or shipping.
+		 * @param array       $address The address fields.
+		 * @param WC_Customer $customer The customer object being saved. @since 3.6.0
+		 */
+		do_action( 'woocommerce_after_save_address_validation', $user_id, $load_address, $address, $customer );
+
+		if ( 0 < wc_notice_count( 'error' ) ) {
+			return;
+		}
+
+		$customer->save();
+
+		wc_add_notice( __( 'Address changed successfully.', 'woocommerce' ) );
+
+		do_action( 'woocommerce_customer_save_address', $user_id, $load_address );
+
+		wp_safe_redirect( wc_get_endpoint_url( 'edit-address', '', wc_get_page_permalink( 'myaccount' ) ) );
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
Broken by https://github.com/woocommerce/woocommerce/pull/22650 phpcs changes here https://github.com/woocommerce/woocommerce/commit/5b3b285a9d6c2e409bc16116d51c1df369aa1747

Looks like the intention of that change was to avoid setting the POST global by storing local variables. But due to this being done over 2 loops, only the last `$value` was saved.

This PR fixes that by moving the setter into the validation/formatting loop then saving once validation is done. 

Note I removed the global customer session set which syncs data because of https://github.com/woocommerce/woocommerce/pull/22392 which means this is no longer needed.