### PR TITLE
Format empty cart message as information notice

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3448,7 +3448,7 @@ function wc_logout_url( $redirect = '' ) {
  * @since 3.1.0
  */
 function wc_empty_cart_message() {
-	echo '<p class="cart-empty">' . wp_kses_post( apply_filters( 'wc_empty_cart_message', __( 'Your cart is currently empty.', 'woocommerce' ) ) ) . '</p>';
+	echo '<p class="cart-empty woocommerce-info">' . wp_kses_post( apply_filters( 'wc_empty_cart_message', __( 'Your cart is currently empty.', 'woocommerce' ) ) ) . '</p>';
 }
 
 /**


### PR DESCRIPTION
Format empty cart message as information notice which looks better.
(similar to "No products were found matching your selection" or "No order has been made yet")

### How to test the changes in this Pull Request:

Do not add any items to cart and then view cart page 

### Changelog entry

Format empty cart message as information notice 