### PR TITLE
Improve user's display_name generation during checkout

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -965,7 +965,15 @@ class WC_Checkout {
 		if ( ! is_user_logged_in() && ( $this->is_registration_required() || ! empty( $data['createaccount'] ) ) ) {
 			$username    = ! empty( $data['account_username'] ) ? $data['account_username'] : '';
 			$password    = ! empty( $data['account_password'] ) ? $data['account_password'] : '';
-			$customer_id = wc_create_new_customer( $data['billing_email'], $username, $password );
+			$customer_id = wc_create_new_customer(
+				$data['billing_email'],
+				$username,
+				$password,
+				array(
+					'first_name' => ! empty( $data['billing_first_name'] ) ? $data['billing_first_name'] : '',
+					'last_name'  => ! empty( $data['billing_last_name'] ) ? $data['billing_last_name'] : '',
+				)
+			);
 
 			if ( is_wp_error( $customer_id ) ) {
 				throw new Exception( $customer_id->get_error_message() );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -384,9 +384,7 @@ add_filter( 'user_has_cap', 'wc_customer_has_capability', 10, 3 );
 function wc_shop_manager_has_capability( $allcaps, $caps, $args, $user ) {
 
 	if ( wc_user_has_role( $user, 'shop_manager' ) ) {
-		/**
-		 * @see wc_modify_map_meta_cap, which limits editing to customers.
-		 */
+		// @see wc_modify_map_meta_cap, which limits editing to customers.
 		$allcaps['edit_users'] = true;
 	}
 

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -32,12 +32,13 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 	/**
 	 * Create a new customer.
 	 *
-	 * @param  string $email Customer email.
+	 * @param  string $email    Customer email.
 	 * @param  string $username Customer username.
 	 * @param  string $password Customer password.
+	 * @param  array  $args     List of arguments to pass to `wp_insert_user()`.
 	 * @return int|WP_Error Returns WP_Error on failure, Int (user ID) on success.
 	 */
-	function wc_create_new_customer( $email, $username = '', $password = '' ) {
+	function wc_create_new_customer( $email, $username = '', $password = '', $args = array() ) {
 
 		// Check the email address.
 		if ( empty( $email ) || ! is_email( $email ) ) {
@@ -96,11 +97,14 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 
 		$new_customer_data = apply_filters(
 			'woocommerce_new_customer_data',
-			array(
-				'user_login' => $username,
-				'user_pass'  => $password,
-				'user_email' => $email,
-				'role'       => 'customer',
+			array_merge(
+				$args,
+				array(
+					'user_login' => $username,
+					'user_pass'  => $password,
+					'user_email' => $email,
+					'role'       => 'customer',
+				)
 			)
 		);
 

--- a/tests/unit-tests/customer/functions.php
+++ b/tests/unit-tests/customer/functions.php
@@ -45,6 +45,19 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 		$userdata = get_userdata( $id );
 		$this->assertEquals( 'fred2', $userdata->user_login );
 
+		// Test extra arguments to generate display_name.
+		$id       = wc_create_new_customer(
+			'john.doe@example.com',
+			'',
+			'testpassword',
+			array(
+				'first_name' => 'John',
+				'last_name'  => 'Doe'
+			)
+		);
+		$userdata = get_userdata( $id );
+		$this->assertEquals( 'John Doe', $userdata->display_name );
+
 		// No password.
 		update_option( 'woocommerce_registration_generate_password', 'no' );
 		$id = wc_create_new_customer( 'joe@example.com', 'joecustomer', '' );

--- a/tests/unit-tests/customer/functions.php
+++ b/tests/unit-tests/customer/functions.php
@@ -1,8 +1,12 @@
 <?php
+/**
+ * Customer functions
+ *
+ * @package WooCommerce\Tests\Customer
+ */
 
 /**
- * Customer functions.
- * @package WooCommerce\Tests\Customer
+ * WC_Tests_Customer_Functions class.
  */
 class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 
@@ -52,7 +56,7 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 			'testpassword',
 			array(
 				'first_name' => 'John',
-				'last_name'  => 'Doe'
+				'last_name'  => 'Doe',
 			)
 		);
 		$userdata = get_userdata( $id );
@@ -83,7 +87,7 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 		$order2 = new WC_Order();
 		$order2->save();
 
-		// Test download permissions
+		// Test download permissions.
 		$prod_download = new WC_Product_Download();
 		$prod_download->set_file( plugin_dir_url( __FILE__ ) . '/assets/images/help.png' );
 		$prod_download->set_id( 'download' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This one is a good complement of https://github.com/woocommerce/woocommerce/pull/22783

When registering an user during checkout we only sent email, username and password to `wp_insert_user()`, this will generally set `display_name` as the username, in most of the cases will be the first part of the user's email address, and if an user like to see a better name on comments or on My Account page they need to set a new display name in `/my-account/edit-account/`, so this PR ensure user's get a better `display_name` during registration on checkout.

### How to test the changes in this Pull Request:

1. Place any order creating a new customer and check the display name on `/my-account`
2. Apply this patch
3. Place a new order and creating a new customer again, see the display name now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Better user's `display_name` generation during checkout.