### PR TITLE
shop_messages shortcode requires wc_print_notices

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -589,7 +589,7 @@ class WC_Shortcodes {
 	 */
 	public static function shop_messages() {
 		if ( ! function_exists( 'wc_print_notices' ) ) {
-			return;
+			return '';
 		}
 		return '<div class="woocommerce">' . wc_print_notices( true ) . '</div>';
 	}

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -588,6 +588,9 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function shop_messages() {
+		if ( ! function_exists( 'wc_print_notices' ) ) {
+			return;
+		}
 		return '<div class="woocommerce">' . wc_print_notices( true ) . '</div>';
 	}
 


### PR DESCRIPTION
Fix #22772

Before rendering the shortcode, check the function exists. Protects against early calls.