### PR TITLE
REST API: Add wc-blocks/v1/products/categories

### DIFF
--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php
@@ -1,0 +1,149 @@
+<?php
+/**
+ * REST API Product Categories controller customized for Products Block.
+ *
+ * Handles requests to the /products/categories endpoint.
+ *
+ * @package WooCommerce\Blocks\Products\Rest\Controller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Product Categories controller class.
+ *
+ * @package WooCommerce/API
+ */
+class WC_REST_Blocks_Product_Categories_Controller extends WC_REST_Product_Categories_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-blocks/v1';
+
+	/**
+	 * Register the routes for products.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param(
+							array(
+								'default' => 'view',
+							)
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check permissions.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @param string          $context Request context.
+	 * @return bool|WP_Error
+	 */
+	protected function check_permissions( $request, $context = 'read' ) {
+		// Get taxonomy.
+		$taxonomy = $this->get_taxonomy( $request );
+		if ( ! $taxonomy || ! taxonomy_exists( $taxonomy ) ) {
+			return new WP_Error( 'woocommerce_rest_taxonomy_invalid', __( 'Taxonomy does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
+		}
+
+		// Check permissions for a single term.
+		$id = intval( $request['id'] );
+		if ( $id ) {
+			$term = get_term( $id, $taxonomy );
+
+			if ( is_wp_error( $term ) || ! $term || $term->taxonomy !== $taxonomy ) {
+				return new WP_Error( 'woocommerce_rest_term_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
+			}
+		}
+
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Prepare a single product category output for response.
+	 *
+	 * @param WP_Term         $item    Term object.
+	 * @param WP_REST_Request $request Request instance.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $item, $request ) {
+		$data = array(
+			'id'     => (int) $item->term_id,
+			'name'   => $item->name,
+			'slug'   => $item->slug,
+			'parent' => (int) $item->parent,
+			'count'  => (int) $item->count,
+		);
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $item, $request ) );
+
+		return $response;
+	}
+
+	/**
+	 * Get the Product's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$raw_schema = parent::get_item_schema();
+		$schema     = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'product_block_category',
+			'type'       => 'object',
+			'properties' => array(),
+		);
+
+		$schema['properties']['id']     = $raw_schema['properties']['id'];
+		$schema['properties']['name']   = $raw_schema['properties']['name'];
+		$schema['properties']['slug']   = $raw_schema['properties']['slug'];
+		$schema['properties']['parent'] = $raw_schema['properties']['parent'];
+		$schema['properties']['count']  = $raw_schema['properties']['count'];
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -238,6 +238,7 @@ class WC_API extends WC_Legacy_API {
 
 		// Blocks REST API V1 controllers.
 		include_once dirname( __FILE__ ) . '/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php';
+		include_once dirname( __FILE__ ) . '/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php';
 	}
 
 	/**
@@ -348,6 +349,7 @@ class WC_API extends WC_Legacy_API {
 
 			// Blocks REST API v1 Controllers.
 			'WC_REST_Blocks_Product_Attribute_Terms_Controller',
+			'WC_REST_Blocks_Product_Categories_Controller',
 		);
 
 		foreach ( $controllers as $controller ) {

--- a/tests/unit-tests/api/wc-blocks/products-categories.php
+++ b/tests/unit-tests/api/wc-blocks/products-categories.php
@@ -1,0 +1,121 @@
+<?php
+/**
+ * @package WooCommerce\Tests\API
+ */
+
+/**
+ * Product Categories Controller  REST API Test
+ *
+ * @since 3.6.0
+ */
+class WC_Tests_API_Products_Categories_Controller extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-blocks/v1';
+
+	/**
+	 * Setup test products data. Called before every test.
+	 *
+	 * @since 3.6.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
+
+		$this->contributor = $this->factory->user->create(
+			array(
+				'role' => 'contributor',
+			)
+		);
+
+        // Create 3 product categories.
+        $parent           = wp_insert_term( 'Parent Category', 'product_cat' );
+        $child            = wp_insert_term(
+            'Child Category',
+            'product_cat',
+            array( 'parent' => $parent['term_id'] )
+        );
+        $single           = wp_insert_term( 'Standalone Category', 'product_cat' );
+        $this->categories = array(
+            'parent' => $parent,
+            'child'  => $child,
+            'single' => $single,
+        );
+
+        // Create two products for the parent category.
+        $this->products    = array();
+        $this->products[0] = WC_Helper_Product::create_simple_product( false );
+        $this->products[0]->set_category_ids( array( $parent['term_id'] ) );
+        $this->products[0]->save();
+
+        $this->products[3] = WC_Helper_Product::create_simple_product( false );
+        $this->products[3]->set_category_ids( array( $parent['term_id'], $single['term_id'] ) );
+        $this->products[3]->save();
+	}
+
+	/**
+	 * Test getting product categories.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_product_categories() {
+		wp_set_current_user( $this->user );
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/categories' );
+
+		$response   = $this->server->dispatch( $request );
+		$categories = $response->get_data();
+        $this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 4, count( $categories ) ); // Three created and `uncategorized`.
+	}
+
+	/**
+	 * Test getting invalid product category.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_invalid_product_category() {
+		wp_set_current_user( $this->user );
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/categories/007' );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 404, $response->get_status() );
+	}
+
+	/**
+	 * Test un-authorized getting product category.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_unauthed_product_category() {
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/categories/' . $this->categories['parent']['term_id'] );
+
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 401, $response->get_status() );
+	}
+
+	/**
+	 * Test getting category as editor.
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_get_attribute_terms_contributor() {
+		wp_set_current_user( $this->contributor );
+		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/categories/' . $this->categories['parent']['term_id'] );
+
+		$response = $this->server->dispatch( $request );
+		$category = $response->get_data();
+        $this->assertEquals( 200, $response->get_status() );
+        $this->assertEquals( $category['name'], 'Parent Category' );
+        $this->assertEquals( $category['parent'], 0 );
+        $this->assertEquals( $category['count'], 2 );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

See #22809 for more background - this branch builds upon what was added there and includes support for the `wc-blocks/v1/products/categories` endpoint.

### How to test the changes in this Pull Request:

1. You can use Postman to make requests to `wc-blocks/v1/products/categories`
2. and/or run `phpunit tests/unit-tests/api/wc-blocks/products-categories.php`

### Other information:

For https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/426

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Adds new `wc-blocks/v1` endpoint for getting product category info for use in Woo Blocks
