### PR TITLE
Track when a product is published.

### DIFF
--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -16,13 +16,14 @@ class WC_Products_Tracking {
 	 */
 	public static function init() {
 		add_action( 'edit_post', array( __CLASS__, 'track_product_updated' ), 10, 2 );
+		add_action( 'transition_post_status', array( __CLASS__, 'track_product_published' ), 10, 3 );
 	}
 
 	/**
 	 * Send a Tracks event when a product is updated.
 	 *
 	 * @param int   $product_id Product id.
-	 * @param array $post WordPress post.
+	 * @param object $post WordPress post.
 	 */
 	public static function track_product_updated( $product_id, $post ) {
 		if ( 'product' !== $post->post_type ) {
@@ -34,5 +35,28 @@ class WC_Products_Tracking {
 		);
 
 		WC_Tracks::record_event( 'update_product', $properties );
+	}
+
+	/**
+	 * Send a Tracks event when a product is published.
+	 *
+	 * @param string $new_status New post_status.
+	 * @param string $old_status Previous post_status.
+	 * @param object $post WordPress post.
+	 */
+	public static function track_product_published( $new_status, $old_status, $post ) {
+		if (
+			'product' !== $post->post_type ||
+			'publish' !== $new_status ||
+			'publish' === $old_status
+		) {
+			return;
+		}
+
+		$properties = array(
+			'product_id' => $post->ID,
+		);
+
+		WC_Tracks::record_event( 'product_add_publish', $properties );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a Tracks event when a Product is transitioned to the "publish" status.

_Note: this PR base can change to `feature/add-tracks` after `add/tracks-product-importer` is merged._

#### Questions:
* Should we fire an event every time a product transitions status to publish, or just the first time?
* Should the product edit/update event fire with this?

### How to test the changes in this Pull Request:

1. Create a new product
2. Publish it
3. Verify the `product_add_publish` event fires
4. Edit a draft product
5. Publish it
6. Verify the `product_add_publish` event fires
7. Update the same product
8. Verify the `product_add_publish` event **does not** fire
