### PR TITLE
Removed URL from translatable string

### DIFF
--- a/templates/emails/admin-failed-order.php
+++ b/templates/emails/admin-failed-order.php
@@ -49,7 +49,10 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 ?>
 <p>
-<?php echo wp_kses_post( __( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/">troubleshooting failed payments</a>.', 'woocommerce' ) ); ?>
+<?php
+	/* translators: %s: documentation link */
+	echo wp_kses_post( sprintf( __( 'Hopefully they’ll be back. Read more about <a href="%s">troubleshooting failed payments</a>.', 'woocommerce' ), 'https://docs.woocommerce.com/document/managing-orders/' ) );
+?>
 </p>
 <?php
 

--- a/templates/emails/plain/admin-failed-order.php
+++ b/templates/emails/plain/admin-failed-order.php
@@ -47,7 +47,8 @@ do_action( 'woocommerce_email_order_meta', $order, $sent_to_admin, $plain_text, 
  */
 do_action( 'woocommerce_email_customer_details', $order, $sent_to_admin, $plain_text, $email );
 
-echo esc_html__( 'Hopefully they’ll be back. Read more about <a href="https://docs.woocommerce.com/document/managing-orders/">troubleshooting failed payments</a>.', 'woocommerce' ) . "\n\n";
+/* translators: %s: documentation link */
+printf( esc_html__( 'Hopefully they’ll be back. Read more about <a href="%s">troubleshooting failed payments</a>.', 'woocommerce' ), 'https://docs.woocommerce.com/document/managing-orders/' ) . "\n\n";
 
 echo "\n=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Not a good idea including hard coded URLs into our translatable strings (since we don't have a localized documentation, also we don't allow users to write they own docs), this will prevent people changing our URLs, and also will prevent make translators work again if we need to change this URL later, like happened with 3.5.6 in https://github.com/woocommerce/woocommerce/pull/22943.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?
