### PR TITLE
Add stock to search results manually

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1562,7 +1562,9 @@ class WC_AJAX {
 			$managing_stock = $product_object->managing_stock();
 
 			if ( $managing_stock && ! empty( $_GET['display_stock'] ) ) {
-				$formatted_name .= ' &ndash; ' . wc_format_stock_for_display( $product_object );
+				$stock_amount    = $product_object->get_stock_quantity();
+				/* Translators: %d stock amount */
+				$formatted_name .= ' &ndash; ' . sprintf( __( 'Stock: %d', 'woocommerce' ), wc_format_stock_quantity_for_display( $stock_amount, $product_object ) );
 			}
 
 			$products[ $product_object->get_id() ] = rawurldecode( $formatted_name );


### PR DESCRIPTION
Fixes #22992

`wc_format_stock_quantity_for_display` is used on the frontend and does not stock status checking. The results are not really suitable in admin where we simply want the stock qty.

This PR adds the quantity to the search results manually.

![Edit order ‹ Test — WordPress 2019-03-12 14-47-50](https://user-images.githubusercontent.com/90977/54209632-05a68500-44d6-11e9-8691-2fde01c8c0b7.png)

To test, search for a product that manages stock in order edit.