### PR TITLE
Update Emogrifier class and usage

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -526,11 +526,11 @@ class WC_Email extends WC_Settings_API {
 			$css = apply_filters( 'woocommerce_email_styles', ob_get_clean(), $this );
 
 			if ( $this->supports_emogrifier() ) {
-				if ( ! class_exists( 'Emogrifier' ) ) {
+				if ( ! class_exists( '\\Pelago\\Emogrifier' ) ) {
 					include_once dirname( dirname( __FILE__ ) ) . '/libraries/class-emogrifier.php';
 				}
 				try {
-					$emogrifier = new Emogrifier( $content, $css );
+					$emogrifier = new \Pelago\Emogrifier( $content, $css ); // phpcs:ignore PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
 					$content    = $emogrifier->emogrify();
 				} catch ( Exception $e ) {
 					$logger = wc_get_logger();

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -526,11 +526,12 @@ class WC_Email extends WC_Settings_API {
 			$css = apply_filters( 'woocommerce_email_styles', ob_get_clean(), $this );
 
 			if ( $this->supports_emogrifier() ) {
-				if ( ! class_exists( '\\Pelago\\Emogrifier' ) ) {
+				$emogrifier_class = '\\Pelago\\Emogrifier';
+				if ( ! class_exists( $emogrifier_class ) ) {
 					include_once dirname( dirname( __FILE__ ) ) . '/libraries/class-emogrifier.php';
 				}
 				try {
-					$emogrifier = new \Pelago\Emogrifier( $content, $css ); // phpcs:ignore PHPCompatibility.LanguageConstructs.NewLanguageConstructs.t_ns_separatorFound
+					$emogrifier = new $emogrifier_class( $content, $css );
 					$content    = $emogrifier->emogrify();
 				} catch ( Exception $e ) {
 					$logger = wc_get_logger();

--- a/includes/libraries/class-emogrifier.php
+++ b/includes/libraries/class-emogrifier.php
@@ -1,4 +1,7 @@
 <?php
+
+namespace Pelago;
+
 /**
  * This class provides functions for converting CSS styles into inline style attributes in your HTML code.
  *


### PR DESCRIPTION
Emogrifier was updated in 3.6 but we removed the namespace. This lead to errors in some cases:

https://github.com/woocommerce/woocommerce/pull/22342#issuecomment-476552068

This fix adds the namespace back, and ensures when Emogrifier is constructed it uses correct namespaces.

Note: we disable this for PHP 5.5 and below so using the namespace is not a problem.

To test, send yourself some invoice emails and ensure they arrive.