### PR TITLE
Prevent a few structured data warnings on product catalog

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -203,16 +203,17 @@ class WC_Structured_Data {
 			'name'  => $product->get_name(),
 		);
 
+		$markup['image']       = wp_get_attachment_url( $product->get_image_id() );
+		$markup['description'] = wp_strip_all_tags( do_shortcode( $product->get_short_description() ? $product->get_short_description() : $product->get_description() ) );
+		$markup['sku']         = $product->get_sku();
+		$markup['brand']       = '';
+
 		if ( apply_filters( 'woocommerce_structured_data_product_limit', is_product_taxonomy() || is_shop() ) ) {
 			$markup['url'] = $permalink;
 
 			$this->set_data( apply_filters( 'woocommerce_structured_data_product_limited', $markup, $product ) );
 			return;
 		}
-
-		$markup['image']       = wp_get_attachment_url( $product->get_image_id() );
-		$markup['description'] = wp_strip_all_tags( do_shortcode( $product->get_short_description() ? $product->get_short_description() : $product->get_description() ) );
-		$markup['sku']         = $product->get_sku();
 
 		if ( '' !== $product->get_price() ) {
 			if ( $product->is_type( 'variable' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

This prevents warnings about 'image', 'description' and 'sku'.
'brand' included as empty fields just to register.

Note that warnings still comes for empty fields like 'sku' or 'brand'.
This is the message that should throw from Google Console:

> The brand field is recommended. Please provide a value if available.

Since is recommended, this PR should solve the max warnings as possible.

Closes #22842

### How to test the changes in this Pull Request:

1. Pull and check the HTML on https://search.google.com/structured-data/testing-tool/

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Included "image", "description", and "sku" to Structured Data on product's catalog.
