### PR TITLE
Tracks: Add tracking for Jetpack activation in OBW

### DIFF
--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -45,6 +45,9 @@ class WC_Admin_Setup_Wizard_Tracking {
 			case 'recommended':
 				add_action( 'admin_init', array( __CLASS__, 'track_recommended' ), 1 );
 				break;
+			case 'activate':
+				add_action( 'admin_init', array( __CLASS__, 'track_activate' ), 1 );
+				break;
 		}
 	}
 
@@ -141,5 +144,14 @@ class WC_Admin_Setup_Wizard_Tracking {
 		// phpcs:enable
 
 		WC_Tracks::record_event( 'obw_recommended', $properties );
+	}
+
+	/**
+	 * Tracks when Jetpack is activated through the OBW.
+	 *
+	 * @return void
+	 */
+	public static function track_activate() {
+		WC_Tracks::record_event( 'obw_activate' );
 	}
 }

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -49,11 +49,33 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
+	 * Check if a step is being saved by step name.
+	 *
+	 * @param string $step_name Step name.
+	 * @return bool
+	 */
+	public static function is_saving_step( $step_name ) {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
+		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
+			return true;
+		}
+		// phpcs:enable
+
+		return false;
+	}
+
+	/**
 	 * Track store setup and store properties on save.
 	 *
 	 * @return void
 	 */
 	public static function track_store_setup() {
+		// First step name is blank.
+		if ( ! self::is_saving_step( '' ) ) {
+			return;
+		}
+
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -49,33 +49,11 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
-	 * Check if a step is being saved by step name.
-	 *
-	 * @param string $step_name Step name.
-	 * @return bool
-	 */
-	public static function is_saving_step( $step_name ) {
-		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
-		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
-		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
-			return true;
-		}
-		// phpcs:enable
-
-		return false;
-	}
-
-	/**
 	 * Track store setup and store properties on save.
 	 *
 	 * @return void
 	 */
 	public static function track_store_setup() {
-		// First step name is blank.
-		if ( ! self::is_saving_step( '' ) ) {
-			return;
-		}
-
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Checks when Jetpack is activated during the OBW.

Question: ~Do we need to track `obw_skip_step`?  This is the only step that allows skipping and we can probably deduce this information without adding an extra event.~ Edit: looks like the "Recommended" step also has a skip step option.

### How to test the changes in this Pull Request:

1. Go to the activate step of the OBW `/wp-admin/admin.php?page=wc-setup&step=activate`
2. Click "Continue with WooCommerce Services" to activate Jetpack.
3. Check that the event is tracked.
4. Go back to the activate step and click "Skip this step."
5. Make sure no event is tracked.

<img width="726" alt="screen shot 2019-02-27 at 2 56 52 pm" src="https://user-images.githubusercontent.com/10561050/53471598-33380b00-3aa0-11e9-8095-8c5479a6d630.png">
