### PR TITLE
Fix PHPCS in the Travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,7 @@ before_script:
   - |
     # Install wpcs globally if needed:
     if [[ ${RUN_PHPCS} == 1 ]] && [[ ${TRAVIS_PHP_VERSION:0:3} != "5.2" ]]; then
-      composer global require wp-coding-standards/wpcs
-      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+      composer require woocommerce/woocommerce-sniffs
     fi
 
 script:

--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -6,6 +6,6 @@ if [[ ${RUN_PHPCS} == 1 ]]; then
 
 	if [ "$CHANGED_FILES" != "" ]; then
 		echo "Running Code Sniffer."
-		phpcs --ignore=$IGNORE --encoding=utf-8 -s -n -p $CHANGED_FILES
+		./vendor/bin/phpcs --ignore=$IGNORE --encoding=utf-8 -s -n -p $CHANGED_FILES
 	fi
 fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PR https://github.com/woocommerce/woocommerce/pull/23082 made some changes to the Travis configuration and one of those changes broke the PHPCS when running inside Travis with the following error:

```
ERROR: Referenced sniff "WooCommerce-Core" does not exist
```

For example: https://travis-ci.org/woocommerce/woocommerce/jobs/509471213#L659

This problem went unnoticed during the PR review as no PHP file was modified in it and thus there was no file for PHPCS to check.

This PR fixes the error above by installing the Composer package `woocommerce/woocommerce-sniffs` which is the package that provides `WooCommerce-Core` sniffs and which installs `wp-coding-standards/wpcs` as one of its requirements. I couldn't find an easy way to make this work installing `woocommerce/woocommerce-sniffs` globally so that is why this commit also removes the `global` parameter when calling composer.

cc @mikejolley @kloon 