### PR TITLE
Update fallback download URL in helper

### DIFF
--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -185,7 +185,7 @@ class WC_Helper {
 			}
 
 			$subscription['download_primary'] = true;
-			$subscription['download_url']     = $subscription['product_url'];
+			$subscription['download_url']     = 'https://woocommerce.com/my-account/downloads/';
 			if ( ! $subscription['local']['installed'] && ! empty( $updates[ $subscription['product_id'] ] ) ) {
 				$subscription['download_url'] = $updates[ $subscription['product_id'] ]['package'];
 			}


### PR DESCRIPTION
Fixes #22695

See explanation in https://github.com/woocommerce/woocommerce/issues/22695#issuecomment-476586080

This updates the fallback download URL in the helper from the product page, to your myaccount/downloads page on woo.com.

Not really a way to test this as it only shows under very specific circumstances (missing update API data).