### PR TITLE
preventDefault when dismissing store notices

### DIFF
--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -25,7 +25,7 @@ jQuery( function( $ ) {
 	}
 
 	// Set a cookie and hide the store notice when the dismiss button is clicked
-	$( '.woocommerce-store-notice__dismiss-link' ).click( function() {
+	$( '.woocommerce-store-notice__dismiss-link' ).click( function( event ) {
 		Cookies.set( cookieName, 'hidden', { path: '/' } );
 		$( '.woocommerce-store-notice' ).hide();
 		event.preventDefault();

--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -28,6 +28,7 @@ jQuery( function( $ ) {
 	$( '.woocommerce-store-notice__dismiss-link' ).click( function() {
 		Cookies.set( cookieName, 'hidden', { path: '/' } );
 		$( '.woocommerce-store-notice' ).hide();
+		event.preventDefault();
 	});
 
 	// Make form field descriptions toggle on focus.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds a preventDefault when dismissing a store notice to avoid jumping to top of the page for notices that are at the bottom of pages since the notice is hidden via JS and has a # in the href property.

Closes #23055 

### How to test the changes in this Pull Request:

1. Enable Storefront theme
2. Enable the store notice via customiser
3. Go to a frontend page that is long and scroll to the bottom
4. Dismiss the store notice at the bottom of the page
5. Ensure the page does not jump to the top
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Jumping to top of page when dismissing store notice.
