### PR TITLE
[3.6] Fix BC break by allowing wc_product_gallery to be called without any arguments.

### DIFF
--- a/assets/js/frontend/single-product.js
+++ b/assets/js/frontend/single-product.js
@@ -317,7 +317,7 @@ jQuery( function( $ ) {
 	 * Function to call wc_product_gallery on jquery selector.
 	 */
 	$.fn.wc_product_gallery = function( args ) {
-		new ProductGallery( this, args );
+		new ProductGallery( this, args || wc_single_product_params );
 		return this;
 	};
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes a bug in WC 3.6.0-rc1 where `wc_product_gallery()` will not work if it is called without any arguments. This was introduced in https://github.com/woocommerce/woocommerce/commit/148e308d3895e7fd9e0348e057d928e46b84abf7#diff-70e6d5d85f9bbb3126dad3190f865c2fR118

This breaks extensions such as Additional Variation Images which updates the gallery and then runs code like:
```php
$( '.woocommerce-product-gallery' ).each( function() {
	$( this ).wc_product_gallery();
} );
```
which fails with:
```
single-product.js?ver=3.6.0:130 Uncaught TypeError: Cannot read property 'flexslider' of undefined
    at new ProductGallery (single-product.js?ver=3.6.0:130)
    at jQuery.fn.init.$.fn.wc_product_gallery (single-product.js?ver=3.6.0:320)
    at <anonymous>:1:42
```
This PR fixes the problem by using the `wc_single_product_params` if args were not passed. Ideally it'll be merged before 3.6 is released so we do not need to update any extensions.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
