### PR TITLE
Improve the speed of the admin dashboard by only updating transients once per class

### DIFF
--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -364,7 +364,7 @@ class WC_Admin_Report {
 	 * Init the static hooks of the class.
 	 */
 	protected static function add_update_transients_hook() {
-		if ( ! has_action( 'shutdown', array( 'WC_Admin_Report', 'maybe_update_transients' ) ) {
+		if ( ! has_action( 'shutdown', array( 'WC_Admin_Report', 'maybe_update_transients' ) ) ) {
 			add_action( 'shutdown', array( 'WC_Admin_Report', 'maybe_update_transients' ) );
 		}
 	}

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -339,15 +339,15 @@ class WC_Admin_Report {
 		$query          = apply_filters( 'woocommerce_reports_get_order_report_query', $query );
 		$query          = implode( ' ', $query );
 		$query_hash     = md5( $query_type . $query );
-		
+
 		if ( $debug ) {
 			echo '<pre>';
 			wc_print_r( $query );
 			echo '</pre>';
 		}
-		
+
 		$result = $this->get_cached_query();
-		
+
 		if ( $debug || $nocache || is_null( $result ) ) {
 			self::enable_big_selects();
 
@@ -356,8 +356,8 @@ class WC_Admin_Report {
 
 		return $result;
 	}
-	
-	
+
+
 	/**
 	 * Enables big mysql selects for reports, just once for this session
 	 */

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -17,17 +17,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Admin_Report {
 
 	/**
-	 * Init the static hooks of the class.
+	 * @var array List of transients name that have been updated and need persisting.
 	 */
-	protected static function add_update_transients_hook() {
-		static $done = false;
-		
-		if ( $done ) {
-			return;
-		}
-		$done = true;
-		add_action( 'shutdown', array( 'WC_Admin_Report', 'maybe_update_transients' ) );
-	}
+	protected static $transients_to_update = array();
+	
+	/**
+	 * @var array The list of transients.
+	 */
+	protected static $cached_results = array();
 
 	/**
 	 * The chart interval.
@@ -357,7 +354,19 @@ class WC_Admin_Report {
 		return $result;
 	}
 
-
+	/**
+	 * Init the static hooks of the class.
+	 */
+	protected static function add_update_transients_hook() {
+		static $done = false;
+		
+		if ( $done ) {
+			return;
+		}
+		$done = true;
+		add_action( 'shutdown', array( 'WC_Admin_Report', 'maybe_update_transients' ) );
+	}
+	
 	/**
 	 * Enables big mysql selects for reports, just once for this session
 	 */
@@ -411,16 +420,6 @@ class WC_Admin_Report {
 		self::$transients_to_update[ $class ]          = $class;
 		self::$cached_results[ $class ][ $query_hash ] = $data;
 	}
-
-	/**
-	 * @var array List of transients name that have been updated and need persisting.
-	 */
-	protected static $transients_to_update = array();
-	
-	/**
-	 * @var array The list of transients.
-	 */
-	protected static $cached_results = array();
 
 	/**
 	 * Function to update the modified transients at the end of the request.

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -17,10 +17,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 class WC_Admin_Report {
 
 	/**
-	 * WC_Admin_Report constructor.
+	 * Init the static hooks of the class.
 	 */
-	public function __construct() {
-		add_action( 'shutdown', array( $this, '_maybe_update_transients' ) );
+	public static function init_class() {
+		add_action( 'shutdown', array( 'WC_Admin_Report', '_maybe_update_transients' ) );
 	}
 
 	/**
@@ -349,7 +349,7 @@ class WC_Admin_Report {
 				$big_selects = true;
 			}
 
-			$this->transients_to_update[ $class ]          = $class;
+			self::$transients_to_update[ $class ]          = $class;
 			self::$cached_results[ $class ][ $query_hash ] = apply_filters( 'woocommerce_reports_get_order_report_data', $wpdb->$query_type( $query ), $data );
 		}
 
@@ -361,7 +361,7 @@ class WC_Admin_Report {
 	/**
 	 * @var array List of transients name that have been updated and need persisting.
 	 */
-	protected $transients_to_update = array();
+	protected static $transients_to_update = array();
 	
 	/**
 	 * @var array The list of transients.
@@ -369,12 +369,14 @@ class WC_Admin_Report {
 	protected static $cached_results = array();
 
 	/**
-	 * Hook to update the updated transients at the end of the request.
+	 * Function to update the modified transients at the end of the request.
 	 */
-	public function _maybe_update_transients() {
-		foreach ( $this->transients_to_update as $transient_name ) {
+	public static function _maybe_update_transients() {
+		foreach ( self::$transients_to_update as $key => $transient_name ) {
 			set_transient( $transient_name, self::$cached_results[ $transient_name ], DAY_IN_SECONDS );
 		}
+		//Reset the transients
+		self::$transients_to_update = array();
 	}
 
 	/**
@@ -705,3 +707,5 @@ class WC_Admin_Report {
 		}
 	}
 }
+
+WC_Admin_Report::init_class();

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -371,7 +371,7 @@ class WC_Admin_Report {
 	/**
 	 * Hook to update the updated transients at the end of the request.
 	 */
-	public function _update_transients() {
+	public function _maybe_update_transients() {
 		foreach ( $this->transients_to_update as $transient_name ) {
 			set_transient( $transient_name, self::$cached_results[ $transient_name ], DAY_IN_SECONDS );
 		}

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -141,8 +141,11 @@ class WC_Admin_Report {
 				case 'order_item':
 					$get_key = "order_items.{$key}";
 					break;
-				default:
-					continue 2; // Skip to the next foreach iteration else the query will be invalid.
+			}
+			
+			if ( empty( $get_key ) ) {
+				// Skip to the next foreach iteration else the query will be invalid.
+				continue;
 			}
 
 			if ( $value['function'] ) {

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -369,7 +369,7 @@ class WC_Admin_Report {
 	protected static $cached_results = array();
 
 	/**
-	 * Hook to update the updated transients at the end of the request
+	 * Hook to update the updated transients at the end of the request.
 	 */
 	public function _update_transients() {
 		foreach ( $this->transients_to_update as $transient_name ) {

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -368,6 +368,9 @@ class WC_Admin_Report {
 	 */
 	protected static $cached_results = array();
 
+	/**
+	 * Hook to update the updated transients at the end of the request
+	 */
 	public function _update_transients() {
 		foreach ( $this->transients_to_update as $transient_name ) {
 			set_transient( $transient_name, self::$cached_results[ $transient_name ], DAY_IN_SECONDS );

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -341,14 +341,20 @@ class WC_Admin_Report {
 			wc_print_r( $query );
 			echo '</pre>';
 		}
-		
-		$query_hash = md5( $query_type . $query );
 
-		if ( $debug || $nocache || is_null( $result = $this->get_cached_query( $query_hash ) ) ) {
+		if ( $debug || $nocache ) {
 			self::enable_big_selects();
 
 			$result = apply_filters( 'woocommerce_reports_get_order_report_data', $wpdb->$query_type( $query ), $data );
-			$this->set_cached_query( $query_hash, $result );	
+		} else {
+			$query_hash = md5( $query_type . $query );
+			$result = $this->get_cached_query( $query_hash );
+			if ( $result === null ) {
+				self::enable_big_selects();
+
+				$result = apply_filters( 'woocommerce_reports_get_order_report_data', $wpdb->$query_type( $query ), $data );
+			}
+			$this->set_cached_query( $query_hash, $result );
 		}
 
 		return $result;

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -338,7 +338,6 @@ class WC_Admin_Report {
 
 		$query          = apply_filters( 'woocommerce_reports_get_order_report_query', $query );
 		$query          = implode( ' ', $query );
-		$query_hash     = md5( $query_type . $query );
 
 		if ( $debug ) {
 			echo '<pre>';
@@ -346,7 +345,7 @@ class WC_Admin_Report {
 			echo '</pre>';
 		}
 
-		$result = $this->get_cached_query( $query_hash );
+		$result = $this->get_cached_query( $query_type, $query );
 
 		if ( $debug || $nocache || is_null( $result ) ) {
 			self::enable_big_selects();
@@ -374,12 +373,14 @@ class WC_Admin_Report {
 
 	/**
 	 * Get the cached query result or null if it's not in the cache
-	 * 
-	 * @param $query_hash
+	 *
+	 * @param string $query_type
+	 * @param string $query
 	 *
 	 * @return mixed
 	 */
-	protected function get_cached_query( $query_hash ) {
+	protected function get_cached_query( $query_type, $query ) {
+		$query_hash = md5( $query_type . $query );
 		$class = strtolower( get_class( $this ) );
 		if ( ! isset( self::$cached_results[ $class ] ) ) {
 			self::$cached_results[ $class ] = get_transient( strtolower( get_class( $this ) ) );

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -358,17 +358,13 @@ class WC_Admin_Report {
 	 * Init the static hooks of the class.
 	 */
 	protected static function add_update_transients_hook() {
-		static $done = false;
-		
-		if ( $done ) {
-			return;
+		if ( ! has_action( 'shutdown', array( 'WC_Admin_Report', 'maybe_update_transients' ) ) {
+			add_action( 'shutdown', array( 'WC_Admin_Report', 'maybe_update_transients' ) );
 		}
-		$done = true;
-		add_action( 'shutdown', array( 'WC_Admin_Report', 'maybe_update_transients' ) );
 	}
 	
 	/**
-	 * Enables big mysql selects for reports, just once for this session
+	 * Enables big mysql selects for reports, just once for this session.
 	 */
 	protected static function enable_big_selects() {
 		static $big_selects = false;
@@ -382,7 +378,7 @@ class WC_Admin_Report {
 	}
 
 	/**
-	 * Get the cached query result or null if it's not in the cache
+	 * Get the cached query result or null if it's not in the cache.
 	 *
 	 * @param string $query_hash
 	 *

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -142,7 +142,7 @@ class WC_Admin_Report {
 					$get_key = "order_items.{$key}";
 					break;
 			}
-			
+
 			if ( empty( $get_key ) ) {
 				// Skip to the next foreach iteration else the query will be invalid.
 				continue;

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -346,7 +346,7 @@ class WC_Admin_Report {
 			echo '</pre>';
 		}
 
-		$result = $this->get_cached_query();
+		$result = $this->get_cached_query( $query_hash );
 
 		if ( $debug || $nocache || is_null( $result ) ) {
 			self::enable_big_selects();

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -20,7 +20,7 @@ class WC_Admin_Report {
 	 * WC_Admin_Report constructor.
 	 */
 	public function __construct() {
-		add_action( 'shutdown', [ $this, '_maybe_update_transients' ] );
+		add_action( 'shutdown', array( $this, '_maybe_update_transients' ) );
 	}
 
 	/**

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -380,6 +380,8 @@ class WC_Admin_Report {
 	 * @return mixed
 	 */
 	protected function get_cached_query( $query_type, $query ) {
+		global $wpdb;
+		
 		$query_hash = md5( $query_type . $query );
 		$class = strtolower( get_class( $this ) );
 		if ( ! isset( self::$cached_results[ $class ] ) ) {

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -386,7 +386,7 @@ class WC_Admin_Report {
 	/**
 	 * Get the cached query result or null if it's not in the cache.
 	 *
-	 * @param string $query_hash
+	 * @param string $query_hash The query hash.
 	 *
 	 * @return mixed
 	 */
@@ -405,10 +405,10 @@ class WC_Admin_Report {
 	}
 
 	/**
-	 * Set the cached query result
+	 * Set the cached query result.
 	 *
-	 * @param string $query_hash
-	 * @param mixed  $data
+	 * @param string $query_hash The query hash.
+	 * @param mixed  $data The data to cache.
 	 */
 	protected function set_cached_query( $query_hash, $data ) {
 		$class = strtolower( get_class( $this ) );

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -375,8 +375,7 @@ class WC_Admin_Report {
 	/**
 	 * Get the cached query result or null if it's not in the cache
 	 *
-	 * @param string $query_type
-	 * @param string $query
+	 * @param string $query_hash
 	 *
 	 * @return mixed
 	 */
@@ -393,10 +392,14 @@ class WC_Admin_Report {
 
 		return null;
 	}
-	
+
+	/**
+	 * Set the cached query result
+	 *
+	 * @param string $query_hash
+	 * @param mixed  $data
+	 */
 	protected function set_cached_query( $query_hash, $data ) {
-		global $wpdb;
-		
 		$class = strtolower( get_class( $this ) );
 		
 		if ( ! isset( self::$cached_results[ $class ] ) ) {

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -353,7 +353,7 @@ class WC_Admin_Report {
 			self::$cached_results[ $class ][ $query_hash ] = apply_filters( 'woocommerce_reports_get_order_report_data', $wpdb->$query_type( $query ), $data );
 		}
 
-		$result = self::$cached_results[ $query_hash ];
+		$result = self::$cached_results[ $class ][ $query_hash ];
 
 		return $result;
 	}

--- a/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
@@ -47,7 +47,7 @@ class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 		) );
 
 		$this->assertEquals( 1, $data->total_orders, 'Expected to see one completed order in the report.' );
-		WC_Admin_Report::_maybe_update_transients();
+		WC_Admin_Report::maybe_update_transients();
 		$this->assertNotEmpty( get_transient( 'wc_admin_report' ), 'Results should be cached in a transient.' );
 	}
 

--- a/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
@@ -47,7 +47,7 @@ class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 		) );
 
 		$this->assertEquals( 1, $data->total_orders, 'Expected to see one completed order in the report.' );
-		$report->_maybe_update_transients();
+		WC_Admin_Report::_maybe_update_transients();
 		$this->assertNotEmpty( get_transient( 'wc_admin_report' ), 'Results should be cached in a transient.' );
 	}
 

--- a/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
@@ -47,6 +47,7 @@ class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 		) );
 
 		$this->assertEquals( 1, $data->total_orders, 'Expected to see one completed order in the report.' );
+		$report->_maybe_update_transients();
 		$this->assertNotEmpty( get_transient( 'wc_admin_report' ), 'Results should be cached in a transient.' );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
While debugging the admin dashboard I found out that some reports transients where updated up to 5 times during the page load, reading is fast but writting is costy, so the query where adding a total of 200ms to the page load (because they are also huge transients)

I've rewritten the transient storage procedure so that per class a transient is only updated once at the end of the request

I also found that a continue was changed for a break line 139 for php7.3 and the new warning it incurs, the problem is it was changed the  wrong way, it should have been a "continue 2" and not a "break".

That makes me wonder if some other "continue" where wrongly changed to "break" someplaces.

### How to test the changes in this Pull Request:

1. Install a query debugger 
2. Go on the admin dashboard
3. Notice that there is 4-6 transient updates with the same name (mostly 'wc_report_sales_by_date')
4. Apply the patch
5. Notice that now there is only one transient update with the same name
