### PR TITLE
Tracks: Add tracking event when OBW is started

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -32,10 +32,7 @@ class WC_Admin {
 		add_action( 'admin_footer', 'wc_print_js', 25 );
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ), 1 );
 		add_action( 'wp_ajax_setup_wizard_check_jetpack', array( $this, 'setup_wizard_check_jetpack' ) );
-
-		if ( 'yes' === get_option( 'woocommerce_allow_tracking', 'no' ) ) {
-			add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
-		}
+		add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
 	}
 
 	/**

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -60,6 +60,7 @@ class WC_Site_Tracking {
 	 * Init tracking.
 	 */
 	public static function init() {
+		add_action( 'add_option_woocommerce_allow_tracking', array( __CLASS__, 'track_obw_start' ), 10, 2 );
 
 		if ( ! self::is_tracking_enabled() ) {
 
@@ -97,5 +98,20 @@ class WC_Site_Tracking {
 				call_user_func( $init_method );
 			}
 		}
+	}
+
+	/**
+	 * Track when tracking is opted into and OBW has started.
+	 *
+	 * @param string $option Option name.
+	 * @param string $value  Option value.
+	 * @return void
+	 */
+	public static function track_obw_start( $option, $value ) {
+		if ( 'yes' !== $value || empty( $_GET['page'] ) || 'wc-setup' !== $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+			return;
+		}
+
+		WC_Tracks::record_event( 'obw_start' );
 	}
 }

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -72,7 +72,6 @@ class WC_Site_Tracking {
 	 * Init tracking.
 	 */
 	public static function init() {
-		add_action( 'add_option_woocommerce_allow_tracking', array( __CLASS__, 'track_obw_start' ), 10, 2 );
 
 		if ( ! self::is_tracking_enabled() ) {
 
@@ -110,20 +109,5 @@ class WC_Site_Tracking {
 				call_user_func( $init_method );
 			}
 		}
-	}
-
-	/**
-	 * Track when tracking is opted into and OBW has started.
-	 *
-	 * @param string $option Option name.
-	 * @param string $value  Option value.
-	 * @return void
-	 */
-	public static function track_obw_start( $option, $value ) {
-		if ( 'yes' !== $value || empty( $_GET['page'] ) || 'wc-setup' !== $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-			return;
-		}
-
-		WC_Tracks::record_event( 'obw_start' );
 	}
 }

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -21,8 +21,20 @@ class WC_Site_Tracking {
 		 * Don't track users who haven't opted-in to tracking or if a filter
 		 * has been applied to turn it off.
 		 */
-		if ( 'yes' !== get_option( 'woocommerce_allow_tracking' ) ||
-			! apply_filters( 'woocommerce_apply_user_tracking', true ) ) {
+
+		if (
+			! apply_filters( 'woocommerce_apply_user_tracking', true ) ||
+			(
+				'yes' !== get_option( 'woocommerce_allow_tracking' ) &&
+				// Check if tracking is actively being opted into.
+				// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
+				(
+					! isset( $_POST['wc_tracker_checkbox'] ) ||
+					'yes' !== sanitize_text_field( $_POST['wc_tracker_checkbox'] )
+				)
+				// phpcs:enable
+			)
+		) {
 			return false;
 		}
 

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -22,19 +22,14 @@ class WC_Site_Tracking {
 		 * has been applied to turn it off.
 		 */
 
-		if (
-			! apply_filters( 'woocommerce_apply_user_tracking', true ) ||
-			(
-				'yes' !== get_option( 'woocommerce_allow_tracking' ) &&
-				// Check if tracking is actively being opted into.
-				// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
-				(
-					! isset( $_POST['wc_tracker_checkbox'] ) ||
-					'yes' !== sanitize_text_field( $_POST['wc_tracker_checkbox'] )
-				)
-				// phpcs:enable
-			)
-		) {
+		if ( ! apply_filters( 'woocommerce_apply_user_tracking', true ) ) {
+			return false;
+		}
+
+		// Check if tracking is actively being opted into.
+		$is_obw_opting_in = isset( $_POST['wc_tracker_checkbox'] ) && 'yes' === sanitize_text_field( $_POST['wc_tracker_checkbox'] ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
+
+		if ( 'yes' !== get_option( 'woocommerce_allow_tracking' ) && ! $is_obw_opting_in ) {
 			return false;
 		}
 

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -76,7 +76,7 @@ class WC_Admin_Setup_Wizard_Tracking {
 				add_action( 'admin_init', array( __CLASS__, 'track_recommended' ), 1 );
 				break;
 			case 'activate':
-				add_action( 'admin_init', array( __CLASS__, 'track_activate' ), 1 );
+				add_action( 'admin_init', array( __CLASS__, 'track_jetpack_activate' ), 1 );
 				break;
 		}
 	}
@@ -193,7 +193,7 @@ class WC_Admin_Setup_Wizard_Tracking {
 	 *
 	 * @return void
 	 */
-	public static function track_activate() {
+	public static function track_jetpack_activate() {
 		WC_Tracks::record_event( 'obw_activate' );
 	}
 

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -81,11 +81,33 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
+	 * Check if a step is being saved by step name.
+	 *
+	 * @param string $step_name Step name.
+	 * @return bool
+	 */
+	public static function is_saving_step( $step_name ) {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
+		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
+			return true;
+		}
+		// phpcs:enable
+
+		return false;
+	}
+
+	/**
 	 * Track store setup and store properties on save.
 	 *
 	 * @return void
 	 */
 	public static function track_store_setup() {
+		// First step name is blank.
+		if ( ! self::is_saving_step( '' ) ) {
+			return;
+		}
+
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -45,9 +45,24 @@ class WC_Admin_Setup_Wizard_Tracking {
 		}
 
 		add_filter( 'woocommerce_setup_wizard_steps', array( __CLASS__, 'set_obw_steps' ) );
-		add_action( 'admin_init', array( __CLASS__, 'track_start' ), 1 );
 		add_action( 'shutdown', array( __CLASS__, 'track_skip_step' ), 1 );
+		add_action( 'add_option_woocommerce_allow_tracking', array( __CLASS__, 'track_start' ), 10, 2 );
 		self::add_step_save_events();
+	}
+
+	/**
+	 * Track when tracking is opted into and OBW has started.
+	 *
+	 * @param string $option Option name.
+	 * @param string $value  Option value.
+	 * @return void
+	 */
+	public static function track_start( $option, $value ) {
+		if ( 'yes' !== $value || empty( $_GET['page'] ) || 'wc-setup' !== $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+			return;
+		}
+
+		WC_Tracks::record_event( 'obw_start' );
 	}
 
 	/**
@@ -79,18 +94,6 @@ class WC_Admin_Setup_Wizard_Tracking {
 				add_action( 'admin_init', array( __CLASS__, 'track_jetpack_activate' ), 1 );
 				break;
 		}
-	}
-
-	/** Track when the OBW has started.
-	 *
-	 * @return void
-	 */
-	public static function track_start() {
-		if ( isset( $_GET['step'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-			return;
-		}
-
-		WC_Tracks::record_event( 'obw_start' );
 	}
 
 	/**

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -81,33 +81,11 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
-	 * Check if a step is being saved by step name.
-	 *
-	 * @param string $step_name Step name.
-	 * @return bool
-	 */
-	public static function is_saving_step( $step_name ) {
-		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
-		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
-		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
-			return true;
-		}
-		// phpcs:enable
-
-		return false;
-	}
-
-	/**
 	 * Track store setup and store properties on save.
 	 *
 	 * @return void
 	 */
 	public static function track_store_setup() {
-		// First step name is blank.
-		if ( ! self::is_saving_step( '' ) ) {
-			return;
-		}
-
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -45,6 +45,7 @@ class WC_Admin_Setup_Wizard_Tracking {
 		}
 
 		add_filter( 'woocommerce_setup_wizard_steps', array( __CLASS__, 'set_obw_steps' ) );
+		add_action( 'admin_init', array( __CLASS__, 'track_start' ), 1 );
 		add_action( 'shutdown', array( __CLASS__, 'track_skip_step' ), 1 );
 		self::add_step_save_events();
 	}
@@ -78,6 +79,18 @@ class WC_Admin_Setup_Wizard_Tracking {
 				add_action( 'admin_init', array( __CLASS__, 'track_activate' ), 1 );
 				break;
 		}
+	}
+
+	/** Track when the OBW has started.
+	 *
+	 * @return void
+	 */
+	public static function track_start() {
+		if ( isset( $_GET['step'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+			return;
+		}
+
+		WC_Tracks::record_event( 'obw_start' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a tracking event when the OBW is started.

*Question*: Will this event ever really get tracked?  `woocommerce_allow_tracking` is not set until after the first step, so this code probably won't get run unless there is another place this can be activated first.

### How to test the changes in this Pull Request:

1. Visit the initial OBW page `/wp-admin/admin.php?page=wc-setup`.
2. Check that the event is fired.
3. Visit the next step and and click "Store setup" to return to the first step.
4. Make sure the event is not tracked again.