### PR TITLE
Update Marketplace suggestions data using WC_Queue

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -88,6 +88,7 @@ class WC_Admin {
 
 		// Marketplace suggestions & related REST API.
 		include_once dirname( __FILE__ ) . '/marketplace-suggestions/class-wc-marketplace-suggestions.php';
+		include_once dirname( __FILE__ ) . '/marketplace-suggestions/class-wc-marketplace-updater.php';
 	}
 
 	/**

--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
@@ -131,30 +131,8 @@ class WC_Marketplace_Suggestions {
 	 * @return array of json API data
 	 */
 	public static function get_suggestions_api_data() {
-		$suggestion_data = get_transient( 'wc_marketplace_suggestions' );
-		if ( false !== $suggestion_data ) {
-			return $suggestion_data;
-		}
-
-		$suggestion_data_url = 'https://d3t0oesq8995hv.cloudfront.net/add-ons/marketplace-suggestions.json';
-		$raw_suggestions     = wp_remote_get(
-			$suggestion_data_url,
-			array( 'user-agent' => 'WooCommerce Marketplace Suggestions' )
-		);
-
-		// Parse the data to check for any errors.
-		// If it's valid, store structure in transient.
-		if ( ! is_wp_error( $raw_suggestions ) ) {
-			$suggestions = json_decode( wp_remote_retrieve_body( $raw_suggestions ) );
-			if ( $suggestions && is_array( $suggestions ) ) {
-				set_transient( 'wc_marketplace_suggestions', $suggestions, WEEK_IN_SECONDS );
-				return $suggestions;
-			}
-		}
-
-		// Cache empty suggestions data to reduce requests if there are any issues with API.
-		set_transient( 'wc_marketplace_suggestions', array(), DAY_IN_SECONDS );
-		return array();
+		$data = get_option( 'woocommerce_marketplace_suggestions', array() );
+		return ! empty( $data['suggestions'] ) ? $data['suggestions'] : array();
 	}
 }
 

--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * REST API Marketplace suggestions API
+ * Marketplace suggestions
  *
- * Handles requests for marketplace suggestions data & rendering
- * templates for suggestion DOM content.
+ * Behaviour for displaying in-context suggestions for marketplace extensions.
  *
  * @package WooCommerce\Classes
  * @since   3.6.0
@@ -12,7 +11,7 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * REST API Marketplace suggestions API and related logic.
+ * Marketplace suggestions core behaviour.
  */
 class WC_Marketplace_Suggestions {
 

--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -1,0 +1,71 @@
+<?php
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Marketplace Suggestions Updater
+ */
+class WC_Marketplace_Updater {
+
+	public static function load() {
+		add_action( 'init', array( __CLASS__, 'init' ) );
+	}
+
+	/**
+	 * Schedule events and hook appropriate actions.
+	 */
+	public static function init() {
+		$queue = WC()->queue();
+		$next = $queue->get_next( 'woocommerce_update_marketplace_suggestions' );
+		if ( ! $next ) {
+			$queue->schedule_recurring( time(), WEEK_IN_SECONDS, 'woocommerce_update_marketplace_suggestions' );
+		}
+
+		add_action( 'woocommerce_update_marketplace_suggestions', array( __CLASS__, 'update_marketplace_suggestions' ) );
+	}
+
+	/**
+	 * Fetches new marketplace data, updates wc_marketplace_suggestions.
+	 */
+	public static function update_marketplace_suggestions() {
+		$data = get_option( 'woocommerce_marketplace_suggestions', array(
+			'suggestions' => array(),
+			'updated' => time(),
+		) );
+
+		$data['updated'] = time();
+
+		$url = 'https://d3t0oesq8995hv.cloudfront.net/add-ons/marketplace-suggestions.json';
+		$request = wp_remote_get( $url );
+
+		if ( is_wp_error( $request ) ) {
+			self::retry();
+			return update_option( 'woocommerce_marketplace_suggestions', $data, false );
+		}
+
+		$body = wp_remote_retrieve_body( $request );
+		if ( empty( $body ) ) {
+			self::retry();
+			return update_option( 'woocommerce_marketplace_suggestions', $data, false );
+		}
+
+		$body = json_decode( $body, true );
+		if ( empty( $body ) || ! is_array( $body ) ) {
+			self::retry();
+			return update_option( 'woocommerce_marketplace_suggestions', $data, false );
+		}
+
+		$data['suggestions'] = $body;
+		return update_option( 'woocommerce_marketplace_suggestions', $data, false );
+	}
+
+	/**
+	 * Used when an error has occured when fetching suggestions.
+	 * Re-schedules the job earlier than the main weekly one.
+	 */
+	public static function retry() {
+		WC()->queue()->cancel( 'woocommerce_update_marketplace_suggestions' );
+		WC()->queue()->schedule_single( time() + DAY_IN_SECONDS, 'woocommerce_update_marketplace_suggestions' );
+	}
+}
+
+WC_Marketplace_Updater::load();

--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Marketplace suggestions updater
+ *
+ * Uses WC_Queue to ensure marketplace suggestions data is up to date and cached locally.
+ *
+ * @package WooCommerce\Classes
+ * @since   3.6.0
+ */
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -6,6 +15,9 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_Marketplace_Updater {
 
+	/**
+	 * Setup.
+	 */
 	public static function load() {
 		add_action( 'init', array( __CLASS__, 'init' ) );
 	}
@@ -15,7 +27,7 @@ class WC_Marketplace_Updater {
 	 */
 	public static function init() {
 		$queue = WC()->queue();
-		$next = $queue->get_next( 'woocommerce_update_marketplace_suggestions' );
+		$next  = $queue->get_next( 'woocommerce_update_marketplace_suggestions' );
 		if ( ! $next ) {
 			$queue->schedule_recurring( time(), WEEK_IN_SECONDS, 'woocommerce_update_marketplace_suggestions' );
 		}
@@ -27,15 +39,18 @@ class WC_Marketplace_Updater {
 	 * Fetches new marketplace data, updates wc_marketplace_suggestions.
 	 */
 	public static function update_marketplace_suggestions() {
-		$data = get_option( 'woocommerce_marketplace_suggestions', array(
-			'suggestions' => array(),
-			'updated' => time(),
-		) );
+		$data = get_option(
+			'woocommerce_marketplace_suggestions',
+			array(
+				'suggestions' => array(),
+				'updated'     => time(),
+			)
+		);
 
 		$data['updated'] = time();
 
-		$url = 'https://d3t0oesq8995hv.cloudfront.net/add-ons/marketplace-suggestions.json';
-		$request = wp_remote_get( $url );
+		$url     = 'https://d3t0oesq8995hv.cloudfront.net/add-ons/marketplace-suggestions.json';
+		$request = wp_safe_remote_get( $url );
 
 		if ( is_wp_error( $request ) ) {
 			self::retry();

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -372,6 +372,7 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-logger.php';
 		include_once WC_ABSPATH . 'includes/queue/class-wc-action-queue.php';
 		include_once WC_ABSPATH . 'includes/queue/class-wc-queue.php';
+		include_once WC_ABSPATH . 'includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php';
 
 		/**
 		 * Data stores - used to store and retrieve CRUD object data from the database.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Schedules an update task to run as soon as possible to fetch the suggestions data, and then run the task again weekly. Failures are cached for a day.

I wish we didn't have to create a separate class for this, but our feature lives inside `is_admin()`, while `WC_Queue` execution does not. If we could somehow make this cleaner I'm happy to hear your thoughts.

### How to test the changes in this Pull Request:

1. Check out the branch
2. Check suggestions data with `wp option get woocommerce_marketplace_suggestions`
3. Can add logging to see how data is updated
4. Change the .json URL to something non-existent to simulate a failure