### PR TITLE
Lookup table SQL: Avoid orderby during updates

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1316,8 +1316,7 @@ function wc_update_product_lookup_tables() {
 
 	// List of column names in the lookup table we need to populate.
 	$columns = array(
-		'min_price',
-		'max_price',
+		'min_max_price',
 		'stock_quantity',
 		'sku',
 		'stock_status',
@@ -1389,41 +1388,22 @@ function wc_update_product_lookup_tables_column( $column ) {
 	global $wpdb;
 	// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 	switch ( $column ) {
-		case 'min_price':
+		case 'min_max_price':
 			$wpdb->query(
 				"
 				UPDATE
 					{$wpdb->wc_product_meta_lookup} lookup_table
 					INNER JOIN (
-						SELECT lookup_table.product_id, meta_value
+						SELECT lookup_table.product_id, MIN( meta_value+0 ) as min_price, MAX( meta_value+0 ) as max_price
 						FROM {$wpdb->wc_product_meta_lookup} lookup_table
 						LEFT JOIN {$wpdb->postmeta} meta1 ON lookup_table.product_id = meta1.post_id AND meta1.meta_key = '_price'
 						WHERE
 							meta1.meta_value <> ''
-						ORDER BY
-							meta1.meta_value+0 ASC
+						GROUP BY lookup_table.product_id
 					) as source on source.product_id = lookup_table.product_id
 				SET
-					lookup_table.min_price = source.meta_value
-				"
-			);
-			break;
-		case 'max_price':
-			$wpdb->query(
-				"
-				UPDATE
-					{$wpdb->wc_product_meta_lookup} lookup_table
-					INNER JOIN (
-						SELECT lookup_table.product_id, meta_value
-						FROM {$wpdb->wc_product_meta_lookup} lookup_table
-						LEFT JOIN {$wpdb->postmeta} meta1 ON lookup_table.product_id = meta1.post_id AND meta1.meta_key = '_price'
-						WHERE
-							meta1.meta_value <> ''
-						ORDER BY
-							meta1.meta_value+0 DESC
-					) as source on source.product_id = lookup_table.product_id
-				SET
-					lookup_table.max_price = source.meta_value
+					lookup_table.min_price = source.min_price,
+					lookup_table.max_price = source.max_price
 				"
 			);
 			break;

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1394,13 +1394,17 @@ function wc_update_product_lookup_tables_column( $column ) {
 				"
 				UPDATE
 					{$wpdb->wc_product_meta_lookup} lookup_table
-					LEFT JOIN {$wpdb->postmeta} meta1 ON lookup_table.product_id = meta1.post_id AND meta1.meta_key = '_price'
+					INNER JOIN (
+						SELECT lookup_table.product_id, meta_value
+						FROM {$wpdb->wc_product_meta_lookup} lookup_table
+						LEFT JOIN {$wpdb->postmeta} meta1 ON lookup_table.product_id = meta1.post_id AND meta1.meta_key = '_price'
+						WHERE
+							meta1.meta_value <> ''
+						ORDER BY
+							meta1.meta_value+0 ASC
+					) as source on source.product_id = lookup_table.product_id
 				SET
-					lookup_table.min_price = meta1.meta_value
-				WHERE
-					meta1.meta_value <> ''
-				ORDER BY
-					meta1.meta_value+0 ASC
+					lookup_table.min_price = source.meta_value
 				"
 			);
 			break;
@@ -1409,13 +1413,17 @@ function wc_update_product_lookup_tables_column( $column ) {
 				"
 				UPDATE
 					{$wpdb->wc_product_meta_lookup} lookup_table
-					LEFT JOIN {$wpdb->postmeta} meta1 ON lookup_table.product_id = meta1.post_id AND meta1.meta_key = '_price'
+					INNER JOIN (
+						SELECT lookup_table.product_id, meta_value
+						FROM {$wpdb->wc_product_meta_lookup} lookup_table
+						LEFT JOIN {$wpdb->postmeta} meta1 ON lookup_table.product_id = meta1.post_id AND meta1.meta_key = '_price'
+						WHERE
+							meta1.meta_value <> ''
+						ORDER BY
+							meta1.meta_value+0 DESC
+					) as source on source.product_id = lookup_table.product_id
 				SET
-					lookup_table.max_price = meta1.meta_value
-				WHERE
-					meta1.meta_value <> ''
-				ORDER BY
-					meta1.meta_value+0 DESC
+					lookup_table.max_price = source.meta_value
 				"
 			);
 			break;


### PR DESCRIPTION
Fixes #23117 (@rodrigoprimo to confirm)

This was not a problem on MariaDB, but MySQL does not like UPDATE statements with multiple tables and ORDER BY (`Incorrect usage of UPDATE and ORDER BY`).

To avoid this, I've added a subquery which has the ORDER BY and instead joined this during the update. In testing on my large install this query ran < 3s, same as the previous version.

To test, start with a new DB and run the 3.6 update, OR clear your lookup table min_price and max_price column and run regeneration from system status > Tools. Once complete, min_price and max_price should be populated.