### PR TITLE
Add caching to attribute functions

### DIFF
--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -2023,6 +2023,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Clear transients
 			delete_transient( 'wc_attribute_taxonomies' );
+			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
 
 			$this->server->send_status( 201 );
 
@@ -2108,6 +2109,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Clear transients
 			delete_transient( 'wc_attribute_taxonomies' );
+			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
 
 			return $this->get_product_attribute( $id );
 		} catch ( WC_API_Exception $e ) {
@@ -2169,6 +2171,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Clear transients
 			delete_transient( 'wc_attribute_taxonomies' );
+			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
 
 			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_attribute' ) );
 		} catch ( WC_API_Exception $e ) {

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -2582,6 +2582,7 @@ class WC_API_Products extends WC_API_Resource {
 			// Clear transients.
 			wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 			delete_transient( 'wc_attribute_taxonomies' );
+			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
 
 			$this->server->send_status( 201 );
 
@@ -2668,6 +2669,7 @@ class WC_API_Products extends WC_API_Resource {
 			// Clear transients.
 			wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 			delete_transient( 'wc_attribute_taxonomies' );
+			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
 
 			return $this->get_product_attribute( $id );
 		} catch ( WC_API_Exception $e ) {
@@ -2730,6 +2732,7 @@ class WC_API_Products extends WC_API_Resource {
 			// Clear transients.
 			wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 			delete_transient( 'wc_attribute_taxonomies' );
+			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
 
 			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_attribute' ) );
 		} catch ( WC_API_Exception $e ) {

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -621,6 +621,9 @@ class WC_Install {
 				); // WPCS: unprepared SQL ok.
 			}
 		}
+
+		// Clear table caches.
+		delete_transient( 'wc_attribute_taxonomies' );
 	}
 
 	/**

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -67,7 +67,8 @@ function wc_get_attribute_taxonomies() {
  * @return array
  */
 function wc_get_attribute_taxonomy_ids() {
-	$cache_key   = 'attribute-ids';
+	$prefix      = WC_Cache_Helper::get_cache_prefix( 'woocommerce-attributes' );
+	$cache_key   = $prefix . 'attribute-ids';
 	$cache_value = wp_cache_get( $cache_key, 'woocommerce-attributes' );
 
 	if ( $cache_value ) {
@@ -579,6 +580,7 @@ function wc_create_attribute( $args ) {
 	// Clear cache and flush rewrite rules.
 	wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 	delete_transient( 'wc_attribute_taxonomies' );
+	WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
 
 	return $id;
 }
@@ -668,6 +670,7 @@ function wc_delete_attribute( $id ) {
 		do_action( 'woocommerce_attribute_deleted', $id, $name, $taxonomy );
 		wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 		delete_transient( 'wc_attribute_taxonomies' );
+		WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
 
 		return true;
 	}
@@ -684,7 +687,8 @@ function wc_delete_attribute( $id ) {
  * @return string
  */
 function wc_attribute_taxonomy_slug( $attribute_name ) {
-	$cache_key   = 'slug-' . $attribute_name;
+	$prefix      = WC_Cache_Helper::get_cache_prefix( 'woocommerce-attributes' );
+	$cache_key   = $prefix . 'slug-' . $attribute_name;
 	$cache_value = wp_cache_get( $cache_key, 'woocommerce-attributes' );
 
 	if ( $cache_value ) {

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -408,6 +408,14 @@ function wc_array_filter_default_attributes( $attribute ) {
  * @return stdClass|null
  */
 function wc_get_attribute( $id ) {
+	$prefix      = WC_Cache_Helper::get_cache_prefix( 'woocommerce-attributes' );
+	$cache_key   = $prefix . 'attribute-' . $id;
+	$cache_value = wp_cache_get( $cache_key, 'woocommerce-attributes' );
+
+	if ( $cache_value ) {
+		return $cache_value;
+	}
+
 	global $wpdb;
 
 	$data = $wpdb->get_row(
@@ -432,6 +440,8 @@ function wc_get_attribute( $id ) {
 	$attribute->type         = $data->attribute_type;
 	$attribute->order_by     = $data->attribute_orderby;
 	$attribute->has_archives = (bool) $data->attribute_public;
+
+	wp_cache_set( $cache_key, $attribute, 'woocommerce-attributes' );
 
 	return $attribute;
 }

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -83,6 +83,28 @@ function wc_get_attribute_taxonomy_ids() {
 }
 
 /**
+ * Get (cached) attribute taxonomy label and name pairs.
+ *
+ * @since 3.6.0
+ * @return array
+ */
+function wc_get_attribute_taxonomy_labels() {
+	$prefix      = WC_Cache_Helper::get_cache_prefix( 'woocommerce-attributes' );
+	$cache_key   = $prefix . 'attribute-labels';
+	$cache_value = wp_cache_get( $cache_key, 'woocommerce-attributes' );
+
+	if ( $cache_value ) {
+		return $cache_value;
+	}
+
+	$taxonomy_labels = wp_list_pluck( wc_get_attribute_taxonomies(), 'attribute_label', 'attribute_name' );
+
+	wp_cache_set( $cache_key, $taxonomy_labels, 'woocommerce-attributes' );
+
+	return $taxonomy_labels;
+}
+
+/**
  * Get a product attribute name.
  *
  * @param string $attribute_name Attribute name.
@@ -140,7 +162,7 @@ function wc_attribute_taxonomy_id_by_name( $name ) {
 function wc_attribute_label( $name, $product = '' ) {
 	if ( taxonomy_is_product_attribute( $name ) ) {
 		$name       = wc_attribute_taxonomy_slug( $name );
-		$all_labels = wp_list_pluck( wc_get_attribute_taxonomies(), 'attribute_label', 'attribute_name' );
+		$all_labels = wc_get_attribute_taxonomy_labels();
 		$label      = isset( $all_labels[ $name ] ) ? $all_labels[ $name ] : $name;
 	} elseif ( $product ) {
 		if ( $product->is_type( 'variation' ) ) {

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -60,7 +60,7 @@ function wc_get_attribute_taxonomies() {
 	if ( false === $raw_attribute_taxonomies ) {
 		global $wpdb;
 
-		$raw_attribute_taxonomies = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_name !='' ORDER BY attribute_name ASC;" );
+		$raw_attribute_taxonomies = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}woocommerce_attribute_taxonomies WHERE attribute_name != '' ORDER BY attribute_name ASC;" );
 
 		set_transient( 'wc_attribute_taxonomies', $raw_attribute_taxonomies );
 	}

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -432,6 +432,7 @@ function wc_get_attribute( $id ) {
 		return null;
 	}
 
+	$data                    = $attributes[ $id ];
 	$attribute               = new stdClass();
 	$attribute->id           = (int) $data->attribute_id;
 	$attribute->name         = $data->attribute_label;

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -672,6 +672,9 @@ function wc_update_220_attributes() {
 			}
 		}
 	}
+
+	delete_transient( 'wc_attribute_taxonomies' );
+	WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
 }
 
 /**

--- a/tests/framework/helpers/class-wc-helper-product.php
+++ b/tests/framework/helpers/class-wc-helper-product.php
@@ -170,6 +170,7 @@ class WC_Helper_Product {
 		$label = $attribute_name;
 
 		delete_transient( 'wc_attribute_taxonomies' );
+		WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
 
 		register_taxonomy( 'pa_' . $attribute_name, array( 'product' ), array(
 			'labels' => array(


### PR DESCRIPTION
This PR adds caching across attribute lookup functions, and removes the need for a few direct DB queries.

Fixes #21034

2 new helpers organise data in a way thats useful to the other functions:

- `wc_get_attribute_taxonomy_ids`
- `wc_get_attribute_taxonomy_labels`

These values are also cached to prevent loops/wp_list_pluck on access.

`wc_get_attribute_taxonomies` is backwards compatible with it's filter but also indexes attributes by ID for easier lookup in other functions. Keys are prefixed with `id:` to prevent issues with numeric associative array keys.

Tests are passing, and I've added cache cleanup where appropriate.

I'm not sure how to best test the case in #21034 however. Our test data doesn't use too many attributes for this to make much difference. @kloon 
