### PR TITLE
[3.6]Tracks: various fixes

### DIFF
--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -26,13 +26,13 @@ class WC_Admin_Setup_Wizard_Tracking {
 			return;
 		}
 
-		add_action( 'wc_setup_footer', array( $this, 'add_footer_scripts' ) );
 		add_filter( 'woocommerce_setup_wizard_steps', array( $this, 'set_obw_steps' ) );
 		add_action( 'shutdown', array( $this, 'track_skip_step' ), 1 );
 		add_action( 'add_option_woocommerce_allow_tracking', array( $this, 'track_start' ), 10, 2 );
 		add_action( 'admin_init', array( $this, 'track_ready_next_steps' ), 1 );
 		add_action( 'wp_print_scripts', array( $this, 'dequeue_non_whitelisted_scripts' ) );
 		$this->add_step_save_events();
+		$this->add_footer_scripts();
 	}
 
 	/**

--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -24,7 +24,14 @@ class WC_Orders_Tracking {
 	 */
 	public function track_orders_view() {
 		if ( isset( $_GET['post_type'] ) && 'shop_order' === wp_unslash( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			WC_Tracks::record_event( 'orders_view' );
+
+			// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
+			$properties = array(
+				'status' => isset( $_GET['post_status'] ) ? sanitize_text_field( $_GET['post_status'] ) : 'all',
+			);
+			// phpcs:enable
+
+			WC_Tracks::record_event( 'orders_view', $properties );
 		}
 	}
 

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -35,7 +35,7 @@ class WC_Products_Tracking {
 			'product_id' => $product_id,
 		);
 
-		WC_Tracks::record_event( 'update_product', $properties );
+		WC_Tracks::record_event( 'product_edit', $properties );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

1. Rename event `wcadmin_update_product` → `wcadmin_ product_edit`.
2. Add `status` property to the `wcadmin_ orders_view` event.
3. Directly call `add_footer_scripts` in OBW tracking as the `wc_setup_footer` event no longer actually added the scripts.

### How to test the changes in this Pull Request:

1. Go to the Orders View, see the new `status` property in the Network request for `t.gif`.
2. Go to any step in the OBW, for example `/wp-admin/admin.php?page=wc-setup&step=next_steps`.
3. Check that `_tkq` and `wcTracks` exist on the window.

