### PR TITLE
Add tracking for extension searches.

### DIFF
--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -23,11 +23,17 @@ class WC_Extensions_Tracking {
 	 */
 	public static function track_extensions_page() {
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		$event      = 'extensions_view';
 		$properties = array(
 			'section' => empty( $_REQUEST['section'] ) ? '_featured' : wc_clean( wp_unslash( $_REQUEST['section'] ) ),
 		);
+
+		if ( ! empty( $_REQUEST['search'] ) ) {
+			$event                     = 'extensions_view_search';
+			$properties['search_term'] = wc_clean( wp_unslash( $_REQUEST['search'] ) );
+		}
 		// phpcs:enable
 
-		WC_Tracks::record_event( 'extensions_view', $properties );
+		WC_Tracks::record_event( $event, $properties );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Add a Tracks event for Extension searches.

Note: this PR base can change to `feature/add-tracks` after `add/tracks-extensions-view` is merged.

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Extensions
2. Search for a term
3. Verify that a `extensions_view_search` Tracks event is fired with the appropriate `search_term`
4. Switch to another section (e.g. Marketing) and perform another search
5. Verify the Tracks event has the appropriate `section`
