### PR TITLE
Track when product categories are created.

### DIFF
--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -17,6 +17,7 @@ class WC_Products_Tracking {
 	public static function init() {
 		add_action( 'edit_post', array( __CLASS__, 'track_product_updated' ), 10, 2 );
 		add_action( 'transition_post_status', array( __CLASS__, 'track_product_published' ), 10, 3 );
+		add_action( 'created_product_cat', array( __CLASS__, 'track_product_category_created' ) );
 	}
 
 	/**
@@ -58,5 +59,32 @@ class WC_Products_Tracking {
 		);
 
 		WC_Tracks::record_event( 'product_add_publish', $properties );
+	}
+
+	/**
+	 * Send a Tracks event when a product category is created.
+	 *
+	 * @param int $category_id Category ID.
+	 */
+	public static function track_product_category_created( $category_id ) {
+		// Only track category creation from the edit product screen or the
+		// category management screen (which both occur via AJAX).
+		if (
+			! defined( 'DOING_AJAX' ) ||
+			empty( $_POST['action'] ) ||
+			(
+				'add-tag' !== $_POST['action'] &&      // Product Categories screen.
+				'add-product_cat' !== $_POST['action'] // Edit Product screen.
+			)
+		) {
+			return;
+		}
+
+		$properties = array(
+			'category_id' => $category_id,
+			'source'      => ( 'add-tag' === $_POST['action'] ) ? 'categories' : 'product',
+		);
+
+		WC_Tracks::record_event( 'product_category_add', $properties );
 	}
 }

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -80,9 +80,11 @@ class WC_Products_Tracking {
 			return;
 		}
 
+		$category   = get_term( $category_id, 'product_cat' );
 		$properties = array(
 			'category_id' => $category_id,
-			'source'      => ( 'add-tag' === $_POST['action'] ) ? 'categories' : 'product',
+			'parent_id'   => $category->parent,
+			'page'        => ( 'add-tag' === $_POST['action'] ) ? 'categories' : 'product',
 		);
 
 		WC_Tracks::record_event( 'product_category_add', $properties );

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -67,14 +67,17 @@ class WC_Products_Tracking {
 	 * @param int $category_id Category ID.
 	 */
 	public static function track_product_category_created( $category_id ) {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
 		// Only track category creation from the edit product screen or the
 		// category management screen (which both occur via AJAX).
 		if (
 			! defined( 'DOING_AJAX' ) ||
 			empty( $_POST['action'] ) ||
 			(
-				'add-tag' !== $_POST['action'] &&      // Product Categories screen.
-				'add-product_cat' !== $_POST['action'] // Edit Product screen.
+				// Product Categories screen.
+				'add-tag' !== $_POST['action'] &&
+				// Edit Product screen.
+				'add-product_cat' !== $_POST['action']
 			)
 		) {
 			return;
@@ -86,6 +89,7 @@ class WC_Products_Tracking {
 			'parent_id'   => $category->parent,
 			'page'        => ( 'add-tag' === $_POST['action'] ) ? 'categories' : 'product',
 		);
+		// phpcs:enable
 
 		WC_Tracks::record_event( 'product_category_add', $properties );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a Tracks event when a Product Category is created from either the Edit Product screen or the Product Categories screen.

_Note: this PR base can change to `feature/add-tracks` after `add/tracks-product-importer` is merged._

### How to test the changes in this Pull Request:

1. Add a category from WooCommerce > Products > Edit
2. Verify that a `product_category_add` event fires with `source` = `product`
3. Add a category from WooCommerce > Products > Categories
4. Verify that a `product_category_add` event fires with `source` = `categories`
