### PR TITLE
Calculate shipping before totals during checkout update

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -333,6 +333,9 @@ class WC_AJAX {
 		}
 
 		WC()->customer->save();
+
+		// Calculate shipping before totals. This will ensure any shipping methods that affect things like taxes are chosen prior to final totals being calculated. Ref: #22708
+		WC()->cart->calculate_shipping();
 		WC()->cart->calculate_totals();
 
 		// Get order review fragment.


### PR DESCRIPTION
Fixes #22708

Because the cart calculation method does taxes first, then shipping, if a chosen shipping method is invalidated it will be set later.

In the case of local pickup, this means taxes are calculated before it switches from local pickup to another method.

Calculating shipping first solves it.

To Test,

1. Setup taxes for Alaska only.
2. Set base location to Alaska
3. Setup a shipping zone for Alaska with local pickup and nothing else
4. Setup a shipping zone for everywhere else with flat rate only
5. Switch between alaska and another state during checkout.

> Make sure local_pickup taxes do not hang around when local_pickup is not available for the selected location during checkout.