### PR TITLE
[3.6] Fix backwards compatibility issues for wc_get_template function w/ tests

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -239,7 +239,7 @@ function wc_get_template( $template_name, $args = array(), $template_path = '', 
 				__( 'action_args should not be overwritten when calling wc_get_template.', 'woocommerce' ),
 				'3.6.0'
 			);
-			return;
+			unset( $args['action_args'] );
 		}
 		extract( $args ); // @codingStandardsIgnoreLine
 	}

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -238,7 +238,7 @@ function wc_get_template( $template_name, $args = array(), $template_path = '', 
 
 	do_action( 'woocommerce_before_template_part', $action_args['template_name'], $action_args['template_path'], $action_args['located'], $action_args['args'] );
 
-	include $template;
+	include $action_args['located'];
 
 	do_action( 'woocommerce_after_template_part', $action_args['template_name'], $action_args['template_path'], $action_args['located'], $action_args['args'] );
 }
@@ -869,7 +869,7 @@ function wc_print_js() {
  * @param  string  $value  Value of the cookie.
  * @param  integer $expire Expiry of the cookie.
  * @param  bool    $secure Whether the cookie should be served only over https.
- * @param  bool    $httponly Whether the cookie is only accessible over HTTP, not scripting languages like JavaScript. @since 3.6.0
+ * @param  bool    $httponly Whether the cookie is only accessible over HTTP, not scripting languages like JavaScript. @since 3.6.0.
  */
 function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = false ) {
 	if ( ! headers_sent() ) {

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -233,6 +233,14 @@ function wc_get_template( $template_name, $args = array(), $template_path = '', 
 	);
 
 	if ( ! empty( $args ) && is_array( $args ) ) {
+		if ( isset( $args['action_args'] ) ) {
+			wc_doing_it_wrong(
+				__FUNCTION__,
+				__( 'action_args should not be overwritten when calling wc_get_template.', 'woocommerce' ),
+				'3.6.0'
+			);
+			return;
+		}
 		extract( $args ); // @codingStandardsIgnoreLine
 	}
 

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -10,7 +10,6 @@
  * Core function unit tests.
  */
 class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
-
 	/**
 	 * Test get_woocommerce_currency().
 	 *
@@ -311,6 +310,9 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	 * @return WC_Logger_Interface
 	 */
 	public function return_valid_logger_instance() {
+		if ( ! class_exists( 'Dummy_WC_Logger' ) ) {
+			include_once 'dummy-wc-logger.php';
+		}
 		return new Dummy_WC_Logger();
 	}
 
@@ -546,12 +548,47 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test the wc_get_template function.
+	 * Test the wc_get_template_part function.
 	 *
 	 * @return void
 	 */
 	public function test_wc_get_template_part() {
 		$this->assertEmpty( wc_get_template_part( 'nothinghere' ) );
+	}
+
+	/**
+	 * Test wc_get_template.
+	 *
+	 * @expectedIncorrectUsage wc_get_template
+	 */
+	public function test_wc_get_template_invalid() {
+		wc_get_template(
+			'does_not_exist.php',
+			array(
+				'action_args' => 'this is bad',
+			)
+		);
+	}
+
+	/**
+	 * Test wc_get_template.
+	 */
+	public function test_wc_get_template() {
+		ob_start();
+		wc_get_template( 'global/wrapper-start.php' );
+		$template = ob_get_clean();
+		$this->assertNotEmpty( $template );
+
+		ob_start();
+		wc_get_template(
+			'global/wrapper-start.php',
+			array(
+				'template' => 'x',
+				'located'  => 'x',
+			)
+		);
+		$template = ob_get_clean();
+		$this->assertNotEmpty( $template );
 	}
 
 	/**

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -561,9 +561,9 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	 *
 	 * @expectedIncorrectUsage wc_get_template
 	 */
-	public function test_wc_get_template_invalid() {
+	public function test_wc_get_template_invalid_action_args() {
 		wc_get_template(
-			'does_not_exist.php',
+			'global/wrapper-start.php',
 			array(
 				'action_args' => 'this is bad',
 			)


### PR DESCRIPTION
Fixes #23182. Closes #23183.

Inside `wc_get_template` there is an `extract` call which can override variables. `$action_args` is in place to make this occurrence less likely.

3.6 RC uses a variable called `$template`. If this is passes as an arg it will overwrite this variable and break the include.

Fixed by using `action_args` instead so if `$template` is overridden, it doesn't matter.

Also included a check to ensure `action_args` _cannot_ be overridden as this is for internal usage and extra overwriting it would break the actions/include.

Also included some unit tests to ensure the include works, and action_args cannot be overridden.

@timmyc 
