### PR TITLE
Tracks: Orders edit screen events

### DIFF
--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -15,8 +15,81 @@ class WC_Orders_Tracking {
 	 * Init tracking.
 	 */
 	public function init() {
+		add_action( 'post_updated', array( $this, 'track_order_actions' ), 10, 2 );
+		add_action( 'woocommerce_new_order_item', array( $this, 'track_edit_order_add_item' ), 10, 3 );
 		add_action( 'woocommerce_order_status_changed', array( $this, 'track_order_status_change' ), 10, 3 );
 		add_action( 'load-edit.php', array( $this, 'track_orders_view' ), 10 );
+		add_action( 'load-post.php', array( $this, 'track_order_note_add' ), 10 );
+	}
+
+	/**
+	 * Send a Tracks event when an order line item is added.
+	 *
+	 * @param int    $item_id  Item id.
+	 * @param object $item  Item added to an order.
+	 */
+	public function track_edit_order_add_item( $item_id, $item ) {
+
+		$type = null;
+
+		if ( $item instanceof WC_Order_Item_Product ) {
+			$type = 'product';
+		} elseif ( $item instanceof WC_Order_Item_Fee ) {
+			$type = 'fee';
+		} elseif ( $item instanceof WC_Order_Item_Shipping ) {
+			$type = 'shipping';
+		} elseif ( $item instanceof WC_Order_Item_Tax ) {
+			$type = 'tax';
+		} elseif ( $item instanceof WC_Order_Item_Coupon ) {
+			$type = 'coupon';
+		}
+
+		if ( $type ) {
+			WC_Tracks::record_event(
+				'orders_edit_order_add_item',
+				array(
+					'type' => $type,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Send a Tracks event when an order action is taken.
+	 */
+	public function track_order_actions() {
+		if ( ! empty( $_POST['wc_order_action'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+
+			$action = wc_clean( wp_unslash( $_POST['wc_order_action'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+
+			WC_Tracks::record_event(
+				'orders_edit_order_action',
+				array(
+					'action' => $action,
+				)
+			);
+		}
+	}
+
+	/**
+	 * Send a Tracks event when an order note is created.
+	 */
+	public function track_order_note_add() {
+		if ( isset( $_GET['post'] ) ) {
+			$order = wc_get_order( intval( $_GET['post'] ) );
+			if ( ! empty( $order ) ) {
+				wc_enqueue_js(
+					"
+					$( 'button.add_note' ).click( function( e ) {
+						var type = $( '#order_note_type' ).val();
+						window.wcTracks.recordEvent( 'orders_edit_order_add_notes', {
+							type: type ? type : 'private'
+						} );
+					} );
+				"
+				);
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add events tracking user interaction on the Orders edit screen.

* `wcadmin_orders_edit_order_add_notes`
* `wcadmin_orders_edit_order_add_item`
* `wcadmin_orders_edit_order_action`

### How to test the changes in this Pull Request:

1. Add the following to check correct requests were made from PHP to log the event along with the correct parameters.

```php
add_filter( 'http_request_args', function( $r, $url ) {
	error_log( $r['method'] . ' ' . $url );
	return $r;
},10, 2 );
```

2. WooCommerce > Orders > choose any order.
3. Add a note, both private and to the customer. Check that the correct request was made by looking at the Network requests for `t.gif`.
4. Add any item, such as product, fee, or coupon. Check that the correct request was made.
5. Choose an order action and click update. Check that the correct request was made.

![Screen Shot 2019-03-27 at 2 10 44 PM](https://user-images.githubusercontent.com/1922453/55043242-31ab3400-509a-11e9-8176-c4cce50e9c64.png)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a short summary of all changes on this Pull Request. This will appear in the changelog if accepted.
