### PR TITLE
Check types of defined Payment Gateways

### DIFF
--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -90,14 +90,21 @@ class WC_Payment_Gateways {
 
 		// Load gateways in order.
 		foreach ( $load_gateways as $gateway ) {
-			$load_gateway = is_string( $gateway ) ? new $gateway() : $gateway;
+			if ( is_string( $gateway ) && class_exists( $gateway ) ) {
+				$gateway = new $gateway();
+			}
 
-			if ( isset( $ordering[ $load_gateway->id ] ) && is_numeric( $ordering[ $load_gateway->id ] ) ) {
+			// Gateways need to be valid and extend WC_Payment_Gateway.
+			if ( ! is_a( $gateway, 'WC_Payment_Gateway' ) ) {
+				continue;
+			}
+
+			if ( isset( $ordering[ $gateway->id ] ) && is_numeric( $ordering[ $gateway->id ] ) ) {
 				// Add in position.
-				$this->payment_gateways[ $ordering[ $load_gateway->id ] ] = $load_gateway;
+				$this->payment_gateways[ $ordering[ $gateway->id ] ] = $gateway;
 			} else {
 				// Add to end of the array.
-				$this->payment_gateways[ $order_end ] = $load_gateway;
+				$this->payment_gateways[ $order_end ] = $gateway;
 				$order_end++;
 			}
 		}

--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -157,7 +157,18 @@ class WC_Payment_Gateways {
 			}
 		}
 
-		return apply_filters( 'woocommerce_available_payment_gateways', $_available_gateways );
+		return array_filter( (array) apply_filters( 'woocommerce_available_payment_gateways', $_available_gateways ), array( $this, 'filter_valid_gateway_class' ) );
+	}
+
+	/**
+	 * Callback for array filter. Returns true if gateway is of correct type.
+	 *
+	 * @since 3.6.0
+	 * @param object $gateway Gateway to check.
+	 * @return bool
+	 */
+	protected function filter_valid_gateway_class( $gateway ) {
+		return $gateway && is_a( $gateway, 'WC_Payment_Gateway' );
 	}
 
 	/**


### PR DESCRIPTION
Protects against #22959 by checking the type of plugin-defined payment gateways to ensure they extend `WC_Payment_Gateway` and are not empty.

> Validate class type of all payment gateways added via hooks.

Closes #22959