### PR TITLE
Tracks: Add store setup event in OBW

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -76,11 +76,13 @@ class WC_Site_Tracking {
 
 		self::enqueue_scripts();
 
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-admin-setup-wizard-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-extensions-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-importer-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-products-tracking.php';
 
 		$tracking_classes = array(
+			'WC_Admin_Setup_Wizard_Tracking',
 			'WC_Extensions_Tracking',
 			'WC_Importer_Tracking',
 			'WC_Products_Tracking',

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * WooCommerce Admin Setup Wizard Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of the WooCommerce Onboarding Wizard.
+ */
+class WC_Admin_Setup_Wizard_Tracking {
+	/**
+	 * Init tracking.
+	 */
+	public static function init() {
+		if ( empty( $_GET['page'] ) || 'wc-setup' !== $_GET['page'] ) { // WPCS: CSRF ok, input var ok.
+			return;
+		}
+
+		add_action( 'admin_init', array( __CLASS__, 'track_store_setup' ), 1 );
+	}
+
+	/**
+	 * Track store setup and store properties on save.
+	 *
+	 * @return void
+	 */
+	public static function track_store_setup() {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
+		$properties = array(
+			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',
+			'currency_code'  => isset( $_POST['currency_code'] ) ? sanitize_text_field( $_POST['currency_code'] ) : '',
+			'product_type'   => isset( $_POST['product_type'] ) ? sanitize_text_field( $_POST['product_type'] ) : '',
+			'sell_in_person' => isset( $_POST['sell_in_person'] ) && ( 'yes' === sanitize_text_field( $_POST['sell_in_person'] ) ),
+		);
+		// phpcs:enable
+
+		WC_Tracks::record_event( 'obw_store_setup', $properties );
+	}
+}

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -23,11 +23,33 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
+	 * Check if a step is being saved by step name.
+	 *
+	 * @param string $step_name Step name.
+	 * @return bool
+	 */
+	public static function is_saving_step( $step_name ) {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
+		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
+			return true;
+		}
+		// phpcs:enable
+
+		return false;
+	}
+
+	/**
 	 * Track store setup and store properties on save.
 	 *
 	 * @return void
 	 */
 	public static function track_store_setup() {
+		// First step name is blank.
+		if ( ! self::is_saving_step( '' ) ) {
+			return;
+		}
+
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -19,17 +19,24 @@ class WC_Admin_Setup_Wizard_Tracking {
 			return;
 		}
 
-		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
-		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
-		if ( ! empty( $_POST['save_step'] ) ) {
-			switch ( $current_step ) {
-				case '':
-				case 'store_setup':
-					add_action( 'admin_init', array( __CLASS__, 'track_store_setup' ), 1 );
-					break;
-			}
+		self::add_step_save_events();
+	}
+
+	/**
+	 * Track various events when a step is saved.
+	 */
+	public static function add_step_save_events() {
+		if ( empty( $_POST['save_step'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+			return;
 		}
-		// phpcs:enable
+
+		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		switch ( $current_step ) {
+			case '':
+			case 'store_setup':
+				add_action( 'admin_init', array( __CLASS__, 'track_store_setup' ), 1 );
+				break;
+		}
 	}
 
 	/**

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -19,24 +19,17 @@ class WC_Admin_Setup_Wizard_Tracking {
 			return;
 		}
 
-		add_action( 'admin_init', array( __CLASS__, 'track_store_setup' ), 1 );
-	}
-
-	/**
-	 * Check if a step is being saved by step name.
-	 *
-	 * @param string $step_name Step name.
-	 * @return bool
-	 */
-	public static function is_saving_step( $step_name ) {
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
 		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
-		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
-			return true;
+		if ( ! empty( $_POST['save_step'] ) ) {
+			switch ( $current_step ) {
+				case '':
+				case 'store_setup':
+					add_action( 'admin_init', array( __CLASS__, 'track_store_setup' ), 1 );
+					break;
+			}
 		}
 		// phpcs:enable
-
-		return false;
 	}
 
 	/**
@@ -45,11 +38,6 @@ class WC_Admin_Setup_Wizard_Tracking {
 	 * @return void
 	 */
 	public static function track_store_setup() {
-		// First step name is blank.
-		if ( ! self::is_saving_step( '' ) ) {
-			return;
-		}
-
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Tracks country, currency, product types sold, and whether or not store owner will sell in person.

### How to test the changes in this Pull Request:

1.  Go to the first step in the OBW `/wp-admin/admin.php?page=wc-setup`
2.  Fill out the step and click "Let's Go" to proceed to the next step.
3.  Check that the event was tracked and contains the country, currency, product type, and sold in person vars.