### PR TITLE
Check if product has stock management enabled

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -776,7 +776,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			}
 
 			// We only need to check products managing stock, with a limited stock qty.
-			if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
+			if ( ! $product->managing_stock() || $product->backorders_allowed() || ! $product->get_manage_stock ) {
 				continue;
 			}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -776,7 +776,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			}
 
 			// We only need to check products managing stock, with a limited stock qty.
-			if ( ! $product->managing_stock() || $product->backorders_allowed() || ! $product->get_manage_stock ) {
+			if ( ! $product->managing_stock() || $product->backorders_allowed() || ! $product->get_manage_stock() ) {
 				continue;
 			}
 

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -152,8 +152,9 @@ class WC_Shortcode_Checkout {
 							// Check stock based on all items in the cart and consider any held stock within pending orders.
 							$held_stock     = ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product, $order->get_id() ) : 0;
 							$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
+							$manage_stock   = $product->get_manage_stock();
 
-							if ( $product->get_stock_quantity() < ( $held_stock + $required_stock ) ) {
+							if ( $manage_stock && ( $product->get_stock_quantity() < ( $held_stock + $required_stock ) ) ) {
 								/* translators: 1: product name 2: quantity in stock */
 								throw new Exception( sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woocommerce' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ) );
 							}

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -145,16 +145,15 @@ class WC_Shortcode_Checkout {
 							}
 
 							// We only need to check products managing stock, with a limited stock qty.
-							if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
+							if ( ! $product->managing_stock() || $product->backorders_allowed() || ! $product->get_manage_stock ) {
 								continue;
 							}
 
 							// Check stock based on all items in the cart and consider any held stock within pending orders.
 							$held_stock     = ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product, $order->get_id() ) : 0;
 							$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
-							$manage_stock   = $product->get_manage_stock();
 
-							if ( $manage_stock && ( $product->get_stock_quantity() < ( $held_stock + $required_stock ) ) ) {
+							if ( $product->get_stock_quantity() < ( $held_stock + $required_stock ) ) {
 								/* translators: 1: product name 2: quantity in stock */
 								throw new Exception( sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woocommerce' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ) );
 							}

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -145,7 +145,7 @@ class WC_Shortcode_Checkout {
 							}
 
 							// We only need to check products managing stock, with a limited stock qty.
-							if ( ! $product->managing_stock() || $product->backorders_allowed() || ! $product->get_manage_stock ) {
+							if ( ! $product->managing_stock() || $product->backorders_allowed() || ! $product->get_manage_stock() ) {
 								continue;
 							}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->
Grabs the product managed stock status and checks if managed stock status is set to true in addition to previous stock quantity check. Will not throw exception if product stock is not being managed.

Closes #23108 .

### How to test the changes in this Pull Request:

1. Create a product in WooCommerce. 
2. Do not enable stock management for product.
3. Then manually create WooCommerce order, adding the new product to the order.
4. Save the order, then click on "Customer payment page"
5. Proceed to checkout

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Check if product has stock management enabled
