### PR TITLE
Use total, not amount, when calculating fees

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1444,7 +1444,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		$cart_subtotal     = 0;
 		$cart_total        = 0;
-		$fee_total         = 0;
+		$fees_total         = 0;
 		$shipping_total    = 0;
 		$cart_subtotal_tax = 0;
 		$cart_total_tax    = 0;
@@ -1464,18 +1464,17 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		// Sum fee costs.
 		foreach ( $this->get_fees() as $item ) {
-			$amount = $item->get_amount();
+			$fee_total = $item->get_total();
 
-			if ( 0 > $amount ) {
-				$item->set_total( $amount );
-				$max_discount = round( $cart_total + $fee_total + $shipping_total, wc_get_price_decimals() ) * -1;
+			if ( 0 > $fee_total ) {
+				$max_discount = round( $cart_total + $fees_total + $shipping_total, wc_get_price_decimals() ) * -1;
 
-				if ( $item->get_total() < $max_discount ) {
+				if ( $fee_total < $max_discount ) {
 					$item->set_total( $max_discount );
 				}
 			}
 
-			$fee_total += $item->get_total();
+			$fees_total += $item->get_total();
 		}
 
 		// Calculate taxes for items, shipping, discounts. Note; this also triggers save().
@@ -1498,7 +1497,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		$this->set_discount_total( $cart_subtotal - $cart_total );
 		$this->set_discount_tax( wc_round_tax_total( $cart_subtotal_tax - $cart_total_tax ) );
-		$this->set_total( round( $cart_total + $fee_total + $this->get_shipping_total() + $this->get_cart_tax() + $this->get_shipping_tax(), wc_get_price_decimals() ) );
+		$this->set_total( round( $cart_total + $fees_total + $this->get_shipping_total() + $this->get_cart_tax() + $this->get_shipping_tax(), wc_get_price_decimals() ) );
 
 		do_action( 'woocommerce_order_after_calculate_totals', $and_taxes, $this );
 


### PR DESCRIPTION
When using the REST API we set the fee 'total' but we don't set the fee 'amount'. Amount and fee pretty much do the same thing, but in general, total is the calculated amount.

This PR adjusts the negative fee handling to look at total rather than amount so that the fee total gets adjusted if negative and > order value.

Fixes #21767

> Correcrly handle negative fees when using the REST API

Test with a PUT request:

```
{
	"status": "on-hold",
	"currency": "USD",
	"discount_total": "0.00",
	"discount_tax": "0.00",
	"shipping_total": "0.00",
	"shipping_tax": "0.00",
	"cart_tax": "0.00",
	"total": "90.00",
	"total_tax": "0.00",
	"prices_include_tax": false,
	"customer_id": 1,
	"payment_method": "bacs",
	"payment_method_title": "Direct bank transfer",
	"transaction_id": "",
	"date_paid": null,
	"date_paid_gmt": null,
	"date_completed": null,
	"date_completed_gmt": null,
	"meta_data": [],
	"line_items": [
		{
			"name": "Hoodie - Blue, Yes",
			"product_id": 58,
			"variation_id": 81,
			"quantity": 1,
			"tax_class": "",
			"subtotal": "45.00",
			"subtotal_tax": "0.00",
			"total": "45.00",
			"total_tax": "0.00",
			"taxes": [],
			"meta_data": [
				{
					"id": 34,
					"key": "pa_color",
					"value": "blue"
				},
				{
					"id": 35,
					"key": "logo",
					"value": "Yes"
				}
			],
			"sku": "woo-hoodie-blue-logo",
			"price": 45
		}
	],
	"tax_lines": [],
	"shipping_lines": [],
	"fee_lines": [
		{
			"name": "Test",
			"total": "-1000"
		}
	]
}
```

Order value should be 0, not -something, after patch.