### PR TITLE
Track settings changes.

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -97,5 +97,10 @@ class WC_Site_Tracking {
 				call_user_func( $init_method );
 			}
 		}
+
+		add_filter( 'http_request_args', function( $r, $url ) {
+			error_log( $r['method'] . ' ' . $url );
+			return $r;
+		},10, 2 );
 	}
 }

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -97,10 +97,5 @@ class WC_Site_Tracking {
 				call_user_func( $init_method );
 			}
 		}
-
-		add_filter( 'http_request_args', function( $r, $url ) {
-			error_log( $r['method'] . ' ' . $url );
-			return $r;
-		},10, 2 );
 	}
 }

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -80,12 +80,14 @@ class WC_Site_Tracking {
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-importer-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-products-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-orders-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-settings-tracking.php';
 
 		$tracking_classes = array(
 			'WC_Extensions_Tracking',
 			'WC_Importer_Tracking',
 			'WC_Products_Tracking',
 			'WC_Orders_Tracking',
+			'WC_Settings_Tracking',
 		);
 
 		foreach ( $tracking_classes as $tracking_class ) {

--- a/includes/tracks/events/class-wc-settings-tracking.php
+++ b/includes/tracks/events/class-wc-settings-tracking.php
@@ -118,7 +118,7 @@ class WC_Settings_Tracking {
 		}
 
 		$properties = array(
-			'settings' => $instance->updated_options,
+			'settings' => implode( $instance->updated_options, ',' ),
 		);
 
 		if ( isset( $current_tab ) ) {

--- a/includes/tracks/events/class-wc-settings-tracking.php
+++ b/includes/tracks/events/class-wc-settings-tracking.php
@@ -1,0 +1,145 @@
+<?php
+/**
+ * WooCommerce Settings Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of WooCommerce Settings.
+ */
+class WC_Settings_Tracking {
+	/**
+	 * Singleton instance.
+	 *
+	 * @var WC_Settings_Tracking
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Whitelisted WooCommerce settings to potentially track updates for.
+	 *
+	 * @var array
+	 */
+	protected $whitelist = array();
+
+	/**
+	 * WooCommerce settings that have been updated (and will be tracked).
+	 *
+	 * @var array
+	 */
+	protected $updated_options = array();
+
+	/**
+	 * Instantiate the singleton.
+	 *
+	 * @return WC_Settings_Tracking Singleton instance.
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new WC_Settings_Tracking();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Init tracking.
+	 */
+	public static function init() {
+		self::instance();
+
+		add_action( 'woocommerce_settings_page_init', array( __CLASS__, 'track_settings_page_view' ) );
+	}
+
+	/**
+	 * Constructor - attach hooks to the singleton instance.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_update_option', array( $this, 'add_option_to_whitelist' ) );
+		add_action( 'woocommerce_update_options', array( $this, 'send_settings_change_event' ) );
+	}
+
+	/**
+	 * Add a WooCommerce option name to our whitelist and attach
+	 * the `update_option` hook. Rather than inspecting every updated
+	 * option and pattern matching for "woocommerce", just build a dynamic
+	 * whitelist for WooCommerce options that might get updated.
+	 *
+	 * See `woocommerce_update_option` hook.
+	 *
+	 * @param array $option WooCommerce option (config) that might get updated.
+	 */
+	public function add_option_to_whitelist( $option ) {
+		$this->whitelist[] = $option['id'];
+
+		// Delay attaching this action since it could get fired a lot.
+		if ( false === has_action( 'update_option', array( $this, 'track_setting_change' ) ) ) {
+			add_action( 'update_option', array( $this, 'track_setting_change' ), 10, 3 );
+		}
+	}
+
+	/**
+	 * Add WooCommerce option to a list of updated options.
+	 *
+	 * @param string $option_name Option being updated.
+	 * @param mixed  $old_value Old value of option.
+	 * @param mixed  $new_value New value of option.
+	 */
+	public function track_setting_change( $option_name, $old_value, $new_value ) {
+		// Make sure this is a WooCommerce option.
+		if ( ! in_array( $option_name, $this->whitelist, true ) ) {
+			return;
+		}
+
+		// Check to make sure the new value is truly different.
+		// `woocommerce_price_num_decimals` tends to trigger this
+		// because form values aren't coerced (e.g. '2' vs. 2).
+		if (
+			is_scalar( $old_value ) &&
+			is_scalar( $new_value ) &&
+			(string) $old_value === (string) $new_value
+		) {
+			return;
+		}
+
+		$this->updated_options[] = $option_name;
+	}
+
+	/**
+	 * Send a Tracks event for WooCommerce options that changed values.
+	 */
+	public function send_settings_change_event() {
+		global $current_tab;
+
+		if ( empty( $this->updated_options ) ) {
+			return;
+		}
+
+		$properties = array(
+			'settings' => $this->updated_options,
+		);
+
+		if ( isset( $current_tab ) ) {
+			$properties['tab'] = $current_tab;
+		}
+
+		WC_Tracks::record_event( 'settings_change', $properties );
+	}
+
+	/**
+	 * Send a Tracks event for WooCommerce settings page views.
+	 */
+	public static function track_settings_page_view() {
+		global $current_tab, $current_section;
+
+		$properties = array(
+			'tab'     => $current_tab,
+			'section' => empty( $current_section ) ? null : $current_section,
+		);
+
+		WC_Tracks::record_event( 'settings_view', $properties );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds Tracks event for settings updates.

Sends a single Tracks event when settings change that includes a list of updated settings and the current tab.

### How to test the changes in this Pull Request:

1. Go to a WooCommerce > Settings page
2. Change some setting values and click "save changes"
3. Verify that a `settings_change` Tracks event fires with a list of only the field names that changed (under `settings`), as well as the current tab (like `general`).
