### PR TITLE
Fixt product_edit to match the event in the spreadsheet

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -27,7 +27,7 @@ class WC_Site_Tracking {
 			'product_id' => $product_id,
 		);
 
-		WC_Tracks::record_event( 'update_product', $properties );
+		WC_Tracks::record_event( 'product_edit', $properties );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Rename the edit product event

