### PR TITLE
Fix typo in lookup table notice markup

### DIFF
--- a/includes/admin/views/html-notice-regenerating-lookup-table.php
+++ b/includes/admin/views/html-notice-regenerating-lookup-table.php
@@ -10,7 +10,7 @@ defined( 'ABSPATH' ) || exit;
 ?>
 <div id="message" class="updated woocommerce-message">
 	<p>
-		<string><?php esc_html_e( 'WooCommerce is updating product data in the background.', 'woocommerce' ); ?></strong>&nbsp;
+		<strong><?php esc_html_e( 'WooCommerce is updating product data in the background.', 'woocommerce' ); ?></strong>&nbsp;
 		<?php
 		echo wp_kses_post(
 			sprintf(


### PR DESCRIPTION
This PR fixes a type in the Regenerating Lookup Tables notice markup.