### PR TITLE
Refactor delete zone/delete zone method data store to remove settings

### DIFF
--- a/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -112,17 +112,31 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 	 * @return void
 	 */
 	public function delete( &$zone, $args = array() ) {
-		if ( $zone->get_id() ) {
+		$zone_id = $zone->get_id();
+
+		if ( $zone_id ) {
 			global $wpdb;
-			$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zone_methods', array( 'zone_id' => $zone->get_id() ) );
-			$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zone_locations', array( 'zone_id' => $zone->get_id() ) );
-			$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zones', array( 'zone_id' => $zone->get_id() ) );
-			WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
-			$id = $zone->get_id();
+
+			// Delete methods and their settings.
+			$methods = $this->get_methods( $zone_id, false );
+
+			if ( $methods ) {
+				foreach ( $methods as $method ) {
+					$this->delete_method( $method->instance_id );
+				}
+			}
+
+			// Delete zone.
+			$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zone_locations', array( 'zone_id' => $zone_id ) );
+			$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zones', array( 'zone_id' => $zone_id ) );
+
 			$zone->set_id( null );
+
+			WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
 			WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
 			WC_Cache_Helper::get_transient_version( 'shipping', true );
-			do_action( 'woocommerce_delete_shipping_zone', $id );
+
+			do_action( 'woocommerce_delete_shipping_zone', $zone_id );
 		}
 	}
 
@@ -193,7 +207,17 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 	 */
 	public function delete_method( $instance_id ) {
 		global $wpdb;
+
+		$method = $this->get_method( $instance_id );
+
+		if ( ! $method ) {
+			return;
+		}
+
+		delete_option( 'woocommerce_' . $method->method_id . '_' . $instance_id . '_settings' );
+
 		$wpdb->delete( $wpdb->prefix . 'woocommerce_shipping_zone_methods', array( 'instance_id' => $instance_id ) );
+
 		do_action( 'woocommerce_delete_shipping_zone_method', $instance_id );
 	}
 

--- a/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -133,7 +133,6 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 			$zone->set_id( null );
 
 			WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
-			WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
 			WC_Cache_Helper::get_transient_version( 'shipping', true );
 
 			do_action( 'woocommerce_delete_shipping_zone', $zone_id );


### PR DESCRIPTION
Fixes #22838

When deleting a zone method, delete the settings in the format `woocommerce_methodname_instanceid_settings`.

Also, when deleting a zone, delete each method individually so that new logic happens.

To test, create a zone with a few shipping methods. Each method needs to be saved so the settings are populated.

Look in the database options table for the settings, e.g. `woocommerce_local_pickup_2_settings`

Delete the zone.

Confirm the settings are removed.

> When deleting zone methods, also remove setting options.