### PR TITLE
Tracks: Move tracking script to make available on page load

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -48,38 +48,28 @@ class WC_Site_Tracking {
 		// Add w.js to the page.
 		wp_enqueue_script( 'woo-tracks', 'https://stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
 
-		// Expose tracking via a function in the wcTracks global namespace.
-		add_filter( 'woocommerce_queued_js', array( __CLASS__, 'add_tracking_function' ), PHP_INT_MAX );
-		// Force wc_print_js to show.
-		wc_enqueue_js( '' );
+		// Expose tracking via a function in the wcTracks global namespace directly before wc_print_js.
+		add_filter( 'admin_footer', array( __CLASS__, 'add_tracking_function' ), 24 );
 
 	}
 
 	/**
-	 * Adds the tracking function to the footer outside the jQuery scope
-	 * to make it readily available to other scripts.
+	 * Adds the tracking function to the admin footer.
 	 */
-	public static function add_tracking_function( $js ) {
-		global $wc_queued_js;
-		$js = empty( trim( $wc_queued_js ) ) ? '' : $js;
-
-		ob_start();
+	public static function add_tracking_function() {
 		?>
 		<!-- WooCommerce Tracks -->
 		<script type="text/javascript">
 			window.wcTracks = window.wcTracks || {};
 			window.wcTracks.recordEvent = function( name, properties ) {
-				var eventName = '<?php echo WC_Tracks::PREFIX; ?>' + name;
+				var eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
 				var eventProperties = properties || {};
-				eventProperties.url = '<?php echo home_url(); ?>'
+				eventProperties.url = '<?php echo esc_html( home_url() ); ?>'
 				window._tkq = window._tkq || [];
 				window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
 			}
 		</script>
 		<?php
-		$tracking_js = ob_get_clean();
-
-		return $tracking_js . $js;
 	}
 
 	/**

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -73,6 +73,19 @@ class WC_Site_Tracking {
 	}
 
 	/**
+	 * Add empty tracking function to admin footer when tracking is disabled in case
+	 * it's called without checking if it's defined beforehand.
+	 */
+	public static function add_empty_tracking_function() {
+		?>
+		<script type="text/javascript">
+			window.wcTracks = window.wcTracks || {};
+			window.wcTracks.recordEvent = function() {};
+		</script>
+		<?php
+	}
+
+	/**
 	 * Init tracking.
 	 */
 	public static function init() {
@@ -80,12 +93,7 @@ class WC_Site_Tracking {
 		if ( ! self::is_tracking_enabled() ) {
 
 			// Define window.wcTracks.recordEvent in case there is an attempt to use it when tracking is turned off.
-			wc_enqueue_js(
-				'
-				window.wcTracks = window.wcTracks || {};
-				window.wcTracks.recordEvent = function() {};
-			'
-			);
+			add_filter( 'admin_footer', array( __CLASS__, 'add_empty_tracking_function' ), 24 );
 
 			return;
 		}

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -68,7 +68,7 @@ class WC_Admin_Setup_Wizard_Tracking {
 	 */
 	public static function add_footer_scripts() {
 		wp_print_scripts();
-		wc_print_js();
+		WC_Site_Tracking::add_tracking_function();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves the tracking script outside the jQuery block so that it is available while the page is loading.  Otherwise, certain scripts (like wc-admin) can't track initial page loads.

Note that there are 2 ways to do this and both are visible in this PR:
https://github.com/woocommerce/woocommerce/pull/22914/commits/6cd605f1b8042dcbfb49a03008a7edaf9e309c53 - Filter `wc_print_js` to force this function outside the jQuery block.
https://github.com/woocommerce/woocommerce/pull/22914/commits/d7b1f82847be3973166460e97ebc138a6f722584 - Add directly to the footer.

I'm partial towards the latter since this is how `wc_print_js` gets added anyway and feels less hacky.

### How to test the changes in this Pull Request:

1.  Check that the script loads in the footer on admin pages still.
2.  Check that script is still available at `/wp-admin/admin.php?page=wc-setup&step=next_steps`.
3.  Check that the script still fires and records an event correctly.
