### PR TITLE
Put back status parameter after extra processing.

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -210,7 +210,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	 * @return array
 	 */
 	protected function prepare_objects_query( $request ) {
-		// This is needed to get around an array to string notice in WC_REST_Orders_Controller::prepare_objects_query.
+		// This is needed to get around an array to string notice in WC_REST_Orders_V2_Controller::prepare_objects_query.
 		$statuses = $request['status'];
 		unset( $request['status'] );
 		$args = parent::prepare_objects_query( $request );
@@ -227,6 +227,9 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 				$args['post_status'][] = $status;
 			}
 		}
+
+		// Put the statuses back for further processing (next/prev links, etc).
+		$request['status'] = $statuses;
 
 		return $args;
 	}


### PR DESCRIPTION
This allows correct further processing of $request, e.g. for next/previous links, etc.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #22701  .

### How to test the changes in this Pull Request:

1. Create at least 10 orders with statuses processing or completed.
2. Go to https://local.wordpress.test/wp-json/wc/v3/orders?status=processing,completed, see the next link in header does not contain query parameter for `status`
3. Apply branch, observe the correct link is produced: https://local.wordpress.test/wp-json/wc/v3/orders?status%5B0%5D=processing&status%5B1%5D=completed&dp=2&page=2

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed next/previous links for orders REST endpoint when `status` query parameter is present.
