### PR TITLE
Add taxonomy-specific classes to active filters widget

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -78,7 +78,7 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 
 						$filter_classes = array( 'chosen', 'chosen-' . sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) ), 'chosen-' . sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) . '-' . $term_slug ) );
 
-						echo '<li class="' . esc_attr( implode( " ", $filter_classes ) ) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . esc_html( $term->name ) . '</a></li>';
+						echo '<li class="' . esc_attr( implode( ' ', $filter_classes ) ) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . esc_html( $term->name ) . '</a></li>';
 					}
 				}
 			}

--- a/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -76,9 +76,9 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 							$link = add_query_arg( $filter_name, implode( ',', $new_filter ), $link );
 						}
 
-						$filter_classes = ['chosen', 'chosen-'.sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) ), 'chosen-'.sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) . '-' . $term_slug )];
+						$filter_classes = array( 'chosen', 'chosen-' . sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) ), 'chosen-' . sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) . '-' . $term_slug ) );
 
-						echo '<li class="' . implode(" ", $filter_classes) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . esc_html( $term->name ) . '</a></li>';
+						echo '<li class="' . esc_attr( implode( " ", $filter_classes ) ) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . esc_html( $term->name ) . '</a></li>';
 					}
 				}
 			}

--- a/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -76,7 +76,9 @@ class WC_Widget_Layered_Nav_Filters extends WC_Widget {
 							$link = add_query_arg( $filter_name, implode( ',', $new_filter ), $link );
 						}
 
-						echo '<li class="chosen"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . esc_html( $term->name ) . '</a></li>';
+						$filter_classes = ['chosen', 'chosen-'.sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) ), 'chosen-'.sanitize_html_class( str_replace( 'pa_', '', $taxonomy ) . '-' . $term_slug )];
+
+						echo '<li class="' . implode(" ", $filter_classes) . '"><a rel="nofollow" aria-label="' . esc_attr__( 'Remove filter', 'woocommerce' ) . '" href="' . esc_url( $link ) . '">' . esc_html( $term->name ) . '</a></li>';
 					}
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add taxonomy-specific classes to active filters so it's easier for developers to style them.
E.g.: Selecting "Rock" in a "Genre" taxonomy will add the following class to the li element: chosen, chosen-genre, chosen-genre-rock

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Use the widget
2. Analyze the source code
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Add taxonomy-specific classes to active filters so it's easier for developers to style them.
E.g.: Selecting "Rock" in a "Genre" taxonomy will add the following class to the li element: chosen, chosen-genre, chosen-genre-rock
