### PR TITLE
Pass user ID when adding coupons via admin

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -384,12 +384,15 @@ jQuery( function ( $ ) {
 			if ( value != null ) {
 				wc_meta_boxes_order_items.block();
 
+				var user_id = $( '#customer_user' ).val();
+
 				var data = $.extend( {}, wc_meta_boxes_order_items.get_taxable_address(), {
 					action   : 'woocommerce_add_coupon_discount',
 					dataType : 'json',
 					order_id : woocommerce_admin_meta_boxes.post_id,
 					security : woocommerce_admin_meta_boxes.order_item_nonce,
-					coupon   : value
+					coupon   : value,
+					user_id  : user_id
 				} );
 
 				$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1155,6 +1155,13 @@ class WC_AJAX {
 				throw new Exception( __( 'Invalid coupon', 'woocommerce' ) );
 			}
 
+			// Add user ID so validation for coupon limits works.
+			$user_id_arg = isset( $_POST['user_id'] ) ? absint( $_POST['user_id'] ) : 0;
+
+			if ( $user_id_arg ) {
+				$order->set_customer_id( $user_id_arg );
+			}
+
 			$result = $order->apply_coupon( wc_clean( wp_unslash( $_POST['coupon'] ) ) );
 
 			if ( is_wp_error( $result ) ) {


### PR DESCRIPTION
Closes #22968

Unsaved orders don't have a user ID which breaks coupon validation. This PR fixes it by sending the user_id with the ajax request.

To test,

1. Create coupon with usage limit 1
2. Checkout via frontend with coupon. It will apply.
3. Checkout via frontend with coupon. It will fail to apply.
4. Create manual order, assign to same user, apply coupon. it should fail after this PR too.

> Validate coupon usage limit for manual orders correctly before order is saved.