### PR TITLE
Add tax query string filter to REST API

### DIFF
--- a/includes/api/v1/class-wc-rest-taxes-controller.php
+++ b/includes/api/v1/class-wc-rest-taxes-controller.php
@@ -235,6 +235,14 @@ class WC_REST_Taxes_V1_Controller extends WC_REST_Controller {
 			$query .= " AND tax_rate_class = '$class'";
 		}
 
+		/**
+		 * Filter the query string to conditionally return tax codes in the REST API.
+		 *
+		 * @param string $query         Query string used to look up tax codes.
+		 * @param array  $prepared_args Array of arguments for $wpdb->get_results().
+		 */
+		$query = apply_filters( 'woocommerce_rest_tax_query_string', $query, $prepared_args );
+
 		// Order tax rates.
 		$order_by = sprintf( ' ORDER BY %s', sanitize_key( $prepared_args['orderby'] ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a filter for the tax query string to filter out the response in the REST API so we can search for tax codes by name in wc-admin.

Closes #22812 

### How to test the changes in this Pull Request:

1.  Make sure tax rest endpoint continues to work as expected.
2.  Run a sample function to see if the query can be modified:
```php
function filter_by_high_priority_taxes( $query, $prepared_args ) {
	$query .= ' AND tax_rate_priority = 1';
	return $query;
}
add_filter( 'woocommerce_rest_tax_query_string', 'filter_by_high_priority_taxes', 10, 2 );
```
3.  Check that tax codes are filtered appropriately in rest response.

### Changelog entry

> Dev - REST API - Add filter 'woocommerce_rest_tax_query_string' to change queried tax codes.