### PR TITLE
Move definition of wcTracks.recordEvent to the page head

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -41,7 +41,7 @@ class WC_Site_Tracking {
 	}
 
 	/**
-	 * Add scripts required to record events from javascript.
+	 * Add recordEvent function to the global namespace.
 	 */
 	public static function print_recordEvent() {
 		echo "<script type='text/javascript'>
@@ -59,9 +59,9 @@ class WC_Site_Tracking {
 	}
 
 	/**
-	 * Add scripts required to record events from javascript.
+	 * Define recordEvent as a function that does nothing in case its used when tracking is turned off.
 	 */
-	public static function print_recordEvent_no_tracking() {
+	public static function print_disabled_recordEvent() {
 		echo "<script type='text/javascript'>
 			window.wcTracks = window.wcTracks || {};
 			window.wcTracks.recordEvent = function() {};
@@ -76,7 +76,7 @@ class WC_Site_Tracking {
 		if ( ! self::is_tracking_enabled() ) {
 
 			// Define window.wcTracks.recordEvent in case there is an attempt to use it when tracking is turned off.
-			add_action( 'admin_head', array( __CLASS__, 'print_recordEvent_no_tracking' ) );
+			add_action( 'admin_head', array( __CLASS__, 'print_disabled_recordEvent' ) );
 
 			return;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure that `window.wcTracks.recordEvent` is defined for page load events by moving its definition to the page `<head>`.

### How to test the changes in this Pull Request:

1. View page source and see `recordEvent` defined in the document head.
1. When tracking is turned on (option `woocommerce_allow_tracking` = 'yes'`), check that `_tkq` is defined in the console.
2. When tracking is off, see that `recordEvent` is defined as an empty function and `_tkq` is not defined.

