### PR TITLE
REST API: Restrict Access to wc-blocks/v1 endpoint

### DIFF
--- a/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
@@ -81,6 +81,15 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'Sorry, you cannot list resources.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
+		// Only allow requests to this endpoint to originate from local requests.
+		// This could obviously be spoofed, but will discourage usage outside of the editor.
+		$admin_url = admin_url();
+		$referrer = wp_get_referer();
+
+		if ( ! stristr( $referrer, $admin_url ) ) {
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'This endpoint is for editor usage only. ' . $admin_url . '  ' . $referrer, 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+		}
+
 		return true;
 	}
 

--- a/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
@@ -87,7 +87,7 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 		$referrer = wp_get_referer();
 
 		if ( ! stristr( $referrer, $admin_url ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'This endpoint is for editor usage only. ' . $admin_url . '  ' . $referrer, 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
+			return new WP_Error( 'woocommerce_rest_cannot_view', __( 'This endpoint is for editor usage only.', 'woocommerce' ), array( 'status' => rest_authorization_required_code() ) );
 		}
 
 		return true;


### PR DESCRIPTION
This is a bit of a `try` branch to explore a possible way to restrict usage of `wc-blocks/v1` endpoints to "internal use" only. This approach, while not fully perfect, does restrict usage of the `wc-blocks/v1/products` endpoint to requests that have a local referring domain set.

I tested this out using the Featured Product block, but it should work for any block that utilizes the products endpoint. Here is a grab of the headers sent on the request from the editor:

![image](https://user-images.githubusercontent.com/22080/53911651-ea3a0680-400b-11e9-88e7-f25616f3a5da.png)

So just adding a check to ensure the `referrer` includes the `admin_url` - if it does not, we throw an error. I'm likely using the incorrect HTTP code for this scenario, but just wanted to get this up for discussion more than anything.

__To Test__
- Open up the editor and add a featured product block
- Verify products are still displayed
- Perform an authenticated request using curl or Postman to the `wc-blocks/v1/products` endpoint and verify no results are returned.

__Thoughts__
This can obviously be circumvented by setting a referring header to include the admin_url - it is not "secure" in that manner, but it is more-or-less a simple deterrent to not try and use these endpoints outside the context of the editor. The existing permissions check is still in place to verify the user has the clearance to `edit_posts`.