### PR TITLE
 Added is-active class to Orders when looking at individual order

### DIFF
--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -149,6 +149,8 @@ function wc_get_account_menu_item_classes( $endpoint ) {
 	$current = isset( $wp->query_vars[ $endpoint ] );
 	if ( 'dashboard' === $endpoint && ( isset( $wp->query_vars['page'] ) || empty( $wp->query_vars ) ) ) {
 		$current = true; // Dashboard is not an endpoint, so needs a custom check.
+	} elseif ( 'orders' === $endpoint && isset( $wp->query_vars['view-order'] ) ) {
+		$current = true; // When looking at individual order, highlight Orders list item (to signify where in the menu the user currently is).
 	}
 
 	if ( $current ) {

--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -61,7 +61,8 @@ function wc_customer_edit_account_url() {
  */
 function wc_edit_address_i18n( $id, $flip = false ) {
 	$slugs = apply_filters(
-		'woocommerce_edit_address_slugs', array(
+		'woocommerce_edit_address_slugs',
+		array(
 			'billing'  => sanitize_title( _x( 'billing', 'edit-address-slug', 'woocommerce' ) ),
 			'shipping' => sanitize_title( _x( 'shipping', 'edit-address-slug', 'woocommerce' ) ),
 		)
@@ -186,7 +187,8 @@ function wc_get_account_endpoint_url( $endpoint ) {
  */
 function wc_get_account_orders_columns() {
 	$columns = apply_filters(
-		'woocommerce_account_orders_columns', array(
+		'woocommerce_account_orders_columns',
+		array(
 			'order-number'  => __( 'Order', 'woocommerce' ),
 			'order-date'    => __( 'Date', 'woocommerce' ),
 			'order-status'  => __( 'Status', 'woocommerce' ),
@@ -207,7 +209,8 @@ function wc_get_account_orders_columns() {
  */
 function wc_get_account_downloads_columns() {
 	$columns = apply_filters(
-		'woocommerce_account_downloads_columns', array(
+		'woocommerce_account_downloads_columns',
+		array(
 			'download-product'   => __( 'Product', 'woocommerce' ),
 			'download-remaining' => __( 'Downloads remaining', 'woocommerce' ),
 			'download-expires'   => __( 'Expires', 'woocommerce' ),
@@ -231,7 +234,8 @@ function wc_get_account_downloads_columns() {
  */
 function wc_get_account_payment_methods_columns() {
 	return apply_filters(
-		'woocommerce_account_payment_methods_columns', array(
+		'woocommerce_account_payment_methods_columns',
+		array(
 			'method'  => __( 'Method', 'woocommerce' ),
 			'expires' => __( 'Expires', 'woocommerce' ),
 			'actions' => '&nbsp;',
@@ -247,7 +251,8 @@ function wc_get_account_payment_methods_columns() {
  */
 function wc_get_account_payment_methods_types() {
 	return apply_filters(
-		'woocommerce_payment_methods_types', array(
+		'woocommerce_payment_methods_types',
+		array(
 			'cc'     => __( 'Credit card', 'woocommerce' ),
 			'echeck' => __( 'eCheck', 'woocommerce' ),
 		)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23219  .

### How to test the changes in this Pull Request:

1. Go to My Account -> Orders -> Order #XYZ
2. Observe the Orders menu item is not marked as active
3. Apply branch and see the difference for Orders menu/list item

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed highlighting of Orders list item in My Account when looking at individual order.
