### PR TITLE
Made WooCommerce roles translatable

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -815,9 +815,15 @@ function wc_update_user_last_active( $user_id ) {
  * @return string
  */
 function wc_translate_user_roles( $translation, $text, $context, $domain ) {
+	// translate_user_role() only accepts a second parameter starting in WP 5.2.
+	if ( version_compare( get_bloginfo( 'version' ), '5.2', '<' ) ) {
+		return $translation;
+	}
+
 	if ( 'User role' === $context && 'default' === $domain && in_array( $text, array( 'Shop manager', 'Customer' ), true ) ) {
 		return translate_user_role( $text, 'woocommerce' );
 	}
+
 	return $translation;
 }
 add_filter( 'gettext_with_context', 'wc_translate_user_roles', 10, 4 );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -803,3 +803,21 @@ function wc_update_user_last_active( $user_id ) {
 	}
 	update_user_meta( $user_id, 'wc_last_active', (string) strtotime( date( 'Y-m-d', current_time( 'timestamp', true ) ) ) );
 }
+
+/**
+ * Translate WC roles using the woocommerce textdomain.
+ *
+ * @since 3.7.0
+ * @param string $translation  Translated text.
+ * @param string $text         Text to translate.
+ * @param string $context      Context information for the translators.
+ * @param string $domain       Text domain. Unique identifier for retrieving translated strings.
+ * @return string
+ */
+function wc_translate_user_roles( $translation, $text, $context, $domain ) {
+	if ( 'User role' === $context && 'default' === $domain && $text === $translation ) {
+		return translate_user_role( $text, 'woocommerce' );
+	}
+	return $translation;
+}
+add_filter( 'gettext_with_context', 'wc_translate_user_roles', 10, 4 );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -815,7 +815,7 @@ function wc_update_user_last_active( $user_id ) {
  * @return string
  */
 function wc_translate_user_roles( $translation, $text, $context, $domain ) {
-	if ( 'User role' === $context && 'default' === $domain && $text === $translation ) {
+	if ( 'User role' === $context && 'default' === $domain && in_array( $text, array( 'Shop manager', 'Customer' ), true ) ) {
 		return translate_user_role( $text, 'woocommerce' );
 	}
 	return $translation;


### PR DESCRIPTION
When WordPress uses `translate_user_role` it always sets the domain to `default`. There is no way to filter this, and no way to filter places in WP Admin which use it, such as the 'role' dropdown in Settings > General, and the role list in Admin > Users.

This leaves us with the `gettext_with_context` filter being the only way to translate roles. This PR adds a filter and only filters on `'User role'` contexts specifically for our role names to prevent it doing unnecessary translations on other strings.

To test, switch to Portuguese (Brazil) language, go to Dashboard > Updates and update language packs, then check Settings > General and Admin > Users to ensure roles are translated.

cc @rodrigoprimo 

> Translate WooCommerce roles in WP Admin