### PR TITLE
Track settings page views.

### DIFF
--- a/includes/tracks/events/class-wc-settings-tracking.php
+++ b/includes/tracks/events/class-wc-settings-tracking.php
@@ -50,6 +50,8 @@ class WC_Settings_Tracking {
 	 */
 	public static function init() {
 		self::instance();
+
+		add_action( 'woocommerce_settings_page_init', array( __CLASS__, 'track_settings_page_view' ) );
 	}
 
 	/**
@@ -122,5 +124,19 @@ class WC_Settings_Tracking {
 		}
 
 		WC_Tracks::record_event( 'settings_change', $properties );
+	}
+
+	/**
+	 * Send a Tracks event for WooCommerce settings page views.
+	 */
+	public static function track_settings_page_view() {
+		global $current_tab, $current_section;
+
+		$properties = array(
+			'tab'     => $current_tab,
+			'section' => empty( $current_section ) ? null : $current_section,
+		);
+
+		WC_Tracks::record_event( 'settings_view', $properties );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Adds a Tracks event for Settings page views. Event includes the tab (page) and section.

_Note: the base branch can change to `feature/add-tracks` after `add/tracks-settings-changed` lands._

### How to test the changes in this Pull Request:

1. Go to a WooCommerce > Settings page
2. Verify that a `settings_view` Tracks event fires with the appropriate `tab`
3. Click a section
4. Verify that a `settings_view` Tracks event fires with the appropriate `tab` and `section` value
