### PR TITLE
Remove structured data from archives and include some recommended fields on single product pages

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -302,8 +302,6 @@ class WC_Structured_Data {
 						'reviewRating' => array(
 							'@type'       => 'Rating',
 							'ratingValue' => $rating,
-							'bestRating'  => 5,
-							'worstRating' => 1,
 						),
 						'author'       => array(
 							'@type' => 'Person',
@@ -342,8 +340,6 @@ class WC_Structured_Data {
 			$markup['reviewRating'] = array(
 				'@type'       => 'Rating',
 				'ratingValue' => $rating,
-				'bestRating'  => 5,
-				'worstRating' => 1,
 			);
 		} elseif ( $comment->comment_parent ) {
 			return;

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -207,13 +207,6 @@ class WC_Structured_Data {
 		$markup['sku']         = $product->get_sku();
 		$markup['brand']       = '';
 
-		if ( apply_filters( 'woocommerce_structured_data_product_limit', false ) ) {
-			$markup['url'] = $permalink;
-
-			$this->set_data( apply_filters( 'woocommerce_structured_data_product_limited', $markup, $product ) );
-			return;
-		}
-
 		if ( '' !== $product->get_price() ) {
 			if ( $product->is_type( 'variable' ) ) {
 				$lowest  = $product->get_variation_price( 'min', false );

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -312,6 +312,11 @@ class WC_Structured_Data {
 			}
 		}
 
+		// Check we have required data.
+		if ( empty( $markup['aggregateRating'] ) && empty( $markup['offers'] ) && empty( $markup['review'] ) ) {
+			return;
+		}
+
 		$this->set_data( apply_filters( 'woocommerce_structured_data_product', $markup, $product ) );
 	}
 

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -197,9 +197,11 @@ class WC_Structured_Data {
 		$permalink = get_permalink( $product->get_id() );
 
 		$markup = array(
-			'@type' => 'Product',
-			'@id'   => $permalink . '#product', // Append '#product' to differentiate between this @id and the @id generated for the Breadcrumblist.
-			'name'  => $product->get_name(),
+			'@type'       => 'Product',
+			'@id'         => $permalink . '#product', // Append '#product' to differentiate between this @id and the @id generated for the Breadcrumblist.
+			'name'        => $product->get_name(),
+			'image'       => wp_get_attachment_url( $product->get_image_id() ),
+			'description' => wp_strip_all_tags( do_shortcode( $product->get_short_description() ? $product->get_short_description() : $product->get_description() ) ),
 		);
 
 		$markup['image']       = wp_get_attachment_url( $product->get_image_id() );

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -119,7 +119,7 @@ class WC_Structured_Data {
 		$types[] = is_shop() || is_product_category() || is_product() ? 'product' : '';
 		$types[] = is_shop() && is_front_page() ? 'website' : '';
 		$types[] = is_product() ? 'review' : '';
-		$types[] = ! is_shop() ? 'breadcrumblist' : '';
+		$types[] = 'breadcrumblist';
 		$types[] = 'order';
 
 		return array_filter( apply_filters( 'woocommerce_structured_data_type_for_page', $types ) );
@@ -382,6 +382,10 @@ class WC_Structured_Data {
 
 			if ( ! empty( $crumb[1] ) ) {
 				$markup['itemListElement'][ $key ]['item'] += array( '@id' => $crumb[1] );
+			} elseif ( isset( $_SERVER['HTTP_HOST'], $_SERVER['REQUEST_URI'] ) ) {
+				$current_url = set_url_scheme( 'http://' . wp_unslash( $_SERVER['HTTP_HOST'] ) . wp_unslash( $_SERVER['REQUEST_URI'] ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+				$markup['itemListElement'][ $key ]['item'] += array( '@id' => $current_url );
 			}
 		}
 

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -268,6 +268,44 @@ class WC_Structured_Data {
 			);
 		}
 
+		// Markup most recent rating/review.
+		$comments = get_comments(
+			array(
+				'number'      => 1,
+				'post_id'     => $product->get_id(),
+				'status'      => 'approve',
+				'post_status' => 'publish',
+				'post_type'   => 'product',
+				'parent'      => 0,
+				'meta_key'    => 'rating',
+				'orderby'     => 'meta_value_num',
+			)
+		);
+
+		if ( $comments ) {
+			foreach ( $comments as $comment ) {
+				$rating = get_comment_meta( $comment->comment_ID, 'rating', true );
+
+				if ( ! $rating ) {
+					continue;
+				}
+
+				$markup['review'] = array(
+					'@type'        => 'Review',
+					'reviewRating' => array(
+						'@type'       => 'Rating',
+						'ratingValue' => $rating,
+						'bestRating'  => 5,
+						'worstRating' => 1,
+					),
+					'author'       => array(
+						'@type' => 'Person',
+						'name'  => get_comment_author( $comment->comment_ID ),
+					),
+				);
+			}
+		}
+
 		$this->set_data( apply_filters( 'woocommerce_structured_data_product', $markup, $product ) );
 	}
 
@@ -294,8 +332,10 @@ class WC_Structured_Data {
 
 		if ( $rating ) {
 			$markup['reviewRating'] = array(
-				'@type'       => 'rating',
+				'@type'       => 'Rating',
 				'ratingValue' => $rating,
+				'bestRating'  => 5,
+				'worstRating' => 1,
 			);
 		} elseif ( $comment->comment_parent ) {
 			return;

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -28,7 +28,6 @@ class WC_Structured_Data {
 		// Generate structured data.
 		add_action( 'woocommerce_before_main_content', array( $this, 'generate_website_data' ), 30 );
 		add_action( 'woocommerce_breadcrumb', array( $this, 'generate_breadcrumblist_data' ), 10 );
-		add_action( 'woocommerce_shop_loop', array( $this, 'generate_product_data' ), 10 );
 		add_action( 'woocommerce_single_product_summary', array( $this, 'generate_product_data' ), 60 );
 		add_action( 'woocommerce_review_meta', array( $this, 'generate_review_data' ), 20 );
 		add_action( 'woocommerce_email_order_details', array( $this, 'generate_order_data' ), 20, 3 );
@@ -153,7 +152,7 @@ class WC_Structured_Data {
 		$data  = $this->get_structured_data( $types );
 
 		if ( $data ) {
-			echo '<script type="application/ld+json">' . wc_esc_json( wp_json_encode( $data ), true ) . '</script>';
+			echo '<script type="application/ld+json">' . wc_esc_json( wp_json_encode( $data ), true ) . '</script>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 
@@ -208,7 +207,7 @@ class WC_Structured_Data {
 		$markup['sku']         = $product->get_sku();
 		$markup['brand']       = '';
 
-		if ( apply_filters( 'woocommerce_structured_data_product_limit', is_product_taxonomy() || is_shop() ) ) {
+		if ( apply_filters( 'woocommerce_structured_data_product_limit', false ) ) {
 			$markup['url'] = $permalink;
 
 			$this->set_data( apply_filters( 'woocommerce_structured_data_product_limited', $markup, $product ) );

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -200,6 +200,7 @@ class WC_Structured_Data {
 			'@type'       => 'Product',
 			'@id'         => $permalink . '#product', // Append '#product' to differentiate between this @id and the @id generated for the Breadcrumblist.
 			'name'        => $product->get_name(),
+			'url'         => $permalink,
 			'image'       => wp_get_attachment_url( $product->get_image_id() ),
 			'description' => wp_strip_all_tags( do_shortcode( $product->get_short_description() ? $product->get_short_description() : $product->get_description() ) ),
 		);

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -205,10 +205,12 @@ class WC_Structured_Data {
 			'description' => wp_strip_all_tags( do_shortcode( $product->get_short_description() ? $product->get_short_description() : $product->get_description() ) ),
 		);
 
-		$markup['image']       = wp_get_attachment_url( $product->get_image_id() );
-		$markup['description'] = wp_strip_all_tags( do_shortcode( $product->get_short_description() ? $product->get_short_description() : $product->get_description() ) );
-		$markup['sku']         = $product->get_sku();
-		$markup['brand']       = '';
+		// Declare SKU or fallback to ID.
+		if ( $product->get_sku() ) {
+			$markup['sku'] = $product->get_sku();
+		} else {
+			$markup['sku'] = $product->get_id();
+		}
 
 		if ( '' !== $product->get_price() ) {
 			if ( $product->is_type( 'variable' ) ) {


### PR DESCRIPTION
- Remove structured data from archives (pulled from https://github.com/woocommerce/woocommerce/pull/22912). This prevents the error "Either offers review or aggregateRating should be specified" since the data was limited.
- Added `review` (resolves a warning in the testing tool) where available.
- Added `priceValidUntil` (resolves a warning in the testing tool) which defaults to a year.
- Added URL field (occasionally appears if there are no offers).
- Added a fallback for SKU so it's never missing.

The only warning I see with these changes is a missing `brand` attribute. We should not include this as there is no brand field in WooCommerce. [WooCommerce Brands](https://woocommerce.com/products/brands/) adds this field as well as updates schema. There are other solutions out there too so thats out of scope for this PR.

To test, visit a product page (preferably once with reviews), view source, and copy the source into the testing tool: https://search.google.com/structured-data/testing-tool/u/0/

![structured data testing tool 2019-03-04 13-26-04](https://user-images.githubusercontent.com/90977/53736254-1a08d300-3e81-11e9-8b4d-fe75ed1dd911.png)

`Brand` warning is expected - no brands exist in WC.
`image` warning is expected if you're testing on localhost and not a live site.

I've added a WIKI article here to cover customisation: https://github.com/woocommerce/woocommerce/wiki/Structured-data-for-products

> Removes invalid product structured data from archives, and include more data on single product pages. Product structured data should only be generated for visible data, and not on archives when there are single product pages available, as per the documentation. Since this change removes structured data from archives, the filters `woocommerce_structured_data_product_limit` and `woocommerce_structured_data_product_limited` have also been removed. To customize product structured data, for example adding custom fields or include on archives despite Google guidelines, see this WIKI article. https://github.com/woocommerce/woocommerce/wiki/Structured-data-for-products

Fixes #22896