### PR TITLE
Add Tracks events for product import start and finish.

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -299,7 +299,7 @@ class WC_Tracker {
 	 *
 	 * @return array
 	 */
-	private static function get_product_counts() {
+	public static function get_product_counts() {
 		$product_count          = array();
 		$product_count_data     = wp_count_posts( 'product' );
 		$product_count['total'] = $product_count_data->publish;

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -76,10 +76,12 @@ class WC_Site_Tracking {
 
 		self::enqueue_scripts();
 
-		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-products-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-extensions-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-importer-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-products-tracking.php';
 
 		$tracking_classes = array(
+			'WC_Extensions_Tracking',
 			'WC_Importer_Tracking',
 			'WC_Products_Tracking',
 		);

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -31,6 +31,63 @@ class WC_Site_Tracking {
 	}
 
 	/**
+	 * Route product importer action to the right callback.
+	 *
+	 * @return void
+	 */
+	public static function tracks_product_importer() {
+		if ( ! isset( $_REQUEST['step'] ) ) {
+			return;
+		}
+
+		if ( 'import' === $_REQUEST['step'] ) {
+			return self::tracks_product_importer_start();
+		}
+
+		if ( 'done' === $_REQUEST['step'] ) {
+			return self::tracks_product_importer_complete();
+		}
+	}
+
+	/**
+	 * Send a Tracks event when the product importer is started.
+	 *
+	 * @return void
+	 */
+	public static function tracks_product_importer_start() {
+		if ( ! isset( $_REQUEST['file'] ) || ! isset( $_REQUEST['_wpnonce'] ) ) {
+			return;
+		}
+
+		$properties = array(
+			'update_existing' => isset( $_REQUEST['update_existing'] ) ? (bool) $_REQUEST['update_existing'] : false,
+			'delimiter'       => empty( $_REQUEST['delimiter'] ) ? ',' : wc_clean( wp_unslash( $_REQUEST['delimiter'] ) ),
+		);
+
+		WC_Tracks::record_event( 'product_import_start', $properties );
+	}
+
+	/**
+	 * Send a Tracks event when the product importer has finished.
+	 *
+	 * @return void
+	 */
+	public static function tracks_product_importer_complete() {
+		if ( ! isset( $_REQUEST['nonce'] ) ) {
+			return;
+		}
+
+		$properties = array(
+			'imported' => isset( $_GET['products-imported'] ) ? absint( $_GET['products-imported'] ) : 0,
+			'updated'  => isset( $_GET['products-updated'] ) ? absint( $_GET['products-updated'] ) : 0,
+			'failed'   => isset( $_GET['products-failed'] ) ? absint( $_GET['products-failed'] ) : 0,
+			'skipped'  => isset( $_GET['products-skipped'] ) ? absint( $_GET['products-skipped'] ) : 0,
+		);
+
+		WC_Tracks::record_event( 'product_import_complete', $properties );
+	}
+
+	/**
 	 * Check if tracking is enabled.
 	 *
 	 * @return bool
@@ -96,5 +153,6 @@ class WC_Site_Tracking {
 		self::enqueue_scripts();
 
 		add_action( 'edit_post', array( 'WC_Site_Tracking', 'tracks_product_updated' ), 10, 2 );
+		add_action( 'product_page_product_importer', array( __CLASS__, 'tracks_product_importer' ) );
 	}
 }

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -72,11 +72,14 @@ class WC_Tracks {
 	 * @return array Blog details.
 	 */
 	public static function get_blog_details( $user_id ) {
+		$product_counts = WC_Tracker::get_product_counts();
+
 		return array(
-			// @todo Add revenue/product info and url similar to wc-tracker.
-			'url'       => get_option( 'siteurl' ),
-			'blog_lang' => get_user_locale( $user_id ),
-			'blog_id'   => ( class_exists( 'Jetpack' ) && Jetpack_Options::get_option( 'id' ) ) || null,
+			// @todo Add revenue info and url similar to wc-tracker.
+			'url'            => get_option( 'siteurl' ),
+			'blog_lang'      => get_user_locale( $user_id ),
+			'blog_id'        => ( class_exists( 'Jetpack' ) && Jetpack_Options::get_option( 'id' ) ) || null,
+			'products_count' => $product_counts['total'],
 		);
 	}
 

--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * WooCommerce Extensions Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of the WooCommerce Extensions page.
+ */
+class WC_Extensions_Tracking {
+	/**
+	 * Init tracking.
+	 */
+	public static function init() {
+		add_action( 'load-woocommerce_page_wc-addons', array( __CLASS__, 'track_extensions_page' ) );
+	}
+
+	/**
+	 * Send a Tracks event when an Extensions page is viewed.
+	 */
+	public static function track_extensions_page() {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		$event      = 'extensions_view';
+		$properties = array(
+			'section' => empty( $_REQUEST['section'] ) ? '_featured' : wc_clean( wp_unslash( $_REQUEST['section'] ) ),
+		);
+
+		if ( ! empty( $_REQUEST['search'] ) ) {
+			$event                     = 'extensions_view_search';
+			$properties['search_term'] = wc_clean( wp_unslash( $_REQUEST['search'] ) );
+		}
+		// phpcs:enable
+
+		WC_Tracks::record_event( $event, $properties );
+	}
+}

--- a/includes/tracks/events/class-wc-importer-tracking.php
+++ b/includes/tracks/events/class-wc-importer-tracking.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * WooCommerce Import Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of WooCommerce Imports.
+ */
+class WC_Importer_Tracking {
+	/**
+	 * Init tracking.
+	 */
+	public static function init() {
+		add_action( 'product_page_product_importer', array( __CLASS__, 'track_product_importer' ) );
+	}
+
+	/**
+	 * Route product importer action to the right callback.
+	 *
+	 * @return void
+	 */
+	public static function track_product_importer() {
+		if ( ! isset( $_REQUEST['step'] ) ) {
+			return;
+		}
+
+		if ( 'import' === $_REQUEST['step'] ) {
+			return self::track_product_importer_start();
+		}
+
+		if ( 'done' === $_REQUEST['step'] ) {
+			return self::track_product_importer_complete();
+		}
+	}
+
+	/**
+	 * Send a Tracks event when the product importer is started.
+	 *
+	 * @return void
+	 */
+	public static function track_product_importer_start() {
+		if ( ! isset( $_REQUEST['file'] ) || ! isset( $_REQUEST['_wpnonce'] ) ) {
+			return;
+		}
+
+		$properties = array(
+			'update_existing' => isset( $_REQUEST['update_existing'] ) ? (bool) $_REQUEST['update_existing'] : false,
+			'delimiter'       => empty( $_REQUEST['delimiter'] ) ? ',' : wc_clean( wp_unslash( $_REQUEST['delimiter'] ) ),
+		);
+
+		WC_Tracks::record_event( 'product_import_start', $properties );
+	}
+
+	/**
+	 * Send a Tracks event when the product importer has finished.
+	 *
+	 * @return void
+	 */
+	public static function track_product_importer_complete() {
+		if ( ! isset( $_REQUEST['nonce'] ) ) {
+			return;
+		}
+
+		$properties = array(
+			'imported' => isset( $_GET['products-imported'] ) ? absint( $_GET['products-imported'] ) : 0,
+			'updated'  => isset( $_GET['products-updated'] ) ? absint( $_GET['products-updated'] ) : 0,
+			'failed'   => isset( $_GET['products-failed'] ) ? absint( $_GET['products-failed'] ) : 0,
+			'skipped'  => isset( $_GET['products-skipped'] ) ? absint( $_GET['products-skipped'] ) : 0,
+		);
+
+		WC_Tracks::record_event( 'product_import_complete', $properties );
+	}
+}

--- a/includes/tracks/events/class-wc-importer-tracking.php
+++ b/includes/tracks/events/class-wc-importer-tracking.php
@@ -24,6 +24,7 @@ class WC_Importer_Tracking {
 	 * @return void
 	 */
 	public static function track_product_importer() {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
 		if ( ! isset( $_REQUEST['step'] ) ) {
 			return;
 		}
@@ -35,6 +36,7 @@ class WC_Importer_Tracking {
 		if ( 'done' === $_REQUEST['step'] ) {
 			return self::track_product_importer_complete();
 		}
+		// phpcs:enable
 	}
 
 	/**
@@ -43,6 +45,7 @@ class WC_Importer_Tracking {
 	 * @return void
 	 */
 	public static function track_product_importer_start() {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
 		if ( ! isset( $_REQUEST['file'] ) || ! isset( $_REQUEST['_wpnonce'] ) ) {
 			return;
 		}
@@ -51,6 +54,7 @@ class WC_Importer_Tracking {
 			'update_existing' => isset( $_REQUEST['update_existing'] ) ? (bool) $_REQUEST['update_existing'] : false,
 			'delimiter'       => empty( $_REQUEST['delimiter'] ) ? ',' : wc_clean( wp_unslash( $_REQUEST['delimiter'] ) ),
 		);
+		// phpcs:enable
 
 		WC_Tracks::record_event( 'product_import_start', $properties );
 	}
@@ -61,6 +65,7 @@ class WC_Importer_Tracking {
 	 * @return void
 	 */
 	public static function track_product_importer_complete() {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
 		if ( ! isset( $_REQUEST['nonce'] ) ) {
 			return;
 		}
@@ -71,6 +76,7 @@ class WC_Importer_Tracking {
 			'failed'   => isset( $_GET['products-failed'] ) ? absint( $_GET['products-failed'] ) : 0,
 			'skipped'  => isset( $_GET['products-skipped'] ) ? absint( $_GET['products-skipped'] ) : 0,
 		);
+		// phpcs:enable
 
 		WC_Tracks::record_event( 'product_import_complete', $properties );
 	}

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * WooCommerce Import Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of WooCommerce Products.
+ */
+class WC_Products_Tracking {
+	/**
+	 * Init tracking.
+	 */
+	public static function init() {
+		add_action( 'edit_post', array( __CLASS__, 'track_product_updated' ), 10, 2 );
+	}
+
+    /**
+	 * Send a Tracks event when a product is updated.
+	 *
+	 * @param int   $product_id Product id.
+	 * @param array $post WordPress post.
+	 */
+	public static function track_product_updated( $product_id, $post ) {
+		if ( 'product' !== $post->post_type ) {
+			return;
+		}
+
+		$properties = array(
+			'product_id' => $product_id,
+		);
+
+		WC_Tracks::record_event( 'update_product', $properties );
+	}
+}

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -18,7 +18,7 @@ class WC_Products_Tracking {
 		add_action( 'edit_post', array( __CLASS__, 'track_product_updated' ), 10, 2 );
 	}
 
-    /**
+	/**
 	 * Send a Tracks event when a product is updated.
 	 *
 	 * @param int   $product_id Product id.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Introduces tracking for the Product Importer.

Adds two events:
* `product_import_start`, with properties: `update_existing`,`delimiter`
* `product_import_complete`, with properties: `imported`,`updated`,`failed`,`skipped` (counts)

The events are hooked into page loads triggered by the `WC_Product_CSV_Importer_Controller` class.

**Question:** should the nonces I'm checking for (to avoid false positives) be verified?

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Products > Import
2. Initiate an import, wait for it to finish
3. Verify that both events fired, and check that the property values were correct
4. Try visiting the import pages manually (`edit.php?post_type=product&page=product_importer&step=import`, etc)
5. Verify that the tracks events aren't fired
