### PR TITLE
remove some obsolete code

### DIFF
--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -109,9 +109,6 @@ class WC_Post_Data {
 	 * @param array  $old_tt_ids Old array of term taxonomy IDs.
 	 */
 	public static function set_object_terms( $object_id, $terms, $tt_ids, $taxonomy, $append, $old_tt_ids ) {
-		foreach ( array_merge( $tt_ids, $old_tt_ids ) as $id ) {
-			delete_transient( 'wc_ln_count_' . md5( sanitize_key( $taxonomy ) . sanitize_key( $id ) ) );
-		}
 		if ( in_array( get_post_type( $object_id ), array( 'product', 'product_variation' ), true ) ) {
 			self::delete_product_query_transients();
 		}

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -134,23 +134,7 @@ class WC_Post_Data {
 	 * Delete product view transients when needed e.g. when post status changes, or visibility/stock status is modified.
 	 */
 	public static function delete_product_query_transients() {
-		// Increments the transient version to invalidate cache.
 		WC_Cache_Helper::get_transient_version( 'product_query', true );
-
-		// If not using an external caching system, we can clear the transients out manually and avoid filling our DB.
-		if ( ! wp_using_ext_object_cache() ) {
-			global $wpdb;
-
-			$wpdb->query(
-				"
-				DELETE FROM `$wpdb->options`
-				WHERE `option_name` LIKE ('\_transient\_wc\_uf\_pid\_%')
-				OR `option_name` LIKE ('\_transient\_timeout\_wc\_uf\_pid\_%')
-				OR `option_name` LIKE ('\_transient\_wc\_products\_will\_display\_%')
-				OR `option_name` LIKE ('\_transient\_timeout\_wc\_products\_will\_display\_%')
-			"
-			);
-		}
 	}
 
 	/**


### PR DESCRIPTION
Pulled from https://github.com/woocommerce/woocommerce/pull/22718

These transients no longer exist in WC core and can be removed.