### PR TITLE
get_downloads_for_customer performance improvement via index

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -124,6 +124,10 @@ class WC_Install {
 			'wc_update_354_modify_shop_manager_caps',
 			'wc_update_354_db_version',
 		),
+		'3.6.0' => array(
+			'wc_update_360_downloadable_product_permissions_index',
+			'wc_update_360_db_version',
+		),
 	);
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -692,7 +692,8 @@ CREATE TABLE {$wpdb->prefix}woocommerce_downloadable_product_permissions (
   PRIMARY KEY  (permission_id),
   KEY download_order_key_product (product_id,order_id,order_key(16),download_id),
   KEY download_order_product (download_id,order_id,product_id),
-  KEY order_id (order_id)
+  KEY order_id (order_id),
+  KEY user_order_remaining_expires (user_id,order_id,downloads_remaining,access_expires)
 ) $collate;
 CREATE TABLE {$wpdb->prefix}woocommerce_order_items (
   order_item_id BIGINT UNSIGNED NOT NULL auto_increment,

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1932,3 +1932,25 @@ function wc_update_354_modify_shop_manager_caps() {
 function wc_update_354_db_version() {
 	WC_Install::update_db_version( '3.5.4' );
 }
+
+/**
+ * Add new user_order_remaining_expires to speed up user download permission fetching.
+ *
+ * @return void
+ */
+function wc_update_360_downloadable_product_permissions_index() {
+	global $wpdb;
+
+	$index_exists = $wpdb->get_row( "SHOW INDEX FROM {$wpdb->prefix}woocommerce_downloadable_product_permissions WHERE key_name = 'user_order_remaining_expires'" );
+
+	if ( is_null( $index_exists ) ) {
+		$wpdb->query( "ALTER TABLE {$wpdb->prefix}woocommerce_downloadable_product_permissions ADD INDEX user_order_remaining_expires (user_id,order_id,downloads_remaining,access_expires)" );
+	}
+}
+
+/**
+ * Update DB Version.
+ */
+function wc_update_360_db_version() {
+	WC_Install::update_db_version( '3.6.0' );
+}

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -740,7 +740,7 @@ function wc_update_240_shipping_methods() {
 		if ( version_compare( $shipping_method->get_option( 'version', 0 ), '2.4.0', '<' ) ) {
 			$shipping_classes  = WC()->shipping()->get_shipping_classes();
 			$has_classes       = count( $shipping_classes ) > 0;
-			$cost_key          = $has_classes ? 'no_class_cost': 'cost';
+			$cost_key          = $has_classes ? 'no_class_cost' : 'cost';
 			$min_fee           = $shipping_method->get_option( 'minimum_fee' );
 			$math_cost_strings = array(
 				'cost'          => array(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds an index to the downloadable_product_permissions table to accommodate the query run by get_downloads_for_customer. In my tests on 500k rows without the index the query ran in just under 0.9s to find downloads for a customer, after adding the index the speed improved to 0.0006

![Before index](https://d.pr/free/i/q3QNp2+)
![After index](https://d.pr/free/i/SVFDBc+)

### How to test the changes in this Pull Request:

1. Populate your downloadable_product_permissions table with a large number of rows
2. Benchmark get_downloads_for_customer
3. Apply the path and run the update routine
2. Benchmark get_downloads_for_customer again and see the difference in speed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> New - Index on downloadable_product_permissions to improve speed when fetching downloads for customers.
