### PR TITLE
[3.6] Prevent removal of the wc- prefix from non core order statuses

### DIFF
--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -58,9 +58,6 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 		$order->set_date_created( current_time( 'timestamp', true ) );
 		$order->set_currency( $order->get_currency() ? $order->get_currency() : get_woocommerce_currency() );
 
-		$raw_status = $order->get_status( 'edit' ) ? $order->get_status( 'edit' ) : apply_filters( 'woocommerce_default_order_status', 'pending' );
-		$status     = wc_is_order_status( 'wc-' . $raw_status ) ? 'wc-' . $raw_status : $raw_status;
-
 		$id = wp_insert_post(
 			apply_filters(
 				'woocommerce_new_order_data',
@@ -68,7 +65,7 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 					'post_date'     => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getOffsetTimestamp() ),
 					'post_date_gmt' => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
 					'post_type'     => $order->get_type( 'edit' ),
-					'post_status'   => $status,
+					'post_status'   => $this->get_post_status( $order ),
 					'ping_status'   => 'closed',
 					'post_author'   => 1,
 					'post_title'    => $this->get_post_title(),
@@ -144,12 +141,10 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 
 		// Only update the post when the post data changes.
 		if ( array_intersect( array( 'date_created', 'date_modified', 'status', 'parent_id', 'post_excerpt' ), array_keys( $changes ) ) ) {
-			$raw_status = $order->get_status( 'edit' ) ? $order->get_status( 'edit' ) : apply_filters( 'woocommerce_default_order_status', 'pending' );
-			$status     = wc_is_order_status( 'wc-' . $raw_status ) ? 'wc-' . $raw_status : $raw_status;
 			$post_data = array(
 				'post_date'         => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getOffsetTimestamp() ),
 				'post_date_gmt'     => gmdate( 'Y-m-d H:i:s', $order->get_date_created( 'edit' )->getTimestamp() ),
-				'post_status'       => $status,
+				'post_status'       => $this->get_post_status( $order ),
 				'post_parent'       => $order->get_parent_id(),
 				'post_excerpt'      => $this->get_post_excerpt( $order ),
 				'post_modified'     => isset( $changes['date_modified'] ) ? gmdate( 'Y-m-d H:i:s', $order->get_date_modified( 'edit' )->getOffsetTimestamp() ) : current_time( 'mysql' ),
@@ -214,6 +209,36 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	| Additional Methods
 	|--------------------------------------------------------------------------
 	*/
+
+	/**
+	 * Get the status to save to the post object.
+	 *
+	 * Plugins extending the order classes can override this to change the stored status/add prefixes etc.
+	 *
+	 * @since 3.6.0
+	 * @param  WC_order $order Order object.
+	 * @return string
+	 */
+	protected function get_post_status( $order ) {
+		$order_status = $order->get_status( 'edit' );
+
+		if ( ! $order_status ) {
+			$order_status = apply_filters( 'woocommerce_default_order_status', 'pending' );
+		}
+
+		$post_status    = $order_status;
+		$valid_statuses = get_post_stati();
+
+		// Add a wc- prefix to the status, but exclude some core statuses which should not be prefixed.
+		// @todo In the future this should only happen based on `wc_is_order_status`, but in order to
+		// preserve back-compatibility this happens to all statuses except a select few. A doing_it_wrong
+		// Notice will be needed here, followed by future removal.
+		if ( ! in_array( $post_status, array( 'auto-draft', 'draft', 'trash' ), true ) && in_array( 'wc-' . $post_status, $valid_statuses, true ) ) {
+			$post_status = 'wc-' . $post_status;
+		}
+
+		return $post_status;
+	}
 
 	/**
 	 * Excerpt for post.


### PR DESCRIPTION
Fixes #23199 

Broken by https://github.com/woocommerce/woocommerce/commit/ae17d6f3bdbe4f55b5d9f569dc9624bcca588618

`wc-` prefix is added to WC order statuses, but Subscriptions plugin is extending orders without registering an order status. This lead to their custom `wc-active` status being saved as `active`.

To fix this, this PR laxes the `wc-` prefix removal and only removes prefix from `auto-draft`, `trash`, and `draft` core statuses. Others get a prefix.

To prevent it prefixing and creating invalid statuses, it does an existence check.

@james-allan Your side, for future compat, you can extend `WC_Order::get_post_status` to handle subscription statuses. That way, if the todo is actioned on it won't break.

```
// Add a wc- prefix to the status, but exclude some core statuses which should not be prefixed.
// @todo In the future this should only happen based on `wc_is_order_status`, but in order to
// preserve back-compatibility this happens to all statuses except a select few. A doing_it_wrong
// Notice will be needed here, followed by future removal.
```

cc @timmyc 