### PR TITLE
[3.6] OBW: Display FB recommendation until removed

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -141,11 +141,7 @@ class WC_Admin_Setup_Wizard {
 	 * @return boolean
 	 */
 	protected function should_show_facebook() {
-		$end_date_facebook_recommendation = new DateTime( '8 October 2019' );
-		$current_user_date = new DateTime( current_time( 'Y-m-d' ) );
-
-		return current_user_can( 'install_plugins' ) &&
-			$end_date_facebook_recommendation >= $current_user_date;
+		return current_user_can( 'install_plugins' );
 	}
 
 	/**


### PR DESCRIPTION
Instead of ending the FB recommendation on a specific date we'll remove it when needed.

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Remove end date for FB recommendation