### PR TITLE
Get insert ID before running actions

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -882,11 +882,13 @@ class WC_Tax {
 
 		$wpdb->insert( $wpdb->prefix . 'woocommerce_tax_rates', self::prepare_tax_rate( $tax_rate ) );
 
+		$tax_rate_id = $wpdb->insert_id;
+
 		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
 
-		do_action( 'woocommerce_tax_rate_added', $wpdb->insert_id, $tax_rate );
+		do_action( 'woocommerce_tax_rate_added', $tax_rate_id, $tax_rate );
 
-		return $wpdb->insert_id;
+		return $tax_rate_id;
 	}
 
 	/**


### PR DESCRIPTION
'_insert_tax_rate' ran some actions before getting the ID from $wpdb. If any insert is done in that action, the returned ID will be wrong. 

Jetpack (possibly sync) made this occur.

Fixes #22743