### PR TITLE
`WC_Ajax::add_variation` force variable product type

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -707,7 +707,7 @@ class WC_AJAX {
 		$product_id       = intval( $_POST['post_id'] );
 		$post             = get_post( $product_id ); // phpcs:ignore
 		$loop             = intval( $_POST['loop'] );
-		$product_object   = wc_get_product( $product_id );
+		$product_object   = new WC_Product_Variable( $product_id ); // Forces type to variable in case product is unsaved.
 		$variation_object = new WC_Product_Variation();
 		$variation_object->set_parent_id( $product_id );
 		$variation_object->set_attributes( array_fill_keys( array_map( 'sanitize_title', array_keys( $product_object->get_variation_attributes() ) ), '' ) );


### PR DESCRIPTION
Fixes #23118

If you have a simple type product that was previously variable, some attributes may already be 'used for variations', so your variation panel is visible. When that occurs, triggering the additon of a variation will use `WC_Ajax::add_variation`. This method loads the product and uses the product `get_variation_attributes` method. Only variable product type has this method so any other type will result in fatal error.

To fix this, when calling `add_variation` we can force the use of a `WC_Product_Variable` type product object.

#23118 explains how to reproduce.

1. Add product
2. Set as variable
3. Add attributes, used for variations, and save attributes
4. Switch to simple product
5. Save as draft
6. Now change to varible product type and on the variations panel, add a variation

Before this patch it will fatal error.