### PR TITLE
Tracks: Add tracking event for skipped step in OBW

### DIFF
--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -52,33 +52,11 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
-	 * Check if a step is being saved by step name.
-	 *
-	 * @param string $step_name Step name.
-	 * @return bool
-	 */
-	public static function is_saving_step( $step_name ) {
-		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
-		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
-		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
-			return true;
-		}
-		// phpcs:enable
-
-		return false;
-	}
-
-	/**
 	 * Track store setup and store properties on save.
 	 *
 	 * @return void
 	 */
 	public static function track_store_setup() {
-		// First step name is blank.
-		if ( ! self::is_saving_step( '' ) ) {
-			return;
-		}
-
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -52,11 +52,33 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
+	 * Check if a step is being saved by step name.
+	 *
+	 * @param string $step_name Step name.
+	 * @return bool
+	 */
+	public static function is_saving_step( $step_name ) {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : '';
+		if ( ! empty( $_POST['save_step'] ) && $current_step === $step_name ) {
+			return true;
+		}
+		// phpcs:enable
+
+		return false;
+	}
+
+	/**
 	 * Track store setup and store properties on save.
 	 *
 	 * @return void
 	 */
 	public static function track_store_setup() {
+		// First step name is blank.
+		if ( ! self::is_saving_step( '' ) ) {
+			return;
+		}
+
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 		$properties = array(
 			'country'        => isset( $_POST['store_country'] ) ? sanitize_text_field( $_POST['store_country'] ) : '',

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -57,6 +57,8 @@ class WC_Admin_Setup_Wizard_Tracking {
 		}
 
 		$current_step = isset( $_GET['step'] ) ? sanitize_key( $_GET['step'] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+		update_option( 'woocommerce_obw_last_completed_step', $current_step );
+
 		switch ( $current_step ) {
 			case '':
 			case 'store_setup':

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -204,7 +204,7 @@ class WC_Admin_Setup_Wizard_Tracking {
 		// If we're going forward more than 1 completed step.
 		if ( $current_step_index > $previous_step_index + 1 ) {
 			$properties = array(
-				'step' => $steps[ $previous_step_index + 1 ],
+				'step' => $steps[ $current_step_index - 1 ],
 			);
 			WC_Tracks::record_event( 'obw_skip_step', $properties );
 		}
@@ -221,5 +221,4 @@ class WC_Admin_Setup_Wizard_Tracking {
 
 		return $steps;
 	}
-
 }

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -11,6 +11,31 @@ defined( 'ABSPATH' ) || exit;
  * This class adds actions to track usage of the WooCommerce Onboarding Wizard.
  */
 class WC_Admin_Setup_Wizard_Tracking {
+
+	/**
+	 * Class instance.
+	 *
+	 * @var WC_Admin_Setup_Wizard_Tracking instance
+	 */
+	protected static $instance = false;
+
+	/**
+	 * Steps for the setup wizard
+	 *
+	 * @var array
+	 */
+	private $steps = array();
+
+	/**
+	 * Get class instance
+	 */
+	public static function get_instance() {
+		if ( ! self::$instance ) {
+			self::$instance = new self();
+		}
+		return self::$instance;
+	}
+
 	/**
 	 * Init tracking.
 	 */
@@ -19,6 +44,7 @@ class WC_Admin_Setup_Wizard_Tracking {
 			return;
 		}
 
+		add_filter( 'woocommerce_setup_wizard_steps', array( __CLASS__, 'set_obw_steps' ) );
 		self::add_step_save_events();
 	}
 
@@ -154,4 +180,17 @@ class WC_Admin_Setup_Wizard_Tracking {
 	public static function track_activate() {
 		WC_Tracks::record_event( 'obw_activate' );
 	}
+
+	/**
+	 * Set the OBW steps inside this class instance.
+	 *
+	 * @param array $steps Array of OBW steps.
+	 */
+	public static function set_obw_steps( $steps ) {
+		$wc_admin_setup_wizard_tracking        = self::get_instance();
+		$wc_admin_setup_wizard_tracking->steps = $steps;
+
+		return $steps;
+	}
+
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Track when a step's save process is bypassed and the step is skipped.

### How to test the changes in this Pull Request:

1.  Go to the OBW `wp-admin/admin.php?page=wc-setup`.
2.  Continue to the next step until you reach a step with a "Skip this step" link in the footer.
3.  Skip the step and note the event is fired with the step name.
4.  Try going through the step normally and making sure the event is not fired.
5.  Click back to previous steps and make sure this event is not fired when moving backwards in step order.