### PR TITLE
Tracks: Orders edit status change

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -79,11 +79,13 @@ class WC_Site_Tracking {
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-extensions-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-importer-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-products-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-orders-tracking.php';
 
 		$tracking_classes = array(
 			'WC_Extensions_Tracking',
 			'WC_Importer_Tracking',
 			'WC_Products_Tracking',
+			'WC_Orders_Tracking',
 		);
 
 		foreach ( $tracking_classes as $tracking_class ) {

--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * WooCommerce Orders Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of WooCommerce Orders.
+ */
+class WC_Orders_Tracking {
+	/**
+	 * Init tracking.
+	 */
+	public static function init() {
+		add_action( 'woocommerce_order_status_changed', array( __CLASS__, 'track_order_status_change' ), 10, 3 );
+		add_action( 'load-edit.php', array( __CLASS__, 'track_orders_view' ), 10 );
+	}
+
+	/**
+	 * Send a Tracks event when the Orders page is viewed.
+	 */
+	public static function track_orders_view() {
+		if ( isset( $_GET['post_type'] ) && 'shop_order' === sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) ) {
+			WC_Tracks::record_event( 'orders_view' );
+		}
+	}
+
+	/**
+	 * Send a Tracks event when an order status is changed.
+	 *
+	 * @param int    $id Order id.
+	 * @param string $previous_status the old WooCommerce order status.
+	 * @param string $next_status the new WooCommerce order status.
+	 */
+	public static function track_order_status_change( $id, $previous_status, $next_status ) {
+		$order = wc_get_order( $id );
+		$date  = $order->get_date_created();
+
+		$properties = array(
+			'order_id'        => $id,
+			'next_status'     => $next_status,
+			'previous_status' => $previous_status,
+			'date_created'    => $date->date( 'Y-m-d' ),
+		);
+
+		WC_Tracks::record_event( 'orders_edit_status_change', $properties );
+	}
+}

--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -23,7 +23,7 @@ class WC_Orders_Tracking {
 	 * Send a Tracks event when the Orders page is viewed.
 	 */
 	public static function track_orders_view() {
-		if ( isset( $_GET['post_type'] ) && 'shop_order' === sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) ) {
+		if ( isset( $_GET['post_type'] ) && 'shop_order' === wp_unslash( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			WC_Tracks::record_event( 'orders_view' );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add Tracks event to Orders status update.

### How to test the changes in this Pull Request:

1. Orders screen
2. See the `orders_view` event fired
3. Change a status on an order
4. See the `orders_edit_status_change` event fired

