### PR TITLE
Refactor WC_Settings_Payment_Gateways::save

### DIFF
--- a/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -212,23 +212,21 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 		global $current_section;
 
 		$wc_payment_gateways = WC_Payment_Gateways::instance();
+		$wc_payment_gateways->process_admin_options();
+		$wc_payment_gateways->init();
 
-		if ( ! $current_section ) {
-			WC_Admin_Settings::save_fields( $this->get_settings() );
-			$wc_payment_gateways->process_admin_options();
-			$wc_payment_gateways->init();
-		} else {
+		if ( $current_section ) {
 			foreach ( $wc_payment_gateways->payment_gateways() as $gateway ) {
 				if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
 					do_action( 'woocommerce_update_options_payment_gateways_' . $gateway->id );
 					$wc_payment_gateways->init();
 				}
 			}
-		}
 
-		if ( $current_section ) {
 			do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
 		}
+
+		WC_Admin_Settings::save_fields( $this->get_settings( $current_section ) );
 	}
 }
 

--- a/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -212,10 +212,16 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 		global $current_section;
 
 		$wc_payment_gateways = WC_Payment_Gateways::instance();
-		$wc_payment_gateways->process_admin_options();
-		$wc_payment_gateways->init();
 
-		if ( $current_section ) {
+		// Save settings fields based on section.
+		WC_Admin_Settings::save_fields( $this->get_settings( $current_section ) );
+
+		if ( ! $current_section ) {
+			// If section is empty, we're on the main settings page. This makes sure 'gateway ordering' is saved.
+			$wc_payment_gateways->process_admin_options();
+			$wc_payment_gateways->init();
+		} else {
+			// There is a section - this may be a gateway or custom section.
 			foreach ( $wc_payment_gateways->payment_gateways() as $gateway ) {
 				if ( in_array( $current_section, array( $gateway->id, sanitize_title( get_class( $gateway ) ) ), true ) ) {
 					do_action( 'woocommerce_update_options_payment_gateways_' . $gateway->id );
@@ -225,8 +231,6 @@ class WC_Settings_Payment_Gateways extends WC_Settings_Page {
 
 			do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
 		}
-
-		WC_Admin_Settings::save_fields( $this->get_settings( $current_section ) );
 	}
 }
 


### PR DESCRIPTION
…o saving the current section.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds additional fallback to the saving functionality of WC_Settings_Payment_Gateways::save as per #22704 which added functionality to load custom sections on the Payments settings.
### How to test the changes in this Pull Request:

1. Use the custom code as per #22696
2. Go to Settings -> Payments -> Custom Page and check that a API field is displayed.
3. Enter a value in the field and save, it should fall save without having any specific code in place to handle saving.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add functionality to save custom section in payment gateway settings page using built in WooCommerce option saving functionality.
