### PR TITLE
Revised sale start/end date save logic

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1504,7 +1504,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 				$on_sale = false;
 			}
 
-			if ( $this->get_date_on_sale_to( $context ) && $this->get_date_on_sale_to( $context )->getTimestamp() + DAY_IN_SECONDS < current_time( 'timestamp', true ) ) {
+			if ( $this->get_date_on_sale_to( $context ) && $this->get_date_on_sale_to( $context )->getTimestamp() < current_time( 'timestamp', true ) ) {
 				$on_sale = false;
 			}
 		} else {

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -214,7 +214,7 @@ class WC_Meta_Box_Product_Data {
 	 * @return array
 	 */
 	private static function prepare_children() {
-		return isset( $_POST['grouped_products'] ) ? array_filter( array_map( 'intval', (array) $_POST['grouped_products'] ) ) : array();
+		return isset( $_POST['grouped_products'] ) ? array_filter( array_map( 'intval', (array) $_POST['grouped_products'] ) ) : array(); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 	}
 
 	/**
@@ -228,7 +228,7 @@ class WC_Meta_Box_Product_Data {
 		$attributes = array();
 
 		if ( ! $data ) {
-			$data = stripslashes_deep( $_POST );
+			$data = stripslashes_deep( $_POST ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 		}
 
 		if ( isset( $data['attribute_names'], $data['attribute_values'] ) ) {
@@ -295,9 +295,9 @@ class WC_Meta_Box_Product_Data {
 					$attribute_key = sanitize_title( $attribute->get_name() );
 
 					if ( ! is_null( $index ) ) {
-						$value = isset( $_POST[ $key_prefix . $attribute_key ][ $index ] ) ? wp_unslash( $_POST[ $key_prefix . $attribute_key ][ $index ] ) : '';
+						$value = isset( $_POST[ $key_prefix . $attribute_key ][ $index ] ) ? wp_unslash( $_POST[ $key_prefix . $attribute_key ][ $index ] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 					} else {
-						$value = isset( $_POST[ $key_prefix . $attribute_key ] ) ? wp_unslash( $_POST[ $key_prefix . $attribute_key ] ) : '';
+						$value = isset( $_POST[ $key_prefix . $attribute_key ] ) ? wp_unslash( $_POST[ $key_prefix . $attribute_key ] ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 					}
 
 					if ( $attribute->is_taxonomy() ) {
@@ -365,39 +365,40 @@ class WC_Meta_Box_Product_Data {
 		$errors = $product->set_props(
 			array(
 				'sku'                => isset( $_POST['_sku'] ) ? wc_clean( wp_unslash( $_POST['_sku'] ) ) : null,
-				'purchase_note'      => wp_kses_post( wp_unslash( $_POST['_purchase_note'] ) ),
+				'purchase_note'      => isset( $_POST['_purchase_note'] ) ? wp_kses_post( wp_unslash( $_POST['_purchase_note'] ) ) : '',
 				'downloadable'       => isset( $_POST['_downloadable'] ),
 				'virtual'            => isset( $_POST['_virtual'] ),
 				'featured'           => isset( $_POST['_featured'] ),
-				'catalog_visibility' => wc_clean( wp_unslash( $_POST['_visibility'] ) ),
+				'catalog_visibility' => isset( $_POST['_visibility'] ) ? wc_clean( wp_unslash( $_POST['_visibility'] ) ) : null,
 				'tax_status'         => isset( $_POST['_tax_status'] ) ? wc_clean( wp_unslash( $_POST['_tax_status'] ) ) : null,
 				'tax_class'          => isset( $_POST['_tax_class'] ) ? wc_clean( wp_unslash( $_POST['_tax_class'] ) ) : null,
-				'weight'             => wc_clean( wp_unslash( $_POST['_weight'] ) ),
-				'length'             => wc_clean( wp_unslash( $_POST['_length'] ) ),
-				'width'              => wc_clean( wp_unslash( $_POST['_width'] ) ),
-				'height'             => wc_clean( wp_unslash( $_POST['_height'] ) ),
-				'shipping_class_id'  => absint( wp_unslash( $_POST['product_shipping_class'] ) ),
+				'weight'             => isset( $_POST['_weight'] ) ? wc_clean( wp_unslash( $_POST['_weight'] ) ) : null,
+				'length'             => isset( $_POST['_length'] ) ? wc_clean( wp_unslash( $_POST['_length'] ) ) : null,
+				'width'              => isset( $_POST['_width'] ) ? wc_clean( wp_unslash( $_POST['_width'] ) ) : null,
+				'height'             => isset( $_POST['_height'] ) ? wc_clean( wp_unslash( $_POST['_height'] ) ) : null,
+				'shipping_class_id'  => isset( $_POST['product_shipping_class'] ) ? absint( wp_unslash( $_POST['product_shipping_class'] ) ) : null,
 				'sold_individually'  => ! empty( $_POST['_sold_individually'] ),
 				'upsell_ids'         => isset( $_POST['upsell_ids'] ) ? array_map( 'intval', (array) wp_unslash( $_POST['upsell_ids'] ) ) : array(),
 				'cross_sell_ids'     => isset( $_POST['crosssell_ids'] ) ? array_map( 'intval', (array) wp_unslash( $_POST['crosssell_ids'] ) ) : array(),
-				'regular_price'      => wc_clean( wp_unslash( $_POST['_regular_price'] ) ),
-				'sale_price'         => wc_clean( wp_unslash( $_POST['_sale_price'] ) ),
+				'regular_price'      => isset( $_POST['_regular_price'] ) ? wc_clean( wp_unslash( $_POST['_regular_price'] ) ) : null,
+				'sale_price'         => isset( $_POST['_sale_price'] ) ? wc_clean( wp_unslash( $_POST['_sale_price'] ) ) : null,
 				'date_on_sale_from'  => $date_on_sale_from,
 				'date_on_sale_to'    => $date_on_sale_to,
 				'manage_stock'       => ! empty( $_POST['_manage_stock'] ),
 				'backorders'         => isset( $_POST['_backorders'] ) ? wc_clean( wp_unslash( $_POST['_backorders'] ) ) : null,
-				'stock_status'       => wc_clean( wp_unslash( $_POST['_stock_status'] ) ),
+				'stock_status'       => isset( $_POST['_stock_status'] ) ? wc_clean( wp_unslash( $_POST['_stock_status'] ) ) : null,
 				'stock_quantity'     => $stock,
 				'low_stock_amount'   => isset( $_POST['_low_stock_amount'] ) && '' !== $_POST['_low_stock_amount'] ? wc_stock_amount( wp_unslash( $_POST['_low_stock_amount'] ) ) : '',
-				'download_limit'     => '' === $_POST['_download_limit'] ? '' : absint( wp_unslash( $_POST['_download_limit'] ) ),
-				'download_expiry'    => '' === $_POST['_download_expiry'] ? '' : absint( wp_unslash( $_POST['_download_expiry'] ) ),
+				'download_limit'     => isset( $_POST['_download_limit'] ) && '' !== $_POST['_download_limit'] ? absint( wp_unslash( $_POST['_download_limit'] ) ) : '',
+				'download_expiry'    => isset( $_POST['_download_expiry'] ) && '' !== $_POST['_download_expiry'] ? absint( wp_unslash( $_POST['_download_expiry'] ) ) : '',
+				// Those are sanitized inside prepare_downloads.
 				'downloads'          => self::prepare_downloads(
-					isset( $_POST['_wc_file_names'] ) ? wp_unslash( $_POST['_wc_file_names'] ) : array(),
-					isset( $_POST['_wc_file_urls'] ) ? wp_unslash( $_POST['_wc_file_urls'] ) : array(),
-					isset( $_POST['_wc_file_hashes'] ) ? wp_unslash( $_POST['_wc_file_hashes'] ) : array()
+					isset( $_POST['_wc_file_names'] ) ? wp_unslash( $_POST['_wc_file_names'] ) : array(), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+					isset( $_POST['_wc_file_urls'] ) ? wp_unslash( $_POST['_wc_file_urls'] ) : array(), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+					isset( $_POST['_wc_file_hashes'] ) ? wp_unslash( $_POST['_wc_file_hashes'] ) : array() // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 				),
-				'product_url'        => esc_url_raw( wp_unslash( $_POST['_product_url'] ) ),
-				'button_text'        => wc_clean( wp_unslash( $_POST['_button_text'] ) ),
+				'product_url'        => isset( $_POST['_product_url'] ) ? esc_url_raw( wp_unslash( $_POST['_product_url'] ) ) : '',
+				'button_text'        => isset( $_POST['_button_text'] ) ? wc_clean( wp_unslash( $_POST['_button_text'] ) ) : '',
 				'children'           => 'grouped' === $product_type ? self::prepare_children() : null,
 				'reviews_allowed'    => ! empty( $_POST['comment_status'] ) && 'open' === $_POST['comment_status'],
 				'attributes'         => $attributes,
@@ -419,7 +420,10 @@ class WC_Meta_Box_Product_Data {
 		$product->save();
 
 		if ( $product->is_type( 'variable' ) ) {
-			$product->get_data_store()->sync_variation_names( $product, wc_clean( wp_unslash( $_POST['original_post_title'] ) ), wc_clean( wp_unslash( $_POST['post_title'] ) ) );
+			$original_post_title = isset( $_POST['original_post_title'] ) ? wc_clean( wp_unslash( $_POST['original_post_title'] ) ) : '';
+			$post_title          = isset( $_POST['post_title'] ) ? wc_clean( wp_unslash( $_POST['post_title'] ) ) : '';
+
+			$product->get_data_store()->sync_variation_names( $product, $original_post_title, $post_title );
 		}
 
 		do_action( 'woocommerce_process_product_meta_' . $product_type, $post_id );
@@ -433,16 +437,17 @@ class WC_Meta_Box_Product_Data {
 	 * @param WP_Post $post Post object.
 	 */
 	public static function save_variations( $post_id, $post ) {
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
 		if ( isset( $_POST['variable_post_id'] ) ) {
 			$parent = wc_get_product( $post_id );
 			$parent->set_default_attributes( self::prepare_set_attributes( $parent->get_attributes(), 'default_attribute_' ) );
 			$parent->save();
 
-			$max_loop   = max( array_keys( wp_unslash( $_POST['variable_post_id'] ) ) );
+			$max_loop   = max( array_keys( wp_unslash( $_POST['variable_post_id'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$data_store = $parent->get_data_store();
 			$data_store->sort_all_product_variations( $parent->get_id() );
 
-			for ( $i = 0; $i <= $max_loop; $i ++ ) {
+			for ( $i = 0; $i <= $max_loop; $i++ ) {
 
 				if ( ! isset( $_POST['variable_post_id'][ $i ] ) ) {
 					continue;
@@ -486,33 +491,34 @@ class WC_Meta_Box_Product_Data {
 				$errors = $variation->set_props(
 					array(
 						'status'            => isset( $_POST['variable_enabled'][ $i ] ) ? 'publish' : 'private',
-						'menu_order'        => wc_clean( wp_unslash( $_POST['variation_menu_order'][ $i ] ) ),
-						'regular_price'     => wc_clean( wp_unslash( $_POST['variable_regular_price'][ $i ] ) ),
-						'sale_price'        => wc_clean( wp_unslash( $_POST['variable_sale_price'][ $i ] ) ),
+						'menu_order'        => isset( $_POST['variation_menu_order'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variation_menu_order'][ $i ] ) ) : null,
+						'regular_price'     => isset( $_POST['variable_regular_price'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_regular_price'][ $i ] ) ) : null,
+						'sale_price'        => isset( $_POST['variable_sale_price'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_sale_price'][ $i ] ) ) : null,
 						'virtual'           => isset( $_POST['variable_is_virtual'][ $i ] ),
 						'downloadable'      => isset( $_POST['variable_is_downloadable'][ $i ] ),
 						'date_on_sale_from' => $date_on_sale_from,
 						'date_on_sale_to'   => $date_on_sale_to,
-						'description'       => wp_kses_post( wp_unslash( $_POST['variable_description'][ $i ] ) ),
-						'download_limit'    => wc_clean( wp_unslash( $_POST['variable_download_limit'][ $i ] ) ),
-						'download_expiry'   => wc_clean( wp_unslash( $_POST['variable_download_expiry'][ $i ] ) ),
+						'description'       => isset( $_POST['variable_description'][ $i ] ) ? wp_kses_post( wp_unslash( $_POST['variable_description'][ $i ] ) ) : null,
+						'download_limit'    => isset( $_POST['variable_download_limit'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_download_limit'][ $i ] ) ) : null,
+						'download_expiry'   => isset( $_POST['variable_download_expiry'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_download_expiry'][ $i ] ) ) : null,
+						// Those are sanitized inside prepare_downloads.
 						'downloads'         => self::prepare_downloads(
-							isset( $_POST['_wc_variation_file_names'][ $variation_id ] ) ? wp_unslash( $_POST['_wc_variation_file_names'][ $variation_id ] ) : array(),
-							isset( $_POST['_wc_variation_file_urls'][ $variation_id ] ) ? wp_unslash( $_POST['_wc_variation_file_urls'][ $variation_id ] ) : array(),
-							isset( $_POST['_wc_variation_file_hashes'][ $variation_id ] ) ? wp_unslash( $_POST['_wc_variation_file_hashes'][ $variation_id ] ) : array()
+							isset( $_POST['_wc_variation_file_names'][ $variation_id ] ) ? wp_unslash( $_POST['_wc_variation_file_names'][ $variation_id ] ) : array(), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+							isset( $_POST['_wc_variation_file_urls'][ $variation_id ] ) ? wp_unslash( $_POST['_wc_variation_file_urls'][ $variation_id ] ) : array(), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+							isset( $_POST['_wc_variation_file_hashes'][ $variation_id ] ) ? wp_unslash( $_POST['_wc_variation_file_hashes'][ $variation_id ] ) : array() // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 						),
 						'manage_stock'      => isset( $_POST['variable_manage_stock'][ $i ] ),
 						'stock_quantity'    => $stock,
 						'backorders'        => isset( $_POST['variable_backorders'], $_POST['variable_backorders'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_backorders'][ $i ] ) ) : null,
-						'stock_status'      => wc_clean( wp_unslash( $_POST['variable_stock_status'][ $i ] ) ),
-						'image_id'          => wc_clean( wp_unslash( $_POST['upload_image_id'][ $i ] ) ),
+						'stock_status'      => isset( $_POST['variable_stock_status'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_stock_status'][ $i ] ) ) : null,
+						'image_id'          => isset( $_POST['upload_image_id'][ $i ] ) ? wc_clean( wp_unslash( $_POST['upload_image_id'][ $i ] ) ) : null,
 						'attributes'        => self::prepare_set_attributes( $parent->get_attributes(), 'attribute_', $i ),
 						'sku'               => isset( $_POST['variable_sku'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_sku'][ $i ] ) ) : '',
 						'weight'            => isset( $_POST['variable_weight'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_weight'][ $i ] ) ) : '',
 						'length'            => isset( $_POST['variable_length'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_length'][ $i ] ) ) : '',
 						'width'             => isset( $_POST['variable_width'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_width'][ $i ] ) ) : '',
 						'height'            => isset( $_POST['variable_height'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_height'][ $i ] ) ) : '',
-						'shipping_class_id' => wc_clean( wp_unslash( $_POST['variable_shipping_class'][ $i ] ) ),
+						'shipping_class_id' => isset( $_POST['variable_shipping_class'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_shipping_class'][ $i ] ) ) : null,
 						'tax_class'         => isset( $_POST['variable_tax_class'][ $i ] ) ? wc_clean( wp_unslash( $_POST['variable_tax_class'][ $i ] ) ) : null,
 					)
 				);
@@ -526,5 +532,6 @@ class WC_Meta_Box_Product_Data {
 				do_action( 'woocommerce_save_product_variation', $variation_id, $i );
 			}
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 	}
 }

--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -1,7 +1,12 @@
 <?php
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+/**
+ * Product general data panel.
+ *
+ * @package WooCommerce/Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
 ?>
 <div id="general_product_data" class="panel woocommerce_options_panel">
 
@@ -102,7 +107,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 								ob_start();
 								require 'html-product-download.php';
 								echo esc_attr( ob_get_clean() );
-							?>
+								?>
 							"><?php esc_html_e( 'Add File', 'woocommerce' ); ?></a>
 						</th>
 					</tr>

--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -50,8 +50,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 			)
 		);
 
-		$sale_price_dates_from = $product_object->get_date_on_sale_from( 'edit' ) && ( $date = $product_object->get_date_on_sale_from( 'edit' )->getOffsetTimestamp() ) ? date_i18n( 'Y-m-d', $date ) : '';
-		$sale_price_dates_to   = $product_object->get_date_on_sale_to( 'edit' ) && ( $date = $product_object->get_date_on_sale_to( 'edit' )->getOffsetTimestamp() ) ? date_i18n( 'Y-m-d', $date ) : '';
+		$sale_price_dates_from_timestamp = $product_object->get_date_on_sale_from( 'edit' ) ? $product_object->get_date_on_sale_from( 'edit' )->getOffsetTimestamp() : false;
+		$sale_price_dates_to_timestamp   = $product_object->get_date_on_sale_to( 'edit' ) ? $product_object->get_date_on_sale_to( 'edit' )->getOffsetTimestamp() : false;
+
+		$sale_price_dates_from = $sale_price_dates_from_timestamp ? date_i18n( 'Y-m-d', $sale_price_dates_from_timestamp ) : '';
+		$sale_price_dates_to   = $sale_price_dates_to_timestamp ? date_i18n( 'Y-m-d', $sale_price_dates_to_timestamp ) : '';
 
 		echo '<p class="form-field sale_price_dates_fields">
 				<label for="_sale_price_dates_from">' . esc_html__( 'Sale price dates', 'woocommerce' ) . '</label>

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -2,14 +2,15 @@
 /**
  * Outputs a variation for editing.
  *
+ * @package WooCommerce\Admin
  * @var int $variation_id
  * @var WP_POST $variation
  * @var WC_Product_Variation $variation_object
  * @var array $variation_data array of variation data @deprecated.
  */
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+
+defined( 'ABSPATH' ) || exit;
+
 ?>
 <div class="woocommerce_variation wc-metabox closed">
 	<h3>
@@ -26,11 +27,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 			}
 			$selected_value = isset( $attribute_values[ sanitize_title( $attribute->get_name() ) ] ) ? $attribute_values[ sanitize_title( $attribute->get_name() ) ] : '';
 			?>
-			<select name="attribute_<?php echo sanitize_title( $attribute->get_name() ) . "[{$loop}]"; ?>">
+			<select name="attribute_<?php echo esc_attr( sanitize_title( $attribute->get_name() ) . "[{$loop}]" ); ?>">
 				<option value="">
 					<?php
 					/* translators: %s: attribute label */
-					printf( esc_html__( 'Any %s&hellip;', 'woocommerce' ), wc_attribute_label( $attribute->get_name() ) );
+					printf( esc_html__( 'Any %s&hellip;', 'woocommerce' ), wc_attribute_label( $attribute->get_name() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 					?>
 				</option>
 				<?php if ( $attribute->is_taxonomy() ) : ?>
@@ -51,11 +52,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<?php
 		/**
-		 * woocommerce_variation_header action.
+		 * Variations header action.
 		 *
 		 * @since 3.6.0
 		 *
-		 * @param WP_Post $variation .
+		 * @param WP_Post $variation Post data.
 		 */
 		do_action( 'woocommerce_variation_header', $variation );
 		?>
@@ -86,7 +87,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<p class="form-row form-row-full options">
 				<label>
 					<?php esc_html_e( 'Enabled', 'woocommerce' ); ?>:
-					<input type="checkbox" class="checkbox" name="variable_enabled[<?php echo $loop; ?>]" <?php checked( in_array( $variation_object->get_status( 'edit' ), array( 'publish', false ), true ), true ); ?> />
+					<input type="checkbox" class="checkbox" name="variable_enabled[<?php echo esc_attr( $loop ); ?>]" <?php checked( in_array( $variation_object->get_status( 'edit' ), array( 'publish', false ), true ), true ); ?> />
 				</label>
 				<label class="tips" data-tip="<?php esc_html_e( 'Enable this option if access is given to a downloadable file upon purchase of a product', 'woocommerce' ); ?>">
 					<?php esc_html_e( 'Downloadable', 'woocommerce' ); ?>:
@@ -152,23 +153,23 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 				echo '<div class="form-field sale_price_dates_fields hidden">
 					<p class="form-row form-row-first">
-						<label>' . __( 'Sale start date', 'woocommerce' ) . '</label>
-						<input type="text" class="sale_price_dates_from" name="variable_sale_price_dates_from[' . $loop . ']" value="' . esc_attr( $sale_price_dates_from ) . '" placeholder="' . _x( 'From&hellip;', 'placeholder', 'woocommerce' ) . ' YYYY-MM-DD" maxlength="10" pattern="' . esc_attr( apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) ) . '" />
+						<label>' . esc_html__( 'Sale start date', 'woocommerce' ) . '</label>
+						<input type="text" class="sale_price_dates_from" name="variable_sale_price_dates_from[' . esc_attr( $loop ) . ']" value="' . esc_attr( $sale_price_dates_from ) . '" placeholder="' . esc_attr_x( 'From&hellip;', 'placeholder', 'woocommerce' ) . ' YYYY-MM-DD" maxlength="10" pattern="' . esc_attr( apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) ) . '" />
 					</p>
 					<p class="form-row form-row-last">
-						<label>' . __( 'Sale end date', 'woocommerce' ) . '</label>
-						<input type="text" class="sale_price_dates_to" name="variable_sale_price_dates_to[' . esc_attr( $loop ) . ']" value="' . esc_attr( $sale_price_dates_to ) . '" placeholder="' . esc_html_x( 'To&hellip;', 'placeholder', 'woocommerce' ) . '  YYYY-MM-DD" maxlength="10" pattern="' . esc_attr( apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) ) . '" />
+						<label>' . esc_html__( 'Sale end date', 'woocommerce' ) . '</label>
+						<input type="text" class="sale_price_dates_to" name="variable_sale_price_dates_to[' . esc_attr( $loop ) . ']" value="' . esc_attr( $sale_price_dates_to ) . '" placeholder="' . esc_attr_x( 'To&hellip;', 'placeholder', 'woocommerce' ) . '  YYYY-MM-DD" maxlength="10" pattern="' . esc_attr( apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) ) . '" />
 					</p>
 				</div>';
 
 				/**
-				 * woocommerce_variation_options_pricing action.
+				 * Variation options pricing action.
 				 *
 				 * @since 2.5.0
 				 *
-				 * @param int     $loop
-				 * @param array   $variation_data
-				 * @param WP_Post $variation
+				 * @param int     $loop           Position in the loop.
+				 * @param array   $variation_data Variation data.
+				 * @param WP_Post $variation      Post data.
 				 */
 				do_action( 'woocommerce_variation_options_pricing', $loop, $variation_data, $variation );
 				?>
@@ -210,13 +211,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 					);
 
 					/**
-					 * woocommerce_variation_options_inventory action.
+					 * Variation options inventory action.
 					 *
 					 * @since 2.5.0
 					 *
-					 * @param int     $loop
-					 * @param array   $variation_data
-					 * @param WP_Post $variation
+					 * @param int     $loop           Position in the loop.
+					 * @param array   $variation_data Variation data.
+					 * @param WP_Post $variation      Post data.
 					 */
 					do_action( 'woocommerce_variation_options_inventory', $loop, $variation_data, $variation );
 					?>
@@ -273,7 +274,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							printf(
 								/* translators: %s: dimension unit */
 								esc_html__( 'Dimensions (L&times;W&times;H) (%s)', 'woocommerce' ),
-								get_option( 'woocommerce_dimension_unit' )
+								esc_html( get_option( 'woocommerce_dimension_unit' ) )
 							);
 							?>
 						</label>
@@ -288,13 +289,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 				}
 
 				/**
-				 * woocommerce_variation_options_dimensions action.
+				 * Variation options dimensions action.
 				 *
 				 * @since 2.5.0
 				 *
-				 * @param int     $loop
-				 * @param array   $variation_data
-				 * @param WP_Post $variation
+				 * @param int     $loop           Position in the loop.
+				 * @param array   $variation_data Variation data.
+				 * @param WP_Post $variation      Post data.
 				 */
 				do_action( 'woocommerce_variation_options_dimensions', $loop, $variation_data, $variation );
 				?>
@@ -333,13 +334,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 					);
 
 					/**
-					 * woocommerce_variation_options_tax action.
+					 * Variation options tax action.
 					 *
 					 * @since 2.5.0
 					 *
-					 * @param int     $loop
-					 * @param array   $variation_data
-					 * @param WP_Post $variation
+					 * @param int     $loop           Position in the loop.
+					 * @param array   $variation_data Variation data.
+					 * @param WP_Post $variation      Post data.
 					 */
 					do_action( 'woocommerce_variation_options_tax', $loop, $variation_data, $variation );
 				}
@@ -373,7 +374,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 						</thead>
 						<tbody>
 							<?php
-							if ( $downloads = $variation_object->get_downloads( 'edit' ) ) {
+							$downloads = $variation_object->get_downloads( 'edit' );
+
+							if ( $downloads ) {
 								foreach ( $downloads as $key => $file ) {
 									include 'html-product-variation-download.php';
 								}
@@ -440,13 +443,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 				);
 
 				/**
-				 * woocommerce_variation_options_download action.
+				 * Variation options download action.
 				 *
 				 * @since 2.5.0
 				 *
-				 * @param int     $loop
-				 * @param array   $variation_data
-				 * @param WP_Post $variation
+				 * @param int     $loop           Position in the loop.
+				 * @param array   $variation_data Variation data.
+				 * @param WP_Post $variation      Post data.
 				 */
 				do_action( 'woocommerce_variation_options_download', $loop, $variation_data, $variation );
 				?>

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -144,8 +144,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 					)
 				);
 
-				$sale_price_dates_from = $variation_object->get_date_on_sale_from( 'edit' ) && ( $date = $variation_object->get_date_on_sale_from( 'edit' )->getOffsetTimestamp() ) ? date_i18n( 'Y-m-d', $date ) : '';
-				$sale_price_dates_to   = $variation_object->get_date_on_sale_to( 'edit' ) && ( $date = $variation_object->get_date_on_sale_to( 'edit' )->getOffsetTimestamp() ) ? date_i18n( 'Y-m-d', $date ) : '';
+				$sale_price_dates_from_timestamp = $variation_object->get_date_on_sale_from( 'edit' ) ? $variation_object->get_date_on_sale_from( 'edit' )->getOffsetTimestamp() : false;
+				$sale_price_dates_to_timestamp   = $variation_object->get_date_on_sale_to( 'edit' ) ? $variation_object->get_date_on_sale_to( 'edit' )->getOffsetTimestamp() : false;
+
+				$sale_price_dates_from = $sale_price_dates_from_timestamp ? date_i18n( 'Y-m-d', $sale_price_dates_from_timestamp ) : '';
+				$sale_price_dates_to   = $sale_price_dates_to_timestamp ? date_i18n( 'Y-m-d', $sale_price_dates_to_timestamp ) : '';
 
 				echo '<div class="form-field sale_price_dates_fields hidden">
 					<p class="form-row form-row-first">

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1034,7 +1034,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					AND postmeta.meta_value > 0
 					AND postmeta.meta_value < %s
 					AND postmeta_2.meta_value != postmeta_3.meta_value",
-				current_time( 'timestamp', true ) - DAY_IN_SECONDS
+				current_time( 'timestamp', true )
 			)
 		);
 	}


### PR DESCRIPTION
See background in #22545

And ref these prs:
https://github.com/woocommerce/woocommerce/pull/22609
https://github.com/woocommerce/woocommerce/pull/22189

These left the saving of dates alone, but added manual offset during logic. There are problems with this because the checking of sale start/end do not use actual saved values. Also anyone referencing sale end date e.g. for a countdown, cannot trust that value because WC treats it differently.

Sale start/end lets the user define the date only, not the time. So for example:

Start: 2019-03-08
End: 2019-03-09

Would start and end at midnight on those dates. So it starts and ends at the beginning of those days.

This PR adjusts the save logic of these fields. So the end date is set to end at 23:59 and the start date at 00:00.

I have no changed the setters in the product class however, because it keeps it flexible enough to support specific end times should the products be updated outside of our UI.

Closes #22545