### PR TITLE
Add quantity input action hooks

### DIFF
--- a/templates/global/quantity-input.php
+++ b/templates/global/quantity-input.php
@@ -28,6 +28,9 @@ if ( $max_value && $min_value === $max_value ) {
 	$labelledby = ! empty( $args['product_name'] ) ? sprintf( __( '%s quantity', 'woocommerce' ), wp_strip_all_tags( $args['product_name'] ) ) : '';
 	?>
 	<div class="quantity">
+
+		<?php do_action( 'woocommerce_before_quantity_input_field' ); ?>
+
 		<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php esc_html_e( 'Quantity', 'woocommerce' ); ?></label>
 		<input
 			type="number"
@@ -44,6 +47,9 @@ if ( $max_value && $min_value === $max_value ) {
 			<?php if ( ! empty( $labelledby ) ) { ?>
 			aria-labelledby="<?php echo esc_attr( $labelledby ); ?>" />
 			<?php } ?>
+
+		<?php do_action( 'woocommerce_after_quantity_input_field' ); ?>
+
 	</div>
 	<?php
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Add quantity input action hooks to enable custom markup before and after the input element.

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. `add_action('woocommerce_before_add_to_cart_quantity', 'custom_markup_before_add_to_cart_quantity', 10);`
2. `add_action('woocommerce_after_add_to_cart_quantity', 'custom_markup_after_add_to_cart_quantity', 10);`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully ran tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
Add quantity input action hooks to enable custom markup before and after the input element.