### PR TITLE
Setup wizard redirection improvements

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -135,11 +135,12 @@ class WC_Admin {
 	 * For setup wizard, transient must be present, the user must have access rights, and we must ignore the network/bulk plugin updaters.
 	 */
 	public function admin_redirects() {
-		// Nonced plugin install redirects (whitelisted)
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		// Nonced plugin install redirects (whitelisted).
 		if ( ! empty( $_GET['wc-install-plugin-redirect'] ) ) {
-			$plugin_slug = wc_clean( $_GET['wc-install-plugin-redirect'] );
+			$plugin_slug = wc_clean( wp_unslash( $_GET['wc-install-plugin-redirect'] ) );
 
-			if ( current_user_can( 'install_plugins' ) && in_array( $plugin_slug, array( 'woocommerce-gateway-stripe' ) ) ) {
+			if ( current_user_can( 'install_plugins' ) && in_array( $plugin_slug, array( 'woocommerce-gateway-stripe' ), true ) ) {
 				$nonce = wp_create_nonce( 'install-plugin_' . $plugin_slug );
 				$url   = self_admin_url( 'update.php?action=install-plugin&plugin=' . $plugin_slug . '&_wpnonce=' . $nonce );
 			} else {
@@ -150,20 +151,29 @@ class WC_Admin {
 			exit;
 		}
 
-		// Setup wizard redirect
-		if ( get_transient( '_wc_activation_redirect' ) ) {
-			delete_transient( '_wc_activation_redirect' );
+		// Setup wizard redirect.
+		if ( get_transient( '_wc_activation_redirect' ) && apply_filters( 'woocommerce_enable_setup_wizard', true ) ) {
+			$do_redirect  = true;
+			$current_page = isset( $_GET['page'] ) ? wc_clean( wp_unslash( $_GET['page'] ) ) : false;
 
-			if ( ( ! empty( $_GET['page'] ) && in_array( $_GET['page'], array( 'wc-setup' ) ) ) || is_network_admin() || isset( $_GET['activate-multi'] ) || ! current_user_can( 'manage_woocommerce' ) || apply_filters( 'woocommerce_prevent_automatic_wizard_redirect', false ) ) {
-				return;
+			// On these pages, or during these events, postpone the redirect.
+			if ( wp_doing_ajax() || is_network_admin() || ! current_user_can( 'manage_woocommerce' ) ) {
+				$do_redirect = false;
 			}
 
-			// If the user needs to install, send them to the setup wizard
-			if ( WC_Admin_Notices::has_notice( 'install' ) ) {
+			// On these pages, or during these events, disable the redirect.
+			if ( 'wc-setup' === $current_page || ! WC_Admin_Notices::has_notice( 'install' ) || apply_filters( 'woocommerce_prevent_automatic_wizard_redirect', false ) || isset( $_GET['activate-multi'] ) ) {
+				delete_transient( '_wc_activation_redirect' );
+				$do_redirect = false;
+			}
+
+			if ( $do_redirect ) {
+				delete_transient( '_wc_activation_redirect' );
 				wp_safe_redirect( admin_url( 'index.php?page=wc-setup' ) );
 				exit;
 			}
 		}
+		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -257,11 +257,15 @@ class WC_Install {
 	/**
 	 * Is this a brand new WC install?
 	 *
+	 * A brand new install has no version yet. Also treat empty installs as 'new'.
+	 *
 	 * @since  3.2.0
 	 * @return boolean
 	 */
 	private static function is_new_install() {
-		return is_null( get_option( 'woocommerce_version', null ) ) && is_null( get_option( 'woocommerce_db_version', null ) );
+		$product_count = array_sum( (array) wp_count_posts( 'product' ) );
+
+		return is_null( get_option( 'woocommerce_version', null ) ) || ( 0 === $product_count && -1 === wc_get_page_id( 'shop' ) );
 	}
 
 	/**
@@ -283,7 +287,7 @@ class WC_Install {
 	 * @since 3.2.0
 	 */
 	private static function maybe_enable_setup_wizard() {
-		if ( apply_filters( 'woocommerce_enable_setup_wizard', self::is_new_install() ) ) {
+		if ( apply_filters( 'woocommerce_enable_setup_wizard', true ) && self::is_new_install() ) {
 			WC_Admin_Notices::add_notice( 'install' );
 			set_transient( '_wc_activation_redirect', 1, 30 );
 		}


### PR DESCRIPTION
This resolves and closes #21017

There are certain events/pages where we don't want to do a redirect. If these are encounted, no redirect will take place because the transient is unset. This was the case on jurassic.ninja when WC is preinstalled.

This PR changes that so the wizard redirect is delayed instead.

This PR also adjusts the 'new store' logic so it includes stores with no content yet, so if the user re-activates they won't miss out on the wizard.

I cannot test this on jurrassic.ninja but you can test a similar scenario.  If you activate WC via CLI:

```
wp plugin activate woocommerce
```

Next time you, as an admin, go to admin, you'll be redirected to wizard.

cc @v18 