### PR TITLE
OBW: Ensure tracker opt-in is always shown.

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -522,24 +522,18 @@ class WC_Admin_Setup_Wizard {
 				<?php esc_html_e( 'I will also be selling products or services in person.', 'woocommerce' ); ?>
 			</label>
 
-			<?php
-			if ( 'unknown' === get_option( 'woocommerce_allow_tracking', 'unknown' ) ) {
-				?>
-				<div class="woocommerce-tracker">
-					<p class="checkbox">
-						<input type="checkbox" id="wc_tracker_checkbox" name="wc_tracker_checkbox" value="yes" checked />
-						<label for="wc_tracker_checkbox"><?php esc_html_e( 'Help WooCommerce improve with usage tracking.', 'woocommerce' ); ?></label>
-					</p>
-					<p>
-					<?php
-					esc_html_e( 'Gathering usage data allows us to make WooCommerce better &mdash; your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense. If you would rather opt-out, and do not check this box, we will not know this store exists and we will not collect any usage data.', 'woocommerce' );
-					echo ' <a target="_blank" href="https://woocommerce.com/usage-tracking/">' . esc_html__( 'Read more about what we collect.', 'woocommerce' ) . '</a>';
-					?>
-					</p>
-				</div>
+			<div class="woocommerce-tracker">
+				<p class="checkbox">
+					<input type="checkbox" id="wc_tracker_checkbox" name="wc_tracker_checkbox" value="yes" checked />
+					<label for="wc_tracker_checkbox"><?php esc_html_e( 'Help WooCommerce improve with usage tracking.', 'woocommerce' ); ?></label>
+				</p>
+				<p>
 				<?php
-			}
-			?>
+				esc_html_e( 'Gathering usage data allows us to make WooCommerce better &mdash; your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense. If you would rather opt-out, and do not check this box, we will not know this store exists and we will not collect any usage data.', 'woocommerce' );
+				echo ' <a target="_blank" href="https://woocommerce.com/usage-tracking/">' . esc_html__( 'Read more about what we collect.', 'woocommerce' ) . '</a>';
+				?>
+				</p>
+			</div>
 			<p class="wc-setup-actions step">
 				<button type="submit" class="button-primary button button-large button-next" value="<?php esc_attr_e( "Let's go!", 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( "Let's go!", 'woocommerce' ); ?></button>
 			</p>
@@ -587,13 +581,12 @@ class WC_Admin_Setup_Wizard {
 				update_option( 'woocommerce_price_thousand_sep', $locale_info[ $country ]['thousand_sep'] );
 			}
 		}
-		if ( 'unknown' === get_option( 'woocommerce_allow_tracking', 'unknown' ) ) {
-			if ( $tracking ) {
-				update_option( 'woocommerce_allow_tracking', 'yes' );
-				wp_schedule_single_event( time() + 10, 'woocommerce_tracker_send_event', array( true ) );
-			} else {
-				update_option( 'woocommerce_allow_tracking', 'no' );
-			}
+
+		if ( $tracking ) {
+			update_option( 'woocommerce_allow_tracking', 'yes' );
+			wp_schedule_single_event( time() + 10, 'woocommerce_tracker_send_event', array( true ) );
+		} else {
+			update_option( 'woocommerce_allow_tracking', 'no' );
 		}
 
 		WC_Install::create_pages();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

From discussion in Slack today, @peterfabian reported that the tracks opt-in was no longer being shown during the OBW. @mikejolley determined this regression was introduced in #22899 with the addition of `woocommerce_allow_tracking` option to the settings page. This resulted in `woocommerce_allow_tracking` defaulting to `no` instead of `unknown` and thus the opt-in not being shown anymore.

![image](https://user-images.githubusercontent.com/22080/55116821-db43f280-50a5-11e9-89e5-f6d753c76d73.png)

The suggested fix in this PR is to remove the conditional display all-together, so regardless of the default value, or what it is currently set to, the opt-in form is displayed.

### How to test the changes in this Pull Request:

1. Visit `/wp-admin/admin.php?page=wc-setup&step=store_setup` and verify the tracking opt-in form is shown, and defaults to checked
2. Leave it checked, and click Let's Go! Verify the setting was set to YES via `/wp-admin/admin.php?page=wc-settings&tab=account`
3. Repeat step one, but this time **un-check** the opt-in, click Let's Go
4. Verify the setting is No/Off in `/wp-admin/admin.php?page=wc-settings&tab=account`

### Changelog entry

Fix: Fixes regression of tracker opt-in no longer being shown in the on-boarding-wizard.
