### PR TITLE
Update class-wc-regenerate-images.php

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -219,7 +219,9 @@ class WC_Regenerate_Images {
 				$imagedata['width']  = $imagedata['sizes']['full']['width'];
 			}
 
-			$ratio_match = wp_image_matches_ratio( $image[1], $image[2], $imagedata['width'], $imagedata['height'] );
+			if ( $image_size['width'] && $image_size['height'] ) {
+                $ratio_match = wp_image_matches_ratio($image[1], $image[2], $imagedata['width'], $imagedata['height']);
+            }
 		} else {
 			$ratio_match = wp_image_matches_ratio( $image[1], $image[2], $image_size['width'], $image_size['height'] );
 		}

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -219,8 +219,8 @@ class WC_Regenerate_Images {
 				$imagedata['width']  = $imagedata['sizes']['full']['width'];
 			}
 
-			if ( $image_size['width'] && $image_size['height'] ) {
-                $ratio_match = wp_image_matches_ratio($image[1], $image[2], $imagedata['width'], $imagedata['height']);
+			if ( $imagedata['width'] && $imagedata['height'] ) {
+                $ratio_match = wp_image_matches_ratio( $image[1], $image[2], $imagedata['width'], $imagedata['height'] );
             }
 		} else {
 			$ratio_match = wp_image_matches_ratio( $image[1], $image[2], $image_size['width'], $image_size['height'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Sometimes imagedata has not $imagedata['sizes']['full'] params. In my case, due to the fact that I am loading the SVG picture.
Therefore, an error is visible *Undefined index: height in class-wc-regenerate-images.php on line 222*
Therefore, a check for the emptiness of these parameters is added.
You can see same errors here (I found these sites just using google):
https://kaboochie.com.au/product/marble-look-ceramic-earrings-pink-teal-blue-and-stripe-marble-look-ceramic-beaded-earrings/
http://www.candises.com/en/boutique/sugar-sticks/box-of-15-sugar-sticks/
https://prnt.sc/mqt6rc
