### PR TITLE
Add hooks for helper subscription changes

### DIFF
--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -407,7 +407,7 @@ class WC_Helper {
 		$valid_filters  = array_keys( self::get_filters() );
 
 		if ( ! empty( $_GET['filter'] ) && in_array( wp_unslash( $_GET['filter'] ), $valid_filters ) ) {
-			$current_filter = wp_unslash( $_GET['filter'] );
+			$current_filter = wc_clean( wp_unslash( $_GET['filter'] ) );
 		}
 
 		return $current_filter;
@@ -480,16 +480,17 @@ class WC_Helper {
 	 * @return array Array pairs of message/type strings with notices.
 	 */
 	private static function _get_return_notices() {
-		$return_status = isset( $_GET['wc-helper-status'] ) ? wp_unslash( $_GET['wc-helper-status'] ) : null;
+		$return_status = isset( $_GET['wc-helper-status'] ) ? wc_clean( wp_unslash( $_GET['wc-helper-status'] ) ) : null;
 		$notices       = array();
 
 		switch ( $return_status ) {
 			case 'activate-success':
-				$subscription = self::_get_subscriptions_from_product_id( absint( $_GET['wc-helper-product-id'] ) );
+				$product_id   = isset( $_GET['wc-helper-product-id'] ) ? absint( $_GET['wc-helper-product-id'] ) : 0;
+				$subscription = self::_get_subscriptions_from_product_id( $product_id );
 				$notices[]    = array(
 					'type'    => 'updated',
-					/* translators: %s: product name */
 					'message' => sprintf(
+						/* translators: %s: product name */
 						__( '%s activated successfully. You will now receive updates for this product.', 'woocommerce' ),
 						'<strong>' . esc_html( $subscription['product_name'] ) . '</strong>'
 					),
@@ -497,11 +498,12 @@ class WC_Helper {
 				break;
 
 			case 'activate-error':
-				$subscription = self::_get_subscriptions_from_product_id( absint( $_GET['wc-helper-product-id'] ) );
+				$product_id   = isset( $_GET['wc-helper-product-id'] ) ? absint( $_GET['wc-helper-product-id'] ) : 0;
+				$subscription = self::_get_subscriptions_from_product_id( $product_id );
 				$notices[]    = array(
 					'type'    => 'error',
-					/* translators: %s: product name */
 					'message' => sprintf(
+						/* translators: %s: product name */
 						__( 'An error has occurred when activating %s. Please try again later.', 'woocommerce' ),
 						'<strong>' . esc_html( $subscription['product_name'] ) . '</strong>'
 					),
@@ -509,11 +511,12 @@ class WC_Helper {
 				break;
 
 			case 'deactivate-success':
-				$subscription = self::_get_subscriptions_from_product_id( absint( $_GET['wc-helper-product-id'] ) );
-				$local        = self::_get_local_from_product_id( absint( $_GET['wc-helper-product-id'] ) );
+				$product_id   = isset( $_GET['wc-helper-product-id'] ) ? absint( $_GET['wc-helper-product-id'] ) : 0;
+				$subscription = self::_get_subscriptions_from_product_id( $product_id );
+				$local        = self::_get_local_from_product_id( $product_id );
 
-				/* translators: %s: product name */
 				$message = sprintf(
+					/* translators: %s: product name */
 					__( 'Subscription for %s deactivated successfully. You will no longer receive updates for this product.', 'woocommerce' ),
 					'<strong>' . esc_html( $subscription['product_name'] ) . '</strong>'
 				);
@@ -531,8 +534,8 @@ class WC_Helper {
 						admin_url( 'admin.php' )
 					);
 
-					/* translators: %1$s: product name, %2$s: deactivate url */
 					$message = sprintf(
+						/* translators: %1$s: product name, %2$s: deactivate url */
 						__( 'Subscription for %1$s deactivated successfully. You will no longer receive updates for this product. <a href="%2$s">Click here</a> if you wish to deactivate the plugin as well.', 'woocommerce' ),
 						'<strong>' . esc_html( $subscription['product_name'] ) . '</strong>',
 						esc_url( $deactivate_plugin_url )
@@ -546,11 +549,12 @@ class WC_Helper {
 				break;
 
 			case 'deactivate-error':
-				$subscription = self::_get_subscriptions_from_product_id( absint( $_GET['wc-helper-product-id'] ) );
+				$product_id   = isset( $_GET['wc-helper-product-id'] ) ? absint( $_GET['wc-helper-product-id'] ) : 0;
+				$subscription = self::_get_subscriptions_from_product_id( $product_id );
 				$notices[]    = array(
 					'type'    => 'error',
-					/* translators: %s: product name */
 					'message' => sprintf(
+						/* translators: %s: product name */
 						__( 'An error has occurred when deactivating the subscription for %s. Please try again later.', 'woocommerce' ),
 						'<strong>' . esc_html( $subscription['product_name'] ) . '</strong>'
 					),
@@ -558,11 +562,12 @@ class WC_Helper {
 				break;
 
 			case 'deactivate-plugin-success':
-				$subscription = self::_get_subscriptions_from_product_id( absint( $_GET['wc-helper-product-id'] ) );
+				$product_id   = isset( $_GET['wc-helper-product-id'] ) ? absint( $_GET['wc-helper-product-id'] ) : 0;
+				$subscription = self::_get_subscriptions_from_product_id( $product_id );
 				$notices[]    = array(
 					'type'    => 'updated',
-					/* translators: %s: product name */
 					'message' => sprintf(
+						/* translators: %s: product name */
 						__( 'The extension %s has been deactivated successfully.', 'woocommerce' ),
 						'<strong>' . esc_html( $subscription['product_name'] ) . '</strong>'
 					),
@@ -570,11 +575,12 @@ class WC_Helper {
 				break;
 
 			case 'deactivate-plugin-error':
-				$subscription = self::_get_subscriptions_from_product_id( absint( $_GET['wc-helper-product-id'] ) );
+				$product_id   = isset( $_GET['wc-helper-product-id'] ) ? absint( $_GET['wc-helper-product-id'] ) : 0;
+				$subscription = self::_get_subscriptions_from_product_id( $product_id );
 				$notices[]    = array(
 					'type'    => 'error',
-					/* translators: %1$s: product name, %2$s: plugins screen url */
 					'message' => sprintf(
+						/* translators: %1$s: product name, %2$s: plugins screen url */
 						__( 'An error has occurred when deactivating the extension %1$s. Please proceed to the <a href="%2$s">Plugins screen</a> to deactivate it manually.', 'woocommerce' ),
 						'<strong>' . esc_html( $subscription['product_name'] ) . '</strong>',
 						admin_url( 'plugins.php' )
@@ -609,6 +615,8 @@ class WC_Helper {
 
 	/**
 	 * Various early-phase actions with possible redirects.
+	 *
+	 * @param object $screen WP screen object.
 	 */
 	public static function current_screen( $screen ) {
 		$wc_screen_id = sanitize_title( __( 'WooCommerce', 'woocommerce' ) );
@@ -654,7 +662,7 @@ class WC_Helper {
 	 * Initiate a new OAuth connection.
 	 */
 	private static function _helper_auth_connect() {
-		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( $_GET['wc-helper-nonce'], 'connect' ) ) {
+		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( wp_unslash( $_GET['wc-helper-nonce'] ), 'connect' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			self::log( 'Could not verify nonce in _helper_auth_connect' );
 			wp_die( 'Could not verify nonce' );
 		}
@@ -714,7 +722,7 @@ class WC_Helper {
 	 * Return from WooCommerce.com OAuth flow.
 	 */
 	private static function _helper_auth_return() {
-		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( $_GET['wc-helper-nonce'], 'connect' ) ) {
+		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( wp_unslash( $_GET['wc-helper-nonce'] ), 'connect' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			self::log( 'Could not verify nonce in _helper_auth_return' );
 			wp_die( 'Something went wrong' );
 		}
@@ -740,7 +748,7 @@ class WC_Helper {
 			'oauth/access_token',
 			array(
 				'body' => array(
-					'request_token' => $_GET['request_token'],
+					'request_token' => wp_unslash( $_GET['request_token'] ), // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 					'home_url'      => home_url(),
 				),
 			)
@@ -808,7 +816,7 @@ class WC_Helper {
 	 * Disconnect from WooCommerce.com, clear OAuth tokens.
 	 */
 	private static function _helper_auth_disconnect() {
-		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( $_GET['wc-helper-nonce'], 'disconnect' ) ) {
+		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( wp_unslash( $_GET['wc-helper-nonce'] ), 'disconnect' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			self::log( 'Could not verify nonce in _helper_auth_disconnect' );
 			wp_die( 'Could not verify nonce' );
 		}
@@ -848,7 +856,7 @@ class WC_Helper {
 	 * User hit the Refresh button, clear all caches.
 	 */
 	private static function _helper_auth_refresh() {
-		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( $_GET['wc-helper-nonce'], 'refresh' ) ) {
+		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( wp_unslash( $_GET['wc-helper-nonce'] ), 'refresh' ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			self::log( 'Could not verify nonce in _helper_auth_refresh' );
 			wp_die( 'Could not verify nonce' );
 		}
@@ -880,10 +888,10 @@ class WC_Helper {
 	 * Active a product subscription.
 	 */
 	private static function _helper_subscription_activate() {
-		$product_key = $_GET['wc-helper-product-key'];
-		$product_id  = absint( $_GET['wc-helper-product-id'] );
+		$product_key = isset( $_GET['wc-helper-product-key'] ) ? wc_clean( wp_unslash( $_GET['wc-helper-product-key'] ) ) : '';
+		$product_id  = isset( $_GET['wc-helper-product-id'] ) ? absint( $_GET['wc-helper-product-id'] ) : 0;
 
-		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( $_GET['wc-helper-nonce'], 'activate:' . $product_key ) ) {
+		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( wp_unslash( $_GET['wc-helper-nonce'] ), 'activate:' . $product_key ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			self::log( 'Could not verify nonce in _helper_subscription_activate' );
 			wp_die( 'Could not verify nonce' );
 		}
@@ -956,10 +964,10 @@ class WC_Helper {
 	 * Deactivate a product subscription.
 	 */
 	private static function _helper_subscription_deactivate() {
-		$product_key = $_GET['wc-helper-product-key'];
-		$product_id  = absint( $_GET['wc-helper-product-id'] );
+		$product_key = isset( $_GET['wc-helper-product-key'] ) ? wc_clean( wp_unslash( $_GET['wc-helper-product-key'] ) ) : '';
+		$product_id  = isset( $_GET['wc-helper-product-id'] ) ? absint( $_GET['wc-helper-product-id'] ) : 0;
 
-		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( $_GET['wc-helper-nonce'], 'deactivate:' . $product_key ) ) {
+		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( wp_unslash( $_GET['wc-helper-nonce'] ), 'deactivate:' . $product_key ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			self::log( 'Could not verify nonce in _helper_subscription_deactivate' );
 			wp_die( 'Could not verify nonce' );
 		}
@@ -1022,10 +1030,10 @@ class WC_Helper {
 	 * Deactivate a plugin.
 	 */
 	private static function _helper_plugin_deactivate() {
-		$product_id  = absint( $_GET['wc-helper-product-id'] );
+		$product_id  = isset( $_GET['wc-helper-product-id'] ) ? absint( $_GET['wc-helper-product-id'] ) : 0;
 		$deactivated = false;
 
-		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( $_GET['wc-helper-nonce'], 'deactivate-plugin:' . $product_id ) ) {
+		if ( empty( $_GET['wc-helper-nonce'] ) || ! wp_verify_nonce( wp_unslash( $_GET['wc-helper-nonce'] ), 'deactivate-plugin:' . $product_id ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			self::log( 'Could not verify nonce in _helper_plugin_deactivate' );
 			wp_die( 'Could not verify nonce' );
 		}
@@ -1167,7 +1175,7 @@ class WC_Helper {
 		foreach ( $themes as $theme ) {
 			$header = $theme->get( 'Woo' );
 
-			// Backwards compatibility for theme_info.txt
+			// Backwards compatibility for theme_info.txt.
 			if ( ! $header ) {
 				$txt = $theme->get_stylesheet_directory() . '/theme_info.txt';
 				if ( is_readable( $txt ) ) {
@@ -1213,7 +1221,8 @@ class WC_Helper {
 	 */
 	public static function get_subscriptions() {
 		$cache_key = '_woocommerce_helper_subscriptions';
-		if ( false !== ( $data = get_transient( $cache_key ) ) ) {
+		$data      = get_transient( $cache_key );
+		if ( false !== $data ) {
 			return $data;
 		}
 
@@ -1251,7 +1260,7 @@ class WC_Helper {
 	public static function activated_plugin( $filename ) {
 		$plugins = self::get_local_woo_plugins();
 
-		// Not a local woo plugin
+		// Not a local woo plugin.
 		if ( empty( $plugins[ $filename ] ) ) {
 			return;
 		}
@@ -1266,7 +1275,7 @@ class WC_Helper {
 		$product_id    = $plugin['_product_id'];
 		$subscriptions = self::_get_subscriptions_from_product_id( $product_id, false );
 
-		// No valid subscriptions for this product
+		// No valid subscriptions for this product.
 		if ( empty( $subscriptions ) ) {
 			return;
 		}
@@ -1352,7 +1361,7 @@ class WC_Helper {
 	public static function deactivated_plugin( $filename ) {
 		$plugins = self::get_local_woo_plugins();
 
-		// Not a local woo plugin
+		// Not a local woo plugin.
 		if ( empty( $plugins[ $filename ] ) ) {
 			return;
 		}
@@ -1449,7 +1458,7 @@ class WC_Helper {
 		// Add a note about available extension updates if Woo core has an update available.
 		$notice = self::_get_extensions_update_notice();
 		if ( ! empty( $notice ) ) {
-			echo '<div class="updated woocommerce-message"><p>' . $notice . '</p></div>';
+			echo '<div class="updated woocommerce-message"><p>' . $notice . '</p></div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 
@@ -1499,7 +1508,7 @@ class WC_Helper {
 			/* translators: %s: helper screen url */
 			$notice = __( '<a href="%s">Connect your store</a> to WooCommerce.com to receive extensions updates and support.', 'woocommerce' );
 			$notice = sprintf( $notice, admin_url( 'admin.php?page=wc-addons&section=helper' ) );
-			echo '<div class="updated woocommerce-message"><p>' . $notice . '</p></div>';
+			echo '<div class="updated woocommerce-message"><p>' . wp_kses_post( $notice ) . '</p></div>';
 		}
 	}
 
@@ -1528,8 +1537,8 @@ class WC_Helper {
 			return;
 		}
 
-		/* translators: %1$s: helper url, %2$d: number of extensions */
 		return sprintf(
+			/* translators: %1$s: helper url, %2$d: number of extensions */
 			_n( 'Note: You currently have <a href="%1$s">%2$d paid extension</a> which should be updated first before updating WooCommerce.', 'Note: You currently have <a href="%1$s">%2$d paid extensions</a> which should be updated first before updating WooCommerce.', $available, 'woocommerce' ),
 			admin_url( 'admin.php?page=wc-addons&section=helper' ),
 			$available
@@ -1568,8 +1577,6 @@ class WC_Helper {
 
 	/**
 	 * Flush auth cache.
-	 *
-	 * @access private
 	 */
 	public static function _flush_authentication_cache() {
 		$request = WC_Helper_API::get(
@@ -1609,8 +1616,8 @@ class WC_Helper {
 	/**
 	 * Sort subscriptions by the product_name.
 	 *
-	 * @param array $a Subscription array
-	 * @param array $b Subscription array
+	 * @param array $a Subscription array.
+	 * @param array $b Subscription array.
 	 *
 	 * @return int
 	 */
@@ -1621,8 +1628,8 @@ class WC_Helper {
 	/**
 	 * Sort subscriptions by the Name.
 	 *
-	 * @param array $a Product array
-	 * @param array $b Product array
+	 * @param array $a Product array.
+	 * @param array $b Product array.
 	 *
 	 * @return int
 	 */
@@ -1634,8 +1641,7 @@ class WC_Helper {
 	 * Log a helper event.
 	 *
 	 * @param string $message Log message.
-	 * @param string $level Optional, defaults to info, valid levels:
-	 *     emergency|alert|critical|error|warning|notice|info|debug
+	 * @param string $level Optional, defaults to info, valid levels: emergency|alert|critical|error|warning|notice|info|debug.
 	 */
 	public static function log( $message, $level = 'info' ) {
 		if ( ! defined( 'WP_DEBUG' ) || ! WP_DEBUG ) {

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -918,20 +918,18 @@ class WC_Helper {
 			/**
 			 * Fires when the Helper activates a product successfully.
 			 *
-			 * @param int        $product_id Product ID being activated.
-			 * @param array|bool $local The array containing the local plugin/theme data or false.
-			 * @param array      $activation_response The response object from wp_safe_remote_request().
+			 * @param int   $product_id Product ID being activated.
+			 * @param array $activation_response The response object from wp_safe_remote_request().
 			 */
-			do_action( 'woocommerce_helper_subscription_activate_success', $product_id, $local, $activation_response );
+			do_action( 'woocommerce_helper_subscription_activate_success', $product_id, $activation_response );
 		} else {
 			/**
 			 * Fires when the Helper fails to activate a product.
 			 *
-			 * @param int        $product_id Product ID being activated.
-			 * @param array|bool $local The array containing the local plugin/theme data or false.
-			 * @param array      $activation_response The response object from wp_safe_remote_request().
+			 * @param int   $product_id Product ID being activated.
+			 * @param array $activation_response The response object from wp_safe_remote_request().
 			 */
-			do_action( 'woocommerce_helper_subscription_activate_error', $product_id, $local, $activation_response );
+			do_action( 'woocommerce_helper_subscription_activate_error', $product_id, $activation_response );
 		}
 
 		self::_flush_subscriptions_cache();
@@ -964,7 +962,7 @@ class WC_Helper {
 			wp_die( 'Could not verify nonce' );
 		}
 
-		$request = WC_Helper_API::post(
+		$deactivation_response = WC_Helper_API::post(
 			'deactivate',
 			array(
 				'authenticated' => true,
@@ -976,13 +974,31 @@ class WC_Helper {
 			)
 		);
 
-		$code        = wp_remote_retrieve_response_code( $request );
+		$code        = wp_remote_retrieve_response_code( $deactivation_response );
 		$deactivated = 200 === $code;
-		if ( ! $deactivated ) {
+
+		if ( $deactivated ) {
+			/**
+			 * Fires when the Helper activates a product successfully.
+			 *
+			 * @param int   $product_id Product ID being deactivated.
+			 * @param array $deactivation_response The response object from wp_safe_remote_request().
+			 */
+			do_action( 'woocommerce_helper_subscription_deactivate_success', $product_id, $deactivation_response );
+		} else {
 			self::log( sprintf( 'Deactivate API call returned a non-200 response code (%d)', $code ) );
+
+			/**
+			 * Fires when the Helper fails to activate a product.
+			 *
+			 * @param int   $product_id Product ID being deactivated.
+			 * @param array $deactivation_response The response object from wp_safe_remote_request().
+			 */
+			do_action( 'woocommerce_helper_subscription_deactivate_error', $product_id, $deactivation_response );
 		}
 
 		self::_flush_subscriptions_cache();
+
 		$redirect_uri = add_query_arg(
 			array(
 				'page'                 => 'wc-addons',


### PR DESCRIPTION
Adds actions when product subscriptions are activated in the helper.

```
woocommerce_helper_subscription_activate_success
woocommerce_helper_subscription_activate_error
woocommerce_helper_subscription_deactivate_success
woocommerce_helper_subscription_deactivate_error
```

All actions give you an ID, key, and the response from our servers.

```
/**
				 * Fires when the Helper fails to activate a product.
				 *
				 * @param int    $product_id Product ID being deactivated.
				 * @param string $product_key Subscription product key.
				 * @param array  $deactivation_response The response object from wp_safe_remote_request().
				 */
```

Commit https://github.com/woocommerce/woocommerce/commit/6b82636e33cc258839415ea5d6078723252ad0c7 is just PHPCS.

You can test by adding some listeners to these actions and activating/deactivating Woo plugins, or doing so from the helper screen. e.g. 

```
add_action( 'woocommerce_helper_subscription_activate_success', function() {
error_log( 'woocommerce_helper_subscription_activate_success' );
});
```

Closes #21701 cc @mattyza @allendav 