### PR TITLE
Tracks: Add selected payment gateways in OBW

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1544,7 +1544,7 @@ class WC_Admin_Setup_Wizard {
 	 *
 	 * @return array
 	 */
-	protected function get_wizard_manual_payment_gateways() {
+	public function get_wizard_manual_payment_gateways() {
 		$gateways = array(
 			'cheque' => array(
 				'name'        => _x( 'Check payments', 'Check payment method', 'woocommerce' ),

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -40,11 +40,33 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
+	 * Check if a step is being saved by step name.
+	 *
+	 * @param string $step_name Step name.
+	 * @return bool
+	 */
+	public static function is_saving_step( $step_name ) {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
+		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
+			return true;
+		}
+		// phpcs:enable
+
+		return false;
+	}
+
+	/**
 	 * Track store setup and store properties on save.
 	 *
 	 * @return void
 	 */
 	public static function track_store_setup() {
+		// First step name is blank.
+		if ( ! self::is_saving_step( '' ) ) {
+			return;
+		}
+
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -40,33 +40,11 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
-	 * Check if a step is being saved by step name.
-	 *
-	 * @param string $step_name Step name.
-	 * @return bool
-	 */
-	public static function is_saving_step( $step_name ) {
-		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
-		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
-		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
-			return true;
-		}
-		// phpcs:enable
-
-		return false;
-	}
-
-	/**
 	 * Track store setup and store properties on save.
 	 *
 	 * @return void
 	 */
 	public static function track_store_setup() {
-		// First step name is blank.
-		if ( ! self::is_saving_step( '' ) ) {
-			return;
-		}
-
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -94,8 +94,8 @@ class WC_Admin_Setup_Wizard_Tracking {
 
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
-			'selected_gateways' => $selected_gateways,
-			'created_accounts'  => $created_accounts,
+			'selected_gateways' => implode( ', ', $selected_gateways ),
+			'created_accounts'  => implode( ', ', $created_accounts ),
 		);
 		// phpcs:enable
 

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -36,6 +36,9 @@ class WC_Admin_Setup_Wizard_Tracking {
 			case 'store_setup':
 				add_action( 'admin_init', array( __CLASS__, 'track_store_setup' ), 1 );
 				break;
+			case 'payment':
+				add_action( 'admin_init', array( __CLASS__, 'track_payments' ), 1 );
+				break;
 		}
 	}
 
@@ -55,5 +58,47 @@ class WC_Admin_Setup_Wizard_Tracking {
 		// phpcs:enable
 
 		WC_Tracks::record_event( 'obw_store_setup', $properties );
+	}
+
+	/**
+	 * Track payment gateways selected.
+	 *
+	 * @return void
+	 */
+	public static function track_payments() {
+		$selected_gateways     = array();
+		$created_accounts      = array();
+		$wc_admin_setup_wizard = new WC_Admin_Setup_Wizard();
+		$gateways              = array_merge( $wc_admin_setup_wizard->get_wizard_in_cart_payment_gateways(), $wc_admin_setup_wizard->get_wizard_manual_payment_gateways() );
+
+		foreach ( $gateways as $gateway_id => $gateway ) {
+			if ( ! empty( $_POST[ 'wc-wizard-service-' . $gateway_id . '-enabled' ] ) ) { // WPCS: CSRF ok, input var ok.
+				$selected_gateways[] = $gateway_id;
+			}
+		}
+
+		// Stripe account being created.
+		if (
+			! empty( $_POST['wc-wizard-service-stripe-enabled'] ) && // WPCS: CSRF ok, input var ok.
+			! empty( $_POST['stripe_create_account'] ) // WPCS: CSRF ok, input var ok.
+		) {
+			$created_accounts[] = 'stripe';
+		}
+		// PayPal account being created.
+		if (
+			! empty( $_POST['wc-wizard-service-ppec_paypal-enabled'] ) && // WPCS: CSRF ok, input var ok.
+			! empty( $_POST['ppec_paypal_reroute_requests'] ) // WPCS: CSRF ok, input var ok.
+		) {
+			$created_accounts[] = 'ppec_paypal';
+		}
+
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
+		$properties = array(
+			'selected_gateways' => $selected_gateways,
+			'created_accounts'  => $created_accounts,
+		);
+		// phpcs:enable
+
+		WC_Tracks::record_event( 'obw_payments', $properties );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds tracking for selected payment gateways and created accounts for Stripe and Paypal.

### How to test the changes in this Pull Request:

1.  Go to the payments step in the OBW `wp-admin/admin.php?page=wc-setup&step=payment`.
2.  Selected various payment gateways and/or check the boxes to create accounts with Stripe or PayPal.
3.  Click "Continue" to go to the next step.
4.  Check that the event is recorded with selected gateways and created accounts.

<img width="669" alt="screen shot 2019-02-27 at 2 00 08 pm" src="https://user-images.githubusercontent.com/10561050/53469233-1ef01000-3a98-11e9-8dfb-abe662807b13.png">

