### PR TITLE
Remember tracking setting when going through the OWB again

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -546,7 +546,7 @@ class WC_Admin_Setup_Wizard {
 		$currency_code  = sanitize_text_field( $_POST['currency_code'] );
 		$product_type   = sanitize_text_field( $_POST['product_type'] );
 		$sell_in_person = isset( $_POST['sell_in_person'] ) && ( 'yes' === sanitize_text_field( $_POST['sell_in_person'] ) );
-		$tracking       = ( isset( $_POST['wc_tracker_checkbox'] ) && ( 'yes' === sanitize_text_field( $_POST['wc_tracker_checkbox'] ) ) ) || ( 'yes' === get_option( 'woocommerce_allow_tracking', 'unknown' ) );
+		$tracking       = isset( $_POST['wc_tracker_checkbox'] ) && ( 'yes' === sanitize_text_field( $_POST['wc_tracker_checkbox'] ) );
 		// phpcs:enable
 
 		if ( ! $state ) {
@@ -577,7 +577,7 @@ class WC_Admin_Setup_Wizard {
 			}
 		}
 
-		if ( $tracking ) {
+		if ( $tracking && 'unknown' === get_option( 'woocommerce_allow_tracking', 'unknown' ) ) {
 			update_option( 'woocommerce_allow_tracking', 'yes' );
 			wp_schedule_single_event( time() + 10, 'woocommerce_tracker_send_event', array( true ) );
 		} else {

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -546,7 +546,7 @@ class WC_Admin_Setup_Wizard {
 		$currency_code  = sanitize_text_field( $_POST['currency_code'] );
 		$product_type   = sanitize_text_field( $_POST['product_type'] );
 		$sell_in_person = isset( $_POST['sell_in_person'] ) && ( 'yes' === sanitize_text_field( $_POST['sell_in_person'] ) );
-		$tracking       = isset( $_POST['wc_tracker_checkbox'] ) && ( 'yes' === sanitize_text_field( $_POST['wc_tracker_checkbox'] ) );
+		$tracking       = ( isset( $_POST['wc_tracker_checkbox'] ) && ( 'yes' === sanitize_text_field( $_POST['wc_tracker_checkbox'] ) ) ) || ( 'yes' === get_option( 'woocommerce_allow_tracking', 'unknown' ) );
 		// phpcs:enable
 
 		if ( ! $state ) {

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -576,12 +576,13 @@ class WC_Admin_Setup_Wizard {
 				update_option( 'woocommerce_price_thousand_sep', $locale_info[ $country ]['thousand_sep'] );
 			}
 		}
-
-		if ( $tracking && 'unknown' === get_option( 'woocommerce_allow_tracking', 'unknown' ) ) {
-			update_option( 'woocommerce_allow_tracking', 'yes' );
-			wp_schedule_single_event( time() + 10, 'woocommerce_tracker_send_event', array( true ) );
-		} else {
-			update_option( 'woocommerce_allow_tracking', 'no' );
+		if ( 'unknown' === get_option( 'woocommerce_allow_tracking', 'unknown' ) ) {
+			if ( $tracking ) {
+				update_option( 'woocommerce_allow_tracking', 'yes' );
+				wp_schedule_single_event( time() + 10, 'woocommerce_tracker_send_event', array( true ) );
+			} else {
+				update_option( 'woocommerce_allow_tracking', 'no' );
+			}
 		}
 
 		WC_Install::create_pages();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes an issue where if you go through the OBW a second or third time it overwrites the previous selected tracker option with a no and does not remember the previous selection.

Closes #22861 

### How to test the changes in this Pull Request:

1. Delete the woocommerce_allow_tracking option `wp option get woocommerce_allow_tracking`
2. Go to `wp-admin/admin.php?page=wc-setup` and complete the wizard, be sure to check the box to opt into tracking on the first page.
3. View the woocommerce_allow_tracking option which should be set to yes now.
4. Go to `wp-admin/admin.php?page=wc-setup` again, this time the tracking option should be hidden, complete the wizard till the last step.
5. View the woocommerce_allow_tracking option and ensure it is still set to yes.
6. Repeat the above process for not enabling tracking, the end result should be that the woocommerce_allow_tracking option should still be set to no.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - OWB not remembering tracking setting when completing the OBW again.
