### PR TITLE
Avoid changing tracking preferences when disconnecting helper

### DIFF
--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -788,9 +788,6 @@ class WC_Helper {
 		self::_flush_subscriptions_cache();
 		self::_flush_updates_cache();
 
-		// Disable tracking when disconnected.
-		update_option( 'woocommerce_allow_tracking', 'no' );
-
 		wp_safe_redirect( $redirect_uri );
 		die();
 	}


### PR DESCRIPTION
Disconnecting from WooCommerce.com via the helper is totally unrelated to the tracking opt-in, so we should avoid updating the tracking option. 

Closes #21785 

Tracker is opted out from system status. That will become a toggle in 3.6.