### PR TITLE
Use version_compare for determining max version number

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -124,6 +124,9 @@ class WC_Install {
 			'wc_update_354_modify_shop_manager_caps',
 			'wc_update_354_db_version',
 		),
+		'3.5.10' => array(
+			'asd',
+		),
 		'3.6.0' => array(
 			'wc_update_360_product_lookup_tables',
 			'wc_update_360_term_meta',
@@ -297,9 +300,10 @@ class WC_Install {
 	public static function needs_db_update() {
 		$current_db_version = get_option( 'woocommerce_db_version', null );
 		$updates            = self::get_db_update_callbacks();
-		uasort( array_keys( $updates ), 'version_compare' );
+		$update_versions    = array_keys( $updates );
+		uasort( $update_versions, 'version_compare' );
 
-		return ! is_null( $current_db_version ) && version_compare( $current_db_version, end( $updates ), '<' );
+		return ! is_null( $current_db_version ) && version_compare( $current_db_version, end( $update_versions ), '<' );
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -297,9 +297,9 @@ class WC_Install {
 	public static function needs_db_update() {
 		$current_db_version = get_option( 'woocommerce_db_version', null );
 		$updates            = self::get_db_update_callbacks();
-		$update_versions    = uasort( array_keys( $updates ), 'version_compare' );
+		uasort( array_keys( $updates ), 'version_compare' );
 
-		return ! is_null( $current_db_version ) && version_compare( $current_db_version, end( $update_versions ), '<' );
+		return ! is_null( $current_db_version ) && version_compare( $current_db_version, end( $updates ), '<' );
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -301,7 +301,7 @@ class WC_Install {
 		$current_db_version = get_option( 'woocommerce_db_version', null );
 		$updates            = self::get_db_update_callbacks();
 		$update_versions    = array_keys( $updates );
-		uasort( $update_versions, 'version_compare' );
+		usort( $update_versions, 'version_compare' );
 
 		return ! is_null( $current_db_version ) && version_compare( $current_db_version, end( $update_versions ), '<' );
 	}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -297,8 +297,9 @@ class WC_Install {
 	public static function needs_db_update() {
 		$current_db_version = get_option( 'woocommerce_db_version', null );
 		$updates            = self::get_db_update_callbacks();
+		$update_versions    = uasort( array_keys( $updates ), 'version_compare' );
 
-		return ! is_null( $current_db_version ) && version_compare( $current_db_version, max( array_keys( $updates ) ), '<' );
+		return ! is_null( $current_db_version ) && version_compare( $current_db_version, end( $update_versions ), '<' );
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -124,9 +124,6 @@ class WC_Install {
 			'wc_update_354_modify_shop_manager_caps',
 			'wc_update_354_db_version',
 		),
-		'3.5.10' => array(
-			'asd',
-		),
 		'3.6.0' => array(
 			'wc_update_360_product_lookup_tables',
 			'wc_update_360_term_meta',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR switches from max to using a usort with version compare to determine the maximum version number in the db updates list. max sees the version numbers as strings and when you have a fix release of .10 and up it starts giving false results. Ie current installed version is 3.4.9 and new update in 3.4.10 contains a DB update will say there is no update available as max will return 3.4.9 instead of 3.4.10.

Closes #23089 

### How to test the changes in this Pull Request:

1. See #23089

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

