### PR TITLE
Add/marketplace suggestions wccom endpoint

### DIFF
--- a/assets/js/admin/marketplace-suggestions.js
+++ b/assets/js/admin/marketplace-suggestions.js
@@ -248,18 +248,18 @@
 
 			// hide promos for things the user already has installed
 			promos = _.filter( promos, function( promo ) {
-				return ! _.contains( marketplace_suggestions.active_plugins, promo['hide-if-installed'] );
+				return ! _.contains( marketplace_suggestions.active_plugins, promo['hide-if-active'] );
 			} );
 
 			// hide promos that are not applicable based on user's installed extensions
 			promos = _.filter( promos, function( promo ) {
-				if ( ! promo['show-if-installed'] ) {
+				if ( ! promo['show-if-active'] ) {
 					// this promotion is relevant to all
 					return true;
 				}
 
 				// if the user has any of the prerequisites, show the promo
-				return ( _.intersection( marketplace_suggestions.active_plugins, promo['show-if-installed'] ).length > 0 );
+				return ( _.intersection( marketplace_suggestions.active_plugins, promo['show-if-active'] ).length > 0 );
 			} );
 
 			return promos;

--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -49,7 +49,7 @@ class WC_Marketplace_Updater {
 
 		$data['updated'] = time();
 
-		$url     = 'https://d3t0oesq8995hv.cloudfront.net/add-ons/marketplace-suggestions.json';
+		$url     = 'https://woocommerce.com/wp-json/wccom/marketplace-suggestions/v1.0/suggestions';
 		$request = wp_safe_remote_get( $url );
 
 		if ( is_wp_error( $request ) ) {

--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -49,7 +49,7 @@ class WC_Marketplace_Updater {
 
 		$data['updated'] = time();
 
-		$url     = 'https://woocommerce.com/wp-json/wccom/marketplace-suggestions/v1.0/suggestions';
+		$url     = 'https://woocommerce.com/wp-json/wccom/marketplace-suggestions/1.0/suggestions.json';
 		$request = wp_safe_remote_get( $url );
 
 		if ( is_wp_error( $request ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Updates the url used for pulling Marketplace Suggestions data, and fixes js code to match a change to the format (`*-if-installed` => `*-if-active`).

### How to test the changes in this Pull Request:

1. Ensure you have the WCCOM endpoint running somewhere (local, staging, or production), accessible to your woo core dev environment.
2. Get woo core dev environment up and running this branch.
3. If necessary, set the URL to point at the WCCOM endpoint you're testing (e.g. hostname of your WCCOM from step 1), or hack `hosts` file as needed.
4. Delete any previously cached suggestion data `wp --allow-root option delete woocommerce_marketplace_suggestions`.
5. Wait a week or so, or manually add an update job using `wp shell`:
    - `$queue = WC()->queue();`
    - `$queue->add( 'woocommerce_update_marketplace_suggestions' );`
6. Ensure the job gets run, e.g. `wp --allow-root cron event run action_scheduler_run_queue`.
7. Check that suggestions are displayed and work correctly, in particular, `show-if-active` and `hide-if-active` logic.
