### PR TITLE
Fix error introduced by commit be05eea5da

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1531,7 +1531,9 @@ class WC_AJAX {
 	public static function json_search_products( $term = '', $include_variations = false ) {
 		check_ajax_referer( 'search-products', 'security' );
 
-		$term = isset( $_GET['term'] ) ? (string) wc_clean( wp_unslash( $_GET['term'] ) ) : '';
+		if ( empty( $term ) && isset( $_GET['term'] ) ) {
+			$term = (string) wc_clean( wp_unslash( $_GET['term'] ) );
+		}
 
 		if ( empty( $term ) ) {
 			wp_die();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Commit https://github.com/woocommerce/woocommerce/commit/be05eea5da5326661383b18905e6d6ce9ea86bbd#diff-133db5662c51f5686d87611121a05a3bR1420 fixed all the PHPCS violations in includes/class-wc-ajax.php, but it unintentionally changed that the logic of WC_Ajax::json_search_products(). This commit reverts the changes to the old logic while keeping the PHPCS fixes.

Before the modification mentioned above, `$_GET['term']` would be used only if `$term` was empty. After this modification, `$_GET['term']` is used whenever it is set and `$term` (the parameter passed to the method) stopped being used. This commit restores the original logic in that what is passed in the first parameter as `$term` is used by default, and `$_GET['term']` is only used if `$term` is empty.

cc @mikejolley 