### PR TITLE
Add gross revenue to Tracks base data.

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -493,7 +493,7 @@ class WC_Tracker {
 	 *
 	 * @return array
 	 */
-	private static function get_order_totals() {
+	public static function get_order_totals() {
 		global $wpdb;
 
 		$gross_total = $wpdb->get_var( "

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -49,6 +49,8 @@ class WC_Site_Tracking {
 				var eventName = '" . WC_Tracks::PREFIX . "' + name;
 				var eventProperties = properties || {};
 				eventProperties.url = '" . home_url() . "'
+				eventProperties.products_count = '" . WC_Tracks::get_products_count() . "'
+				eventProperties.orders_gross = '" . WC_Tracks::get_total_revenue() . "'
 				window._tkq = window._tkq || [];
 				window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
 			}

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -57,7 +57,7 @@ class WC_Tracks {
 	/**
 	 * Get total product counts.
 	 *
-	 * @return array
+	 * @return int Number of products.
 	 */
 	public static function get_products_count() {
 		$product_counts = WC_Tracker::get_product_counts();

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -16,20 +16,67 @@ class WC_Tracks {
 	const PREFIX = 'wcadmin_';
 
 	/**
+	 * Option name for total store revenue.
+	 */
+	const REVENUE_CACHE_OPTION = 'woocommerce_tracker_orders_totals';
+
+	/**
+	 * Initialize necessary hooks.
+	 */
+	public static function init() {
+		add_action( 'woocommerce_new_order', array( __CLASS__, 'update_revenue_cache' ) );
+		add_action( 'woocommerce_update_order', array( __CLASS__, 'update_revenue_cache' ) );
+		add_action( 'woocommerce_delete_order', array( __CLASS__, 'update_revenue_cache' ) );
+		add_action( 'woocommerce_order_refunded', array( __CLASS__, 'update_revenue_cache' ) );
+	}
+
+	/**
+	 * Recalculate store gross revenue and update cache.
+	 */
+	public static function update_revenue_cache() {
+		update_option( self::REVENUE_CACHE_OPTION, WC_Tracker::get_order_totals() );
+	}
+
+	/**
+	 * Get the (cached) store gross revenue total.
+	 *
+	 * @return null|string Store gross revenue, or null if cache error.
+	 */
+	public static function get_total_revenue() {
+		$total_revenue = get_option( self::REVENUE_CACHE_OPTION, false );
+
+		if ( false === $total_revenue ) {
+			$total_revenue = WC_Tracker::get_order_totals();
+
+			update_option( self::REVENUE_CACHE_OPTION, $total_revenue );
+		}
+
+		return empty( $total_revenue['gross'] ) ? null : $total_revenue['gross'];
+	}
+
+	/**
+	 * Get total product counts.
+	 *
+	 * @return array
+	 */
+	public static function get_products_count() {
+		$product_counts = WC_Tracker::get_product_counts();
+		return $product_counts['total'];
+	}
+
+	/**
 	 * Gather blog related properties.
 	 *
 	 * @param int $user_id User id.
 	 * @return array Blog details.
 	 */
 	public static function get_blog_details( $user_id ) {
-		$product_counts = WC_Tracker::get_product_counts();
-
 		return array(
-			// @todo Add revenue info and url similar to wc-tracker.
 			'url'            => home_url(),
 			'blog_lang'      => get_user_locale( $user_id ),
 			'blog_id'        => ( class_exists( 'Jetpack' ) && Jetpack_Options::get_option( 'id' ) ) || null,
-			'products_count' => $product_counts['total'],
+			'products_count' => self::get_products_count(),
+			'orders_gross'   => self::get_total_revenue(),
 		);
 	}
 
@@ -98,3 +145,4 @@ class WC_Tracks {
 	}
 }
 
+WC_Tracks::init();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds gross revenue to the base data included in all Tracks events. In order to accomplish this, `WC_Tracker::get_order_totals()` was utilized (and made `public` for reuse) and a caching layer was added to it.

The gross revenue value cache is stored in the `woocommerce_tracker_orders_totals` option, and is updated by:
* Unprimed cache retrieval
* `woocommerce_new_order` action
* `woocommerce_update_order` action
* `woocommerce_delete_order` action
* `woocommerce_order_refunded` action

_Question: are these actions sufficient?_

If there's an error fetching the value, the `orders_gross` property is omitted from the Tracks event.

### How to test the changes in this Pull Request:

1. Kick off any Tracks event
2. Verify `orders_gross` is in the payload
3. Delete `woocommerce_tracker_orders_totals` option
4. Perform a CRUD operation on an Order, or kick off another Tracks event
5. Verify `woocommerce_tracker_orders_totals` option is populated

