### PR TITLE
Track Subscriptions connection actions

### DIFF
--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -693,6 +693,10 @@ class WC_Helper {
 
 		// Bail if the user clicked deny.
 		if ( ! empty( $_GET['deny'] ) ) {
+			/**
+			 * Fires when the Helper connection process is denied/cancelled.
+			 */
+			do_action( 'woocommerce_helper_denied' );
 			wp_safe_redirect( admin_url( 'admin.php?page=wc-addons&section=helper' ) );
 			die();
 		}

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -823,6 +823,11 @@ class WC_Helper {
 			wp_die( 'Could not verify nonce' );
 		}
 
+		/**
+		 * Fires when Helper subscriptions are refreshed.
+		 */
+		do_action( 'woocommerce_helper_subscriptions_refresh' );
+
 		$redirect_uri = add_query_arg(
 			array(
 				'page'             => 'wc-addons',

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -750,6 +750,11 @@ class WC_Helper {
 		self::_flush_subscriptions_cache();
 		self::_flush_updates_cache();
 
+		/**
+		 * Fires when the Helper connection process has completed successfully.
+		 */
+		do_action( 'woocommerce_helper_connected' );
+
 		// Enable tracking when connected.
 		if ( class_exists( 'WC_Tracker' ) ) {
 			update_option( 'woocommerce_allow_tracking', 'yes' );

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -782,6 +782,11 @@ class WC_Helper {
 			wp_die( 'Could not verify nonce' );
 		}
 
+		/**
+		 * Fires when the Helper has been disconnected.
+		 */
+		do_action( 'woocommerce_helper_disconnected' );
+
 		$redirect_uri = add_query_arg(
 			array(
 				'page'             => 'wc-addons',

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -665,6 +665,11 @@ class WC_Helper {
 			wp_die( 'Something went wrong' );
 		}
 
+		/**
+		 * Fires when the Helper connection process is initiated.
+		 */
+		do_action( 'woocommerce_helper_connect_start' );
+
 		$connect_url = add_query_arg(
 			array(
 				'home_url'     => rawurlencode( home_url() ),

--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -19,6 +19,7 @@ class WC_Extensions_Tracking {
 		add_action( 'woocommerce_helper_connect_start', array( __CLASS__, 'track_helper_connection_start' ) );
 		add_action( 'woocommerce_helper_denied', array( __CLASS__, 'track_helper_connection_cancelled' ) );
 		add_action( 'woocommerce_helper_connected', array( __CLASS__, 'track_helper_connection_complete' ) );
+		add_action( 'woocommerce_helper_disconnected', array( __CLASS__, 'track_helper_disconnected' ) );
 	}
 
 	/**
@@ -59,5 +60,12 @@ class WC_Extensions_Tracking {
 	 */
 	public static function track_helper_connection_complete() {
 		WC_Tracks::record_event( 'extensions_subscriptions_connected' );
+	}
+
+	/**
+	 * Send a Tracks even when a Helper has been disconnected.
+	 */
+	public static function track_helper_disconnected() {
+		WC_Tracks::record_event( 'extensions_subscriptions_disconnect' );
 	}
 }

--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -16,6 +16,7 @@ class WC_Extensions_Tracking {
 	 */
 	public static function init() {
 		add_action( 'load-woocommerce_page_wc-addons', array( __CLASS__, 'track_extensions_page' ) );
+		add_action( 'woocommerce_helper_connect_start', array( __CLASS__, 'track_helper_connection_start' ) );
 	}
 
 	/**
@@ -35,5 +36,12 @@ class WC_Extensions_Tracking {
 		// phpcs:enable
 
 		WC_Tracks::record_event( $event, $properties );
+	}
+
+	/**
+	 * Send a Tracks even when a Helper connection process is initiated.
+	 */
+	public static function track_helper_connection_start() {
+		WC_Tracks::record_event( 'extensions_subscriptions_connect' );
 	}
 }

--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -17,6 +17,7 @@ class WC_Extensions_Tracking {
 	public static function init() {
 		add_action( 'load-woocommerce_page_wc-addons', array( __CLASS__, 'track_extensions_page' ) );
 		add_action( 'woocommerce_helper_connect_start', array( __CLASS__, 'track_helper_connection_start' ) );
+		add_action( 'woocommerce_helper_denied', array( __CLASS__, 'track_helper_connection_cancelled' ) );
 	}
 
 	/**
@@ -43,5 +44,12 @@ class WC_Extensions_Tracking {
 	 */
 	public static function track_helper_connection_start() {
 		WC_Tracks::record_event( 'extensions_subscriptions_connect' );
+	}
+
+	/**
+	 * Send a Tracks even when a Helper connection process is cancelled.
+	 */
+	public static function track_helper_connection_cancelled() {
+		WC_Tracks::record_event( 'extensions_subscriptions_cancelled' );
 	}
 }

--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -18,6 +18,7 @@ class WC_Extensions_Tracking {
 		add_action( 'load-woocommerce_page_wc-addons', array( __CLASS__, 'track_extensions_page' ) );
 		add_action( 'woocommerce_helper_connect_start', array( __CLASS__, 'track_helper_connection_start' ) );
 		add_action( 'woocommerce_helper_denied', array( __CLASS__, 'track_helper_connection_cancelled' ) );
+		add_action( 'woocommerce_helper_connected', array( __CLASS__, 'track_helper_connection_complete' ) );
 	}
 
 	/**
@@ -51,5 +52,12 @@ class WC_Extensions_Tracking {
 	 */
 	public static function track_helper_connection_cancelled() {
 		WC_Tracks::record_event( 'extensions_subscriptions_cancelled' );
+	}
+
+	/**
+	 * Send a Tracks even when a Helper connection process completed successfully.
+	 */
+	public static function track_helper_connection_complete() {
+		WC_Tracks::record_event( 'extensions_subscriptions_connected' );
 	}
 }

--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -20,6 +20,7 @@ class WC_Extensions_Tracking {
 		add_action( 'woocommerce_helper_denied', array( __CLASS__, 'track_helper_connection_cancelled' ) );
 		add_action( 'woocommerce_helper_connected', array( __CLASS__, 'track_helper_connection_complete' ) );
 		add_action( 'woocommerce_helper_disconnected', array( __CLASS__, 'track_helper_disconnected' ) );
+		add_action( 'woocommerce_helper_subscriptions_refresh', array( __CLASS__, 'track_helper_subscriptions_refresh' ) );
 	}
 
 	/**
@@ -67,5 +68,12 @@ class WC_Extensions_Tracking {
 	 */
 	public static function track_helper_disconnected() {
 		WC_Tracks::record_event( 'extensions_subscriptions_disconnect' );
+	}
+
+	/**
+	 * Send a Tracks even when Helper subscriptions are refreshed.
+	 */
+	public static function track_helper_subscriptions_refresh() {
+		WC_Tracks::record_event( 'extensions_subscriptions_update' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds Tracks events for the Extension Subscriptions connection process.

_Note: this PR base can change to `feature/add-tracks` after `add/tracks-extensions-view` is merged._

### How to test the changes in this Pull Request:

With a disconnected store..

1. Go to WooCommerce > Extensions > WooCommerce.com Subscriptions
2. Click "connect"
3. Verify a `extensions_subscriptions_connect` event has fired
4. Click "deny"
5. Verify a `extensions_subscriptions_cancelled` event has fired
6. Click "connect", then "approve"
7. Verify a `extensions_subscriptions_connected` event has fired
8. Click "refresh"
9. Verify a `extensions_subscriptions_update` event has fired
10. Click "Connected to WooCommerce.com" > Disconnect
11. Verify a `extensions_subscriptions_disconnect` event has fired
