### PR TITLE
Increase Tracks performance (perhaps..)

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -63,6 +63,7 @@ class WC_Admin {
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
 
 		// Help Tabs

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -55,28 +55,21 @@ class WC_Tracks_Client {
 	 * Synchronously request the pixel.
 	 *
 	 * @param string $pixel pixel url and query string.
-	 * @return bool|WP_Error         True on success, WP_Error on failure.
+	 * @return bool Always returns true.
 	 */
 	public static function record_pixel( $pixel ) {
 		// Add the Request Timestamp and URL terminator just before the HTTP request.
 		$pixel .= '&_rt=' . self::build_timestamp() . '&_=_';
 
-		$response = wp_safe_remote_get(
+		wp_safe_remote_get(
 			$pixel,
 			array(
-				'blocking'    => true, // The default, but being explicit here.
+				'blocking'    => false,
 				'redirection' => 2,
 				'httpversion' => '1.1',
+				'timeout'     => 1,
 			)
 		);
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		if ( 200 !== wp_remote_retrieve_response_code( $response ) ) {
-			return new WP_Error( 'request_failed', 'Tracks pixel request failed', $code );
-		}
 
 		return true;
 	}

--- a/includes/tracks/class-wc-tracks-event.php
+++ b/includes/tracks/class-wc-tracks-event.php
@@ -49,10 +49,17 @@ class WC_Tracks_Event {
 	/**
 	 * Record Tracks event
 	 *
-	 * @return bool|WP_Error True on success, WP_Error on failure.
+	 * @return bool Always returns true.
 	 */
 	public function record() {
-		return WC_Tracks_Client::record_event( $this );
+		if (
+			( defined( 'DOING_AJAX' ) && DOING_AJAX ) ||
+			( defined( 'REST_REQUEST' ) && REST_REQUEST )
+		) {
+			return WC_Tracks_Client::record_event( $this );
+		}
+
+		return WC_Tracks_Footer_Pixel::record_event( $this );
 	}
 
 	/**

--- a/includes/tracks/class-wc-tracks-event.php
+++ b/includes/tracks/class-wc-tracks-event.php
@@ -53,7 +53,7 @@ class WC_Tracks_Event {
 	 */
 	public function record() {
 		if (
-			( defined( 'DOING_AJAX' ) && DOING_AJAX ) ||
+			wp_doing_ajax() ||
 			( defined( 'REST_REQUEST' ) && REST_REQUEST )
 		) {
 			return WC_Tracks_Client::record_event( $this );

--- a/includes/tracks/class-wc-tracks-footer-pixel.php
+++ b/includes/tracks/class-wc-tracks-footer-pixel.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * Send Tracks events on behalf of a user using pixel images in page footer.
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Tracks_Footer_Pixel class.
+ */
+class WC_Tracks_Footer_Pixel {
+	/**
+	 * Singleton instance.
+	 *
+	 * @var WC_Tracks_Footer_Pixel
+	 */
+	protected static $instance = null;
+
+	/**
+	 * Tracks pixels to add to footer.
+	 *
+	 * @var array
+	 */
+	protected $pixels = array();
+
+	/**
+	 * Instantiate the singleton.
+	 *
+	 * @return WC_Tracks_Footer_Pixel
+	 */
+	public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new WC_Tracks_Footer_Pixel();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Constructor - attach hooks to the singleton instance.
+	 */
+	public function __construct() {
+		add_action( 'admin_footer', array( $this, 'render_tracking_pixels' ) );
+	}
+
+	/**
+	 * Record a Tracks event
+	 *
+	 * @param  array $event Array of event properties.
+	 * @return bool|WP_Error         True on success, WP_Error on failure.
+	 */
+	public static function record_event( $event ) {
+		if ( ! $event instanceof WC_Tracks_Event ) {
+			$event = new WC_Tracks_Event( $event );
+		}
+
+		if ( is_wp_error( $event ) ) {
+			return $event;
+		}
+
+		$pixel = $event->build_pixel_url( $event );
+
+		if ( ! $pixel ) {
+			return new WP_Error( 'invalid_pixel', 'cannot generate tracks pixel for given input', 400 );
+		}
+
+		return self::record_pixel( $pixel );
+	}
+
+	/**
+	 * Add a pixel to the queue.
+	 *
+	 * @param string $pixel pixel url and query string.
+	 */
+	public function add_pixel( $pixel ) {
+		$this->pixels[] = $pixel;
+	}
+
+	/**
+	 * Queue a pixel for inclusion.
+	 *
+	 * @param string $pixel pixel url and query string.
+	 * @return bool Always returns true.
+	 */
+	public static function record_pixel( $pixel ) {
+		self::instance()->add_pixel( $pixel );
+
+		return true;
+	}
+
+	/**
+	 * Add tracking pixels to page footer.
+	 */
+	public function render_tracking_pixels() {
+		if ( empty( $this->pixels ) ) {
+			return;
+		}
+
+		foreach ( $this->pixels as $pixel ) {
+			echo '<img src="', esc_url( $pixel ), '" />';
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Attempts to reduce the performance overhead of sending Tracks events by:
* Set `blocking` to `false` and reduce `timeout` for Tracks requests
* Render tracking pixels in admin footer when possible to avoid server-side requests

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Extensions
3. Verify that a pixel image is in the page footer, with correct params (`extensions_view`)
4. Go to Products > Categories
5. Add a new category
6. Verify that a Tracks HTTP request was made from the server _(I like to use the `http_request_args` filter for this)_