### PR TITLE
Fix image regeneration check when image is not cropped

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -215,7 +215,7 @@ class WC_Regenerate_Images {
 		$uncropped    = '' === $target_size['width'] || '' === $target_size['height'];
 
 		// If '' is passed to either size, we test ratios against the original file. It's uncropped.
-		if ( $uncropped ) {
+		if ( $uncropped || ! $target_size['crop'] ) {
 			$full_size = self::get_full_size_image_dimensions( $attachment_id );
 
 			if ( ! $full_size || ! $full_size['width'] || ! $full_size['height'] ) {


### PR DESCRIPTION
Resolves #21800.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #21800.

### How to test the changes in this Pull Request:

1. Add this code to your theme:
```php
add_filter( 'woocommerce_get_image_size_single', function( $size ) {
	return array(
		'width' => 100,
		'height' => 1000,
		'crop' => 0,
	);
} );
```
2. Upload an image which is larger than 100 x 1000, e.g., 1500 x 1500
3. Set the image as a product image and visit the product page.  Without this PR, it will regenerate the image every time.  With this PR, it will not regenerate the image and it should be faster.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Fix - Avoid regenerating thumbnails on every page load. #21800