### PR TITLE
Remove whitespace characters from Select2 option title

### DIFF
--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -392,8 +392,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 											}
 
 										?>
-										>
-										<?php echo esc_html( $val ); ?></option>
+										><?php echo esc_html( $val ); ?></option>
 										<?php
 									}
 									?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Before:
![obraz](https://user-images.githubusercontent.com/2657856/53362249-0669e380-393a-11e9-8839-7934426fbc5d.png)

After:
![obraz](https://user-images.githubusercontent.com/2657856/53362270-0ec21e80-393a-11e9-8a80-d2b7c1dbf23e.png)

Select2 by default creates `title` attribute from options. In PHP there are some tabs, and Select2 displays them after leaving mouse over selected option.