### PR TITLE
Add check for VAT exemption inside `display_prices_including_tax`

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -361,7 +361,9 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return bool
 	 */
 	public function display_prices_including_tax() {
-		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, 'incl' === $this->tax_display_cart );
+		$customer_exempt = $this->get_customer() && $this->get_customer()->get_is_vat_exempt();
+
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, 'incl' === $this->tax_display_cart && ! $customer_exempt );
 	}
 
 	/*
@@ -634,9 +636,9 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param bool $clear_persistent_cart Should the persistant cart be cleared too. Defaults to true.
 	 */
 	public function empty_cart( $clear_persistent_cart = true ) {
-		
+
 		do_action( 'woocommerce_before_cart_emptied' );
-		
+
 		$this->cart_contents              = array();
 		$this->removed_cart_contents      = array();
 		$this->shipping_methods           = array();


### PR DESCRIPTION
Fixes #23168 

- The `tax_display_cart` method variable in `WC_Cart` is set during construct based on store settings and whether the customer is VAT exempt or not.
- `display_prices_including_tax` uses this variable before rendering products/totals.
- If customer VAT exempt status changes after `WC_Cart` is constructed, the prices will not reflect the status of the customer.

Fixed by checking customer status inside `display_prices_including_tax`.

> Fix - Subtotals and totals not consistently including/excluding taxes in order-review-summary when customer becomes VAT exempt.

To test, I forced customer VAT exempt true after the constructor:

```
WC()->customer->set_is_vat_exempt( true );
```

And called this via the JS console on checkout:

```
jQuery('body').trigger('update_checkout');
```

Prices were show correct after the refresh.