### PR TITLE
Include products count in base Tracks data.

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -299,7 +299,7 @@ class WC_Tracker {
 	 *
 	 * @return array
 	 */
-	private static function get_product_counts() {
+	public static function get_product_counts() {
 		$product_count          = array();
 		$product_count_data     = wp_count_posts( 'product' );
 		$product_count['total'] = $product_count_data->publish;

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -72,11 +72,14 @@ class WC_Tracks {
 	 * @return array Blog details.
 	 */
 	public static function get_blog_details( $user_id ) {
+		$product_counts = WC_Tracker::get_product_counts();
+
 		return array(
-			// @todo Add revenue/product info and url similar to wc-tracker.
-			'url'       => get_option( 'siteurl' ),
-			'blog_lang' => get_user_locale( $user_id ),
-			'blog_id'   => ( class_exists( 'Jetpack' ) && Jetpack_Options::get_option( 'id' ) ) || null,
+			// @todo Add revenue info and url similar to wc-tracker.
+			'url'            => get_option( 'siteurl' ),
+			'blog_lang'      => get_user_locale( $user_id ),
+			'blog_id'        => ( class_exists( 'Jetpack' ) && Jetpack_Options::get_option( 'id' ) ) || null,
+			'products_count' => $product_counts['total'],
 		);
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds `products_count` to all Tracks events (containing the total number of published products).

_Note: this PR base can change to `feature/add-tracks` after `add/tracks-product-importer` is merged._

### How to test the changes in this Pull Request:

1. Kick off any Tracks event
2. Verify that `products_count` is in the request and matches the number of published products
