### PR TITLE
Make 'refund amount' read-only

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -105,19 +105,24 @@ if ( wc_tax_enabled() ) {
 				<li><strong><?php esc_html_e( 'Coupon(s)', 'woocommerce' ); ?></strong></li>
 				<?php
 				foreach ( $coupons as $item_id => $item ) :
-					$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' LIMIT 1;", $item->get_code() ) );
+					$post_id = $wpdb->get_var( $wpdb->prepare( "SELECT ID FROM {$wpdb->posts} WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' LIMIT 1;", $item->get_code() ) ); // phpcs:disable WordPress.WP.GlobalVariablesOverride.OverrideProhibited
 					$class   = $order->is_editable() ? 'code editable' : 'code';
 					?>
 					<li class="<?php echo esc_attr( $class ); ?>">
 						<?php if ( $post_id ) : ?>
 							<?php
-							$post_url = apply_filters( 'woocommerce_admin_order_item_coupon_url', add_query_arg(
-								array(
-									'post'   => $post_id,
-									'action' => 'edit',
+							$post_url = apply_filters(
+								'woocommerce_admin_order_item_coupon_url',
+								add_query_arg(
+									array(
+										'post'   => $post_id,
+										'action' => 'edit',
+									),
+									admin_url( 'post.php' )
 								),
-								admin_url( 'post.php' )
-							), $item, $order );
+								$item,
+								$order
+							);
 							?>
 							<a href="<?php echo esc_url( $post_url ); ?>" class="tips" data-tip="<?php echo esc_attr( wc_price( $item->get_discount(), array( 'currency' => $order->get_currency() ) ) ); ?>">
 								<span><?php echo esc_html( $item->get_code() ); ?></span>
@@ -156,11 +161,11 @@ if ( wc_tax_enabled() ) {
 					<?php
 					$refunded = $order->get_total_shipping_refunded();
 					if ( $refunded > 0 ) {
-						echo '<del>' . strip_tags( wc_price( $order->get_shipping_total(), array( 'currency' => $order->get_currency() ) ) ) . '</del> <ins>' . wc_price( $order->get_shipping_total() - $refunded, array( 'currency' => $order->get_currency() ) ) . '</ins>'; // WPCS: XSS ok.
+						echo '<del>' . wp_strip_all_tags( wc_price( $order->get_shipping_total(), array( 'currency' => $order->get_currency() ) ) ) . '</del> <ins>' . wc_price( $order->get_shipping_total() - $refunded, array( 'currency' => $order->get_currency() ) ) . '</ins>'; // WPCS: XSS ok.
 					} else {
 						echo wc_price( $order->get_shipping_total(), array( 'currency' => $order->get_currency() ) ); // WPCS: XSS ok.
 					}
-				?>
+					?>
 				</td>
 			</tr>
 		<?php endif; ?>
@@ -168,19 +173,19 @@ if ( wc_tax_enabled() ) {
 		<?php do_action( 'woocommerce_admin_order_totals_after_shipping', $order->get_id() ); ?>
 
 		<?php if ( wc_tax_enabled() ) : ?>
-			<?php foreach ( $order->get_tax_totals() as $code => $tax ) : ?>
+			<?php foreach ( $order->get_tax_totals() as $code => $tax_total ) : ?>
 				<tr>
-					<td class="label"><?php echo esc_html( $tax->label ); ?>:</td>
+					<td class="label"><?php echo esc_html( $tax_total->label ); ?>:</td>
 					<td width="1%"></td>
 					<td class="total">
 						<?php
-						$refunded = $order->get_total_tax_refunded_by_rate_id( $tax->rate_id );
+						$refunded = $order->get_total_tax_refunded_by_rate_id( $tax_total->rate_id );
 						if ( $refunded > 0 ) {
-							echo '<del>' . strip_tags( $tax->formatted_amount ) . '</del> <ins>' . wc_price( WC_Tax::round( $tax->amount, wc_get_price_decimals() ) - WC_Tax::round( $refunded, wc_get_price_decimals() ), array( 'currency' => $order->get_currency() ) ) . '</ins>'; // WPCS: XSS ok.
+							echo '<del>' . wp_strip_all_tags( $tax_total->formatted_amount ) . '</del> <ins>' . wc_price( WC_Tax::round( $tax_total->amount, wc_get_price_decimals() ) - WC_Tax::round( $refunded, wc_get_price_decimals() ), array( 'currency' => $order->get_currency() ) ) . '</ins>'; // WPCS: XSS ok.
 						} else {
-							echo wp_kses_post( $tax->formatted_amount );
+							echo wp_kses_post( $tax_total->formatted_amount );
 						}
-					?>
+						?>
 					</td>
 				</tr>
 			<?php endforeach; ?>
@@ -272,13 +277,15 @@ if ( wc_tax_enabled() ) {
 				</label>
 			</td>
 			<td class="total">
-				<input type="text" id="refund_amount" name="refund_amount" class="wc_input_price" <?php
+				<input type="text" id="refund_amount" name="refund_amount" class="wc_input_price"
+				<?php
 				if ( wc_tax_enabled() ) {
 					// If taxes are enabled, using this refund amount can cause issues due to taxes not being refunded also.
 					// The refunds should be added to the line items, not the order as a whole.
 					echo 'readonly';
 				}
-				?>/>
+				?>
+				/>
 				<div class="clear"></div>
 			</td>
 		</tr>

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -265,14 +265,30 @@ if ( wc_tax_enabled() ) {
 			<td class="total"><?php echo wc_price( $order->get_total() - $order->get_total_refunded(), array( 'currency' => $order->get_currency() ) ); // WPCS: XSS ok. ?></td>
 		</tr>
 		<tr>
-			<td class="label"><label for="refund_amount"><?php esc_html_e( 'Refund amount', 'woocommerce' ); ?>:</label></td>
+			<td class="label">
+				<label for="refund_amount">
+					<?php echo wc_help_tip( __( 'Refund the line items above. This will show the total amount to be refunded', 'woocommerce' ) ); ?>
+					<?php esc_html_e( 'Refund amount', 'woocommerce' ); ?>:
+				</label>
+			</td>
 			<td class="total">
-				<input type="text" id="refund_amount" name="refund_amount" class="wc_input_price" />
+				<input type="text" id="refund_amount" name="refund_amount" class="wc_input_price" <?php
+				if ( wc_tax_enabled() ) {
+					// If taxes are enabled, using this refund amount can cause issues due to taxes not being refunded also.
+					// The refunds should be added to the line items, not the order as a whole.
+					echo 'readonly';
+				}
+				?>/>
 				<div class="clear"></div>
 			</td>
 		</tr>
 		<tr>
-			<td class="label"><label for="refund_reason"><?php echo wc_help_tip( __( 'Note: the refund reason will be visible by the customer.', 'woocommerce' ) ); ?> <?php esc_html_e( 'Reason for refund (optional):', 'woocommerce' ); ?></label></td>
+			<td class="label">
+				<label for="refund_reason">
+					<?php echo wc_help_tip( __( 'Note: the refund reason will be visible by the customer.', 'woocommerce' ) ); ?>
+					<?php esc_html_e( 'Reason for refund (optional):', 'woocommerce' ); ?>
+				</label>
+			</td>
 			<td class="total">
 				<input type="text" id="refund_reason" name="refund_reason" />
 				<div class="clear"></div>


### PR DESCRIPTION
Fixes #22496

#22496 and other related issues show that some people refund via this box instead of refunding the line items. This can cause incorrect calculations if taxes are present.

This PR makes the box readonly if taxes are enabled, and adds a tooltip to explain usage.

> Added tooltip to refund-amount input box and made it readonly when taxes are enabled.