### PR TITLE
Only set user first and last names when those fields are empty

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -989,17 +989,17 @@ class WC_Checkout {
 		if ( $customer_id && apply_filters( 'woocommerce_checkout_update_customer_data', true, $this ) ) {
 			$customer = new WC_Customer( $customer_id );
 
-			if ( ! empty( $data['billing_first_name'] ) ) {
+			if ( ! empty( $data['billing_first_name'] ) && '' === $customer->get_first_name() ) {
 				$customer->set_first_name( $data['billing_first_name'] );
 			}
 
-			if ( ! empty( $data['billing_last_name'] ) ) {
+			if ( ! empty( $data['billing_last_name'] ) && '' === $customer->get_last_name() ) {
 				$customer->set_last_name( $data['billing_last_name'] );
 			}
 
 			// If the display name is an email, update to the user's full name.
 			if ( is_email( $customer->get_display_name() ) ) {
-				$customer->set_display_name( $data['billing_first_name'] . ' ' . $data['billing_last_name'] );
+				$customer->set_display_name( $customer->get_first_name() . ' ' . $customer->get_last_name() );
 			}
 
 			foreach ( $data as $key => $value ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

User's account first and last names are changed during checkout every time billing fields are updated.
Now with this PR should update only when is empty those fields.

Closes #22765.

### How to test the changes in this Pull Request:

1. Login with a registered customer
2. Place a new order changing the billing first and last names
3. Note that this also changes the name on the user's account on WooCommerce instead of just the billing address.
4. Apply this patch and repeat step 2
5. Note that now user's account are not changing anymore.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Fill user's account first name and last name only when those fields are empty.
