### PR TITLE
Update refund reason to make it clear refunding is manual

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -772,7 +772,7 @@ function wc_order_fully_refunded( $order_id ) {
 	wc_create_refund(
 		array(
 			'amount'     => $max_refund,
-			'reason'     => __( 'Order fully refunded', 'woocommerce' ),
+			'reason'     => __( 'Order status set to refunded. To return funds to the customer you will need to issue a refund through your payment gateway.', 'woocommerce' ),
 			'order_id'   => $order_id,
 			'line_items' => array(),
 		)


### PR DESCRIPTION
For #23144, this tweaks the refund reason when chaning order status to refunded to make it clear that no funds have been refunded to the customer. 

![Edit order ‹ Test — WordPress 2019-03-26 12-47-55](https://user-images.githubusercontent.com/90977/54998174-64372d00-4fc5-11e9-9344-9c9ca1a029f6.png)

To test, change an order status to refunded and check the note.
