### PR TITLE
OBW: track a users next step

### DIFF
--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -30,7 +30,7 @@ class WC_Admin_Setup_Wizard_Tracking {
 		add_filter( 'woocommerce_setup_wizard_steps', array( $this, 'set_obw_steps' ) );
 		add_action( 'shutdown', array( $this, 'track_skip_step' ), 1 );
 		add_action( 'add_option_woocommerce_allow_tracking', array( $this, 'track_start' ), 10, 2 );
-		add_action( 'admin_init', array( $this, 'track_marketing_signup' ), 1 );
+		add_action( 'admin_init', array( $this, 'track_ready_next_steps' ), 1 );
 		add_action( 'wp_print_scripts', array( $this, 'dequeue_non_whitelisted_scripts' ) );
 		$this->add_step_save_events();
 	}
@@ -86,7 +86,7 @@ class WC_Admin_Setup_Wizard_Tracking {
 	/**
 	 * Track the marketing form on submit.
 	 */
-	public function track_marketing_signup() {
+	public function track_ready_next_steps() {
 		if ( 'next_steps' !== $this->get_current_step() ) {
 			return;
 		}
@@ -96,6 +96,13 @@ class WC_Admin_Setup_Wizard_Tracking {
 			var form = $( '.newsletter-form-email' ).closest( 'form' );
 			$( document ).on( 'submit', form, function() {
 				window.wcTracks.recordEvent( 'obw_marketing_signup' );
+			} );
+			$( '.wc-setup-content a' ).click( function trackNextScreen( e ) {
+				var properties = {
+					next_url: e.target.href,
+					button: e.target.textContent && e.target.textContent.trim()
+				};
+				window.wcTracks.recordEvent( 'obw_ready_next_step', properties );
 			} );
 		"
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Depends on https://github.com/woocommerce/woocommerce/pull/22903

Track where users go after the "Ready" step in the Onboarding Wizard (OBW)

### How to test the changes in this Pull Request:

1. Go to the last step of the OBW, `/wp-admin/admin.php?page=wc-setup&step=next_steps`
2. Open the Network tab and click "preserve log" so you can see events after page load
3. Watch for `t.gif`
4. Click any link in the content part of the page. See a request made to record Tracks event.
5. Click any link outside the content part, notice no event being fired.
