### PR TITLE
Replace full stops before running through `parse_str`

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -686,15 +686,21 @@ function wc_query_string_form_fields( $values = null, $exclude = array(), $curre
 		$values    = array();
 
 		if ( ! empty( $url_parts['query'] ) ) {
-			// This is to preserve full-stops in the query string when ran through parse_str.
-			$query_string = str_replace( '.', '{dot}', $url_parts['query'] );
+			// This is to preserve full-stops and spaces in the query string when ran through parse_str.
+			$replace_chars = array(
+				'.'   => '{dot}',
+				'+'   => '{plus}',
+				'%20' => '{space}',
+			);
+
+			$query_string = str_replace( array_keys( $replace_chars ), array_values( $replace_chars ), $url_parts['query'] );
 
 			// Parse the string.
 			parse_str( $query_string, $parsed_query_string );
 
 			// Convert the full-stops back and add to values array.
 			foreach ( $parsed_query_string as $key => $value ) {
-				$values[ str_replace( '{dot}', '.', $key ) ] = $value;
+				$values[ str_replace( array_values( $replace_chars ), array_keys( $replace_chars ), $key ) ] = $value;
 			}
 		}
 	}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -686,7 +686,16 @@ function wc_query_string_form_fields( $values = null, $exclude = array(), $curre
 		$values    = array();
 
 		if ( ! empty( $url_parts['query'] ) ) {
-			parse_str( $url_parts['query'], $values );
+			// This is to preserve full-stops in the query string when ran through parse_str.
+			$query_string = str_replace( '.', '{dot}', $url_parts['query'] );
+
+			// Parse the string.
+			parse_str( $query_string, $parsed_query_string );
+
+			// Convert the full-stops back and add to values array.
+			foreach ( $parsed_query_string as $key => $value ) {
+				$values[ str_replace( '{dot}', '.', $key ) ] = $value;
+			}
 		}
 	}
 	$html = '';

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -115,4 +115,31 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 
 		unset( $_REQUEST['attribute_pa_size'] );
 	}
+
+	/**
+	 * Test wc_query_string_form_fields.
+	 *
+	 * @return void
+	 */
+	public function test_wc_query_string_form_fields() {
+		$actual_html   = wc_query_string_form_fields( '?test=1', array(), '', true );
+		$expected_html = '<input type="hidden" name="test" value="1" />';
+		$this->assertEquals( $expected_html, $actual_html, var_export( $actual_html, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+
+		$actual_html   = wc_query_string_form_fields( '?test=1&test2=something', array(), '', true );
+		$expected_html = '<input type="hidden" name="test" value="1" /><input type="hidden" name="test2" value="something" />';
+		$this->assertEquals( $expected_html, $actual_html, var_export( $actual_html, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+
+		$actual_html   = wc_query_string_form_fields( '?test.something=something', array(), '', true );
+		$expected_html = '<input type="hidden" name="test.something" value="something" />';
+		$this->assertEquals( $expected_html, $actual_html, var_export( $actual_html, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+
+		$actual_html   = wc_query_string_form_fields( '?test+something=something', array(), '', true );
+		$expected_html = '<input type="hidden" name="test+something" value="something" />';
+		$this->assertEquals( $expected_html, $actual_html, var_export( $actual_html, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+
+		$actual_html   = wc_query_string_form_fields( '?test%20something=something', array(), '', true );
+		$expected_html = '<input type="hidden" name="test%20something" value="something" />';
+		$this->assertEquals( $expected_html, $actual_html, var_export( $actual_html, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce/issues/23195

`parse_str` converts `.` to `_` which leads to broken URLs in external products if using those variables. Test instructions in #23195

To get around this, replaces `.` with `{dot}` before parse_str then converts back again. This is a little hacky but the alternatives are just as bad. Using a custom parse function is possible but it would be hard to mimic `parse_str` exactly and is likely not worth the effort.

> Fix - Preserve full-stops in external product URLs.