### PR TITLE
Correctly show state fields after posting the edit address form

### DIFF
--- a/assets/js/frontend/address-i18n.js
+++ b/assets/js/frontend/address-i18n.js
@@ -22,7 +22,7 @@ jQuery( function( $ ) {
 			}
 		} else {
 			field.find( 'label .required' ).remove();
-			field.removeClass( 'validate-required' );
+			field.removeClass( 'validate-required woocommerce-invalid woocommerce-invalid-required-field' );
 
 			if ( field.find( 'label .optional' ).length === 0 ) {
 				field.find( 'label' ).append( '&nbsp;<span class="optional">(' + wc_address_i18n_params.i18n_optional_text + ')</span>' );

--- a/assets/js/frontend/country-select.js
+++ b/assets/js/frontend/country-select.js
@@ -77,11 +77,15 @@ jQuery( function( $ ) {
 
 	/* State/Country select boxes */
 	var states_json = wc_country_select_params.countries.replace( /&quot;/g, '"' ),
-		states = $.parseJSON( states_json );
+		states = $.parseJSON( states_json ),
+		wrapper_selectors = '.woocommerce-billing-fields,' +
+			'.woocommerce-shipping-fields,' +
+			'.woocommerce-address-fields,' +
+			'.woocommerce-shipping-calculator';
 
-	$( document.body ).on( 'change', 'select.country_to_state, input.country_to_state', function() {
+	$( document.body ).on( 'change refresh', 'select.country_to_state, input.country_to_state', function() {
 		// Grab wrapping element to target only stateboxes in same 'group'
-		var $wrapper    = $( this ).closest('.woocommerce-billing-fields, .woocommerce-shipping-fields, .woocommerce-shipping-calculator');
+		var $wrapper = $( this ).closest( wrapper_selectors );
 
 		if ( ! $wrapper.length ) {
 			$wrapper = $( this ).closest('.form-row').parent();
@@ -98,7 +102,7 @@ jQuery( function( $ ) {
 		if ( states[ country ] ) {
 			if ( $.isEmptyObject( states[ country ] ) ) {
 
-				$statebox.closest( 'p.form-row' ).hide().find( '.select2-container' ).remove();
+				$parent.hide().find( '.select2-container' ).remove();
 				$statebox.replaceWith(
 					'<input type="hidden" class="hidden" name="' +
 					input_name +
@@ -126,7 +130,7 @@ jQuery( function( $ ) {
 					placeholder = wc_country_select_params.i18n_select_state_text;
 				}
 
-				$statebox.closest( 'p.form-row' ).show();
+				$parent.show();
 
 				if ( $statebox.is( 'input' ) ) {
 					// Change for select
@@ -149,8 +153,8 @@ jQuery( function( $ ) {
 
 			}
 		} else {
-			if ( $statebox.is( 'select' ) ) {
 
+			if ( $statebox.is( 'select, input[type="hidden"]' ) ) {
 				$parent.show().find( '.select2-container' ).remove();
 				$statebox.replaceWith(
 					'<input type="text" class="input-text" name="' +
@@ -161,24 +165,7 @@ jQuery( function( $ ) {
 					placeholder +
 					'" />'
 				);
-
 				$( document.body ).trigger( 'country_to_state_changed', [country, $wrapper ] );
-
-			} else if ( $statebox.is( 'input[type="hidden"]' ) ) {
-
-				$parent.show().find( '.select2-container' ).remove();
-				$statebox.replaceWith(
-					'<input type="text" class="input-text" name="' +
-					input_name +
-					'" id="' +
-					input_id +
-					'" placeholder="' +
-					placeholder +
-					'" />'
-				);
-
-				$( document.body ).trigger( 'country_to_state_changed', [country, $wrapper ] );
-
 			}
 		}
 
@@ -188,7 +175,7 @@ jQuery( function( $ ) {
 
 	$( document.body ).on( 'wc_address_i18n_ready', function() {
 		// Init country selects with their default value once the page loads.
-		$('.woocommerce-billing-fields, .woocommerce-shipping-fields, .woocommerce-shipping-calculator').each( function() {
+		$( wrapper_selectors ).each( function() {
 			var $wrapper       = $( this ),
 				$country_input = $wrapper.find( '#billing_country, #shipping_country, #calc_shipping_country' );
 
@@ -202,7 +189,7 @@ jQuery( function( $ ) {
 				return;
 			}
 
-			$( document.body ).trigger( 'country_to_state_changing', [country, $wrapper ] );
+			$country_input.trigger( 'refresh' ); // Custom event to init the state field.
 		});
 	});
 

--- a/assets/js/frontend/country-select.js
+++ b/assets/js/frontend/country-select.js
@@ -6,53 +6,53 @@ jQuery( function( $ ) {
 		return false;
 	}
 
-	function getEnhancedSelectFormatString() {
-		return {
-			'language': {
-				errorLoading: function() {
-					// Workaround for https://github.com/select2/select2/issues/4355 instead of i18n_ajax_error.
-					return wc_country_select_params.i18n_searching;
-				},
-				inputTooLong: function( args ) {
-					var overChars = args.input.length - args.maximum;
-
-					if ( 1 === overChars ) {
-						return wc_country_select_params.i18n_input_too_long_1;
-					}
-
-					return wc_country_select_params.i18n_input_too_long_n.replace( '%qty%', overChars );
-				},
-				inputTooShort: function( args ) {
-					var remainingChars = args.minimum - args.input.length;
-
-					if ( 1 === remainingChars ) {
-						return wc_country_select_params.i18n_input_too_short_1;
-					}
-
-					return wc_country_select_params.i18n_input_too_short_n.replace( '%qty%', remainingChars );
-				},
-				loadingMore: function() {
-					return wc_country_select_params.i18n_load_more;
-				},
-				maximumSelected: function( args ) {
-					if ( args.maximum === 1 ) {
-						return wc_country_select_params.i18n_selection_too_long_1;
-					}
-
-					return wc_country_select_params.i18n_selection_too_long_n.replace( '%qty%', args.maximum );
-				},
-				noResults: function() {
-					return wc_country_select_params.i18n_no_matches;
-				},
-				searching: function() {
-					return wc_country_select_params.i18n_searching;
-				}
-			}
-		};
-	}
-
 	// Select2 Enhancement if it exists
 	if ( $().selectWoo ) {
+		var getEnhancedSelectFormatString = function() {
+			return {
+				'language': {
+					errorLoading: function() {
+						// Workaround for https://github.com/select2/select2/issues/4355 instead of i18n_ajax_error.
+						return wc_country_select_params.i18n_searching;
+					},
+					inputTooLong: function( args ) {
+						var overChars = args.input.length - args.maximum;
+
+						if ( 1 === overChars ) {
+							return wc_country_select_params.i18n_input_too_long_1;
+						}
+
+						return wc_country_select_params.i18n_input_too_long_n.replace( '%qty%', overChars );
+					},
+					inputTooShort: function( args ) {
+						var remainingChars = args.minimum - args.input.length;
+
+						if ( 1 === remainingChars ) {
+							return wc_country_select_params.i18n_input_too_short_1;
+						}
+
+						return wc_country_select_params.i18n_input_too_short_n.replace( '%qty%', remainingChars );
+					},
+					loadingMore: function() {
+						return wc_country_select_params.i18n_load_more;
+					},
+					maximumSelected: function( args ) {
+						if ( args.maximum === 1 ) {
+							return wc_country_select_params.i18n_selection_too_long_1;
+						}
+
+						return wc_country_select_params.i18n_selection_too_long_n.replace( '%qty%', args.maximum );
+					},
+					noResults: function() {
+						return wc_country_select_params.i18n_no_matches;
+					},
+					searching: function() {
+						return wc_country_select_params.i18n_searching;
+					}
+				}
+			};
+		}
+
 		var wc_country_select_select2 = function() {
 			$( 'select.country_select:visible, select.state_select:visible' ).each( function() {
 				var select2_args = $.extend({
@@ -60,11 +60,11 @@ jQuery( function( $ ) {
 					width: '100%'
 				}, getEnhancedSelectFormatString() );
 
-				$( this ).selectWoo( select2_args );
-				// Maintain focus after select https://github.com/select2/select2/issues/4384
-				$( this ).on( 'select2:select', function() {
-					$( this ).focus();
-				} );
+				$( this )
+					.on( 'select2:select', function() {
+						$( this ).focus(); // Maintain focus after select https://github.com/select2/select2/issues/4384
+					} )
+					.selectWoo( select2_args );
 			});
 		};
 
@@ -76,8 +76,8 @@ jQuery( function( $ ) {
 	}
 
 	/* State/Country select boxes */
-	var states_json = wc_country_select_params.countries.replace( /&quot;/g, '"' ),
-		states = $.parseJSON( states_json ),
+	var states_json       = wc_country_select_params.countries.replace( /&quot;/g, '"' ),
+		states            = $.parseJSON( states_json ),
 		wrapper_selectors = '.woocommerce-billing-fields,' +
 			'.woocommerce-shipping-fields,' +
 			'.woocommerce-address-fields,' +
@@ -101,7 +101,6 @@ jQuery( function( $ ) {
 
 		if ( states[ country ] ) {
 			if ( $.isEmptyObject( states[ country ] ) ) {
-
 				$parent.hide().find( '.select2-container' ).remove();
 				$statebox.replaceWith(
 					'<input type="hidden" class="hidden" name="' +
@@ -112,15 +111,13 @@ jQuery( function( $ ) {
 					placeholder +
 					'" />'
 				);
-
 				$( document.body ).trigger( 'country_to_state_changed', [ country, $wrapper ] );
-
 			} else {
 
 				var options = '',
-					state = states[ country ];
+					state   = states[ country ];
 
-				for( var index in state ) {
+				for ( var index in state ) {
 					if ( state.hasOwnProperty( index ) ) {
 						options = options + '<option value="' + index + '">' + state[ index ] + '</option>';
 					}
@@ -150,7 +147,6 @@ jQuery( function( $ ) {
 				$statebox.val( value ).change();
 
 				$( document.body ).trigger( 'country_to_state_changed', [country, $wrapper ] );
-
 			}
 		} else {
 
@@ -170,27 +166,18 @@ jQuery( function( $ ) {
 		}
 
 		$( document.body ).trigger( 'country_to_state_changing', [country, $wrapper ] );
-
 	});
 
 	$( document.body ).on( 'wc_address_i18n_ready', function() {
 		// Init country selects with their default value once the page loads.
 		$( wrapper_selectors ).each( function() {
-			var $wrapper       = $( this ),
-				$country_input = $wrapper.find( '#billing_country, #shipping_country, #calc_shipping_country' );
+			var $country_input = $( this ).find( '#billing_country, #shipping_country, #calc_shipping_country' );
 
-			if ( 0 === $country_input.length ) {
+			if ( 0 === $country_input.length || 0 === $country_input.val().length ) {
 				return;
 			}
 
-			var country = $country_input.val();
-
-			if ( 0 === country.length ) {
-				return;
-			}
-
-			$country_input.trigger( 'refresh' ); // Custom event to init the state field.
+			$country_input.trigger( 'refresh' );
 		});
 	});
-
 });


### PR DESCRIPTION
Fixes #22940

When the address form is posted, but unsaved, the fields were not being initialised.

To resolve this, trigger a custom event on page load which inits the state fields. This used a custom event instead of `change` so validation is not also triggered on init. https://github.com/woocommerce/woocommerce/commit/9b6ded2cef2aae31bca0780c4a230146efc68e81

https://github.com/woocommerce/woocommerce/commit/023217c03d8d447a81e6c0cf4d607edd3e64c52b makes it so when a required field goes optional, the red styling is removed.

https://github.com/woocommerce/woocommerce/commit/406364fefb88b6499331960360af8a943503443a just tidies up unused variables and improves code formatting.

Testing instructions in #22940

> Fix - Correctly show state fields after posting the edit address form.