### PR TITLE
Make coupon code sanitization match post_title sanitization

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -193,7 +193,7 @@ class WC_AJAX {
 		check_ajax_referer( 'apply-coupon', 'security' );
 
 		if ( ! empty( $_POST['coupon_code'] ) ) {
-			WC()->cart->add_discount( sanitize_text_field( wp_unslash( $_POST['coupon_code'] ) ) );
+			WC()->cart->add_discount( wc_format_coupon_code( wp_unslash( $_POST['coupon_code'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		} else {
 			wc_add_notice( WC_Coupon::get_generic_coupon_error( WC_Coupon::E_WC_COUPON_PLEASE_ENTER ), 'error' );
 		}
@@ -208,7 +208,7 @@ class WC_AJAX {
 	public static function remove_coupon() {
 		check_ajax_referer( 'remove-coupon', 'security' );
 
-		$coupon = isset( $_POST['coupon'] ) ? wc_clean( $_POST['coupon'] ) : false;
+		$coupon = isset( $_POST['coupon'] ) ? wc_format_coupon_code( wp_unslash( $_POST['coupon'] ) ) : false; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( empty( $coupon ) ) {
 			wc_add_notice( __( 'Sorry there was a problem removing this coupon.', 'woocommerce' ), 'error' );
@@ -1082,7 +1082,7 @@ class WC_AJAX {
 		try {
 			$order_id = absint( $_POST['order_id'] );
 			$order    = wc_get_order( $order_id );
-			$result   = $order->apply_coupon( wc_clean( $_POST['coupon'] ) );
+			$result   = $order->apply_coupon( wc_format_coupon_code( wp_unslash( $_POST['coupon'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
 			if ( is_wp_error( $result ) ) {
 				throw new Exception( html_entity_decode( wp_strip_all_tags( $result->get_error_message() ) ) );
@@ -1115,7 +1115,7 @@ class WC_AJAX {
 			$order_id = absint( $_POST['order_id'] );
 			$order    = wc_get_order( $order_id );
 
-			$order->remove_coupon( wc_clean( $_POST['coupon'] ) );
+			$order->remove_coupon( wc_format_coupon_code( wp_unslash( $_POST['coupon'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.InputNotValidated
 
 			ob_start();
 			include 'admin/meta-boxes/views/html-order-items.php';

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -547,10 +547,10 @@ class WC_Form_Handler {
 		$nonce_value = wc_get_var( $_REQUEST['woocommerce-cart-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
 
 		if ( ! empty( $_POST['apply_coupon'] ) && ! empty( $_POST['coupon_code'] ) ) {
-			WC()->cart->add_discount( sanitize_text_field( wp_unslash( $_POST['coupon_code'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+			WC()->cart->add_discount( wc_format_coupon_code( wp_unslash( $_POST['coupon_code'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		} elseif ( isset( $_GET['remove_coupon'] ) ) {
-			WC()->cart->remove_coupon( wc_clean( wp_unslash( $_GET['remove_coupon'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+			WC()->cart->remove_coupon( wc_format_coupon_code( urldecode( wp_unslash( $_GET['remove_coupon'] ) ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		} elseif ( ! empty( $_GET['remove_item'] ) && wp_verify_nonce( $nonce_value, 'woocommerce-cart' ) ) {
 			$cart_item_key = sanitize_text_field( wp_unslash( $_GET['remove_item'] ) );

--- a/includes/class-wc-order-item-coupon.php
+++ b/includes/class-wc-order-item-coupon.php
@@ -47,7 +47,7 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	 * @param string $value Coupon code.
 	 */
 	public function set_code( $value ) {
-		$this->set_prop( 'code', wc_clean( $value ) );
+		$this->set_prop( 'code', wc_format_coupon_code( $value ) );
 	}
 
 	/**

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -34,7 +34,7 @@ require WC_ABSPATH . 'includes/wc-webhook-functions.php';
  * Filters on data used in admin and frontend.
  */
 add_filter( 'woocommerce_coupon_code', 'html_entity_decode' );
-add_filter( 'woocommerce_coupon_code', 'sanitize_text_field' );
+add_filter( 'woocommerce_coupon_code', 'wc_sanitize_coupon_code' );
 add_filter( 'woocommerce_coupon_code', 'wc_strtolower' );
 add_filter( 'woocommerce_stock_amount', 'intval' ); // Stock amounts are integers by default.
 add_filter( 'woocommerce_shipping_rate_label', 'sanitize_text_field' ); // Shipping rate label.

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -1122,7 +1122,7 @@ add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_hold_stock_m
  * @return string
  */
 function wc_sanitize_term_text_based( $term ) {
-	return trim( wp_unslash( strip_tags( $term ) ) );
+	return trim( wp_strip_all_tags( wp_unslash( $term ) ) );
 }
 
 if ( ! function_exists( 'wc_make_numeric_postcode' ) ) {
@@ -1397,9 +1397,9 @@ function wc_implode_html_attributes( $raw_attributes ) {
 function wc_esc_json( $json, $html = false ) {
 	return _wp_specialchars(
 		$json,
-		$html ? ENT_NOQUOTES : ENT_QUOTES, // Escape quotes in attribute nodes only,
+		$html ? ENT_NOQUOTES : ENT_QUOTES, // Escape quotes in attribute nodes only.
 		'UTF-8',                           // json_encode() outputs UTF-8 (really just ASCII), not the blog's charset.
-		true                               // Double escape entities: `&amp;` -> `&amp;amp;`
+		true                               // Double escape entities: `&amp;` -> `&amp;amp;`.
 	);
 }
 

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -363,6 +363,20 @@ function wc_format_coupon_code( $value ) {
 }
 
 /**
+ * Sanitize a coupon code.
+ *
+ * Uses sanitize_post_field since coupon codes are stored as
+ * post_titles - the sanitization and escaping must match.
+ *
+ * @since  3.6.0
+ * @param  string $value Coupon code to format.
+ * @return string
+ */
+function wc_sanitize_coupon_code( $value ) {
+	return sanitize_post_field( 'post_title', $value, 0, 'db' );
+}
+
+/**
  * Clean variables using sanitize_text_field. Arrays are cleaned recursively.
  * Non-scalar values are ignored.
  *

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -12,6 +12,9 @@
  */
 class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
+	/**
+	 * Setup class.
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -48,10 +51,13 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 * @since 3.3.0
 	 */
 	public function test_wc_string_to_array() {
-		$this->assertEquals( array(
-			'foo',
-			'bar',
-		), wc_string_to_array( 'foo|bar', '|' ) );
+		$this->assertEquals(
+			array(
+				'foo',
+				'bar',
+			),
+			wc_string_to_array( 'foo|bar', '|' )
+		);
 	}
 
 	/**
@@ -97,64 +103,82 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		$default_unit = get_option( 'woocommerce_dimension_unit' );
 
 		// cm (default unit).
-		$this->assertEquals( array( 10, 3.937, 0.10936133, 100, 0.1 ), array(
-			wc_get_dimension( 10, 'cm' ),
-			wc_get_dimension( 10, 'in' ),
-			wc_get_dimension( 10, 'yd' ),
-			wc_get_dimension( 10, 'mm' ),
-			wc_get_dimension( 10, 'm' ),
-		) );
+		$this->assertEquals(
+			array( 10, 3.937, 0.10936133, 100, 0.1 ),
+			array(
+				wc_get_dimension( 10, 'cm' ),
+				wc_get_dimension( 10, 'in' ),
+				wc_get_dimension( 10, 'yd' ),
+				wc_get_dimension( 10, 'mm' ),
+				wc_get_dimension( 10, 'm' ),
+			)
+		);
 
 		// in.
 		update_option( 'woocommerce_dimension_unit', 'in' );
-		$this->assertEquals( array( 25.4, 10, 0.2777777782, 254, 0.254 ), array(
-			wc_get_dimension( 10, 'cm' ),
-			wc_get_dimension( 10, 'in' ),
-			wc_get_dimension( 10, 'yd' ),
-			wc_get_dimension( 10, 'mm' ),
-			wc_get_dimension( 10, 'm' ),
-		) );
+		$this->assertEquals(
+			array( 25.4, 10, 0.2777777782, 254, 0.254 ),
+			array(
+				wc_get_dimension( 10, 'cm' ),
+				wc_get_dimension( 10, 'in' ),
+				wc_get_dimension( 10, 'yd' ),
+				wc_get_dimension( 10, 'mm' ),
+				wc_get_dimension( 10, 'm' ),
+			)
+		);
 
 		// m.
 		update_option( 'woocommerce_dimension_unit', 'm' );
-		$this->assertEquals( array( 1000, 393.7, 10.936133, 10000, 10 ), array(
-			wc_get_dimension( 10, 'cm' ),
-			wc_get_dimension( 10, 'in' ),
-			wc_get_dimension( 10, 'yd' ),
-			wc_get_dimension( 10, 'mm' ),
-			wc_get_dimension( 10, 'm' ),
-		) );
+		$this->assertEquals(
+			array( 1000, 393.7, 10.936133, 10000, 10 ),
+			array(
+				wc_get_dimension( 10, 'cm' ),
+				wc_get_dimension( 10, 'in' ),
+				wc_get_dimension( 10, 'yd' ),
+				wc_get_dimension( 10, 'mm' ),
+				wc_get_dimension( 10, 'm' ),
+			)
+		);
 
 		// mm.
 		update_option( 'woocommerce_dimension_unit', 'mm' );
-		$this->assertEquals( array( 1, 0.3937, 0.010936133, 10, 0.01 ), array(
-			wc_get_dimension( 10, 'cm' ),
-			wc_get_dimension( 10, 'in' ),
-			wc_get_dimension( 10, 'yd' ),
-			wc_get_dimension( 10, 'mm' ),
-			wc_get_dimension( 10, 'm' ),
-		) );
+		$this->assertEquals(
+			array( 1, 0.3937, 0.010936133, 10, 0.01 ),
+			array(
+				wc_get_dimension( 10, 'cm' ),
+				wc_get_dimension( 10, 'in' ),
+				wc_get_dimension( 10, 'yd' ),
+				wc_get_dimension( 10, 'mm' ),
+				wc_get_dimension( 10, 'm' ),
+			)
+		);
 
 		// yd.
 		update_option( 'woocommerce_dimension_unit', 'yd' );
-		$this->assertEquals( array( 914.4, 359.99928, 10, 9144, 9.144 ), array(
-			wc_get_dimension( 10, 'cm' ),
-			wc_get_dimension( 10, 'in' ),
-			wc_get_dimension( 10, 'yd' ),
-			wc_get_dimension( 10, 'mm' ),
-			wc_get_dimension( 10, 'm' ),
-		) );
+		$this->assertEquals(
+			array( 914.4, 359.99928, 10, 9144, 9.144 ),
+			array(
+				wc_get_dimension( 10, 'cm' ),
+				wc_get_dimension( 10, 'in' ),
+				wc_get_dimension( 10, 'yd' ),
+				wc_get_dimension( 10, 'mm' ),
+				wc_get_dimension( 10, 'm' ),
+			)
+		);
 
 		// Negative.
 		$this->assertEquals( 0, wc_get_dimension( -10, 'mm' ) );
 
 		// Custom.
-		$this->assertEquals( array( 25.4, 914.4, 393.7, 0.010936133 ), array(
-			wc_get_dimension( 10, 'cm', 'in' ),
-			wc_get_dimension( 10, 'cm', 'yd' ),
-			wc_get_dimension( 10, 'in', 'm' ),
-			wc_get_dimension( 10, 'yd', 'mm' ),
-		) );
+		$this->assertEquals(
+			array( 25.4, 914.4, 393.7, 0.010936133 ),
+			array(
+				wc_get_dimension( 10, 'cm', 'in' ),
+				wc_get_dimension( 10, 'cm', 'yd' ),
+				wc_get_dimension( 10, 'in', 'm' ),
+				wc_get_dimension( 10, 'yd', 'mm' ),
+			)
+		);
 
 		// Restore default.
 		update_option( 'woocommerce_dimension_unit', $default_unit );
@@ -368,7 +392,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 * @since 3.3.0
 	 */
 	public function test_wc_format_coupon_code() {
-		$this->assertEquals( 'foo#bar', wc_format_coupon_code( 'FOO#bar<script>alert();</script>' ) );
+		$this->assertEquals( 'foo#baralert();', wc_format_coupon_code( 'FOO#bar<script>alert();</script>' ) );
 	}
 
 	/**
@@ -578,13 +602,16 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 * @since 2.2
 	 */
 	public function test_wc_let_to_num() {
-		$this->assertEquals( array( 10240, 10485760, 10737418240, 10995116277760, 11258999068426240 ), array(
-			wc_let_to_num( '10K' ),
-			wc_let_to_num( '10M' ),
-			wc_let_to_num( '10G' ),
-			wc_let_to_num( '10T' ),
-			wc_let_to_num( '10P' ),
-		) );
+		$this->assertEquals(
+			array( 10240, 10485760, 10737418240, 10995116277760, 11258999068426240 ),
+			array(
+				wc_let_to_num( '10K' ),
+				wc_let_to_num( '10M' ),
+				wc_let_to_num( '10G' ),
+				wc_let_to_num( '10T' ),
+				wc_let_to_num( '10P' ),
+			)
+		);
 	}
 
 	/**
@@ -911,7 +938,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 *
 	 * This function is called by WP_HTTP_TestCase::http_request_listner().
 	 *
-	 * @param array $request Request arguments.
+	 * @param array  $request Request arguments.
 	 * @param string $url URL of the request.
 	 *
 	 * @return array|false mocked response or false to let WP perform a regular request.
@@ -975,16 +1002,19 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->assertEquals( array(
-			'A'   => 'tom',
-			'sum' => 30,
-			'C'   => array(
-				'x',
-				'y',
-				'z' => 145,
-				'w' => 1,
+		$this->assertEquals(
+			array(
+				'A'   => 'tom',
+				'sum' => 30,
+				'C'   => array(
+					'x',
+					'y',
+					'z' => 145,
+					'w' => 1,
+				),
 			),
-		), wc_array_merge_recursive_numeric( $a, $b, $c ) );
+			wc_array_merge_recursive_numeric( $a, $b, $c )
+		);
 	}
 
 	/**


### PR DESCRIPTION
This PR closes #22937

Removes sanitize_text_field from formatting of coupon codes since that strips `%` characters followed by numbers as they are entities. Switches formatting to match post_title instead.

See #22937 for test instructions. You can test with a coupon named `%20test` or similar.

- Check it saves in admin
- Check it applies from cart
- Check it removes from cart
- Check it applies manually to existing order
- Check it removes from existing order
- Check coupon code field does not allow XSS via script tags.

@kloon does this look safe to you?