### PR TITLE
Add/wc blocks/product attribute terms

### DIFF
--- a/includes/api/wc-blocks/class-wc-blocks-rest-product-attribute-terms-controller.php
+++ b/includes/api/wc-blocks/class-wc-blocks-rest-product-attribute-terms-controller.php
@@ -2,7 +2,7 @@
 /**
  * REST API Product Attribute Terms controller customized for Products Block.
  *
- * Handles requests to the /products/categories endpoint.
+ * Handles requests to the /products/attributes/<attribute_id/terms endpoint.
  *
  * @package WooCommerce\Blocks\Products\Rest\Controller
  */
@@ -114,8 +114,11 @@ class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_
 			'name'      => $item->name,
 			'slug'      => $item->slug,
 			'count'     => (int) $item->count,
-			'attr_name' => $attribute->name,
-			'attr_slug' => $attribute->slug,
+			'attribute' => array(
+				'id'    => $attribute->id,
+				'name'  => $attribute->name,
+				'slug'  => $attribute->slug,
+			),
 		);
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
@@ -138,7 +141,7 @@ class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_
 		$raw_schema = parent::get_item_schema();
 		$schema     = array(
 			'$schema'    => 'http://json-schema.org/draft-04/schema#',
-			'title'      => 'product_block_category',
+			'title'      => 'product_attribute_term',
 			'type'       => 'object',
 			'properties' => array(),
 		);
@@ -147,20 +150,30 @@ class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_
 		$schema['properties']['name']      = $raw_schema['properties']['name'];
 		$schema['properties']['slug']      = $raw_schema['properties']['slug'];
 		$schema['properties']['count']     = $raw_schema['properties']['count'];
-		$schema['properties']['attr_name'] = array(
-			'description' => __( 'Attribute group name.', 'woo-gutenberg-products-block' ),
-			'type'        => 'string',
+		$schema['properties']['attribute'] = array(
+			'description' => __( 'Attribute.', 'woocommerce' ),
+			'type'        => 'object',
 			'context'     => array( 'view', 'edit' ),
-			'arg_options' => array(
-				'sanitize_callback' => 'sanitize_text_field',
-			),
-		);
-		$schema['properties']['attr_slug'] = array(
-			'description' => __( 'An alphanumeric identifier for the resource unique to its type.', 'woo-gutenberg-products-block' ),
-			'type'        => 'string',
-			'context'     => array( 'view', 'edit' ),
-			'arg_options' => array(
-				'sanitize_callback' => 'sanitize_title',
+			'readonly'    => true,
+			'properties' => array(
+				'id' => array(
+					'description' => __( 'Attribute ID.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
+				'name' => array(
+					'description' => __( 'Attribute name.', 'woocommerce' ),
+						'type'        => 'string',
+						'context'     => array( 'view', 'edit' ),
+						'readonly'    => true,
+				),
+				'slug' => array(
+					'description' => __( 'Attribute slug.', 'woocommerce' ),
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
+				),
 			),
 		);
 

--- a/includes/api/wc-blocks/class-wc-blocks-rest-product-attribute-terms-controller.php
+++ b/includes/api/wc-blocks/class-wc-blocks-rest-product-attribute-terms-controller.php
@@ -1,0 +1,169 @@
+<?php
+/**
+ * REST API Product Attribute Terms controller customized for Products Block.
+ *
+ * Handles requests to the /products/categories endpoint.
+ *
+ * @package WooCommerce\Blocks\Products\Rest\Controller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Product Attribute Terms controller class.
+ *
+ * @package WooCommerce/API
+ */
+class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_Attribute_Terms_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-blocks/v1';
+
+	/**
+	 * Register the routes for products.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the resource.', 'woo-gutenberg-products-block' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param(
+							array(
+								'default' => 'view',
+							)
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check permissions.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @param string          $context Request context.
+	 * @return bool|WP_Error
+	 */
+	protected function check_permissions( $request, $context = 'read' ) {
+		// Get taxonomy.
+		$taxonomy = $this->get_taxonomy( $request );
+		if ( ! $taxonomy || ! taxonomy_exists( $taxonomy ) ) {
+			return new WP_Error( 'woocommerce_rest_taxonomy_invalid', __( 'Taxonomy does not exist.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
+		}
+
+		// Check permissions for a single term.
+		$id = intval( $request['id'] );
+		if ( $id ) {
+			$term = get_term( $id, $taxonomy );
+
+			if ( is_wp_error( $term ) || ! $term || $term->taxonomy !== $taxonomy ) {
+				return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Resource does not exist.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
+			}
+		}
+
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Prepare a single product category output for response.
+	 *
+	 * @param WP_Term         $item    Term object.
+	 * @param WP_REST_Request $request Request instance.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		// Get the attribute slug.
+		$attribute_id = absint( $request->get_param( 'attribute_id' ) );
+		$attribute    = wc_get_attribute( $attribute_id );
+
+		$data = array(
+			'id'        => (int) $item->term_id,
+			'name'      => $item->name,
+			'slug'      => $item->slug,
+			'count'     => (int) $item->count,
+			'attr_name' => $attribute->name,
+			'attr_slug' => $attribute->slug,
+		);
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $item, $request ) );
+
+		return $response;
+	}
+
+	/**
+	 * Get the Product's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$raw_schema = parent::get_item_schema();
+		$schema     = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'product_block_category',
+			'type'       => 'object',
+			'properties' => array(),
+		);
+
+		$schema['properties']['id']        = $raw_schema['properties']['id'];
+		$schema['properties']['name']      = $raw_schema['properties']['name'];
+		$schema['properties']['slug']      = $raw_schema['properties']['slug'];
+		$schema['properties']['count']     = $raw_schema['properties']['count'];
+		$schema['properties']['attr_name'] = array(
+			'description' => __( 'Attribute group name.', 'woo-gutenberg-products-block' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'arg_options' => array(
+				'sanitize_callback' => 'sanitize_text_field',
+			),
+		);
+		$schema['properties']['attr_slug'] = array(
+			'description' => __( 'An alphanumeric identifier for the resource unique to its type.', 'woo-gutenberg-products-block' ),
+			'type'        => 'string',
+			'context'     => array( 'view', 'edit' ),
+			'arg_options' => array(
+				'sanitize_callback' => 'sanitize_title',
+			),
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php
@@ -49,7 +49,7 @@ class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_
 			array(
 				'args'   => array(
 					'id' => array(
-						'description' => __( 'Unique identifier for the resource.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
 						'type'        => 'integer',
 					),
 				),
@@ -81,7 +81,7 @@ class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_
 		// Get taxonomy.
 		$taxonomy = $this->get_taxonomy( $request );
 		if ( ! $taxonomy || ! taxonomy_exists( $taxonomy ) ) {
-			return new WP_Error( 'woocommerce_rest_taxonomy_invalid', __( 'Taxonomy does not exist.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
+			return new WP_Error( 'woocommerce_rest_taxonomy_invalid', __( 'Taxonomy does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 		}
 
 		// Check permissions for a single term.
@@ -90,7 +90,7 @@ class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_
 			$term = get_term( $id, $taxonomy );
 
 			if ( is_wp_error( $term ) || ! $term || $term->taxonomy !== $taxonomy ) {
-				return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Resource does not exist.', 'woo-gutenberg-products-block' ), array( 'status' => 404 ) );
+				return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
 			}
 		}
 
@@ -164,9 +164,9 @@ class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_
 				),
 				'name' => array(
 					'description' => __( 'Attribute name.', 'woocommerce' ),
-						'type'        => 'string',
-						'context'     => array( 'view', 'edit' ),
-						'readonly'    => true,
+					'type'        => 'string',
+					'context'     => array( 'view', 'edit' ),
+					'readonly'    => true,
 				),
 				'slug' => array(
 					'description' => __( 'Attribute slug.', 'woocommerce' ),

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -235,6 +235,9 @@ class WC_API extends WC_Legacy_API {
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-data-continents-controller.php';
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-data-countries-controller.php';
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-data-currencies-controller.php';
+
+		// Blocks REST API V1 controllers.
+		include_once dirname( __FILE__ ) . '/api/wc-blocks/class-wc-blocks-rest-product-attribute-terms-controller.php';
 	}
 
 	/**
@@ -342,6 +345,9 @@ class WC_API extends WC_Legacy_API {
 			'WC_REST_Data_Continents_Controller',
 			'WC_REST_Data_Countries_Controller',
 			'WC_REST_Data_Currencies_Controller',
+
+			// Blocks REST API v1 Controllers.
+			'WC_REST_Blocks_Product_Attribute_Terms_Controller',
 		);
 
 		foreach ( $controllers as $controller ) {

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -237,7 +237,7 @@ class WC_API extends WC_Legacy_API {
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-data-currencies-controller.php';
 
 		// Blocks REST API V1 controllers.
-		include_once dirname( __FILE__ ) . '/api/wc-blocks/class-wc-blocks-rest-product-attribute-terms-controller.php';
+		include_once dirname( __FILE__ ) . '/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php';
 	}
 
 	/**

--- a/tests/unit-tests/api/wc-blocks/products-attributes-terms.php
+++ b/tests/unit-tests/api/wc-blocks/products-attributes-terms.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * @package WooCommerce\Tests\API
+ */
+
+/**
+ * Product Controller "products attributes terms" REST API Test
+ *
+ * @since 3.6.0
+ */
+class WC_Tests_API_Products_Attributes_Terms_Controller extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-blocks/v1';
+
+	/**
+	 * Setup test products data. Called before every test.
+	 *
+	 * @since 3.6.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+        );
+        
+        $this->editor = $this->factory->user->create(
+			array(
+				'role' => 'editor',
+			)
+		);
+
+		// Create 2 product attributes with terms.
+		$this->attr_color = WC_Helper_Product::create_attribute( 'color', array( 'red', 'yellow', 'blue' ) );
+		$this->attr_size  = WC_Helper_Product::create_attribute( 'size', array( 'small', 'medium', 'large', 'xlarge' ) );
+	}
+
+	/**
+	 * Test getting attribute terms.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_terms() {
+        wp_set_current_user( $this->user );
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/' . $this->attr_color['attribute_id'] . '/terms' );
+
+		$response       = $this->server->dispatch( $request );
+		$response_terms = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+        $this->assertEquals( 3, count( $response_terms ) );
+        $term = $response_terms[0];
+        $this->assertArrayHasKey( 'attr_name', $term );
+        $this->assertArrayHasKey( 'attr_slug', $term );
+    }
+    
+    /**
+	 * Test getting invalid attribute terms.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_invalid_attribute_terms() {
+        wp_set_current_user( $this->user );
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/99999/terms' );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->get_status() );
+    }
+    
+    /**
+	 * Test un-authorized getting attribute terms.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_unauthed_attribute_terms() {
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/'. $this->attr_size['attribute_id'] . '/terms' );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+    /**
+	 * Test getting attribute terms as editor.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_attribute_terms_editor() {
+        wp_set_current_user( $this->editor );
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/'. $this->attr_size['attribute_id'] . '/terms' );
+
+        $response       = $this->server->dispatch( $request );
+        $response_terms = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+        $this->assertEquals( 4, count( $response_terms ) );
+	}
+}

--- a/tests/unit-tests/api/wc-blocks/products-attributes-terms.php
+++ b/tests/unit-tests/api/wc-blocks/products-attributes-terms.php
@@ -31,9 +31,9 @@ class WC_Tests_API_Products_Attributes_Terms_Controller extends WC_REST_Unit_Tes
 			)
         );
         
-        $this->editor = $this->factory->user->create(
+        $this->contributor = $this->factory->user->create(
 			array(
-				'role' => 'editor',
+				'role' => 'contributor',
 			)
 		);
 
@@ -56,8 +56,11 @@ class WC_Tests_API_Products_Attributes_Terms_Controller extends WC_REST_Unit_Tes
 		$this->assertEquals( 200, $response->get_status() );
         $this->assertEquals( 3, count( $response_terms ) );
         $term = $response_terms[0];
-        $this->assertArrayHasKey( 'attr_name', $term );
-        $this->assertArrayHasKey( 'attr_slug', $term );
+		$this->assertArrayHasKey( 'attribute', $term );
+		$attribute = $term['attribute'];
+        $this->assertArrayHasKey( 'id', $attribute );
+        $this->assertArrayHasKey( 'name', $attribute );
+        $this->assertArrayHasKey( 'slug', $attribute );
     }
     
     /**
@@ -91,7 +94,7 @@ class WC_Tests_API_Products_Attributes_Terms_Controller extends WC_REST_Unit_Tes
 	 * @since 3.6.0
 	 */
 	public function test_get_attribute_terms_editor() {
-        wp_set_current_user( $this->editor );
+        wp_set_current_user( $this->contributor );
 		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/'. $this->attr_size['attribute_id'] . '/terms' );
 
         $response       = $this->server->dispatch( $request );

--- a/tests/unit-tests/api/wc-blocks/products-attributes-terms.php
+++ b/tests/unit-tests/api/wc-blocks/products-attributes-terms.php
@@ -29,9 +29,9 @@ class WC_Tests_API_Products_Attributes_Terms_Controller extends WC_REST_Unit_Tes
 			array(
 				'role' => 'administrator',
 			)
-        );
-        
-        $this->contributor = $this->factory->user->create(
+		);
+
+		$this->contributor = $this->factory->user->create(
 			array(
 				'role' => 'contributor',
 			)
@@ -48,58 +48,58 @@ class WC_Tests_API_Products_Attributes_Terms_Controller extends WC_REST_Unit_Tes
 	 * @since 3.6.0
 	 */
 	public function test_get_terms() {
-        wp_set_current_user( $this->user );
+		wp_set_current_user( $this->user );
 		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/' . $this->attr_color['attribute_id'] . '/terms' );
 
 		$response       = $this->server->dispatch( $request );
 		$response_terms = $response->get_data();
 		$this->assertEquals( 200, $response->get_status() );
-        $this->assertEquals( 3, count( $response_terms ) );
-        $term = $response_terms[0];
+		$this->assertEquals( 3, count( $response_terms ) );
+		$term = $response_terms[0];
 		$this->assertArrayHasKey( 'attribute', $term );
 		$attribute = $term['attribute'];
-        $this->assertArrayHasKey( 'id', $attribute );
-        $this->assertArrayHasKey( 'name', $attribute );
-        $this->assertArrayHasKey( 'slug', $attribute );
-    }
-    
-    /**
+		$this->assertArrayHasKey( 'id', $attribute );
+		$this->assertArrayHasKey( 'name', $attribute );
+		$this->assertArrayHasKey( 'slug', $attribute );
+	}
+
+	/**
 	 * Test getting invalid attribute terms.
 	 *
 	 * @since 3.6.0
 	 */
 	public function test_get_invalid_attribute_terms() {
-        wp_set_current_user( $this->user );
+		wp_set_current_user( $this->user );
 		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/99999/terms' );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
-    }
-    
-    /**
+	}
+
+	/**
 	 * Test un-authorized getting attribute terms.
 	 *
 	 * @since 3.6.0
 	 */
 	public function test_get_unauthed_attribute_terms() {
-		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/'. $this->attr_size['attribute_id'] . '/terms' );
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/' . $this->attr_size['attribute_id'] . '/terms' );
 
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
 
-    /**
+	/**
 	 * Test getting attribute terms as editor.
 	 *
 	 * @since 3.6.0
 	 */
 	public function test_get_attribute_terms_editor() {
-        wp_set_current_user( $this->contributor );
-		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/'. $this->attr_size['attribute_id'] . '/terms' );
+		wp_set_current_user( $this->contributor );
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/' . $this->attr_size['attribute_id'] . '/terms' );
 
-        $response       = $this->server->dispatch( $request );
-        $response_terms = $response->get_data();
+		$response       = $this->server->dispatch( $request );
+		$response_terms = $response->get_data();
 		$this->assertEquals( 200, $response->get_status() );
-        $this->assertEquals( 4, count( $response_terms ) );
+		$this->assertEquals( 4, count( $response_terms ) );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Supersedes #22793

This branch introduces a new REST API namespace for the WooCommerce Blocks functionality: `wc-blocks/v1`. The first endpoint implemented here is the logic that currently exists in the Woo Blocks plugin for [attributes terms](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/includes/class-wgpb-product-attribute-terms-controller.php) `wc-blocks/v1/products/attributes/%d/terms`

### How to test the changes in this Pull Request:

1. You can use Postman to make requests to `wc-blocks/v1/products/attributes/%d/terms`
2. and/or run `phpunit tests/unit-tests/api/wc-blocks/products-attributes-terms.php`

### Other information:

For https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/426

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Adds new `wc-blocks/v1` endpoint for getting attribute terms for use in Woo Blocks
