### PR TITLE
Use day, not time, in status widget for caching

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -91,7 +91,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 
 			$sales_by_date                 = new WC_Report_Sales_By_Date();
 			$sales_by_date->start_date     = strtotime( date( 'Y-m-01', current_time( 'timestamp' ) ) );
-			$sales_by_date->end_date       = current_time( 'timestamp' );
+			$sales_by_date->end_date       = strtotime( date( 'Y-m-d', current_time( 'timestamp' ) ) );
 			$sales_by_date->chart_groupby  = 'day';
 			$sales_by_date->group_by_query = 'YEAR(posts.post_date), MONTH(posts.post_date), DAY(posts.post_date)';
 


### PR DESCRIPTION
"This month" view in the reports section uses the current day, but not the time, in the query. e.g. `2019-02-06 00:00:00`.

The status widget, which is also labeled "this month", uses the current time. This bypasses caching.

This PR makes it use the day only so the queries matchup (using `2019-02-06 00:00:00` for example) and share caching.

Closes #22947