### PR TITLE
API: Fix issue where meta key order prevents correct attribute term counts

### DIFF
--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-attributes-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-attributes-controller.php
@@ -139,12 +139,15 @@ class WC_REST_Blocks_Product_Attributes_Controller extends WC_REST_Product_Attri
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$taxonomy = wc_attribute_taxonomy_name( $item->attribute_name );
+		// wc_change_get_terms_defaults adds a meta key 'order', which is not set.
+		remove_filter( 'get_terms_defaults', 'wc_change_get_terms_defaults', 10, 2 );
 		$data     = array(
 			'id'    => (int) $item->attribute_id,
 			'name'  => $item->attribute_label,
 			'slug'  => $taxonomy,
 			'count' => wp_count_terms( $taxonomy ),
 		);
+		add_filter( 'get_terms_defaults', 'wc_change_get_terms_defaults', 10, 2 );
 
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data    = $this->add_additional_fields_to_object( $data, $request );

--- a/tests/unit-tests/api/wc-blocks/products-attributes.php
+++ b/tests/unit-tests/api/wc-blocks/products-attributes.php
@@ -60,6 +60,7 @@ class WC_Tests_API_Products_Attributes_Controller extends WC_REST_Unit_Test_Case
 		$this->assertArrayHasKey( 'name', $attribute );
 		$this->assertArrayHasKey( 'slug', $attribute );
 		$this->assertArrayHasKey( 'count', $attribute );
+		$this->assertEquals( 3, $attribute['count'] );
 	}
 
 	/**


### PR DESCRIPTION
Closes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/485 – The code added in #22570, which was only brought into #22954 with the last master merge, broke the terms count for the attribute endpoint. You can see in [the blocks project issue](https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/485) that this breaks the "Products by Attribute" block.

The addition of the [`wc_change_get_terms_defaults` filter](https://github.com/woocommerce/woocommerce/blob/master/includes/wc-term-functions.php#L13-L22) seems to be the cause. By adding `menu_order` as the default sort, the attribute term query used by `wp_count_terms` ends up looking for a meta key called `order`. For example, this is the SQL query I see for the attribute "Color":

```sql
SELECT DISTINCT COUNT(*) FROM wp_terms AS t
INNER JOIN wp_termmeta ON ( t.term_id = wp_termmeta.term_id )
INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id
WHERE tt.taxonomy IN ('pa_color') AND ( wp_termmeta.meta_key = 'order' )
```

There is no meta_key `order`, so this returns 0. There is a key `order_pa_color`, so this could also be a bug with that function? In any case, my "quick fix" is to remove the filter before querying for the attribute term count. I also added a test to specifically check that the term count is correct.

### To test

1. Create some product attributes with terms
2. Make a request to `/wc-blocks/v1/products/attributes/{termId}`
3. You should see the correct number of terms in the `count` property
