### PR TITLE
Blocks: Prevent duplicate class loading for blocks feature plugin

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -383,6 +383,7 @@ module.exports = function( grunt ) {
 						)
 						// Replace class & constant prefixes.
 						.replace( /WGPB_/g, 'WC_' )
+						.replace( /FP_VERSION/g, 'WGPB_VERSION' )
 						// Replace file imports
 						.replace( /-wgpb-/g, '-wc-' )
 				}

--- a/includes/blocks/class-wc-block-library.php
+++ b/includes/blocks/class-wc-block-library.php
@@ -37,6 +37,11 @@ class WC_Block_Library {
 	 * Constructor.
 	 */
 	public function __construct() {
+		// Shortcut out if we see the feature plugin, v1.4 or below.
+		// note: `WGPB_VERSION` is transformed to `WC_VERSION` in the grunt copy task.
+		if ( defined( 'WGPB_VERSION' ) && version_compare( WGPB_VERSION, '1.4.0', '<=' ) ) {
+			return;
+		}
 		if ( function_exists( 'register_block_type' ) ) {
 			add_action( 'init', array( 'WC_Block_Library', 'register_blocks' ) );
 			add_action( 'init', array( 'WC_Block_Library', 'register_assets' ) );

--- a/package-lock.json
+++ b/package-lock.json
@@ -361,9 +361,9 @@
       }
     },
     "@woocommerce/block-library": {
-      "version": "2.0.0-rc1",
-      "resolved": "https://registry.npmjs.org/@woocommerce/block-library/-/block-library-2.0.0-rc1.tgz",
-      "integrity": "sha512-NoQ41eaelbQaHPJZFmdmUtYYsBA29T5dUKehnYwMopZeQiZvhOu0gvEHpKWahI87ZIFcfqyy0aT1HIuy9wdjiQ==",
+      "version": "2.0.0-rc2",
+      "resolved": "https://registry.npmjs.org/@woocommerce/block-library/-/block-library-2.0.0-rc2.tgz",
+      "integrity": "sha512-rOCsrosIjdaAGeq9e4B2ZtIR9lnRvwc+/Y1KoNrQzOoTrlbsM87P3WWWzwjIvUIJBYbeIEcoLQoyMeIOjUCFDQ==",
       "requires": {
         "@woocommerce/components": "1.6.0",
         "gridicons": "3.1.1"
@@ -510,9 +510,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -549,9 +549,9 @@
           },
           "dependencies": {
             "@babel/runtime": {
-              "version": "7.4.0",
-              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-              "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+              "version": "7.4.2",
+              "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+              "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
               "requires": {
                 "regenerator-runtime": "^0.13.2"
               }
@@ -664,9 +664,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -721,9 +721,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -744,9 +744,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -779,9 +779,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -802,9 +802,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -862,9 +862,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -895,9 +895,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -920,9 +920,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -948,9 +948,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -995,9 +995,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -1022,9 +1022,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -1062,7 +1062,7 @@
     "abbrev": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
-      "integrity": "sha1-+PLIh60Qv2f2NPAFtph/7TF5qsg=",
+      "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
       "dev": true
     },
     "acorn": {
@@ -1157,7 +1157,7 @@
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
-      "integrity": "sha1-VT3Lj5HjyImEXf26NMd3IbkLnXo=",
+      "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1220,7 +1220,7 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha1-NgSLv/TntH4TZkQxbJlmnqWukfE=",
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
       "dev": true
     },
     "arr-union": {
@@ -2615,7 +2615,7 @@
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha1-ry87iPpvXB5MY00aD46sT1WzleM=",
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
       "dev": true
     },
     "bail": {
@@ -2775,7 +2775,7 @@
     "browser-stdout": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
-      "integrity": "sha1-uqVZ7hTO1zRSIputcyZGfGH6vWA=",
+      "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
     },
     "browserslist": {
@@ -3563,7 +3563,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dev": true,
       "requires": {
         "ms": "2.0.0"
@@ -3823,9 +3823,9 @@
       },
       "dependencies": {
         "@babel/runtime": {
-          "version": "7.4.0",
-          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.0.tgz",
-          "integrity": "sha512-/eftZ45kD0OfOFHAmN02WP6N1NVphY+lBf8c2Q/P9VW3tj+N5NlBBAWfqOLOl96YDGMqpIBO5O/hQNx4A/lAng==",
+          "version": "7.4.2",
+          "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.2.tgz",
+          "integrity": "sha512-7Bl2rALb7HpvXFL7TETNzKSAeBVCPHELzc0C//9FCxN8nsiueWSJBqaF+2oIJScyILStASR/Cx5WMkXGYTiJFA==",
           "requires": {
             "regenerator-runtime": "^0.13.2"
           }
@@ -5063,7 +5063,7 @@
     "fs-extra": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-5.0.0.tgz",
-      "integrity": "sha1-QU0BEM3QZwVzTQVWUsVBEmDDGr0=",
+      "integrity": "sha512-66Pm4RYbjzdyeuqudYqhFiNBbCIuI9kgRqLPSHIlXHidW8NIQtVdkM1yeZ4lXwuhbTETv3EUGMNHAAw6hiundQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
@@ -5084,7 +5084,7 @@
     "fs-readdir-recursive": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fs-readdir-recursive/-/fs-readdir-recursive-1.1.0.tgz",
-      "integrity": "sha1-4y/AMKLM7kSmtTcTCNpUvgs5fSc=",
+      "integrity": "sha512-GNanXlVr2pf02+sPN40XN8HG+ePaNcvM0q5mZBd668Obwb0yD5GiUbZOFgwn8kGMY6I3mdyDJzieUy3PTYyTRA==",
       "dev": true
     },
     "fs.realpath": {
@@ -5343,7 +5343,7 @@
     "globals": {
       "version": "9.18.0",
       "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-      "integrity": "sha1-qjiWs+abSH8X4x7SFD1pqOMMLYo=",
+      "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
       "dev": true
     },
     "globby": {
@@ -5435,7 +5435,7 @@
     "growl": {
       "version": "1.10.5",
       "resolved": "https://registry.npmjs.org/growl/-/growl-1.10.5.tgz",
-      "integrity": "sha1-8nNdwig2dPpnR4sQGBBZNVw2nl4=",
+      "integrity": "sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==",
       "dev": true
     },
     "grunt": {
@@ -5766,7 +5766,7 @@
     "grunt-postcss": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/grunt-postcss/-/grunt-postcss-0.9.0.tgz",
-      "integrity": "sha1-++WTSmvp6siTr20FfiMYyX+unaM=",
+      "integrity": "sha512-lglLcVaoOIqH0sFv7RqwUKkEFGQwnlqyAKbatxZderwZGV1nDyKHN7gZS9LUiTx1t5GOvRBx0BEalHMyVwFAIA==",
       "dev": true,
       "requires": {
         "chalk": "^2.1.0",
@@ -6634,7 +6634,7 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4=",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
       "dev": true
     },
     "is-builtin-module": {
@@ -6925,7 +6925,7 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha1-0YUOuXkezRjmGCzhKjDzlmNLsZ0=",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
       "dev": true
     },
     "is-word-character": {
@@ -7299,7 +7299,7 @@
     "jszip": {
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/jszip/-/jszip-3.1.5.tgz",
-      "integrity": "sha1-48KmxtcGrG5gMxQDbUPNQL7v3zc=",
+      "integrity": "sha512-5W8NUaFRFRqTOL7ZDDrx5qWHJyBXy6velVudIzQUSoqAAYqzSh2Z7/m0Rf1QbmQJccegD0r+YZxBjzqoBiEeJQ==",
       "dev": true,
       "requires": {
         "core-js": "~2.3.0",
@@ -8136,7 +8136,7 @@
     "marked": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha1-XUf3CcTJ/Dwha21GEnKA9As515A="
+      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg=="
     },
     "matcher": {
       "version": "1.1.1",
@@ -8315,7 +8315,7 @@
     "minimatch": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
-      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
@@ -9257,7 +9257,7 @@
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
-      "integrity": "sha1-EvlaMH1YNSB1oEkHuErIvpisAS8=",
+      "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
         "hosted-git-info": "^2.1.4",
@@ -10337,7 +10337,7 @@
     "private": {
       "version": "0.1.8",
       "resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
-      "integrity": "sha1-I4Hts2ifelPWUxkAYPz4ItLzaP8=",
+      "integrity": "sha512-VvivMrbvd2nKkiG38qjULzlc+4Vx4wm/whI9pQD35YrARNnhxeiRktSOhSukRLFNlzg6Br/cJPet5J/u19r/mg==",
       "dev": true
     },
     "process-nextick-args": {
@@ -10670,9 +10670,9 @@
       }
     },
     "react-transition-group": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.6.1.tgz",
-      "integrity": "sha512-9DHwCy0aOYEe35frlEN68N9ut/THDQBLnVoQuKTvzF4/s3tk7lqkefCqxK2Nv96fOh6JXk6tQtliygk6tl3bQA==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-2.7.0.tgz",
+      "integrity": "sha512-CzF22K0x6arjQO4AxkasMaiYcFG/QH0MhPNs45FmNsfWsQmsO9jv52sIZJAalnlryD5RgrrbLtV5CMJSokrrMA==",
       "requires": {
         "dom-helpers": "^3.3.1",
         "loose-envify": "^1.4.0",
@@ -11117,13 +11117,13 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha1-vgWtf5v30i4Fb5cmzuUBf78Z4uk=",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
-      "integrity": "sha1-HkmWg3Ix2ot/PPQRTXG1aRoGgN0=",
+      "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
       "dev": true,
       "requires": {
         "babel-runtime": "^6.18.0",
@@ -11134,7 +11134,7 @@
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
-      "integrity": "sha1-db3FiioUls7EihKDW8VMjVYjNt0=",
+      "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
       "dev": true,
       "optional": true,
       "requires": {
@@ -11584,7 +11584,7 @@
     "safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha1-RPoWGwGHuVSd2Eu5GAL5vYOFzWo="
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "sass-graph": {
       "version": "2.2.4",
@@ -11610,7 +11610,7 @@
     "sax": {
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-      "integrity": "sha1-KBYjTiN4vdxOU1T6tcqold9xANk=",
+      "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
     },
     "scheduler": {
@@ -11651,7 +11651,7 @@
     "selenium-webdriver": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/selenium-webdriver/-/selenium-webdriver-3.6.0.tgz",
-      "integrity": "sha1-K6h6FmLAILiYjJga5iyyoBKY6vw=",
+      "integrity": "sha512-WH7Aldse+2P5bbFBO4Gle/nuQOdVwpHMTL6raL3uuBj/vPG07k6uzt3aiahu352ONBr5xXh0hDlM3LhtXPOC4Q==",
       "dev": true,
       "requires": {
         "jszip": "^3.1.3",
@@ -11924,7 +11924,7 @@
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha1-dHIq8y6WFOnCh6jQu95IteLxomM=",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "dev": true
     },
     "source-map-resolve": {
@@ -11943,7 +11943,7 @@
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
-      "integrity": "sha1-Aoam3ovkJkEzhZTpfM6nXwosWF8=",
+      "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
       "dev": true,
       "requires": {
         "source-map": "^0.5.6"
@@ -13324,6 +13324,7 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.9.tgz",
       "integrity": "sha512-8CJsbKOtEbnJsTyv6LE6m6ZKniqMiFWmm9sRbopbkGs3gMPPfd3Fh8iIA4Ykv5MgaTbqHr4BaoGLJLZNhsrW1Q==",
       "dev": true,
+      "optional": true,
       "requires": {
         "commander": "~2.17.1",
         "source-map": "~0.6.1"
@@ -13333,7 +13334,8 @@
           "version": "2.17.1",
           "resolved": "https://registry.npmjs.org/commander/-/commander-2.17.1.tgz",
           "integrity": "sha512-wPMUt6FnH2yzG95SA6mzjQOEKUU3aLaDEmzs1ti+1E9h+CsrZghRlqEM/EJ4KscsQVG8uNN4uVreUeT8+drlgg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -13657,7 +13659,7 @@
     "wc-e2e-page-objects": {
       "version": "0.10.0",
       "resolved": "https://registry.npmjs.org/wc-e2e-page-objects/-/wc-e2e-page-objects-0.10.0.tgz",
-      "integrity": "sha1-opnsEUmyVMO2PErx7sNGRww61kg=",
+      "integrity": "sha512-sPxL/xvxyGjkDW/Nn5TXfRxM8rid2L0BCRZKblSz14/M096IXU7C7a647IiJ2c6KkEWpw2Za/BCiGhBxbj6JFg==",
       "dev": true,
       "requires": {
         "lodash": "^4.13.1",
@@ -13686,7 +13688,7 @@
     "websocket-extensions": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/websocket-extensions/-/websocket-extensions-0.1.3.tgz",
-      "integrity": "sha1-XS/yKXcAPsaHpLhwc9+7rBRszyk=",
+      "integrity": "sha512-nqHUnMXmBzT0w570r2JpJxfiSD1IzoI+HGVdd3aZ0yNi3ngvQ4jv1dtHt5VGxfI2yj5yqImPhOK4vmIh2xMbGg==",
       "dev": true
     },
     "whatwg-fetch": {
@@ -13727,7 +13729,7 @@
     "wp-e2e-page-objects": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/wp-e2e-page-objects/-/wp-e2e-page-objects-0.8.1.tgz",
-      "integrity": "sha1-m1+Nx1p9pU7q4YDUxp0FBIIksg0=",
+      "integrity": "sha512-oChVuw7w/QDN9I271aw65iRXBQVMMIMwlxgf7dxzeYf9dfZ0rY7d63Mi4Tnp1aQzVUhhNEqjLTQ4uqjsm0p7MA==",
       "dev": true,
       "requires": {
         "deprecate": "^1.0.0",
@@ -13748,7 +13750,7 @@
     "wp-e2e-webdriver": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/wp-e2e-webdriver/-/wp-e2e-webdriver-0.14.0.tgz",
-      "integrity": "sha1-fHJnxDUv4barX10yu2rt+SaMdP8=",
+      "integrity": "sha512-7oS5k6IzAFCzoTEgu9x9+1x9PbtOVDef39UF5JEOCsxo2Zi6Ag9VH4jHkVUmbm5uLOrvJyP3k3S8CgCu/tQevA==",
       "dev": true,
       "requires": {
         "chromedriver": "^2.37.0",
@@ -13833,7 +13835,7 @@
     "xml2js": {
       "version": "0.4.19",
       "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-      "integrity": "sha1-aGwg8hMgnpSr8NG88e+qKRx4J6c=",
+      "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
       "dev": true,
       "requires": {
         "sax": ">=0.6.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "npm": ">=6.4.1"
   },
   "dependencies": {
-    "@woocommerce/block-library": "2.0.0-rc1",
+    "@woocommerce/block-library": "./woocommerce-block-library-2.0.0-rc2.tgz",
     "github-contributors-list": "https://github.com/woocommerce/github-contributors-list/tarball/master"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "npm": ">=6.4.1"
   },
   "dependencies": {
-    "@woocommerce/block-library": "./woocommerce-block-library-2.0.0-rc2.tgz",
+    "@woocommerce/block-library": "2.0.0-rc2",
     "github-contributors-list": "https://github.com/woocommerce/github-contributors-list/tarball/master"
   },
   "husky": {


### PR DESCRIPTION
Fixes #23049 – This issue is only reproducible with WooCommerce Blocks 1.4.0, not the dev version from github. The issue is that the feature plugin uses the class name `WC_Block_Featured_Product` for the Featured Product's callback. It was changed in the development process for the feature plugin to `WGPB_Block_Featured_Product`, but when cloned into WooCommerce core it's renamed to `WC_Block_Featured_Product`, hence the conflict with the current stable version.

I've updated the feature plugin to shortcut out if the WooCommerce Blocks plugin v 1.4.0 or below is found, which prevents the fatal error. 

Below is the previous approach, which isn't relevant anymore.

------

We could rename the class in woocommerce, but then there are cascading issues where duplicate blocks are registered, and it's not clear which plugin is registering them. Instead, we should automatically deactivate the feature plugin if it's `<=1.4.0`. We'll do that by checking for the `WGPB_VERSION` constant, which has been in place since 1.0.0.

This PR also adds a check when a plugin is activated, to see if it's the feature plugin & immediately deactivate it if so. This prevents any of the feature plugin code from running, otherwise it fatal-errors for a page load before the deactivation can hook into it.

We should also add a notice, but I'm not sure what that should say– since we still want people to use the feature plugin, just that WC 3.6 requires 2.0 of the feature plugin (which isn't on .org yet).

**To test**

- Install WooCommerce Blocks 1.4.0 (or do `git checkout cb30d3d` to switch to the 1.4.0 tagged version)
- Before this branch, it would fatal error
- With this branch, it should silently deactivate WooCommerce Blocks
- If you try reactivating WooCommerce Blocks, it will not reactivate
- Update WooCommerce Blocks to use 2.0.0, either by `git checkout master` or downloading [the 2.0.0-rc](https://github.com/woocommerce/woocommerce-gutenberg-products-block/releases/tag/v2.0.0-rc1)
- You should be able to activate WooCommerce Blocks with no fatal error