### PR TITLE
Experiment with composer based autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,6 +9,17 @@
   "require": {
     "composer/installers": "~1.6"
   },
+  "autoload": {
+    "classmap": ["includes/"],
+    "files": [
+      "includes/admin/wc-meta-box-functions.php",
+      "includes/admin/wc-admin-functions.php"
+    ]
+  },
+  "config": {
+    "optimize-autoloader": true,
+    "classmap-authoritative": true
+  },
   "require-dev": {
     "apigen/apigen": "4.1.2",
     "nette/utils": "2.5.3",

--- a/composer.json
+++ b/composer.json
@@ -11,9 +11,28 @@
   },
   "autoload": {
     "classmap": ["includes/"],
+    "exclude-from-classmap": ["/tests/", "**/legacy/", "**/deprecated/"],
     "files": [
+      "includes/wc-core-functions.php",
       "includes/admin/wc-meta-box-functions.php",
-      "includes/admin/wc-admin-functions.php"
+      "includes/admin/wc-admin-functions.php",
+      "includes/wc-attribute-functions.php",
+      "includes/wc-cart-functions.php",
+      "includes/wc-conditional-functions.php",
+      "includes/wc-coupon-functions.php",
+      "includes/wc-deprecated-functions.php",
+      "includes/wc-formatting-functions.php",
+      "includes/wc-notice-functions.php",
+      "includes/wc-order-functions.php",
+      "includes/wc-order-item-functions.php",
+      "includes/wc-page-functions.php",
+      "includes/wc-product-functions.php",
+      "includes/wc-rest-functions.php",
+      "includes/wc-stock-functions.php",
+      "includes/wc-term-functions.php",
+      "includes/wc-user-functions.php",
+      "includes/wc-webhook-functions.php",
+      "includes/wc-widget-functions.php"
     ]
   },
   "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -1,7 +1,7 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
     "content-hash": "67b8066152baf2f08393562b576da266",
@@ -1275,23 +1275,23 @@
         },
         {
             "name": "nette/di",
-            "version": "v2.4.14",
+            "version": "v2.4.15",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/di.git",
-                "reference": "923da3e2c0aa53162ef455472c0ac7787b096c5a"
+                "reference": "d0561b8f77e8ef2ed6d83328860e16c81a5a8649"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/di/zipball/923da3e2c0aa53162ef455472c0ac7787b096c5a",
-                "reference": "923da3e2c0aa53162ef455472c0ac7787b096c5a",
+                "url": "https://api.github.com/repos/nette/di/zipball/d0561b8f77e8ef2ed6d83328860e16c81a5a8649",
+                "reference": "d0561b8f77e8ef2ed6d83328860e16c81a5a8649",
                 "shasum": ""
             },
             "require": {
                 "ext-tokenizer": "*",
                 "nette/neon": "^2.3.3 || ~3.0.0",
-                "nette/php-generator": "^2.6.1 || ~3.0.0",
-                "nette/utils": "^2.4.3 || ~3.0.0",
+                "nette/php-generator": "^2.6.1 || ^3.0.0",
+                "nette/utils": "^2.5.0 || ~3.0.0",
                 "php": ">=5.6.0"
             },
             "conflict": {
@@ -1340,7 +1340,7 @@
                 "nette",
                 "static"
             ],
-            "time": "2018-09-17T15:47:40+00:00"
+            "time": "2019-01-30T13:26:05+00:00"
         },
         {
             "name": "nette/finder",
@@ -1607,21 +1607,21 @@
         },
         {
             "name": "nette/php-generator",
-            "version": "v3.0.5",
+            "version": "v3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/php-generator.git",
-                "reference": "ea90209c2e8a7cd087b2742ca553c047a8df5eff"
+                "reference": "9de4e093a130f7a1bd175198799ebc0efbac6924"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/php-generator/zipball/ea90209c2e8a7cd087b2742ca553c047a8df5eff",
-                "reference": "ea90209c2e8a7cd087b2742ca553c047a8df5eff",
+                "url": "https://api.github.com/repos/nette/php-generator/zipball/9de4e093a130f7a1bd175198799ebc0efbac6924",
+                "reference": "9de4e093a130f7a1bd175198799ebc0efbac6924",
                 "shasum": ""
             },
             "require": {
                 "nette/utils": "^2.4.2 || ~3.0.0",
-                "php": ">=7.0"
+                "php": ">=7.1"
             },
             "conflict": {
                 "nette/nette": "<2.2"
@@ -1633,7 +1633,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.2-dev"
                 }
             },
             "autoload": {
@@ -1657,7 +1657,7 @@
                     "homepage": "https://nette.org/contributors"
                 }
             ],
-            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 7.2 features.",
+            "description": "🐘 Nette PHP Generator: generates neat PHP code for you. Supports new PHP 7.3 features.",
             "homepage": "https://nette.org",
             "keywords": [
                 "code",
@@ -1665,7 +1665,7 @@
                 "php",
                 "scaffolding"
             ],
-            "time": "2018-08-09T14:32:27+00:00"
+            "time": "2018-11-27T19:00:14+00:00"
         },
         {
             "name": "nette/reflection",
@@ -1799,32 +1799,29 @@
         },
         {
             "name": "nette/safe-stream",
-            "version": "v2.3.3",
+            "version": "v2.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/safe-stream.git",
-                "reference": "0fcd45ae82be5817f4b3ad25bc8955968f355412"
+                "reference": "5e46d5fe397956d697501785d50b16fecea8e935"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/safe-stream/zipball/0fcd45ae82be5817f4b3ad25bc8955968f355412",
-                "reference": "0fcd45ae82be5817f4b3ad25bc8955968f355412",
+                "url": "https://api.github.com/repos/nette/safe-stream/zipball/5e46d5fe397956d697501785d50b16fecea8e935",
+                "reference": "5e46d5fe397956d697501785d50b16fecea8e935",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.1"
-            },
-            "conflict": {
-                "nette/nette": "<2.2"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "nette/tester": "~1.7",
+                "nette/tester": "^2.0",
                 "tracy/tracy": "^2.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.3-dev"
+                    "dev-master": "2.4-dev"
                 }
             },
             "autoload": {
@@ -1856,7 +1853,7 @@
                 "nette",
                 "safe"
             ],
-            "time": "2017-07-13T18:20:37+00:00"
+            "time": "2019-02-06T00:22:25+00:00"
         },
         {
             "name": "nette/utils",
@@ -2805,6 +2802,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2018-08-09T05:50:03+00:00"
         },
         {
@@ -3731,7 +3729,7 @@
                 },
                 {
                     "name": "Gert de Pagter",
-                    "email": "backendtea@gmail.com"
+                    "email": "BackEndTea@gmail.com"
                 }
             ],
             "description": "Symfony polyfill for ctype functions",
@@ -3895,27 +3893,28 @@
         },
         {
             "name": "tracy/tracy",
-            "version": "v2.5.5",
+            "version": "v2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/tracy.git",
-                "reference": "35fa649b483b28e16f61de07110ea0585fc8d6ea"
+                "reference": "28c54772200b5fefd8c9a421b36019cda2b2f9f4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/tracy/zipball/35fa649b483b28e16f61de07110ea0585fc8d6ea",
-                "reference": "35fa649b483b28e16f61de07110ea0585fc8d6ea",
+                "url": "https://api.github.com/repos/nette/tracy/zipball/28c54772200b5fefd8c9a421b36019cda2b2f9f4",
+                "reference": "28c54772200b5fefd8c9a421b36019cda2b2f9f4",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
                 "ext-session": "*",
-                "php": ">=5.4.4"
+                "php": ">=7.1"
             },
             "require-dev": {
-                "nette/di": "~2.3",
-                "nette/tester": "~1.7",
-                "nette/utils": "~2.3"
+                "nette/di": "^2.4 || ~3.0.0",
+                "nette/tester": "^2.1",
+                "nette/utils": "^2.4 || ^3.0",
+                "psr/log": "^1.0"
             },
             "suggest": {
                 "https://nette.org/donate": "Please support Tracy via a donation"
@@ -3923,7 +3922,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.5-dev"
+                    "dev-master": "2.6-dev"
                 }
             },
             "autoload": {
@@ -3931,7 +3930,7 @@
                     "src"
                 ],
                 "files": [
-                    "src/shortcuts.php"
+                    "src/Tracy/shortcuts.php"
                 ]
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -3957,7 +3956,7 @@
                 "nette",
                 "profiler"
             ],
-            "time": "2018-11-05T15:10:59+00:00"
+            "time": "2019-02-20T06:26:57+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -2,15 +2,10 @@
 /**
  * Addons Page
  *
- * @author   WooThemes
- * @category Admin
  * @package  WooCommerce/Admin
- * @version  2.5.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Addons Class.

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -2,423 +2,458 @@
 /**
  * Load assets
  *
- * @package     WooCommerce/Admin
- * @version     2.1.0
+ * @package WooCommerce/Admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
+/**
+ * WC_Admin_Assets Class.
+ */
+class WC_Admin_Assets {
 
 	/**
-	 * WC_Admin_Assets Class.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Assets|null
 	 */
-	class WC_Admin_Assets {
+	protected static $instance = null;
 
-		/**
-		 * Hook in tabs.
-		 */
-		public function __construct() {
-			add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
-			add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Assets
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
+		add_action( 'admin_enqueue_scripts', array( $this, 'admin_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
+	}
+
+	/**
+	 * Enqueue styles.
+	 */
+	public function admin_styles() {
+		global $wp_scripts;
+
+		$screen    = get_current_screen();
+		$screen_id = $screen ? $screen->id : '';
+
+		// Register admin styles.
+		wp_register_style( 'woocommerce_admin_menu_styles', WC()->plugin_url() . '/assets/css/menu.css', array(), WC_VERSION );
+		wp_register_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), WC_VERSION );
+		wp_register_style( 'jquery-ui-style', WC()->plugin_url() . '/assets/css/jquery-ui/jquery-ui.min.css', array(), WC_VERSION );
+		wp_register_style( 'woocommerce_admin_dashboard_styles', WC()->plugin_url() . '/assets/css/dashboard.css', array(), WC_VERSION );
+		wp_register_style( 'woocommerce_admin_print_reports_styles', WC()->plugin_url() . '/assets/css/reports-print.css', array(), WC_VERSION, 'print' );
+
+		// Add RTL support for admin styles.
+		wp_style_add_data( 'woocommerce_admin_menu_styles', 'rtl', 'replace' );
+		wp_style_add_data( 'woocommerce_admin_styles', 'rtl', 'replace' );
+		wp_style_add_data( 'woocommerce_admin_dashboard_styles', 'rtl', 'replace' );
+		wp_style_add_data( 'woocommerce_admin_print_reports_styles', 'rtl', 'replace' );
+
+		// Sitewide menu CSS.
+		wp_enqueue_style( 'woocommerce_admin_menu_styles' );
+
+		// Admin styles for WC pages only.
+		if ( in_array( $screen_id, wc_get_screen_ids() ) ) {
+			wp_enqueue_style( 'woocommerce_admin_styles' );
+			wp_enqueue_style( 'jquery-ui-style' );
+			wp_enqueue_style( 'wp-color-picker' );
 		}
 
-		/**
-		 * Enqueue styles.
-		 */
-		public function admin_styles() {
-			global $wp_scripts;
-
-			$screen    = get_current_screen();
-			$screen_id = $screen ? $screen->id : '';
-
-			// Register admin styles.
-			wp_register_style( 'woocommerce_admin_menu_styles', WC()->plugin_url() . '/assets/css/menu.css', array(), WC_VERSION );
-			wp_register_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), WC_VERSION );
-			wp_register_style( 'jquery-ui-style', WC()->plugin_url() . '/assets/css/jquery-ui/jquery-ui.min.css', array(), WC_VERSION );
-			wp_register_style( 'woocommerce_admin_dashboard_styles', WC()->plugin_url() . '/assets/css/dashboard.css', array(), WC_VERSION );
-			wp_register_style( 'woocommerce_admin_print_reports_styles', WC()->plugin_url() . '/assets/css/reports-print.css', array(), WC_VERSION, 'print' );
-
-			// Add RTL support for admin styles.
-			wp_style_add_data( 'woocommerce_admin_menu_styles', 'rtl', 'replace' );
-			wp_style_add_data( 'woocommerce_admin_styles', 'rtl', 'replace' );
-			wp_style_add_data( 'woocommerce_admin_dashboard_styles', 'rtl', 'replace' );
-			wp_style_add_data( 'woocommerce_admin_print_reports_styles', 'rtl', 'replace' );
-
-			// Sitewide menu CSS.
-			wp_enqueue_style( 'woocommerce_admin_menu_styles' );
-
-			// Admin styles for WC pages only.
-			if ( in_array( $screen_id, wc_get_screen_ids() ) ) {
-				wp_enqueue_style( 'woocommerce_admin_styles' );
-				wp_enqueue_style( 'jquery-ui-style' );
-				wp_enqueue_style( 'wp-color-picker' );
-			}
-
-			if ( in_array( $screen_id, array( 'dashboard' ) ) ) {
-				wp_enqueue_style( 'woocommerce_admin_dashboard_styles' );
-			}
-
-			if ( in_array( $screen_id, array( 'woocommerce_page_wc-reports', 'toplevel_page_wc-reports' ) ) ) {
-				wp_enqueue_style( 'woocommerce_admin_print_reports_styles' );
-			}
-
-			// @deprecated 2.3.
-			if ( has_action( 'woocommerce_admin_css' ) ) {
-				do_action( 'woocommerce_admin_css' );
-				wc_deprecated_function( 'The woocommerce_admin_css action', '2.3', 'admin_enqueue_scripts' );
-			}
+		if ( in_array( $screen_id, array( 'dashboard' ) ) ) {
+			wp_enqueue_style( 'woocommerce_admin_dashboard_styles' );
 		}
 
+		if ( in_array( $screen_id, array( 'woocommerce_page_wc-reports', 'toplevel_page_wc-reports' ) ) ) {
+			wp_enqueue_style( 'woocommerce_admin_print_reports_styles' );
+		}
 
-		/**
-		 * Enqueue scripts.
-		 */
-		public function admin_scripts() {
-			global $wp_query, $post;
-
-			$screen       = get_current_screen();
-			$screen_id    = $screen ? $screen->id : '';
-			$wc_screen_id = sanitize_title( __( 'WooCommerce', 'woocommerce' ) );
-			$suffix       = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-
-			// Register scripts.
-			wp_register_script( 'woocommerce_admin', WC()->plugin_url() . '/assets/js/admin/woocommerce_admin' . $suffix . '.js', array( 'jquery', 'jquery-blockui', 'jquery-ui-sortable', 'jquery-ui-widget', 'jquery-ui-core', 'jquery-tiptip' ), WC_VERSION );
-			wp_register_script( 'jquery-blockui', WC()->plugin_url() . '/assets/js/jquery-blockui/jquery.blockUI' . $suffix . '.js', array( 'jquery' ), '2.70', true );
-			wp_register_script( 'jquery-tiptip', WC()->plugin_url() . '/assets/js/jquery-tiptip/jquery.tipTip' . $suffix . '.js', array( 'jquery' ), WC_VERSION, true );
-			wp_register_script( 'round', WC()->plugin_url() . '/assets/js/round/round' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
-			wp_register_script( 'wc-admin-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes' . $suffix . '.js', array( 'jquery', 'jquery-ui-datepicker', 'jquery-ui-sortable', 'accounting', 'round', 'wc-enhanced-select', 'plupload-all', 'stupidtable', 'jquery-tiptip' ), WC_VERSION );
-			wp_register_script( 'zeroclipboard', WC()->plugin_url() . '/assets/js/zeroclipboard/jquery.zeroclipboard' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
-			wp_register_script( 'qrcode', WC()->plugin_url() . '/assets/js/jquery-qrcode/jquery.qrcode' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
-			wp_register_script( 'stupidtable', WC()->plugin_url() . '/assets/js/stupidtable/stupidtable' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
-			wp_register_script( 'serializejson', WC()->plugin_url() . '/assets/js/jquery-serializejson/jquery.serializejson' . $suffix . '.js', array( 'jquery' ), '2.8.1' );
-			wp_register_script( 'flot', WC()->plugin_url() . '/assets/js/jquery-flot/jquery.flot' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
-			wp_register_script( 'flot-resize', WC()->plugin_url() . '/assets/js/jquery-flot/jquery.flot.resize' . $suffix . '.js', array( 'jquery', 'flot' ), WC_VERSION );
-			wp_register_script( 'flot-time', WC()->plugin_url() . '/assets/js/jquery-flot/jquery.flot.time' . $suffix . '.js', array( 'jquery', 'flot' ), WC_VERSION );
-			wp_register_script( 'flot-pie', WC()->plugin_url() . '/assets/js/jquery-flot/jquery.flot.pie' . $suffix . '.js', array( 'jquery', 'flot' ), WC_VERSION );
-			wp_register_script( 'flot-stack', WC()->plugin_url() . '/assets/js/jquery-flot/jquery.flot.stack' . $suffix . '.js', array( 'jquery', 'flot' ), WC_VERSION );
-			wp_register_script( 'wc-settings-tax', WC()->plugin_url() . '/assets/js/admin/settings-views-html-settings-tax' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-blockui' ), WC_VERSION );
-			wp_register_script( 'wc-backbone-modal', WC()->plugin_url() . '/assets/js/admin/backbone-modal' . $suffix . '.js', array( 'underscore', 'backbone', 'wp-util' ), WC_VERSION );
-			wp_register_script( 'wc-shipping-zones', WC()->plugin_url() . '/assets/js/admin/wc-shipping-zones' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-ui-sortable', 'wc-enhanced-select', 'wc-backbone-modal' ), WC_VERSION );
-			wp_register_script( 'wc-shipping-zone-methods', WC()->plugin_url() . '/assets/js/admin/wc-shipping-zone-methods' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-ui-sortable', 'wc-backbone-modal' ), WC_VERSION );
-			wp_register_script( 'wc-shipping-classes', WC()->plugin_url() . '/assets/js/admin/wc-shipping-classes' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone' ), WC_VERSION );
-			wp_register_script( 'wc-clipboard', WC()->plugin_url() . '/assets/js/admin/wc-clipboard' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
-			wp_register_script( 'select2', WC()->plugin_url() . '/assets/js/select2/select2.full' . $suffix . '.js', array( 'jquery' ), '4.0.3' );
-			wp_register_script( 'selectWoo', WC()->plugin_url() . '/assets/js/selectWoo/selectWoo.full' . $suffix . '.js', array( 'jquery' ), '1.0.4' );
-			wp_register_script( 'wc-enhanced-select', WC()->plugin_url() . '/assets/js/admin/wc-enhanced-select' . $suffix . '.js', array( 'jquery', 'selectWoo' ), WC_VERSION );
-			wp_localize_script(
-				'wc-enhanced-select',
-				'wc_enhanced_select_params',
-				array(
-					'i18n_no_matches'           => _x( 'No matches found', 'enhanced select', 'woocommerce' ),
-					'i18n_ajax_error'           => _x( 'Loading failed', 'enhanced select', 'woocommerce' ),
-					'i18n_input_too_short_1'    => _x( 'Please enter 1 or more characters', 'enhanced select', 'woocommerce' ),
-					'i18n_input_too_short_n'    => _x( 'Please enter %qty% or more characters', 'enhanced select', 'woocommerce' ),
-					'i18n_input_too_long_1'     => _x( 'Please delete 1 character', 'enhanced select', 'woocommerce' ),
-					'i18n_input_too_long_n'     => _x( 'Please delete %qty% characters', 'enhanced select', 'woocommerce' ),
-					'i18n_selection_too_long_1' => _x( 'You can only select 1 item', 'enhanced select', 'woocommerce' ),
-					'i18n_selection_too_long_n' => _x( 'You can only select %qty% items', 'enhanced select', 'woocommerce' ),
-					'i18n_load_more'            => _x( 'Loading more results&hellip;', 'enhanced select', 'woocommerce' ),
-					'i18n_searching'            => _x( 'Searching&hellip;', 'enhanced select', 'woocommerce' ),
-					'ajax_url'                  => admin_url( 'admin-ajax.php' ),
-					'search_products_nonce'     => wp_create_nonce( 'search-products' ),
-					'search_customers_nonce'    => wp_create_nonce( 'search-customers' ),
-					'search_categories_nonce'   => wp_create_nonce( 'search-categories' ),
-				)
-			);
-
-			wp_register_script( 'accounting', WC()->plugin_url() . '/assets/js/accounting/accounting' . $suffix . '.js', array( 'jquery' ), '0.4.2' );
-			wp_localize_script(
-				'accounting',
-				'accounting_params',
-				array(
-					'mon_decimal_point' => wc_get_price_decimal_separator(),
-				)
-			);
-
-			wp_register_script( 'wc-orders', WC()->plugin_url() . '/assets/js/admin/wc-orders' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-blockui' ), WC_VERSION );
-			wp_localize_script(
-				'wc-orders',
-				'wc_orders_params',
-				array(
-					'ajax_url'      => admin_url( 'admin-ajax.php' ),
-					'preview_nonce' => wp_create_nonce( 'woocommerce-preview-order' ),
-				)
-			);
-
-			// WooCommerce admin pages.
-			if ( in_array( $screen_id, wc_get_screen_ids() ) ) {
-				wp_enqueue_script( 'iris' );
-				wp_enqueue_script( 'woocommerce_admin' );
-				wp_enqueue_script( 'wc-enhanced-select' );
-				wp_enqueue_script( 'jquery-ui-sortable' );
-				wp_enqueue_script( 'jquery-ui-autocomplete' );
-
-				$locale  = localeconv();
-				$decimal = isset( $locale['decimal_point'] ) ? $locale['decimal_point'] : '.';
-
-				$params = array(
-					/* translators: %s: decimal */
-					'i18n_decimal_error'                => sprintf( __( 'Please enter in decimal (%s) format without thousand separators.', 'woocommerce' ), $decimal ),
-					/* translators: %s: price decimal separator */
-					'i18n_mon_decimal_error'            => sprintf( __( 'Please enter in monetary decimal (%s) format without thousand separators and currency symbols.', 'woocommerce' ), wc_get_price_decimal_separator() ),
-					'i18n_country_iso_error'            => __( 'Please enter in country code with two capital letters.', 'woocommerce' ),
-					'i18n_sale_less_than_regular_error' => __( 'Please enter in a value less than the regular price.', 'woocommerce' ),
-					'i18n_delete_product_notice'        => __( 'This product has produced sales and may be linked to existing orders. Are you sure you want to delete it?', 'woocommerce' ),
-					'i18n_remove_personal_data_notice'  => __( 'This action cannot be reversed. Are you sure you wish to erase personal data from the selected orders?', 'woocommerce' ),
-					'decimal_point'                     => $decimal,
-					'mon_decimal_point'                 => wc_get_price_decimal_separator(),
-					'ajax_url'                          => admin_url( 'admin-ajax.php' ),
-					'strings'                           => array(
-						'import_products' => __( 'Import', 'woocommerce' ),
-						'export_products' => __( 'Export', 'woocommerce' ),
-					),
-					'nonces'                            => array(
-						'gateway_toggle' => wp_create_nonce( 'woocommerce-toggle-payment-gateway-enabled' ),
-					),
-					'urls'                              => array(
-						'import_products' => current_user_can( 'import' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_importer' ) ) : null,
-						'export_products' => current_user_can( 'export' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_exporter' ) ) : null,
-					),
-				);
-
-				wp_localize_script( 'woocommerce_admin', 'woocommerce_admin', $params );
-			}
-
-			// Edit product category pages.
-			if ( in_array( $screen_id, array( 'edit-product_cat' ) ) ) {
-				wp_enqueue_media();
-			}
-
-			// Products.
-			if ( in_array( $screen_id, array( 'edit-product' ) ) ) {
-				wp_enqueue_script( 'woocommerce_quick-edit', WC()->plugin_url() . '/assets/js/admin/quick-edit' . $suffix . '.js', array( 'jquery', 'woocommerce_admin' ), WC_VERSION );
-
-				$params = array(
-					'strings' => array(
-						'allow_reviews' => esc_js( __( 'Enable reviews', 'woocommerce' ) ),
-					),
-				);
-
-				wp_localize_script( 'woocommerce_quick-edit', 'woocommerce_quick_edit', $params );
-			}
-
-			// Meta boxes.
-			if ( in_array( $screen_id, array( 'product', 'edit-product' ) ) ) {
-				wp_enqueue_media();
-				wp_register_script( 'wc-admin-product-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'media-models' ), WC_VERSION );
-				wp_register_script( 'wc-admin-variation-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product-variation' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'serializejson', 'media-models' ), WC_VERSION );
-
-				wp_enqueue_script( 'wc-admin-product-meta-boxes' );
-				wp_enqueue_script( 'wc-admin-variation-meta-boxes' );
-
-				$params = array(
-					'post_id'                             => isset( $post->ID ) ? $post->ID : '',
-					'plugin_url'                          => WC()->plugin_url(),
-					'ajax_url'                            => admin_url( 'admin-ajax.php' ),
-					'woocommerce_placeholder_img_src'     => wc_placeholder_img_src(),
-					'add_variation_nonce'                 => wp_create_nonce( 'add-variation' ),
-					'link_variation_nonce'                => wp_create_nonce( 'link-variations' ),
-					'delete_variations_nonce'             => wp_create_nonce( 'delete-variations' ),
-					'load_variations_nonce'               => wp_create_nonce( 'load-variations' ),
-					'save_variations_nonce'               => wp_create_nonce( 'save-variations' ),
-					'bulk_edit_variations_nonce'          => wp_create_nonce( 'bulk-edit-variations' ),
-					/* translators: %d: Number of variations */
-					'i18n_link_all_variations'            => esc_js( sprintf( __( 'Are you sure you want to link all variations? This will create a new variation for each and every possible combination of variation attributes (max %d per run).', 'woocommerce' ), defined( 'WC_MAX_LINKED_VARIATIONS' ) ? WC_MAX_LINKED_VARIATIONS : 50 ) ),
-					'i18n_enter_a_value'                  => esc_js( __( 'Enter a value', 'woocommerce' ) ),
-					'i18n_enter_menu_order'               => esc_js( __( 'Variation menu order (determines position in the list of variations)', 'woocommerce' ) ),
-					'i18n_enter_a_value_fixed_or_percent' => esc_js( __( 'Enter a value (fixed or %)', 'woocommerce' ) ),
-					'i18n_delete_all_variations'          => esc_js( __( 'Are you sure you want to delete all variations? This cannot be undone.', 'woocommerce' ) ),
-					'i18n_last_warning'                   => esc_js( __( 'Last warning, are you sure?', 'woocommerce' ) ),
-					'i18n_choose_image'                   => esc_js( __( 'Choose an image', 'woocommerce' ) ),
-					'i18n_set_image'                      => esc_js( __( 'Set variation image', 'woocommerce' ) ),
-					'i18n_variation_added'                => esc_js( __( 'variation added', 'woocommerce' ) ),
-					'i18n_variations_added'               => esc_js( __( 'variations added', 'woocommerce' ) ),
-					'i18n_no_variations_added'            => esc_js( __( 'No variations added', 'woocommerce' ) ),
-					'i18n_remove_variation'               => esc_js( __( 'Are you sure you want to remove this variation?', 'woocommerce' ) ),
-					'i18n_scheduled_sale_start'           => esc_js( __( 'Sale start date (YYYY-MM-DD format or leave blank)', 'woocommerce' ) ),
-					'i18n_scheduled_sale_end'             => esc_js( __( 'Sale end date (YYYY-MM-DD format or leave blank)', 'woocommerce' ) ),
-					'i18n_edited_variations'              => esc_js( __( 'Save changes before changing page?', 'woocommerce' ) ),
-					'i18n_variation_count_single'         => esc_js( __( '%qty% variation', 'woocommerce' ) ),
-					'i18n_variation_count_plural'         => esc_js( __( '%qty% variations', 'woocommerce' ) ),
-					'variations_per_page'                 => absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) ),
-				);
-
-				wp_localize_script( 'wc-admin-variation-meta-boxes', 'woocommerce_admin_meta_boxes_variations', $params );
-			}
-			if ( in_array( str_replace( 'edit-', '', $screen_id ), wc_get_order_types( 'order-meta-boxes' ) ) ) {
-				$default_location = wc_get_customer_default_location();
-
-				wp_enqueue_script( 'wc-admin-order-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-order' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'wc-backbone-modal', 'selectWoo', 'wc-clipboard' ), WC_VERSION );
-				wp_localize_script(
-					'wc-admin-order-meta-boxes',
-					'woocommerce_admin_meta_boxes_order',
-					array(
-						'countries'              => wp_json_encode( array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ) ),
-						'i18n_select_state_text' => esc_attr__( 'Select an option&hellip;', 'woocommerce' ),
-						'default_country'        => isset( $default_location['country'] ) ? $default_location['country'] : '',
-						'default_state'          => isset( $default_location['state'] ) ? $default_location['state'] : '',
-						'placeholder_name'       => esc_attr__( 'Name (required)', 'woocommerce' ),
-						'placeholder_value'      => esc_attr__( 'Value (required)', 'woocommerce' ),
-					)
-				);
-			}
-			if ( in_array( $screen_id, array( 'shop_coupon', 'edit-shop_coupon' ) ) ) {
-				wp_enqueue_script( 'wc-admin-coupon-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-coupon' . $suffix . '.js', array( 'wc-admin-meta-boxes' ), WC_VERSION );
-			}
-			if ( in_array( str_replace( 'edit-', '', $screen_id ), array_merge( array( 'shop_coupon', 'product' ), wc_get_order_types( 'order-meta-boxes' ) ) ) ) {
-				$post_id            = isset( $post->ID ) ? $post->ID : '';
-				$currency           = '';
-				$remove_item_notice = __( 'Are you sure you want to remove the selected items?', 'woocommerce' );
-
-				if ( $post_id && in_array( get_post_type( $post_id ), wc_get_order_types( 'order-meta-boxes' ) ) ) {
-					$order = wc_get_order( $post_id );
-					if ( $order ) {
-						$currency           = $order->get_currency();
-
-						if ( ! $order->has_status( array( 'pending', 'failed', 'cancelled' ) ) ) {
-							$remove_item_notice = $remove_item_notice . ' ' . __( "You may need to manually restore the item's stock.", 'woocommerce' );
-						}
-					}
-				}
-
-				$params = array(
-					'remove_item_notice'            => $remove_item_notice,
-					'i18n_select_items'             => __( 'Please select some items.', 'woocommerce' ),
-					'i18n_do_refund'                => __( 'Are you sure you wish to process this refund? This action cannot be undone.', 'woocommerce' ),
-					'i18n_delete_refund'            => __( 'Are you sure you wish to delete this refund? This action cannot be undone.', 'woocommerce' ),
-					'i18n_delete_tax'               => __( 'Are you sure you wish to delete this tax column? This action cannot be undone.', 'woocommerce' ),
-					'remove_item_meta'              => __( 'Remove this item meta?', 'woocommerce' ),
-					'remove_attribute'              => __( 'Remove this attribute?', 'woocommerce' ),
-					'name_label'                    => __( 'Name', 'woocommerce' ),
-					'remove_label'                  => __( 'Remove', 'woocommerce' ),
-					'click_to_toggle'               => __( 'Click to toggle', 'woocommerce' ),
-					'values_label'                  => __( 'Value(s)', 'woocommerce' ),
-					'text_attribute_tip'            => __( 'Enter some text, or some attributes by pipe (|) separating values.', 'woocommerce' ),
-					'visible_label'                 => __( 'Visible on the product page', 'woocommerce' ),
-					'used_for_variations_label'     => __( 'Used for variations', 'woocommerce' ),
-					'new_attribute_prompt'          => __( 'Enter a name for the new attribute term:', 'woocommerce' ),
-					'calc_totals'                   => __( 'Recalculate totals? This will calculate taxes based on the customers country (or the store base country) and update totals.', 'woocommerce' ),
-					'copy_billing'                  => __( 'Copy billing information to shipping information? This will remove any currently entered shipping information.', 'woocommerce' ),
-					'load_billing'                  => __( "Load the customer's billing information? This will remove any currently entered billing information.", 'woocommerce' ),
-					'load_shipping'                 => __( "Load the customer's shipping information? This will remove any currently entered shipping information.", 'woocommerce' ),
-					'featured_label'                => __( 'Featured', 'woocommerce' ),
-					'prices_include_tax'            => esc_attr( get_option( 'woocommerce_prices_include_tax' ) ),
-					'tax_based_on'                  => esc_attr( get_option( 'woocommerce_tax_based_on' ) ),
-					'round_at_subtotal'             => esc_attr( get_option( 'woocommerce_tax_round_at_subtotal' ) ),
-					'no_customer_selected'          => __( 'No customer selected', 'woocommerce' ),
-					'plugin_url'                    => WC()->plugin_url(),
-					'ajax_url'                      => admin_url( 'admin-ajax.php' ),
-					'order_item_nonce'              => wp_create_nonce( 'order-item' ),
-					'add_attribute_nonce'           => wp_create_nonce( 'add-attribute' ),
-					'save_attributes_nonce'         => wp_create_nonce( 'save-attributes' ),
-					'calc_totals_nonce'             => wp_create_nonce( 'calc-totals' ),
-					'get_customer_details_nonce'    => wp_create_nonce( 'get-customer-details' ),
-					'search_products_nonce'         => wp_create_nonce( 'search-products' ),
-					'grant_access_nonce'            => wp_create_nonce( 'grant-access' ),
-					'revoke_access_nonce'           => wp_create_nonce( 'revoke-access' ),
-					'add_order_note_nonce'          => wp_create_nonce( 'add-order-note' ),
-					'delete_order_note_nonce'       => wp_create_nonce( 'delete-order-note' ),
-					'calendar_image'                => WC()->plugin_url() . '/assets/images/calendar.png',
-					'post_id'                       => isset( $post->ID ) ? $post->ID : '',
-					'base_country'                  => WC()->countries->get_base_country(),
-					'currency_format_num_decimals'  => wc_get_price_decimals(),
-					'currency_format_symbol'        => get_woocommerce_currency_symbol( $currency ),
-					'currency_format_decimal_sep'   => esc_attr( wc_get_price_decimal_separator() ),
-					'currency_format_thousand_sep'  => esc_attr( wc_get_price_thousand_separator() ),
-					'currency_format'               => esc_attr( str_replace( array( '%1$s', '%2$s' ), array( '%s', '%v' ), get_woocommerce_price_format() ) ), // For accounting JS.
-					'rounding_precision'            => wc_get_rounding_precision(),
-					'tax_rounding_mode'             => wc_get_tax_rounding_mode(),
-					'product_types'                 => array_unique( array_merge( array( 'simple', 'grouped', 'variable', 'external' ), array_keys( wc_get_product_types() ) ) ),
-					'i18n_download_permission_fail' => __( 'Could not grant access - the user may already have permission for this file or billing email is not set. Ensure the billing email is set, and the order has been saved.', 'woocommerce' ),
-					'i18n_permission_revoke'        => __( 'Are you sure you want to revoke access to this download?', 'woocommerce' ),
-					'i18n_tax_rate_already_exists'  => __( 'You cannot add the same tax rate twice!', 'woocommerce' ),
-					'i18n_delete_note'              => __( 'Are you sure you wish to delete this note? This action cannot be undone.', 'woocommerce' ),
-					'i18n_apply_coupon'             => __( 'Enter a coupon code to apply. Discounts are applied to line totals, before taxes.', 'woocommerce' ),
-					'i18n_add_fee'                  => __( 'Enter a fixed amount or percentage to apply as a fee.', 'woocommerce' ),
-				);
-
-				wp_localize_script( 'wc-admin-meta-boxes', 'woocommerce_admin_meta_boxes', $params );
-			}
-
-			// Term ordering - only when sorting by term_order.
-			if ( ( strstr( $screen_id, 'edit-pa_' ) || ( ! empty( $_GET['taxonomy'] ) && in_array( wp_unslash( $_GET['taxonomy'] ), apply_filters( 'woocommerce_sortable_taxonomies', array( 'product_cat' ) ) ) ) ) && ! isset( $_GET['orderby'] ) ) {
-
-				wp_register_script( 'woocommerce_term_ordering', WC()->plugin_url() . '/assets/js/admin/term-ordering' . $suffix . '.js', array( 'jquery-ui-sortable' ), WC_VERSION );
-				wp_enqueue_script( 'woocommerce_term_ordering' );
-
-				$taxonomy = isset( $_GET['taxonomy'] ) ? wc_clean( wp_unslash( $_GET['taxonomy'] ) ) : '';
-
-				$woocommerce_term_order_params = array(
-					'taxonomy' => $taxonomy,
-				);
-
-				wp_localize_script( 'woocommerce_term_ordering', 'woocommerce_term_ordering_params', $woocommerce_term_order_params );
-			}
-
-			// Product sorting - only when sorting by menu order on the products page.
-			if ( current_user_can( 'edit_others_pages' ) && 'edit-product' === $screen_id && isset( $wp_query->query['orderby'] ) && 'menu_order title' === $wp_query->query['orderby'] ) {
-				wp_register_script( 'woocommerce_product_ordering', WC()->plugin_url() . '/assets/js/admin/product-ordering' . $suffix . '.js', array( 'jquery-ui-sortable' ), WC_VERSION, true );
-				wp_enqueue_script( 'woocommerce_product_ordering' );
-			}
-
-			// Reports Pages.
-			if ( in_array( $screen_id, apply_filters( 'woocommerce_reports_screen_ids', array( $wc_screen_id . '_page_wc-reports', 'toplevel_page_wc-reports', 'dashboard' ) ) ) ) {
-				wp_register_script( 'wc-reports', WC()->plugin_url() . '/assets/js/admin/reports' . $suffix . '.js', array( 'jquery', 'jquery-ui-datepicker' ), WC_VERSION );
-
-				wp_enqueue_script( 'wc-reports' );
-				wp_enqueue_script( 'flot' );
-				wp_enqueue_script( 'flot-resize' );
-				wp_enqueue_script( 'flot-time' );
-				wp_enqueue_script( 'flot-pie' );
-				wp_enqueue_script( 'flot-stack' );
-			}
-
-			// API settings.
-			if ( $wc_screen_id . '_page_wc-settings' === $screen_id && isset( $_GET['section'] ) && 'keys' == $_GET['section'] ) {
-				wp_register_script( 'wc-api-keys', WC()->plugin_url() . '/assets/js/admin/api-keys' . $suffix . '.js', array( 'jquery', 'woocommerce_admin', 'underscore', 'backbone', 'wp-util', 'qrcode', 'wc-clipboard' ), WC_VERSION, true );
-				wp_enqueue_script( 'wc-api-keys' );
-				wp_localize_script(
-					'wc-api-keys',
-					'woocommerce_admin_api_keys',
-					array(
-						'ajax_url'         => admin_url( 'admin-ajax.php' ),
-						'update_api_nonce' => wp_create_nonce( 'update-api-key' ),
-						'clipboard_failed' => esc_html__( 'Copying to clipboard failed. Please press Ctrl/Cmd+C to copy.', 'woocommerce' ),
-					)
-				);
-			}
-
-			// System status.
-			if ( $wc_screen_id . '_page_wc-status' === $screen_id ) {
-				wp_register_script( 'wc-admin-system-status', WC()->plugin_url() . '/assets/js/admin/system-status' . $suffix . '.js', array( 'wc-clipboard' ), WC_VERSION );
-				wp_enqueue_script( 'wc-admin-system-status' );
-				wp_localize_script(
-					'wc-admin-system-status',
-					'woocommerce_admin_system_status',
-					array(
-						'delete_log_confirmation' => esc_js( __( 'Are you sure you want to delete this log?', 'woocommerce' ) ),
-					)
-				);
-			}
-
-			if ( in_array( $screen_id, array( 'user-edit', 'profile' ) ) ) {
-				wp_register_script( 'wc-users', WC()->plugin_url() . '/assets/js/admin/users' . $suffix . '.js', array( 'jquery', 'wc-enhanced-select', 'selectWoo' ), WC_VERSION, true );
-				wp_enqueue_script( 'wc-users' );
-				wp_localize_script(
-					'wc-users',
-					'wc_users_params',
-					array(
-						'countries'              => wp_json_encode( array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ) ),
-						'i18n_select_state_text' => esc_attr__( 'Select an option&hellip;', 'woocommerce' ),
-					)
-				);
-			}
+		// @deprecated 2.3.
+		if ( has_action( 'woocommerce_admin_css' ) ) {
+			do_action( 'woocommerce_admin_css' );
+			wc_deprecated_function( 'The woocommerce_admin_css action', '2.3', 'admin_enqueue_scripts' );
 		}
 	}
 
-endif;
 
-return new WC_Admin_Assets();
+	/**
+	 * Enqueue scripts.
+	 */
+	public function admin_scripts() {
+		global $wp_query, $post;
+
+		$screen       = get_current_screen();
+		$screen_id    = $screen ? $screen->id : '';
+		$wc_screen_id = sanitize_title( __( 'WooCommerce', 'woocommerce' ) );
+		$suffix       = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+
+		// Register scripts.
+		wp_register_script( 'woocommerce_admin', WC()->plugin_url() . '/assets/js/admin/woocommerce_admin' . $suffix . '.js', array( 'jquery', 'jquery-blockui', 'jquery-ui-sortable', 'jquery-ui-widget', 'jquery-ui-core', 'jquery-tiptip' ), WC_VERSION );
+		wp_register_script( 'jquery-blockui', WC()->plugin_url() . '/assets/js/jquery-blockui/jquery.blockUI' . $suffix . '.js', array( 'jquery' ), '2.70', true );
+		wp_register_script( 'jquery-tiptip', WC()->plugin_url() . '/assets/js/jquery-tiptip/jquery.tipTip' . $suffix . '.js', array( 'jquery' ), WC_VERSION, true );
+		wp_register_script( 'round', WC()->plugin_url() . '/assets/js/round/round' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
+		wp_register_script( 'wc-admin-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes' . $suffix . '.js', array( 'jquery', 'jquery-ui-datepicker', 'jquery-ui-sortable', 'accounting', 'round', 'wc-enhanced-select', 'plupload-all', 'stupidtable', 'jquery-tiptip' ), WC_VERSION );
+		wp_register_script( 'zeroclipboard', WC()->plugin_url() . '/assets/js/zeroclipboard/jquery.zeroclipboard' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
+		wp_register_script( 'qrcode', WC()->plugin_url() . '/assets/js/jquery-qrcode/jquery.qrcode' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
+		wp_register_script( 'stupidtable', WC()->plugin_url() . '/assets/js/stupidtable/stupidtable' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
+		wp_register_script( 'serializejson', WC()->plugin_url() . '/assets/js/jquery-serializejson/jquery.serializejson' . $suffix . '.js', array( 'jquery' ), '2.8.1' );
+		wp_register_script( 'flot', WC()->plugin_url() . '/assets/js/jquery-flot/jquery.flot' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
+		wp_register_script( 'flot-resize', WC()->plugin_url() . '/assets/js/jquery-flot/jquery.flot.resize' . $suffix . '.js', array( 'jquery', 'flot' ), WC_VERSION );
+		wp_register_script( 'flot-time', WC()->plugin_url() . '/assets/js/jquery-flot/jquery.flot.time' . $suffix . '.js', array( 'jquery', 'flot' ), WC_VERSION );
+		wp_register_script( 'flot-pie', WC()->plugin_url() . '/assets/js/jquery-flot/jquery.flot.pie' . $suffix . '.js', array( 'jquery', 'flot' ), WC_VERSION );
+		wp_register_script( 'flot-stack', WC()->plugin_url() . '/assets/js/jquery-flot/jquery.flot.stack' . $suffix . '.js', array( 'jquery', 'flot' ), WC_VERSION );
+		wp_register_script( 'wc-settings-tax', WC()->plugin_url() . '/assets/js/admin/settings-views-html-settings-tax' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-blockui' ), WC_VERSION );
+		wp_register_script( 'wc-backbone-modal', WC()->plugin_url() . '/assets/js/admin/backbone-modal' . $suffix . '.js', array( 'underscore', 'backbone', 'wp-util' ), WC_VERSION );
+		wp_register_script( 'wc-shipping-zones', WC()->plugin_url() . '/assets/js/admin/wc-shipping-zones' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-ui-sortable', 'wc-enhanced-select', 'wc-backbone-modal' ), WC_VERSION );
+		wp_register_script( 'wc-shipping-zone-methods', WC()->plugin_url() . '/assets/js/admin/wc-shipping-zone-methods' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-ui-sortable', 'wc-backbone-modal' ), WC_VERSION );
+		wp_register_script( 'wc-shipping-classes', WC()->plugin_url() . '/assets/js/admin/wc-shipping-classes' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone' ), WC_VERSION );
+		wp_register_script( 'wc-clipboard', WC()->plugin_url() . '/assets/js/admin/wc-clipboard' . $suffix . '.js', array( 'jquery' ), WC_VERSION );
+		wp_register_script( 'select2', WC()->plugin_url() . '/assets/js/select2/select2.full' . $suffix . '.js', array( 'jquery' ), '4.0.3' );
+		wp_register_script( 'selectWoo', WC()->plugin_url() . '/assets/js/selectWoo/selectWoo.full' . $suffix . '.js', array( 'jquery' ), '1.0.4' );
+		wp_register_script( 'wc-enhanced-select', WC()->plugin_url() . '/assets/js/admin/wc-enhanced-select' . $suffix . '.js', array( 'jquery', 'selectWoo' ), WC_VERSION );
+		wp_localize_script(
+			'wc-enhanced-select',
+			'wc_enhanced_select_params',
+			array(
+				'i18n_no_matches'           => _x( 'No matches found', 'enhanced select', 'woocommerce' ),
+				'i18n_ajax_error'           => _x( 'Loading failed', 'enhanced select', 'woocommerce' ),
+				'i18n_input_too_short_1'    => _x( 'Please enter 1 or more characters', 'enhanced select', 'woocommerce' ),
+				'i18n_input_too_short_n'    => _x( 'Please enter %qty% or more characters', 'enhanced select', 'woocommerce' ),
+				'i18n_input_too_long_1'     => _x( 'Please delete 1 character', 'enhanced select', 'woocommerce' ),
+				'i18n_input_too_long_n'     => _x( 'Please delete %qty% characters', 'enhanced select', 'woocommerce' ),
+				'i18n_selection_too_long_1' => _x( 'You can only select 1 item', 'enhanced select', 'woocommerce' ),
+				'i18n_selection_too_long_n' => _x( 'You can only select %qty% items', 'enhanced select', 'woocommerce' ),
+				'i18n_load_more'            => _x( 'Loading more results&hellip;', 'enhanced select', 'woocommerce' ),
+				'i18n_searching'            => _x( 'Searching&hellip;', 'enhanced select', 'woocommerce' ),
+				'ajax_url'                  => admin_url( 'admin-ajax.php' ),
+				'search_products_nonce'     => wp_create_nonce( 'search-products' ),
+				'search_customers_nonce'    => wp_create_nonce( 'search-customers' ),
+				'search_categories_nonce'   => wp_create_nonce( 'search-categories' ),
+			)
+		);
+
+		wp_register_script( 'accounting', WC()->plugin_url() . '/assets/js/accounting/accounting' . $suffix . '.js', array( 'jquery' ), '0.4.2' );
+		wp_localize_script(
+			'accounting',
+			'accounting_params',
+			array(
+				'mon_decimal_point' => wc_get_price_decimal_separator(),
+			)
+		);
+
+		wp_register_script( 'wc-orders', WC()->plugin_url() . '/assets/js/admin/wc-orders' . $suffix . '.js', array( 'jquery', 'wp-util', 'underscore', 'backbone', 'jquery-blockui' ), WC_VERSION );
+		wp_localize_script(
+			'wc-orders',
+			'wc_orders_params',
+			array(
+				'ajax_url'      => admin_url( 'admin-ajax.php' ),
+				'preview_nonce' => wp_create_nonce( 'woocommerce-preview-order' ),
+			)
+		);
+
+		// WooCommerce admin pages.
+		if ( in_array( $screen_id, wc_get_screen_ids() ) ) {
+			wp_enqueue_script( 'iris' );
+			wp_enqueue_script( 'woocommerce_admin' );
+			wp_enqueue_script( 'wc-enhanced-select' );
+			wp_enqueue_script( 'jquery-ui-sortable' );
+			wp_enqueue_script( 'jquery-ui-autocomplete' );
+
+			$locale  = localeconv();
+			$decimal = isset( $locale['decimal_point'] ) ? $locale['decimal_point'] : '.';
+
+			$params = array(
+				/* translators: %s: decimal */
+				'i18n_decimal_error'                => sprintf( __( 'Please enter in decimal (%s) format without thousand separators.', 'woocommerce' ), $decimal ),
+				/* translators: %s: price decimal separator */
+				'i18n_mon_decimal_error'            => sprintf( __( 'Please enter in monetary decimal (%s) format without thousand separators and currency symbols.', 'woocommerce' ), wc_get_price_decimal_separator() ),
+				'i18n_country_iso_error'            => __( 'Please enter in country code with two capital letters.', 'woocommerce' ),
+				'i18n_sale_less_than_regular_error' => __( 'Please enter in a value less than the regular price.', 'woocommerce' ),
+				'i18n_delete_product_notice'        => __( 'This product has produced sales and may be linked to existing orders. Are you sure you want to delete it?', 'woocommerce' ),
+				'i18n_remove_personal_data_notice'  => __( 'This action cannot be reversed. Are you sure you wish to erase personal data from the selected orders?', 'woocommerce' ),
+				'decimal_point'                     => $decimal,
+				'mon_decimal_point'                 => wc_get_price_decimal_separator(),
+				'ajax_url'                          => admin_url( 'admin-ajax.php' ),
+				'strings'                           => array(
+					'import_products' => __( 'Import', 'woocommerce' ),
+					'export_products' => __( 'Export', 'woocommerce' ),
+				),
+				'nonces'                            => array(
+					'gateway_toggle' => wp_create_nonce( 'woocommerce-toggle-payment-gateway-enabled' ),
+				),
+				'urls'                              => array(
+					'import_products' => current_user_can( 'import' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_importer' ) ) : null,
+					'export_products' => current_user_can( 'export' ) ? esc_url_raw( admin_url( 'edit.php?post_type=product&page=product_exporter' ) ) : null,
+				),
+			);
+
+			wp_localize_script( 'woocommerce_admin', 'woocommerce_admin', $params );
+		}
+
+		// Edit product category pages.
+		if ( in_array( $screen_id, array( 'edit-product_cat' ) ) ) {
+			wp_enqueue_media();
+		}
+
+		// Products.
+		if ( in_array( $screen_id, array( 'edit-product' ) ) ) {
+			wp_enqueue_script( 'woocommerce_quick-edit', WC()->plugin_url() . '/assets/js/admin/quick-edit' . $suffix . '.js', array( 'jquery', 'woocommerce_admin' ), WC_VERSION );
+
+			$params = array(
+				'strings' => array(
+					'allow_reviews' => esc_js( __( 'Enable reviews', 'woocommerce' ) ),
+				),
+			);
+
+			wp_localize_script( 'woocommerce_quick-edit', 'woocommerce_quick_edit', $params );
+		}
+
+		// Meta boxes.
+		if ( in_array( $screen_id, array( 'product', 'edit-product' ) ) ) {
+			wp_enqueue_media();
+			wp_register_script( 'wc-admin-product-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'media-models' ), WC_VERSION );
+			wp_register_script( 'wc-admin-variation-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-product-variation' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'serializejson', 'media-models' ), WC_VERSION );
+
+			wp_enqueue_script( 'wc-admin-product-meta-boxes' );
+			wp_enqueue_script( 'wc-admin-variation-meta-boxes' );
+
+			$params = array(
+				'post_id'                             => isset( $post->ID ) ? $post->ID : '',
+				'plugin_url'                          => WC()->plugin_url(),
+				'ajax_url'                            => admin_url( 'admin-ajax.php' ),
+				'woocommerce_placeholder_img_src'     => wc_placeholder_img_src(),
+				'add_variation_nonce'                 => wp_create_nonce( 'add-variation' ),
+				'link_variation_nonce'                => wp_create_nonce( 'link-variations' ),
+				'delete_variations_nonce'             => wp_create_nonce( 'delete-variations' ),
+				'load_variations_nonce'               => wp_create_nonce( 'load-variations' ),
+				'save_variations_nonce'               => wp_create_nonce( 'save-variations' ),
+				'bulk_edit_variations_nonce'          => wp_create_nonce( 'bulk-edit-variations' ),
+				/* translators: %d: Number of variations */
+				'i18n_link_all_variations'            => esc_js( sprintf( __( 'Are you sure you want to link all variations? This will create a new variation for each and every possible combination of variation attributes (max %d per run).', 'woocommerce' ), defined( 'WC_MAX_LINKED_VARIATIONS' ) ? WC_MAX_LINKED_VARIATIONS : 50 ) ),
+				'i18n_enter_a_value'                  => esc_js( __( 'Enter a value', 'woocommerce' ) ),
+				'i18n_enter_menu_order'               => esc_js( __( 'Variation menu order (determines position in the list of variations)', 'woocommerce' ) ),
+				'i18n_enter_a_value_fixed_or_percent' => esc_js( __( 'Enter a value (fixed or %)', 'woocommerce' ) ),
+				'i18n_delete_all_variations'          => esc_js( __( 'Are you sure you want to delete all variations? This cannot be undone.', 'woocommerce' ) ),
+				'i18n_last_warning'                   => esc_js( __( 'Last warning, are you sure?', 'woocommerce' ) ),
+				'i18n_choose_image'                   => esc_js( __( 'Choose an image', 'woocommerce' ) ),
+				'i18n_set_image'                      => esc_js( __( 'Set variation image', 'woocommerce' ) ),
+				'i18n_variation_added'                => esc_js( __( 'variation added', 'woocommerce' ) ),
+				'i18n_variations_added'               => esc_js( __( 'variations added', 'woocommerce' ) ),
+				'i18n_no_variations_added'            => esc_js( __( 'No variations added', 'woocommerce' ) ),
+				'i18n_remove_variation'               => esc_js( __( 'Are you sure you want to remove this variation?', 'woocommerce' ) ),
+				'i18n_scheduled_sale_start'           => esc_js( __( 'Sale start date (YYYY-MM-DD format or leave blank)', 'woocommerce' ) ),
+				'i18n_scheduled_sale_end'             => esc_js( __( 'Sale end date (YYYY-MM-DD format or leave blank)', 'woocommerce' ) ),
+				'i18n_edited_variations'              => esc_js( __( 'Save changes before changing page?', 'woocommerce' ) ),
+				'i18n_variation_count_single'         => esc_js( __( '%qty% variation', 'woocommerce' ) ),
+				'i18n_variation_count_plural'         => esc_js( __( '%qty% variations', 'woocommerce' ) ),
+				'variations_per_page'                 => absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) ),
+			);
+
+			wp_localize_script( 'wc-admin-variation-meta-boxes', 'woocommerce_admin_meta_boxes_variations', $params );
+
+			if ( ! empty( $_GET['tutorial'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+				$pointers = new WC_Admin_Pointers();
+				$pointers->create_product_tutorial();
+			}
+		}
+		if ( in_array( str_replace( 'edit-', '', $screen_id ), wc_get_order_types( 'order-meta-boxes' ) ) ) {
+			$default_location = wc_get_customer_default_location();
+
+			wp_enqueue_script( 'wc-admin-order-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-order' . $suffix . '.js', array( 'wc-admin-meta-boxes', 'wc-backbone-modal', 'selectWoo', 'wc-clipboard' ), WC_VERSION );
+			wp_localize_script(
+				'wc-admin-order-meta-boxes',
+				'woocommerce_admin_meta_boxes_order',
+				array(
+					'countries'              => wp_json_encode( array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ) ),
+					'i18n_select_state_text' => esc_attr__( 'Select an option&hellip;', 'woocommerce' ),
+					'default_country'        => isset( $default_location['country'] ) ? $default_location['country'] : '',
+					'default_state'          => isset( $default_location['state'] ) ? $default_location['state'] : '',
+					'placeholder_name'       => esc_attr__( 'Name (required)', 'woocommerce' ),
+					'placeholder_value'      => esc_attr__( 'Value (required)', 'woocommerce' ),
+				)
+			);
+		}
+		if ( in_array( $screen_id, array( 'shop_coupon', 'edit-shop_coupon' ) ) ) {
+			wp_enqueue_script( 'wc-admin-coupon-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-coupon' . $suffix . '.js', array( 'wc-admin-meta-boxes' ), WC_VERSION );
+		}
+		if ( in_array( str_replace( 'edit-', '', $screen_id ), array_merge( array( 'shop_coupon', 'product' ), wc_get_order_types( 'order-meta-boxes' ) ) ) ) {
+			$post_id            = isset( $post->ID ) ? $post->ID : '';
+			$currency           = '';
+			$remove_item_notice = __( 'Are you sure you want to remove the selected items?', 'woocommerce' );
+
+			if ( $post_id && in_array( get_post_type( $post_id ), wc_get_order_types( 'order-meta-boxes' ) ) ) {
+				$order = wc_get_order( $post_id );
+				if ( $order ) {
+					$currency           = $order->get_currency();
+
+					if ( ! $order->has_status( array( 'pending', 'failed', 'cancelled' ) ) ) {
+						$remove_item_notice = $remove_item_notice . ' ' . __( "You may need to manually restore the item's stock.", 'woocommerce' );
+					}
+				}
+			}
+
+			$params = array(
+				'remove_item_notice'            => $remove_item_notice,
+				'i18n_select_items'             => __( 'Please select some items.', 'woocommerce' ),
+				'i18n_do_refund'                => __( 'Are you sure you wish to process this refund? This action cannot be undone.', 'woocommerce' ),
+				'i18n_delete_refund'            => __( 'Are you sure you wish to delete this refund? This action cannot be undone.', 'woocommerce' ),
+				'i18n_delete_tax'               => __( 'Are you sure you wish to delete this tax column? This action cannot be undone.', 'woocommerce' ),
+				'remove_item_meta'              => __( 'Remove this item meta?', 'woocommerce' ),
+				'remove_attribute'              => __( 'Remove this attribute?', 'woocommerce' ),
+				'name_label'                    => __( 'Name', 'woocommerce' ),
+				'remove_label'                  => __( 'Remove', 'woocommerce' ),
+				'click_to_toggle'               => __( 'Click to toggle', 'woocommerce' ),
+				'values_label'                  => __( 'Value(s)', 'woocommerce' ),
+				'text_attribute_tip'            => __( 'Enter some text, or some attributes by pipe (|) separating values.', 'woocommerce' ),
+				'visible_label'                 => __( 'Visible on the product page', 'woocommerce' ),
+				'used_for_variations_label'     => __( 'Used for variations', 'woocommerce' ),
+				'new_attribute_prompt'          => __( 'Enter a name for the new attribute term:', 'woocommerce' ),
+				'calc_totals'                   => __( 'Recalculate totals? This will calculate taxes based on the customers country (or the store base country) and update totals.', 'woocommerce' ),
+				'copy_billing'                  => __( 'Copy billing information to shipping information? This will remove any currently entered shipping information.', 'woocommerce' ),
+				'load_billing'                  => __( "Load the customer's billing information? This will remove any currently entered billing information.", 'woocommerce' ),
+				'load_shipping'                 => __( "Load the customer's shipping information? This will remove any currently entered shipping information.", 'woocommerce' ),
+				'featured_label'                => __( 'Featured', 'woocommerce' ),
+				'prices_include_tax'            => esc_attr( get_option( 'woocommerce_prices_include_tax' ) ),
+				'tax_based_on'                  => esc_attr( get_option( 'woocommerce_tax_based_on' ) ),
+				'round_at_subtotal'             => esc_attr( get_option( 'woocommerce_tax_round_at_subtotal' ) ),
+				'no_customer_selected'          => __( 'No customer selected', 'woocommerce' ),
+				'plugin_url'                    => WC()->plugin_url(),
+				'ajax_url'                      => admin_url( 'admin-ajax.php' ),
+				'order_item_nonce'              => wp_create_nonce( 'order-item' ),
+				'add_attribute_nonce'           => wp_create_nonce( 'add-attribute' ),
+				'save_attributes_nonce'         => wp_create_nonce( 'save-attributes' ),
+				'calc_totals_nonce'             => wp_create_nonce( 'calc-totals' ),
+				'get_customer_details_nonce'    => wp_create_nonce( 'get-customer-details' ),
+				'search_products_nonce'         => wp_create_nonce( 'search-products' ),
+				'grant_access_nonce'            => wp_create_nonce( 'grant-access' ),
+				'revoke_access_nonce'           => wp_create_nonce( 'revoke-access' ),
+				'add_order_note_nonce'          => wp_create_nonce( 'add-order-note' ),
+				'delete_order_note_nonce'       => wp_create_nonce( 'delete-order-note' ),
+				'calendar_image'                => WC()->plugin_url() . '/assets/images/calendar.png',
+				'post_id'                       => isset( $post->ID ) ? $post->ID : '',
+				'base_country'                  => WC()->countries->get_base_country(),
+				'currency_format_num_decimals'  => wc_get_price_decimals(),
+				'currency_format_symbol'        => get_woocommerce_currency_symbol( $currency ),
+				'currency_format_decimal_sep'   => esc_attr( wc_get_price_decimal_separator() ),
+				'currency_format_thousand_sep'  => esc_attr( wc_get_price_thousand_separator() ),
+				'currency_format'               => esc_attr( str_replace( array( '%1$s', '%2$s' ), array( '%s', '%v' ), get_woocommerce_price_format() ) ), // For accounting JS.
+				'rounding_precision'            => wc_get_rounding_precision(),
+				'tax_rounding_mode'             => wc_get_tax_rounding_mode(),
+				'product_types'                 => array_unique( array_merge( array( 'simple', 'grouped', 'variable', 'external' ), array_keys( wc_get_product_types() ) ) ),
+				'i18n_download_permission_fail' => __( 'Could not grant access - the user may already have permission for this file or billing email is not set. Ensure the billing email is set, and the order has been saved.', 'woocommerce' ),
+				'i18n_permission_revoke'        => __( 'Are you sure you want to revoke access to this download?', 'woocommerce' ),
+				'i18n_tax_rate_already_exists'  => __( 'You cannot add the same tax rate twice!', 'woocommerce' ),
+				'i18n_delete_note'              => __( 'Are you sure you wish to delete this note? This action cannot be undone.', 'woocommerce' ),
+				'i18n_apply_coupon'             => __( 'Enter a coupon code to apply. Discounts are applied to line totals, before taxes.', 'woocommerce' ),
+				'i18n_add_fee'                  => __( 'Enter a fixed amount or percentage to apply as a fee.', 'woocommerce' ),
+			);
+
+			wp_localize_script( 'wc-admin-meta-boxes', 'woocommerce_admin_meta_boxes', $params );
+		}
+
+		// Term ordering - only when sorting by term_order.
+		if ( ( strstr( $screen_id, 'edit-pa_' ) || ( ! empty( $_GET['taxonomy'] ) && in_array( wp_unslash( $_GET['taxonomy'] ), apply_filters( 'woocommerce_sortable_taxonomies', array( 'product_cat' ) ) ) ) ) && ! isset( $_GET['orderby'] ) ) {
+
+			wp_register_script( 'woocommerce_term_ordering', WC()->plugin_url() . '/assets/js/admin/term-ordering' . $suffix . '.js', array( 'jquery-ui-sortable' ), WC_VERSION );
+			wp_enqueue_script( 'woocommerce_term_ordering' );
+
+			$taxonomy = isset( $_GET['taxonomy'] ) ? wc_clean( wp_unslash( $_GET['taxonomy'] ) ) : '';
+
+			$woocommerce_term_order_params = array(
+				'taxonomy' => $taxonomy,
+			);
+
+			wp_localize_script( 'woocommerce_term_ordering', 'woocommerce_term_ordering_params', $woocommerce_term_order_params );
+		}
+
+		// Product sorting - only when sorting by menu order on the products page.
+		if ( current_user_can( 'edit_others_pages' ) && 'edit-product' === $screen_id && isset( $wp_query->query['orderby'] ) && 'menu_order title' === $wp_query->query['orderby'] ) {
+			wp_register_script( 'woocommerce_product_ordering', WC()->plugin_url() . '/assets/js/admin/product-ordering' . $suffix . '.js', array( 'jquery-ui-sortable' ), WC_VERSION, true );
+			wp_enqueue_script( 'woocommerce_product_ordering' );
+		}
+
+		// Reports Pages.
+		if ( in_array( $screen_id, apply_filters( 'woocommerce_reports_screen_ids', array( $wc_screen_id . '_page_wc-reports', 'toplevel_page_wc-reports', 'dashboard' ) ) ) ) {
+			wp_register_script( 'wc-reports', WC()->plugin_url() . '/assets/js/admin/reports' . $suffix . '.js', array( 'jquery', 'jquery-ui-datepicker' ), WC_VERSION );
+
+			wp_enqueue_script( 'wc-reports' );
+			wp_enqueue_script( 'flot' );
+			wp_enqueue_script( 'flot-resize' );
+			wp_enqueue_script( 'flot-time' );
+			wp_enqueue_script( 'flot-pie' );
+			wp_enqueue_script( 'flot-stack' );
+		}
+
+		// API settings.
+		if ( $wc_screen_id . '_page_wc-settings' === $screen_id && isset( $_GET['section'] ) && 'keys' == $_GET['section'] ) {
+			wp_register_script( 'wc-api-keys', WC()->plugin_url() . '/assets/js/admin/api-keys' . $suffix . '.js', array( 'jquery', 'woocommerce_admin', 'underscore', 'backbone', 'wp-util', 'qrcode', 'wc-clipboard' ), WC_VERSION, true );
+			wp_enqueue_script( 'wc-api-keys' );
+			wp_localize_script(
+				'wc-api-keys',
+				'woocommerce_admin_api_keys',
+				array(
+					'ajax_url'         => admin_url( 'admin-ajax.php' ),
+					'update_api_nonce' => wp_create_nonce( 'update-api-key' ),
+					'clipboard_failed' => esc_html__( 'Copying to clipboard failed. Please press Ctrl/Cmd+C to copy.', 'woocommerce' ),
+				)
+			);
+		}
+
+		// System status.
+		if ( $wc_screen_id . '_page_wc-status' === $screen_id ) {
+			wp_register_script( 'wc-admin-system-status', WC()->plugin_url() . '/assets/js/admin/system-status' . $suffix . '.js', array( 'wc-clipboard' ), WC_VERSION );
+			wp_enqueue_script( 'wc-admin-system-status' );
+			wp_localize_script(
+				'wc-admin-system-status',
+				'woocommerce_admin_system_status',
+				array(
+					'delete_log_confirmation' => esc_js( __( 'Are you sure you want to delete this log?', 'woocommerce' ) ),
+				)
+			);
+		}
+
+		if ( in_array( $screen_id, array( 'user-edit', 'profile' ) ) ) {
+			wp_register_script( 'wc-users', WC()->plugin_url() . '/assets/js/admin/users' . $suffix . '.js', array( 'jquery', 'wc-enhanced-select', 'selectWoo' ), WC_VERSION, true );
+			wp_enqueue_script( 'wc-users' );
+			wp_localize_script(
+				'wc-users',
+				'wc_users_params',
+				array(
+					'countries'              => wp_json_encode( array_merge( WC()->countries->get_allowed_country_states(), WC()->countries->get_shipping_country_states() ) ),
+					'i18n_select_state_text' => esc_attr__( 'Select an option&hellip;', 'woocommerce' ),
+				)
+			);
+		}
+	}
+}

--- a/includes/admin/class-wc-admin-customize.php
+++ b/includes/admin/class-wc-admin-customize.php
@@ -2,97 +2,125 @@
 /**
  * Setup customize items.
  *
- * @author   WooCommerce
- * @category Admin
- * @package  WooCommerce/Admin/Customize
- * @version  3.1.0
+ * @package WooCommerce/Admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'WC_Admin_Customize', false ) ) :
+/**
+ * WC_Admin_Customize Class.
+ */
+class WC_Admin_Customize {
 
 	/**
-	 * WC_Admin_Customize Class.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Customize|null
 	 */
-	class WC_Admin_Customize {
+	protected static $instance = null;
 
-		/**
-		 * Initialize customize actions.
-		 */
-		public function __construct() {
-			// Include custom items to customizer nav menu settings.
-			add_filter( 'customize_nav_menu_available_item_types', array( $this, 'register_customize_nav_menu_item_types' ) );
-			add_filter( 'customize_nav_menu_available_items', array( $this, 'register_customize_nav_menu_items' ), 10, 4 );
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Customize
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-
-		/**
-		 * Register customize new nav menu item types.
-		 * This will register WooCommerce account endpoints as a nav menu item type.
-		 *
-		 * @since  3.1.0
-		 * @param  array $item_types Menu item types.
-		 * @return array
-		 */
-		public function register_customize_nav_menu_item_types( $item_types ) {
-			$item_types[] = array(
-				'title'      => __( 'WooCommerce Endpoints', 'woocommerce' ),
-				'type_label' => __( 'WooCommerce Endpoint', 'woocommerce' ),
-				'type'       => 'woocommerce_nav',
-				'object'     => 'woocommerce_endpoint',
-			);
-
-			return $item_types;
-		}
-
-		/**
-		 * Register account endpoints to customize nav menu items.
-		 *
-		 * @since  3.1.0
-		 * @param  array   $items  List of nav menu items.
-		 * @param  string  $type   Nav menu type.
-		 * @param  string  $object Nav menu object.
-		 * @param  integer $page   Page number.
-		 * @return array
-		 */
-		public function register_customize_nav_menu_items( $items = array(), $type = '', $object = '', $page = 0 ) {
-			if ( 'woocommerce_endpoint' !== $object ) {
-				return $items;
-			}
-
-			// Don't allow pagination since all items are loaded at once.
-			if ( 0 < $page ) {
-				return $items;
-			}
-
-			// Get items from account menu.
-			$endpoints = wc_get_account_menu_items();
-
-			// Remove dashboard item.
-			if ( isset( $endpoints['dashboard'] ) ) {
-				unset( $endpoints['dashboard'] );
-			}
-
-			// Include missing lost password.
-			$endpoints['lost-password'] = __( 'Lost password', 'woocommerce' );
-
-			$endpoints = apply_filters( 'woocommerce_custom_nav_menu_items', $endpoints );
-
-			foreach ( $endpoints as $endpoint => $title ) {
-				$items[] = array(
-					'id'         => $endpoint,
-					'title'      => $title,
-					'type_label' => __( 'Custom Link', 'woocommerce' ),
-					'url'        => esc_url_raw( wc_get_account_endpoint_url( $endpoint ) ),
-				);
-			}
-
-			return $items;
-		}
+		return self::$instance;
 	}
 
-endif;
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
 
-return new WC_Admin_Customize();
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
+		// Include custom items to customizer nav menu settings.
+		add_filter( 'customize_nav_menu_available_item_types', array( $this, 'register_customize_nav_menu_item_types' ) );
+		add_filter( 'customize_nav_menu_available_items', array( $this, 'register_customize_nav_menu_items' ), 10, 4 );
+	}
+
+	/**
+	 * Register customize new nav menu item types.
+	 * This will register WooCommerce account endpoints as a nav menu item type.
+	 *
+	 * @since  3.1.0
+	 * @param  array $item_types Menu item types.
+	 * @return array
+	 */
+	public function register_customize_nav_menu_item_types( $item_types ) {
+		$item_types[] = array(
+			'title'      => __( 'WooCommerce Endpoints', 'woocommerce' ),
+			'type_label' => __( 'WooCommerce Endpoint', 'woocommerce' ),
+			'type'       => 'woocommerce_nav',
+			'object'     => 'woocommerce_endpoint',
+		);
+
+		return $item_types;
+	}
+
+	/**
+	 * Register account endpoints to customize nav menu items.
+	 *
+	 * @since  3.1.0
+	 * @param  array   $items  List of nav menu items.
+	 * @param  string  $type   Nav menu type.
+	 * @param  string  $object Nav menu object.
+	 * @param  integer $page   Page number.
+	 * @return array
+	 */
+	public function register_customize_nav_menu_items( $items = array(), $type = '', $object = '', $page = 0 ) {
+		if ( 'woocommerce_endpoint' !== $object ) {
+			return $items;
+		}
+
+		// Don't allow pagination since all items are loaded at once.
+		if ( 0 < $page ) {
+			return $items;
+		}
+
+		// Get items from account menu.
+		$endpoints = wc_get_account_menu_items();
+
+		// Remove dashboard item.
+		if ( isset( $endpoints['dashboard'] ) ) {
+			unset( $endpoints['dashboard'] );
+		}
+
+		// Include missing lost password.
+		$endpoints['lost-password'] = __( 'Lost password', 'woocommerce' );
+
+		$endpoints = apply_filters( 'woocommerce_custom_nav_menu_items', $endpoints );
+
+		foreach ( $endpoints as $endpoint => $title ) {
+			$items[] = array(
+				'id'         => $endpoint,
+				'title'      => $title,
+				'type_label' => __( 'Custom Link', 'woocommerce' ),
+				'url'        => esc_url_raw( wc_get_account_endpoint_url( $endpoint ) ),
+			);
+		}
+
+		return $items;
+	}
+}

--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -2,392 +2,419 @@
 /**
  * Admin Dashboard
  *
- * @package     WooCommerce/Admin
- * @version     2.1.0
+ * @package WooCommerce/Admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
+defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
+/**
+ * WC_Admin_Dashboard Class.
+ */
+class WC_Admin_Dashboard {
 
 	/**
-	 * WC_Admin_Dashboard Class.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Dashboard|null
 	 */
-	class WC_Admin_Dashboard {
+	protected static $instance = null;
 
-		/**
-		 * Hook in tabs.
-		 */
-		public function __construct() {
-			// Only hook in admin parts if the user has admin access.
-			if ( current_user_can( 'view_woocommerce_reports' ) || current_user_can( 'manage_woocommerce' ) || current_user_can( 'publish_shop_orders' ) ) {
-				// If on network admin, only load the widget that works in that context and skip the rest.
-				if ( is_multisite() && is_network_admin() ) {
-					add_action( 'wp_network_dashboard_setup', array( $this, 'register_network_order_widget' ) );
-				} else {
-					add_action( 'wp_dashboard_setup', array( $this, 'init' ) );
-				}
-			}
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Dashboard
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
+		if ( ! current_user_can( 'view_woocommerce_reports' ) && ! current_user_can( 'manage_woocommerce' ) && ! current_user_can( 'publish_shop_orders' ) ) {
+			return;
+		}
+		add_action( 'wp_network_dashboard_setup', array( $this, 'add_dashboard_widgets' ) );
+		add_action( 'wp_dashboard_setup', array( $this, 'add_dashboard_widgets' ) );
+	}
+
+	/**
+	 * Init dashboard widgets.
+	 */
+	public function add_dashboard_widgets() {
+		if ( is_multisite() && ( is_main_site() || is_network_admin() ) ) {
+			$this->register_network_order_widget();
 		}
 
-		/**
-		 * Init dashboard widgets.
-		 */
-		public function init() {
+		if ( ! is_network_admin() ) {
 			if ( current_user_can( 'publish_shop_orders' ) && post_type_supports( 'product', 'comments' ) ) {
 				wp_add_dashboard_widget( 'woocommerce_dashboard_recent_reviews', __( 'WooCommerce Recent Reviews', 'woocommerce' ), array( $this, 'recent_reviews' ) );
 			}
 			wp_add_dashboard_widget( 'woocommerce_dashboard_status', __( 'WooCommerce Status', 'woocommerce' ), array( $this, 'status_widget' ) );
-
-			// Network Order Widget.
-			if ( is_multisite() && is_main_site() ) {
-				$this->register_network_order_widget();
-			}
 		}
-
-		/**
-		 * Register the network order dashboard widget.
-		 */
-		public function register_network_order_widget() {
-			wp_add_dashboard_widget( 'woocommerce_network_orders', __( 'WooCommerce Network Orders', 'woocommerce' ), array( $this, 'network_orders' ) );
-		}
-
-		/**
-		 * Get top seller from DB.
-		 *
-		 * @return object
-		 */
-		private function get_top_seller() {
-			global $wpdb;
-
-			$query            = array();
-			$query['fields']  = "SELECT SUM( order_item_meta.meta_value ) as qty, order_item_meta_2.meta_value as product_id
-			FROM {$wpdb->posts} as posts";
-			$query['join']    = "INNER JOIN {$wpdb->prefix}woocommerce_order_items AS order_items ON posts.ID = order_id ";
-			$query['join']   .= "INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id ";
-			$query['join']   .= "INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS order_item_meta_2 ON order_items.order_item_id = order_item_meta_2.order_item_id ";
-			$query['where']   = "WHERE posts.post_type IN ( '" . implode( "','", wc_get_order_types( 'order-count' ) ) . "' ) ";
-			$query['where']  .= "AND posts.post_status IN ( 'wc-" . implode( "','wc-", apply_filters( 'woocommerce_reports_order_statuses', array( 'completed', 'processing', 'on-hold' ) ) ) . "' ) ";
-			$query['where']  .= "AND order_item_meta.meta_key = '_qty' ";
-			$query['where']  .= "AND order_item_meta_2.meta_key = '_product_id' ";
-			$query['where']  .= "AND posts.post_date >= '" . date( 'Y-m-01', current_time( 'timestamp' ) ) . "' ";
-			$query['where']  .= "AND posts.post_date <= '" . date( 'Y-m-d H:i:s', current_time( 'timestamp' ) ) . "' ";
-			$query['groupby'] = 'GROUP BY product_id';
-			$query['orderby'] = 'ORDER BY qty DESC';
-			$query['limits']  = 'LIMIT 1';
-
-			return $wpdb->get_row( implode( ' ', apply_filters( 'woocommerce_dashboard_status_widget_top_seller_query', $query ) ) );
-		}
-
-		/**
-		 * Get sales report data.
-		 *
-		 * @return object
-		 */
-		private function get_sales_report_data() {
-			include_once dirname( __FILE__ ) . '/reports/class-wc-report-sales-by-date.php';
-
-			$sales_by_date                 = new WC_Report_Sales_By_Date();
-			$sales_by_date->start_date     = strtotime( date( 'Y-m-01', current_time( 'timestamp' ) ) );
-			$sales_by_date->end_date       = current_time( 'timestamp' );
-			$sales_by_date->chart_groupby  = 'day';
-			$sales_by_date->group_by_query = 'YEAR(posts.post_date), MONTH(posts.post_date), DAY(posts.post_date)';
-
-			return $sales_by_date->get_report_data();
-		}
-
-		/**
-		 * Show status widget.
-		 */
-		public function status_widget() {
-			include_once dirname( __FILE__ ) . '/reports/class-wc-admin-report.php';
-
-			$reports = new WC_Admin_Report();
-
-			echo '<ul class="wc_status_list">';
-
-			if ( current_user_can( 'view_woocommerce_reports' ) ) {
-				$report_data = $this->get_sales_report_data();
-				if ( $report_data ) {
-					?>
-				<li class="sales-this-month">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=orders&range=month' ) ); ?>">
-					<?php echo $reports->sales_sparkline( '', max( 7, date( 'd', current_time( 'timestamp' ) ) ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
-					<?php
-						printf(
-							/* translators: %s: net sales */
-							esc_html__( '%s net sales this month', 'woocommerce' ),
-							'<strong>' . wc_price( $report_data->net_sales ) . '</strong>'
-						); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-					?>
-					</a>
-				</li>
-					<?php
-				}
-
-				$top_seller = $this->get_top_seller();
-				if ( $top_seller && $top_seller->qty ) {
-					?>
-				<li class="best-seller-this-month">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=orders&report=sales_by_product&range=month&product_ids=' . $top_seller->product_id ) ); ?>">
-					<?php echo $reports->sales_sparkline( $top_seller->product_id, max( 7, date( 'd', current_time( 'timestamp' ) ) ), 'count' ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
-					<?php
-						printf(
-							/* translators: 1: top seller product title 2: top seller quantity */
-							esc_html__( '%1$s top seller this month (sold %2$d)', 'woocommerce' ),
-							'<strong>' . get_the_title( $top_seller->product_id ) . '</strong>',
-							$top_seller->qty
-						); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-					?>
-					</a>
-				</li>
-					<?php
-				}
-			}
-
-			$this->status_widget_order_rows();
-			$this->status_widget_stock_rows();
-
-			do_action( 'woocommerce_after_dashboard_status_widget', $reports );
-			echo '</ul>';
-		}
-
-		/**
-		 * Show order data is status widget.
-		 */
-		private function status_widget_order_rows() {
-			if ( ! current_user_can( 'edit_shop_orders' ) ) {
-				return;
-			}
-			$on_hold_count    = 0;
-			$processing_count = 0;
-
-			foreach ( wc_get_order_types( 'order-count' ) as $type ) {
-				$counts            = (array) wp_count_posts( $type );
-				$on_hold_count    += isset( $counts['wc-on-hold'] ) ? $counts['wc-on-hold'] : 0;
-				$processing_count += isset( $counts['wc-processing'] ) ? $counts['wc-processing'] : 0;
-			}
-			?>
-			<li class="processing-orders">
-			<a href="<?php echo esc_url( admin_url( 'edit.php?post_status=wc-processing&post_type=shop_order' ) ); ?>">
-				<?php
-					printf(
-						/* translators: %s: order count */
-						_n( '<strong>%s order</strong> awaiting processing', '<strong>%s orders</strong> awaiting processing', $processing_count, 'woocommerce' ),
-						$processing_count
-					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-				?>
-				</a>
-			</li>
-			<li class="on-hold-orders">
-				<a href="<?php echo esc_url( admin_url( 'edit.php?post_status=wc-on-hold&post_type=shop_order' ) ); ?>">
-				<?php
-					printf(
-						/* translators: %s: order count */
-						_n( '<strong>%s order</strong> on-hold', '<strong>%s orders</strong> on-hold', $on_hold_count, 'woocommerce' ),
-						$on_hold_count
-					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-				?>
-				</a>
-			</li>
-			<?php
-		}
-
-		/**
-		 * Show stock data is status widget.
-		 */
-		private function status_widget_stock_rows() {
-			global $wpdb;
-
-			// Get products using a query - this is too advanced for get_posts.
-			$stock          = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
-			$nostock        = absint( max( get_option( 'woocommerce_notify_no_stock_amount' ), 0 ) );
-			$transient_name = 'wc_low_stock_count';
-
-			$lowinstock_count = get_transient( $transient_name );
-			if ( false === $lowinstock_count ) {
-				$query_from       = apply_filters(
-					'woocommerce_report_low_in_stock_query_from',
-					"FROM {$wpdb->posts} as posts
-					INNER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id
-					INNER JOIN {$wpdb->postmeta} AS postmeta2 ON posts.ID = postmeta2.post_id
-					WHERE 1=1
-					AND posts.post_type IN ( 'product', 'product_variation' )
-					AND posts.post_status = 'publish'
-					AND postmeta2.meta_key = '_manage_stock' AND postmeta2.meta_value = 'yes'
-					AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= '{$stock}'
-					AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) > '{$nostock}'"
-				);
-				$lowinstock_count = absint( $wpdb->get_var( "SELECT COUNT( DISTINCT posts.ID ) {$query_from};" ) );
-				set_transient( $transient_name, $lowinstock_count, DAY_IN_SECONDS * 30 );
-			}
-
-			$transient_name = 'wc_outofstock_count';
-
-			$outofstock_count = get_transient( $transient_name );
-			if ( false === $outofstock_count ) {
-				$query_from       = apply_filters(
-					'woocommerce_report_out_of_stock_query_from',
-					"FROM {$wpdb->posts} as posts
-					INNER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id
-					INNER JOIN {$wpdb->postmeta} AS postmeta2 ON posts.ID = postmeta2.post_id
-					WHERE 1=1
-					AND posts.post_type IN ( 'product', 'product_variation' )
-					AND posts.post_status = 'publish'
-					AND postmeta2.meta_key = '_manage_stock' AND postmeta2.meta_value = 'yes'
-					AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= '{$nostock}'"
-				);
-				$outofstock_count = absint( $wpdb->get_var( "SELECT COUNT( DISTINCT posts.ID ) {$query_from};" ) );
-				set_transient( $transient_name, $outofstock_count, DAY_IN_SECONDS * 30 );
-			}
-			?>
-			<li class="low-in-stock">
-			<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=stock&report=low_in_stock' ) ); ?>">
-				<?php
-					printf(
-						/* translators: %s: order count */
-						_n( '<strong>%s product</strong> low in stock', '<strong>%s products</strong> low in stock', $lowinstock_count, 'woocommerce' ),
-						$lowinstock_count
-					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-				?>
-				</a>
-			</li>
-			<li class="out-of-stock">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=stock&report=out_of_stock' ) ); ?>">
-				<?php
-					printf(
-						/* translators: %s: order count */
-						_n( '<strong>%s product</strong> out of stock', '<strong>%s products</strong> out of stock', $outofstock_count, 'woocommerce' ),
-						$outofstock_count
-					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
-				?>
-				</a>
-			</li>
-			<?php
-		}
-
-		/**
-		 * Recent reviews widget.
-		 */
-		public function recent_reviews() {
-			global $wpdb;
-
-			$query_from = apply_filters(
-				'woocommerce_report_recent_reviews_query_from',
-				"FROM {$wpdb->comments} comments
-				LEFT JOIN {$wpdb->posts} posts ON (comments.comment_post_ID = posts.ID)
-				WHERE comments.comment_approved = '1'
-				AND comments.comment_type = 'review'
-				AND posts.post_password = ''
-				AND posts.post_type = 'product'
-				AND comments.comment_parent = 0
-				ORDER BY comments.comment_date_gmt DESC
-				LIMIT 5"
-			);
-
-			$comments = $wpdb->get_results(
-				"SELECT posts.ID, posts.post_title, comments.comment_author, comments.comment_ID, comments.comment_content {$query_from};"
-			);
-
-			if ( $comments ) {
-				echo '<ul>';
-				foreach ( $comments as $comment ) {
-
-					echo '<li>';
-
-					echo get_avatar( $comment->comment_author, '32' );
-
-					$rating = intval( get_comment_meta( $comment->comment_ID, 'rating', true ) );
-
-					/* translators: %s: rating */
-					echo '<div class="star-rating"><span style="width:' . esc_html( $rating * 20 ) . '%">' . sprintf( esc_html__( '%s out of 5', 'woocommerce' ), esc_html( $rating ) ) . '</span></div>';
-
-					/* translators: %s: review author */
-					echo '<h4 class="meta"><a href="' . esc_url( get_permalink( $comment->ID ) ) . '#comment-' . esc_html( absint( $comment->comment_ID ) ) . '">' . esc_html( apply_filters( 'woocommerce_admin_dashboard_recent_reviews', $comment->post_title, $comment ) ) . '</a> ' . sprintf( esc_html__( 'reviewed by %s', 'woocommerce' ), esc_html( $comment->comment_author ) ) . '</h4>';
-					echo '<blockquote>' . wp_kses_data( $comment->comment_content ) . '</blockquote></li>';
-
-				}
-				echo '</ul>';
-			} else {
-				echo '<p>' . esc_html__( 'There are no product reviews yet.', 'woocommerce' ) . '</p>';
-			}
-		}
-
-		/**
-		 * Network orders widget.
-		 */
-		public function network_orders() {
-			$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
-
-			wp_enqueue_style( 'wc-network-orders', WC()->plugin_url() . '/assets/css/network-order-widget.css', array(), WC_VERSION );
-
-			wp_enqueue_script( 'wc-network-orders', WC()->plugin_url() . '/assets/js/admin/network-orders' . $suffix . '.js', array( 'jquery', 'underscore' ), WC_VERSION, true );
-
-			$user     = wp_get_current_user();
-			$blogs    = get_blogs_of_user( $user->ID );
-			$blog_ids = wp_list_pluck( $blogs, 'userblog_id' );
-
-			wp_localize_script(
-				'wc-network-orders',
-				'woocommerce_network_orders',
-				array(
-					'nonce'          => wp_create_nonce( 'wp_rest' ),
-					'sites'          => array_values( $blog_ids ),
-					'order_endpoint' => get_rest_url( null, 'wc/v3/orders/network' ),
-				)
-			);
-			?>
-			<div class="post-type-shop_order">
-			<div id="woocommerce-network-order-table-loading" class="woocommerce-network-order-table-loading is-active">
-				<p>
-					<span class="spinner is-active"></span> <?php esc_html_e( 'Loading network orders', 'woocommerce' ); ?>
-				</p>
-
-			</div>
-			<table id="woocommerce-network-order-table" class="woocommerce-network-order-table">
-				<thead>
-					<tr>
-						<td><?php esc_html_e( 'Order', 'woocommerce' ); ?></td>
-						<td><?php esc_html_e( 'Status', 'woocommerce' ); ?></td>
-						<td><?php esc_html_e( 'Total', 'woocommerce' ); ?></td>
-					</tr>
-				</thead>
-				<tbody id="network-orders-tbody">
-
-				</tbody>
-			</table>
-			<div id="woocommerce-network-orders-no-orders" class="woocommerce-network-orders-no-orders">
-				<p>
-					<?php esc_html_e( 'No orders found', 'woocommerce' ); ?>
-				</p>
-			</div>
-			<?php // @codingStandardsIgnoreStart ?>
-			<script type="text/template" id="network-orders-row-template">
-				<tr>
-					<td>
-						<a href="<%- edit_url %>" class="order-view"><strong>#<%- number %> <%- customer %></strong></a>
-						<br>
-						<em>
-							<%- blog.blogname %>
-						</em>
-					</td>
-					<td>
-						<mark class="order-status status-<%- status %>"><span><%- status_name %></span></mark>
-					</td>
-					<td>
-						<%= formatted_total %>
-					</td>
-				</tr>
-			</script>
-			<?php // @codingStandardsIgnoreEnd ?>
-		</div>
-			<?php
-		}
-
 	}
 
-endif;
+	/**
+	 * Register the network order dashboard widget.
+	 */
+	public function register_network_order_widget() {
+		wp_add_dashboard_widget( 'woocommerce_network_orders', __( 'WooCommerce Network Orders', 'woocommerce' ), array( $this, 'network_orders' ) );
+	}
 
-return new WC_Admin_Dashboard();
+	/**
+	 * Get top seller from DB.
+	 *
+	 * @return object
+	 */
+	private function get_top_seller() {
+		global $wpdb;
+
+		$query            = array();
+		$query['fields']  = "SELECT SUM( order_item_meta.meta_value ) as qty, order_item_meta_2.meta_value as product_id
+		FROM {$wpdb->posts} as posts";
+		$query['join']    = "INNER JOIN {$wpdb->prefix}woocommerce_order_items AS order_items ON posts.ID = order_id ";
+		$query['join']   .= "INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id ";
+		$query['join']   .= "INNER JOIN {$wpdb->prefix}woocommerce_order_itemmeta AS order_item_meta_2 ON order_items.order_item_id = order_item_meta_2.order_item_id ";
+		$query['where']   = "WHERE posts.post_type IN ( '" . implode( "','", wc_get_order_types( 'order-count' ) ) . "' ) ";
+		$query['where']  .= "AND posts.post_status IN ( 'wc-" . implode( "','wc-", apply_filters( 'woocommerce_reports_order_statuses', array( 'completed', 'processing', 'on-hold' ) ) ) . "' ) ";
+		$query['where']  .= "AND order_item_meta.meta_key = '_qty' ";
+		$query['where']  .= "AND order_item_meta_2.meta_key = '_product_id' ";
+		$query['where']  .= "AND posts.post_date >= '" . date( 'Y-m-01', current_time( 'timestamp' ) ) . "' ";
+		$query['where']  .= "AND posts.post_date <= '" . date( 'Y-m-d H:i:s', current_time( 'timestamp' ) ) . "' ";
+		$query['groupby'] = 'GROUP BY product_id';
+		$query['orderby'] = 'ORDER BY qty DESC';
+		$query['limits']  = 'LIMIT 1';
+
+		return $wpdb->get_row( implode( ' ', apply_filters( 'woocommerce_dashboard_status_widget_top_seller_query', $query ) ) );
+	}
+
+	/**
+	 * Get sales report data.
+	 *
+	 * @return object
+	 */
+	private function get_sales_report_data() {
+		include_once dirname( __FILE__ ) . '/reports/class-wc-report-sales-by-date.php';
+
+		$sales_by_date                 = new WC_Report_Sales_By_Date();
+		$sales_by_date->start_date     = strtotime( date( 'Y-m-01', current_time( 'timestamp' ) ) );
+		$sales_by_date->end_date       = current_time( 'timestamp' );
+		$sales_by_date->chart_groupby  = 'day';
+		$sales_by_date->group_by_query = 'YEAR(posts.post_date), MONTH(posts.post_date), DAY(posts.post_date)';
+
+		return $sales_by_date->get_report_data();
+	}
+
+	/**
+	 * Show status widget.
+	 */
+	public function status_widget() {
+		include_once dirname( __FILE__ ) . '/reports/class-wc-admin-report.php';
+
+		$reports = new WC_Admin_Report();
+
+		echo '<ul class="wc_status_list">';
+
+		if ( current_user_can( 'view_woocommerce_reports' ) ) {
+			$report_data = $this->get_sales_report_data();
+			if ( $report_data ) {
+				?>
+			<li class="sales-this-month">
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=orders&range=month' ) ); ?>">
+				<?php echo $reports->sales_sparkline( '', max( 7, date( 'd', current_time( 'timestamp' ) ) ) ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+				<?php
+					printf(
+						/* translators: %s: net sales */
+						esc_html__( '%s net sales this month', 'woocommerce' ),
+						'<strong>' . wc_price( $report_data->net_sales ) . '</strong>'
+					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+				?>
+				</a>
+			</li>
+				<?php
+			}
+
+			$top_seller = $this->get_top_seller();
+			if ( $top_seller && $top_seller->qty ) {
+				?>
+			<li class="best-seller-this-month">
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=orders&report=sales_by_product&range=month&product_ids=' . $top_seller->product_id ) ); ?>">
+				<?php echo $reports->sales_sparkline( $top_seller->product_id, max( 7, date( 'd', current_time( 'timestamp' ) ) ), 'count' ); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped ?>
+				<?php
+					printf(
+						/* translators: 1: top seller product title 2: top seller quantity */
+						esc_html__( '%1$s top seller this month (sold %2$d)', 'woocommerce' ),
+						'<strong>' . get_the_title( $top_seller->product_id ) . '</strong>',
+						$top_seller->qty
+					); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+				?>
+				</a>
+			</li>
+				<?php
+			}
+		}
+
+		$this->status_widget_order_rows();
+		$this->status_widget_stock_rows();
+
+		do_action( 'woocommerce_after_dashboard_status_widget', $reports );
+		echo '</ul>';
+	}
+
+	/**
+	 * Show order data is status widget.
+	 */
+	private function status_widget_order_rows() {
+		if ( ! current_user_can( 'edit_shop_orders' ) ) {
+			return;
+		}
+		$on_hold_count    = 0;
+		$processing_count = 0;
+
+		foreach ( wc_get_order_types( 'order-count' ) as $type ) {
+			$counts            = (array) wp_count_posts( $type );
+			$on_hold_count    += isset( $counts['wc-on-hold'] ) ? $counts['wc-on-hold'] : 0;
+			$processing_count += isset( $counts['wc-processing'] ) ? $counts['wc-processing'] : 0;
+		}
+		?>
+		<li class="processing-orders">
+		<a href="<?php echo esc_url( admin_url( 'edit.php?post_status=wc-processing&post_type=shop_order' ) ); ?>">
+			<?php
+				printf(
+					/* translators: %s: order count */
+					_n( '<strong>%s order</strong> awaiting processing', '<strong>%s orders</strong> awaiting processing', $processing_count, 'woocommerce' ),
+					$processing_count
+				); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+			?>
+			</a>
+		</li>
+		<li class="on-hold-orders">
+			<a href="<?php echo esc_url( admin_url( 'edit.php?post_status=wc-on-hold&post_type=shop_order' ) ); ?>">
+			<?php
+				printf(
+					/* translators: %s: order count */
+					_n( '<strong>%s order</strong> on-hold', '<strong>%s orders</strong> on-hold', $on_hold_count, 'woocommerce' ),
+					$on_hold_count
+				); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+			?>
+			</a>
+		</li>
+		<?php
+	}
+
+	/**
+	 * Show stock data is status widget.
+	 */
+	private function status_widget_stock_rows() {
+		global $wpdb;
+
+		// Get products using a query - this is too advanced for get_posts.
+		$stock          = absint( max( get_option( 'woocommerce_notify_low_stock_amount' ), 1 ) );
+		$nostock        = absint( max( get_option( 'woocommerce_notify_no_stock_amount' ), 0 ) );
+		$transient_name = 'wc_low_stock_count';
+
+		$lowinstock_count = get_transient( $transient_name );
+		if ( false === $lowinstock_count ) {
+			$query_from       = apply_filters(
+				'woocommerce_report_low_in_stock_query_from',
+				"FROM {$wpdb->posts} as posts
+				INNER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id
+				INNER JOIN {$wpdb->postmeta} AS postmeta2 ON posts.ID = postmeta2.post_id
+				WHERE 1=1
+				AND posts.post_type IN ( 'product', 'product_variation' )
+				AND posts.post_status = 'publish'
+				AND postmeta2.meta_key = '_manage_stock' AND postmeta2.meta_value = 'yes'
+				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= '{$stock}'
+				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) > '{$nostock}'"
+			);
+			$lowinstock_count = absint( $wpdb->get_var( "SELECT COUNT( DISTINCT posts.ID ) {$query_from};" ) );
+			set_transient( $transient_name, $lowinstock_count, DAY_IN_SECONDS * 30 );
+		}
+
+		$transient_name = 'wc_outofstock_count';
+
+		$outofstock_count = get_transient( $transient_name );
+		if ( false === $outofstock_count ) {
+			$query_from       = apply_filters(
+				'woocommerce_report_out_of_stock_query_from',
+				"FROM {$wpdb->posts} as posts
+				INNER JOIN {$wpdb->postmeta} AS postmeta ON posts.ID = postmeta.post_id
+				INNER JOIN {$wpdb->postmeta} AS postmeta2 ON posts.ID = postmeta2.post_id
+				WHERE 1=1
+				AND posts.post_type IN ( 'product', 'product_variation' )
+				AND posts.post_status = 'publish'
+				AND postmeta2.meta_key = '_manage_stock' AND postmeta2.meta_value = 'yes'
+				AND postmeta.meta_key = '_stock' AND CAST(postmeta.meta_value AS SIGNED) <= '{$nostock}'"
+			);
+			$outofstock_count = absint( $wpdb->get_var( "SELECT COUNT( DISTINCT posts.ID ) {$query_from};" ) );
+			set_transient( $transient_name, $outofstock_count, DAY_IN_SECONDS * 30 );
+		}
+		?>
+		<li class="low-in-stock">
+		<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=stock&report=low_in_stock' ) ); ?>">
+			<?php
+				printf(
+					/* translators: %s: order count */
+					_n( '<strong>%s product</strong> low in stock', '<strong>%s products</strong> low in stock', $lowinstock_count, 'woocommerce' ),
+					$lowinstock_count
+				); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+			?>
+			</a>
+		</li>
+		<li class="out-of-stock">
+			<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=stock&report=out_of_stock' ) ); ?>">
+			<?php
+				printf(
+					/* translators: %s: order count */
+					_n( '<strong>%s product</strong> out of stock', '<strong>%s products</strong> out of stock', $outofstock_count, 'woocommerce' ),
+					$outofstock_count
+				); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped
+			?>
+			</a>
+		</li>
+		<?php
+	}
+
+	/**
+	 * Recent reviews widget.
+	 */
+	public function recent_reviews() {
+		global $wpdb;
+
+		$query_from = apply_filters(
+			'woocommerce_report_recent_reviews_query_from',
+			"FROM {$wpdb->comments} comments
+			LEFT JOIN {$wpdb->posts} posts ON (comments.comment_post_ID = posts.ID)
+			WHERE comments.comment_approved = '1'
+			AND comments.comment_type = 'review'
+			AND posts.post_password = ''
+			AND posts.post_type = 'product'
+			AND comments.comment_parent = 0
+			ORDER BY comments.comment_date_gmt DESC
+			LIMIT 5"
+		);
+
+		$comments = $wpdb->get_results(
+			"SELECT posts.ID, posts.post_title, comments.comment_author, comments.comment_ID, comments.comment_content {$query_from};"
+		);
+
+		if ( $comments ) {
+			echo '<ul>';
+			foreach ( $comments as $comment ) {
+
+				echo '<li>';
+
+				echo get_avatar( $comment->comment_author, '32' );
+
+				$rating = intval( get_comment_meta( $comment->comment_ID, 'rating', true ) );
+
+				/* translators: %s: rating */
+				echo '<div class="star-rating"><span style="width:' . esc_html( $rating * 20 ) . '%">' . sprintf( esc_html__( '%s out of 5', 'woocommerce' ), esc_html( $rating ) ) . '</span></div>';
+
+				/* translators: %s: review author */
+				echo '<h4 class="meta"><a href="' . esc_url( get_permalink( $comment->ID ) ) . '#comment-' . esc_html( absint( $comment->comment_ID ) ) . '">' . esc_html( apply_filters( 'woocommerce_admin_dashboard_recent_reviews', $comment->post_title, $comment ) ) . '</a> ' . sprintf( esc_html__( 'reviewed by %s', 'woocommerce' ), esc_html( $comment->comment_author ) ) . '</h4>';
+				echo '<blockquote>' . wp_kses_data( $comment->comment_content ) . '</blockquote></li>';
+
+			}
+			echo '</ul>';
+		} else {
+			echo '<p>' . esc_html__( 'There are no product reviews yet.', 'woocommerce' ) . '</p>';
+		}
+	}
+
+	/**
+	 * Network orders widget.
+	 */
+	public function network_orders() {
+		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+
+		wp_enqueue_style( 'wc-network-orders', WC()->plugin_url() . '/assets/css/network-order-widget.css', array(), WC_VERSION );
+
+		wp_enqueue_script( 'wc-network-orders', WC()->plugin_url() . '/assets/js/admin/network-orders' . $suffix . '.js', array( 'jquery', 'underscore' ), WC_VERSION, true );
+
+		$user     = wp_get_current_user();
+		$blogs    = get_blogs_of_user( $user->ID );
+		$blog_ids = wp_list_pluck( $blogs, 'userblog_id' );
+
+		wp_localize_script(
+			'wc-network-orders',
+			'woocommerce_network_orders',
+			array(
+				'nonce'          => wp_create_nonce( 'wp_rest' ),
+				'sites'          => array_values( $blog_ids ),
+				'order_endpoint' => get_rest_url( null, 'wc/v3/orders/network' ),
+			)
+		);
+		?>
+		<div class="post-type-shop_order">
+		<div id="woocommerce-network-order-table-loading" class="woocommerce-network-order-table-loading is-active">
+			<p>
+				<span class="spinner is-active"></span> <?php esc_html_e( 'Loading network orders', 'woocommerce' ); ?>
+			</p>
+
+		</div>
+		<table id="woocommerce-network-order-table" class="woocommerce-network-order-table">
+			<thead>
+				<tr>
+					<td><?php esc_html_e( 'Order', 'woocommerce' ); ?></td>
+					<td><?php esc_html_e( 'Status', 'woocommerce' ); ?></td>
+					<td><?php esc_html_e( 'Total', 'woocommerce' ); ?></td>
+				</tr>
+			</thead>
+			<tbody id="network-orders-tbody">
+
+			</tbody>
+		</table>
+		<div id="woocommerce-network-orders-no-orders" class="woocommerce-network-orders-no-orders">
+			<p>
+				<?php esc_html_e( 'No orders found', 'woocommerce' ); ?>
+			</p>
+		</div>
+		<?php // @codingStandardsIgnoreStart ?>
+		<script type="text/template" id="network-orders-row-template">
+			<tr>
+				<td>
+					<a href="<%- edit_url %>" class="order-view"><strong>#<%- number %> <%- customer %></strong></a>
+					<br>
+					<em>
+						<%- blog.blogname %>
+					</em>
+				</td>
+				<td>
+					<mark class="order-status status-<%- status %>"><span><%- status_name %></span></mark>
+				</td>
+				<td>
+					<%= formatted_total %>
+				</td>
+			</tr>
+		</script>
+		<?php // @codingStandardsIgnoreEnd ?>
+	</div>
+		<?php
+	}
+
+}

--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -118,8 +118,6 @@ class WC_Admin_Dashboard {
 	 * @return object
 	 */
 	private function get_sales_report_data() {
-		include_once dirname( __FILE__ ) . '/reports/class-wc-report-sales-by-date.php';
-
 		$sales_by_date                 = new WC_Report_Sales_By_Date();
 		$sales_by_date->start_date     = strtotime( date( 'Y-m-01', current_time( 'timestamp' ) ) );
 		$sales_by_date->end_date       = current_time( 'timestamp' );
@@ -133,8 +131,6 @@ class WC_Admin_Dashboard {
 	 * Show status widget.
 	 */
 	public function status_widget() {
-		include_once dirname( __FILE__ ) . '/reports/class-wc-admin-report.php';
-
 		$reports = new WC_Admin_Report();
 
 		echo '<ul class="wc_status_list">';

--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -1,8 +1,4 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * Duplicate product functionality
  *
@@ -12,9 +8,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @version     3.0.0
  */
 
-if ( class_exists( 'WC_Admin_Duplicate_Product', false ) ) {
-	return new WC_Admin_Duplicate_Product();
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Duplicate_Product Class.
@@ -22,9 +16,48 @@ if ( class_exists( 'WC_Admin_Duplicate_Product', false ) ) {
 class WC_Admin_Duplicate_Product {
 
 	/**
-	 * Constructor.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Duplicate_Product|null
 	 */
-	public function __construct() {
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Duplicate_Product
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
 		add_action( 'admin_action_duplicate_product', array( $this, 'duplicate_product_action' ) );
 		add_filter( 'post_row_actions', array( $this, 'dupe_link' ), 10, 2 );
 		add_action( 'post_submitbox_start', array( $this, 'dupe_button' ) );
@@ -217,4 +250,4 @@ class WC_Admin_Duplicate_Product {
 	}
 }
 
-return new WC_Admin_Duplicate_Product();
+return WC_Admin_Duplicate_Product::instance();

--- a/includes/admin/class-wc-admin-exporters.php
+++ b/includes/admin/class-wc-admin-exporters.php
@@ -135,7 +135,6 @@ class WC_Admin_Exporters {
 	 * Export page UI.
 	 */
 	public function product_exporter() {
-		include_once WC_ABSPATH . 'includes/export/class-wc-product-csv-exporter.php';
 		include_once dirname( __FILE__ ) . '/views/html-admin-page-product-export.php';
 	}
 
@@ -144,7 +143,6 @@ class WC_Admin_Exporters {
 	 */
 	public function download_export_file() {
 		if ( isset( $_GET['action'], $_GET['nonce'] ) && wp_verify_nonce( wp_unslash( $_GET['nonce'] ), 'product-csv' ) && 'download_product_csv' === wp_unslash( $_GET['action'] ) ) { // WPCS: input var ok, sanitization ok.
-			include_once WC_ABSPATH . 'includes/export/class-wc-product-csv-exporter.php';
 			$exporter = new WC_Product_CSV_Exporter();
 
 			if ( ! empty( $_GET['filename'] ) ) { // WPCS: input var ok.
@@ -164,8 +162,6 @@ class WC_Admin_Exporters {
 		if ( ! $this->export_allowed() ) {
 			wp_send_json_error( array( 'message' => __( 'Insufficient privileges to export products.', 'woocommerce' ) ) );
 		}
-
-		include_once WC_ABSPATH . 'includes/export/class-wc-product-csv-exporter.php';
 
 		$step     = isset( $_POST['step'] ) ? absint( $_POST['step'] ) : 1; // WPCS: input var ok, sanitization ok.
 		$exporter = new WC_Product_CSV_Exporter();

--- a/includes/admin/class-wc-admin-exporters.php
+++ b/includes/admin/class-wc-admin-exporters.php
@@ -2,13 +2,10 @@
 /**
  * Init WooCommerce data exporters.
  *
- * @package     WooCommerce/Admin
- * @version     3.1.0
+ * @package WooCommerce/Admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Exporters Class.
@@ -23,9 +20,48 @@ class WC_Admin_Exporters {
 	protected $exporters = array();
 
 	/**
-	 * Constructor.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Exporters|null
 	 */
-	public function __construct() {
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Exporters
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
 		if ( ! $this->export_allowed() ) {
 			return;
 		}
@@ -189,5 +225,3 @@ class WC_Admin_Exporters {
 		}
 	}
 }
-
-new WC_Admin_Exporters();

--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -2,17 +2,10 @@
 /**
  * Add some content to the help tab
  *
- * @package     WooCommerce/Admin
- * @version     2.1.0
+ * @package WooCommerce/Admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-if ( class_exists( 'WC_Admin_Help', false ) ) {
-	return new WC_Admin_Help();
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Help Class.
@@ -20,10 +13,51 @@ if ( class_exists( 'WC_Admin_Help', false ) ) {
 class WC_Admin_Help {
 
 	/**
-	 * Hook in tabs.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Help|null
 	 */
-	public function __construct() {
-		add_action( 'current_screen', array( $this, 'add_tabs' ), 50 );
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Help
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Add help tabs.
+	 */
+	public function init() {
+		if ( apply_filters( 'woocommerce_enable_admin_help_tab', true ) ) {
+			$this->add_tabs();
+		}
 	}
 
 	/**
@@ -32,7 +66,7 @@ class WC_Admin_Help {
 	public function add_tabs() {
 		$screen = get_current_screen();
 
-		if ( ! $screen || ! in_array( $screen->id, wc_get_screen_ids() ) ) {
+		if ( ! $screen || ! in_array( $screen->id, wc_get_screen_ids(), true ) ) {
 			return;
 		}
 
@@ -104,5 +138,3 @@ class WC_Admin_Help {
 		);
 	}
 }
-
-return new WC_Admin_Help();

--- a/includes/admin/class-wc-admin-importers.php
+++ b/includes/admin/class-wc-admin-importers.php
@@ -135,10 +135,6 @@ class WC_Admin_Importers {
 			wp_safe_redirect( admin_url( 'edit.php?post_type=product&page=product_importer' ) );
 			exit;
 		}
-
-		include_once WC_ABSPATH . 'includes/import/class-wc-product-csv-importer.php';
-		include_once WC_ABSPATH . 'includes/admin/importers/class-wc-product-csv-importer-controller.php';
-
 		$importer = new WC_Product_CSV_Importer_Controller();
 		$importer->dispatch();
 	}
@@ -246,9 +242,6 @@ class WC_Admin_Importers {
 		if ( ! $this->import_allowed() || ! isset( $_POST['file'] ) ) { // PHPCS: input var ok.
 			wp_send_json_error( array( 'message' => __( 'Insufficient privileges to import products.', 'woocommerce' ) ) );
 		}
-
-		include_once WC_ABSPATH . 'includes/admin/importers/class-wc-product-csv-importer-controller.php';
-		include_once WC_ABSPATH . 'includes/import/class-wc-product-csv-importer.php';
 
 		$file   = wc_clean( wp_unslash( $_POST['file'] ) ); // PHPCS: input var ok.
 		$params = array(

--- a/includes/admin/class-wc-admin-importers.php
+++ b/includes/admin/class-wc-admin-importers.php
@@ -20,9 +20,48 @@ class WC_Admin_Importers {
 	protected $importers = array();
 
 	/**
-	 * Constructor.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Importers|null
 	 */
-	public function __construct() {
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Importers
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
 		if ( ! $this->import_allowed() ) {
 			return;
 		}
@@ -299,5 +338,3 @@ class WC_Admin_Importers {
 		}
 	}
 }
-
-new WC_Admin_Importers();

--- a/includes/admin/class-wc-admin-meta-boxes.php
+++ b/includes/admin/class-wc-admin-meta-boxes.php
@@ -34,9 +34,48 @@ class WC_Admin_Meta_Boxes {
 	public static $meta_box_errors = array();
 
 	/**
-	 * Constructor.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Meta_Boxes|null
 	 */
-	public function __construct() {
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Meta_Boxes
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
 		add_action( 'add_meta_boxes', array( $this, 'remove_meta_boxes' ), 10 );
 		add_action( 'add_meta_boxes', array( $this, 'rename_meta_boxes' ), 20 );
 		add_action( 'add_meta_boxes', array( $this, 'add_meta_boxes' ), 30 );
@@ -221,5 +260,3 @@ class WC_Admin_Meta_Boxes {
 		}
 	}
 }
-
-new WC_Admin_Meta_Boxes();

--- a/includes/admin/class-wc-admin-permalink-settings.php
+++ b/includes/admin/class-wc-admin-permalink-settings.php
@@ -2,20 +2,10 @@
 /**
  * Adds settings to the permalinks admin settings page
  *
- * @class       WC_Admin_Permalink_Settings
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce/Admin
- * @version     2.3.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-if ( class_exists( 'WC_Admin_Permalink_Settings', false ) ) {
-	return new WC_Admin_Permalink_Settings();
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Permalink_Settings Class.
@@ -30,9 +20,48 @@ class WC_Admin_Permalink_Settings {
 	private $permalinks = array();
 
 	/**
-	 * Hook in tabs.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Permalink_Settings|null
 	 */
-	public function __construct() {
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Permalink_Settings
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Add options and handle save.
+	 */
+	public function init() {
 		$this->settings_init();
 		$this->settings_save();
 	}
@@ -167,10 +196,6 @@ class WC_Admin_Permalink_Settings {
 	 * Save the settings.
 	 */
 	public function settings_save() {
-		if ( ! is_admin() ) {
-			return;
-		}
-
 		// We need to save the options ourselves; settings api does not trigger save for the permalinks page.
 		if ( isset( $_POST['permalink_structure'], $_POST['wc-permalinks-nonce'], $_POST['woocommerce_product_category_slug'], $_POST['woocommerce_product_tag_slug'], $_POST['woocommerce_product_attribute_slug'] ) && wp_verify_nonce( wp_unslash( $_POST['wc-permalinks-nonce'] ), 'wc-permalinks' ) ) { // WPCS: input var ok, sanitization ok.
 			wc_switch_to_site_locale();
@@ -213,5 +238,3 @@ class WC_Admin_Permalink_Settings {
 		}
 	}
 }
-
-return new WC_Admin_Permalink_Settings();

--- a/includes/admin/class-wc-admin-pointers.php
+++ b/includes/admin/class-wc-admin-pointers.php
@@ -2,15 +2,10 @@
 /**
  * Adds and controls pointers for contextual help/tutorials
  *
- * @author   WooThemes
- * @category Admin
  * @package  WooCommerce/Admin
- * @version  2.4.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Pointers Class.
@@ -18,34 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Admin_Pointers {
 
 	/**
-	 * Constructor.
-	 */
-	public function __construct() {
-		add_action( 'admin_enqueue_scripts', array( $this, 'setup_pointers_for_screen' ) );
-	}
-
-	/**
-	 * Setup pointers for screen.
-	 */
-	public function setup_pointers_for_screen() {
-		if ( ! $screen = get_current_screen() ) {
-			return;
-		}
-
-		switch ( $screen->id ) {
-			case 'product':
-				$this->create_product_tutorial();
-				break;
-		}
-	}
-
-	/**
 	 * Pointers for creating a product.
 	 */
 	public function create_product_tutorial() {
-		if ( ! isset( $_GET['tutorial'] ) || ! current_user_can( 'manage_options' ) ) {
-			return;
-		}
 		// These pointers will chain - they will not be shown at once.
 		$pointers = array(
 			'pointers' => array(
@@ -281,6 +251,11 @@ class WC_Admin_Pointers {
 			});"
 		);
 	}
-}
 
-new WC_Admin_Pointers();
+	/**
+	 * Setup pointers for screen.
+	 *
+	 * @deprecated
+	 */
+	public function setup_pointers_for_screen() {}
+}

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -2,18 +2,10 @@
 /**
  * Post Types Admin
  *
- * @package  WooCommerce/admin
- * @version  3.3.0
+ * @package WooCommerce/admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-if ( class_exists( 'WC_Admin_Post_Types', false ) ) {
-	new WC_Admin_Post_Types();
-	return;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Post_Types Class.
@@ -23,9 +15,48 @@ if ( class_exists( 'WC_Admin_Post_Types', false ) ) {
 class WC_Admin_Post_Types {
 
 	/**
-	 * Constructor.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Post_Types|null
 	 */
-	public function __construct() {
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Post_Types
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
 		include_once dirname( __FILE__ ) . '/class-wc-admin-meta-boxes.php';
 
 		if ( ! function_exists( 'duplicate_post_plugin_activation' ) ) {
@@ -99,6 +130,8 @@ class WC_Admin_Post_Types {
 			case 'edit-product':
 				include_once 'list-tables/class-wc-admin-list-table-products.php';
 				$wc_list_table = new WC_Admin_List_Table_Products();
+
+
 				break;
 		}
 
@@ -896,5 +929,3 @@ class WC_Admin_Post_Types {
 		return $post_states;
 	}
 }
-
-new WC_Admin_Post_Types();

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -57,11 +57,11 @@ class WC_Admin_Post_Types {
 	 * Hook into WP actions/filters.
 	 */
 	public function init() {
-		include_once dirname( __FILE__ ) . '/class-wc-admin-meta-boxes.php';
-
 		if ( ! function_exists( 'duplicate_post_plugin_activation' ) ) {
-			include_once 'class-wc-admin-duplicate-product.php';
+			WC_Admin_Duplicate_Product::instance()->init();
 		}
+
+		WC_Admin_Meta_Boxes::instance()->init();
 
 		// Load correct list table classes for current screen.
 		add_action( 'current_screen', array( $this, 'setup_screen' ) );
@@ -120,18 +120,15 @@ class WC_Admin_Post_Types {
 
 		switch ( $screen_id ) {
 			case 'edit-shop_order':
-				include_once 'list-tables/class-wc-admin-list-table-orders.php';
-				$wc_list_table = new WC_Admin_List_Table_Orders();
+				WC_Admin_List_Table_Orders::instance()->init();
 				break;
 			case 'edit-shop_coupon':
 				include_once 'list-tables/class-wc-admin-list-table-coupons.php';
-				$wc_list_table = new WC_Admin_List_Table_Coupons();
+				WC_Admin_List_Table_Coupons::instance()->init();
 				break;
 			case 'edit-product':
 				include_once 'list-tables/class-wc-admin-list-table-products.php';
-				$wc_list_table = new WC_Admin_List_Table_Products();
-
-
+				WC_Admin_List_Table_Products::instance()->init();
 				break;
 		}
 

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -123,11 +123,9 @@ class WC_Admin_Post_Types {
 				WC_Admin_List_Table_Orders::instance()->init();
 				break;
 			case 'edit-shop_coupon':
-				include_once 'list-tables/class-wc-admin-list-table-coupons.php';
 				WC_Admin_List_Table_Coupons::instance()->init();
 				break;
 			case 'edit-product':
-				include_once 'list-tables/class-wc-admin-list-table-products.php';
 				WC_Admin_List_Table_Products::instance()->init();
 				break;
 		}

--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -2,246 +2,273 @@
 /**
  * Add extra profile fields for users in admin
  *
- * @author   WooThemes
- * @category Admin
  * @package  WooCommerce/Admin
- * @version  2.4.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
+defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
+/**
+ * WC_Admin_Profile Class.
+ */
+class WC_Admin_Profile {
 
 	/**
-	 * WC_Admin_Profile Class.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Profile|null
 	 */
-	class WC_Admin_Profile {
+	protected static $instance = null;
 
-		/**
-		 * Hook in tabs.
-		 */
-		public function __construct() {
-			add_action( 'show_user_profile', array( $this, 'add_customer_meta_fields' ) );
-			add_action( 'edit_user_profile', array( $this, 'add_customer_meta_fields' ) );
-
-			add_action( 'personal_options_update', array( $this, 'save_customer_meta_fields' ) );
-			add_action( 'edit_user_profile_update', array( $this, 'save_customer_meta_fields' ) );
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Profile
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
+		return self::$instance;
+	}
 
-		/**
-		 * Get Address Fields for the edit user pages.
-		 *
-		 * @return array Fields to display which are filtered through woocommerce_customer_meta_fields before being returned
-		 */
-		public function get_customer_meta_fields() {
-			$show_fields = apply_filters(
-				'woocommerce_customer_meta_fields', array(
-					'billing'  => array(
-						'title'  => __( 'Customer billing address', 'woocommerce' ),
-						'fields' => array(
-							'billing_first_name' => array(
-								'label'       => __( 'First name', 'woocommerce' ),
-								'description' => '',
-							),
-							'billing_last_name'  => array(
-								'label'       => __( 'Last name', 'woocommerce' ),
-								'description' => '',
-							),
-							'billing_company'    => array(
-								'label'       => __( 'Company', 'woocommerce' ),
-								'description' => '',
-							),
-							'billing_address_1'  => array(
-								'label'       => __( 'Address line 1', 'woocommerce' ),
-								'description' => '',
-							),
-							'billing_address_2'  => array(
-								'label'       => __( 'Address line 2', 'woocommerce' ),
-								'description' => '',
-							),
-							'billing_city'       => array(
-								'label'       => __( 'City', 'woocommerce' ),
-								'description' => '',
-							),
-							'billing_postcode'   => array(
-								'label'       => __( 'Postcode / ZIP', 'woocommerce' ),
-								'description' => '',
-							),
-							'billing_country'    => array(
-								'label'       => __( 'Country', 'woocommerce' ),
-								'description' => '',
-								'class'       => 'js_field-country',
-								'type'        => 'select',
-								'options'     => array( '' => __( 'Select a country&hellip;', 'woocommerce' ) ) + WC()->countries->get_allowed_countries(),
-							),
-							'billing_state'      => array(
-								'label'       => __( 'State / County', 'woocommerce' ),
-								'description' => __( 'State / County or state code', 'woocommerce' ),
-								'class'       => 'js_field-state',
-							),
-							'billing_phone'      => array(
-								'label'       => __( 'Phone', 'woocommerce' ),
-								'description' => '',
-							),
-							'billing_email'      => array(
-								'label'       => __( 'Email address', 'woocommerce' ),
-								'description' => '',
-							),
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
+		add_action( 'show_user_profile', array( $this, 'add_customer_meta_fields' ) );
+		add_action( 'edit_user_profile', array( $this, 'add_customer_meta_fields' ) );
+		add_action( 'personal_options_update', array( $this, 'save_customer_meta_fields' ) );
+		add_action( 'edit_user_profile_update', array( $this, 'save_customer_meta_fields' ) );
+	}
+
+	/**
+	 * Get Address Fields for the edit user pages.
+	 *
+	 * @return array Fields to display which are filtered through woocommerce_customer_meta_fields before being returned
+	 */
+	public function get_customer_meta_fields() {
+		$show_fields = apply_filters(
+			'woocommerce_customer_meta_fields', array(
+				'billing'  => array(
+					'title'  => __( 'Customer billing address', 'woocommerce' ),
+					'fields' => array(
+						'billing_first_name' => array(
+							'label'       => __( 'First name', 'woocommerce' ),
+							'description' => '',
+						),
+						'billing_last_name'  => array(
+							'label'       => __( 'Last name', 'woocommerce' ),
+							'description' => '',
+						),
+						'billing_company'    => array(
+							'label'       => __( 'Company', 'woocommerce' ),
+							'description' => '',
+						),
+						'billing_address_1'  => array(
+							'label'       => __( 'Address line 1', 'woocommerce' ),
+							'description' => '',
+						),
+						'billing_address_2'  => array(
+							'label'       => __( 'Address line 2', 'woocommerce' ),
+							'description' => '',
+						),
+						'billing_city'       => array(
+							'label'       => __( 'City', 'woocommerce' ),
+							'description' => '',
+						),
+						'billing_postcode'   => array(
+							'label'       => __( 'Postcode / ZIP', 'woocommerce' ),
+							'description' => '',
+						),
+						'billing_country'    => array(
+							'label'       => __( 'Country', 'woocommerce' ),
+							'description' => '',
+							'class'       => 'js_field-country',
+							'type'        => 'select',
+							'options'     => array( '' => __( 'Select a country&hellip;', 'woocommerce' ) ) + WC()->countries->get_allowed_countries(),
+						),
+						'billing_state'      => array(
+							'label'       => __( 'State / County', 'woocommerce' ),
+							'description' => __( 'State / County or state code', 'woocommerce' ),
+							'class'       => 'js_field-state',
+						),
+						'billing_phone'      => array(
+							'label'       => __( 'Phone', 'woocommerce' ),
+							'description' => '',
+						),
+						'billing_email'      => array(
+							'label'       => __( 'Email address', 'woocommerce' ),
+							'description' => '',
 						),
 					),
-					'shipping' => array(
-						'title'  => __( 'Customer shipping address', 'woocommerce' ),
-						'fields' => array(
-							'copy_billing'        => array(
-								'label'       => __( 'Copy from billing address', 'woocommerce' ),
-								'description' => '',
-								'class'       => 'js_copy-billing',
-								'type'        => 'button',
-								'text'        => __( 'Copy', 'woocommerce' ),
-							),
-							'shipping_first_name' => array(
-								'label'       => __( 'First name', 'woocommerce' ),
-								'description' => '',
-							),
-							'shipping_last_name'  => array(
-								'label'       => __( 'Last name', 'woocommerce' ),
-								'description' => '',
-							),
-							'shipping_company'    => array(
-								'label'       => __( 'Company', 'woocommerce' ),
-								'description' => '',
-							),
-							'shipping_address_1'  => array(
-								'label'       => __( 'Address line 1', 'woocommerce' ),
-								'description' => '',
-							),
-							'shipping_address_2'  => array(
-								'label'       => __( 'Address line 2', 'woocommerce' ),
-								'description' => '',
-							),
-							'shipping_city'       => array(
-								'label'       => __( 'City', 'woocommerce' ),
-								'description' => '',
-							),
-							'shipping_postcode'   => array(
-								'label'       => __( 'Postcode / ZIP', 'woocommerce' ),
-								'description' => '',
-							),
-							'shipping_country'    => array(
-								'label'       => __( 'Country', 'woocommerce' ),
-								'description' => '',
-								'class'       => 'js_field-country',
-								'type'        => 'select',
-								'options'     => array( '' => __( 'Select a country&hellip;', 'woocommerce' ) ) + WC()->countries->get_allowed_countries(),
-							),
-							'shipping_state'      => array(
-								'label'       => __( 'State / County', 'woocommerce' ),
-								'description' => __( 'State / County or state code', 'woocommerce' ),
-								'class'       => 'js_field-state',
-							),
+				),
+				'shipping' => array(
+					'title'  => __( 'Customer shipping address', 'woocommerce' ),
+					'fields' => array(
+						'copy_billing'        => array(
+							'label'       => __( 'Copy from billing address', 'woocommerce' ),
+							'description' => '',
+							'class'       => 'js_copy-billing',
+							'type'        => 'button',
+							'text'        => __( 'Copy', 'woocommerce' ),
+						),
+						'shipping_first_name' => array(
+							'label'       => __( 'First name', 'woocommerce' ),
+							'description' => '',
+						),
+						'shipping_last_name'  => array(
+							'label'       => __( 'Last name', 'woocommerce' ),
+							'description' => '',
+						),
+						'shipping_company'    => array(
+							'label'       => __( 'Company', 'woocommerce' ),
+							'description' => '',
+						),
+						'shipping_address_1'  => array(
+							'label'       => __( 'Address line 1', 'woocommerce' ),
+							'description' => '',
+						),
+						'shipping_address_2'  => array(
+							'label'       => __( 'Address line 2', 'woocommerce' ),
+							'description' => '',
+						),
+						'shipping_city'       => array(
+							'label'       => __( 'City', 'woocommerce' ),
+							'description' => '',
+						),
+						'shipping_postcode'   => array(
+							'label'       => __( 'Postcode / ZIP', 'woocommerce' ),
+							'description' => '',
+						),
+						'shipping_country'    => array(
+							'label'       => __( 'Country', 'woocommerce' ),
+							'description' => '',
+							'class'       => 'js_field-country',
+							'type'        => 'select',
+							'options'     => array( '' => __( 'Select a country&hellip;', 'woocommerce' ) ) + WC()->countries->get_allowed_countries(),
+						),
+						'shipping_state'      => array(
+							'label'       => __( 'State / County', 'woocommerce' ),
+							'description' => __( 'State / County or state code', 'woocommerce' ),
+							'class'       => 'js_field-state',
 						),
 					),
-				)
-			);
-			return $show_fields;
+				),
+			)
+		);
+		return $show_fields;
+	}
+
+	/**
+	 * Show Address Fields on edit user pages.
+	 *
+	 * @param WP_User $user
+	 */
+	public function add_customer_meta_fields( $user ) {
+		if ( ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), $user->ID ) ) {
+			return;
 		}
 
-		/**
-		 * Show Address Fields on edit user pages.
-		 *
-		 * @param WP_User $user
-		 */
-		public function add_customer_meta_fields( $user ) {
-			if ( ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), $user->ID ) ) {
-				return;
-			}
+		$show_fields = $this->get_customer_meta_fields();
 
-			$show_fields = $this->get_customer_meta_fields();
+		foreach ( $show_fields as $fieldset_key => $fieldset ) :
+			?>
+			<h2><?php echo $fieldset['title']; ?></h2>
+			<table class="form-table" id="<?php echo esc_attr( 'fieldset-' . $fieldset_key ); ?>">
+				<?php foreach ( $fieldset['fields'] as $key => $field ) : ?>
+					<tr>
+						<th>
+							<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $field['label'] ); ?></label>
+						</th>
+						<td>
+							<?php if ( ! empty( $field['type'] ) && 'select' === $field['type'] ) : ?>
+								<select name="<?php echo esc_attr( $key ); ?>" id="<?php echo esc_attr( $key ); ?>" class="<?php echo esc_attr( $field['class'] ); ?>" style="width: 25em;">
+									<?php
+										$selected = esc_attr( get_user_meta( $user->ID, $key, true ) );
+									foreach ( $field['options'] as $option_key => $option_value ) :
+										?>
+										<option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( $selected, $option_key, true ); ?>><?php echo esc_attr( $option_value ); ?></option>
+									<?php endforeach; ?>
+								</select>
+							<?php elseif ( ! empty( $field['type'] ) && 'checkbox' === $field['type'] ) : ?>
+								<input type="checkbox" name="<?php echo esc_attr( $key ); ?>" id="<?php echo esc_attr( $key ); ?>" value="1" class="<?php echo esc_attr( $field['class'] ); ?>" <?php checked( (int) get_user_meta( $user->ID, $key, true ), 1, true ); ?> />
+							<?php elseif ( ! empty( $field['type'] ) && 'button' === $field['type'] ) : ?>
+								<button type="button" id="<?php echo esc_attr( $key ); ?>" class="button <?php echo esc_attr( $field['class'] ); ?>"><?php echo esc_html( $field['text'] ); ?></button>
+							<?php else : ?>
+								<input type="text" name="<?php echo esc_attr( $key ); ?>" id="<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $this->get_user_meta( $user->ID, $key ) ); ?>" class="<?php echo ( ! empty( $field['class'] ) ? esc_attr( $field['class'] ) : 'regular-text' ); ?>" />
+							<?php endif; ?>
+							<p class="description"><?php echo wp_kses_post( $field['description'] ); ?></p>
+						</td>
+					</tr>
+				<?php endforeach; ?>
+			</table>
+			<?php
+		endforeach;
+	}
 
-			foreach ( $show_fields as $fieldset_key => $fieldset ) :
-				?>
-				<h2><?php echo $fieldset['title']; ?></h2>
-				<table class="form-table" id="<?php echo esc_attr( 'fieldset-' . $fieldset_key ); ?>">
-					<?php foreach ( $fieldset['fields'] as $key => $field ) : ?>
-						<tr>
-							<th>
-								<label for="<?php echo esc_attr( $key ); ?>"><?php echo esc_html( $field['label'] ); ?></label>
-							</th>
-							<td>
-								<?php if ( ! empty( $field['type'] ) && 'select' === $field['type'] ) : ?>
-									<select name="<?php echo esc_attr( $key ); ?>" id="<?php echo esc_attr( $key ); ?>" class="<?php echo esc_attr( $field['class'] ); ?>" style="width: 25em;">
-										<?php
-											$selected = esc_attr( get_user_meta( $user->ID, $key, true ) );
-										foreach ( $field['options'] as $option_key => $option_value ) :
-											?>
-											<option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( $selected, $option_key, true ); ?>><?php echo esc_attr( $option_value ); ?></option>
-										<?php endforeach; ?>
-									</select>
-								<?php elseif ( ! empty( $field['type'] ) && 'checkbox' === $field['type'] ) : ?>
-									<input type="checkbox" name="<?php echo esc_attr( $key ); ?>" id="<?php echo esc_attr( $key ); ?>" value="1" class="<?php echo esc_attr( $field['class'] ); ?>" <?php checked( (int) get_user_meta( $user->ID, $key, true ), 1, true ); ?> />
-								<?php elseif ( ! empty( $field['type'] ) && 'button' === $field['type'] ) : ?>
-									<button type="button" id="<?php echo esc_attr( $key ); ?>" class="button <?php echo esc_attr( $field['class'] ); ?>"><?php echo esc_html( $field['text'] ); ?></button>
-								<?php else : ?>
-									<input type="text" name="<?php echo esc_attr( $key ); ?>" id="<?php echo esc_attr( $key ); ?>" value="<?php echo esc_attr( $this->get_user_meta( $user->ID, $key ) ); ?>" class="<?php echo ( ! empty( $field['class'] ) ? esc_attr( $field['class'] ) : 'regular-text' ); ?>" />
-								<?php endif; ?>
-								<p class="description"><?php echo wp_kses_post( $field['description'] ); ?></p>
-							</td>
-						</tr>
-					<?php endforeach; ?>
-				</table>
-				<?php
-			endforeach;
+	/**
+	 * Save Address Fields on edit user pages.
+	 *
+	 * @param int $user_id User ID of the user being saved
+	 */
+	public function save_customer_meta_fields( $user_id ) {
+		if ( ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), $user_id ) ) {
+			return;
 		}
 
-		/**
-		 * Save Address Fields on edit user pages.
-		 *
-		 * @param int $user_id User ID of the user being saved
-		 */
-		public function save_customer_meta_fields( $user_id ) {
-			if ( ! apply_filters( 'woocommerce_current_user_can_edit_customer_meta_fields', current_user_can( 'manage_woocommerce' ), $user_id ) ) {
-				return;
-			}
+		$save_fields = $this->get_customer_meta_fields();
 
-			$save_fields = $this->get_customer_meta_fields();
+		foreach ( $save_fields as $fieldset ) {
 
-			foreach ( $save_fields as $fieldset ) {
+			foreach ( $fieldset['fields'] as $key => $field ) {
 
-				foreach ( $fieldset['fields'] as $key => $field ) {
-
-					if ( isset( $field['type'] ) && 'checkbox' === $field['type'] ) {
-						update_user_meta( $user_id, $key, isset( $_POST[ $key ] ) );
-					} elseif ( isset( $_POST[ $key ] ) ) {
-						update_user_meta( $user_id, $key, wc_clean( $_POST[ $key ] ) );
-					}
+				if ( isset( $field['type'] ) && 'checkbox' === $field['type'] ) {
+					update_user_meta( $user_id, $key, isset( $_POST[ $key ] ) );
+				} elseif ( isset( $_POST[ $key ] ) ) {
+					update_user_meta( $user_id, $key, wc_clean( $_POST[ $key ] ) );
 				}
 			}
 		}
-
-		/**
-		 * Get user meta for a given key, with fallbacks to core user info for pre-existing fields.
-		 *
-		 * @since 3.1.0
-		 * @param int    $user_id User ID of the user being edited
-		 * @param string $key     Key for user meta field
-		 * @return string
-		 */
-		protected function get_user_meta( $user_id, $key ) {
-			$value           = get_user_meta( $user_id, $key, true );
-			$existing_fields = array( 'billing_first_name', 'billing_last_name' );
-			if ( ! $value && in_array( $key, $existing_fields ) ) {
-				$value = get_user_meta( $user_id, str_replace( 'billing_', '', $key ), true );
-			} elseif ( ! $value && ( 'billing_email' === $key ) ) {
-				$user  = get_userdata( $user_id );
-				$value = $user->user_email;
-			}
-
-			return $value;
-		}
 	}
 
-endif;
+	/**
+	 * Get user meta for a given key, with fallbacks to core user info for pre-existing fields.
+	 *
+	 * @since 3.1.0
+	 * @param int    $user_id User ID of the user being edited
+	 * @param string $key     Key for user meta field
+	 * @return string
+	 */
+	protected function get_user_meta( $user_id, $key ) {
+		$value           = get_user_meta( $user_id, $key, true );
+		$existing_fields = array( 'billing_first_name', 'billing_last_name' );
+		if ( ! $value && in_array( $key, $existing_fields ) ) {
+			$value = get_user_meta( $user_id, str_replace( 'billing_', '', $key ), true );
+		} elseif ( ! $value && ( 'billing_email' === $key ) ) {
+			$user  = get_userdata( $user_id );
+			$value = $user->user_email;
+		}
 
-return new WC_Admin_Profile();
+		return $value;
+	}
+}

--- a/includes/admin/class-wc-admin-reports.php
+++ b/includes/admin/class-wc-admin-reports.php
@@ -4,19 +4,10 @@
  *
  * Functions used for displaying sales and customer reports in admin.
  *
- * @author      WooThemes
- * @category    Admin
- * @package     WooCommerce/Admin/Reports
- * @version     2.0.0
+ * @package WooCommerce/Admin/Reports
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-if ( class_exists( 'WC_Admin_Reports', false ) ) {
-	return;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Reports Class.

--- a/includes/admin/class-wc-admin-reports.php
+++ b/includes/admin/class-wc-admin-reports.php
@@ -22,8 +22,6 @@ class WC_Admin_Reports {
 		$first_tab      = array_keys( $reports );
 		$current_tab    = ! empty( $_GET['tab'] ) && array_key_exists( $_GET['tab'], $reports ) ? sanitize_title( $_GET['tab'] ) : $first_tab[0];
 		$current_report = isset( $_GET['report'] ) ? sanitize_title( $_GET['report'] ) : current( array_keys( $reports[ $current_tab ]['reports'] ) );
-
-		include_once dirname( __FILE__ ) . '/reports/class-wc-admin-report.php';
 		include_once dirname( __FILE__ ) . '/views/html-admin-page-reports.php';
 	}
 
@@ -157,8 +155,6 @@ class WC_Admin_Reports {
 	public static function get_report( $name ) {
 		$name  = sanitize_title( str_replace( '_', '-', $name ) );
 		$class = 'WC_Report_' . str_replace( '-', '_', $name );
-
-		include_once apply_filters( 'wc_admin_reports_path', 'reports/class-wc-report-' . $name . '.php', $name, $class );
 
 		if ( ! class_exists( $class ) ) {
 			return;

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -117,10 +117,7 @@ class WC_Admin_Settings {
 	 */
 	public static function get_settings_pages() {
 		if ( empty( self::$settings ) ) {
-			$settings = array();
-
-			include_once dirname( __FILE__ ) . '/settings/class-wc-settings-page.php';
-
+			$settings   = array();
 			$settings[] = include 'settings/class-wc-settings-general.php';
 			$settings[] = include 'settings/class-wc-settings-products.php';
 			$settings[] = include 'settings/class-wc-settings-tax.php';

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -2,884 +2,956 @@
 /**
  * WooCommerce Admin Settings Class
  *
- * @package  WooCommerce/Admin
- * @version  3.4.0
+ * @package WooCommerce/Admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
+/**
+ * WC_Admin_Settings Class.
+ */
+class WC_Admin_Settings {
 
 	/**
-	 * WC_Admin_Settings Class.
+	 * Setting pages.
+	 *
+	 * @var array
 	 */
-	class WC_Admin_Settings {
+	private static $settings = array();
 
-		/**
-		 * Setting pages.
-		 *
-		 * @var array
-		 */
-		private static $settings = array();
+	/**
+	 * Error messages.
+	 *
+	 * @var array
+	 */
+	private static $errors = array();
 
-		/**
-		 * Error messages.
-		 *
-		 * @var array
-		 */
-		private static $errors = array();
+	/**
+	 * Update messages.
+	 *
+	 * @var array
+	 */
+	private static $messages = array();
 
-		/**
-		 * Update messages.
-		 *
-		 * @var array
-		 */
-		private static $messages = array();
+	/**
+	 * Current tab.
+	 *
+	 * @var string
+	 */
+	private static $current_tab = '';
 
-		/**
-		 * Include the settings page classes.
-		 */
-		public static function get_settings_pages() {
-			if ( empty( self::$settings ) ) {
-				$settings = array();
+	/**
+	 * Current section.
+	 *
+	 * @var string
+	 */
+	private static $current_section = '';
 
-				include_once dirname( __FILE__ ) . '/settings/class-wc-settings-page.php';
+	/**
+	 * Return the current tab name if set.
+	 *
+	 * @return string
+	 */
+	public static function get_current_tab() {
+		if ( ! self::$current_tab ) {
+			self::$current_tab = empty( $_GET['tab'] ) ? 'general' : sanitize_title( wp_unslash( $_GET['tab'] ) ); // WPCS: input var okay, CSRF ok.
+		}
+		return self::$current_tab;
+	}
 
-				$settings[] = include 'settings/class-wc-settings-general.php';
-				$settings[] = include 'settings/class-wc-settings-products.php';
-				$settings[] = include 'settings/class-wc-settings-tax.php';
-				$settings[] = include 'settings/class-wc-settings-shipping.php';
-				$settings[] = include 'settings/class-wc-settings-payment-gateways.php';
-				$settings[] = include 'settings/class-wc-settings-accounts.php';
-				$settings[] = include 'settings/class-wc-settings-emails.php';
-				$settings[] = include 'settings/class-wc-settings-integrations.php';
-				$settings[] = include 'settings/class-wc-settings-advanced.php';
+	/**
+	 * Return the current section name if set.
+	 *
+	 * @return string
+	 */
+	public static function get_current_section() {
+		if ( ! self::$current_section ) {
+			self::$current_section = empty( $_REQUEST['section'] ) ? '' : sanitize_title( wp_unslash( $_REQUEST['section'] ) ); // WPCS: input var okay, CSRF ok.
+		}
+		return self::$current_section;
+	}
 
-				self::$settings = apply_filters( 'woocommerce_get_settings_pages', $settings );
-			}
+	/**
+	 * Init the main WC settings screen.
+	 */
+	public static function init() {
+		$current_tab     = self::get_current_tab();
+		$current_section = self::get_current_section();
 
-			return self::$settings;
+		// Set globals for bw compat.
+		$GLOBALS['current_tab']     = $current_tab;
+		$GLOBALS['current_section'] = $current_section;
+
+		// Initialize classes before settings pages are loaded.
+		WC()->payment_gateways();
+		WC()->shipping();
+
+		// Include settings pages.
+		WC_Admin_Settings::get_settings_pages();
+
+		// Save settings if data has been posted.
+		$posted = ! empty( $_POST['save'] ); // WPCS: input var okay, CSRF ok.
+
+		if ( $current_section && apply_filters( "woocommerce_save_settings_{$current_tab}_{$current_section}", $posted ) ) {
+			WC_Admin_Settings::save();
 		}
 
-		/**
-		 * Save the settings.
-		 */
-		public static function save() {
-			global $current_tab;
-
-			check_admin_referer( 'woocommerce-settings' );
-
-			// Trigger actions.
-			do_action( 'woocommerce_settings_save_' . $current_tab );
-			do_action( 'woocommerce_update_options_' . $current_tab );
-			do_action( 'woocommerce_update_options' );
-
-			self::add_message( __( 'Your settings have been saved.', 'woocommerce' ) );
-			self::check_download_folder_protection();
-
-			// Clear any unwanted data and flush rules.
-			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
-			WC()->query->init_query_vars();
-			WC()->query->add_endpoints();
-
-			do_action( 'woocommerce_settings_saved' );
+		if ( ! $current_section && apply_filters( "woocommerce_save_settings_{$current_tab}", $posted ) ) {
+			WC_Admin_Settings::save();
 		}
 
-		/**
-		 * Add a message.
-		 *
-		 * @param string $text Message.
-		 */
-		public static function add_message( $text ) {
-			self::$messages[] = $text;
+		// Add any posted messages.
+		if ( ! empty( $_GET['wc_error'] ) ) { // WPCS: input var okay, CSRF ok.
+			WC_Admin_Settings::add_error( wp_kses_post( wp_unslash( $_GET['wc_error'] ) ) ); // WPCS: input var okay, CSRF ok.
 		}
 
-		/**
-		 * Add an error.
-		 *
-		 * @param string $text Message.
-		 */
-		public static function add_error( $text ) {
-			self::$errors[] = $text;
+		if ( ! empty( $_GET['wc_message'] ) ) { // WPCS: input var okay, CSRF ok.
+			WC_Admin_Settings::add_message( wp_kses_post( wp_unslash( $_GET['wc_message'] ) ) ); // WPCS: input var okay, CSRF ok.
 		}
 
-		/**
-		 * Output messages + errors.
-		 */
-		public static function show_messages() {
-			if ( count( self::$errors ) > 0 ) {
-				foreach ( self::$errors as $error ) {
-					echo '<div id="message" class="error inline"><p><strong>' . esc_html( $error ) . '</strong></p></div>';
-				}
-			} elseif ( count( self::$messages ) > 0 ) {
-				foreach ( self::$messages as $message ) {
-					echo '<div id="message" class="updated inline"><p><strong>' . esc_html( $message ) . '</strong></p></div>';
-				}
-			}
+		do_action( 'woocommerce_settings_page_init' );
+	}
+
+	/**
+	 * Include the settings page classes.
+	 */
+	public static function get_settings_pages() {
+		if ( empty( self::$settings ) ) {
+			$settings = array();
+
+			include_once dirname( __FILE__ ) . '/settings/class-wc-settings-page.php';
+
+			$settings[] = include 'settings/class-wc-settings-general.php';
+			$settings[] = include 'settings/class-wc-settings-products.php';
+			$settings[] = include 'settings/class-wc-settings-tax.php';
+			$settings[] = include 'settings/class-wc-settings-shipping.php';
+			$settings[] = include 'settings/class-wc-settings-payment-gateways.php';
+			$settings[] = include 'settings/class-wc-settings-accounts.php';
+			$settings[] = include 'settings/class-wc-settings-emails.php';
+			$settings[] = include 'settings/class-wc-settings-integrations.php';
+			$settings[] = include 'settings/class-wc-settings-advanced.php';
+
+			self::$settings = apply_filters( 'woocommerce_get_settings_pages', $settings );
 		}
 
-		/**
-		 * Settings page.
-		 *
-		 * Handles the display of the main woocommerce settings page in admin.
-		 */
-		public static function output() {
-			global $current_section, $current_tab;
+		return self::$settings;
+	}
 
-			$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+	/**
+	 * Save the settings.
+	 */
+	public static function save() {
+		global $current_tab;
 
-			do_action( 'woocommerce_settings_start' );
+		check_admin_referer( 'woocommerce-settings' );
 
-			wp_enqueue_script( 'woocommerce_settings', WC()->plugin_url() . '/assets/js/admin/settings' . $suffix . '.js', array( 'jquery', 'wp-util', 'jquery-ui-datepicker', 'jquery-ui-sortable', 'iris', 'selectWoo' ), WC()->version, true );
+		// Trigger actions.
+		do_action( 'woocommerce_settings_save_' . $current_tab );
+		do_action( 'woocommerce_update_options_' . $current_tab );
+		do_action( 'woocommerce_update_options' );
 
-			wp_localize_script(
-				'woocommerce_settings', 'woocommerce_settings_params', array(
-					'i18n_nav_warning' => __( 'The changes you made will be lost if you navigate away from this page.', 'woocommerce' ),
-					'i18n_moved_up'    => __( 'Item moved up', 'woocommerce' ),
-					'i18n_moved_down'  => __( 'Item moved down', 'woocommerce' ),
-				)
-			);
+		self::add_message( __( 'Your settings have been saved.', 'woocommerce' ) );
+		self::check_download_folder_protection();
 
-			// Get tabs for the settings page.
-			$tabs = apply_filters( 'woocommerce_settings_tabs_array', array() );
+		// Clear any unwanted data and flush rules.
+		update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
+		WC()->query->init_query_vars();
+		WC()->query->add_endpoints();
 
-			include dirname( __FILE__ ) . '/views/html-admin-settings.php';
-		}
+		do_action( 'woocommerce_settings_saved' );
+	}
 
-		/**
-		 * Get a setting from the settings API.
-		 *
-		 * @param string $option_name Option name.
-		 * @param mixed  $default     Default value.
-		 * @return mixed
-		 */
-		public static function get_option( $option_name, $default = '' ) {
-			// Array value.
-			if ( strstr( $option_name, '[' ) ) {
+	/**
+	 * Add a message.
+	 *
+	 * @param string $text Message.
+	 */
+	public static function add_message( $text ) {
+		self::$messages[] = $text;
+	}
 
-				parse_str( $option_name, $option_array );
+	/**
+	 * Add an error.
+	 *
+	 * @param string $text Message.
+	 */
+	public static function add_error( $text ) {
+		self::$errors[] = $text;
+	}
 
-				// Option name is first key.
-				$option_name = current( array_keys( $option_array ) );
-
-				// Get value.
-				$option_values = get_option( $option_name, '' );
-
-				$key = key( $option_array[ $option_name ] );
-
-				if ( isset( $option_values[ $key ] ) ) {
-					$option_value = $option_values[ $key ];
-				} else {
-					$option_value = null;
-				}
-			} else {
-				// Single value.
-				$option_value = get_option( $option_name, null );
+	/**
+	 * Output messages + errors.
+	 */
+	public static function show_messages() {
+		if ( count( self::$errors ) > 0 ) {
+			foreach ( self::$errors as $error ) {
+				echo '<div id="message" class="error inline"><p><strong>' . esc_html( $error ) . '</strong></p></div>';
 			}
-
-			if ( is_array( $option_value ) ) {
-				$option_value = array_map( 'stripslashes', $option_value );
-			} elseif ( ! is_null( $option_value ) ) {
-				$option_value = stripslashes( $option_value );
-			}
-
-			return ( null === $option_value ) ? $default : $option_value;
-		}
-
-		/**
-		 * Output admin fields.
-		 *
-		 * Loops though the woocommerce options array and outputs each field.
-		 *
-		 * @param array[] $options Opens array to output.
-		 */
-		public static function output_fields( $options ) {
-			foreach ( $options as $value ) {
-				if ( ! isset( $value['type'] ) ) {
-					continue;
-				}
-				if ( ! isset( $value['id'] ) ) {
-					$value['id'] = '';
-				}
-				if ( ! isset( $value['title'] ) ) {
-					$value['title'] = isset( $value['name'] ) ? $value['name'] : '';
-				}
-				if ( ! isset( $value['class'] ) ) {
-					$value['class'] = '';
-				}
-				if ( ! isset( $value['css'] ) ) {
-					$value['css'] = '';
-				}
-				if ( ! isset( $value['default'] ) ) {
-					$value['default'] = '';
-				}
-				if ( ! isset( $value['desc'] ) ) {
-					$value['desc'] = '';
-				}
-				if ( ! isset( $value['desc_tip'] ) ) {
-					$value['desc_tip'] = false;
-				}
-				if ( ! isset( $value['placeholder'] ) ) {
-					$value['placeholder'] = '';
-				}
-				if ( ! isset( $value['suffix'] ) ) {
-					$value['suffix'] = '';
-				}
-
-				// Custom attribute handling.
-				$custom_attributes = array();
-
-				if ( ! empty( $value['custom_attributes'] ) && is_array( $value['custom_attributes'] ) ) {
-					foreach ( $value['custom_attributes'] as $attribute => $attribute_value ) {
-						$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
-					}
-				}
-
-				// Description handling.
-				$field_description = self::get_field_description( $value );
-				$description       = $field_description['description'];
-				$tooltip_html      = $field_description['tooltip_html'];
-
-				// Switch based on type.
-				switch ( $value['type'] ) {
-
-					// Section Titles.
-					case 'title':
-						if ( ! empty( $value['title'] ) ) {
-							echo '<h2>' . esc_html( $value['title'] ) . '</h2>';
-						}
-						if ( ! empty( $value['desc'] ) ) {
-							echo '<div id="' . esc_attr( sanitize_title( $value['id'] ) ) . '-description">';
-							echo wp_kses_post( wpautop( wptexturize( $value['desc'] ) ) );
-							echo '</div>';
-						}
-						echo '<table class="form-table">' . "\n\n";
-						if ( ! empty( $value['id'] ) ) {
-							do_action( 'woocommerce_settings_' . sanitize_title( $value['id'] ) );
-						}
-						break;
-
-					// Section Ends.
-					case 'sectionend':
-						if ( ! empty( $value['id'] ) ) {
-							do_action( 'woocommerce_settings_' . sanitize_title( $value['id'] ) . '_end' );
-						}
-						echo '</table>';
-						if ( ! empty( $value['id'] ) ) {
-							do_action( 'woocommerce_settings_' . sanitize_title( $value['id'] ) . '_after' );
-						}
-						break;
-
-					// Standard text inputs and subtypes like 'number'.
-					case 'text':
-					case 'password':
-					case 'datetime':
-					case 'datetime-local':
-					case 'date':
-					case 'month':
-					case 'time':
-					case 'week':
-					case 'number':
-					case 'email':
-					case 'url':
-					case 'tel':
-						$option_value = self::get_option( $value['id'], $value['default'] );
-
-						?><tr valign="top">
-							<th scope="row" class="titledesc">
-								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
-							</th>
-							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
-								<input
-									name="<?php echo esc_attr( $value['id'] ); ?>"
-									id="<?php echo esc_attr( $value['id'] ); ?>"
-									type="<?php echo esc_attr( $value['type'] ); ?>"
-									style="<?php echo esc_attr( $value['css'] ); ?>"
-									value="<?php echo esc_attr( $option_value ); ?>"
-									class="<?php echo esc_attr( $value['class'] ); ?>"
-									placeholder="<?php echo esc_attr( $value['placeholder'] ); ?>"
-									<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
-									/><?php echo esc_html( $value['suffix'] ); ?> <?php echo $description; // WPCS: XSS ok. ?>
-							</td>
-						</tr>
-						<?php
-						break;
-
-					// Color picker.
-					case 'color':
-						$option_value = self::get_option( $value['id'], $value['default'] );
-
-						?>
-						<tr valign="top">
-							<th scope="row" class="titledesc">
-								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
-							</th>
-							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">&lrm;
-								<span class="colorpickpreview" style="background: <?php echo esc_attr( $option_value ); ?>">&nbsp;</span>
-								<input
-									name="<?php echo esc_attr( $value['id'] ); ?>"
-									id="<?php echo esc_attr( $value['id'] ); ?>"
-									type="text"
-									dir="ltr"
-									style="<?php echo esc_attr( $value['css'] ); ?>"
-									value="<?php echo esc_attr( $option_value ); ?>"
-									class="<?php echo esc_attr( $value['class'] ); ?>colorpick"
-									placeholder="<?php echo esc_attr( $value['placeholder'] ); ?>"
-									<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
-									/>&lrm; <?php echo $description; // WPCS: XSS ok. ?>
-									<div id="colorPickerDiv_<?php echo esc_attr( $value['id'] ); ?>" class="colorpickdiv" style="z-index: 100;background:#eee;border:1px solid #ccc;position:absolute;display:none;"></div>
-							</td>
-						</tr>
-						<?php
-						break;
-
-					// Textarea.
-					case 'textarea':
-						$option_value = self::get_option( $value['id'], $value['default'] );
-
-						?>
-						<tr valign="top">
-							<th scope="row" class="titledesc">
-								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
-							</th>
-							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
-								<?php echo $description; // WPCS: XSS ok. ?>
-
-								<textarea
-									name="<?php echo esc_attr( $value['id'] ); ?>"
-									id="<?php echo esc_attr( $value['id'] ); ?>"
-									style="<?php echo esc_attr( $value['css'] ); ?>"
-									class="<?php echo esc_attr( $value['class'] ); ?>"
-									placeholder="<?php echo esc_attr( $value['placeholder'] ); ?>"
-									<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
-									><?php echo esc_textarea( $option_value ); // WPCS: XSS ok. ?></textarea>
-							</td>
-						</tr>
-						<?php
-						break;
-
-					// Select boxes.
-					case 'select':
-					case 'multiselect':
-						$option_value = self::get_option( $value['id'], $value['default'] );
-
-						?>
-						<tr valign="top">
-							<th scope="row" class="titledesc">
-								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
-							</th>
-							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
-								<select
-									name="<?php echo esc_attr( $value['id'] ); ?><?php echo ( 'multiselect' === $value['type'] ) ? '[]' : ''; ?>"
-									id="<?php echo esc_attr( $value['id'] ); ?>"
-									style="<?php echo esc_attr( $value['css'] ); ?>"
-									class="<?php echo esc_attr( $value['class'] ); ?>"
-									<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
-									<?php echo 'multiselect' === $value['type'] ? 'multiple="multiple"' : ''; ?>
-									>
-									<?php
-									foreach ( $value['options'] as $key => $val ) {
-										?>
-										<option value="<?php echo esc_attr( $key ); ?>"
-											<?php
-
-											if ( is_array( $option_value ) ) {
-												selected( in_array( (string) $key, $option_value, true ), true );
-											} else {
-												selected( $option_value, (string) $key );
-											}
-
-										?>
-										>
-										<?php echo esc_html( $val ); ?></option>
-										<?php
-									}
-									?>
-								</select> <?php echo $description; // WPCS: XSS ok. ?>
-							</td>
-						</tr>
-						<?php
-						break;
-
-					// Radio inputs.
-					case 'radio':
-						$option_value = self::get_option( $value['id'], $value['default'] );
-
-						?>
-						<tr valign="top">
-							<th scope="row" class="titledesc">
-								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
-							</th>
-							<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
-								<fieldset>
-									<?php echo $description; // WPCS: XSS ok. ?>
-									<ul>
-									<?php
-									foreach ( $value['options'] as $key => $val ) {
-										?>
-										<li>
-											<label><input
-												name="<?php echo esc_attr( $value['id'] ); ?>"
-												value="<?php echo esc_attr( $key ); ?>"
-												type="radio"
-												style="<?php echo esc_attr( $value['css'] ); ?>"
-												class="<?php echo esc_attr( $value['class'] ); ?>"
-												<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
-												<?php checked( $key, $option_value ); ?>
-												/> <?php echo esc_html( $val ); ?></label>
-										</li>
-										<?php
-									}
-									?>
-									</ul>
-								</fieldset>
-							</td>
-						</tr>
-						<?php
-						break;
-
-					// Checkbox input.
-					case 'checkbox':
-						$option_value     = self::get_option( $value['id'], $value['default'] );
-						$visibility_class = array();
-
-						if ( ! isset( $value['hide_if_checked'] ) ) {
-							$value['hide_if_checked'] = false;
-						}
-						if ( ! isset( $value['show_if_checked'] ) ) {
-							$value['show_if_checked'] = false;
-						}
-						if ( 'yes' === $value['hide_if_checked'] || 'yes' === $value['show_if_checked'] ) {
-							$visibility_class[] = 'hidden_option';
-						}
-						if ( 'option' === $value['hide_if_checked'] ) {
-							$visibility_class[] = 'hide_options_if_checked';
-						}
-						if ( 'option' === $value['show_if_checked'] ) {
-							$visibility_class[] = 'show_options_if_checked';
-						}
-
-						if ( ! isset( $value['checkboxgroup'] ) || 'start' === $value['checkboxgroup'] ) {
-							?>
-								<tr valign="top" class="<?php echo esc_attr( implode( ' ', $visibility_class ) ); ?>">
-									<th scope="row" class="titledesc"><?php echo esc_html( $value['title'] ); ?></th>
-									<td class="forminp forminp-checkbox">
-										<fieldset>
-							<?php
-						} else {
-							?>
-								<fieldset class="<?php echo esc_attr( implode( ' ', $visibility_class ) ); ?>">
-							<?php
-						}
-
-						if ( ! empty( $value['title'] ) ) {
-							?>
-								<legend class="screen-reader-text"><span><?php echo esc_html( $value['title'] ); ?></span></legend>
-							<?php
-						}
-
-						?>
-							<label for="<?php echo esc_attr( $value['id'] ); ?>">
-								<input
-									name="<?php echo esc_attr( $value['id'] ); ?>"
-									id="<?php echo esc_attr( $value['id'] ); ?>"
-									type="checkbox"
-									class="<?php echo esc_attr( isset( $value['class'] ) ? $value['class'] : '' ); ?>"
-									value="1"
-									<?php checked( $option_value, 'yes' ); ?>
-									<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
-								/> <?php echo $description; // WPCS: XSS ok. ?>
-							</label> <?php echo $tooltip_html; // WPCS: XSS ok. ?>
-						<?php
-
-						if ( ! isset( $value['checkboxgroup'] ) || 'end' === $value['checkboxgroup'] ) {
-										?>
-										</fieldset>
-									</td>
-								</tr>
-							<?php
-						} else {
-							?>
-								</fieldset>
-							<?php
-						}
-						break;
-
-					// Image width settings. @todo deprecate and remove in 4.0. No longer needed by core.
-					case 'image_width':
-						$image_size       = str_replace( '_image_size', '', $value['id'] );
-						$size             = wc_get_image_size( $image_size );
-						$width            = isset( $size['width'] ) ? $size['width'] : $value['default']['width'];
-						$height           = isset( $size['height'] ) ? $size['height'] : $value['default']['height'];
-						$crop             = isset( $size['crop'] ) ? $size['crop'] : $value['default']['crop'];
-						$disabled_attr    = '';
-						$disabled_message = '';
-
-						if ( has_filter( 'woocommerce_get_image_size_' . $image_size ) ) {
-							$disabled_attr    = 'disabled="disabled"';
-							$disabled_message = '<p><small>' . esc_html__( 'The settings of this image size have been disabled because its values are being overwritten by a filter.', 'woocommerce' ) . '</small></p>';
-						}
-
-						?>
-						<tr valign="top">
-							<th scope="row" class="titledesc">
-							<label><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html . $disabled_message; // WPCS: XSS ok. ?></label>
-						</th>
-							<td class="forminp image_width_settings">
-
-								<input name="<?php echo esc_attr( $value['id'] ); ?>[width]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-width" type="text" size="3" value="<?php echo esc_attr( $width ); ?>" /> &times; <input name="<?php echo esc_attr( $value['id'] ); ?>[height]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-height" type="text" size="3" value="<?php echo esc_attr( $height ); ?>" />px
-
-								<label><input name="<?php echo esc_attr( $value['id'] ); ?>[crop]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-crop" type="checkbox" value="1" <?php checked( 1, $crop ); ?> /> <?php esc_html_e( 'Hard crop?', 'woocommerce' ); ?></label>
-
-								</td>
-						</tr>
-						<?php
-						break;
-
-					// Single page selects.
-					case 'single_select_page':
-						$args = array(
-							'name'             => $value['id'],
-							'id'               => $value['id'],
-							'sort_column'      => 'menu_order',
-							'sort_order'       => 'ASC',
-							'show_option_none' => ' ',
-							'class'            => $value['class'],
-							'echo'             => false,
-							'selected'         => absint( self::get_option( $value['id'], $value['default'] ) ),
-							'post_status'      => 'publish,private,draft',
-						);
-
-						if ( isset( $value['args'] ) ) {
-							$args = wp_parse_args( $value['args'], $args );
-						}
-
-						?>
-						<tr valign="top" class="single_select_page">
-							<th scope="row" class="titledesc">
-								<label><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
-							</th>
-							<td class="forminp">
-								<?php echo str_replace( ' id=', " data-placeholder='" . esc_attr__( 'Select a page&hellip;', 'woocommerce' ) . "' style='" . $value['css'] . "' class='" . $value['class'] . "' id=", wp_dropdown_pages( $args ) ); // WPCS: XSS ok. ?> <?php echo $description; // WPCS: XSS ok. ?>
-							</td>
-						</tr>
-						<?php
-						break;
-
-					// Single country selects.
-					case 'single_select_country':
-						$country_setting = (string) self::get_option( $value['id'], $value['default'] );
-
-						if ( strstr( $country_setting, ':' ) ) {
-							$country_setting = explode( ':', $country_setting );
-							$country         = current( $country_setting );
-							$state           = end( $country_setting );
-						} else {
-							$country = $country_setting;
-							$state   = '*';
-						}
-						?>
-						<tr valign="top">
-							<th scope="row" class="titledesc">
-								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
-							</th>
-							<td class="forminp"><select name="<?php echo esc_attr( $value['id'] ); ?>" style="<?php echo esc_attr( $value['css'] ); ?>" data-placeholder="<?php esc_attr_e( 'Choose a country&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country', 'woocommerce' ); ?>" class="wc-enhanced-select">
-								<?php WC()->countries->country_dropdown_options( $country, $state ); ?>
-							</select> <?php echo $description; // WPCS: XSS ok. ?>
-							</td>
-						</tr>
-						<?php
-						break;
-
-					// Country multiselects.
-					case 'multi_select_countries':
-						$selections = (array) self::get_option( $value['id'], $value['default'] );
-
-						if ( ! empty( $value['options'] ) ) {
-							$countries = $value['options'];
-						} else {
-							$countries = WC()->countries->countries;
-						}
-
-						asort( $countries );
-						?>
-						<tr valign="top">
-							<th scope="row" class="titledesc">
-								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
-							</th>
-							<td class="forminp">
-								<select multiple="multiple" name="<?php echo esc_attr( $value['id'] ); ?>[]" style="width:350px" data-placeholder="<?php esc_attr_e( 'Choose countries&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country', 'woocommerce' ); ?>" class="wc-enhanced-select">
-									<?php
-									if ( ! empty( $countries ) ) {
-										foreach ( $countries as $key => $val ) {
-											echo '<option value="' . esc_attr( $key ) . '"' . wc_selected( $key, $selections ) . '>' . esc_html( $val ) . '</option>'; // WPCS: XSS ok.
-										}
-									}
-									?>
-								</select> <?php echo ( $description ) ? $description : ''; // WPCS: XSS ok. ?> <br /><a class="select_all button" href="#"><?php esc_html_e( 'Select all', 'woocommerce' ); ?></a> <a class="select_none button" href="#"><?php esc_html_e( 'Select none', 'woocommerce' ); ?></a>
-							</td>
-						</tr>
-						<?php
-						break;
-
-					// Days/months/years selector.
-					case 'relative_date_selector':
-						$periods      = array(
-							'days'   => __( 'Day(s)', 'woocommerce' ),
-							'weeks'  => __( 'Week(s)', 'woocommerce' ),
-							'months' => __( 'Month(s)', 'woocommerce' ),
-							'years'  => __( 'Year(s)', 'woocommerce' ),
-						);
-						$option_value = wc_parse_relative_date_option( self::get_option( $value['id'], $value['default'] ) );
-						?>
-						<tr valign="top">
-							<th scope="row" class="titledesc">
-								<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
-							</th>
-							<td class="forminp">
-							<input
-									name="<?php echo esc_attr( $value['id'] ); ?>[number]"
-									id="<?php echo esc_attr( $value['id'] ); ?>"
-									type="number"
-									style="width: 80px;"
-									value="<?php echo esc_attr( $option_value['number'] ); ?>"
-									class="<?php echo esc_attr( $value['class'] ); ?>"
-									placeholder="<?php echo esc_attr( $value['placeholder'] ); ?>"
-									step="1"
-									min="1"
-									<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
-								/>&nbsp;
-								<select name="<?php echo esc_attr( $value['id'] ); ?>[unit]" style="width: auto;">
-									<?php
-									foreach ( $periods as $value => $label ) {
-										echo '<option value="' . esc_attr( $value ) . '"' . selected( $option_value['unit'], $value, false ) . '>' . esc_html( $label ) . '</option>';
-									}
-									?>
-								</select> <?php echo ( $description ) ? $description : ''; // WPCS: XSS ok. ?>
-							</td>
-						</tr>
-						<?php
-						break;
-
-					// Default: run an action.
-					default:
-						do_action( 'woocommerce_admin_field_' . $value['type'], $value );
-						break;
-				}
-			}
-		}
-
-		/**
-		 * Helper function to get the formatted description and tip HTML for a
-		 * given form field. Plugins can call this when implementing their own custom
-		 * settings types.
-		 *
-		 * @param  array $value The form field value array.
-		 * @return array The description and tip as a 2 element array.
-		 */
-		public static function get_field_description( $value ) {
-			$description  = '';
-			$tooltip_html = '';
-
-			if ( true === $value['desc_tip'] ) {
-				$tooltip_html = $value['desc'];
-			} elseif ( ! empty( $value['desc_tip'] ) ) {
-				$description  = $value['desc'];
-				$tooltip_html = $value['desc_tip'];
-			} elseif ( ! empty( $value['desc'] ) ) {
-				$description = $value['desc'];
-			}
-
-			if ( $description && in_array( $value['type'], array( 'textarea', 'radio' ), true ) ) {
-				$description = '<p style="margin-top:0">' . wp_kses_post( $description ) . '</p>';
-			} elseif ( $description && in_array( $value['type'], array( 'checkbox' ), true ) ) {
-				$description = wp_kses_post( $description );
-			} elseif ( $description ) {
-				$description = '<span class="description">' . wp_kses_post( $description ) . '</span>';
-			}
-
-			if ( $tooltip_html && in_array( $value['type'], array( 'checkbox' ), true ) ) {
-				$tooltip_html = '<p class="description">' . $tooltip_html . '</p>';
-			} elseif ( $tooltip_html ) {
-				$tooltip_html = wc_help_tip( $tooltip_html );
-			}
-
-			return array(
-				'description'  => $description,
-				'tooltip_html' => $tooltip_html,
-			);
-		}
-
-		/**
-		 * Save admin fields.
-		 *
-		 * Loops though the woocommerce options array and outputs each field.
-		 *
-		 * @param array $options Options array to output.
-		 * @param array $data    Optional. Data to use for saving. Defaults to $_POST.
-		 * @return bool
-		 */
-		public static function save_fields( $options, $data = null ) {
-			if ( is_null( $data ) ) {
-				$data = $_POST; // WPCS: input var okay, CSRF ok.
-			}
-			if ( empty( $data ) ) {
-				return false;
-			}
-
-			// Options to update will be stored here and saved later.
-			$update_options   = array();
-			$autoload_options = array();
-
-			// Loop options and get values to save.
-			foreach ( $options as $option ) {
-				if ( ! isset( $option['id'] ) || ! isset( $option['type'] ) ) {
-					continue;
-				}
-
-				// Get posted value.
-				if ( strstr( $option['id'], '[' ) ) {
-					parse_str( $option['id'], $option_name_array );
-					$option_name  = current( array_keys( $option_name_array ) );
-					$setting_name = key( $option_name_array[ $option_name ] );
-					$raw_value    = isset( $data[ $option_name ][ $setting_name ] ) ? wp_unslash( $data[ $option_name ][ $setting_name ] ) : null;
-				} else {
-					$option_name  = $option['id'];
-					$setting_name = '';
-					$raw_value    = isset( $data[ $option['id'] ] ) ? wp_unslash( $data[ $option['id'] ] ) : null;
-				}
-
-				// Format the value based on option type.
-				switch ( $option['type'] ) {
-					case 'checkbox':
-						$value = '1' === $raw_value || 'yes' === $raw_value ? 'yes' : 'no';
-						break;
-					case 'textarea':
-						$value = wp_kses_post( trim( $raw_value ) );
-						break;
-					case 'multiselect':
-					case 'multi_select_countries':
-						$value = array_filter( array_map( 'wc_clean', (array) $raw_value ) );
-						break;
-					case 'image_width':
-						$value = array();
-						if ( isset( $raw_value['width'] ) ) {
-							$value['width']  = wc_clean( $raw_value['width'] );
-							$value['height'] = wc_clean( $raw_value['height'] );
-							$value['crop']   = isset( $raw_value['crop'] ) ? 1 : 0;
-						} else {
-							$value['width']  = $option['default']['width'];
-							$value['height'] = $option['default']['height'];
-							$value['crop']   = $option['default']['crop'];
-						}
-						break;
-					case 'select':
-						$allowed_values = empty( $option['options'] ) ? array() : array_map( 'strval', array_keys( $option['options'] ) );
-						if ( empty( $option['default'] ) && empty( $allowed_values ) ) {
-							$value = null;
-							break;
-						}
-						$default = ( empty( $option['default'] ) ? $allowed_values[0] : $option['default'] );
-						$value   = in_array( $raw_value, $allowed_values, true ) ? $raw_value : $default;
-						break;
-					case 'relative_date_selector':
-						$value = wc_parse_relative_date_option( $raw_value );
-						break;
-					default:
-						$value = wc_clean( $raw_value );
-						break;
-				}
-
-				/**
-				 * Fire an action when a certain 'type' of field is being saved.
-				 *
-				 * @deprecated 2.4.0 - doesn't allow manipulation of values!
-				 */
-				if ( has_action( 'woocommerce_update_option_' . sanitize_title( $option['type'] ) ) ) {
-					wc_deprecated_function( 'The woocommerce_update_option_X action', '2.4.0', 'woocommerce_admin_settings_sanitize_option filter' );
-					do_action( 'woocommerce_update_option_' . sanitize_title( $option['type'] ), $option );
-					continue;
-				}
-
-				/**
-				 * Sanitize the value of an option.
-				 *
-				 * @since 2.4.0
-				 */
-				$value = apply_filters( 'woocommerce_admin_settings_sanitize_option', $value, $option, $raw_value );
-
-				/**
-				 * Sanitize the value of an option by option name.
-				 *
-				 * @since 2.4.0
-				 */
-				$value = apply_filters( "woocommerce_admin_settings_sanitize_option_$option_name", $value, $option, $raw_value );
-
-				if ( is_null( $value ) ) {
-					continue;
-				}
-
-				// Check if option is an array and handle that differently to single values.
-				if ( $option_name && $setting_name ) {
-					if ( ! isset( $update_options[ $option_name ] ) ) {
-						$update_options[ $option_name ] = get_option( $option_name, array() );
-					}
-					if ( ! is_array( $update_options[ $option_name ] ) ) {
-						$update_options[ $option_name ] = array();
-					}
-					$update_options[ $option_name ][ $setting_name ] = $value;
-				} else {
-					$update_options[ $option_name ] = $value;
-				}
-
-				$autoload_options[ $option_name ] = isset( $option['autoload'] ) ? (bool) $option['autoload'] : true;
-
-				/**
-				 * Fire an action before saved.
-				 *
-				 * @deprecated 2.4.0 - doesn't allow manipulation of values!
-				 */
-				do_action( 'woocommerce_update_option', $option );
-			}
-
-			// Save all options in our array.
-			foreach ( $update_options as $name => $value ) {
-				update_option( $name, $value, $autoload_options[ $name ] ? 'yes' : 'no' );
-			}
-
-			return true;
-		}
-
-		/**
-		 * Checks which method we're using to serve downloads.
-		 *
-		 * If using force or x-sendfile, this ensures the .htaccess is in place.
-		 */
-		public static function check_download_folder_protection() {
-			$upload_dir      = wp_upload_dir();
-			$downloads_url   = $upload_dir['basedir'] . '/woocommerce_uploads';
-			$download_method = get_option( 'woocommerce_file_download_method' );
-
-			if ( 'redirect' === $download_method ) {
-
-				// Redirect method - don't protect.
-				if ( file_exists( $downloads_url . '/.htaccess' ) ) {
-					unlink( $downloads_url . '/.htaccess' ); // @codingStandardsIgnoreLine
-				}
-			} else {
-
-				// Force method - protect, add rules to the htaccess file.
-				if ( ! file_exists( $downloads_url . '/.htaccess' ) ) {
-					$file_handle = @fopen( $downloads_url . '/.htaccess', 'w' ); // @codingStandardsIgnoreLine
-					if ( $file_handle ) {
-						fwrite( $file_handle, 'deny from all' ); // @codingStandardsIgnoreLine
-						fclose( $file_handle ); // @codingStandardsIgnoreLine
-					}
-				}
+		} elseif ( count( self::$messages ) > 0 ) {
+			foreach ( self::$messages as $message ) {
+				echo '<div id="message" class="updated inline"><p><strong>' . esc_html( $message ) . '</strong></p></div>';
 			}
 		}
 	}
 
-endif;
+	/**
+	 * Settings page.
+	 *
+	 * Handles the display of the main woocommerce settings page in admin.
+	 */
+	public static function output() {
+		global $current_section, $current_tab;
+
+		$suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
+
+		do_action( 'woocommerce_settings_start' );
+
+		wp_enqueue_script( 'woocommerce_settings', WC()->plugin_url() . '/assets/js/admin/settings' . $suffix . '.js', array( 'jquery', 'wp-util', 'jquery-ui-datepicker', 'jquery-ui-sortable', 'iris', 'selectWoo' ), WC()->version, true );
+
+		wp_localize_script(
+			'woocommerce_settings', 'woocommerce_settings_params', array(
+				'i18n_nav_warning' => __( 'The changes you made will be lost if you navigate away from this page.', 'woocommerce' ),
+				'i18n_moved_up'    => __( 'Item moved up', 'woocommerce' ),
+				'i18n_moved_down'  => __( 'Item moved down', 'woocommerce' ),
+			)
+		);
+
+		// Get tabs for the settings page.
+		$tabs = apply_filters( 'woocommerce_settings_tabs_array', array() );
+
+		include dirname( __FILE__ ) . '/views/html-admin-settings.php';
+	}
+
+	/**
+	 * Get a setting from the settings API.
+	 *
+	 * @param string $option_name Option name.
+	 * @param mixed  $default     Default value.
+	 * @return mixed
+	 */
+	public static function get_option( $option_name, $default = '' ) {
+		// Array value.
+		if ( strstr( $option_name, '[' ) ) {
+
+			parse_str( $option_name, $option_array );
+
+			// Option name is first key.
+			$option_name = current( array_keys( $option_array ) );
+
+			// Get value.
+			$option_values = get_option( $option_name, '' );
+
+			$key = key( $option_array[ $option_name ] );
+
+			if ( isset( $option_values[ $key ] ) ) {
+				$option_value = $option_values[ $key ];
+			} else {
+				$option_value = null;
+			}
+		} else {
+			// Single value.
+			$option_value = get_option( $option_name, null );
+		}
+
+		if ( is_array( $option_value ) ) {
+			$option_value = array_map( 'stripslashes', $option_value );
+		} elseif ( ! is_null( $option_value ) ) {
+			$option_value = stripslashes( $option_value );
+		}
+
+		return ( null === $option_value ) ? $default : $option_value;
+	}
+
+	/**
+	 * Output admin fields.
+	 *
+	 * Loops though the woocommerce options array and outputs each field.
+	 *
+	 * @param array[] $options Opens array to output.
+	 */
+	public static function output_fields( $options ) {
+		foreach ( $options as $value ) {
+			if ( ! isset( $value['type'] ) ) {
+				continue;
+			}
+			if ( ! isset( $value['id'] ) ) {
+				$value['id'] = '';
+			}
+			if ( ! isset( $value['title'] ) ) {
+				$value['title'] = isset( $value['name'] ) ? $value['name'] : '';
+			}
+			if ( ! isset( $value['class'] ) ) {
+				$value['class'] = '';
+			}
+			if ( ! isset( $value['css'] ) ) {
+				$value['css'] = '';
+			}
+			if ( ! isset( $value['default'] ) ) {
+				$value['default'] = '';
+			}
+			if ( ! isset( $value['desc'] ) ) {
+				$value['desc'] = '';
+			}
+			if ( ! isset( $value['desc_tip'] ) ) {
+				$value['desc_tip'] = false;
+			}
+			if ( ! isset( $value['placeholder'] ) ) {
+				$value['placeholder'] = '';
+			}
+			if ( ! isset( $value['suffix'] ) ) {
+				$value['suffix'] = '';
+			}
+
+			// Custom attribute handling.
+			$custom_attributes = array();
+
+			if ( ! empty( $value['custom_attributes'] ) && is_array( $value['custom_attributes'] ) ) {
+				foreach ( $value['custom_attributes'] as $attribute => $attribute_value ) {
+					$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $attribute_value ) . '"';
+				}
+			}
+
+			// Description handling.
+			$field_description = self::get_field_description( $value );
+			$description       = $field_description['description'];
+			$tooltip_html      = $field_description['tooltip_html'];
+
+			// Switch based on type.
+			switch ( $value['type'] ) {
+
+				// Section Titles.
+				case 'title':
+					if ( ! empty( $value['title'] ) ) {
+						echo '<h2>' . esc_html( $value['title'] ) . '</h2>';
+					}
+					if ( ! empty( $value['desc'] ) ) {
+						echo '<div id="' . esc_attr( sanitize_title( $value['id'] ) ) . '-description">';
+						echo wp_kses_post( wpautop( wptexturize( $value['desc'] ) ) );
+						echo '</div>';
+					}
+					echo '<table class="form-table">' . "\n\n";
+					if ( ! empty( $value['id'] ) ) {
+						do_action( 'woocommerce_settings_' . sanitize_title( $value['id'] ) );
+					}
+					break;
+
+				// Section Ends.
+				case 'sectionend':
+					if ( ! empty( $value['id'] ) ) {
+						do_action( 'woocommerce_settings_' . sanitize_title( $value['id'] ) . '_end' );
+					}
+					echo '</table>';
+					if ( ! empty( $value['id'] ) ) {
+						do_action( 'woocommerce_settings_' . sanitize_title( $value['id'] ) . '_after' );
+					}
+					break;
+
+				// Standard text inputs and subtypes like 'number'.
+				case 'text':
+				case 'password':
+				case 'datetime':
+				case 'datetime-local':
+				case 'date':
+				case 'month':
+				case 'time':
+				case 'week':
+				case 'number':
+				case 'email':
+				case 'url':
+				case 'tel':
+					$option_value = self::get_option( $value['id'], $value['default'] );
+
+					?><tr valign="top">
+						<th scope="row" class="titledesc">
+							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
+						</th>
+						<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
+							<input
+								name="<?php echo esc_attr( $value['id'] ); ?>"
+								id="<?php echo esc_attr( $value['id'] ); ?>"
+								type="<?php echo esc_attr( $value['type'] ); ?>"
+								style="<?php echo esc_attr( $value['css'] ); ?>"
+								value="<?php echo esc_attr( $option_value ); ?>"
+								class="<?php echo esc_attr( $value['class'] ); ?>"
+								placeholder="<?php echo esc_attr( $value['placeholder'] ); ?>"
+								<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
+								/><?php echo esc_html( $value['suffix'] ); ?> <?php echo $description; // WPCS: XSS ok. ?>
+						</td>
+					</tr>
+					<?php
+					break;
+
+				// Color picker.
+				case 'color':
+					$option_value = self::get_option( $value['id'], $value['default'] );
+
+					?>
+					<tr valign="top">
+						<th scope="row" class="titledesc">
+							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
+						</th>
+						<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">&lrm;
+							<span class="colorpickpreview" style="background: <?php echo esc_attr( $option_value ); ?>">&nbsp;</span>
+							<input
+								name="<?php echo esc_attr( $value['id'] ); ?>"
+								id="<?php echo esc_attr( $value['id'] ); ?>"
+								type="text"
+								dir="ltr"
+								style="<?php echo esc_attr( $value['css'] ); ?>"
+								value="<?php echo esc_attr( $option_value ); ?>"
+								class="<?php echo esc_attr( $value['class'] ); ?>colorpick"
+								placeholder="<?php echo esc_attr( $value['placeholder'] ); ?>"
+								<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
+								/>&lrm; <?php echo $description; // WPCS: XSS ok. ?>
+								<div id="colorPickerDiv_<?php echo esc_attr( $value['id'] ); ?>" class="colorpickdiv" style="z-index: 100;background:#eee;border:1px solid #ccc;position:absolute;display:none;"></div>
+						</td>
+					</tr>
+					<?php
+					break;
+
+				// Textarea.
+				case 'textarea':
+					$option_value = self::get_option( $value['id'], $value['default'] );
+
+					?>
+					<tr valign="top">
+						<th scope="row" class="titledesc">
+							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
+						</th>
+						<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
+							<?php echo $description; // WPCS: XSS ok. ?>
+
+							<textarea
+								name="<?php echo esc_attr( $value['id'] ); ?>"
+								id="<?php echo esc_attr( $value['id'] ); ?>"
+								style="<?php echo esc_attr( $value['css'] ); ?>"
+								class="<?php echo esc_attr( $value['class'] ); ?>"
+								placeholder="<?php echo esc_attr( $value['placeholder'] ); ?>"
+								<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
+								><?php echo esc_textarea( $option_value ); // WPCS: XSS ok. ?></textarea>
+						</td>
+					</tr>
+					<?php
+					break;
+
+				// Select boxes.
+				case 'select':
+				case 'multiselect':
+					$option_value = self::get_option( $value['id'], $value['default'] );
+
+					?>
+					<tr valign="top">
+						<th scope="row" class="titledesc">
+							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
+						</th>
+						<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
+							<select
+								name="<?php echo esc_attr( $value['id'] ); ?><?php echo ( 'multiselect' === $value['type'] ) ? '[]' : ''; ?>"
+								id="<?php echo esc_attr( $value['id'] ); ?>"
+								style="<?php echo esc_attr( $value['css'] ); ?>"
+								class="<?php echo esc_attr( $value['class'] ); ?>"
+								<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
+								<?php echo 'multiselect' === $value['type'] ? 'multiple="multiple"' : ''; ?>
+								>
+								<?php
+								foreach ( $value['options'] as $key => $val ) {
+									?>
+									<option value="<?php echo esc_attr( $key ); ?>"
+										<?php
+
+										if ( is_array( $option_value ) ) {
+											selected( in_array( (string) $key, $option_value, true ), true );
+										} else {
+											selected( $option_value, (string) $key );
+										}
+
+									?>
+									>
+									<?php echo esc_html( $val ); ?></option>
+									<?php
+								}
+								?>
+							</select> <?php echo $description; // WPCS: XSS ok. ?>
+						</td>
+					</tr>
+					<?php
+					break;
+
+				// Radio inputs.
+				case 'radio':
+					$option_value = self::get_option( $value['id'], $value['default'] );
+
+					?>
+					<tr valign="top">
+						<th scope="row" class="titledesc">
+							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
+						</th>
+						<td class="forminp forminp-<?php echo esc_attr( sanitize_title( $value['type'] ) ); ?>">
+							<fieldset>
+								<?php echo $description; // WPCS: XSS ok. ?>
+								<ul>
+								<?php
+								foreach ( $value['options'] as $key => $val ) {
+									?>
+									<li>
+										<label><input
+											name="<?php echo esc_attr( $value['id'] ); ?>"
+											value="<?php echo esc_attr( $key ); ?>"
+											type="radio"
+											style="<?php echo esc_attr( $value['css'] ); ?>"
+											class="<?php echo esc_attr( $value['class'] ); ?>"
+											<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
+											<?php checked( $key, $option_value ); ?>
+											/> <?php echo esc_html( $val ); ?></label>
+									</li>
+									<?php
+								}
+								?>
+								</ul>
+							</fieldset>
+						</td>
+					</tr>
+					<?php
+					break;
+
+				// Checkbox input.
+				case 'checkbox':
+					$option_value     = self::get_option( $value['id'], $value['default'] );
+					$visibility_class = array();
+
+					if ( ! isset( $value['hide_if_checked'] ) ) {
+						$value['hide_if_checked'] = false;
+					}
+					if ( ! isset( $value['show_if_checked'] ) ) {
+						$value['show_if_checked'] = false;
+					}
+					if ( 'yes' === $value['hide_if_checked'] || 'yes' === $value['show_if_checked'] ) {
+						$visibility_class[] = 'hidden_option';
+					}
+					if ( 'option' === $value['hide_if_checked'] ) {
+						$visibility_class[] = 'hide_options_if_checked';
+					}
+					if ( 'option' === $value['show_if_checked'] ) {
+						$visibility_class[] = 'show_options_if_checked';
+					}
+
+					if ( ! isset( $value['checkboxgroup'] ) || 'start' === $value['checkboxgroup'] ) {
+						?>
+							<tr valign="top" class="<?php echo esc_attr( implode( ' ', $visibility_class ) ); ?>">
+								<th scope="row" class="titledesc"><?php echo esc_html( $value['title'] ); ?></th>
+								<td class="forminp forminp-checkbox">
+									<fieldset>
+						<?php
+					} else {
+						?>
+							<fieldset class="<?php echo esc_attr( implode( ' ', $visibility_class ) ); ?>">
+						<?php
+					}
+
+					if ( ! empty( $value['title'] ) ) {
+						?>
+							<legend class="screen-reader-text"><span><?php echo esc_html( $value['title'] ); ?></span></legend>
+						<?php
+					}
+
+					?>
+						<label for="<?php echo esc_attr( $value['id'] ); ?>">
+							<input
+								name="<?php echo esc_attr( $value['id'] ); ?>"
+								id="<?php echo esc_attr( $value['id'] ); ?>"
+								type="checkbox"
+								class="<?php echo esc_attr( isset( $value['class'] ) ? $value['class'] : '' ); ?>"
+								value="1"
+								<?php checked( $option_value, 'yes' ); ?>
+								<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
+							/> <?php echo $description; // WPCS: XSS ok. ?>
+						</label> <?php echo $tooltip_html; // WPCS: XSS ok. ?>
+					<?php
+
+					if ( ! isset( $value['checkboxgroup'] ) || 'end' === $value['checkboxgroup'] ) {
+									?>
+									</fieldset>
+								</td>
+							</tr>
+						<?php
+					} else {
+						?>
+							</fieldset>
+						<?php
+					}
+					break;
+
+				// Image width settings. @todo deprecate and remove in 4.0. No longer needed by core.
+				case 'image_width':
+					$image_size       = str_replace( '_image_size', '', $value['id'] );
+					$size             = wc_get_image_size( $image_size );
+					$width            = isset( $size['width'] ) ? $size['width'] : $value['default']['width'];
+					$height           = isset( $size['height'] ) ? $size['height'] : $value['default']['height'];
+					$crop             = isset( $size['crop'] ) ? $size['crop'] : $value['default']['crop'];
+					$disabled_attr    = '';
+					$disabled_message = '';
+
+					if ( has_filter( 'woocommerce_get_image_size_' . $image_size ) ) {
+						$disabled_attr    = 'disabled="disabled"';
+						$disabled_message = '<p><small>' . esc_html__( 'The settings of this image size have been disabled because its values are being overwritten by a filter.', 'woocommerce' ) . '</small></p>';
+					}
+
+					?>
+					<tr valign="top">
+						<th scope="row" class="titledesc">
+						<label><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html . $disabled_message; // WPCS: XSS ok. ?></label>
+					</th>
+						<td class="forminp image_width_settings">
+
+							<input name="<?php echo esc_attr( $value['id'] ); ?>[width]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-width" type="text" size="3" value="<?php echo esc_attr( $width ); ?>" /> &times; <input name="<?php echo esc_attr( $value['id'] ); ?>[height]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-height" type="text" size="3" value="<?php echo esc_attr( $height ); ?>" />px
+
+							<label><input name="<?php echo esc_attr( $value['id'] ); ?>[crop]" <?php echo $disabled_attr; // WPCS: XSS ok. ?> id="<?php echo esc_attr( $value['id'] ); ?>-crop" type="checkbox" value="1" <?php checked( 1, $crop ); ?> /> <?php esc_html_e( 'Hard crop?', 'woocommerce' ); ?></label>
+
+							</td>
+					</tr>
+					<?php
+					break;
+
+				// Single page selects.
+				case 'single_select_page':
+					$args = array(
+						'name'             => $value['id'],
+						'id'               => $value['id'],
+						'sort_column'      => 'menu_order',
+						'sort_order'       => 'ASC',
+						'show_option_none' => ' ',
+						'class'            => $value['class'],
+						'echo'             => false,
+						'selected'         => absint( self::get_option( $value['id'], $value['default'] ) ),
+						'post_status'      => 'publish,private,draft',
+					);
+
+					if ( isset( $value['args'] ) ) {
+						$args = wp_parse_args( $value['args'], $args );
+					}
+
+					?>
+					<tr valign="top" class="single_select_page">
+						<th scope="row" class="titledesc">
+							<label><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
+						</th>
+						<td class="forminp">
+							<?php echo str_replace( ' id=', " data-placeholder='" . esc_attr__( 'Select a page&hellip;', 'woocommerce' ) . "' style='" . $value['css'] . "' class='" . $value['class'] . "' id=", wp_dropdown_pages( $args ) ); // WPCS: XSS ok. ?> <?php echo $description; // WPCS: XSS ok. ?>
+						</td>
+					</tr>
+					<?php
+					break;
+
+				// Single country selects.
+				case 'single_select_country':
+					$country_setting = (string) self::get_option( $value['id'], $value['default'] );
+
+					if ( strstr( $country_setting, ':' ) ) {
+						$country_setting = explode( ':', $country_setting );
+						$country         = current( $country_setting );
+						$state           = end( $country_setting );
+					} else {
+						$country = $country_setting;
+						$state   = '*';
+					}
+					?>
+					<tr valign="top">
+						<th scope="row" class="titledesc">
+							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
+						</th>
+						<td class="forminp"><select name="<?php echo esc_attr( $value['id'] ); ?>" style="<?php echo esc_attr( $value['css'] ); ?>" data-placeholder="<?php esc_attr_e( 'Choose a country&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country', 'woocommerce' ); ?>" class="wc-enhanced-select">
+							<?php WC()->countries->country_dropdown_options( $country, $state ); ?>
+						</select> <?php echo $description; // WPCS: XSS ok. ?>
+						</td>
+					</tr>
+					<?php
+					break;
+
+				// Country multiselects.
+				case 'multi_select_countries':
+					$selections = (array) self::get_option( $value['id'], $value['default'] );
+
+					if ( ! empty( $value['options'] ) ) {
+						$countries = $value['options'];
+					} else {
+						$countries = WC()->countries->countries;
+					}
+
+					asort( $countries );
+					?>
+					<tr valign="top">
+						<th scope="row" class="titledesc">
+							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
+						</th>
+						<td class="forminp">
+							<select multiple="multiple" name="<?php echo esc_attr( $value['id'] ); ?>[]" style="width:350px" data-placeholder="<?php esc_attr_e( 'Choose countries&hellip;', 'woocommerce' ); ?>" aria-label="<?php esc_attr_e( 'Country', 'woocommerce' ); ?>" class="wc-enhanced-select">
+								<?php
+								if ( ! empty( $countries ) ) {
+									foreach ( $countries as $key => $val ) {
+										echo '<option value="' . esc_attr( $key ) . '"' . wc_selected( $key, $selections ) . '>' . esc_html( $val ) . '</option>'; // WPCS: XSS ok.
+									}
+								}
+								?>
+							</select> <?php echo ( $description ) ? $description : ''; // WPCS: XSS ok. ?> <br /><a class="select_all button" href="#"><?php esc_html_e( 'Select all', 'woocommerce' ); ?></a> <a class="select_none button" href="#"><?php esc_html_e( 'Select none', 'woocommerce' ); ?></a>
+						</td>
+					</tr>
+					<?php
+					break;
+
+				// Days/months/years selector.
+				case 'relative_date_selector':
+					$periods      = array(
+						'days'   => __( 'Day(s)', 'woocommerce' ),
+						'weeks'  => __( 'Week(s)', 'woocommerce' ),
+						'months' => __( 'Month(s)', 'woocommerce' ),
+						'years'  => __( 'Year(s)', 'woocommerce' ),
+					);
+					$option_value = wc_parse_relative_date_option( self::get_option( $value['id'], $value['default'] ) );
+					?>
+					<tr valign="top">
+						<th scope="row" class="titledesc">
+							<label for="<?php echo esc_attr( $value['id'] ); ?>"><?php echo esc_html( $value['title'] ); ?> <?php echo $tooltip_html; // WPCS: XSS ok. ?></label>
+						</th>
+						<td class="forminp">
+						<input
+								name="<?php echo esc_attr( $value['id'] ); ?>[number]"
+								id="<?php echo esc_attr( $value['id'] ); ?>"
+								type="number"
+								style="width: 80px;"
+								value="<?php echo esc_attr( $option_value['number'] ); ?>"
+								class="<?php echo esc_attr( $value['class'] ); ?>"
+								placeholder="<?php echo esc_attr( $value['placeholder'] ); ?>"
+								step="1"
+								min="1"
+								<?php echo implode( ' ', $custom_attributes ); // WPCS: XSS ok. ?>
+							/>&nbsp;
+							<select name="<?php echo esc_attr( $value['id'] ); ?>[unit]" style="width: auto;">
+								<?php
+								foreach ( $periods as $value => $label ) {
+									echo '<option value="' . esc_attr( $value ) . '"' . selected( $option_value['unit'], $value, false ) . '>' . esc_html( $label ) . '</option>';
+								}
+								?>
+							</select> <?php echo ( $description ) ? $description : ''; // WPCS: XSS ok. ?>
+						</td>
+					</tr>
+					<?php
+					break;
+
+				// Default: run an action.
+				default:
+					do_action( 'woocommerce_admin_field_' . $value['type'], $value );
+					break;
+			}
+		}
+	}
+
+	/**
+	 * Helper function to get the formatted description and tip HTML for a
+	 * given form field. Plugins can call this when implementing their own custom
+	 * settings types.
+	 *
+	 * @param  array $value The form field value array.
+	 * @return array The description and tip as a 2 element array.
+	 */
+	public static function get_field_description( $value ) {
+		$description  = '';
+		$tooltip_html = '';
+
+		if ( true === $value['desc_tip'] ) {
+			$tooltip_html = $value['desc'];
+		} elseif ( ! empty( $value['desc_tip'] ) ) {
+			$description  = $value['desc'];
+			$tooltip_html = $value['desc_tip'];
+		} elseif ( ! empty( $value['desc'] ) ) {
+			$description = $value['desc'];
+		}
+
+		if ( $description && in_array( $value['type'], array( 'textarea', 'radio' ), true ) ) {
+			$description = '<p style="margin-top:0">' . wp_kses_post( $description ) . '</p>';
+		} elseif ( $description && in_array( $value['type'], array( 'checkbox' ), true ) ) {
+			$description = wp_kses_post( $description );
+		} elseif ( $description ) {
+			$description = '<span class="description">' . wp_kses_post( $description ) . '</span>';
+		}
+
+		if ( $tooltip_html && in_array( $value['type'], array( 'checkbox' ), true ) ) {
+			$tooltip_html = '<p class="description">' . $tooltip_html . '</p>';
+		} elseif ( $tooltip_html ) {
+			$tooltip_html = wc_help_tip( $tooltip_html );
+		}
+
+		return array(
+			'description'  => $description,
+			'tooltip_html' => $tooltip_html,
+		);
+	}
+
+	/**
+	 * Save admin fields.
+	 *
+	 * Loops though the woocommerce options array and outputs each field.
+	 *
+	 * @param array $options Options array to output.
+	 * @param array $data    Optional. Data to use for saving. Defaults to $_POST.
+	 * @return bool
+	 */
+	public static function save_fields( $options, $data = null ) {
+		if ( is_null( $data ) ) {
+			$data = $_POST; // WPCS: input var okay, CSRF ok.
+		}
+		if ( empty( $data ) ) {
+			return false;
+		}
+
+		// Options to update will be stored here and saved later.
+		$update_options   = array();
+		$autoload_options = array();
+
+		// Loop options and get values to save.
+		foreach ( $options as $option ) {
+			if ( ! isset( $option['id'] ) || ! isset( $option['type'] ) ) {
+				continue;
+			}
+
+			// Get posted value.
+			if ( strstr( $option['id'], '[' ) ) {
+				parse_str( $option['id'], $option_name_array );
+				$option_name  = current( array_keys( $option_name_array ) );
+				$setting_name = key( $option_name_array[ $option_name ] );
+				$raw_value    = isset( $data[ $option_name ][ $setting_name ] ) ? wp_unslash( $data[ $option_name ][ $setting_name ] ) : null;
+			} else {
+				$option_name  = $option['id'];
+				$setting_name = '';
+				$raw_value    = isset( $data[ $option['id'] ] ) ? wp_unslash( $data[ $option['id'] ] ) : null;
+			}
+
+			// Format the value based on option type.
+			switch ( $option['type'] ) {
+				case 'checkbox':
+					$value = '1' === $raw_value || 'yes' === $raw_value ? 'yes' : 'no';
+					break;
+				case 'textarea':
+					$value = wp_kses_post( trim( $raw_value ) );
+					break;
+				case 'multiselect':
+				case 'multi_select_countries':
+					$value = array_filter( array_map( 'wc_clean', (array) $raw_value ) );
+					break;
+				case 'image_width':
+					$value = array();
+					if ( isset( $raw_value['width'] ) ) {
+						$value['width']  = wc_clean( $raw_value['width'] );
+						$value['height'] = wc_clean( $raw_value['height'] );
+						$value['crop']   = isset( $raw_value['crop'] ) ? 1 : 0;
+					} else {
+						$value['width']  = $option['default']['width'];
+						$value['height'] = $option['default']['height'];
+						$value['crop']   = $option['default']['crop'];
+					}
+					break;
+				case 'select':
+					$allowed_values = empty( $option['options'] ) ? array() : array_map( 'strval', array_keys( $option['options'] ) );
+					if ( empty( $option['default'] ) && empty( $allowed_values ) ) {
+						$value = null;
+						break;
+					}
+					$default = ( empty( $option['default'] ) ? $allowed_values[0] : $option['default'] );
+					$value   = in_array( $raw_value, $allowed_values, true ) ? $raw_value : $default;
+					break;
+				case 'relative_date_selector':
+					$value = wc_parse_relative_date_option( $raw_value );
+					break;
+				default:
+					$value = wc_clean( $raw_value );
+					break;
+			}
+
+			/**
+			 * Fire an action when a certain 'type' of field is being saved.
+			 *
+			 * @deprecated 2.4.0 - doesn't allow manipulation of values!
+			 */
+			if ( has_action( 'woocommerce_update_option_' . sanitize_title( $option['type'] ) ) ) {
+				wc_deprecated_function( 'The woocommerce_update_option_X action', '2.4.0', 'woocommerce_admin_settings_sanitize_option filter' );
+				do_action( 'woocommerce_update_option_' . sanitize_title( $option['type'] ), $option );
+				continue;
+			}
+
+			/**
+			 * Sanitize the value of an option.
+			 *
+			 * @since 2.4.0
+			 */
+			$value = apply_filters( 'woocommerce_admin_settings_sanitize_option', $value, $option, $raw_value );
+
+			/**
+			 * Sanitize the value of an option by option name.
+			 *
+			 * @since 2.4.0
+			 */
+			$value = apply_filters( "woocommerce_admin_settings_sanitize_option_$option_name", $value, $option, $raw_value );
+
+			if ( is_null( $value ) ) {
+				continue;
+			}
+
+			// Check if option is an array and handle that differently to single values.
+			if ( $option_name && $setting_name ) {
+				if ( ! isset( $update_options[ $option_name ] ) ) {
+					$update_options[ $option_name ] = get_option( $option_name, array() );
+				}
+				if ( ! is_array( $update_options[ $option_name ] ) ) {
+					$update_options[ $option_name ] = array();
+				}
+				$update_options[ $option_name ][ $setting_name ] = $value;
+			} else {
+				$update_options[ $option_name ] = $value;
+			}
+
+			$autoload_options[ $option_name ] = isset( $option['autoload'] ) ? (bool) $option['autoload'] : true;
+
+			/**
+			 * Fire an action before saved.
+			 *
+			 * @deprecated 2.4.0 - doesn't allow manipulation of values!
+			 */
+			do_action( 'woocommerce_update_option', $option );
+		}
+
+		// Save all options in our array.
+		foreach ( $update_options as $name => $value ) {
+			update_option( $name, $value, $autoload_options[ $name ] ? 'yes' : 'no' );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Checks which method we're using to serve downloads.
+	 *
+	 * If using force or x-sendfile, this ensures the .htaccess is in place.
+	 */
+	public static function check_download_folder_protection() {
+		$upload_dir      = wp_upload_dir();
+		$downloads_url   = $upload_dir['basedir'] . '/woocommerce_uploads';
+		$download_method = get_option( 'woocommerce_file_download_method' );
+
+		if ( 'redirect' === $download_method ) {
+
+			// Redirect method - don't protect.
+			if ( file_exists( $downloads_url . '/.htaccess' ) ) {
+				unlink( $downloads_url . '/.htaccess' ); // @codingStandardsIgnoreLine
+			}
+		} else {
+
+			// Force method - protect, add rules to the htaccess file.
+			if ( ! file_exists( $downloads_url . '/.htaccess' ) ) {
+				$file_handle = @fopen( $downloads_url . '/.htaccess', 'w' ); // @codingStandardsIgnoreLine
+				if ( $file_handle ) {
+					fwrite( $file_handle, 'deny from all' ); // @codingStandardsIgnoreLine
+					fclose( $file_handle ); // @codingStandardsIgnoreLine
+				}
+			}
+		}
+	}
+}

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -4,13 +4,10 @@
  *
  * Takes new users through some basic steps to setup their store.
  *
- * @package     WooCommerce/Admin
- * @version     2.6.0
+ * @package WooCommerce/Admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Setup_Wizard class.
@@ -49,22 +46,43 @@ class WC_Admin_Setup_Wizard {
 	);
 
 	/**
-	 * Hook in tabs.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Setup_Wizard|null
 	 */
-	public function __construct() {
-		if ( apply_filters( 'woocommerce_enable_setup_wizard', true ) && current_user_can( 'manage_woocommerce' ) ) {
-			add_action( 'admin_menu', array( $this, 'admin_menus' ) );
-			add_action( 'admin_init', array( $this, 'setup_wizard' ) );
-			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_scripts' ) );
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Setup_Wizard
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
+		return self::$instance;
 	}
 
 	/**
-	 * Add admin menus/screens.
+	 * Singleton. Prevent clone.
 	 */
-	public function admin_menus() {
-		add_dashboard_page( '', '', 'manage_options', 'wc-setup', '' );
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
 	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
 
 	/**
 	 * The theme "extra" should only be shown if the current user can modify themes
@@ -205,9 +223,8 @@ class WC_Admin_Setup_Wizard {
 	 * Show the setup wizard.
 	 */
 	public function setup_wizard() {
-		if ( empty( $_GET['page'] ) || 'wc-setup' !== $_GET['page'] ) { // WPCS: CSRF ok, input var ok.
-			return;
-		}
+		$this->enqueue_scripts();
+
 		$default_steps = array(
 			'store_setup' => array(
 				'name'    => __( 'Store setup', 'woocommerce' ),
@@ -2328,5 +2345,3 @@ class WC_Admin_Setup_Wizard {
 		<?php
 	}
 }
-
-new WC_Admin_Setup_Wizard();

--- a/includes/admin/class-wc-admin-taxonomies.php
+++ b/includes/admin/class-wc-admin-taxonomies.php
@@ -2,26 +2,15 @@
 /**
  * Handles taxonomies in admin
  *
- * @class    WC_Admin_Taxonomies
- * @version  2.3.10
- * @package  WooCommerce/Admin
+ * @package WooCommerce/Admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Taxonomies class.
  */
 class WC_Admin_Taxonomies {
-
-	/**
-	 * Class instance.
-	 *
-	 * @var WC_Admin_Taxonomies instance
-	 */
-	protected static $instance = false;
 
 	/**
 	 * Default category ID.
@@ -31,19 +20,55 @@ class WC_Admin_Taxonomies {
 	private $default_cat_id = 0;
 
 	/**
-	 * Get class instance
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_Taxonomies|null
 	 */
-	public static function get_instance() {
-		if ( ! self::$instance ) {
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_Taxonomies
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
 			self::$instance = new self();
 		}
 		return self::$instance;
 	}
 
 	/**
-	 * Constructor.
+	 * Get class instance
 	 */
-	public function __construct() {
+	public static function get_instance() {
+		return self::instance();
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
 		// Default category ID.
 		$this->default_cat_id = get_option( 'default_product_cat', 0 );
 
@@ -491,5 +516,3 @@ class WC_Admin_Taxonomies {
 		");
 	}
 }
-
-$wc_admin_taxonomies = WC_Admin_Taxonomies::get_instance();

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -14,22 +14,13 @@ defined( 'ABSPATH' ) || exit;
 class WC_Admin_Webhooks {
 
 	/**
-	 * Initialize the webhooks admin actions.
-	 */
-	public function __construct() {
-		add_action( 'admin_init', array( $this, 'actions' ) );
-		add_action( 'woocommerce_settings_page_init', array( $this, 'screen_option' ) );
-		add_filter( 'woocommerce_save_settings_advanced_webhooks', array( $this, 'allow_save_settings' ) );
-	}
-
-	/**
 	 * Check if should allow save settings.
 	 * This prevents "Your settings have been saved." notices on the table list.
 	 *
 	 * @param  bool $allow If allow save settings.
 	 * @return bool
 	 */
-	public function allow_save_settings( $allow ) {
+	public static function allow_save_settings( $allow ) {
 		if ( ! isset( $_GET['edit-webhook'] ) ) { // WPCS: input var okay, CSRF ok.
 			return false;
 		}
@@ -42,14 +33,14 @@ class WC_Admin_Webhooks {
 	 *
 	 * @return bool
 	 */
-	private function is_webhook_settings_page() {
+	private static function is_webhook_settings_page() {
 		return isset( $_GET['page'], $_GET['tab'], $_GET['section'] ) && 'wc-settings' === $_GET['page'] && 'advanced' === $_GET['tab'] && 'webhooks' === $_GET['section']; // WPCS: input var okay, CSRF ok.
 	}
 
 	/**
 	 * Save method.
 	 */
-	private function save() {
+	private static function save() {
 		check_admin_referer( 'woocommerce-settings' );
 
 		if ( ! current_user_can( 'manage_woocommerce' ) ) {
@@ -168,14 +159,14 @@ class WC_Admin_Webhooks {
 	/**
 	 * Delete webhook.
 	 */
-	private function delete() {
+	private static function delete() {
 		check_admin_referer( 'delete-webhook' );
 
 		if ( isset( $_GET['delete'] ) ) { // WPCS: input var okay, CSRF ok.
 			$webhook_id = absint( $_GET['delete'] ); // WPCS: input var okay, CSRF ok.
 
 			if ( $webhook_id ) {
-				$this->bulk_delete( array( $webhook_id ) );
+				self::bulk_delete( array( $webhook_id ) );
 			}
 		}
 	}
@@ -183,16 +174,16 @@ class WC_Admin_Webhooks {
 	/**
 	 * Webhooks admin actions.
 	 */
-	public function actions() {
-		if ( $this->is_webhook_settings_page() ) {
+	public static function actions() {
+		if ( self::is_webhook_settings_page() ) {
 			// Save.
 			if ( isset( $_POST['save'] ) && isset( $_POST['webhook_id'] ) ) { // WPCS: input var okay, CSRF ok.
-				$this->save();
+				self::save();
 			}
 
 			// Delete webhook.
 			if ( isset( $_GET['delete'] ) ) { // WPCS: input var okay, CSRF ok.
-				$this->delete();
+				self::delete();
 			}
 		}
 	}
@@ -244,10 +235,10 @@ class WC_Admin_Webhooks {
 	/**
 	 * Add screen option.
 	 */
-	public function screen_option() {
+	public static function screen_option() {
 		global $webhooks_table_list;
 
-		if ( ! isset( $_GET['edit-webhook'] ) && $this->is_webhook_settings_page() ) { // WPCS: input var okay, CSRF ok.
+		if ( ! isset( $_GET['edit-webhook'] ) && self::is_webhook_settings_page() ) { // WPCS: input var okay, CSRF ok.
 			$webhooks_table_list = new WC_Admin_Webhooks_Table_List();
 
 			// Add screen option.
@@ -345,5 +336,3 @@ class WC_Admin_Webhooks {
 		wc_deprecated_function( 'WC_Admin_Webhooks::get_logs_navigation', '3.3' );
 	}
 }
-
-new WC_Admin_Webhooks();

--- a/includes/admin/helper/class-wc-helper-api.php
+++ b/includes/admin/helper/class-wc-helper-api.php
@@ -133,5 +133,3 @@ class WC_Helper_API {
 		return $endpoint;
 	}
 }
-
-WC_Helper_API::load();

--- a/includes/admin/helper/class-wc-helper-compat.php
+++ b/includes/admin/helper/class-wc-helper-compat.php
@@ -193,5 +193,3 @@ class WC_Helper_Compat {
 		include WC_Helper::get_view_filename( 'html-helper-compat.php' );
 	}
 }
-
-WC_Helper_Compat::load();

--- a/includes/admin/helper/class-wc-helper-file-headers.php
+++ b/includes/admin/helper/class-wc-helper-file-headers.php
@@ -40,5 +40,3 @@ class WC_Helper_File_Headers {
 		return $headers;
 	}
 }
-
-WC_Helper_File_Headers::load();

--- a/includes/admin/helper/class-wc-helper-plugin-info.php
+++ b/includes/admin/helper/class-wc-helper-plugin-info.php
@@ -71,5 +71,3 @@ class WC_Helper_Plugin_Info {
 		return $response;
 	}
 }
-
-WC_Helper_Plugin_Info::load();

--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -318,5 +318,3 @@ class WC_Helper_Updater {
 		delete_transient( '_woocommerce_helper_updates_count' );
 	}
 }
-
-WC_Helper_Updater::load();

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -1,7 +1,11 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+/**
+ * WooCommerce extension helper.
+ *
+ * @package WooCommerce/Admin/Helper
+ */
+
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Helper Class
@@ -33,12 +37,18 @@ class WC_Helper {
 		add_action( 'woocommerce_helper_output', array( __CLASS__, 'render_helper_output' ) );
 		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'admin_enqueue_scripts' ) );
 
-		// Attempt to toggle subscription state upon plugin activation/deactivation
+		// Attempt to toggle subscription state upon plugin activation/deactivation.
 		add_action( 'activated_plugin', array( __CLASS__, 'activated_plugin' ) );
 		add_action( 'deactivated_plugin', array( __CLASS__, 'deactivated_plugin' ) );
 
-		// Add some nags about extension updates
+		// Add some nags about extension updates.
 		add_action( 'admin_notices', array( __CLASS__, 'admin_notices' ) );
+
+		// Include rest of helper.
+		WC_Helper_API::load();
+		WC_Helper_Compat::load();
+		WC_Helper_Plugin_Info::load();
+		WC_Helper_Updater::load();
 
 		do_action( 'woocommerce_helper_loaded' );
 	}
@@ -1498,5 +1508,3 @@ class WC_Helper {
 		self::$log->log( $level, $message, array( 'source' => 'helper' ) );
 	}
 }
-
-WC_Helper::load();

--- a/includes/admin/list-tables/abstract-class-wc-admin-list-table.php
+++ b/includes/admin/list-tables/abstract-class-wc-admin-list-table.php
@@ -10,10 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( class_exists( 'WC_Admin_List_Table', false ) ) {
-	return;
-}
-
 /**
  * WC_Admin_List_Table Class.
  */
@@ -34,9 +30,9 @@ abstract class WC_Admin_List_Table {
 	protected $object = null;
 
 	/**
-	 * Constructor.
+	 * Hook into WP actions/filters.
 	 */
-	public function __construct() {
+	public function init() {
 		if ( $this->list_table_type ) {
 			add_action( 'manage_posts_extra_tablenav', array( $this, 'maybe_render_blank_state' ) );
 			add_filter( 'view_mode_post_types', array( $this, 'disable_view_mode' ) );

--- a/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
@@ -10,14 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( class_exists( 'WC_Admin_List_Table_Coupons', false ) ) {
-	return;
-}
-
-if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once 'abstract-class-wc-admin-list-table.php';
-}
-
 /**
  * WC_Admin_List_Table_Coupons Class.
  */
@@ -31,10 +23,44 @@ class WC_Admin_List_Table_Coupons extends WC_Admin_List_Table {
 	protected $list_table_type = 'shop_coupon';
 
 	/**
-	 * Constructor.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_List_Table_Coupons|null
 	 */
-	public function __construct() {
-		parent::__construct();
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_List_Table_Coupons
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
+		parent::init();
 		add_filter( 'disable_months_dropdown', '__return_true' );
 	}
 

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -10,14 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( class_exists( 'WC_Admin_List_Table_Orders', false ) ) {
-	return;
-}
-
-if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once 'abstract-class-wc-admin-list-table.php';
-}
-
 /**
  * WC_Admin_List_Table_Orders Class.
  */
@@ -31,10 +23,44 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 	protected $list_table_type = 'shop_order';
 
 	/**
-	 * Constructor.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_List_Table_Orders|null
 	 */
-	public function __construct() {
-		parent::__construct();
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_List_Table_Orders
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
+		parent::init();
 		add_action( 'admin_notices', array( $this, 'bulk_admin_notices' ) );
 		add_action( 'admin_footer', array( $this, 'order_preview_template' ) );
 		add_filter( 'get_search_query', array( $this, 'search_label' ) );

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -10,14 +10,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( class_exists( 'WC_Admin_List_Table_Products', false ) ) {
-	return;
-}
-
-if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once 'abstract-class-wc-admin-list-table.php';
-}
-
 /**
  * WC_Admin_List_Table_Products Class.
  */
@@ -31,10 +23,44 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	protected $list_table_type = 'product';
 
 	/**
-	 * Constructor.
+	 * Singleton instance.
+	 *
+	 * @var WC_Admin_List_Table_Products|null
 	 */
-	public function __construct() {
-		parent::__construct();
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Admin_List_Table_Products
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
+		parent::init();
 		add_filter( 'disable_months_dropdown', '__return_true' );
 		add_filter( 'query_vars', array( $this, 'add_custom_query_var' ) );
 		add_filter( 'views_edit-product', array( $this, 'product_views' ) );

--- a/includes/admin/plugin-updates/class-wc-plugin-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugin-updates.php
@@ -2,13 +2,10 @@
 /**
  * Class for displaying plugin warning notifications and determining 3rd party plugin compatibility.
  *
- * @package     WooCommerce/Admin
- * @version     3.2.0
+ * @package WooCommerce/Admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * WC_Admin_Plugin_Updates Class.

--- a/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
@@ -2,17 +2,10 @@
 /**
  * Manages WooCommerce plugin updating on the Plugins screen.
  *
- * @package     WooCommerce/Admin
- * @version     3.2.0
+ * @package WooCommerce/Admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-if ( ! class_exists( 'WC_Plugin_Updates' ) ) {
-	include_once dirname( __FILE__ ) . '/class-wc-plugin-updates.php';
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Class WC_Plugins_Screen_Updates
@@ -27,9 +20,48 @@ class WC_Plugins_Screen_Updates extends WC_Plugin_Updates {
 	protected $upgrade_notice = '';
 
 	/**
-	 * Constructor.
+	 * Singleton instance.
+	 *
+	 * @var WC_Plugins_Screen_Updates|null
 	 */
-	public function __construct() {
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Plugins_Screen_Updates
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
 		add_action( 'in_plugin_update_message-woocommerce/woocommerce.php', array( $this, 'in_plugin_update_message' ), 10, 2 );
 	}
 
@@ -168,4 +200,3 @@ class WC_Plugins_Screen_Updates extends WC_Plugin_Updates {
 		$this->generic_modal_js();
 	}
 }
-new WC_Plugins_Screen_Updates();

--- a/includes/admin/plugin-updates/class-wc-updates-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-updates-screen-updates.php
@@ -2,17 +2,10 @@
 /**
  * Manages WooCommerce plugin updating on the Updates screen.
  *
- * @package     WooCommerce/Admin
- * @version     3.2.0
+ * @package WooCommerce/Admin
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
-if ( ! class_exists( 'WC_Plugin_Updates' ) ) {
-	include_once dirname( __FILE__ ) . '/class-wc-plugin-updates.php';
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
  * Class WC_Updates_Screen_Updates
@@ -20,9 +13,48 @@ if ( ! class_exists( 'WC_Plugin_Updates' ) ) {
 class WC_Updates_Screen_Updates extends WC_Plugin_Updates {
 
 	/**
-	 * Constructor.
+	 * Singleton instance.
+	 *
+	 * @var WC_Plugins_Screen_Updates|null
 	 */
-	public function __construct() {
+	protected static $instance = null;
+
+	/**
+	 * Return singleston instance.
+	 *
+	 * @static
+	 * @return WC_Plugins_Screen_Updates
+	 */
+	final public static function instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
+	/**
+	 * Singleton. Prevent clone.
+	 */
+	final public function __clone() {
+		trigger_error( 'Singleton. No cloning allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent serialization.
+	 */
+	final public function __wakeup() {
+		trigger_error( 'Singleton. No serialization allowed!', E_USER_ERROR ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_trigger_error
+	}
+
+	/**
+	 * Singleton. Prevent construct.
+	 */
+	final private function __construct() {}
+
+	/**
+	 * Hook into WP actions/filters.
+	 */
+	public function init() {
 		add_action( 'admin_print_footer_scripts', array( $this, 'update_screen_modal' ) );
 	}
 
@@ -92,4 +124,3 @@ class WC_Updates_Screen_Updates extends WC_Plugin_Updates {
 		$this->generic_modal_js();
 	}
 }
-new WC_Updates_Screen_Updates();

--- a/includes/admin/reports/class-wc-report-low-in-stock.php
+++ b/includes/admin/reports/class-wc-report-low-in-stock.php
@@ -1,20 +1,14 @@
 <?php
+/**
+ * Low stock report.
+ *
+ * @package WooCommerce/Admin/Reports
+ */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
-
-if ( ! class_exists( 'WC_Report_Stock' ) ) {
-	require_once dirname( __FILE__ ) . '/class-wc-report-stock.php';
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
- * WC_Report_Low_In_Stock.
- *
- * @author      WooThemes
- * @category    Admin
- * @package     WooCommerce/Admin/Reports
- * @version     2.1.0
+ * WC_Report_Low_In_Stock class.
  */
 class WC_Report_Low_In_Stock extends WC_Report_Stock {
 

--- a/includes/admin/reports/class-wc-report-most-stocked.php
+++ b/includes/admin/reports/class-wc-report-most-stocked.php
@@ -1,20 +1,14 @@
 <?php
+/**
+ * Most stocked report.
+ *
+ * @package WooCommerce/Admin/Reports
+ */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
-
-if ( ! class_exists( 'WC_Report_Stock' ) ) {
-	require_once dirname( __FILE__ ) . '/class-wc-report-stock.php';
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
- * WC_Report_Most_Stocked.
- *
- * @author      WooThemes
- * @category    Admin
- * @package     WooCommerce/Admin/Reports
- * @version     2.1.0
+ * WC_Report_Most_Stocked class.
  */
 class WC_Report_Most_Stocked extends WC_Report_Stock {
 

--- a/includes/admin/reports/class-wc-report-out-of-stock.php
+++ b/includes/admin/reports/class-wc-report-out-of-stock.php
@@ -1,20 +1,14 @@
 <?php
+/**
+ * Out of stock report.
+ *
+ * @package WooCommerce/Admin/Reports
+ */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
-
-if ( ! class_exists( 'WC_Report_Stock' ) ) {
-	require_once dirname( __FILE__ ) . '/class-wc-report-stock.php';
-}
+defined( 'ABSPATH' ) || exit;
 
 /**
- * WC_Report_Out_Of_Stock.
- *
- * @author      WooThemes
- * @category    Admin
- * @package     WooCommerce/Admin/Reports
- * @version     2.1.0
+ * WC_Report_Out_Of_Stock class.
  */
 class WC_Report_Out_Of_Stock extends WC_Report_Stock {
 

--- a/includes/admin/reports/class-wc-report-sales-by-category.php
+++ b/includes/admin/reports/class-wc-report-sales-by-category.php
@@ -222,8 +222,6 @@ class WC_Report_Sales_By_Category extends WC_Admin_Report {
 						$r['value']        = 'id';
 						$r['selected']     = $this->show_categories;
 
-						include_once WC()->plugin_path() . '/includes/walkers/class-wc-product-cat-dropdown-walker.php';
-
 						echo wc_walk_category_dropdown_tree( $categories, 0, $r ); // @codingStandardsIgnoreLine
 					?>
 				</select>

--- a/includes/admin/settings/class-wc-settings-advanced.php
+++ b/includes/admin/settings/class-wc-settings-advanced.php
@@ -27,7 +27,18 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 		$this->label = __( 'Advanced', 'woocommerce' );
 
 		parent::__construct();
-		$this->notices();
+
+		$current_section = WC_Admin_Settings::get_current_section();
+
+		if ( 'keys' === $current_section ) {
+			WC_Admin_API_Keys::actions();
+			WC_Admin_API_Keys::notices();
+			WC_Admin_API_Keys::screen_option();
+		} elseif ( 'webhooks' === $current_section ) {
+			WC_Admin_Webhooks::actions();
+			WC_Admin_Webhooks::notices();
+			WC_Admin_Webhooks::screen_option();
+		}
 	}
 
 	/**
@@ -337,22 +348,10 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 	}
 
 	/**
-	 * Notices.
-	 */
-	private function notices() {
-		if ( isset( $_GET['section'] ) && 'webhooks' === $_GET['section'] ) { // WPCS: input var okay, CSRF ok.
-			WC_Admin_Webhooks::notices();
-		}
-		if ( isset( $_GET['section'] ) && 'keys' === $_GET['section'] ) { // WPCS: input var okay, CSRF ok.
-			WC_Admin_API_Keys::notices();
-		}
-	}
-
-	/**
 	 * Output the settings.
 	 */
 	public function output() {
-		global $current_section;
+		$current_section = WC_Admin_Settings::get_current_section();
 
 		if ( 'webhooks' === $current_section ) {
 			WC_Admin_Webhooks::page_output();
@@ -368,7 +367,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 	 * Save settings.
 	 */
 	public function save() {
-		global $current_section;
+		$current_section = WC_Admin_Settings::get_current_section();
 
 		if ( apply_filters( 'woocommerce_rest_api_valid_to_save', ! in_array( $current_section, array( 'keys', 'webhooks' ), true ) ) ) {
 			$settings = $this->get_settings( $current_section );

--- a/includes/admin/settings/class-wc-settings-checkout.php
+++ b/includes/admin/settings/class-wc-settings-checkout.php
@@ -8,4 +8,4 @@
 
 defined( 'ABSPATH' ) || exit;
 
-return include 'class-wc-settings-payment-gateways.php';
+return new WC_Settings_Payment_Gateways();

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -17,7 +17,11 @@ class WC_AJAX {
 	 * Hook in ajax handlers.
 	 */
 	public static function init() {
-		add_action( 'init', array( __CLASS__, 'define_ajax' ), 0 );
+		if ( ! WP_DEBUG || ( WP_DEBUG && ! WP_DEBUG_DISPLAY ) ) {
+			@ini_set( 'display_errors', 0 ); // Turn off display_errors during AJAX events to prevent malformed JSON.
+		}
+		$GLOBALS['wpdb']->hide_errors();
+
 		add_action( 'template_redirect', array( __CLASS__, 'do_wc_ajax' ), 0 );
 		self::add_ajax_events();
 	}
@@ -31,20 +35,6 @@ class WC_AJAX {
 	 */
 	public static function get_endpoint( $request = '' ) {
 		return esc_url_raw( apply_filters( 'woocommerce_ajax_get_endpoint', add_query_arg( 'wc-ajax', $request, remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart', 'order_again', '_wpnonce' ), home_url( '/', 'relative' ) ) ), $request ) );
-	}
-
-	/**
-	 * Set WC AJAX constant and headers.
-	 */
-	public static function define_ajax() {
-		if ( ! empty( $_GET['wc-ajax'] ) ) {
-			wc_maybe_define_constant( 'DOING_AJAX', true );
-			wc_maybe_define_constant( 'WC_DOING_AJAX', true );
-			if ( ! WP_DEBUG || ( WP_DEBUG && ! WP_DEBUG_DISPLAY ) ) {
-				@ini_set( 'display_errors', 0 ); // Turn off display_errors during AJAX events to prevent malformed JSON.
-			}
-			$GLOBALS['wpdb']->hide_errors();
-		}
 	}
 
 	/**
@@ -2845,6 +2835,11 @@ class WC_AJAX {
 		wp_send_json_error( 'invalid_gateway_id' );
 		wp_die();
 	}
-}
 
-WC_AJAX::init();
+	/**
+	 * Set WC AJAX constant and headers.
+	 *
+	 * @deprecated
+	 */
+	public static function define_ajax() {}
+}

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -13,6 +13,10 @@
 
 defined( 'ABSPATH' ) || exit;
 
+if ( ! class_exists( 'WC_Legacy_API', false ) ) {
+	include_once WC_ABSPATH . 'includes/legacy/class-wc-legacy-api.php';
+}
+
 /**
  * WC_API class.
  */

--- a/includes/class-wc-auth.php
+++ b/includes/class-wc-auth.php
@@ -418,4 +418,3 @@ class WC_Auth {
 		}
 	}
 }
-new WC_Auth();

--- a/includes/class-wc-autoloader.php
+++ b/includes/class-wc-autoloader.php
@@ -3,7 +3,7 @@
  * WooCommerce Autoloader.
  *
  * @package WooCommerce/Classes
- * @version 2.3.0
+ * @deprecated
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-background-emailer.php
+++ b/includes/class-wc-background-emailer.php
@@ -8,10 +8,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'WC_Background_Process', false ) ) {
-	include_once dirname( __FILE__ ) . '/abstracts/class-wc-background-process.php';
-}
-
 /**
  * WC_Background_Emailer Class.
  */

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -283,5 +283,3 @@ class WC_Cache_Helper {
 		}
 	}
 }
-
-WC_Cache_Helper::init();

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -12,8 +12,6 @@
 defined( 'ABSPATH' ) || exit;
 
 require_once WC_ABSPATH . 'includes/legacy/class-wc-legacy-cart.php';
-require_once WC_ABSPATH . 'includes/class-wc-cart-fees.php';
-require_once WC_ABSPATH . 'includes/class-wc-cart-session.php';
 
 /**
  * WC_Cart class.

--- a/includes/class-wc-cli.php
+++ b/includes/class-wc-cli.php
@@ -15,29 +15,9 @@ class WC_CLI {
 	/**
 	 * Load required files and hooks to make the CLI work.
 	 */
-	public function __construct() {
-		$this->includes();
-		$this->hooks();
-	}
-
-	/**
-	 * Load command files.
-	 */
-	private function includes() {
-		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-runner.php';
-		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-rest-command.php';
-		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-tool-command.php';
-		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-update-command.php';
-	}
-
-	/**
-	 * Sets up and hooks WP CLI to our CLI code.
-	 */
-	private function hooks() {
+	public static function init() {
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Runner::after_wp_load' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Tool_Command::register_commands' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Update_Command::register_commands' );
 	}
 }
-
-new WC_CLI();

--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -428,5 +428,3 @@ class WC_Comments {
 		return $comment_data;
 	}
 }
-
-WC_Comments::init();

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -586,5 +586,3 @@ class WC_Download_Handler {
 		wp_die( $message, $title, array( 'response' => $status ) ); // WPCS: XSS ok.
 	}
 }
-
-WC_Download_Handler::init();

--- a/includes/class-wc-embed.php
+++ b/includes/class-wc-embed.php
@@ -174,5 +174,3 @@ class WC_Embed {
 		<?php
 	}
 }
-
-WC_Embed::init();

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -1123,5 +1123,3 @@ class WC_Form_Handler {
 		}
 	}
 }
-
-WC_Form_Handler::init();

--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -605,5 +605,3 @@ class WC_Frontend_Scripts {
 		}
 	}
 }
-
-WC_Frontend_Scripts::init();

--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -373,5 +373,3 @@ class WC_Geolocation {
 		return $country_code;
 	}
 }
-
-WC_Geolocation::init();

--- a/includes/class-wc-https.php
+++ b/includes/class-wc-https.php
@@ -134,5 +134,3 @@ class WC_HTTPS {
 		}
 	}
 }
-
-WC_HTTPS::init();

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -243,8 +243,8 @@ class WC_Install {
 	 * @since 3.2.0
 	 */
 	private static function setup_environment() {
-		WC_Post_types::register_post_types();
-		WC_Post_types::register_taxonomies();
+		WC_Post_Types::register_post_types();
+		WC_Post_Types::register_taxonomies();
 		WC()->query->init_query_vars();
 		WC()->query->add_endpoints();
 		WC_API::add_endpoint();
@@ -1450,5 +1450,3 @@ CREATE TABLE {$wpdb->prefix}woocommerce_termmeta (
 		}
 	}
 }
-
-WC_Install::init();

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -541,5 +541,3 @@ class WC_Post_Data {
 		}
 	}
 }
-
-WC_Post_Data::init();

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -606,5 +606,3 @@ class WC_Post_Types {
 		return $post_types;
 	}
 }
-
-WC_Post_types::init();

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -8,10 +8,6 @@
 
 defined( 'ABSPATH' ) || exit;
 
-if ( ! class_exists( 'WC_Privacy_Background_Process', false ) ) {
-	include_once dirname( __FILE__ ) . '/class-wc-privacy-background-process.php';
-}
-
 /**
  * WC_Privacy Class.
  */
@@ -33,10 +29,6 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		if ( ! self::$background_process ) {
 			self::$background_process = new WC_Privacy_Background_Process();
 		}
-
-		// Include supporting classes.
-		include_once 'class-wc-privacy-erasers.php';
-		include_once 'class-wc-privacy-exporters.php';
 
 		// This hook registers WooCommerce data exporters.
 		$this->add_exporter( 'woocommerce-customer-data', __( 'WooCommerce Customer Data', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'customer_data_exporter' ) );
@@ -349,5 +341,3 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		return $count;
 	}
 }
-
-new WC_Privacy();

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -44,8 +44,6 @@ class WC_Regenerate_Images {
 		}
 
 		if ( apply_filters( 'woocommerce_background_image_regeneration', true ) ) {
-			include_once WC_ABSPATH . 'includes/class-wc-regenerate-images-request.php';
-
 			self::$background_process = new WC_Regenerate_Images_Request();
 
 			add_action( 'admin_init', array( __CLASS__, 'regenerating_notice' ) );
@@ -407,5 +405,3 @@ class WC_Regenerate_Images {
 		self::$background_process->save()->dispatch();
 	}
 }
-
-add_action( 'init', array( 'WC_Regenerate_Images', 'init' ) );

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -1078,4 +1078,3 @@ class WC_Tax {
 		return $rates;
 	}
 }
-WC_Tax::init();

--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -553,5 +553,3 @@ class WC_Template_Loader {
 		return $tabs;
 	}
 }
-
-add_action( 'init', array( 'WC_Template_Loader', 'init' ) );

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -28,7 +28,9 @@ class WC_Tracker {
 	 * Hook into cron event.
 	 */
 	public static function init() {
-		add_action( 'woocommerce_tracker_send_event', array( __CLASS__, 'send_tracking_data' ) );
+		if ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
+			add_action( 'woocommerce_tracker_send_event', array( __CLASS__, 'send_tracking_data' ) );
+		}
 	}
 
 	/**
@@ -563,5 +565,3 @@ class WC_Tracker {
 		) );
 	}
 }
-
-WC_Tracker::init();

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -301,7 +301,6 @@ final class WooCommerce {
 		/**
 		 * Core classes.
 		 */
-		include_once WC_ABSPATH . 'includes/wc-core-functions.php';
 		include_once WC_ABSPATH . 'includes/class-wc-datetime.php';
 		include_once WC_ABSPATH . 'includes/class-wc-post-types.php';
 		include_once WC_ABSPATH . 'includes/class-wc-install.php';
@@ -445,8 +444,6 @@ final class WooCommerce {
 	 * Include required frontend files.
 	 */
 	public function frontend_includes() {
-		include_once WC_ABSPATH . 'includes/wc-cart-functions.php';
-		include_once WC_ABSPATH . 'includes/wc-notice-functions.php';
 		include_once WC_ABSPATH . 'includes/wc-template-hooks.php';
 		include_once WC_ABSPATH . 'includes/class-wc-template-loader.php';
 		include_once WC_ABSPATH . 'includes/class-wc-frontend-scripts.php';

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -28,7 +28,7 @@ final class WooCommerce {
 	 * @var WooCommerce
 	 * @since 2.1
 	 */
-	protected static $_instance = null;
+	protected static $instance = null;
 
 	/**
 	 * Session instance.
@@ -111,10 +111,10 @@ final class WooCommerce {
 	 * @return WooCommerce - Main instance.
 	 */
 	public static function instance() {
-		if ( is_null( self::$_instance ) ) {
-			self::$_instance = new self();
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
 		}
-		return self::$_instance;
+		return self::$instance;
 	}
 
 	/**
@@ -152,6 +152,16 @@ final class WooCommerce {
 	 */
 	public function __construct() {
 		$this->define_constants();
+
+		/**
+		 * Class autoloader.
+		 */
+		$loader = include_once WC_ABSPATH . 'vendor/autoload.php';
+
+		if ( ! $loader ) {
+			throw new Exception( 'vendor/autoload.php missing please run `composer install`' );
+		}
+
 		$this->includes();
 		$this->init_hooks();
 	}
@@ -284,13 +294,10 @@ final class WooCommerce {
 
 	/**
 	 * Include required core files used in admin and on the frontend.
+	 *
+	 * @throws Exception When composer install hasn't been ran.
 	 */
 	public function includes() {
-		/**
-		 * Class autoloader.
-		 */
-		include_once WC_ABSPATH . 'includes/class-wc-autoloader.php';
-
 		/**
 		 * Interfaces.
 		 */
@@ -419,7 +426,7 @@ final class WooCommerce {
 		}
 
 		if ( $this->is_request( 'admin' ) ) {
-			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
+			WC_Admin::instance()->init();
 		}
 
 		if ( $this->is_request( 'frontend' ) ) {

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -340,34 +340,6 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/queue/class-wc-queue.php';
 
 		/**
-		 * Data stores - used to store and retrieve CRUD object data from the database.
-		 */
-		include_once WC_ABSPATH . 'includes/class-wc-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-data-store-wp.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-coupon-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-grouped-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-variable-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-product-variation-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/abstract-wc-order-item-type-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-coupon-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-fee-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-product-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-shipping-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-item-tax-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-payment-token-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-customer-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-customer-data-store-session.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-customer-download-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-customer-download-log-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-shipping-zone-data-store.php';
-		include_once WC_ABSPATH . 'includes/data-stores/abstract-wc-order-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-order-refund-data-store-cpt.php';
-		include_once WC_ABSPATH . 'includes/data-stores/class-wc-webhook-data-store.php';
-
-		/**
 		 * REST API.
 		 */
 		include_once WC_ABSPATH . 'includes/legacy/class-wc-legacy-api.php';

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -299,46 +299,6 @@ final class WooCommerce {
 	 */
 	public function includes() {
 		/**
-		 * Interfaces.
-		 */
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-abstract-order-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-coupon-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-customer-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-customer-download-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-customer-download-log-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-object-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-order-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-order-item-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-order-item-product-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-order-item-type-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-order-refund-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-payment-token-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-product-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-product-variable-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-shipping-zone-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-logger-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-log-handler-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-webhooks-data-store-interface.php';
-		include_once WC_ABSPATH . 'includes/interfaces/class-wc-queue-interface.php';
-
-		/**
-		 * Abstract classes.
-		 */
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-data.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-object-query.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-payment-token.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-product.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-order.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-settings-api.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-shipping-method.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-payment-gateway.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-integration.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-log-handler.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-deprecated-hooks.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-session.php';
-		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-privacy.php';
-
-		/**
 		 * Core classes.
 		 */
 		include_once WC_ABSPATH . 'includes/wc-core-functions.php';

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -14,13 +14,13 @@ defined( 'ABSPATH' ) || exit;
 class WC_Shop_Customizer {
 
 	/**
-	 * Constructor.
+	 * Init customizer sections.
 	 */
-	public function __construct() {
-		add_action( 'customize_register', array( $this, 'add_sections' ) );
-		add_action( 'customize_controls_print_styles', array( $this, 'add_styles' ) );
-		add_action( 'customize_controls_print_scripts', array( $this, 'add_scripts' ), 30 );
-		add_action( 'wp_enqueue_scripts', array( $this, 'add_frontend_scripts' ) );
+	public static function init() {
+		add_action( 'customize_register', array( __CLASS__, 'add_sections' ) );
+		add_action( 'customize_controls_print_styles', array( __CLASS__, 'add_styles' ) );
+		add_action( 'customize_controls_print_scripts', array( __CLASS__, 'add_scripts' ), 30 );
+		add_action( 'wp_enqueue_scripts', array( __CLASS__, 'add_frontend_scripts' ) );
 	}
 
 	/**
@@ -28,7 +28,7 @@ class WC_Shop_Customizer {
 	 *
 	 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
 	 */
-	public function add_sections( $wp_customize ) {
+	public static function add_sections( $wp_customize ) {
 		$wp_customize->add_panel( 'woocommerce', array(
 			'priority'       => 200,
 			'capability'     => 'manage_woocommerce',
@@ -36,16 +36,16 @@ class WC_Shop_Customizer {
 			'title'          => __( 'WooCommerce', 'woocommerce' ),
 		) );
 
-		$this->add_store_notice_section( $wp_customize );
-		$this->add_product_catalog_section( $wp_customize );
-		$this->add_product_images_section( $wp_customize );
-		$this->add_checkout_section( $wp_customize );
+		self::add_store_notice_section( $wp_customize );
+		self::add_product_catalog_section( $wp_customize );
+		self::add_product_images_section( $wp_customize );
+		self::add_checkout_section( $wp_customize );
 	}
 
 	/**
 	 * Frontend CSS styles.
 	 */
-	public function add_frontend_scripts() {
+	public static function add_frontend_scripts() {
 		if ( ! is_customize_preview() || ! is_store_notice_showing() ) {
 			return;
 		}
@@ -57,7 +57,7 @@ class WC_Shop_Customizer {
 	/**
 	 * CSS styles to improve our form.
 	 */
-	public function add_styles() {
+	public static function add_styles() {
 		?>
 		<style type="text/css">
 			.woocommerce-cropping-control {
@@ -87,7 +87,7 @@ class WC_Shop_Customizer {
 	/**
 	 * Scripts to improve our form.
 	 */
-	public function add_scripts() {
+	public static function add_scripts() {
 		$min_rows    = wc_get_theme_support( 'product_grid::min_rows', 1 );
 		$max_rows    = wc_get_theme_support( 'product_grid::max_rows', '' );
 		$min_columns = wc_get_theme_support( 'product_grid::min_columns', 1 );
@@ -254,7 +254,7 @@ class WC_Shop_Customizer {
 	 * @param string $value '', 'subcategories', or 'both'.
 	 * @return string
 	 */
-	public function sanitize_archive_display( $value ) {
+	public static function sanitize_archive_display( $value ) {
 		$options = array( '', 'subcategories', 'both' );
 
 		return in_array( $value, $options, true ) ? $value : '';
@@ -266,7 +266,7 @@ class WC_Shop_Customizer {
 	 * @param string $value An array key from the below array.
 	 * @return string
 	 */
-	public function sanitize_default_catalog_orderby( $value ) {
+	public static function sanitize_default_catalog_orderby( $value ) {
 		$options = apply_filters( 'woocommerce_default_catalog_orderby_options', array(
 			'menu_order' => __( 'Default sorting (custom ordering + name)', 'woocommerce' ),
 			'popularity' => __( 'Popularity (sales)', 'woocommerce' ),
@@ -284,7 +284,7 @@ class WC_Shop_Customizer {
 	 *
 	 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
 	 */
-	private function add_store_notice_section( $wp_customize ) {
+	private static function add_store_notice_section( $wp_customize ) {
 		$wp_customize->add_section(
 			'woocommerce_store_notice',
 			array(
@@ -353,7 +353,7 @@ class WC_Shop_Customizer {
 	 *
 	 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
 	 */
-	public function add_product_catalog_section( $wp_customize ) {
+	public static function add_product_catalog_section( $wp_customize ) {
 		$wp_customize->add_section(
 			'woocommerce_product_catalog',
 			array(
@@ -369,7 +369,7 @@ class WC_Shop_Customizer {
 				'default'           => '',
 				'type'              => 'option',
 				'capability'        => 'manage_woocommerce',
-				'sanitize_callback' => array( $this, 'sanitize_archive_display' ),
+				'sanitize_callback' => array( __CLASS__, 'sanitize_archive_display' ),
 			)
 		);
 
@@ -395,7 +395,7 @@ class WC_Shop_Customizer {
 				'default'           => '',
 				'type'              => 'option',
 				'capability'        => 'manage_woocommerce',
-				'sanitize_callback' => array( $this, 'sanitize_archive_display' ),
+				'sanitize_callback' => array( __CLASS__, 'sanitize_archive_display' ),
 			)
 		);
 
@@ -421,7 +421,7 @@ class WC_Shop_Customizer {
 				'default'           => 'menu_order',
 				'type'              => 'option',
 				'capability'        => 'manage_woocommerce',
-				'sanitize_callback' => array( $this, 'sanitize_default_catalog_orderby' ),
+				'sanitize_callback' => array( __CLASS__, 'sanitize_default_catalog_orderby' ),
 			)
 		);
 
@@ -512,7 +512,7 @@ class WC_Shop_Customizer {
 	 *
 	 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
 	 */
-	private function add_product_images_section( $wp_customize ) {
+	private static function add_product_images_section( $wp_customize ) {
 		if ( class_exists( 'Jetpack' ) && Jetpack::is_module_active( 'photon' ) ) {
 			$regen_description = ''; // Nothing to report; Jetpack will handle magically.
 		} elseif ( apply_filters( 'woocommerce_background_image_regeneration', true ) && ! is_multisite() ) {
@@ -661,7 +661,7 @@ class WC_Shop_Customizer {
 	 *
 	 * @param WP_Customize_Manager $wp_customize Theme Customizer object.
 	 */
-	public function add_checkout_section( $wp_customize ) {
+	public static function add_checkout_section( $wp_customize ) {
 		$wp_customize->add_section(
 			'woocommerce_checkout',
 			array(
@@ -685,7 +685,7 @@ class WC_Shop_Customizer {
 					'default'           => 'phone' === $field ? 'required' : 'optional',
 					'type'              => 'option',
 					'capability'        => 'manage_woocommerce',
-					'sanitize_callback' => array( $this, 'sanitize_checkout_field_display' ),
+					'sanitize_callback' => array( __CLASS__, 'sanitize_checkout_field_display' ),
 				)
 			);
 			$wp_customize->add_control(
@@ -841,10 +841,8 @@ class WC_Shop_Customizer {
 	 * @param string $value '', 'subcategories', or 'both'.
 	 * @return string
 	 */
-	public function sanitize_checkout_field_display( $value ) {
+	public static function sanitize_checkout_field_display( $value ) {
 		$options = array( 'hidden', 'optional', 'required' );
 		return in_array( $value, $options, true ) ? $value : '';
 	}
 }
-
-new WC_Shop_Customizer();

--- a/includes/theme-support/class-wc-twenty-eleven.php
+++ b/includes/theme-support/class-wc-twenty-eleven.php
@@ -49,5 +49,3 @@ class WC_Twenty_Eleven {
 		echo '</div></div>';
 	}
 }
-
-WC_Twenty_Eleven::init();

--- a/includes/theme-support/class-wc-twenty-fifteen.php
+++ b/includes/theme-support/class-wc-twenty-fifteen.php
@@ -50,5 +50,3 @@ class WC_Twenty_Fifteen {
 		echo '</div></div>';
 	}
 }
-
-WC_Twenty_Fifteen::init();

--- a/includes/theme-support/class-wc-twenty-fourteen.php
+++ b/includes/theme-support/class-wc-twenty-fourteen.php
@@ -51,5 +51,3 @@ class WC_Twenty_Fourteen {
 		get_sidebar( 'content' );
 	}
 }
-
-WC_Twenty_Fourteen::init();

--- a/includes/theme-support/class-wc-twenty-nineteen.php
+++ b/includes/theme-support/class-wc-twenty-nineteen.php
@@ -123,5 +123,3 @@ class WC_Twenty_Nineteen {
 		return $css;
 	}
 }
-
-WC_Twenty_Nineteen::init();

--- a/includes/theme-support/class-wc-twenty-seventeen.php
+++ b/includes/theme-support/class-wc-twenty-seventeen.php
@@ -105,5 +105,3 @@ class WC_Twenty_Seventeen {
 		return $css;
 	}
 }
-
-WC_Twenty_Seventeen::init();

--- a/includes/theme-support/class-wc-twenty-sixteen.php
+++ b/includes/theme-support/class-wc-twenty-sixteen.php
@@ -49,5 +49,3 @@ class WC_Twenty_Sixteen {
 		echo '</main></div>';
 	}
 }
-
-WC_Twenty_Sixteen::init();

--- a/includes/theme-support/class-wc-twenty-ten.php
+++ b/includes/theme-support/class-wc-twenty-ten.php
@@ -49,5 +49,3 @@ class WC_Twenty_Ten {
 		echo '</div></div>';
 	}
 }
-
-WC_Twenty_Ten::init();

--- a/includes/theme-support/class-wc-twenty-thirteen.php
+++ b/includes/theme-support/class-wc-twenty-thirteen.php
@@ -50,5 +50,3 @@ class WC_Twenty_Thirteen {
 		echo '</div></div>';
 	}
 }
-
-WC_Twenty_Thirteen::init();

--- a/includes/theme-support/class-wc-twenty-twelve.php
+++ b/includes/theme-support/class-wc-twenty-twelve.php
@@ -50,5 +50,3 @@ class WC_Twenty_Twelve {
 		echo '</div></div>';
 	}
 }
-
-WC_Twenty_Twelve::init();

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -12,24 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-// Include core functions (available in both admin and frontend).
-require WC_ABSPATH . 'includes/wc-conditional-functions.php';
-require WC_ABSPATH . 'includes/wc-coupon-functions.php';
-require WC_ABSPATH . 'includes/wc-user-functions.php';
-require WC_ABSPATH . 'includes/wc-deprecated-functions.php';
-require WC_ABSPATH . 'includes/wc-formatting-functions.php';
-require WC_ABSPATH . 'includes/wc-order-functions.php';
-require WC_ABSPATH . 'includes/wc-order-item-functions.php';
-require WC_ABSPATH . 'includes/wc-page-functions.php';
-require WC_ABSPATH . 'includes/wc-product-functions.php';
-require WC_ABSPATH . 'includes/wc-stock-functions.php';
-require WC_ABSPATH . 'includes/wc-account-functions.php';
-require WC_ABSPATH . 'includes/wc-term-functions.php';
-require WC_ABSPATH . 'includes/wc-attribute-functions.php';
-require WC_ABSPATH . 'includes/wc-rest-functions.php';
-require WC_ABSPATH . 'includes/wc-widget-functions.php';
-require WC_ABSPATH . 'includes/wc-webhook-functions.php';
-
 /**
  * Filters on data used in admin and frontend.
  */


### PR DESCRIPTION
This is an experimental branch with the following changes:

- Classes which return an instance refactored to use singletons.
- Classes with hooks in constructor refactored to use method.
- Removed legacy autoloader code.
- Added composer autoloader.
- Removed hardcoded includes where possible.
- Refactored some methods so that code can run before the file is included.

Checkout and run the following to make it autoload correctly:

```bash
composer install
composer dump-autoload -o
```

This generates the map of classes. I'm not sure but I believe we'd need to build composer into the deploy process to include the autoloader script and run this command if we go this route.

Initally, only noticed a small perf increase, but the memory usage is notably lower in testing.

cc @claudiosanches @kloon 