### PR TITLE
Fixing order of JP address.

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -960,12 +960,21 @@ class WC_Countries {
 						),
 					),
 					'JP' => array(
+						'postcode' => array(
+							'priority' => 65,
+						),
 						'state'    => array(
 							'label'    => __( 'Prefecture', 'woocommerce' ),
 							'priority' => 66,
 						),
-						'postcode' => array(
-							'priority' => 65,
+						'city' => array(
+							'priority' => 67,
+						),
+						'address_1' => array(
+							'priority' => 68,
+						),
+						'address_2' => array(
+							'priority' => 69,
 						),
 					),
 					'KR' => array(


### PR DESCRIPTION
JP address must be ordered as 'Postal Code' -> 'State (Prefecture)' -> 'City' -> 'address'.
This patch changes the priority for JP address.

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #12577 . (Already merged but not fixed for JP users.)

### How to test the changes in this Pull Request:

1. Add some items to the cart.
2. Proceed to checkout.
3. At billing (or shipping) address, change country to Japan.
4. The fields order will be changed to 'Postal Code', 'State', 'City', 'address 1', 'address 2'.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?  
`This not may be needed, I suppose.`
* [ ] Have you successfully ran tests with your changes locally?  
`This not may be needed, either.`

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

For address for Japan, the order of the fields has been fixed.
