### PR TITLE
Tracks: enqueue w.js

### DIFF
--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -145,4 +145,3 @@ class WC_Tracks {
 	}
 }
 
-


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add `w.js` to the page if tracking is enabled and expose a function `window.wcSettings.recordEvent` for recording an event from javascript.

### How to test the changes in this Pull Request:

1. Ensure `woocommerce_allow_tracking` option is set to `yes`.
2. Load an wp-admin page.
3. In the console, check that `_tkq` is defined in the global scope.
4. Check that `wcSettings.recordEvent` exists.
5. Call `wcSettings.recordEvent( 'my-event', {} )` and see the `t.gif` request in the Networks tab.
6. Turn off the tracking opt-in or force `is_tracking_enabled` to return false.
7. Repeat step 5 and see that no errors occur and no request is made to `pixel.wp.com/t.gif`.


