### PR TITLE
Bugfix/Ajax Warning/Notices: Add Fix for Warning and Notices on save attribute button click

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -632,7 +632,7 @@ class WC_AJAX {
 			ob_start();
 			$attributes = $product->get_attributes( 'edit' );
 			$i          = -1;
-			if( isset( $data['attribute_names'] ) && !empty( $data['attribute_names'] ) ){
+			if( ! empty( $data['attribute_names'] ) ) {
 				foreach ( $data['attribute_names'] as $attribute_name ) {
 					$attribute = isset( $attributes[ sanitize_title( $attribute_name ) ] ) ? $attributes[ sanitize_title( $attribute_name ) ] : false;
 					if ( ! $attribute ) {

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -632,21 +632,22 @@ class WC_AJAX {
 			ob_start();
 			$attributes = $product->get_attributes( 'edit' );
 			$i          = -1;
+			if( isset( $data['attribute_names'] ) && !empty( $data['attribute_names'] ) ){
+				foreach ( $data['attribute_names'] as $attribute_name ) {
+					$attribute = isset( $attributes[ sanitize_title( $attribute_name ) ] ) ? $attributes[ sanitize_title( $attribute_name ) ] : false;
+					if ( ! $attribute ) {
+						continue;
+					}
+					$i++;
+					$metabox_class = array();
 
-			foreach ( $data['attribute_names'] as $attribute_name ) {
-				$attribute = isset( $attributes[ sanitize_title( $attribute_name ) ] ) ? $attributes[ sanitize_title( $attribute_name ) ] : false;
-				if ( ! $attribute ) {
-					continue;
+					if ( $attribute->is_taxonomy() ) {
+						$metabox_class[] = 'taxonomy';
+						$metabox_class[] = $attribute->get_name();
+					}
+
+					include( 'admin/meta-boxes/views/html-product-attribute.php' );
 				}
-				$i++;
-				$metabox_class = array();
-
-				if ( $attribute->is_taxonomy() ) {
-					$metabox_class[] = 'taxonomy';
-					$metabox_class[] = $attribute->get_name();
-				}
-
-				include( 'admin/meta-boxes/views/html-product-attribute.php' );
 			}
 
 			$response['html'] = ob_get_clean();


### PR DESCRIPTION
PHP Notice:  Undefined index: attribute_names in /srv/www/wordpress-new/public_html/wp-content/plugins/woocommerce/includes/class-wc-ajax.php on line 635
Warning:  Invalid argument supplied for foreach() in /srv/www/wordpress-new/public_html/wp-content/plugins/woocommerce/includes/class-wc-ajax.php on line 635

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #22821 

### How to test the changes in this Pull Request:

1. pull the code branch
2. follow the step of from the issue description
3. check the log file for notices and warning

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added isset and empty check for empty array field.