### PR TITLE
Updates - Docs and ActionScheduler implementation

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -211,8 +211,9 @@ class WC_Admin_Notices {
 	 */
 	public static function update_notice() {
 		if ( version_compare( get_option( 'woocommerce_db_version' ), WC_VERSION, '<' ) ) {
-			$updater = new WC_Background_Updater();
-			if ( $updater->is_updating() || ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok, CSRF ok.
+			$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_run_update_callback', null, 'woocommerce-db-updates' );
+
+			if ( $next_scheduled_date || ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok, CSRF ok.
 				include dirname( __FILE__ ) . '/views/html-notice-updating.php';
 			} else {
 				include dirname( __FILE__ ) . '/views/html-notice-update.php';

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -210,7 +210,7 @@ class WC_Admin_Notices {
 	 * If we need to update, include a message with the update button.
 	 */
 	public static function update_notice() {
-		if ( version_compare( get_option( 'woocommerce_db_version' ), WC_VERSION, '<' ) ) {
+		if ( WC_Install::needs_db_update() ) {
 			$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_run_update_callback', null, 'woocommerce-db-updates' );
 
 			if ( $next_scheduled_date || ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok, CSRF ok.
@@ -219,6 +219,7 @@ class WC_Admin_Notices {
 				include dirname( __FILE__ ) . '/views/html-notice-update.php';
 			}
 		} else {
+			WC_Install::update_db_version();
 			include dirname( __FILE__ ) . '/views/html-notice-updated.php';
 		}
 	}

--- a/includes/admin/views/html-notice-update.php
+++ b/includes/admin/views/html-notice-update.php
@@ -18,14 +18,14 @@ $update_url = wp_nonce_url(
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p>
-		<strong><?php esc_html_e( 'Database update required', 'woocommerce' ); ?></strong>
+		<strong><?php esc_html_e( 'WooCommerce database update required', 'woocommerce' ); ?></strong>
 	</p>
 	<p>
 		<?php
 			esc_html_e( 'WooCommerce has been updated! To keep things running smoothly, we have to update your database to the newest version.', 'woocommerce' );
 
 			/* translators: 1: Link to docs 2: Close link. */
-			printf( ' ' . esc_html__( 'The database update process may take a little while, so please be patient. Advanced users can alternatively update via %1$sWP CLI%2$s.', 'woocommerce' ), '<a href="https://github.com/woocommerce/woocommerce/wiki/Upgrading-the-database-using-WP-CLI">', '</a>' );
+			printf( ' ' . esc_html__( 'The database update process runs in the background and may take a little while, so please be patient. Advanced users can alternatively update via %1$sWP CLI%2$s.', 'woocommerce' ), '<a href="https://github.com/woocommerce/woocommerce/wiki/Upgrading-the-database-using-WP-CLI">', '</a>' );
 		?>
 	</p>
 	<p class="submit">

--- a/includes/admin/views/html-notice-update.php
+++ b/includes/admin/views/html-notice-update.php
@@ -18,16 +18,22 @@ $update_url = wp_nonce_url(
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p>
-		<strong><?php esc_html_e( 'WooCommerce data update', 'woocommerce' ); ?></strong> &#8211; <?php esc_html_e( 'We need to update your store database to the latest version.', 'woocommerce' ); ?>
+		<strong><?php esc_html_e( 'Database Update Required', 'woocommerce' ); ?></strong>
+	</p>
+	<p>
+		<?php
+			esc_html_e( 'WooCommerce has been updated! To keep things running smoothly, we have to update your database to the newest version.', 'woocommerce' );
+
+			/* translators: 1: Link to docs 2: Close link. */
+			printf( ' ' . esc_html__( 'The database update process may take a little while, so please be patient. Advanced users can alternatively update via %1$sWP CLI%2$s.', 'woocommerce' ), '<a href="https://github.com/woocommerce/woocommerce/wiki/Upgrading-the-database-using-WP-CLI">', '</a>' );
+		?>
 	</p>
 	<p class="submit">
 		<a href="<?php echo esc_url( $update_url ); ?>" class="wc-update-now button-primary">
-			<?php esc_html_e( 'Run the updater', 'woocommerce' ); ?>
+			<?php esc_html_e( 'Update WooCommerce Database', 'woocommerce' ); ?>
+		</a>
+		<a href="https://docs.woocommerce.com/document/how-to-update-woocommerce/" class="button-secondary">
+			<?php esc_html_e( 'Learn more about updates', 'woocommerce' ); ?>
 		</a>
 	</p>
 </div>
-<script type="text/javascript">
-	jQuery( '.wc-update-now' ).click( 'click', function() {
-		return window.confirm( '<?php echo esc_js( __( 'It is strongly recommended that you backup your database before proceeding. Are you sure you wish to run the updater now?', 'woocommerce' ) ); ?>' ); // jshint ignore:line
-	});
-</script>

--- a/includes/admin/views/html-notice-update.php
+++ b/includes/admin/views/html-notice-update.php
@@ -18,7 +18,7 @@ $update_url = wp_nonce_url(
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p>
-		<strong><?php esc_html_e( 'Database Update Required', 'woocommerce' ); ?></strong>
+		<strong><?php esc_html_e( 'Database update required', 'woocommerce' ); ?></strong>
 	</p>
 	<p>
 		<?php

--- a/includes/admin/views/html-notice-updated.php
+++ b/includes/admin/views/html-notice-updated.php
@@ -1,6 +1,8 @@
 <?php
 /**
- * Admin View: Notice - Updated
+ * Admin View: Notice - Updated.
+ *
+ * @package WooCommerce\Admin
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -9,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div id="message" class="updated woocommerce-message wc-connect woocommerce-message--success">
-	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'update', remove_query_arg( 'do_update_woocommerce' ) ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php _e( 'Dismiss', 'woocommerce' ); ?></a>
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'update', remove_query_arg( 'do_update_woocommerce' ) ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 
-	<p><?php _e( 'WooCommerce data update complete. Thank you for updating to the latest version!', 'woocommerce' ); ?></p>
+	<p><?php esc_html_e( 'WooCommerce database update complete. Thank you for updating to the latest version!', 'woocommerce' ); ?></p>
 </div>

--- a/includes/admin/views/html-notice-updating.php
+++ b/includes/admin/views/html-notice-updating.php
@@ -8,19 +8,9 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
-
-$force_update_url = wp_nonce_url(
-	add_query_arg( 'force_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ),
-	'wc_force_db_update',
-	'wc_force_db_update_nonce'
-);
-
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p>
-		<strong><?php esc_html_e( 'WooCommerce data update', 'woocommerce' ); ?></strong> &#8211; <?php esc_html_e( 'Your database is being updated in the background.', 'woocommerce' ); ?>
-		<a href="<?php echo esc_url( $force_update_url ); ?>">
-			<?php esc_html_e( 'Taking a while? Click here to run it now.', 'woocommerce' ); ?>
-		</a>
+		<strong><?php esc_html_e( 'WooCommerce database update', 'woocommerce' ); ?></strong> &#8211; <?php esc_html_e( 'WooCommerce is updating the database in the background. The database update process may take a little while, so please be patient.', 'woocommerce' ); ?>
 	</p>
 </div>

--- a/includes/class-wc-background-updater.php
+++ b/includes/class-wc-background-updater.php
@@ -3,6 +3,7 @@
  * Background Updater
  *
  * @version 2.6.0
+ * @deprecated 3.6.0 Replaced with queue.
  * @package WooCommerce/Classes
  */
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -239,17 +239,6 @@ class WC_Install {
 			self::update();
 			WC_Admin_Notices::add_notice( 'update' );
 		}
-		if ( ! empty( $_GET['force_update_woocommerce'] ) ) { // WPCS: input var ok.
-			check_admin_referer( 'wc_force_db_update', 'wc_force_db_update_nonce' );
-			$blog_id = get_current_blog_id();
-
-			// Used to fire an action added in WP_Background_Process::_construct() that calls WP_Background_Process::handle_cron_healthcheck().
-			// This method will make sure the database updates are executed even if cron is disabled. Nothing will happen if the updates are already running.
-			do_action( 'wp_' . $blog_id . '_wc_updater_cron' );
-
-			wp_safe_redirect( admin_url( 'admin.php?page=wc-settings' ) );
-			exit;
-		}
 	}
 
 	/**

--- a/includes/cli/class-wc-cli-update-command.php
+++ b/includes/cli/class-wc-cli-update-command.php
@@ -37,20 +37,39 @@ class WC_CLI_Update_Command {
 
 		$current_db_version = get_option( 'woocommerce_db_version' );
 		$update_count       = 0;
+		$callbacks          = WC_Install::get_db_update_callbacks();
+		$callbacks_to_run   = array();
 
-		foreach ( WC_Install::get_db_update_callbacks() as $version => $update_callbacks ) {
+		foreach ( $callbacks as $version => $update_callbacks ) {
 			if ( version_compare( $current_db_version, $version, '<' ) ) {
 				foreach ( $update_callbacks as $update_callback ) {
-					/* translators: %s: DB update callback key */
-					WP_CLI::log( sprintf( __( 'Calling update function: %s', 'woocommerce' ), $update_callback ) );
-					call_user_func( $update_callback );
-					$update_count ++;
+					$callbacks_to_run[] = $update_callback;
 				}
 			}
 		}
 
+		if ( empty( $callbacks_to_run ) ) {
+			/* translators: %s Database version number */
+			WP_CLI::success( sprintf( __( 'No updates required. Database version is %s', 'woocommerce' ), get_option( 'woocommerce_db_version' ) ) );
+			return;
+		}
+
+		/* translators: 1: Number of database updates 2: List of update callbacks */
+		WP_CLI::log( sprintf( __( 'Found %1$d updates (%2$s)', 'woocommerce' ), count( $callbacks_to_run ), implode( ', ', $callbacks_to_run ) ) );
+
+		$progress = \WP_CLI\Utils\make_progress_bar( __( 'Updating database', 'woocommerce' ), count( $callbacks_to_run ) ); // phpcs:ignore PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
+
+		foreach ( $callbacks_to_run as $update_callback ) {
+			call_user_func( $update_callback );
+			$update_count ++;
+			$progress->tick();
+		}
+
+		$progress->finish();
+
 		WC_Admin_Notices::remove_notice( 'update' );
+
 		/* translators: 1: Number of database updates performed 2: Database version number */
-		WP_CLI::success( sprintf( __( '%1$d updates complete. Database version is %2$s', 'woocommerce' ), absint( $update_count ), get_option( 'woocommerce_db_version' ) ) );
+		WP_CLI::success( sprintf( __( '%1$d update functions completed. Database version is %2$s', 'woocommerce' ), absint( $update_count ), get_option( 'woocommerce_db_version' ) ) );
 	}
 }

--- a/includes/cli/class-wc-cli-update-command.php
+++ b/includes/cli/class-wc-cli-update-command.php
@@ -61,6 +61,10 @@ class WC_CLI_Update_Command {
 
 		foreach ( $callbacks_to_run as $update_callback ) {
 			call_user_func( $update_callback );
+			$result = false;
+			while ( $result ) {
+				$result = (bool) call_user_func( $update_callback );
+			}
 			$update_count ++;
 			$progress->tick();
 		}


### PR DESCRIPTION
This PR moves away from Background Processing to the WC Queue (ActionScheduler) which includes it's own logging and ways to trigger events that fail to run.

Events are queued in time() + X order to make sure they run in order.

I updated the CLI to include a progress bar and to handle repeating events which was missing. A link to CLI docs is included in the admin notices.

This PR also updates the wording in update notices, as well as includes a link to the docs (closes #20577).

To test,
1. Edit the database and update woocommerce_db_version/woocommerce_version to something in the past. e.g. 3.5.0.
2. Go to WP admin. A notice will appear telling you to update.
3. Update. Check for the events in Tools > Scheduled Actions
4. When events complete the notice will update.
5. Check the DB - both versions should be current.