### PR TITLE
Tracks: Add an opt in/out toggle on settings page

### DIFF
--- a/includes/admin/settings/class-wc-settings-accounts.php
+++ b/includes/admin/settings/class-wc-settings-accounts.php
@@ -36,6 +36,8 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 			$erasure_text = sprintf( '<a href="%s">%s</a>', esc_url( admin_url( 'tools.php?page=remove_personal_data' ) ), $erasure_text );
 		}
 
+		$tracking_info_text = sprintf( '<a href="%s" target="_blank">%s</a>','https://woocommerce.com/usage-tracking', esc_html__( 'Read more about what we collect', 'woocommerce' ) );
+
 		$settings = apply_filters(
 			'woocommerce_' . $this->id . '_settings',
 			array(
@@ -231,6 +233,26 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				array(
 					'type' => 'sectionend',
 					'id'   => 'personal_data_retention',
+				),
+				array(
+					'title' => esc_html__( 'Usage Tracking', 'woocommerce' ),
+					'type'  => 'title',
+					'id'    => 'tracking_options',
+					'desc'  => __( 'Gathering usage data allows us to make WooCommerce better — your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense.', 'woocommerce' ),
+				),
+				array(
+					'title'         => __( 'Enable tracking', 'woocommerce' ),
+					'desc'          => __( 'Allow usage of WooCommerce to be tracked', 'woocommerce' ),
+					'desc_tip'      => sprintf( esc_html__( 'If you would rather opt-out, and do not check this box, we will not know this store exists and we will not collect any usage data. %s.', 'woocommerce' ), $tracking_info_text ),
+					'id'            => 'woocommerce_allow_tracking',
+					'type'          => 'checkbox',
+					'checkboxgroup' => 'start',
+					'default'       => 'no',
+					'autoload'      => false,
+				),
+				array(
+					'type' => 'sectionend',
+					'id'   => 'tracking_options',
 				),
 			)
 		);

--- a/includes/api/v2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-tools-v2-controller.php
@@ -181,11 +181,6 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 					__( 'This option will delete ALL of your tax rates, use with caution. This action cannot be reversed.', 'woocommerce' )
 				),
 			),
-			'reset_tracking'                     => array(
-				'name'   => __( 'Reset usage tracking', 'woocommerce' ),
-				'button' => __( 'Reset', 'woocommerce' ),
-				'desc'   => __( 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data.', 'woocommerce' ),
-			),
 			'regenerate_thumbnails'              => array(
 				'name'   => __( 'Regenerate shop thumbnails', 'woocommerce' ),
 				'button' => __( 'Regenerate', 'woocommerce' ),
@@ -528,16 +523,6 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 				$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}woocommerce_tax_rate_locations;" );
 				WC_Cache_Helper::incr_cache_prefix( 'taxes' );
 				$message = __( 'Tax rates successfully deleted', 'woocommerce' );
-				break;
-
-			case 'reset_tracking':
-				if ( ! class_exists( 'WC_Tracker' ) ) {
-					include_once WC_ABSPATH . 'includes/class-wc-tracker.php';
-				}
-				WC_Tracker::opt_out_request();
-				delete_option( 'woocommerce_allow_tracking' );
-				WC_Admin_Notices::add_notice( 'tracking' );
-				$message = __( 'Usage tracking settings successfully reset.', 'woocommerce' );
 				break;
 
 			case 'regenerate_thumbnails':

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -540,28 +540,6 @@ class WC_Tracker {
 
 		return $min_max;
 	}
-
-	/**
-	 * Make a request when opting out of tracker usage.
-	 *
-	 * @return void
-	 */
-	public static function opt_out_request() {
-		$body = array(
-			'event' => 'opt-out',
-			'email' => apply_filters( 'woocommerce_tracker_admin_email', get_option( 'admin_email' ) ),
-			'url'   => home_url(),
-		);
-		wp_safe_remote_post( self::$api_url . 'event/', array(
-			'method'      => 'POST',
-			'redirection' => 5,
-			'httpversion' => '1.0',
-			'blocking'    => false,
-			'headers'     => array( 'user-agent' => 'WooCommerceTracker/' . md5( esc_url_raw( home_url( '/' ) ) ) . ';' ),
-			'body'        => wp_json_encode( $body ),
-			'cookies'     => array(),
-		) );
-	}
 }
 
 WC_Tracker::init();

--- a/tests/unit-tests/api/system-status.php
+++ b/tests/unit-tests/api/system-status.php
@@ -238,15 +238,15 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( count( $raw_tools ), count( $data ) );
 		$this->assertContains(
 			array(
-				'id'          => 'reset_tracking',
-				'name'        => 'Reset usage tracking',
-				'action'      => 'Reset',
-				'description' => 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data.',
+				'id'          => 'regenerate_thumbnails',
+				'name'        => 'Regenerate shop thumbnails',
+				'action'      => 'Regenerate',
+				'description' => 'This will regenerate all shop thumbnails to match your theme and/or image settings.',
 				'_links'      => array(
 					'item' => array(
 						array(
-							'href'       => rest_url( '/wc/v3/system_status/tools/reset_tracking' ),
-							'embeddable' => true,
+							'href'       => rest_url( '/wc/v3/system_status/tools/regenerate_thumbnails' ),
+							'embeddable' => 1,
 						),
 					),
 				),
@@ -266,8 +266,8 @@ class WC_Tests_REST_System_Status extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( count( $raw_tools ), count( $data ) );
 		$this->assertContains(
 			array(
-				'id'   => 'reset_tracking',
-				'name' => 'Reset usage tracking',
+				'id'   => 'regenerate_thumbnails',
+				'name' => 'Regenerate shop thumbnails',
 			),
 			$data
 		);

--- a/tests/unit-tests/api/v2/system-status.php
+++ b/tests/unit-tests/api/v2/system-status.php
@@ -235,14 +235,14 @@ class WC_Tests_REST_System_Status_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( count( $raw_tools ), count( $data ) );
 		$this->assertContains(
 			array(
-				'id'          => 'reset_tracking',
-				'name'        => 'Reset usage tracking',
-				'action'      => 'Reset',
-				'description' => 'This will reset your usage tracking settings, causing it to show the opt-in banner again and not sending any data.',
+				'id'          => 'regenerate_thumbnails',
+				'name'        => 'Regenerate shop thumbnails',
+				'action'      => 'Regenerate',
+				'description' => 'This will regenerate all shop thumbnails to match your theme and/or image settings.',
 				'_links'      => array(
 					'item' => array(
 						array(
-							'href'       => rest_url( '/wc/v2/system_status/tools/reset_tracking' ),
+							'href'       => rest_url( '/wc/v2/system_status/tools/regenerate_thumbnails' ),
 							'embeddable' => true,
 						),
 					),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add a toggle in Accounts & Privacy section of WooCommerce Settings. The language is the same from the Onboarding Wizard, which has been left unchanged.

![screen shot 2019-02-28 at 1 47 20 pm](https://user-images.githubusercontent.com/1922453/53533452-d2700780-3b5f-11e9-92fe-63b1c671d358.png)

The "Reset usage tracking" tool is removed and unit tests that used its presence as a check have been updated.

_Note_: We'll need to update the documentation to reflect this change and others:
https://woocommerce.com/usage-tracking/ 

### How to test the changes in this Pull Request:

1. Load the Accounts & Privacy tab of Settings page.
2. See the Enable tracking section reflect your current selection.
3. Toggle on/off and check to make sure events are fired/not-fired accordingly.
4. In Status > Tools ensure the "Reset usage tracking" is not visible.
