### PR TITLE
REST API: Add Private REST API docblock and response headers.

### DIFF
--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * REST API Product Attribute Terms controller customized for Products Block.
- *
+ * Private API: This endpoint is designed to only
  * Handles requests to the /products/attributes/<attribute_id/terms endpoint.
  *
  * @package WooCommerce\Blocks\Products\Rest\Controller
@@ -127,6 +127,7 @@ class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_
 
 		$response = rest_ensure_response( $data );
 
+		$response->header( 'X-Woo-Notice', __( 'Private REST API for use by block editor only.', 'woocommerce' ) );	
 		$response->add_links( $this->prepare_links( $item, $request ) );
 
 		return $response;

--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php
@@ -127,7 +127,8 @@ class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_
 
 		$response = rest_ensure_response( $data );
 
-		$response->header( 'X-Woo-Notice', __( 'Private REST API for use by block editor only.', 'woocommerce' ) );	
+		$response->header( 'X-Woo-Notice', __( 'Private REST API for use by block editor only.', 'woocommerce' ) );
+
 		$response->add_links( $this->prepare_links( $item, $request ) );
 
 		return $response;

--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php
@@ -1,9 +1,10 @@
 <?php
 /**
  * REST API Product Attribute Terms controller customized for Products Block.
- * Private API: This endpoint is designed to only
+ *
  * Handles requests to the /products/attributes/<attribute_id/terms endpoint.
  *
+ * @internal This API is used internally by the block post editor--it is still in flux. It should not be used outside of wc-blocks.
  * @package WooCommerce\Blocks\Products\Rest\Controller
  */
 

--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-attributes-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-attributes-controller.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * REST API Product Attributes controller customized for Products Block.
- * Private API: This endpoint is designed to only be used `internally` by the block post editor.
  *
  * Handles requests to the /products/attributes endpoint.
  *
+ * @internal This API is used internally by the block post editor--it is still in flux. It should not be used outside of wc-blocks.
  * @package WooCommerce\Blocks\Products\Rest\Controller
  */
 

--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-attributes-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-attributes-controller.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * REST API Product Attributes controller customized for Products Block.
+ * Private API: This endpoint is designed to only be used `internally` by the block post editor.
  *
  * Handles requests to the /products/attributes endpoint.
  *
@@ -152,6 +153,7 @@ class WC_REST_Blocks_Product_Attributes_Controller extends WC_REST_Product_Attri
 
 		$response = rest_ensure_response( $data );
 
+		$response->header( 'X-Woo-Notice', __( 'Private REST API for use by block editor only.', 'woocommerce' ) );
 		$response->add_links( $this->prepare_links( $item ) );
 
 		return $response;

--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * REST API Product Categories controller customized for Products Block.
+ * Private API: This endpoint is designed to only be used `internally` by the block post editor.
  *
  * Handles requests to the /products/categories endpoint.
  *
@@ -119,6 +120,7 @@ class WC_REST_Blocks_Product_Categories_Controller extends WC_REST_Product_Categ
 
 		$response = rest_ensure_response( $data );
 
+		$response->header( 'X-Woo-Notice', __( 'Private REST API for use by block editor only.', 'woocommerce' ) );	
 		$response->add_links( $this->prepare_links( $item, $request ) );
 
 		return $response;

--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * REST API Product Categories controller customized for Products Block.
- * Private API: This endpoint is designed to only be used `internally` by the block post editor.
  *
  * Handles requests to the /products/categories endpoint.
  *
+ * @internal This API is used internally by the block post editor--it is still in flux. It should not be used outside of wc-blocks.
  * @package WooCommerce\Blocks\Products\Rest\Controller
  */
 

--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php
@@ -120,7 +120,7 @@ class WC_REST_Blocks_Product_Categories_Controller extends WC_REST_Product_Categ
 
 		$response = rest_ensure_response( $data );
 
-		$response->header( 'X-Woo-Notice', __( 'Private REST API for use by block editor only.', 'woocommerce' ) );	
+		$response->header( 'X-Woo-Notice', __( 'Private REST API for use by block editor only.', 'woocommerce' ) );
 		$response->add_links( $this->prepare_links( $item, $request ) );
 
 		return $response;

--- a/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
@@ -1,6 +1,7 @@
 <?php
 /**
  * REST API Products controller customized for Products Block.
+ * Private API: This endpoint is designed to only be used `internally` by the block post editor.
  *
  * Handles requests to the /products endpoint.
  *
@@ -120,6 +121,7 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 		$response = rest_ensure_response( $objects );
 		$response->header( 'X-WP-Total', $query_results['total'] );
 		$response->header( 'X-WP-TotalPages', (int) $max_pages );
+		$response->header( 'X-Woo-Notice', __( 'Private REST API for use by block editor only.', 'woocommerce' ) );
 
 		$base          = $this->rest_base;
 		$attrib_prefix = '(?P<';
@@ -214,7 +216,7 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 
 		// Wrap the data in a response object.
 		$response = rest_ensure_response( $data );
-
+		$response->header( 'X-Woo-Notice', __( 'Private REST API for use by block editor only.', 'woocommerce' ) );
 		$response->add_links( $this->prepare_links( $product, $request ) );
 
 		return $response;

--- a/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
@@ -1,10 +1,10 @@
 <?php
 /**
  * REST API Products controller customized for Products Block.
- * Private API: This endpoint is designed to only be used `internally` by the block post editor.
  *
  * Handles requests to the /products endpoint.
  *
+ * @internal This API is used internally by the block post editor--it is still in flux. It should not be used outside of wc-blocks.
  * @package WooCommerce\Blocks\Products\Rest\Controller
  */
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Supercedes #22953

This branch adds in doc blocks denoting the `wc-blocks/v1` endpoints as internal use only. Additionally a response header is added to each endpoint that also messages that the endpoints are for use by the block editor only.

### How to test the changes in this Pull Request:

1. Verify phpunit tests pass
2. curl the endpoints, or use postman and note the new header being sent in the response

![woo-notice](https://user-images.githubusercontent.com/22080/54243051-2544aa00-44e4-11e9-8d25-c44b58a8109e.png)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

REST API: Add documentation and REST response headers denoting wc-blocks/v1 endpoints are for internal/block editor use only.
