### PR TITLE
Check for decoded taxonomy name when unsetting terms

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -748,6 +748,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 						if ( taxonomy_exists( $attribute_key ) ) {
 							// Handle attributes that have been unset.
 							wp_set_object_terms( $product->get_id(), array(), $attribute_key );
+						} elseif ( taxonomy_exists( urldecode( $attribute_key ) ) ) {
+							// Handle attributes that have been unset.
+							wp_set_object_terms( $product->get_id(), array(), urldecode( $attribute_key ) );
 						}
 						continue;
 

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -417,7 +417,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		$query_hash = md5( $query );
 
 		// Maybe store a transient of the count values.
-		$cache = false;//apply_filters( 'woocommerce_layered_nav_count_maybe_cache', true );
+		$cache = apply_filters( 'woocommerce_layered_nav_count_maybe_cache', true );
 		if ( true === $cache ) {
 			$cached_counts = (array) get_transient( 'wc_layered_nav_counts_' . sanitize_title( $taxonomy ) );
 		} else {

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -417,7 +417,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 		$query_hash = md5( $query );
 
 		// Maybe store a transient of the count values.
-		$cache = apply_filters( 'woocommerce_layered_nav_count_maybe_cache', true );
+		$cache = false;//apply_filters( 'woocommerce_layered_nav_count_maybe_cache', true );
 		if ( true === $cache ) {
 			$cached_counts = (array) get_transient( 'wc_layered_nav_counts_' . sanitize_title( $taxonomy ) );
 		} else {


### PR DESCRIPTION
Fixes #22403 

When you **unset all terms** from a product, the attribute object is NULL. Therefore it's impossible to get the real taxonomy name from `$attribute->get_name()` since we only have access to the key. 

The key in this case is sanitized here: https://github.com/woocommerce/woocommerce/blob/889cf64ac465826104080e5f8ce23e09109cf777/includes/abstracts/abstract-wc-product.php#L1111

This replaces unicode chars with percent encoded chars.

Whilst we could try to update all instances of `sanitize_title` with something else as previously attempted, the simpler solution is to decode this key when unsetting terms. This PR does just that.

> Fix unset of terms when removing an attribute from a product.