### PR TITLE
Allow extension of WC_Breadcrumb class

### DIFF
--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -18,7 +18,7 @@ class WC_Breadcrumb {
 	 *
 	 * @var array
 	 */
-	private $crumbs = array();
+	protected $crumbs = array();
 
 	/**
 	 * Add a crumb so we don't get lost.
@@ -92,7 +92,7 @@ class WC_Breadcrumb {
 	/**
 	 * Prepend the shop page to shop breadcrumbs.
 	 */
-	private function prepend_shop_page() {
+	protected function prepend_shop_page() {
 		$permalinks   = wc_get_permalink_structure();
 		$shop_page_id = wc_get_page_id( 'shop' );
 		$shop_page    = get_post( $shop_page_id );
@@ -106,21 +106,21 @@ class WC_Breadcrumb {
 	/**
 	 * Is home trail..
 	 */
-	private function add_crumbs_home() {
+	protected function add_crumbs_home() {
 		$this->add_crumb( single_post_title( '', false ) );
 	}
 
 	/**
 	 * 404 trail.
 	 */
-	private function add_crumbs_404() {
+	protected function add_crumbs_404() {
 		$this->add_crumb( __( 'Error 404', 'woocommerce' ) );
 	}
 
 	/**
 	 * Attachment trail.
 	 */
-	private function add_crumbs_attachment() {
+	protected function add_crumbs_attachment() {
 		global $post;
 
 		$this->add_crumbs_single( $post->post_parent, get_permalink( $post->post_parent ) );
@@ -133,7 +133,7 @@ class WC_Breadcrumb {
 	 * @param int    $post_id   Post ID.
 	 * @param string $permalink Post permalink.
 	 */
-	private function add_crumbs_single( $post_id = 0, $permalink = '' ) {
+	protected function add_crumbs_single( $post_id = 0, $permalink = '' ) {
 		if ( ! $post_id ) {
 			global $post;
 		} else {
@@ -184,7 +184,7 @@ class WC_Breadcrumb {
 	/**
 	 * Page trail.
 	 */
-	private function add_crumbs_page() {
+	protected function add_crumbs_page() {
 		global $post;
 
 		if ( $post->post_parent ) {
@@ -211,7 +211,7 @@ class WC_Breadcrumb {
 	/**
 	 * Product category trail.
 	 */
-	private function add_crumbs_product_category() {
+	protected function add_crumbs_product_category() {
 		$current_term = $GLOBALS['wp_query']->get_queried_object();
 
 		$this->prepend_shop_page();
@@ -222,7 +222,7 @@ class WC_Breadcrumb {
 	/**
 	 * Product tag trail.
 	 */
-	private function add_crumbs_product_tag() {
+	protected function add_crumbs_product_tag() {
 		$current_term = $GLOBALS['wp_query']->get_queried_object();
 
 		$this->prepend_shop_page();
@@ -234,7 +234,7 @@ class WC_Breadcrumb {
 	/**
 	 * Shop breadcrumb.
 	 */
-	private function add_crumbs_shop() {
+	protected function add_crumbs_shop() {
 		if ( intval( get_option( 'page_on_front' ) ) === wc_get_page_id( 'shop' ) ) {
 			return;
 		}
@@ -252,7 +252,7 @@ class WC_Breadcrumb {
 	/**
 	 * Post type archive trail.
 	 */
-	private function add_crumbs_post_type_archive() {
+	protected function add_crumbs_post_type_archive() {
 		$post_type = get_post_type_object( get_post_type() );
 
 		if ( $post_type ) {
@@ -263,7 +263,7 @@ class WC_Breadcrumb {
 	/**
 	 * Category trail.
 	 */
-	private function add_crumbs_category() {
+	protected function add_crumbs_category() {
 		$this_category = get_category( $GLOBALS['wp_query']->get_queried_object() );
 
 		if ( 0 !== intval( $this_category->parent ) ) {
@@ -276,7 +276,7 @@ class WC_Breadcrumb {
 	/**
 	 * Tag trail.
 	 */
-	private function add_crumbs_tag() {
+	protected function add_crumbs_tag() {
 		$queried_object = $GLOBALS['wp_query']->get_queried_object();
 
 		/* translators: %s: tag name */
@@ -286,7 +286,7 @@ class WC_Breadcrumb {
 	/**
 	 * Add crumbs for date based archives.
 	 */
-	private function add_crumbs_date() {
+	protected function add_crumbs_date() {
 		if ( is_year() || is_month() || is_day() ) {
 			$this->add_crumb( get_the_time( 'Y' ), get_year_link( get_the_time( 'Y' ) ) );
 		}
@@ -301,7 +301,7 @@ class WC_Breadcrumb {
 	/**
 	 * Add crumbs for taxonomies
 	 */
-	private function add_crumbs_tax() {
+	protected function add_crumbs_tax() {
 		$this_term = $GLOBALS['wp_query']->get_queried_object();
 		$taxonomy  = get_taxonomy( $this_term->taxonomy );
 
@@ -317,7 +317,7 @@ class WC_Breadcrumb {
 	/**
 	 * Add a breadcrumb for author archives.
 	 */
-	private function add_crumbs_author() {
+	protected function add_crumbs_author() {
 		global $author;
 
 		$userdata = get_userdata( $author );
@@ -332,7 +332,7 @@ class WC_Breadcrumb {
 	 * @param int    $term_id  Term ID.
 	 * @param string $taxonomy Taxonomy.
 	 */
-	private function term_ancestors( $term_id, $taxonomy ) {
+	protected function term_ancestors( $term_id, $taxonomy ) {
 		$ancestors = get_ancestors( $term_id, $taxonomy );
 		$ancestors = array_reverse( $ancestors );
 
@@ -348,7 +348,7 @@ class WC_Breadcrumb {
 	/**
 	 * Endpoints.
 	 */
-	private function endpoint_trail() {
+	protected function endpoint_trail() {
 		$endpoint       = is_wc_endpoint_url() ? WC()->query->get_current_endpoint() : '';
 		$endpoint_title = $endpoint ? WC()->query->get_endpoint_title( $endpoint ) : '';
 
@@ -360,7 +360,7 @@ class WC_Breadcrumb {
 	/**
 	 * Add a breadcrumb for search results.
 	 */
-	private function search_trail() {
+	protected function search_trail() {
 		if ( is_search() ) {
 			/* translators: %s: search term */
 			$this->add_crumb( sprintf( __( 'Search results for &ldquo;%s&rdquo;', 'woocommerce' ), get_search_query() ), remove_query_arg( 'paged' ) );
@@ -370,7 +370,7 @@ class WC_Breadcrumb {
 	/**
 	 * Add a breadcrumb for pagination.
 	 */
-	private function paged_trail() {
+	protected function paged_trail() {
 		if ( get_query_var( 'paged' ) && 'subcategories' !== woocommerce_get_loop_display_mode() ) {
 			/* translators: %d: page number */
 			$this->add_crumb( sprintf( __( 'Page %d', 'woocommerce' ), get_query_var( 'paged' ) ) );


### PR DESCRIPTION
Changing the private class methods to protected allows extending the class to work with the built-in functionality. 

The desired effect - removing the "Shop" crumb - was not possible with the few filters available interspersed in this class. 

After much hair-pulling over the simple task of excluding one breadcrumb and the stubborn refusal to copy-pasta the entire class into my theme, I choose to extend the WC_Breadcrumb class to override the already-public add_crumb method. Without access to the other methods on the class, this was futile. 

There are several asks around the web for removing or updating the breadcrumbs. The accepted answer to these appears to be to "just hide it with CSS" which is a poor workaround.

Issue: https://github.com/woocommerce/woocommerce/issues/23058

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Allows extension of WC_Breadcrumb class, which properly solves removing individual breadcrumbs and possibly other issues. Removing a breadcrumb is a question that exists in multiple places online, and is most often answered with "hide it with CSS", or to remove items in the 'woocommerce_get_breadcrumb' filter - which causes other issues with rendering as there appears to be some other reliance on array length unrelated to the returned value of that filter. 

### How to test the changes in this Pull Request:

1. Extend WC_Breadcrumb class and utilize any protected method.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Changed 'private' methods on WC_Breadcrumb class to 'protected' 
