### PR TITLE
REST API: Add Blocks Products Controller

### DIFF
--- a/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
@@ -229,11 +229,16 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 	 */
 	protected function prepare_objects_query( $request ) {
 		$args = parent::prepare_objects_query( $request );
+		$operator_mapping = array(
+			'in'     => 'IN',
+			'not_in' => 'NOT IN',
+			'and'    => 'AND',
+		);
 
 		$orderby            = $request->get_param( 'orderby' );
 		$order              = $request->get_param( 'order' );
-		$cat_operator       = $request->get_param( 'cat_operator' );
-		$attr_operator      = $request->get_param( 'attr_operator' );
+		$category_operator  = $operator_mapping[ $request->get_param( 'category_operator' ) ];
+		$attribute_operator = $operator_mapping[ $request->get_param( 'attribute_operator' ) ];
 		$catalog_visibility = $request->get_param( 'catalog_visibility' );
 
 		$ordering_args   = WC()->query->get_catalog_ordering_args( $orderby, $order );
@@ -243,19 +248,19 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 			$args['meta_key'] = $ordering_args['meta_key']; // WPCS: slow query ok.
 		}
 
-		if ( $cat_operator && isset( $args['tax_query'] ) ) {
+		if ( $category_operator && isset( $args['tax_query'] ) ) {
 			foreach ( $args['tax_query'] as $i => $tax_query ) {
 				if ( 'product_cat' === $tax_query['taxonomy'] ) {
-					$args['tax_query'][ $i ]['operator']         = $cat_operator;
-					$args['tax_query'][ $i ]['include_children'] = 'AND' === $cat_operator ? false : true;
+					$args['tax_query'][ $i ]['operator']         = $category_operator;
+					$args['tax_query'][ $i ]['include_children'] = 'AND' === $category_operator ? false : true;
 				}
 			}
 		}
 
-		if ( $attr_operator && isset( $args['tax_query'] ) ) {
+		if ( $attribute_operator && isset( $args['tax_query'] ) ) {
 			foreach ( $args['tax_query'] as $i => $tax_query ) {
 				if ( in_array( $tax_query['taxonomy'], wc_get_attribute_taxonomy_names(), true ) ) {
-					$args['tax_query'][ $i ]['operator'] = $attr_operator;
+					$args['tax_query'][ $i ]['operator'] = $attribute_operator;
 				}
 			}
 		}
@@ -303,24 +308,26 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 	/**
 	 * Update the collection params.
 	 *
-	 * Adds new options for 'orderby', and new parameters 'cat_operator', 'attr_operator'.
+	 * Adds new options for 'orderby', and new parameters 'category_operator', 'attribute_operator'.
 	 *
 	 * @return array
 	 */
 	public function get_collection_params() {
 		$params                       = parent::get_collection_params();
 		$params['orderby']['enum']    = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating', 'menu_order' ) );
-		$params['cat_operator']       = array(
+		$params['category_operator']       = array(
 			'description'       => __( 'Operator to compare product category terms.', 'woocommerce' ),
 			'type'              => 'string',
-			'enum'              => array( 'IN', 'NOT IN', 'AND' ),
+			'enum'              => array( 'in', 'not_in', 'and' ),
+			'default'           => 'in',
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['attr_operator']      = array(
+		$params['attribute_operator']      = array(
 			'description'       => __( 'Operator to compare product attribute terms.', 'woocommerce' ),
 			'type'              => 'string',
-			'enum'              => array( 'IN', 'NOT IN', 'AND' ),
+			'enum'              => array( 'in', 'not_in', 'and' ),
+			'default'           => 'in',
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		);

--- a/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
@@ -49,7 +49,7 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 			array(
 				'args'   => array(
 					'id' => array(
-						'description' => __( 'Unique identifier for the resource.', 'woo-gutenberg-products-block' ),
+						'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
 						'type'        => 'integer',
 					),
 				),
@@ -78,7 +78,7 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 	 */
 	public function get_items_permissions_check( $request ) {
 		if ( ! current_user_can( 'edit_posts' ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woo-gutenberg-products-block' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -92,7 +92,7 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 	 */
 	public function get_item_permissions_check( $request ) {
 		if ( ! current_user_can( 'edit_posts' ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woo-gutenberg-products-block' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;
@@ -311,21 +311,21 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 		$params                       = parent::get_collection_params();
 		$params['orderby']['enum']    = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating', 'menu_order' ) );
 		$params['cat_operator']       = array(
-			'description'       => __( 'Operator to compare product category terms.', 'woo-gutenberg-products-block' ),
+			'description'       => __( 'Operator to compare product category terms.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array( 'IN', 'NOT IN', 'AND' ),
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['attr_operator']      = array(
-			'description'       => __( 'Operator to compare product attribute terms.', 'woo-gutenberg-products-block' ),
+			'description'       => __( 'Operator to compare product attribute terms.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array( 'IN', 'NOT IN', 'AND' ),
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['catalog_visibility'] = array(
-			'description'       => __( 'Determines if hidden or visible catalog products are shown.', 'woo-gutenberg-products-block' ),
+			'description'       => __( 'Determines if hidden or visible catalog products are shown.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array( 'visible', 'catalog', 'search', 'hidden' ),
 			'sanitize_callback' => 'sanitize_text_field',

--- a/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
@@ -228,7 +228,7 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 	 * @return array
 	 */
 	protected function prepare_objects_query( $request ) {
-		$args = parent::prepare_objects_query( $request );
+		$args             = parent::prepare_objects_query( $request );
 		$operator_mapping = array(
 			'in'     => 'IN',
 			'not_in' => 'NOT IN',
@@ -315,27 +315,27 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 	public function get_collection_params() {
 		$params                       = parent::get_collection_params();
 		$params['orderby']['enum']    = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating', 'menu_order' ) );
-		$params['category_operator']       = array(
+		$params['category_operator']  = array(
 			'description'       => __( 'Operator to compare product category terms.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array( 'in', 'not_in', 'and' ),
 			'default'           => 'in',
-			'sanitize_callback' => 'sanitize_text_field',
+			'sanitize_callback' => 'sanitize_key',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['attribute_operator']      = array(
+		$params['attribute_operator'] = array(
 			'description'       => __( 'Operator to compare product attribute terms.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array( 'in', 'not_in', 'and' ),
 			'default'           => 'in',
-			'sanitize_callback' => 'sanitize_text_field',
+			'sanitize_callback' => 'sanitize_key',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['catalog_visibility'] = array(
 			'description'       => __( 'Determines if hidden or visible catalog products are shown.', 'woocommerce' ),
 			'type'              => 'string',
 			'enum'              => array( 'visible', 'catalog', 'search', 'hidden' ),
-			'sanitize_callback' => 'sanitize_text_field',
+			'sanitize_callback' => 'sanitize_key',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
 

--- a/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
@@ -1,0 +1,379 @@
+<?php
+/**
+ * REST API Products controller customized for Products Block.
+ *
+ * Handles requests to the /products endpoint.
+ *
+ * @package WooCommerce\Blocks\Products\Rest\Controller
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * REST API Products controller class.
+ *
+ * @package WooCommerce/API
+ */
+class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
+
+	/**
+	 * Endpoint namespace.
+	 *
+	 * @var string
+	 */
+	protected $namespace = 'wc-blocks/v1';
+
+	/**
+	 * Register the routes for products.
+	 */
+	public function register_routes() {
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the resource.', 'woo-gutenberg-products-block' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param(
+							array(
+								'default' => 'view',
+							)
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+	}
+
+	/**
+	 * Check if a given request has access to read items.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_items_permissions_check( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woo-gutenberg-products-block' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Check if a given request has access to read an item.
+	 *
+	 * @param  WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|boolean
+	 */
+	public function get_item_permissions_check( $request ) {
+		if ( ! current_user_can( 'edit_posts' ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot view this resource.', 'woo-gutenberg-products-block' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Get a collection of posts.
+	 *
+	 * @param WP_REST_Request $request Full details about the request.
+	 * @return WP_Error|WP_REST_Response
+	 */
+	public function get_items( $request ) {
+		$query_args    = $this->prepare_objects_query( $request );
+		$query_results = $this->get_objects( $query_args );
+
+		$objects = array();
+		foreach ( $query_results['objects'] as $object ) {
+			$data      = $this->prepare_object_for_response( $object, $request );
+			$objects[] = $this->prepare_response_for_collection( $data );
+		}
+
+		$page      = (int) $query_args['paged'];
+		$max_pages = $query_results['pages'];
+
+		$response = rest_ensure_response( $objects );
+		$response->header( 'X-WP-Total', $query_results['total'] );
+		$response->header( 'X-WP-TotalPages', (int) $max_pages );
+
+		$base          = $this->rest_base;
+		$attrib_prefix = '(?P<';
+		if ( strpos( $base, $attrib_prefix ) !== false ) {
+			$attrib_names = array();
+			preg_match( '/\(\?P<[^>]+>.*\)/', $base, $attrib_names, PREG_OFFSET_CAPTURE );
+			foreach ( $attrib_names as $attrib_name_match ) {
+				$beginning_offset = strlen( $attrib_prefix );
+				$attrib_name_end  = strpos( $attrib_name_match[0], '>', $attrib_name_match[1] );
+				$attrib_name      = substr( $attrib_name_match[0], $beginning_offset, $attrib_name_end - $beginning_offset );
+				if ( isset( $request[ $attrib_name ] ) ) {
+					$base = str_replace( "(?P<$attrib_name>[\d]+)", $request[ $attrib_name ], $base );
+				}
+			}
+		}
+		$base = add_query_arg( $request->get_query_params(), rest_url( sprintf( '/%s/%s', $this->namespace, $base ) ) );
+
+		if ( $page > 1 ) {
+			$prev_page = $page - 1;
+			if ( $prev_page > $max_pages ) {
+				$prev_page = $max_pages;
+			}
+			$prev_link = add_query_arg( 'page', $prev_page, $base );
+			$response->link_header( 'prev', $prev_link );
+		}
+		if ( $max_pages > $page ) {
+			$next_page = $page + 1;
+			$next_link = add_query_arg( 'page', $next_page, $base );
+			$response->link_header( 'next', $next_link );
+		}
+
+		return $response;
+	}
+
+	/**
+	 * Get the images for a product or product variation.
+	 *
+	 * @param WC_Product|WC_Product_Variation $product Product instance.
+	 * @return array
+	 */
+	protected function get_images( $product ) {
+		$images         = array();
+		$attachment_ids = array();
+
+		// Add featured image.
+		if ( has_post_thumbnail( $product->get_id() ) ) {
+			$attachment_ids[] = $product->get_image_id();
+		}
+
+		// Add gallery images.
+		$attachment_ids = array_merge( $attachment_ids, $product->get_gallery_image_ids() );
+
+		// Build image data.
+		foreach ( $attachment_ids as $attachment_id ) {
+			$attachment_post = get_post( $attachment_id );
+			if ( is_null( $attachment_post ) ) {
+				continue;
+			}
+
+			$attachment = wp_get_attachment_image_src( $attachment_id, 'full' );
+			if ( ! is_array( $attachment ) ) {
+				continue;
+			}
+
+			$images[] = array(
+				'id'   => (int) $attachment_id,
+				'src'  => current( $attachment ),
+				'name' => get_the_title( $attachment_id ),
+				'alt'  => get_post_meta( $attachment_id, '_wp_attachment_image_alt', true ),
+			);
+		}
+
+		return $images;
+	}
+
+	/**
+	 * Prepare a single product output for response.
+	 *
+	 * @deprecated 3.0.0
+	 *
+	 * @param WP_Post         $post    Post object.
+	 * @param WP_REST_Request $request Request object.
+	 * @return WP_REST_Response
+	 */
+	public function prepare_item_for_response( $post, $request ) {
+		$product = wc_get_product( $post );
+		$data    = $this->get_product_data( $product );
+
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = $this->add_additional_fields_to_object( $data, $request );
+		$data    = $this->filter_response_by_context( $data, $context );
+
+		// Wrap the data in a response object.
+		$response = rest_ensure_response( $data );
+
+		$response->add_links( $this->prepare_links( $product, $request ) );
+
+		return $response;
+	}
+
+	/**
+	 * Make extra product orderby features supported by WooCommerce available to the WC API.
+	 * This includes 'price', 'popularity', and 'rating'.
+	 *
+	 * @param WP_REST_Request $request Request data.
+	 * @return array
+	 */
+	protected function prepare_objects_query( $request ) {
+		$args = parent::prepare_objects_query( $request );
+
+		$orderby            = $request->get_param( 'orderby' );
+		$order              = $request->get_param( 'order' );
+		$cat_operator       = $request->get_param( 'cat_operator' );
+		$attr_operator      = $request->get_param( 'attr_operator' );
+		$catalog_visibility = $request->get_param( 'catalog_visibility' );
+
+		$ordering_args   = WC()->query->get_catalog_ordering_args( $orderby, $order );
+		$args['orderby'] = $ordering_args['orderby'];
+		$args['order']   = $ordering_args['order'];
+		if ( $ordering_args['meta_key'] ) {
+			$args['meta_key'] = $ordering_args['meta_key']; // WPCS: slow query ok.
+		}
+
+		if ( $cat_operator && isset( $args['tax_query'] ) ) {
+			foreach ( $args['tax_query'] as $i => $tax_query ) {
+				if ( 'product_cat' === $tax_query['taxonomy'] ) {
+					$args['tax_query'][ $i ]['operator']         = $cat_operator;
+					$args['tax_query'][ $i ]['include_children'] = 'AND' === $cat_operator ? false : true;
+				}
+			}
+		}
+
+		if ( $attr_operator && isset( $args['tax_query'] ) ) {
+			foreach ( $args['tax_query'] as $i => $tax_query ) {
+				if ( in_array( $tax_query['taxonomy'], wc_get_attribute_taxonomy_names(), true ) ) {
+					$args['tax_query'][ $i ]['operator'] = $attr_operator;
+				}
+			}
+		}
+
+		if ( in_array( $catalog_visibility, array_keys( wc_get_product_visibility_options() ), true ) ) {
+			$exclude_from_catalog = 'search' === $catalog_visibility ? '' : 'exclude-from-catalog';
+			$exclude_from_search  = 'catalog' === $catalog_visibility ? '' : 'exclude-from-search';
+
+			$args['tax_query'][] = array(
+				'taxonomy' => 'product_visibility',
+				'field'    => 'name',
+				'terms'    => array( $exclude_from_catalog, $exclude_from_search ),
+				'operator' => 'hidden' === $catalog_visibility ? 'AND' : 'NOT IN',
+			);
+		}
+
+		return $args;
+	}
+
+	/**
+	 * Get product data.
+	 *
+	 * @param WC_Product $product Product instance.
+	 * @param string     $context Request context.
+	 *                            Options: 'view' and 'edit'.
+	 * @return array
+	 */
+	protected function get_product_data( $product, $context = 'view' ) {
+		$raw_data = parent::get_product_data( $product, $context );
+		$data     = array();
+
+		$data['id']                = $raw_data['id'];
+		$data['name']              = $raw_data['name'];
+		$data['permalink']         = $raw_data['permalink'];
+		$data['sku']               = $raw_data['sku'];
+		$data['description']       = $raw_data['description'];
+		$data['short_description'] = $raw_data['short_description'];
+		$data['price']             = $raw_data['price'];
+		$data['price_html']        = $raw_data['price_html'];
+		$data['images']            = $raw_data['images'];
+
+		return $data;
+	}
+
+	/**
+	 * Update the collection params.
+	 *
+	 * Adds new options for 'orderby', and new parameters 'cat_operator', 'attr_operator'.
+	 *
+	 * @return array
+	 */
+	public function get_collection_params() {
+		$params                       = parent::get_collection_params();
+		$params['orderby']['enum']    = array_merge( $params['orderby']['enum'], array( 'price', 'popularity', 'rating', 'menu_order' ) );
+		$params['cat_operator']       = array(
+			'description'       => __( 'Operator to compare product category terms.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'enum'              => array( 'IN', 'NOT IN', 'AND' ),
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['attr_operator']      = array(
+			'description'       => __( 'Operator to compare product attribute terms.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'enum'              => array( 'IN', 'NOT IN', 'AND' ),
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['catalog_visibility'] = array(
+			'description'       => __( 'Determines if hidden or visible catalog products are shown.', 'woo-gutenberg-products-block' ),
+			'type'              => 'string',
+			'enum'              => array( 'visible', 'catalog', 'search', 'hidden' ),
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+
+		return $params;
+	}
+
+	/**
+	 * Get the Product's schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$raw_schema = parent::get_item_schema();
+		$schema     = array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'product_block_product',
+			'type'       => 'object',
+			'properties' => array(),
+		);
+
+		$schema['properties']['id']                = $raw_schema['properties']['id'];
+		$schema['properties']['name']              = $raw_schema['properties']['name'];
+		$schema['properties']['permalink']         = $raw_schema['properties']['permalink'];
+		$schema['properties']['sku']               = $raw_schema['properties']['sku'];
+		$schema['properties']['description']       = $raw_schema['properties']['description'];
+		$schema['properties']['short_description'] = $raw_schema['properties']['short_description'];
+		$schema['properties']['price']             = $raw_schema['properties']['price'];
+		$schema['properties']['price_html']        = $raw_schema['properties']['price_html'];
+		$schema['properties']['images']            = array(
+			'description' => $raw_schema['properties']['images']['description'],
+			'type'        => 'object',
+			'context'     => array( 'view', 'edit' ),
+			'items'       => array(
+				'type'       => 'object',
+				'properties' => array(),
+			),
+		);
+
+		$images_schema = $raw_schema['properties']['images']['items']['properties'];
+
+		$schema['properties']['images']['items']['properties']['id']   = $images_schema['id'];
+		$schema['properties']['images']['items']['properties']['src']  = $images_schema['src'];
+		$schema['properties']['images']['items']['properties']['name'] = $images_schema['name'];
+		$schema['properties']['images']['items']['properties']['alt']  = $images_schema['alt'];
+
+		return $this->add_additional_fields_schema( $schema );
+	}
+}

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -239,6 +239,7 @@ class WC_API extends WC_Legacy_API {
 		// Blocks REST API V1 controllers.
 		include_once dirname( __FILE__ ) . '/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php';
 		include_once dirname( __FILE__ ) . '/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php';
+		include_once dirname( __FILE__ ) . '/api/wc-blocks/class-wc-rest-blocks-products-controller.php';
 	}
 
 	/**
@@ -350,6 +351,7 @@ class WC_API extends WC_Legacy_API {
 			// Blocks REST API v1 Controllers.
 			'WC_REST_Blocks_Product_Attribute_Terms_Controller',
 			'WC_REST_Blocks_Product_Categories_Controller',
+			'WC_REST_Blocks_Products_Controller',
 		);
 
 		foreach ( $controllers as $controller ) {

--- a/tests/unit-tests/api/wc-blocks/products.php
+++ b/tests/unit-tests/api/wc-blocks/products.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * @package WooCommerce\Tests\API
+ */
+
+/**
+ * Blocks Product Controller REST API Test
+ *
+ * @since 3.6.0
+ */
+class WC_Tests_API_Products_Controller extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Endpoints.
+	 *
+	 * @var string
+	 */
+	protected $endpoint = '/wc-blocks/v1';
+
+	/**
+	 * Setup test products data. Called before every test.
+	 *
+	 * @since 1.2.0
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->user        = $this->factory->user->create(
+			array(
+				'role' => 'author',
+			)
+		);
+		$this->contributor = $this->factory->user->create(
+			array(
+				'role' => 'contributor',
+			)
+		);
+		$this->subscriber  = $this->factory->user->create(
+			array(
+				'role' => 'subscriber',
+			)
+		);
+	}
+
+	/**
+	 * Test route registration.
+	 *
+	 * @since 1.2.0
+	 */
+	public function test_register_routes() {
+		$routes = $this->server->get_routes();
+
+		$this->assertArrayHasKey( '/wc-blocks/v1/products', $routes );
+		$this->assertArrayHasKey( '/wc-blocks/v1/products/(?P<id>[\d]+)', $routes );
+	}
+
+	/**
+	 * Test getting products.
+	 *
+	 * @since 1.2.0
+	 */
+	public function test_get_products() {
+		wp_set_current_user( $this->user );
+		WC_Helper_Product::create_external_product();
+		sleep( 1 ); // So both products have different timestamps.
+		$product  = WC_Helper_Product::create_simple_product();
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc-blocks/v1/products' ) );
+		$products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertEquals( 2, count( $products ) );
+		$this->assertEquals( 'Dummy Product', $products[0]['name'] );
+		$this->assertEquals( 'DUMMY SKU', $products[0]['sku'] );
+		$this->assertEquals( 'Dummy External Product', $products[1]['name'] );
+		$this->assertEquals( 'DUMMY EXTERNAL SKU', $products[1]['sku'] );
+	}
+
+	/**
+	 * Test getting products as an contributor.
+	 *
+	 * @since 1.2.0
+	 */
+	public function test_get_products_as_contributor() {
+		wp_set_current_user( $this->contributor );
+		WC_Helper_Product::create_simple_product();
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc-blocks/v1/products' ) );
+		$this->assertEquals( 200, $response->get_status() );
+	}
+
+	/**
+	 * Test getting products as an subscriber.
+	 *
+	 * @since 1.2.0
+	 */
+	public function test_get_products_as_subscriber() {
+		wp_set_current_user( $this->subscriber );
+		WC_Helper_Product::create_simple_product();
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc-blocks/v1/products' ) );
+		$this->assertEquals( 403, $response->get_status() );
+	}
+
+	/**
+	 * Test getting products with custom ordering.
+	 *
+	 * @since 1.2.0
+	 */
+	public function test_get_products_order_by_price() {
+		wp_set_current_user( $this->user );
+		WC_Helper_Product::create_external_product();
+		sleep( 1 ); // So both products have different timestamps.
+		$product = WC_Helper_Product::create_simple_product( false ); // Prevent saving, since we save here.
+		// Customize the price, otherwise both are 10.
+		$product->set_props(
+			array(
+				'regular_price' => 15,
+				'price'         => 15,
+			)
+		);
+		$product->save();
+
+		$request = new WP_REST_Request( 'GET', '/wc-blocks/v1/products' );
+		$request->set_param( 'orderby', 'price' );
+		$request->set_param( 'order', 'asc' );
+		$response = $this->server->dispatch( $request );
+		$products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $products ) );
+
+		// The external product should be first, then the simple product.
+		$this->assertEquals( 'Dummy External Product', $products[0]['name'] );
+		$this->assertEquals( 'Dummy Product', $products[1]['name'] );
+		$this->assertEquals( '10', $products[0]['price'] );
+		$this->assertEquals( '15', $products[1]['price'] );
+	}
+
+	/**
+	 * Test product_visibility queries.
+	 *
+	 * @since 1.3.1
+	 */
+	public function test_product_visibility() {
+		wp_set_current_user( $this->user );
+		$visible_product = WC_Helper_Product::create_simple_product();
+		$visible_product->set_name( 'Visible Product' );
+		$visible_product->set_catalog_visibility( 'visible' );
+		$visible_product->save();
+
+		$catalog_product = WC_Helper_Product::create_simple_product();
+		$catalog_product->set_name( 'Catalog Product' );
+		$catalog_product->set_catalog_visibility( 'catalog' );
+		$catalog_product->save();
+
+		$search_product = WC_Helper_Product::create_simple_product();
+		$search_product->set_name( 'Search Product' );
+		$search_product->set_catalog_visibility( 'search' );
+		$search_product->save();
+
+		$hidden_product = WC_Helper_Product::create_simple_product();
+		$hidden_product->set_name( 'Hidden Product' );
+		$hidden_product->set_catalog_visibility( 'hidden' );
+		$hidden_product->save();
+
+		$query_params = array(
+			'catalog_visibility' => 'visible',
+		);
+		$request      = new WP_REST_REQUEST( 'GET', '/wc-blocks/v1/products' );
+		$request->set_query_params( $query_params );
+		$response = $this->server->dispatch( $request );
+		$products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $products ) );
+		$this->assertEquals( 'Visible Product', $products[0]['name'] );
+
+		$query_params = array(
+			'catalog_visibility' => 'catalog',
+			'orderby'            => 'id',
+			'order'              => 'asc',
+		);
+		$request      = new WP_REST_REQUEST( 'GET', '/wc-blocks/v1/products' );
+		$request->set_query_params( $query_params );
+		$response = $this->server->dispatch( $request );
+		$products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $products ) );
+		$this->assertEquals( 'Visible Product', $products[0]['name'] );
+		$this->assertEquals( 'Catalog Product', $products[1]['name'] );
+
+		$query_params = array(
+			'catalog_visibility' => 'search',
+			'orderby'            => 'id',
+			'order'              => 'asc',
+		);
+		$request      = new WP_REST_REQUEST( 'GET', '/wc-blocks/v1/products' );
+		$request->set_query_params( $query_params );
+		$response = $this->server->dispatch( $request );
+		$products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 2, count( $products ) );
+		$this->assertEquals( 'Visible Product', $products[0]['name'] );
+		$this->assertEquals( 'Search Product', $products[1]['name'] );
+
+		$query_params = array(
+			'catalog_visibility' => 'hidden',
+		);
+		$request      = new WP_REST_REQUEST( 'GET', '/wc-blocks/v1/products' );
+		$request->set_query_params( $query_params );
+		$response = $this->server->dispatch( $request );
+		$products = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( 1, count( $products ) );
+		$this->assertEquals( 'Hidden Product', $products[0]['name'] );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

See #22809 for more background - this branch builds upon what was added there and includes support for the `wc-blocks/v1/products` endpoint.

### How to test the changes in this Pull Request:

1. You can use Postman to make requests to `wc-blocks/v1/products`
2. and/or run `phpunit tests/unit-tests/api/wc-blocks/products.php`

### Other information:

For https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/426

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

Adds new `wc-blocks/v1` endpoint for getting product info for use in Woo Blocks
