### PR TITLE
[3.6] Fix results from wp_term_counts when sorting by menu_order

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -83,7 +83,7 @@ function wc_terms_clauses( $clauses, $taxonomies, $args ) {
 	global $wpdb;
 
 	// No need to filter when counting.
-	if ( strpos( 'COUNT(*)', $clauses['fields'] ) !== false ) {
+	if ( strpos( $clauses['fields'], 'COUNT(*)' ) !== false ) {
 		return $clauses;
 	}
 

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -34,8 +34,6 @@ function wc_change_get_terms_defaults( $defaults, $taxonomies ) {
 
 	switch ( $orderby ) {
 		case 'menu_order':
-			$defaults['orderby']               = 'meta_value_num';
-			$defaults['meta_key']              = 'order'; // phpcs:ignore
 			$defaults['force_menu_order_sort'] = true;
 			break;
 		case 'name_num':
@@ -60,14 +58,21 @@ add_filter( 'get_terms_defaults', 'wc_change_get_terms_defaults', 10, 2 );
 function wc_change_pre_get_terms( $terms_query ) {
 	$args = &$terms_query->query_vars;
 
-	if ( ! empty( $args['menu_order'] ) ) {
-		$args['order']                 = 'DESC' === strtoupper( $args['menu_order'] ) ? 'DESC' : 'ASC';
-		$args['orderby']               = 'meta_value_num';
-		$args['meta_key']              = 'order'; // phpcs:ignore
-		$args['force_menu_order_sort'] = true;
-		$terms_query->meta_query->parse_query_vars( $args );
+	// When COUNTING, disable custom sorting.
+	if ( 'count' === $args['fields'] ) {
+		return;
 	}
 
+	if ( ! empty( $args['menu_order'] ) ) {
+		$args['order']                 = 'DESC' === strtoupper( $args['menu_order'] ) ? 'DESC' : 'ASC';
+		$args['force_menu_order_sort'] = true;
+	}
+
+	if ( ! empty( $args['force_menu_order_sort'] ) ) {
+		$args['orderby']  = 'meta_value_num';
+		$args['meta_key'] = 'order'; // phpcs:ignore
+		$terms_query->meta_query->parse_query_vars( $args );
+	}
 }
 add_action( 'pre_get_terms', 'wc_change_pre_get_terms', 10, 1 );
 

--- a/tests/unit-tests/attributes/functions.php
+++ b/tests/unit-tests/attributes/functions.php
@@ -1,9 +1,13 @@
 <?php
-
 /**
- * Class Functions.
+ * Attribute function tests.
+ *
  * @package WooCommerce\Tests\Attributes
  * @since 3.2.0
+ */
+
+/**
+ * WC_Tests_Attributes_Functions class.
  */
 class WC_Tests_Attributes_Functions extends WC_Unit_Test_Case {
 
@@ -201,5 +205,20 @@ class WC_Tests_Attributes_Functions extends WC_Unit_Test_Case {
 		// Failure.
 		$result = wc_delete_attribute( 9999999 );
 		$this->assertFalse( $result );
+	}
+
+	/**
+	 * Test counts of attributes.
+	 */
+	public function test_count_attribute_terms() {
+		$global_attribute_data = WC_Helper_Product::create_attribute( 'test', array( 'Chicken', 'Nuggets' ) );
+		$count                 = wp_count_terms(
+			$global_attribute_data['attribute_taxonomy'],
+			array(
+				'hide_empty' => false,
+			)
+		);
+
+		$this->assertEquals( 2, $count );
 	}
 }


### PR DESCRIPTION
Fixes #23171 - see that issue for test instructions. Added a unit test to catch this.

Issue is resolved by:
- Including https://github.com/woocommerce/woocommerce/pull/23175
- Flipping sorting logic so rather than setting meta_key by default, it's added later via `pre_get_terms` hook. This is not ran if it's a COUNT query.

@timmyc 

> Fix results from wp_term_counts when sorting by menu_order