### PR TITLE
Only install Chrome and Nginx in the build job that uses it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,6 @@
 language: php
 dist: trusty
 
-addons:
-  chrome: stable
-  apt:
-    packages:
-      - nginx
-
 sudo: false
 
 cache:
@@ -40,6 +34,11 @@ matrix:
   - name: "e2e tests"
     php: 7.2
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_E2E=1
+    addons:
+      chrome: stable
+      apt:
+        packages:
+          - nginx
   - name: "Unit tests code coverage"
     php: 7.3
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes Travis configuration to only install Chrome and Nginx in the e2e tests build job, which is the only one that requires those packages. This change should save a little bit of time in the Travis build as before Travis was installing Chrome and Nginx in all the jobs.

### How to test the changes in this Pull Request:

1. Check that the Travis build succeed
2. Check in the Travis build logs that Chrome and Nginx are installed only on the e2e tests build job (lines showing the installation of those two packages: https://travis-ci.org/rodrigoprimo/woocommerce/jobs/509579125#L414 and https://travis-ci.org/rodrigoprimo/woocommerce/jobs/509579125#L452)
