### PR TITLE
Change default completed email wording

### DIFF
--- a/templates/emails/customer-completed-order.php
+++ b/templates/emails/customer-completed-order.php
@@ -27,7 +27,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <?php /* translators: %s: Customer first name */ ?>
 <p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
 <?php /* translators: %s: Site title */ ?>
-<p><?php printf( esc_html__( 'Your %s order has been marked complete on our side.', 'woocommerce' ), esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) ); ?></p>
+<p><?php esc_html_e( 'We have finished processing your order.', 'woocommerce' ); ?></p>
 <?php
 
 /*

--- a/templates/emails/plain/customer-completed-order.php
+++ b/templates/emails/plain/customer-completed-order.php
@@ -24,7 +24,7 @@ echo '= ' . esc_html( $email_heading ) . " =\n\n";
 /* translators: %s: Customer first name */
 echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ) . "\n\n";
 /* translators: %s: Site title */
-echo sprintf( esc_html__( 'Your %s order has been marked complete on our side.', 'woocommerce' ), esc_html( wp_specialchars_decode( get_option( 'blogname' ), ENT_QUOTES ) ) ) . "\n\n";
+echo esc_html__( 'We have finished processing your order.', 'woocommerce' ) . "\n\n";
 
 echo "=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=\n\n";
 


### PR DESCRIPTION
Changes:

> Your store.com order has been marked complete on our side.

to:

> We have finished processing your order.

Closes #23078

Based on suggestion in https://github.com/woocommerce/woocommerce/issues/23078#issuecomment-475641794

@MarinaWoo is this ok with you or did you feel strongly about "We have completed your order"? To me that makes some technical sense but not much real world sense. 