### PR TITLE
Fixed "e is null" error on checkout page

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -333,7 +333,7 @@ jQuery( function( $ ) {
 				success:	function( data ) {
 
 					// Reload the page if requested
-					if ( true === data.reload ) {
+					if ( data && true === data.reload ) {
 						window.location.reload();
 						return;
 					}


### PR DESCRIPTION
Fixed "e is null" on checkout page which caused the order panel to be disabled.  WooCommerce with StoreFront theme and WPML.  Disabling WPML did not make a difference.

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Added a null check before checking for variable's properties.

Closes # .

### How to test the changes in this Pull Request:

1. Open checkout page.
2. Order details should not be disabled by overlay and a spinner.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [-] Have you written new tests for your changes, as applicable?
* [X] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Null check variable before accessing its properties.