### PR TITLE
Hide 'other' payment method from invoice

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -186,7 +186,7 @@ class WC_Meta_Box_Order_Data {
 
 					$meta_list = array();
 
-					if ( $payment_method ) {
+					if ( $payment_method && 'other' !== $payment_method ) {
 						/* translators: %s: payment method */
 						$payment_method_string = sprintf(
 							__( 'Payment via %s', 'woocommerce' ),

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1953,7 +1953,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @param string $tax_display Tax to display.
 	 */
 	protected function add_order_item_totals_payment_method_row( &$total_rows, $tax_display ) {
-		if ( $this->get_total() > 0 && $this->get_payment_method_title() ) {
+		if ( $this->get_total() > 0 && $this->get_payment_method_title() && 'other' !== $this->get_payment_method_title() ) {
 			$total_rows['payment_method'] = array(
 				'label' => __( 'Payment method:', 'woocommerce' ),
 				'value' => $this->get_payment_method_title(),


### PR DESCRIPTION
When you select 'Other' in the backend for the payment method, no gateway exists to look up a proper gateway title.

Therefore, we shouldn't output anything if using 'other' on invoices.

Closes #22817

To test, edit order and set the payment method to "other", send yourself an invoice, check it shows nothing after this patch.