### PR TITLE
Add transient caching to tracks blog data collection.

### DIFF
--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -71,13 +71,18 @@ class WC_Tracks {
 	 * @return array Blog details.
 	 */
 	public static function get_blog_details( $user_id ) {
-		return array(
-			'url'            => home_url(),
-			'blog_lang'      => get_user_locale( $user_id ),
-			'blog_id'        => ( class_exists( 'Jetpack' ) && Jetpack_Options::get_option( 'id' ) ) || null,
-			'products_count' => self::get_products_count(),
-			'orders_gross'   => self::get_total_revenue(),
-		);
+		$blog_details = get_transient( 'wc_tracks_blog_details' );
+		if ( false === $blog_details ) {
+			$blog_details = array(
+				'url'            => home_url(),
+				'blog_lang'      => get_user_locale( $user_id ),
+				'blog_id'        => ( class_exists( 'Jetpack' ) && Jetpack_Options::get_option( 'id' ) ) || null,
+				'products_count' => self::get_products_count(),
+				'orders_gross'   => self::get_total_revenue(),
+			);
+			set_transient( 'wc_tracks_blog_details', $blog_details, DAY_IN_SECONDS );
+		}
+		return $blog_details;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds transient caching to WC_Tracks::get_blog_details. Since this function is called on each data collection event it can slow things down doing DB queries each time. In the PR I added caching for one day.

### How to test the changes in this Pull Request:

1. Before checking out branch visit the order listview page in wp-admin and see it fire a wp_post_count call for products on each page load.
2. Checkout this branch and repeat above steps
3. Function should only be called once and then cached for a day.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

