### PR TITLE
Add precision to tax in discount class

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -910,7 +910,13 @@ class WC_Discounts {
 			return wc_add_number_precision( $this->object->get_displayed_subtotal() );
 		} elseif ( is_a( $this->object, 'WC_Order' ) ) {
 			$subtotal = wc_add_number_precision( $this->object->get_subtotal() );
-			return $this->object->get_prices_include_tax() ? $subtotal + round( $this->object->get_total_tax(), wc_get_price_decimals() ) : $subtotal;
+
+			if ( $this->object->get_prices_include_tax() ) {
+				// Add tax to tax-exclusive subtotal.
+				$subtotal = $subtotal + wc_add_number_precision( round( $this->object->get_total_tax(), wc_get_price_decimals() ) );
+			}
+
+			return $subtotal;
 		} else {
 			return array_sum( wp_list_pluck( $this->items, 'price' ) );
 		}


### PR DESCRIPTION
The min spend validation in discounts class was correcrly adding taxes to the calculation for orders, however, it was adding it without precision. For the test case in #22870 this meant it was adding $3 tax instead of 300c tax.

Adding precision solves the issue.

cc @rrennick 