### PR TITLE
feat: wc_product_stock_status_options filter added for stock status options

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -848,11 +848,11 @@ function wc_get_product_tax_class_options() {
  * @return array
  */
 function wc_get_product_stock_status_options() {
-	return array(
+	return apply_filters( 'wc_product_stock_status_options', array(
 		'instock'     => __( 'In stock', 'woocommerce' ),
 		'outofstock'  => __( 'Out of stock', 'woocommerce' ),
 		'onbackorder' => __( 'On backorder', 'woocommerce' ),
-	);
+	) );
 }
 
 /**

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -848,7 +848,7 @@ function wc_get_product_tax_class_options() {
  * @return array
  */
 function wc_get_product_stock_status_options() {
-	return apply_filters( 'wc_product_stock_status_options', array(
+	return apply_filters( 'woocommerce_product_stock_status_options', array(
 		'instock'     => __( 'In stock', 'woocommerce' ),
 		'outofstock'  => __( 'Out of stock', 'woocommerce' ),
 		'onbackorder' => __( 'On backorder', 'woocommerce' ),

--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -1028,4 +1028,21 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 
 		unset( $image_attr, $expected_attr );
 	}
+
+	/**
+	 * Test wc_get_product_stock_status_options().
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_wc_get_product_stock_status_options() {
+		$status_options = (array) apply_filters(
+			'woocommerce_product_stock_status_options', array(
+				'instock'     => 'In stock',
+				'outofstock'  => 'Out of stock',
+				'onbackorder' => 'On backorder',
+			)
+		);
+
+		$this->assertEquals( $status_options, wc_get_product_stock_status_options() );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #22757 

### How to test the changes in this Pull Request:

1. As described in #22757 
