### PR TITLE
Phone number sanitize function

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -216,7 +216,7 @@ class WC_Gateway_Paypal_Request {
 	 * @return array
 	 */
 	protected function get_phone_number_args( $order ) {
-		$phone_number = str_replace( array( '(', '-', ' ', ')', '.' ), '', $order->get_billing_phone() );
+		$phone_number = wc_sanitize_phone_number( $order->get_billing_phone() );
 
 		if ( in_array( $order->get_billing_country(), array( 'US', 'CA' ), true ) ) {
 			$phone_number = ltrim( $phone_number, '+1' );

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -1108,7 +1108,7 @@ add_filter( 'woocommerce_admin_settings_sanitize_option_woocommerce_hold_stock_m
  * @return string
  */
 function wc_sanitize_term_text_based( $term ) {
-	return trim( wp_unslash( strip_tags( $term ) ) );
+	return trim( wp_unslash( wp_strip_all_tags( $term ) ) );
 }
 
 if ( ! function_exists( 'wc_make_numeric_postcode' ) ) {
@@ -1383,9 +1383,9 @@ function wc_implode_html_attributes( $raw_attributes ) {
 function wc_esc_json( $json, $html = false ) {
 	return _wp_specialchars(
 		$json,
-		$html ? ENT_NOQUOTES : ENT_QUOTES, // Escape quotes in attribute nodes only,
+		$html ? ENT_NOQUOTES : ENT_QUOTES, // Escape quotes in attribute nodes only.
 		'UTF-8',                           // json_encode() outputs UTF-8 (really just ASCII), not the blog's charset.
-		true                               // Double escape entities: `&amp;` -> `&amp;amp;`
+		true                               // Double escape entities: `&amp;` -> `&amp;amp;`.
 	);
 }
 

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -969,7 +969,7 @@ function wc_format_phone_number( $phone ) {
 
 /**
  * Sanitize phone number.
- * Remove all characters allowing just numbers and "+" (plus sign).
+ * Allows only numbers and "+" (plus sign).
  *
  * @since 3.6.0
  * @param string $phone Phone number.

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -968,6 +968,18 @@ function wc_format_phone_number( $phone ) {
 }
 
 /**
+ * Sanitize phone number.
+ * Remove all characters allowing just numbers and "+" (plus sign).
+ *
+ * @since 3.6.0
+ * @param string $phone Phone number.
+ * @return string
+ */
+function wc_sanitize_phone_number( $phone ) {
+	return preg_replace( '/[^\d+]/', '', $phone );
+}
+
+/**
  * Wrapper for mb_strtoupper which see's if supported first.
  *
  * @since  3.1.0

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -768,6 +768,20 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test wc_sanitize_phone_number().
+	 *
+	 * @since 3.6.0
+	 */
+	public function test_wc_sanitize_phone_number() {
+		$this->assertEquals( '+16103850000', wc_sanitize_phone_number( '+1.610.385.0000' ) );
+		// This number contains non-visible unicode chars at the beginning and end of string.
+		$this->assertEquals( '+47000000003', wc_sanitize_phone_number( '‭+47 0000 00003‬' ) );
+		$this->assertEquals( '2700000000', wc_sanitize_phone_number( '27 00 00 0000' ) );
+		// Check with a invalid number too.
+		$this->assertEquals( '1800', wc_sanitize_phone_number( '1-800-not a phone number' ) );
+	}
+
+	/**
 	 * Test wc_trim_string().
 	 *
 	 * @since 2.2

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -804,7 +804,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		// This number contains non-visible unicode chars at the beginning and end of string.
 		$this->assertEquals( '+47000000003', wc_sanitize_phone_number( '‭+47 0000 00003‬' ) );
 		$this->assertEquals( '2700000000', wc_sanitize_phone_number( '27 00 00 0000' ) );
-		// Check with a invalid number too.
+		// Check with an invalid number too.
 		$this->assertEquals( '1800', wc_sanitize_phone_number( '1-800-not a phone number' ) );
 	}
 

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -12,6 +12,9 @@
  */
 class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
+	/**
+	 * Set up.
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -48,10 +51,13 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 * @since 3.3.0
 	 */
 	public function test_wc_string_to_array() {
-		$this->assertEquals( array(
-			'foo',
-			'bar',
-		), wc_string_to_array( 'foo|bar', '|' ) );
+		$this->assertEquals(
+			array(
+				'foo',
+				'bar',
+			),
+			wc_string_to_array( 'foo|bar', '|' )
+		);
 	}
 
 	/**
@@ -97,64 +103,82 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		$default_unit = get_option( 'woocommerce_dimension_unit' );
 
 		// cm (default unit).
-		$this->assertEquals( array( 10, 3.937, 0.10936133, 100, 0.1 ), array(
-			wc_get_dimension( 10, 'cm' ),
-			wc_get_dimension( 10, 'in' ),
-			wc_get_dimension( 10, 'yd' ),
-			wc_get_dimension( 10, 'mm' ),
-			wc_get_dimension( 10, 'm' ),
-		) );
+		$this->assertEquals(
+			array( 10, 3.937, 0.10936133, 100, 0.1 ),
+			array(
+				wc_get_dimension( 10, 'cm' ),
+				wc_get_dimension( 10, 'in' ),
+				wc_get_dimension( 10, 'yd' ),
+				wc_get_dimension( 10, 'mm' ),
+				wc_get_dimension( 10, 'm' ),
+			)
+		);
 
 		// in.
 		update_option( 'woocommerce_dimension_unit', 'in' );
-		$this->assertEquals( array( 25.4, 10, 0.2777777782, 254, 0.254 ), array(
-			wc_get_dimension( 10, 'cm' ),
-			wc_get_dimension( 10, 'in' ),
-			wc_get_dimension( 10, 'yd' ),
-			wc_get_dimension( 10, 'mm' ),
-			wc_get_dimension( 10, 'm' ),
-		) );
+		$this->assertEquals(
+			array( 25.4, 10, 0.2777777782, 254, 0.254 ),
+			array(
+				wc_get_dimension( 10, 'cm' ),
+				wc_get_dimension( 10, 'in' ),
+				wc_get_dimension( 10, 'yd' ),
+				wc_get_dimension( 10, 'mm' ),
+				wc_get_dimension( 10, 'm' ),
+			)
+		);
 
 		// m.
 		update_option( 'woocommerce_dimension_unit', 'm' );
-		$this->assertEquals( array( 1000, 393.7, 10.936133, 10000, 10 ), array(
-			wc_get_dimension( 10, 'cm' ),
-			wc_get_dimension( 10, 'in' ),
-			wc_get_dimension( 10, 'yd' ),
-			wc_get_dimension( 10, 'mm' ),
-			wc_get_dimension( 10, 'm' ),
-		) );
+		$this->assertEquals(
+			array( 1000, 393.7, 10.936133, 10000, 10 ),
+			array(
+				wc_get_dimension( 10, 'cm' ),
+				wc_get_dimension( 10, 'in' ),
+				wc_get_dimension( 10, 'yd' ),
+				wc_get_dimension( 10, 'mm' ),
+				wc_get_dimension( 10, 'm' ),
+			)
+		);
 
 		// mm.
 		update_option( 'woocommerce_dimension_unit', 'mm' );
-		$this->assertEquals( array( 1, 0.3937, 0.010936133, 10, 0.01 ), array(
-			wc_get_dimension( 10, 'cm' ),
-			wc_get_dimension( 10, 'in' ),
-			wc_get_dimension( 10, 'yd' ),
-			wc_get_dimension( 10, 'mm' ),
-			wc_get_dimension( 10, 'm' ),
-		) );
+		$this->assertEquals(
+			array( 1, 0.3937, 0.010936133, 10, 0.01 ),
+			array(
+				wc_get_dimension( 10, 'cm' ),
+				wc_get_dimension( 10, 'in' ),
+				wc_get_dimension( 10, 'yd' ),
+				wc_get_dimension( 10, 'mm' ),
+				wc_get_dimension( 10, 'm' ),
+			)
+		);
 
 		// yd.
 		update_option( 'woocommerce_dimension_unit', 'yd' );
-		$this->assertEquals( array( 914.4, 359.99928, 10, 9144, 9.144 ), array(
-			wc_get_dimension( 10, 'cm' ),
-			wc_get_dimension( 10, 'in' ),
-			wc_get_dimension( 10, 'yd' ),
-			wc_get_dimension( 10, 'mm' ),
-			wc_get_dimension( 10, 'm' ),
-		) );
+		$this->assertEquals(
+			array( 914.4, 359.99928, 10, 9144, 9.144 ),
+			array(
+				wc_get_dimension( 10, 'cm' ),
+				wc_get_dimension( 10, 'in' ),
+				wc_get_dimension( 10, 'yd' ),
+				wc_get_dimension( 10, 'mm' ),
+				wc_get_dimension( 10, 'm' ),
+			)
+		);
 
 		// Negative.
 		$this->assertEquals( 0, wc_get_dimension( -10, 'mm' ) );
 
 		// Custom.
-		$this->assertEquals( array( 25.4, 914.4, 393.7, 0.010936133 ), array(
-			wc_get_dimension( 10, 'cm', 'in' ),
-			wc_get_dimension( 10, 'cm', 'yd' ),
-			wc_get_dimension( 10, 'in', 'm' ),
-			wc_get_dimension( 10, 'yd', 'mm' ),
-		) );
+		$this->assertEquals(
+			array( 25.4, 914.4, 393.7, 0.010936133 ),
+			array(
+				wc_get_dimension( 10, 'cm', 'in' ),
+				wc_get_dimension( 10, 'cm', 'yd' ),
+				wc_get_dimension( 10, 'in', 'm' ),
+				wc_get_dimension( 10, 'yd', 'mm' ),
+			)
+		);
 
 		// Restore default.
 		update_option( 'woocommerce_dimension_unit', $default_unit );
@@ -578,13 +602,16 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 * @since 2.2
 	 */
 	public function test_wc_let_to_num() {
-		$this->assertEquals( array( 10240, 10485760, 10737418240, 10995116277760, 11258999068426240 ), array(
-			wc_let_to_num( '10K' ),
-			wc_let_to_num( '10M' ),
-			wc_let_to_num( '10G' ),
-			wc_let_to_num( '10T' ),
-			wc_let_to_num( '10P' ),
-		) );
+		$this->assertEquals(
+			array( 10240, 10485760, 10737418240, 10995116277760, 11258999068426240 ),
+			array(
+				wc_let_to_num( '10K' ),
+				wc_let_to_num( '10M' ),
+				wc_let_to_num( '10G' ),
+				wc_let_to_num( '10T' ),
+				wc_let_to_num( '10P' ),
+			)
+		);
 	}
 
 	/**
@@ -925,7 +952,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 *
 	 * This function is called by WP_HTTP_TestCase::http_request_listner().
 	 *
-	 * @param array $request Request arguments.
+	 * @param array  $request Request arguments.
 	 * @param string $url URL of the request.
 	 *
 	 * @return array|false mocked response or false to let WP perform a regular request.
@@ -989,16 +1016,19 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 			),
 		);
 
-		$this->assertEquals( array(
-			'A'   => 'tom',
-			'sum' => 30,
-			'C'   => array(
-				'x',
-				'y',
-				'z' => 145,
-				'w' => 1,
+		$this->assertEquals(
+			array(
+				'A'   => 'tom',
+				'sum' => 30,
+				'C'   => array(
+					'x',
+					'y',
+					'z' => 145,
+					'w' => 1,
+				),
 			),
-		), wc_array_merge_recursive_numeric( $a, $b, $c ) );
+			wc_array_merge_recursive_numeric( $a, $b, $c )
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Introduces a new helper function to sanitize phone numbers and still allows `+` at the start.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced `wc_sanitize_phone_number()` function.
