### PR TITLE
Updated back to link for attribute terms.

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -235,6 +235,8 @@ class WC_Post_Types {
 							'new_item_name'     => sprintf( __( 'New %s', 'woocommerce' ), $label ),
 							/* translators: %s: attribute name */
 							'not_found'         => sprintf( __( 'No &quot;%s&quot; found', 'woocommerce' ), $label ),
+							/* translators: %s: attribute name */
+							'back_to_items'     => sprintf( __( '&larr; Back to Terms for %s', 'woocommerce' ), $label ),
 						),
 						'show_ui'               => true,
 						'show_in_quick_edit'    => false,

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -236,7 +236,7 @@ class WC_Post_Types {
 							/* translators: %s: attribute name */
 							'not_found'         => sprintf( __( 'No &quot;%s&quot; found', 'woocommerce' ), $label ),
 							/* translators: %s: attribute name */
-							'back_to_items'     => sprintf( __( '&larr; Back to Terms for %s', 'woocommerce' ), $label ),
+							'back_to_items'     => sprintf( __( '&larr; Back to "%s" attributes', 'woocommerce' ), $label ),
 						),
 						'show_ui'               => true,
 						'show_in_quick_edit'    => false,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23224  .

### How to test the changes in this Pull Request:

1. Update attribute term. Link at the top says '⬅️Back to Tags'
2. After the change, the link should say '⬅️Back to Terms for %attribute_name'

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Updated Back to Items link when editing attribute terms.
