### PR TITLE
Prevent calculate available variations several times for the same product.

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -37,6 +37,13 @@ class WC_Product_Variable extends WC_Product {
 	protected $variation_attributes = null;
 
 	/**
+	 * Array of available variations.
+	 *
+	 * @var array
+	 */
+	protected $variations_available = array();
+
+	/**
 	 * Get internal type.
 	 *
 	 * @return string
@@ -285,9 +292,10 @@ class WC_Product_Variable extends WC_Product {
 	 * @return array
 	 */
 	public function get_available_variations() {
-
+		if ( ! empty( $this->variations_available ) ) {
+			return $this->variations_available;
+		}
 		$variation_ids        = $this->get_children();
-		$available_variations = array();
 
 		if ( is_callable( '_prime_post_caches' ) ) {
 			_prime_post_caches( $variation_ids );
@@ -307,12 +315,12 @@ class WC_Product_Variable extends WC_Product {
 				continue;
 			}
 
-			$available_variations[] = $this->get_available_variation( $variation );
+			$this->variations_available[] = $this->get_available_variation( $variation );
 		}
 
-		$available_variations = array_values( array_filter( $available_variations ) );
+		$this->variations_available = array_values( array_filter( $this->variations_available) );
 
-		return $available_variations;
+		return $this->variations_available;
 	}
 
 	/**

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -292,10 +292,8 @@ class WC_Product_Variable extends WC_Product {
 	 * @return array
 	 */
 	public function get_available_variations() {
-		if ( ! empty( $this->variations_available ) ) {
-			return $this->variations_available;
-		}
 		$variation_ids        = $this->get_children();
+		$available_variations = array();
 
 		if ( is_callable( '_prime_post_caches' ) ) {
 			_prime_post_caches( $variation_ids );
@@ -315,12 +313,17 @@ class WC_Product_Variable extends WC_Product {
 				continue;
 			}
 
-			$this->variations_available[] = $this->get_available_variation( $variation );
+			// Prevent re-loading variations.
+			if ( ! isset( $this->variations_available[ $child_id ] ) ) {
+			  $this->variations_available[ $child_id ] = $this->get_available_variation( $variation );
+			}
+
+			$available_variations[] = $this->variations_available[ $child_id ];
 		}
 
-		$this->variations_available = array_values( array_filter( $this->variations_available) );
+		$available_variations = array_values( array_filter( $available_variations ) );
 
-		return $this->variations_available;
+		return $available_variations;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Performance improvement for the use case of high amount of product variations.

The `->get_available_variations()` have a fixed return value for a given product in request runtime, but it's value is calculated for each execution of it. Also this method is generically used as 'cost 0' for plugins and themes, so is easy that several requests for the same product exists. For pages with hundred of products with hundred of variations and/or heavly adding filters to the process this is a performance killer. 

The proposed solution basically adds the attribute to the class to store it and serve it's value for a subsequent requests to it.

### How to test the changes in this Pull Request:

1. Create a product with several variations.
2. Use some plugin or themes that relaies on checking the available variations, most of the more common does.
3. Use a profiler or other debug tool to check that it's redundantly calculated.

For a real case with about 10 products loaded per page with an avarage of 100 variations and a ` wp plugin list | wc -l` output of 79 the performance improvement is about 0.5~1sec

### Other information:

* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Prevent calculate available variations several times for the same product.