### PR TITLE
Loop attribute panels to disable options rather than look at values

### DIFF
--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -470,13 +470,13 @@ jQuery( function( $ ) {
 				show_and_hide_panels();
 
 				// Make sure the dropdown is not disabled for empty value attributes.
-				var nr_elements = original_data.length / 6;
-				for ( var i = 0; i < nr_elements; i++ ) {
-					if ( typeof( original_data ) !== 'undefined' && original_data[ i * 6 + 2 ].value === '' ) {
-						$( 'select.attribute_taxonomy' )
-							.find( 'option[value="' + original_data[ i * 6 ].value + '"]' ).removeAttr( 'disabled' );
+				$( 'select.attribute_taxonomy' ).find( 'option' ).prop( 'disabled', false );
+
+				$( '.product_attributes .woocommerce_attribute' ).each( function( index, el ) {
+					if ( $( el ).css( 'display' ) !== 'none' && $( el ).is( '.taxonomy' ) ) {
+						$( 'select.attribute_taxonomy' ).find( 'option[value="' + $( el ).data( 'taxonomy' ) + '"]' ).prop( 'disabled', true );
 					}
-				}
+				});
 
 				// Reload variations panel.
 				var this_page = window.location.toString();


### PR DESCRIPTION
This was caused by https://github.com/woocommerce/woocommerce/commit/f637cf3005adbdf8600579bfa02b606daf950f37

Fixes #22673

When a global attribute is added to a product, it becomes greyed out to prevent it being added twice.

Rather than loop over options to see if values are empty like in f637cf3005adbdf8600579bfa02b606daf950f37 we can instead repeat the logic ran on page load; enable all options, then disable the attributes rendered in the panel.

cc @kloon See any issues with that?