### PR TITLE
Change coupon amount field type based on coupon type

### DIFF
--- a/assets/js/admin/meta-boxes-coupon.js
+++ b/assets/js/admin/meta-boxes-coupon.js
@@ -23,8 +23,10 @@ jQuery(function( $ ) {
 
 			if ( select_val !== 'fixed_cart' ) {
 				$( '.limit_usage_to_x_items_field' ).show();
+				$( '#coupon_amount' ).removeClass( 'wc_input_price' ).addClass( 'wc_input_decimal' );
 			} else {
 				$( '.limit_usage_to_x_items_field' ).hide();
+				$( '#coupon_amount' ).removeClass( 'wc_input_decimal' ).addClass( 'wc_input_price' );
 			}
 		}
 	};

--- a/assets/js/admin/meta-boxes-coupon.js
+++ b/assets/js/admin/meta-boxes-coupon.js
@@ -21,12 +21,16 @@ jQuery(function( $ ) {
 			// Get value
 			var select_val = $( this ).val();
 
-			if ( select_val !== 'fixed_cart' ) {
-				$( '.limit_usage_to_x_items_field' ).show();
+			if ( 'percent' === select_val ) {
 				$( '#coupon_amount' ).removeClass( 'wc_input_price' ).addClass( 'wc_input_decimal' );
 			} else {
-				$( '.limit_usage_to_x_items_field' ).hide();
 				$( '#coupon_amount' ).removeClass( 'wc_input_decimal' ).addClass( 'wc_input_price' );
+			}
+
+			if ( select_val !== 'fixed_cart' ) {
+				$( '.limit_usage_to_x_items_field' ).show();
+			} else {
+				$( '.limit_usage_to_x_items_field' ).hide();
 			}
 		}
 	};

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -90,7 +90,7 @@ class WC_Meta_Box_Coupon_Data {
 						'label'       => __( 'Coupon amount', 'woocommerce' ),
 						'placeholder' => wc_format_localized_price( 0 ),
 						'description' => __( 'Value of the coupon.', 'woocommerce' ),
-						'data_type'   => 'price',
+						'data_type'   => 'percent' === $coupon->get_discount_type( 'edit' ) ? 'decimal' : 'price',
 						'desc_tip'    => true,
 						'value'       => $coupon->get_amount( 'edit' ),
 					)

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -199,7 +199,7 @@ class WC_Coupon extends WC_Legacy_Coupon {
 	 * @return float
 	 */
 	public function get_amount( $context = 'view' ) {
-		return (float) $this->get_prop( 'amount', $context );
+		return wc_format_decimal( $this->get_prop( 'amount', $context ) );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #23051

Makes percent type coupons validate as decimal, and other types validate as monetary. This doesn't affect saving, just the inline validation and formatting.

To test,

Set decimal separator to `,` comma.
Create percent coupon. 99.99 valid. 99,99 invalid.
Create fixed coupon. 99.99 invalid. 99,99 valid.

> Switch coupon amount validation based on type (price and decimal)