### PR TITLE
Shipping method get_option function filters

### DIFF
--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -263,16 +263,23 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * @param array $args Arguments (default: array()).
 	 */
 	public function add_rate( $args = array() ) {
-		$args = apply_filters( 'woocommerce_shipping_method_add_rate_args', wp_parse_args( $args, array(
-			'id'        => $this->get_rate_id(), // ID for the rate. If not passed, this id:instance default will be used.
-			'label'     => '', // Label for the rate.
-			'cost'      => '0', // Amount or array of costs (per item shipping).
-			'taxes'     => '', // Pass taxes, or leave empty to have it calculated for you, or 'false' to disable calculations.
-			'calc_tax'  => 'per_order', // Calc tax per_order or per_item. Per item needs an array of costs.
-			'meta_data' => array(), // Array of misc meta data to store along with this rate - key value pairs.
-			'package'   => false, // Package array this rate was generated for @since 2.6.0.
-			'price_decimals' => wc_get_price_decimals(),
-		) ), $this );
+		$args = apply_filters(
+			'woocommerce_shipping_method_add_rate_args',
+			wp_parse_args(
+				$args,
+				array(
+					'id'        => $this->get_rate_id(), // ID for the rate. If not passed, this id:instance default will be used.
+					'label'     => '', // Label for the rate.
+					'cost'      => '0', // Amount or array of costs (per item shipping).
+					'taxes'     => '', // Pass taxes, or leave empty to have it calculated for you, or 'false' to disable calculations.
+					'calc_tax'  => 'per_order', // Calc tax per_order or per_item. Per item needs an array of costs.
+					'meta_data' => array(), // Array of misc meta data to store along with this rate - key value pairs.
+					'package'   => false, // Package array this rate was generated for @since 2.6.0.
+					'price_decimals' => wc_get_price_decimals(),
+				)
+			),
+			$this
+		);
 
 		// ID and label are required.
 		if ( ! $args['id'] || ! $args['label'] ) {
@@ -323,7 +330,6 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	 * Calc taxes per item being shipping in costs array.
 	 *
 	 * @since 2.6.0
-	 * @access protected
 	 * @param  array $costs Costs.
 	 * @return array of taxes
 	 */
@@ -456,12 +462,12 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	public function get_option( $key, $empty_value = null ) {
 		// Instance options take priority over global options.
 		if ( $this->instance_id && array_key_exists( $key, $this->get_instance_form_fields() ) ) {
-			$instance_option = apply_filters( 'woocommerce_shipping_' . $this->id . '_instance_option', $this->get_instance_option( $key, $empty_value ), $this );
+			$instance_option = apply_filters( 'woocommerce_shipping_' . $this->id . '_instance_option', $this->get_instance_option( $key, $empty_value ), $key, $empty_value, $this );
 			return $instance_option;
 		}
 
 		// Return global option.
-		$global_option = apply_filters( 'woocommerce_shipping_' . $this->id . '_global_option', parent::get_option( $key, $empty_value ), $this );
+		$global_option = apply_filters( 'woocommerce_shipping_' . $this->id . '_global_option', parent::get_option( $key, $empty_value ), $key, $empty_value, $this );
 		return $global_option;
 	}
 

--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -456,11 +456,13 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	public function get_option( $key, $empty_value = null ) {
 		// Instance options take priority over global options.
 		if ( $this->instance_id && array_key_exists( $key, $this->get_instance_form_fields() ) ) {
-			return $this->get_instance_option( $key, $empty_value );
+			$instance_option = apply_filters( 'woocommerce_shipping_' . $this->id . '_instance_option', $this->get_instance_option( $key, $empty_value ), $this );
+			return $instance_option;
 		}
 
 		// Return global option.
-		return parent::get_option( $key, $empty_value );
+		$global_option = apply_filters( 'woocommerce_shipping_' . $this->id . '_global_option', parent::get_option( $key, $empty_value ), $this );
+		return $global_option;
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -462,13 +462,12 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	public function get_option( $key, $empty_value = null ) {
 		// Instance options take priority over global options.
 		if ( $this->instance_id && array_key_exists( $key, $this->get_instance_form_fields() ) ) {
-			$instance_option = apply_filters( 'woocommerce_shipping_' . $this->id . '_instance_option', $this->get_instance_option( $key, $empty_value ), $key, $empty_value, $this );
-			return $instance_option;
+			return $this->get_instance_option( $key, $empty_value );
 		}
 
 		// Return global option.
-		$global_option = apply_filters( 'woocommerce_shipping_' . $this->id . '_global_option', parent::get_option( $key, $empty_value ), $key, $empty_value, $this );
-		return $global_option;
+		$option = apply_filters( 'woocommerce_shipping_' . $this->id . '_option', parent::get_option( $key, $empty_value ), $key, $this );
+		return $option;
 	}
 
 	/**
@@ -493,7 +492,8 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 			$this->instance_settings[ $key ] = $empty_value;
 		}
 
-		return $this->instance_settings[ $key ];
+		$instance_option = apply_filters( 'woocommerce_shipping_' . $this->id . '_instance_option', $this->instance_settings[ $key ], $key, $this );
+		return $instance_option;
 	}
 
 	/**

--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -169,8 +169,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 				// Also handles BW compatibility when slugs were used instead of ids.
 				$shipping_class_term = get_term_by( 'slug', $shipping_class, 'product_shipping_class' );
 				$class_cost_string   = $shipping_class_term && $shipping_class_term->term_id ? $this->get_option( 'class_cost_' . $shipping_class_term->term_id, $this->get_option( 'class_cost_' . $shipping_class, '' ) ) : $this->get_option( 'no_class_cost', '' );
-
-				$class_cost_string = apply_filters( 'woocommerce_' . $this->id . '_shipping_class_cost', $class_cost_string, $shipping_class_term, $this );
+				$class_cost_string   = apply_filters( 'woocommerce_' . $this->id . '_shipping_class_cost', $class_cost_string, $shipping_class_term, $this );
 
 				if ( '' === $class_cost_string ) {
 					continue;

--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -111,7 +111,9 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 				'percent' => '',
 				'min_fee' => '',
 				'max_fee' => '',
-			), $atts, 'fee'
+			),
+			$atts,
+			'fee'
 		);
 
 		$calculated_fee = 0;
@@ -146,12 +148,13 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 
 		// Calculate the costs.
 		$has_costs = false; // True when a cost is set. False if all costs are blank strings.
-		$cost      = apply_filters( 'woocommerce_' . $this->id . '_shipping_cost', $this->get_option( 'cost' ), $this );
+		$cost      = $this->get_option( 'cost' );
 
 		if ( '' !== $cost ) {
 			$has_costs    = true;
 			$rate['cost'] = $this->evaluate_cost(
-				$cost, array(
+				$cost,
+				array(
 					'qty'  => $this->get_package_item_qty( $package ),
 					'cost' => $package['contents_cost'],
 				)
@@ -169,7 +172,6 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 				// Also handles BW compatibility when slugs were used instead of ids.
 				$shipping_class_term = get_term_by( 'slug', $shipping_class, 'product_shipping_class' );
 				$class_cost_string   = $shipping_class_term && $shipping_class_term->term_id ? $this->get_option( 'class_cost_' . $shipping_class_term->term_id, $this->get_option( 'class_cost_' . $shipping_class, '' ) ) : $this->get_option( 'no_class_cost', '' );
-				$class_cost_string   = apply_filters( 'woocommerce_' . $this->id . '_shipping_class_cost', $class_cost_string, $shipping_class_term, $this );
 
 				if ( '' === $class_cost_string ) {
 					continue;
@@ -177,7 +179,8 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 
 				$has_costs  = true;
 				$class_cost = $this->evaluate_cost(
-					$class_cost_string, array(
+					$class_cost_string,
+					array(
 						'qty'  => array_sum( wp_list_pluck( $products, 'quantity' ) ),
 						'cost' => array_sum( wp_list_pluck( $products, 'line_total' ) ),
 					)

--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -146,7 +146,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 
 		// Calculate the costs.
 		$has_costs = false; // True when a cost is set. False if all costs are blank strings.
-		$cost      = $this->get_option( 'cost' );
+		$cost      = apply_filters( 'woocommerce_' . $this->id . '_shipping_cost', $this->get_option( 'cost' ), $this );
 
 		if ( '' !== $cost ) {
 			$has_costs    = true;
@@ -169,6 +169,8 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 				// Also handles BW compatibility when slugs were used instead of ids.
 				$shipping_class_term = get_term_by( 'slug', $shipping_class, 'product_shipping_class' );
 				$class_cost_string   = $shipping_class_term && $shipping_class_term->term_id ? $this->get_option( 'class_cost_' . $shipping_class_term->term_id, $this->get_option( 'class_cost_' . $shipping_class, '' ) ) : $this->get_option( 'no_class_cost', '' );
+
+				$class_cost_string = apply_filters( 'woocommerce_' . $this->id . '_shipping_class_cost', $class_cost_string, $shipping_class_term, $this );
 
 				if ( '' === $class_cost_string ) {
 					continue;


### PR DESCRIPTION
Allows to tweak flat rate shipping cost / class cost before it gets
calculated and applied to shipping. Very useful for multicurrency
plugins, because you can add field for fixed shipping cost in another
currency and use this value instead of the default value from cost
field.