### PR TITLE
PayPal: Add meta data, before changing order status

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -201,12 +201,11 @@ class WC_Gateway_Paypal_IPN_Handler extends WC_Gateway_Paypal_Response {
 				$this->payment_status_paid_cancelled_order( $order, $posted );
 			}
 
-			$this->payment_complete( $order, ( ! empty( $posted['txn_id'] ) ? wc_clean( $posted['txn_id'] ) : '' ), __( 'IPN payment completed', 'woocommerce' ) );
-
 			if ( ! empty( $posted['mc_fee'] ) ) {
-				// Log paypal transaction fee.
-				update_post_meta( $order->get_id(), 'PayPal Transaction Fee', wc_clean( $posted['mc_fee'] ) );
+				$order->add_meta_data( 'PayPal Transaction Fee', wc_clean( $posted['mc_fee'] ) );
 			}
+
+			$this->payment_complete( $order, ( ! empty( $posted['txn_id'] ) ? wc_clean( $posted['txn_id'] ) : '' ), __( 'IPN payment completed', 'woocommerce' ) );
 		} else {
 			if ( 'authorization' === $posted['pending_reason'] ) {
 				$this->payment_on_hold( $order, __( 'Payment authorized. Change payment status to processing or complete to capture funds.', 'woocommerce' ) );

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-pdt-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-pdt-handler.php
@@ -89,7 +89,7 @@ class WC_Gateway_Paypal_PDT_Handler extends WC_Gateway_Paypal_Response {
 
 		$order_id    = wc_clean( wp_unslash( $_REQUEST['cm'] ) ); // WPCS: input var ok, CSRF ok, sanitization ok.
 		$status      = wc_clean( strtolower( wp_unslash( $_REQUEST['st'] ) ) ); // WPCS: input var ok, CSRF ok, sanitization ok.
-		$amount      = wc_clean( wp_unslash( $_REQUEST['amt'] ) ); // WPCS: input var ok, CSRF ok, sanitization ok.
+		$amount      = isset( $_REQUEST['amt'] ) ? wc_clean( wp_unslash( $_REQUEST['amt'] ) ) : 0; // WPCS: input var ok, CSRF ok, sanitization ok.
 		$transaction = wc_clean( wp_unslash( $_REQUEST['tx'] ) ); // WPCS: input var ok, CSRF ok, sanitization ok.
 		$order       = $this->get_paypal_order( $order_id );
 
@@ -102,8 +102,8 @@ class WC_Gateway_Paypal_PDT_Handler extends WC_Gateway_Paypal_Response {
 		if ( $transaction_result ) {
 			WC_Gateway_Paypal::log( 'PDT Transaction Status: ' . wc_print_r( $status, true ) );
 
-			update_post_meta( $order->get_id(), '_paypal_status', $status );
-			update_post_meta( $order->get_id(), '_transaction_id', $transaction );
+			$order->add_meta_data( '_paypal_status', $status );
+			$order->set_transaction_id( $transaction );
 
 			if ( 'completed' === $status ) {
 				if ( number_format( $order->get_total(), 2, '.', '' ) !== number_format( $amount, 2, '.', '' ) ) {
@@ -111,15 +111,15 @@ class WC_Gateway_Paypal_PDT_Handler extends WC_Gateway_Paypal_Response {
 					/* translators: 1: Payment amount */
 					$this->payment_on_hold( $order, sprintf( __( 'Validation error: PayPal amounts do not match (amt %s).', 'woocommerce' ), $amount ) );
 				} else {
-					$this->payment_complete( $order, $transaction, __( 'PDT payment completed', 'woocommerce' ) );
-
 					// Log paypal transaction fee and payment type.
 					if ( ! empty( $transaction_result['mc_fee'] ) ) {
-						update_post_meta( $order->get_id(), 'PayPal Transaction Fee', $transaction_result['mc_fee'] );
+						$order->add_meta_data( 'PayPal Transaction Fee', wc_clean( $transaction_result['mc_fee'] ) );
 					}
 					if ( ! empty( $transaction_result['payment_type'] ) ) {
-						update_post_meta( $order->get_id(), 'Payment type', $transaction_result['payment_type'] );
+						$order->add_meta_data( 'Payment type', wc_clean( $transaction_result['payment_type'] ) );
 					}
+
+					$this->payment_complete( $order, $transaction, __( 'PDT payment completed', 'woocommerce' ) );
 				}
 			} else {
 				if ( 'authorization' === $transaction_result['pending_reason'] ) {


### PR DESCRIPTION
Fixes #22886

Updates IPN and PDT to:

a. Use CRUD rather than direct meta calls
b. set meta values before changing order status

These changes ensure the fee meta is available prior to the new email being sent.

To test,

1. Do a sandbox checkout with IPN or PDT
2. Check new order meta data to ensure values are sent for fee/payment type

To test the email you'd need to customise them first to output the fee in the template. You can do this manually if you wish.