### PR TITLE
Update the rating request text in the footer to be friendlier for screen reader users

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -258,7 +258,7 @@ class WC_Admin {
 					/* translators: 1: WooCommerce 2:: five stars */
 					__( 'If you like %1$s please leave us a %2$s rating. A huge thanks in advance!', 'woocommerce' ),
 					sprintf( '<strong>%s</strong>', esc_html__( 'WooCommerce', 'woocommerce' ) ),
-					'<a href="https://wordpress.org/support/plugin/woocommerce/reviews?rate=5#new-post" target="_blank" class="wc-rating-link" data-rated="' . esc_attr__( 'Thanks :)', 'woocommerce' ) . '">&#9733;&#9733;&#9733;&#9733;&#9733;</a>'
+					'<a href="https://wordpress.org/support/plugin/woocommerce/reviews?rate=5#new-post" target="_blank" class="wc-rating-link" aria-label="' . esc_attr__( 'five star', 'woocommerce' ) . '" data-rated="' . esc_attr__( 'Thanks :)', 'woocommerce' ) . '">&#9733;&#9733;&#9733;&#9733;&#9733;</a>'
 				);
 				wc_enqueue_js(
 					"jQuery( 'a.wc-rating-link' ).click( function() {


### PR DESCRIPTION
I was testing with VoiceOver, and noticed the footer text is read as "If you like WooCommerce please leave us a black star black star black star rating. A huge thanks in advance!" 

This PR updates it to read  "If you like WooCommerce please leave us a five star rating. A huge thanks in advance!" 

It would be better if the link text was more descriptive about where it's going, but this is a good, simple improvement.

### How to test the changes in this Pull Request:

1. Use VoiceOver, NVDA, or another screen reader to read any WooCommerce page
2. Skip down to the content info using VO's router (or however you navigate)
3. Have VO read the sentence, it should be a coherent sentence now.
4. You can also check Chrome's Accessibility parsing with inspect element on that paragraph, you should see fragments that form a coherent sentence:

![Screen Shot 2019-03-15 at 12 07 37 PM](https://user-images.githubusercontent.com/541093/54445378-067c2880-471b-11e9-90a6-564831f91861.png)
