### PR TITLE
Tracks: Status page events

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -108,6 +108,7 @@ class WC_Site_Tracking {
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-products-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-orders-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-settings-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-status-tracking.php';
 
 		$tracking_classes = array(
 			'WC_Admin_Setup_Wizard_Tracking',
@@ -116,6 +117,7 @@ class WC_Site_Tracking {
 			'WC_Products_Tracking',
 			'WC_Orders_Tracking',
 			'WC_Settings_Tracking',
+			'WC_Status_Tracking',
 		);
 
 		foreach ( $tracking_classes as $tracking_class ) {

--- a/includes/tracks/events/class-wc-status-tracking.php
+++ b/includes/tracks/events/class-wc-status-tracking.php
@@ -1,0 +1,48 @@
+<?php
+/**
+ * WooCommerce Status Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of WooCommerce Orders.
+ */
+class WC_Status_Tracking {
+	/**
+	 * Init tracking.
+	 */
+	public function init() {
+		add_action( 'admin_init', array( $this, 'track_status_view' ), 10 );
+	}
+
+	/**
+	 * Add Tracks events to the status page.
+	 */
+	public function track_status_view() {
+		if ( isset( $_GET['page'] ) && 'wc-status' === sanitize_text_field( wp_unslash( $_GET['page'] ) ) ) {
+
+			$tab = isset( $_GET['tab'] ) ? sanitize_text_field( wp_unslash( $_GET['tab'] ) ) : 'status';
+
+			WC_Tracks::record_event(
+				'status_view',
+				array(
+					'tab'       => $tab,
+					'tool_used' => isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : null,
+				)
+			);
+
+			if ( 'status' === $tab ) {
+				wc_enqueue_js(
+					"
+					$( 'a.debug-report' ).click( function() {
+						window.wcTracks.recordEvent( 'status_view_reports' );
+					} );
+				"
+				);
+			}
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add Tracks events to the Status page.

### How to test the changes in this Pull Request:

1. Open the Network tab and filter by `t.gif`.
2. WooCommerce > Status.
3. See the page view event in the Network.
4. View tabs and see the property reflected in the request.
5. Use any of the tools and see also see the property reflected in the request.
6. In the System Status tab, click "Get system report" and see an event fired for that.
