### PR TITLE
Added possibility to exclude variable products from product search.

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1544,7 +1544,7 @@ class WC_AJAX {
 		}
 
 		$data_store = WC_Data_Store::load( 'product' );
-		$ids        = $data_store->search_products( $term, '', (bool) $include_variations, false, $limit );
+		$ids        = $data_store->search_products( $term, '', (bool) $include_variations, false, $limit, false );
 
 		if ( ! empty( $_GET['exclude'] ) ) {
 			$ids = array_diff( $ids, array_map( 'absint', (array) wp_unslash( $_GET['exclude'] ) ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes #23052 .

I'm not completely sure in what other circumstances it might be needed, so tried to make a change that wouldn't affect the search in other contexts, e.g. 
https://github.com/woocommerce/woocommerce/issues/18882 requested variable products to be added to search by SKU of its variation, but I'm not completely sure where this is used, maybe @mikejolley remembers? 
Either way, I think it does not make sense to add parent products to orders, so here's the change.

### How to test the changes in this Pull Request:

1. Create a variable product with a couple of variations.
2. Go to Admin -> Orders -> Add order
3. Add items -> Add products -> search for a word from the product title
4. Results should not include the parent variable product, only variations after the change. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added possibility to exclude variable products from product search in certain contexts, e.g. for adding products to orders manually.
