### PR TITLE
[3.6] Update opt-out usage tracking text.

### DIFF
--- a/includes/admin/settings/class-wc-settings-accounts.php
+++ b/includes/admin/settings/class-wc-settings-accounts.php
@@ -36,7 +36,7 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 			$erasure_text = sprintf( '<a href="%s">%s</a>', esc_url( admin_url( 'tools.php?page=remove_personal_data' ) ), $erasure_text );
 		}
 
-		$tracking_info_text = sprintf( '<a href="%s" target="_blank">%s</a>', 'https://woocommerce.com/usage-tracking', esc_html__( 'Read more about what we collect', 'woocommerce' ) );
+		$tracking_info_text = sprintf( '<a href="%s" target="_blank">%s</a>', 'https://woocommerce.com/usage-tracking', esc_html__( 'WooCommerce.com Usage Tracking Documentation', 'woocommerce' ) );
 
 		$settings = apply_filters(
 			'woocommerce_' . $this->id . '_settings',
@@ -244,7 +244,7 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 					'title'         => __( 'Enable tracking', 'woocommerce' ),
 					'desc'          => __( 'Allow usage of WooCommerce to be tracked', 'woocommerce' ),
 					/* Translators: %s URL to tracking info screen. */
-					'desc_tip'      => sprintf( esc_html__( 'To opt-out, simply leave this box unchecked. We won’t know this store exists and won’t collect any usage data. %s.', 'woocommerce' ), $tracking_info_text ),
+					'desc_tip'      => sprintf( esc_html__( 'To opt-out, leave this box unticked. Your store remains untracked, and no data will be collected. Read about what usage data is tracked at: %s.', 'woocommerce' ), $tracking_info_text ),
 					'id'            => 'woocommerce_allow_tracking',
 					'type'          => 'checkbox',
 					'checkboxgroup' => 'start',

--- a/includes/admin/settings/class-wc-settings-accounts.php
+++ b/includes/admin/settings/class-wc-settings-accounts.php
@@ -244,7 +244,7 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 					'title'         => __( 'Enable tracking', 'woocommerce' ),
 					'desc'          => __( 'Allow usage of WooCommerce to be tracked', 'woocommerce' ),
 					/* Translators: %s URL to tracking info screen. */
-					'desc_tip'      => sprintf( esc_html__( 'If you would rather opt-out, and do not check this box, we will not know this store exists and we will not collect any usage data. %s.', 'woocommerce' ), $tracking_info_text ),
+					'desc_tip'      => sprintf( esc_html__( 'To opt-out, simply leave this box unchecked. We won’t know this store exists and won’t collect any usage data. %s.', 'woocommerce' ), $tracking_info_text ),
 					'id'            => 'woocommerce_allow_tracking',
 					'type'          => 'checkbox',
 					'checkboxgroup' => 'start',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This change seeks to make the opt-out explanation more clear. The suggested changes here were given by the Editorial team. /cc @seb86 could you let us know if this reads better to you?

Closes #23208

### How to test the changes in this Pull Request:

1. View the updated text in `/wp-admin/admin.php?page=wc-settings&tab=account`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: Make usage tracking opt-out instructions more clear.
