### PR TITLE
Introduce `wc_create_new_customer_username` function

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -39,8 +39,6 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 	 * @return int|WP_Error Returns WP_Error on failure, Int (user ID) on success.
 	 */
 	function wc_create_new_customer( $email, $username = '', $password = '', $args = array() ) {
-
-		// Check the email address.
 		if ( empty( $email ) || ! is_email( $email ) ) {
 			return new WP_Error( 'registration-error-invalid-email', __( 'Please provide a valid email address.', 'woocommerce' ) );
 		}
@@ -49,28 +47,18 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 			return new WP_Error( 'registration-error-email-exists', apply_filters( 'woocommerce_registration_error_email_exists', __( 'An account is already registered with your email address. Please log in.', 'woocommerce' ), $email ) );
 		}
 
-		// Handle username creation.
-		if ( 'no' === get_option( 'woocommerce_registration_generate_username' ) || ! empty( $username ) ) {
-			$username = sanitize_user( $username );
+		if ( 'yes' === get_option( 'woocommerce_registration_generate_username', 'yes' ) && empty( $username ) ) {
+			$username = wc_create_new_customer_username( $email, $args );
+		}
 
-			if ( empty( $username ) || ! validate_username( $username ) ) {
-				return new WP_Error( 'registration-error-invalid-username', __( 'Please enter a valid account username.', 'woocommerce' ) );
-			}
+		$username = sanitize_user( $username );
 
-			if ( username_exists( $username ) ) {
-				return new WP_Error( 'registration-error-username-exists', __( 'An account is already registered with that username. Please choose another.', 'woocommerce' ) );
-			}
-		} else {
-			$username = sanitize_user( current( explode( '@', $email ) ), true );
+		if ( empty( $username ) || ! validate_username( $username ) ) {
+			return new WP_Error( 'registration-error-invalid-username', __( 'Please enter a valid account username.', 'woocommerce' ) );
+		}
 
-			// Ensure username is unique.
-			$append     = 1;
-			$o_username = $username;
-
-			while ( username_exists( $username ) ) {
-				$username = $o_username . $append;
-				$append++;
-			}
+		if ( username_exists( $username ) ) {
+			return new WP_Error( 'registration-error-username-exists', __( 'An account is already registered with that username. Please choose another.', 'woocommerce' ) );
 		}
 
 		// Handle password creation.
@@ -118,6 +106,66 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 
 		return $customer_id;
 	}
+}
+
+/**
+ * Create a unique username for a new customer.
+ *
+ * @since 3.6.0
+ * @param string $email New customer email address.
+ * @param array  $new_user_args Array of new user args, maybe including first and last names.
+ * @param int    $suffix Append number to username to make it more unique.
+ * @return string Generated username.
+ */
+function wc_create_new_customer_username( $email, $new_user_args, $suffix = 0 ) {
+	$username_parts = array();
+
+	if ( isset( $new_user_args['first_name'] ) ) {
+		$username_parts[] = sanitize_user( $new_user_args['first_name'], true );
+	}
+
+	if ( isset( $new_user_args['last_name'] ) ) {
+		$username_parts[] = sanitize_user( $new_user_args['last_name'], true );
+	}
+
+	// Remove empty parts.
+	$username_parts = array_filter( $username_parts );
+
+	// If there are no parts, e.g. name had unicode chars, or was not provided, fallback to email.
+	if ( empty( $username_parts ) ) {
+		$email_parts    = explode( '@', $email );
+		$email_username = $email_parts[0];
+
+		// Exclude common prefixes.
+		if ( in_array(
+			$email_username,
+			array(
+				'sales',
+				'hello',
+				'mail',
+				'contact',
+				'info',
+			),
+			true
+		) ) {
+			// Get the domain part.
+			$email_username = $email_parts[1];
+		}
+
+		$username_parts[] = sanitize_user( $email_username, true );
+	}
+
+	$username = wc_strtolower( implode( '', $username_parts ) );
+
+	if ( $suffix ) {
+		$username .= $suffix;
+	}
+
+	if ( username_exists( $username ) ) {
+		return wc_create_new_customer_username( $email, $new_user_args, ++$suffix );
+	}
+
+	return $username;
 }
 
 /**

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -114,10 +114,10 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
  * @since 3.6.0
  * @param string $email New customer email address.
  * @param array  $new_user_args Array of new user args, maybe including first and last names.
- * @param int    $suffix Append number to username to make it more unique.
+ * @param string $suffix Append string to username to make it unique.
  * @return string Generated username.
  */
-function wc_create_new_customer_username( $email, $new_user_args, $suffix = 0 ) {
+function wc_create_new_customer_username( $email, $new_user_args, $suffix = '' ) {
 	$username_parts = array();
 
 	if ( isset( $new_user_args['first_name'] ) ) {
@@ -162,7 +162,9 @@ function wc_create_new_customer_username( $email, $new_user_args, $suffix = 0 ) 
 	}
 
 	if ( username_exists( $username ) ) {
-		return wc_create_new_customer_username( $email, $new_user_args, ++$suffix );
+		// Generate something unique to append to the username in case of a conflict with another user.
+		$suffix = '-' . zeroise( wp_rand( 0, 9999 ), 4 );
+		return wc_create_new_customer_username( $email, $new_user_args, $suffix );
 	}
 
 	return $username;

--- a/tests/unit-tests/customer/functions.php
+++ b/tests/unit-tests/customer/functions.php
@@ -44,10 +44,12 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( 'fred', $userdata->user_login );
 		$id       = wc_create_new_customer( 'fred@mail.com', '', 'testpassword' );
 		$userdata = get_userdata( $id );
-		$this->assertEquals( 'fred1', $userdata->user_login );
+		$this->assertNotEquals( 'fred', $userdata->user_login );
+		$this->assertContains( 'fred', $userdata->user_login );
 		$id       = wc_create_new_customer( 'fred@test.com', '', 'testpassword' );
 		$userdata = get_userdata( $id );
-		$this->assertEquals( 'fred2', $userdata->user_login );
+		$this->assertNotEquals( 'fred', $userdata->user_login );
+		$this->assertContains( 'fred', $userdata->user_login );
 
 		// Test extra arguments to generate display_name.
 		$id       = wc_create_new_customer(
@@ -82,7 +84,9 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 
 		// Test getting name if username exists.
 		wc_create_new_customer( 'mike@fakemail.com', '', 'testpassword' );
-		$this->assertEquals( 'mike1', wc_create_new_customer_username( 'mike@fakemail.com', array() ) );
+		$username = wc_create_new_customer_username( 'mike@fakemail.com', array() );
+		$this->assertNotEquals( 'mike', $username, $username );
+		$this->assertContains( 'mike', $username, $username );
 
 		// Test common email prefix avoidance.
 		$this->assertEquals( 'somecompany.com', wc_create_new_customer_username( 'info@somecompany.com', array() ) );

--- a/tests/unit-tests/customer/functions.php
+++ b/tests/unit-tests/customer/functions.php
@@ -74,6 +74,45 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test username generation.
+	 */
+	public function test_wc_create_new_customer_username() {
+		// Test getting name from email.
+		$this->assertEquals( 'mike', wc_create_new_customer_username( 'mike@fakemail.com', array() ) );
+
+		// Test getting name if username exists.
+		wc_create_new_customer( 'mike@fakemail.com', '', 'testpassword' );
+		$this->assertEquals( 'mike1', wc_create_new_customer_username( 'mike@fakemail.com', array() ) );
+
+		// Test common email prefix avoidance.
+		$this->assertEquals( 'somecompany.com', wc_create_new_customer_username( 'info@somecompany.com', array() ) );
+
+		// Test first/last name generation.
+		$this->assertEquals(
+			'bobbobson',
+			wc_create_new_customer_username(
+				'bob@bobbobson.com',
+				array(
+					'first_name' => 'Bob',
+					'last_name' => 'Bobson',
+				)
+			)
+		);
+
+		// Test unicode fallbacks.
+		$this->assertEquals(
+			'unicode',
+			wc_create_new_customer_username(
+				'unicode@unicode.com',
+				array(
+					'first_name' => 'こんにちは',
+					'last_name' => 'こんにちは',
+				)
+			)
+		);
+	}
+
+	/**
 	 * Test wc_update_new_customer_past_orders.
 	 *
 	 * @since 3.1


### PR DESCRIPTION
Fixes #23107

Adds a function to generate usernames to reduce liklihood of conclicts.

Uses first and last name if they exist, otherwise falls back to email.

When using email, if the first part of the email is common e.g. info, sales, hello etc, uses the domain part instead.

If username is still found to exist, calls itself again with a numeric suffix.

Has unit tests. To test, create a new account during checkout with username field disabled. Check new account username matches the rules of this function.

> Improved username generation and introduced `wc_create_new_customer_username` function. 