### PR TITLE
Fixed WooCommerce writes current_theme_supports_woocommerce option on every page view.

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -295,7 +295,8 @@ class WC_Post_Types {
 		}
 
 		// If theme support changes, we may need to flush permalinks since some are changed based on this flag.
-		if ( update_option( 'current_theme_supports_woocommerce', current_theme_supports( 'woocommerce' ) ? 'yes' : 'no' ) ) {
+		$theme_support = current_theme_supports( 'woocommerce' ) ? 'yes' : 'no';
+		if ( $theme_support !== get_option('current_theme_supports_woocommerce') && update_option( 'current_theme_supports_woocommerce', $theme_support ) ) {
 			update_option( 'woocommerce_queue_flush_rewrite_rules', 'yes' );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WooCommerce updates the option `current_theme_supports_woocommerce` whenever a new post type registered, which causes the whole options cache containing all autoload options to be regenerated on every regular page view.

That's bad for performance.

### How to test the changes in this Pull Request:

– not testable –

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

### Changelog entry

> Fixed WooCommerce writes current_theme_supports_woocommerce option on every regular page view.
