### PR TITLE
Remove ActionScheduler Tools Menu

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -30,6 +30,7 @@ class WC_Admin {
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ), 1 );
 		add_action( 'wp_ajax_setup_wizard_check_jetpack', array( $this, 'setup_wizard_check_jetpack' ) );
 		add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
+		add_action( 'admin_menu', array( $this, 'remove_action_scheduler_tools_menu' ), 9999 );
 	}
 
 	/**
@@ -287,6 +288,18 @@ class WC_Admin {
 				'is_active' => $jetpack_active ? 'yes' : 'no',
 			)
 		);
+	}
+
+	/**
+	 * Remove ActionScheduler Tools Menu, WC has it under WooCommerce -> Status
+	 *
+	 * @since 3.6.0
+	 * @return void
+	 */
+	public function remove_action_scheduler_tools_menu() {
+		if ( class_exists( 'ActionScheduler' ) ) {
+			remove_submenu_page( 'tools.php', 'action-scheduler' );
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The ActionScheduler library that is bundled with WooCommerce for the Queues includes a menu to view scheduled actions under the WordPress tools menu. WooCommerce also has this same page under WooCommerce -> Status. There is no need to have these pages in both places and since the library is included in core we can just keep the one under Status. This PR removes the Tools menu option.

Closes #23048

cc @thenbrent @rrennick just so you are aware of this change.

### How to test the changes in this Pull Request:

1. Before checking out branch check under Tools, there should be a Scheduled Actions menu
2. Apply patch and check Tool menu again, there should be no more Scheduled Actions menu.
3. Check WooCommerce -> Status, there should be a Scheduled Actions tab which loads the same page that was under tools.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> When WooCommerce is active with Action Scheduler as Queue system, remove Scheduled Actions menu from tools.
