### PR TITLE
If someone tries to load WC_REST class to early, throw notice

### DIFF
--- a/includes/class-wc-autoloader.php
+++ b/includes/class-wc-autoloader.php
@@ -90,6 +90,12 @@ class WC_Autoloader {
 			$path = $this->include_path . 'log-handlers/';
 		}
 
+		// Prevent plugins from breaking if they extend the rest API early.
+		if ( 0 === strpos( $class, 'wc_rest_' ) && ! did_action( 'rest_api_init' ) ) {
+			wc_doing_it_wrong( $class, __( 'Classes that extend the WooCommerce/WordPress REST API should only be loaded during the rest_api_init action, or should call WC()->api->rest_api_includes() manually.', 'woocommerce' ), '3.6' );
+			WC()->api->rest_api_includes();
+		}
+
 		if ( empty( $path ) || ! $this->load_file( $path . $file ) ) {
 			$this->load_file( $this->include_path . $file );
 		}

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -256,13 +256,10 @@ final class WooCommerce {
 			return false;
 		}
 
-		// REST API prefix.
-		$rest_prefix = trailingslashit( rest_get_url_prefix() );
+		$rest_prefix         = trailingslashit( rest_get_url_prefix() );
+		$is_rest_api_request = ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix ) ); // phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-		// Check if this is a WC endpoint.
-		$is_woocommerce_endpoint = ( false !== strpos( $_SERVER['REQUEST_URI'], $rest_prefix . 'wc/' ) ); // phpcs:disable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-
-		return apply_filters( 'woocommerce_is_rest_api_request', $is_woocommerce_endpoint );
+		return apply_filters( 'woocommerce_is_rest_api_request', $is_rest_api_request );
 	}
 
 	/**

--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -43,7 +43,7 @@ function wc_do_deprecated_action( $tag, $args, $version, $replacement = null, $m
  */
 function wc_deprecated_function( $function, $version, $replacement = null ) {
 	// @codingStandardsIgnoreStart
-	if ( is_ajax() ) {
+	if ( is_ajax() || WC()->is_rest_api_request() ) {
 		do_action( 'deprecated_function_run', $function, $replacement, $version );
 		$log_string  = "The {$function} function is deprecated since version {$version}.";
 		$log_string .= $replacement ? " Replace with {$replacement}." : '';
@@ -65,7 +65,7 @@ function wc_deprecated_function( $function, $version, $replacement = null ) {
  */
 function wc_deprecated_hook( $hook, $version, $replacement = null, $message = null ) {
 	// @codingStandardsIgnoreStart
-	if ( is_ajax() ) {
+	if ( is_ajax() || WC()->is_rest_api_request() ) {
 		do_action( 'deprecated_hook_run', $hook, $replacement, $version, $message );
 
 		$message    = empty( $message ) ? '' : ' ' . $message;
@@ -109,7 +109,7 @@ function wc_doing_it_wrong( $function, $message, $version ) {
 	// @codingStandardsIgnoreStart
 	$message .= ' Backtrace: ' . wp_debug_backtrace_summary();
 
-	if ( is_ajax() ) {
+	if ( is_ajax() || WC()->is_rest_api_request() ) {
 		do_action( 'doing_it_wrong_run', $function, $message, $version );
 		error_log( "{$function} was called incorrectly. {$message}. This message was added in version {$version}." );
 	} else {
@@ -127,7 +127,7 @@ function wc_doing_it_wrong( $function, $message, $version ) {
  * @param  string $replacement
  */
 function wc_deprecated_argument( $argument, $version, $message = null ) {
-	if ( is_ajax() ) {
+	if ( is_ajax() || WC()->is_rest_api_request() ) {
 		do_action( 'deprecated_argument_run', $argument, $message, $version );
 		error_log( "The {$argument} argument is deprecated since version {$version}. {$message}" );
 	} else {


### PR DESCRIPTION
As of 3.6, rest API classes only get included during the `rest_api_init` hook to prevent performance issues on non-rest api pages.

Some extensions extend these classes early/outside of this hook.

To prevent this causing fatal errors, this PR adds some code to the autoloader to include those files if missing, outputting a notice to inform the developer whats going on:

![image](https://user-images.githubusercontent.com/90977/54764340-7abd3d00-4bef-11e9-9376-d33b3b3f0207.png)

You can test by installing the printful intgration from WordPress.org which suffers from this. You should see the above notice with DEBUG mode on, but there will be no fatal error.

cc @timmyc 
