### PR TITLE
Variation stock status field handling (displaying/hiding when needed)

### DIFF
--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -62,11 +62,16 @@ jQuery( function( $ ) {
 		 */
 		variable_manage_stock: function() {
 			$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_manage_stock' ).hide();
-			$( this ).closest( '.woocommerce_variation' ).find( '.hide_if_variation_manage_stock' ).show();
+			$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).show();
 
 			if ( $( this ).is( ':checked' ) ) {
 				$( this ).closest( '.woocommerce_variation' ).find( '.show_if_variation_manage_stock' ).show();
-				$( this ).closest( '.woocommerce_variation' ).find( '.hide_if_variation_manage_stock' ).hide();
+				$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).hide();
+			}
+
+			// Parent level.
+			if ( $( 'input#_manage_stock:checked' ).length ) {
+				$( this ).closest( '.woocommerce_variation' ).find( '.variable_stock_status' ).hide();
 			}
 		},
 

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -240,6 +240,8 @@ jQuery( function( $ ) {
 			$( 'div.stock_fields' ).hide();
 			$( 'p.stock_status_field:not( .hide_if_' + product_type + ' )' ).show();
 		}
+
+		$( 'input.variable_manage_stock' ).change();
 	}).change();
 
 	// Date picker fields.

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -235,7 +235,7 @@ defined( 'ABSPATH' ) || exit;
 						'options'       => wc_get_product_stock_status_options(),
 						'desc_tip'      => true,
 						'description'   => __( 'Controls whether or not the product is listed as "in stock" or "out of stock" on the frontend.', 'woocommerce' ),
-						'wrapper_class' => 'form-row form-row-full hide_if_variation_manage_stock',
+						'wrapper_class' => 'form-row form-row-full variable_stock_status',
 					)
 				);
 


### PR DESCRIPTION
Fixes #23061

Stock status for variations needs special handling.

- When managing stock at variation level, it's set automatically and his thus hidden
- When managing stock at parent level, variations which do not manage their own stock sync with the parent and also should have their fields hidden (this patch)
- Variations which are not stock managed at all can set stock status

To test, edit variable product and set stock management at product level. Stock status select should be hidden on each variation.

> Hide stock status for variations when the parent is managing stock