### PR TITLE
Setup Wizard: Add keyboard events for custom input toggles

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -670,6 +670,7 @@ body {
 		position: relative;
 		max-height: 1.5em;
 		align-self: flex-start;
+		order: 3;
 	}
 
 	.wc-wizard-service-toggle {

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -67,6 +67,15 @@ jQuery( function( $ ) {
 		}
 	} );
 
+	$( '.wc-wizard-services' ).on( 'keyup', function( e ) {
+		var code = e.keyCode || e.which,
+			$focused = $( document.activeElement );
+
+		if ( $focused.is( '.wc-wizard-service-toggle, .wc-wizard-service-enable' ) && ( 13 === code || 32 === code ) ) {
+			$focused.find( ':input' ).click();
+		}
+	} );
+
 	$( '.wc-wizard-services' ).on( 'click', '.wc-wizard-service-enable', function( e ) {
 		var eventTarget = $( e.target );
 

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1631,6 +1631,18 @@ class WC_Admin_Setup_Wizard {
 					<p><?php echo esc_html( $item_info['name'] ); ?></p>
 				<?php endif; ?>
 			</div>
+			<div class="wc-wizard-service-enable">
+				<span class="wc-wizard-service-toggle <?php echo esc_attr( $should_enable_toggle ? '' : 'disabled' ); ?>" tabindex="0">
+					<input
+						id="wc-wizard-service-<?php echo esc_attr( $item_id ); ?>"
+						type="checkbox"
+						name="wc-wizard-service-<?php echo esc_attr( $item_id ); ?>-enabled"
+						value="yes" <?php checked( $should_enable_toggle ); ?>
+						data-plugins="<?php echo wc_esc_json( wp_json_encode( $plugins ) ); ?>"
+					/>
+					<label for="wc-wizard-service-<?php echo esc_attr( $item_id ); ?>">
+				</span>
+			</div>
 			<div class="wc-wizard-service-description">
 				<?php echo wp_kses_post( wpautop( $item_info['description'] ) ); ?>
 				<?php if ( ! empty( $item_info['settings'] ) ) : ?>
@@ -1679,18 +1691,6 @@ class WC_Admin_Setup_Wizard {
 						<?php endforeach; ?>
 					</div>
 				<?php endif; ?>
-			</div>
-			<div class="wc-wizard-service-enable">
-				<span class="wc-wizard-service-toggle <?php echo esc_attr( $should_enable_toggle ? '' : 'disabled' ); ?>">
-					<input
-						id="wc-wizard-service-<?php echo esc_attr( $item_id ); ?>"
-						type="checkbox"
-						name="wc-wizard-service-<?php echo esc_attr( $item_id ); ?>-enabled"
-						value="yes" <?php checked( $should_enable_toggle ); ?>
-						data-plugins="<?php echo wc_esc_json( wp_json_encode( $plugins ) ); ?>"
-					/>
-					<label for="wc-wizard-service-<?php echo esc_attr( $item_id ); ?>">
-				</span>
 			</div>
 		</li>
 		<?php
@@ -1769,7 +1769,7 @@ class WC_Admin_Setup_Wizard {
 					<div class="wc-wizard-service-description">
 						<?php esc_html_e( 'Collect payments from customers offline.', 'woocommerce' ); ?>
 					</div>
-					<div class="wc-wizard-service-enable">
+					<div class="wc-wizard-service-enable" tabindex="0">
 						<input class="wc-wizard-service-list-toggle" id="wc-wizard-service-list-toggle" type="checkbox">
 						<label for="wc-wizard-service-list-toggle"></label>
 					</div>


### PR DESCRIPTION
Updates the setup wizards custom toggles to support tabbing, and to support toggling on enter/space input.

I reordered the inputs so you can tab to the contents after a section is opened. Note, you need to minify files after checking out this PR.

Demo:

![2019-03-05 14 26 10](https://user-images.githubusercontent.com/90977/53812105-ac2cdc00-3f52-11e9-8425-b399c2f6fd09.gif)

> Setup Wizard: support keyboard navigation to toggle on/off features