### PR TITLE
Updating geolocation download to avoid wp_upload_dir and direct filesystem access

### DIFF
--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -237,13 +237,13 @@ class WC_Geolocation {
 	 * @return string
 	 */
 	public static function get_local_database_path( $deprecated = '2' ) {
-		$upload_dir = wp_get_upload_dir();
-
-		return apply_filters( 'woocommerce_geolocation_local_database_path', $upload_dir['basedir'] . '/GeoLite2-Country.mmdb', $deprecated );
+		return apply_filters( 'woocommerce_geolocation_local_database_path', WP_CONTENT_DIR . '/uploads/GeoLite2-Country.mmdb', $deprecated );
 	}
 
 	/**
 	 * Update geoip database.
+	 *
+	 * Extract files with PharData. Tool built into PHP since 5.3.
 	 */
 	public static function update_database() {
 		$logger = wc_get_logger();
@@ -255,31 +255,28 @@ class WC_Geolocation {
 
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 
-		$upload_dir        = wp_upload_dir();
-		$tmp_database_path = download_url( self::GEOLITE2_DB );
+		$database             = 'GeoLite2-Country.mmdb';
+		$target_database_path = self::get_local_database_path();
+		$tmp_database_path    = download_url( self::GEOLITE2_DB );
 
 		if ( ! is_wp_error( $tmp_database_path ) ) {
 			try {
-				// GeoLite2 database name.
-				$database  = 'GeoLite2-Country.mmdb';
-				$dest_path = trailingslashit( $upload_dir['basedir'] ) . $database;
+				WP_Filesystem();
+
+				global $wp_filesystem;
+
+				// Make sure target dir exists.
+				$wp_filesystem->mkdir( dirname( $target_database_path ) );
 
 				// Extract files with PharData. Tool built into PHP since 5.3.
 				$file      = new PharData( $tmp_database_path ); // phpcs:ignore PHPCompatibility.Classes.NewClasses.phardataFound
 				$file_path = trailingslashit( $file->current()->getFileName() ) . $database;
+				$file->extractTo( dirname( $tmp_database_path ), $file_path, true );
 
-				// Extract under uploads directory.
-				$file->extractTo( $upload_dir['basedir'], $file_path, true );
-
-				// Remove old database.
-				@unlink( $dest_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink
-
-				// Copy database and delete tmp directories.
-				@rename( trailingslashit( $upload_dir['basedir'] ) . $file_path, $dest_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.VIP.FileSystemWritesDisallow.file_ops_rename
-				@rmdir( trailingslashit( $upload_dir['basedir'] ) . $file->current()->getFileName() ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.VIP.FileSystemWritesDisallow.directory_rmdir
-
-				// Set correct file permission.
-				@chmod( $dest_path, 0644 ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.VIP.FileSystemWritesDisallow.chmod_chmod
+				// Move file and delete temp.
+				$wp_filesystem->move( trailingslashit( dirname( $tmp_database_path ) ) . $file_path, $target_database_path, true );
+				$wp_filesystem->unlink( trailingslashit( dirname( $tmp_database_path ) ) . $file->current()->getFileName() );
+				$wp_filesystem->unlink( $tmp_database_path );
 			} catch ( Exception $e ) {
 				$logger->notice( $e->getMessage(), array( 'source' => 'geolocation' ) );
 
@@ -287,8 +284,6 @@ class WC_Geolocation {
 				wp_clear_scheduled_hook( 'woocommerce_geoip_updater' );
 				wp_schedule_event( strtotime( 'first tuesday of next month' ), 'monthly', 'woocommerce_geoip_updater' );
 			}
-
-			@unlink( $tmp_database_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.VIP.FileSystemWritesDisallow.file_ops_unlink
 		} else {
 			$logger->notice(
 				'Unable to download GeoIP Database: ' . $tmp_database_path->get_error_message(),

--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -260,11 +260,11 @@ class WC_Geolocation {
 		$tmp_database_path    = download_url( self::GEOLITE2_DB );
 
 		if ( ! is_wp_error( $tmp_database_path ) ) {
+			WP_Filesystem();
+
+			global $wp_filesystem;
+
 			try {
-				WP_Filesystem();
-
-				global $wp_filesystem;
-
 				// Make sure target dir exists.
 				$wp_filesystem->mkdir( dirname( $target_database_path ) );
 
@@ -275,8 +275,7 @@ class WC_Geolocation {
 
 				// Move file and delete temp.
 				$wp_filesystem->move( trailingslashit( dirname( $tmp_database_path ) ) . $file_path, $target_database_path, true );
-				$wp_filesystem->unlink( trailingslashit( dirname( $tmp_database_path ) ) . $file->current()->getFileName() );
-				$wp_filesystem->unlink( $tmp_database_path );
+				$wp_filesystem->delete( trailingslashit( dirname( $tmp_database_path ) ) . $file->current()->getFileName() );
 			} catch ( Exception $e ) {
 				$logger->notice( $e->getMessage(), array( 'source' => 'geolocation' ) );
 
@@ -284,6 +283,8 @@ class WC_Geolocation {
 				wp_clear_scheduled_hook( 'woocommerce_geoip_updater' );
 				wp_schedule_event( strtotime( 'first tuesday of next month' ), 'monthly', 'woocommerce_geoip_updater' );
 			}
+			// Delete temp file regardless of success.
+			$wp_filesystem->delete( $tmp_database_path );
 		} else {
 			$logger->notice(
 				'Unable to download GeoIP Database: ' . $tmp_database_path->get_error_message(),

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -404,7 +404,7 @@ class WC_Install {
 		wp_schedule_event( strtotime( 'first tuesday of next month' ), 'monthly', 'woocommerce_geoip_updater' );
 		wp_schedule_event( time() + 10, apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' ), 'woocommerce_tracker_send_event' );
 
-		// Trigger GeoLite2 database download after 1 minute1.
+		// Trigger GeoLite2 database download after 1 minute.
 		wp_schedule_single_event( time() + ( MINUTE_IN_SECONDS * 1 ), 'woocommerce_geoip_updater' );
 	}
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -404,8 +404,8 @@ class WC_Install {
 		wp_schedule_event( strtotime( 'first tuesday of next month' ), 'monthly', 'woocommerce_geoip_updater' );
 		wp_schedule_event( time() + 10, apply_filters( 'woocommerce_tracker_event_recurrence', 'daily' ), 'woocommerce_tracker_send_event' );
 
-		// Trigger GeoLite2 database download after 5 minutes.
-		wp_schedule_single_event( time() + ( MINUTE_IN_SECONDS * 5 ), 'woocommerce_geoip_updater' );
+		// Trigger GeoLite2 database download after 1 minute1.
+		wp_schedule_single_event( time() + ( MINUTE_IN_SECONDS * 1 ), 'woocommerce_geoip_updater' );
 	}
 
 	/**


### PR DESCRIPTION
Closes #22976

This PR stops using wp_upload_dir for working out where the geolocation file is to prevent other plugins hooking in and changing the path e.g. if using s3 for upload hosting.

This also switches to wp_filesystem methods to avoid accessing the filesystem directly. This still uses PHAR as there is no alternative for dealing with these files. Maxmind only offers tar.gz and a zipped CSV file which is not suitable for this usage.

To test, delete the geolocation file in your uploads directory. De-activate and re-activate woocommerce. After a few minutes the file will be back. Check error log is empty.