### PR TITLE
Tracks: Add tracking for shipping units and labels

### DIFF
--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -39,6 +39,9 @@ class WC_Admin_Setup_Wizard_Tracking {
 			case 'payment':
 				add_action( 'admin_init', array( __CLASS__, 'track_payments' ), 1 );
 				break;
+			case 'shipping':
+				add_action( 'admin_init', array( __CLASS__, 'track_shipping' ), 1 );
+				break;
 		}
 	}
 
@@ -101,4 +104,24 @@ class WC_Admin_Setup_Wizard_Tracking {
 
 		WC_Tracks::record_event( 'obw_payments', $properties );
 	}
+
+	/**
+	 * Track shipping units and whether or not labels are set.
+	 *
+	 * @return void
+	 */
+	public static function track_shipping() {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
+		$properties = array(
+			'weight_unit'       => isset( $_POST['weight_unit'] ) ? sanitize_text_field( wp_unslash( $_POST['weight_unit'] ) ) : '',
+			'dimension_unit'    => isset( $_POST['dimension_unit'] ) ? sanitize_text_field( wp_unslash( $_POST['dimension_unit'] ) ) : '',
+			'setup_wcs_labels'  => isset( $_POST['setup_woocommerce_services'] ) && 'yes' === $_POST['setup_woocommerce_services'],
+			'setup_shipstation' => isset( $_POST['setup_shipstation'] ) && 'yes' === $_POST['setup_shipstation'],
+		);
+		// phpcs:enable
+
+		WC_Tracks::record_event( 'obw_shipping', $properties );
+	}
+
+
 }

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -43,11 +43,33 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
+	 * Check if a step is being saved by step name.
+	 *
+	 * @param string $step_name Step name.
+	 * @return bool
+	 */
+	public static function is_saving_step( $step_name ) {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
+		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
+			return true;
+		}
+		// phpcs:enable
+
+		return false;
+	}
+
+	/**
 	 * Track store setup and store properties on save.
 	 *
 	 * @return void
 	 */
 	public static function track_store_setup() {
+		// First step name is blank.
+		if ( ! self::is_saving_step( '' ) ) {
+			return;
+		}
+
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -43,33 +43,11 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
-	 * Check if a step is being saved by step name.
-	 *
-	 * @param string $step_name Step name.
-	 * @return bool
-	 */
-	public static function is_saving_step( $step_name ) {
-		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
-		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
-		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
-			return true;
-		}
-		// phpcs:enable
-
-		return false;
-	}
-
-	/**
 	 * Track store setup and store properties on save.
 	 *
 	 * @return void
 	 */
 	public static function track_store_setup() {
-		// First step name is blank.
-		if ( ! self::is_saving_step( '' ) ) {
-			return;
-		}
-
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Tracks weight and dimension units as well as shipping label options if selected.

### How to test the changes in this Pull Request:

1. Go to the Shipping step in the OBW `wp-admin/admin.php?page=wc-setup&step=shipping`.
2. Select various dimensions and weight units and shipping label statuses.  Note that the country should be US for wcs labels and either AU, CA, or GB for shipping station labels.
3. Click "Continue" to go to the next step.
4. Check that the event was fired and properties sent.

<img width="727" alt="screen shot 2019-02-27 at 2 20 28 pm" src="https://user-images.githubusercontent.com/10561050/53470312-33cea280-3a9c-11e9-9814-28cdb6e0dd5d.png">
