### PR TITLE
REST API: Add wc-blocks/v1/products/attributes controller.

### DIFF
--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-attributes-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-attributes-controller.php
@@ -1,0 +1,186 @@
+<?php
+/**
+ * REST API Product Attributes controller customized for Products Block.
+ *
+ * Handles requests to the /products/attributes endpoint.
+ *
+ * @package WooCommerce\Blocks\Products\Rest\Controller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Product Attributes controller class.
+ *
+ * @package WooCommerce/API
+ */
+class WC_REST_Blocks_Product_Attributes_Controller extends WC_REST_Product_Attributes_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-blocks/v1';
+
+	/**
+	 * Register the routes for products.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param(
+							array(
+								'default' => 'view',
+							)
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check if a given request has access to read the attributes.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+	/**
+	 * Check if a given request has access to read a attribute.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		$taxonomy = $this->get_taxonomy( $request );
+
+		if ( ! $taxonomy || ! taxonomy_exists( $taxonomy ) ) {
+			return new WP_Error( 'woocommerce_rest_taxonomy_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check permissions.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @param string          $context Request context.
+	 * @return bool|WP_Error
+	 */
+	protected function check_permissions( $request, $context = 'read' ) {
+		// Get taxonomy.
+		$taxonomy = $this->get_taxonomy( $request );
+		if ( ! $taxonomy || ! taxonomy_exists( $taxonomy ) ) {
+			return new WP_Error( 'woocommerce_rest_taxonomy_invalid', __( 'Taxonomy does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		// Check permissions for a single term.
+		$id = intval( $request['id'] );
+		if ( $id ) {
+			$term = get_term( $id, $taxonomy );
+
+			if ( is_wp_error( $term ) || ! $term || $term->taxonomy !== $taxonomy ) {
+				return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
+			}
+		}
+
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Prepare a single product category output for response.
+	 *
+	 * @param WP_Term         $item    Term object.
+	 * @param WP_REST_Request $request Request instance.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$taxonomy = wc_attribute_taxonomy_name( $item->attribute_name );
+		$data     = array(
+			'id'    => (int) $item->attribute_id,
+			'name'  => $item->attribute_label,
+			'slug'  => $taxonomy,
+			'count' => wp_count_terms( $taxonomy ),
+		);
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $item ) );
+
+		return $response;
+	}
+
+	/**
+	 * Get the Product's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$raw_schema = parent::get_item_schema();
+		$schema     = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'product_block_attribute',
+			'type'       => 'object',
+			'properties' => array(),
+		);
+
+		$schema['properties']['id']    = $raw_schema['properties']['id'];
+		$schema['properties']['name']  = $raw_schema['properties']['name'];
+		$schema['properties']['slug']  = $raw_schema['properties']['slug'];
+		$schema['properties']['count'] = array(
+			'description' => __( 'Number of terms in the attribute taxonomy.', 'woocommerce' ),
+			'type'        => 'integer',
+			'context'     => array( 'view', 'edit' ),
+			'readonly'    => true,
+		);
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -237,6 +237,7 @@ class WC_API extends WC_Legacy_API {
 		include_once dirname( __FILE__ ) . '/api/class-wc-rest-data-currencies-controller.php';
 
 		// Blocks REST API V1 controllers.
+		include_once dirname( __FILE__ ) . '/api/wc-blocks/class-wc-rest-blocks-product-attributes-controller.php';
 		include_once dirname( __FILE__ ) . '/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php';
 	}
 
@@ -347,6 +348,7 @@ class WC_API extends WC_Legacy_API {
 			'WC_REST_Data_Currencies_Controller',
 
 			// Blocks REST API v1 Controllers.
+			'WC_REST_Blocks_Product_Attributes_Controller',
 			'WC_REST_Blocks_Product_Attribute_Terms_Controller',
 		);
 

--- a/tests/unit-tests/api/wc-blocks/products-attributes.php
+++ b/tests/unit-tests/api/wc-blocks/products-attributes.php
@@ -1,0 +1,105 @@
+<?php
+/**
+ * @package WooCommerce\Tests\API
+ */
+
+/**
+ * Product Controller "products attributes" REST API Test
+ *
+ * @since 3.6.0
+ */
+class WC_Tests_API_Products_Attributes_Controller extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-blocks/v1';
+
+	/**
+	 * Setup test products data. Called before every test.
+	 *
+	 * @since 3.6.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		$this->contributor = $this->factory->user->create(
+			array(
+				'role' => 'contributor',
+			)
+		);
+
+		// Create 2 product attributes with terms.
+		$this->attr_color = WC_Helper_Product::create_attribute( 'color', array( 'red', 'yellow', 'blue' ) );
+		$this->attr_size  = WC_Helper_Product::create_attribute( 'size', array( 'small', 'medium', 'large', 'xlarge' ) );
+	}
+
+	/**
+	 * Test getting attributes.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_attributes() {
+		wp_set_current_user( $this->user );
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes' );
+
+		$response       = $this->server->dispatch( $request );
+		$response_attributes = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $response_attributes ) );
+		$attribute = $response_attributes[0];
+		$this->assertArrayHasKey( 'id', $attribute );
+		$this->assertArrayHasKey( 'name', $attribute );
+		$this->assertArrayHasKey( 'slug', $attribute );
+		$this->assertArrayHasKey( 'count', $attribute );
+	}
+
+	/**
+	 * Test getting invalid attribute.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_invalid_attribute_terms() {
+		wp_set_current_user( $this->user );
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/11111' );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test un-authorized getting attribute.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_unauthed_attribute_terms() {
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/' . $this->attr_size['attribute_id'] );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test getting attribute terms as editor.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_attribute_terms_editor() {
+		wp_set_current_user( $this->contributor );
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/' . $this->attr_size['attribute_id'] );
+
+		$response       = $this->server->dispatch( $request );
+		$attribute = $response->get_data();
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $this->attr_size['attribute_id'], $attribute['id'] );
+		$this->assertEquals( $this->attr_size['attribute_name'], $attribute['name'] );
+	}
+}

--- a/tests/unit-tests/api/wc-blocks/products-attributes.php
+++ b/tests/unit-tests/api/wc-blocks/products-attributes.php
@@ -67,7 +67,7 @@ class WC_Tests_API_Products_Attributes_Controller extends WC_REST_Unit_Test_Case
 	 *
 	 * @since 3.6.0
 	 */
-	public function test_get_invalid_attribute_terms() {
+	public function test_get_invalid_attribute() {
 		wp_set_current_user( $this->user );
 		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/11111' );
 
@@ -80,7 +80,7 @@ class WC_Tests_API_Products_Attributes_Controller extends WC_REST_Unit_Test_Case
 	 *
 	 * @since 3.6.0
 	 */
-	public function test_get_unauthed_attribute_terms() {
+	public function test_get_unauthed_attribute() {
 		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/' . $this->attr_size['attribute_id'] );
 
 		$response = $this->server->dispatch( $request );
@@ -88,11 +88,11 @@ class WC_Tests_API_Products_Attributes_Controller extends WC_REST_Unit_Test_Case
 	}
 
 	/**
-	 * Test getting attribute terms as editor.
+	 * Test getting attribute as editor.
 	 *
 	 * @since 3.6.0
 	 */
-	public function test_get_attribute_terms_editor() {
+	public function test_get_attribute_editor() {
 		wp_set_current_user( $this->contributor );
 		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/' . $this->attr_size['attribute_id'] );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

See #22809 for more background - this branch builds upon what was added there and includes support for the `wc-blocks/v1/products/attributes` endpoint.

### How to test the changes in this Pull Request:

1. You can use Postman to make requests to `wc-blocks/v1/products/attributes`
2. and/or run `phpunit tests/unit-tests/api/wc-blocks/products-attributes.php`

### Other information:

For https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/426

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Adds new `wc-blocks/v1` endpoint for getting product attribute info for use in Woo Blocks
