### PR TITLE
Performance: delete empty meta

### DIFF
--- a/includes/api/v2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-tools-v2-controller.php
@@ -478,12 +478,12 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 				 * that don't have address indexes yet.
 				 */
 				$sql   = "INSERT INTO {$wpdb->postmeta}( post_id, meta_key, meta_value )
-					SELECT post_id, '%s', GROUP_CONCAT( meta_value SEPARATOR ' ' )
+					SELECT post_id, %s, GROUP_CONCAT( meta_value SEPARATOR ' ' )
 					FROM {$wpdb->postmeta}
-					WHERE meta_key IN ( '%s', '%s' )
+					WHERE meta_key IN ( %s, %s )
 					AND post_id IN ( SELECT DISTINCT post_id FROM {$wpdb->postmeta}
-						WHERE post_id NOT IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key='%s' )
-						AND post_id IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key='%s' ) )
+						WHERE post_id NOT IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key=%s )
+						AND post_id IN ( SELECT post_id FROM {$wpdb->postmeta} WHERE meta_key=%s ) )
 					GROUP BY post_id";
 				$rows  = $wpdb->query( $wpdb->prepare( $sql, '_billing_address_index', '_billing_first_name', '_billing_last_name', '_billing_address_index', '_billing_last_name' ) ); // WPCS: unprepared SQL ok.
 				$rows += $wpdb->query( $wpdb->prepare( $sql, '_shipping_address_index', '_shipping_first_name', '_shipping_last_name', '_shipping_address_index', '_shipping_last_name' ) ); // WPCS: unprepared SQL ok.

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -294,12 +294,15 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 
 		foreach ( $props_to_update as $meta_key => $prop ) {
 			$value = $order->{"get_$prop"}( 'edit' );
+			$value = is_string( $value ) ? wp_slash( $value ) : $value;
 
 			if ( 'prices_include_tax' === $prop ) {
 				$value = $value ? 'yes' : 'no';
 			}
 
-			if ( update_post_meta( $order->get_id(), $meta_key, $value ) ) {
+			$updated = $this->update_or_delete_post_meta( $order, $meta_key, $value );
+
+			if ( $updated ) {
 				$updated_props[] = $prop;
 			}
 		}

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -115,7 +115,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 				'description'                 => $post_object->post_excerpt,
 				'date_created'                => 0 < $post_object->post_date_gmt ? wc_string_to_timestamp( $post_object->post_date_gmt ) : null,
 				'date_modified'               => 0 < $post_object->post_modified_gmt ? wc_string_to_timestamp( $post_object->post_modified_gmt ) : null,
-				'date_expires'                => metadata_exists( 'post', $coupon_id, 'date_expires' ) ? get_post_meta( $coupon_id, 'date_expires', true ) : get_post_meta( $coupon_id, 'expiry_date', true ),
+				'date_expires'                => get_post_meta( $coupon_id, 'date_expires', true ),
 				'discount_type'               => get_post_meta( $coupon_id, 'discount_type', true ),
 				'amount'                      => get_post_meta( $coupon_id, 'coupon_amount', true ),
 				'usage_count'                 => get_post_meta( $coupon_id, 'usage_count', true ),
@@ -248,33 +248,33 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		$props_to_update = $this->get_props_to_update( $coupon, $meta_key_to_props );
 		foreach ( $props_to_update as $meta_key => $prop ) {
 			$value = $coupon->{"get_$prop"}( 'edit' );
+			$value = is_string( $value ) ? wp_slash( $value ) : $value;
 			switch ( $prop ) {
 				case 'individual_use':
 				case 'free_shipping':
 				case 'exclude_sale_items':
-					$updated = update_post_meta( $coupon->get_id(), $meta_key, wc_bool_to_string( $value ) );
+					$value = wc_bool_to_string( $value );
 					break;
 				case 'product_ids':
 				case 'excluded_product_ids':
-					$updated = update_post_meta( $coupon->get_id(), $meta_key, implode( ',', array_filter( array_map( 'intval', $value ) ) ) );
+					$value = implode( ',', array_filter( array_map( 'intval', $value ) ) );
 					break;
 				case 'product_categories':
 				case 'excluded_product_categories':
-					$updated = update_post_meta( $coupon->get_id(), $meta_key, array_filter( array_map( 'intval', $value ) ) );
+					$value = array_filter( array_map( 'intval', $value ) );
 					break;
 				case 'email_restrictions':
-					$updated = update_post_meta( $coupon->get_id(), $meta_key, array_filter( array_map( 'sanitize_email', $value ) ) );
+					$value = array_filter( array_map( 'sanitize_email', $value ) );
 					break;
 				case 'date_expires':
-					$updated = update_post_meta( $coupon->get_id(), $meta_key, ( $value ? $value->getTimestamp() : null ) );
-					update_post_meta( $coupon->get_id(), 'expiry_date', ( $value ? $value->date( 'Y-m-d' ) : '' ) ); // Update the old meta key for backwards compatibility.
-					break;
-				default:
-					$updated = update_post_meta( $coupon->get_id(), $meta_key, $value );
+					$value = $value ? $value->getTimestamp() : null;
 					break;
 			}
+
+			$updated = $this->update_or_delete_post_meta( $coupon, $meta_key, $value );
+
 			if ( $updated ) {
-				$updated_props[] = $prop;
+				$this->updated_props[] = $prop;
 			}
 		}
 

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -231,8 +231,8 @@ class WC_Data_Store_WP {
 	 * @return bool True if updated/deleted.
 	 */
 	protected function update_or_delete_post_meta( $object, $meta_key, $meta_value ) {
-		if ( ! empty( $value ) || is_numeric( $value ) || in_array( $meta_key, $this->must_exist_meta_keys, true ) ) {
-			$updated = update_post_meta( $object->get_id(), $meta_key, $value );
+		if ( ! empty( $meta_value ) || is_numeric( $meta_value ) || in_array( $meta_key, $this->must_exist_meta_keys, true ) ) {
+			$updated = update_post_meta( $object->get_id(), $meta_key, $meta_value );
 		} else {
 			$updated = delete_post_meta( $object->get_id(), $meta_key );
 		}

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -218,9 +218,13 @@ class WC_Data_Store_WP {
 	}
 
 	/**
-	 * Update non-empty meta, or delete it.
+	 * Update meta data in, or delete it from, the database.
 	 *
-	 * Numeric meta is stored regardless. Also, data-stores can force meta to exist using ``.
+	 * Avoids storing meta when it's either an empty string or empty array.
+	 * Other empty values such as numeric 0 and null should still be stored.
+	 * Data-stores can force meta to exist using `must_exist_meta_keys`.
+	 *
+	 * Note: WordPress `get_metadata` function returns an empty string when meta data does not exist.
 	 *
 	 * @param WC_Data $object The WP_Data object (WC_Coupon for coupons, etc).
 	 * @param string  $meta_key Meta key to update.
@@ -231,10 +235,10 @@ class WC_Data_Store_WP {
 	 * @return bool True if updated/deleted.
 	 */
 	protected function update_or_delete_post_meta( $object, $meta_key, $meta_value ) {
-		if ( ! empty( $meta_value ) || is_numeric( $meta_value ) || in_array( $meta_key, $this->must_exist_meta_keys, true ) ) {
-			$updated = update_post_meta( $object->get_id(), $meta_key, $meta_value );
-		} else {
+		if ( in_array( $meta_value, array( array(), '' ), true ) && ! in_array( $meta_key, $this->must_exist_meta_keys, true ) ) {
 			$updated = delete_post_meta( $object->get_id(), $meta_key );
+		} else {
+			$updated = update_post_meta( $object->get_id(), $meta_key, $meta_value );
 		}
 
 		return (bool) $updated;

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -38,9 +38,19 @@ class WC_Data_Store_WP {
 	 * Data stored in meta keys, but not considered "meta" for an object.
 	 *
 	 * @since 3.0.0
+	 *
 	 * @var array
 	 */
 	protected $internal_meta_keys = array();
+
+	/**
+	 * Meta data which should exist in the DB, even if empty.
+	 *
+	 * @since 3.6.0
+	 *
+	 * @var array
+	 */
+	protected $must_exist_meta_keys = array();
 
 	/**
 	 * Get and store terms from a taxonomy.
@@ -208,6 +218,29 @@ class WC_Data_Store_WP {
 	}
 
 	/**
+	 * Update non-empty meta, or delete it.
+	 *
+	 * Numeric meta is stored regardless. Also, data-stores can force meta to exist using ``.
+	 *
+	 * @param WC_Data $object The WP_Data object (WC_Coupon for coupons, etc).
+	 * @param string  $meta_key Meta key to update.
+	 * @param mixed   $meta_value Value to save.
+	 *
+	 * @since 3.6.0 Added to prevent empty meta being stored unless required.
+	 *
+	 * @return bool True if updated/deleted.
+	 */
+	protected function update_or_delete_post_meta( $object, $meta_key, $meta_value ) {
+		if ( ! empty( $value ) || is_numeric( $value ) || in_array( $meta_key, $this->must_exist_meta_keys, true ) ) {
+			$updated = update_post_meta( $object->get_id(), $meta_key, $value );
+		} else {
+			$updated = delete_post_meta( $object->get_id(), $meta_key );
+		}
+
+		return (bool) $updated;
+	}
+
+	/**
 	 * Get valid WP_Query args from a WC_Object_Query's query variables.
 	 *
 	 * @since 3.1.0
@@ -219,7 +252,7 @@ class WC_Data_Store_WP {
 		$skipped_values = array( '', array(), null );
 		$wp_query_args  = array(
 			'errors'     => array(),
-			'meta_query' => array(), // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_query
+			'meta_query' => array(), // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		);
 
 		foreach ( $query_vars as $key => $value ) {
@@ -377,7 +410,7 @@ class WC_Data_Store_WP {
 
 		// Build meta query for unrecognized keys.
 		if ( ! isset( $wp_query_args['meta_query'] ) ) {
-			$wp_query_args['meta_query'] = array(); // phpcs:ignore WordPress.VIP.SlowDBQuery.slow_db_query_meta_query
+			$wp_query_args['meta_query'] = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 		}
 
 		// Meta dates are stored as timestamps in the db.

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -199,26 +199,19 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 
 		foreach ( $props_to_update as $meta_key => $prop ) {
 			$value = $order->{"get_$prop"}( 'edit' );
-
-			if ( 'date_paid' === $prop ) {
-				// In 3.0.x we store this as a UTC timestamp.
-				update_post_meta( $id, $meta_key, ! is_null( $value ) ? $value->getTimestamp() : '' );
-
-				// In 2.6.x date_paid was stored as _paid_date in local mysql format.
-				update_post_meta( $id, '_paid_date', ! is_null( $value ) ? $value->date( 'Y-m-d H:i:s' ) : '' );
-
-			} elseif ( 'date_completed' === $prop ) {
-				// In 3.0.x we store this as a UTC timestamp.
-				update_post_meta( $id, $meta_key, ! is_null( $value ) ? $value->getTimestamp() : '' );
-
-				// In 2.6.x date_paid was stored as _paid_date in local mysql format.
-				update_post_meta( $id, '_completed_date', ! is_null( $value ) ? $value->date( 'Y-m-d H:i:s' ) : '' );
-
-			} else {
-				update_post_meta( $id, $meta_key, $value );
+			$value = is_string( $value ) ? wp_slash( $value ) : $value;
+			switch ( $prop ) {
+				case 'date_paid':
+				case 'date_completed':
+					$value = ! is_null( $value ) ? $value->getTimestamp() : '';
+					break;
 			}
 
-			$updated_props[] = $prop;
+			$updated = $this->update_or_delete_post_meta( $order, $meta_key, $value );
+
+			if ( $updated ) {
+				$updated_props[] = $prop;
+			}
 		}
 
 		$address_props = array(
@@ -251,10 +244,14 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		foreach ( $address_props as $props_key => $props ) {
 			$props_to_update = $this->get_props_to_update( $order, $props );
 			foreach ( $props_to_update as $meta_key => $prop ) {
-				$value = $order->{"get_$prop"}( 'edit' );
-				update_post_meta( $id, $meta_key, $value );
-				$updated_props[] = $prop;
-				$updated_props[] = $props_key;
+				$value   = $order->{"get_$prop"}( 'edit' );
+				$value   = is_string( $value ) ? wp_slash( $value ) : $value;
+				$updated = $this->update_or_delete_post_meta( $order, $meta_key, $value );
+
+				if ( $updated ) {
+					$updated_props[] = $prop;
+					$updated_props[] = $props_key;
+				}
 			}
 		}
 
@@ -266,6 +263,18 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		}
 		if ( in_array( 'shipping', $updated_props, true ) || ! metadata_exists( 'post', $id, '_shipping_address_index' ) ) {
 			update_post_meta( $id, '_shipping_address_index', implode( ' ', $order->get_address( 'shipping' ) ) );
+		}
+
+		// Legacy date handling. @todo remove in 4.0.
+		if ( 'date_paid' === $prop ) {
+			$value = $order->get_date_paid( 'edit' );
+			// In 2.6.x date_paid was stored as _paid_date in local mysql format.
+			update_post_meta( $id, '_paid_date', ! is_null( $value ) ? $value->date( 'Y-m-d H:i:s' ) : '' );
+		}
+		if ( 'date_completed' === $prop ) {
+			$value = $order->get_date_completed( 'edit' );
+			// In 2.6.x date_paid was stored as _paid_date in local mysql format.
+			update_post_meta( $id, '_completed_date', ! is_null( $value ) ? $value->date( 'Y-m-d H:i:s' ) : '' );
 		}
 
 		// If customer changed, update any downloadable permissions.

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -446,7 +446,14 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 
 		$order1 = WC_Helper_Order::create_order();
 		$order2 = WC_Helper_Order::create_order();
+
+		// Make sure order has shipping name set.
+		$order2->set_shipping_first_name( 'Firstname' );
+		$order2->set_shipping_last_name( 'Surname' );
+		$order2->save();
+
 		delete_post_meta( $order1->get_id(), '_billing_address_index' );
+		delete_post_meta( $order1->get_id(), '_shipping_address_index' );
 		delete_post_meta( $order2->get_id(), '_billing_address_index' );
 		delete_post_meta( $order2->get_id(), '_shipping_address_index' );
 
@@ -457,6 +464,8 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$this->assertTrue( $data['success'] );
 		$this->assertNotEmpty( get_post_meta( $order1->get_id(), '_billing_address_index', true ) );
 		$this->assertNotEmpty( get_post_meta( $order2->get_id(), '_billing_address_index', true ) );
+
+		$this->assertEmpty( get_post_meta( $order1->get_id(), '_shipping_address_index', true ) );
 		$this->assertNotEmpty( get_post_meta( $order2->get_id(), '_shipping_address_index', true ) );
 
 	}

--- a/tests/unit-tests/api/v2/system-status.php
+++ b/tests/unit-tests/api/v2/system-status.php
@@ -362,7 +362,14 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 
 		$order1 = WC_Helper_Order::create_order();
 		$order2 = WC_Helper_Order::create_order();
+
+		// Make sure order has shipping name set.
+		$order2->set_shipping_first_name( 'Firstname' );
+		$order2->set_shipping_last_name( 'Surname' );
+		$order2->save();
+
 		delete_post_meta( $order1->get_id(), '_billing_address_index' );
+		delete_post_meta( $order1->get_id(), '_shipping_address_index' );
 		delete_post_meta( $order2->get_id(), '_billing_address_index' );
 		delete_post_meta( $order2->get_id(), '_shipping_address_index' );
 
@@ -373,7 +380,8 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertTrue( $data['success'] );
 		$this->assertNotEmpty( get_post_meta( $order1->get_id(), '_billing_address_index', true ) );
 		$this->assertNotEmpty( get_post_meta( $order2->get_id(), '_billing_address_index', true ) );
-		$this->assertNotEmpty( get_post_meta( $order2->get_id(), '_shipping_address_index', true ) );
 
+		$this->assertEmpty( get_post_meta( $order1->get_id(), '_shipping_address_index', true ) );
+		$this->assertNotEmpty( get_post_meta( $order2->get_id(), '_shipping_address_index', true ) );
 	}
 }


### PR DESCRIPTION
This PR adjusts the data stores so that avoid storing empty (string or array) values. Null and 0 data is preserved.

This doesn't create too much of a performance boost in itself, but it reduces the number of rows in postmeta which should cause an indirect performance boost.

@kloon See anything wrong with this idea?