### PR TITLE
Tracks: Add coupons view events

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -112,6 +112,7 @@ class WC_Site_Tracking {
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-orders-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-settings-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-status-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-coupons-tracking.php';
 
 		$tracking_classes = array(
 			'WC_Admin_Setup_Wizard_Tracking',
@@ -121,6 +122,7 @@ class WC_Site_Tracking {
 			'WC_Orders_Tracking',
 			'WC_Settings_Tracking',
 			'WC_Status_Tracking',
+			'WC_Coupons_Tracking',
 		);
 
 		foreach ( $tracking_classes as $tracking_class ) {

--- a/includes/tracks/events/class-wc-coupons-tracking.php
+++ b/includes/tracks/events/class-wc-coupons-tracking.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * WooCommerce Coupons Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of WooCommerce Orders.
+ */
+class WC_Coupons_Tracking {
+	/**
+	 * Init tracking.
+	 */
+	public function init() {
+		add_action( 'load-edit.php', array( $this, 'tracks_coupons_events' ), 10 );
+	}
+
+	/**
+	 * Add a listener on the "Apply" button to track bulk actions.
+	 */
+	public function tracks_coupons_bulk_actions() {
+		wc_enqueue_js(
+			"
+			var apply = $( '#posts-filter input[type=\"submit\"]' );
+			$( apply ).on( 'click', function() {
+				var action = $('select[name=\"action\"]').val();
+				if ( '-1' !== action ) {
+					window.wcTracks.recordEvent( 'coupons_view_bulk_action', {
+						action: action
+					} );
+				}
+			} );
+		"
+		);
+	}
+
+	/**
+	 * Track page view events.
+	 */
+	public function tracks_coupons_events() {
+		if ( isset( $_GET['post_type'] ) && 'shop_coupon' === wp_verify_nonce( sanitize_key( $_GET['post_type'] ) ) ) {
+
+			$this->tracks_coupons_bulk_actions();
+
+			WC_Tracks::record_event(
+				'coupons_view',
+				array(
+					'status' => isset( $_GET['post_status'] ) ? sanitize_text_field( wp_unslash( $_GET['post_status'] ) ) : 'all',
+				)
+			);
+
+			if ( isset( $_GET['filter_action'] ) && 'Filter' === sanitize_text_field( wp_unslash( $_GET['filter_action'] ) ) && isset( $_GET['coupon_type'] ) ) {
+				WC_Tracks::record_event(
+					'coupons_filter',
+					array(
+						'filter' => 'coupon_type',
+						'value'  => sanitize_text_field( wp_unslash( $_GET['coupon_type'] ) ),
+					)
+				);
+			}
+
+			if ( isset( $_GET['s'] ) && 0 < strlen( sanitize_text_field( wp_unslash( $_GET['s'] ) ) ) ) {
+				WC_Tracks::record_event( 'coupons_search' );
+			}
+		}
+	}
+}

--- a/includes/tracks/events/class-wc-coupons-tracking.php
+++ b/includes/tracks/events/class-wc-coupons-tracking.php
@@ -24,15 +24,16 @@ class WC_Coupons_Tracking {
 	public function tracks_coupons_bulk_actions() {
 		wc_enqueue_js(
 			"
-			var apply = $( '#posts-filter input[type=\"submit\"]' );
-			$( apply ).on( 'click', function() {
+			function onApplyBulkActions() {
 				var action = $('select[name=\"action\"]').val();
 				if ( '-1' !== action ) {
 					window.wcTracks.recordEvent( 'coupons_view_bulk_action', {
 						action: action
 					} );
 				}
-			} );
+			}
+			$( '#doaction' ).on( 'click', onApplyBulkActions );
+			$( '#doaction2' ).on( 'click', onApplyBulkActions );
 		"
 		);
 	}
@@ -41,7 +42,7 @@ class WC_Coupons_Tracking {
 	 * Track page view events.
 	 */
 	public function tracks_coupons_events() {
-		if ( isset( $_GET['post_type'] ) && 'shop_coupon' === wp_verify_nonce( sanitize_key( $_GET['post_type'] ) ) ) {
+		if ( isset( $_GET['post_type'] ) && 'shop_coupon' === $_GET['post_type'] ) {
 
 			$this->tracks_coupons_bulk_actions();
 

--- a/includes/tracks/events/class-wc-coupons-tracking.php
+++ b/includes/tracks/events/class-wc-coupons-tracking.php
@@ -24,16 +24,18 @@ class WC_Coupons_Tracking {
 	public function tracks_coupons_bulk_actions() {
 		wc_enqueue_js(
 			"
-			function onApplyBulkActions() {
-				var action = $('select[name=\"action\"]').val();
-				if ( '-1' !== action ) {
+			function onApplyBulkActions( event ) {
+				var id = event.data.id;
+				var action = $( '#' + id ).val();
+				
+				if ( action && '-1' !== action ) {
 					window.wcTracks.recordEvent( 'coupons_view_bulk_action', {
 						action: action
 					} );
 				}
 			}
-			$( '#doaction' ).on( 'click', onApplyBulkActions );
-			$( '#doaction2' ).on( 'click', onApplyBulkActions );
+			$( '#doaction' ).on( 'click', { id: 'bulk-action-selector-top' }, onApplyBulkActions );
+			$( '#doaction2' ).on( 'click', { id: 'bulk-action-selector-bottom' }, onApplyBulkActions );
 		"
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add Coupons view Tracks events.

### How to test the changes in this Pull Request:

1. Visit coupons page, `/wp-admin/edit.php?post_type=shop_coupon`.
2. Open the Network tab and filter for `t.gif`.
3. See the page view event along with the correct status (all, publish, trash).
4. Now, filter and search and inspect the t.gif request properties.
5. Try again now with "bulk actions". You'll likely need to `preserve log` in the Network tab in case a post request refreshes the screen.

