### PR TITLE
Add extensions page view tracking.

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -41,10 +41,12 @@ class WC_Site_Tracking {
 			return;
 		}
 
-		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-products-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-extensions-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-importer-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-products-tracking.php';
 
 		$tracking_classes = array(
+			'WC_Extensions_Tracking',
 			'WC_Importer_Tracking',
 			'WC_Products_Tracking',
 		);

--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -23,11 +23,17 @@ class WC_Extensions_Tracking {
 	 */
 	public static function track_extensions_page() {
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		$event      = 'extensions_view';
 		$properties = array(
 			'section' => empty( $_REQUEST['section'] ) ? '_featured' : wc_clean( wp_unslash( $_REQUEST['section'] ) ),
 		);
+
+		if ( ! empty( $_REQUEST['search'] ) ) {
+			$event                     = 'extensions_view_search';
+			$properties['search_term'] = wc_clean( wp_unslash( $_REQUEST['search'] ) );
+		}
 		// phpcs:enable
 
-		WC_Tracks::record_event( 'extensions_view', $properties );
+		WC_Tracks::record_event( $event, $properties );
 	}
 }

--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * WooCommerce Extensions Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of the WooCommerce Extensions page.
+ */
+class WC_Extensions_Tracking {
+	/**
+	 * Init tracking.
+	 */
+	public static function init() {
+		add_action( 'load-woocommerce_page_wc-addons', array( __CLASS__, 'track_extensions_page' ) );
+	}
+
+	/**
+	 * Send a Tracks event when an Extensions page is viewed.
+	 */
+	public static function track_extensions_page() {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		$properties = array(
+			'section' => empty( $_REQUEST['section'] ) ? '_featured' : wc_clean( wp_unslash( $_REQUEST['section'] ) ),
+		);
+		// phpcs:enable
+
+		WC_Tracks::record_event( 'extensions_view', $properties );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add a Tracks event when the Extensions page is viewed.

Note: this PR base can change to `feature/add-tracks` after `add/tracks-product-importer` is merged.

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Extensions
2. Verify a Tracks event is fired with `extensions_view`, and the appropriate `section`
3. Try another section (e.g. Marketing) and verify event
