### PR TITLE
Refactor comment/rating update functions

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -195,12 +195,12 @@ class WC_Comments {
 	 * @param int $post_id Post ID.
 	 */
 	public static function clear_transients( $post_id ) {
-
 		if ( 'product' === get_post_type( $post_id ) ) {
 			$product = wc_get_product( $post_id );
-			self::get_rating_counts_for_product( $product );
-			self::get_average_rating_for_product( $product );
-			self::get_review_count_for_product( $product );
+			$product->set_rating_count( self::get_rating_counts_for_product( $product ) );
+			$product->set_average_rating( self::get_average_rating_for_product( $product ) );
+			$product->set_review_count( self::get_review_count_for_product( $product ) );
+			$product->save();
 		}
 	}
 
@@ -337,11 +337,6 @@ class WC_Comments {
 			$average = 0;
 		}
 
-		$product->set_average_rating( $average );
-
-		$data_store = $product->get_data_store();
-		$data_store->update_average_rating( $product );
-
 		return $average;
 	}
 
@@ -366,11 +361,6 @@ class WC_Comments {
 				$product->get_id()
 			)
 		);
-
-		$product->set_review_count( $count );
-
-		$data_store = $product->get_data_store();
-		$data_store->update_review_count( $product );
 
 		return $count;
 	}
@@ -404,11 +394,6 @@ class WC_Comments {
 		foreach ( $raw_counts as $count ) {
 			$counts[ $count->meta_value ] = absint( $count->meta_value_count ); // WPCS: slow query ok.
 		}
-
-		$product->set_rating_counts( $counts );
-
-		$data_store = $product->get_data_store();
-		$data_store->update_rating_counts( $product );
 
 		return $counts;
 	}

--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -197,7 +197,7 @@ class WC_Comments {
 	public static function clear_transients( $post_id ) {
 		if ( 'product' === get_post_type( $post_id ) ) {
 			$product = wc_get_product( $post_id );
-			$product->set_rating_count( self::get_rating_counts_for_product( $product ) );
+			$product->set_rating_counts( self::get_rating_counts_for_product( $product ) );
 			$product->set_average_rating( self::get_average_rating_for_product( $product ) );
 			$product->set_review_count( self::get_review_count_for_product( $product ) );
 			$product->save();

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -340,7 +340,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$set_props = array();
 
 		foreach ( $meta_key_to_props as $meta_key => $prop ) {
-			$meta_value         = isset( $post_meta_values[ $meta_key ][0] ) ? $post_meta_values[ $meta_key ][0] : '';
+			$meta_value         = isset( $post_meta_values[ $meta_key ][0] ) ? $post_meta_values[ $meta_key ][0] : null;
 			$set_props[ $prop ] = maybe_unserialize( $meta_value ); // get_post_meta only unserializes single values.
 		}
 
@@ -349,28 +349,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$set_props['shipping_class_id'] = current( $this->get_term_ids( $product, 'product_shipping_class' ) );
 		$set_props['gallery_image_ids'] = array_filter( explode( ',', $set_props['gallery_image_ids'] ) );
 
-		if ( '' === $set_props['review_count'] ) {
-			unset( $set_props['review_count'] );
-			WC_Comments::get_review_count_for_product( $product );
-		}
-
-		if ( '' === $set_props['rating_counts'] ) {
-			unset( $set_props['rating_counts'] );
-			WC_Comments::get_rating_counts_for_product( $product );
-		}
-
-		if ( '' === $set_props['average_rating'] ) {
-			unset( $set_props['average_rating'] );
-			WC_Comments::get_average_rating_for_product( $product );
-		}
-
 		$product->set_props( $set_props );
-
-		// Handle sale dates on the fly in case of missed cron schedule.
-		if ( $product->is_type( 'simple' ) && $product->is_on_sale( 'edit' ) && $product->get_sale_price( 'edit' ) !== $product->get_price( 'edit' ) ) {
-			update_post_meta( $product->get_id(), '_price', $product->get_sale_price( 'edit' ) );
-			$product->set_price( $product->get_sale_price( 'edit' ) );
-		}
 	}
 
 	/**

--- a/includes/legacy/abstract-wc-legacy-product.php
+++ b/includes/legacy/abstract-wc-legacy-product.php
@@ -653,6 +653,7 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 */
 	public static function sync_average_rating( $post_id ) {
 		wc_deprecated_function( 'WC_Product::sync_average_rating', '3.0', 'WC_Comments::get_average_rating_for_product or leave to CRUD.' );
+		self::sync_rating_count( $post_id );
 		$average = WC_Comments::get_average_rating_for_product( wc_get_product( $post_id ) );
 		update_post_meta( $post_id, '_wc_average_rating', $average );
 	}

--- a/includes/legacy/abstract-wc-legacy-product.php
+++ b/includes/legacy/abstract-wc-legacy-product.php
@@ -653,6 +653,8 @@ abstract class WC_Abstract_Legacy_Product extends WC_Data {
 	 */
 	public static function sync_average_rating( $post_id ) {
 		wc_deprecated_function( 'WC_Product::sync_average_rating', '3.0', 'WC_Comments::get_average_rating_for_product or leave to CRUD.' );
+		// See notes in https://github.com/woocommerce/woocommerce/pull/22909#discussion_r262393401.
+		// Sync count first like in the original method https://github.com/woocommerce/woocommerce/blob/2.6.0/includes/abstracts/abstract-wc-product.php#L1101-L1128.
 		self::sync_rating_count( $post_id );
 		$average = WC_Comments::get_average_rating_for_product( wc_get_product( $post_id ) );
 		update_post_meta( $post_id, '_wc_average_rating', $average );


### PR DESCRIPTION
get_rating_counts_for_product, get_average_rating_for_product, get_review_count_for_product have some strange behavior where they update values from within rather than just return values as they are documented/intended to do so.

This appears to be an error and/or legacy. The setters should set those values to prevent issues on read or undesired updates of data.

In additon, the data-store is trying to set and save these values on read. This is not neccessary because those values always exist. This is a throw back to when these values were transients which is no longer the case.

If unit tests pass, this should be enough to merge.

Taken from https://github.com/woocommerce/woocommerce/pull/22718