### PR TITLE
Move PayPal BN partner ID

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -61,9 +61,12 @@ class WC_Gateway_Paypal_Request {
 	 * @return string
 	 */
 	public function get_request_url( $order, $sandbox = false ) {
-		$this->endpoint = $sandbox ? 'https://www.sandbox.paypal.com/cgi-bin/webscr?test_ipn=1&' : 'https://www.paypal.com/cgi-bin/webscr?';
-		$paypal_args    = $this->get_paypal_args( $order );
-		$mask           = array(
+		$this->endpoint    = $sandbox ? 'https://www.sandbox.paypal.com/cgi-bin/webscr?test_ipn=1&' : 'https://www.paypal.com/cgi-bin/webscr?';
+		$paypal_args       = $this->get_paypal_args( $order );
+		$paypal_args['bn'] = 'WooThemes_Cart'; // Append WooCommerce PayPal Partner Attribution ID. This should not be overridden for this gateway.
+
+		// Mask (remove) PII from the logs.
+		$mask = array(
 			'first_name'    => '***',
 			'last_name'     => '***',
 			'address1'      => '***',
@@ -122,7 +125,6 @@ class WC_Gateway_Paypal_Request {
 				'page_style'    => $this->gateway->get_option( 'page_style' ),
 				'image_url'     => esc_url_raw( $this->gateway->get_option( 'image_url' ) ),
 				'paymentaction' => $this->gateway->get_option( 'paymentaction' ),
-				'bn'            => 'WooThemes_Cart',
 				'invoice'       => $this->limit_length( $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number(), 127 ),
 				'custom'        => wp_json_encode(
 					array(


### PR DESCRIPTION
Moves the PayPal bn (https://developer.paypal.com/docs/api/overview/#api-requests) outside of the `woocommerce_paypal_args` filter in PayPal standard--this value should _not_ be modified. This change prevents abuse from 3rd parties changing BN code through unrelated plugins and/or gateways.

Other args being passed to PayPal can still be changed via `woocommerce_paypal_args` as documented. Also note this change has no implications nor side-effects for merchants.

Developers wanting to change BN code should extend or fork this gateway into a new gateway/product. 

cc @peterfabian for 3.5.5