### PR TITLE
Introduce IN and NOT IN clauses in `WC_Product_Data_Store_CPT::search_products

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1543,16 +1543,11 @@ class WC_AJAX {
 			$limit = absint( apply_filters( 'woocommerce_json_search_limit', 30 ) );
 		}
 
+		$include_ids = ! empty( $_GET['include'] ) ? array_map( 'absint', (array) wp_unslash( $_GET['include'] ) ) : array();
+		$exclude_ids = ! empty( $_GET['exclude'] ) ? array_map( 'absint', (array) wp_unslash( $_GET['exclude'] ) ) : array();
+
 		$data_store = WC_Data_Store::load( 'product' );
-		$ids        = $data_store->search_products( $term, '', (bool) $include_variations, false, $limit );
-
-		if ( ! empty( $_GET['exclude'] ) ) {
-			$ids = array_diff( $ids, array_map( 'absint', (array) wp_unslash( $_GET['exclude'] ) ) );
-		}
-
-		if ( ! empty( $_GET['include'] ) ) {
-			$ids = array_intersect( $ids, array_map( 'absint', (array) wp_unslash( $_GET['include'] ) ) );
-		}
+		$ids        = $data_store->search_products( $term, '', (bool) $include_variations, false, $limit, $include_ids, $exclude_ids );
 
 		$product_objects = array_filter( array_map( 'wc_get_product', $ids ), 'wc_products_array_filter_readable' );
 		$products        = array();

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1585,21 +1585,18 @@ class WC_AJAX {
 	public static function json_search_downloadable_products_and_variations() {
 		check_ajax_referer( 'search-products', 'security' );
 
+		if ( ! empty( $_GET['limit'] ) ) {
+			$limit = absint( $_GET['limit'] );
+		} else {
+			$limit = absint( apply_filters( 'woocommerce_json_search_limit', 30 ) );
+		}
+
+		$include_ids = ! empty( $_GET['include'] ) ? array_map( 'absint', (array) wp_unslash( $_GET['include'] ) ) : array();
+		$exclude_ids = ! empty( $_GET['exclude'] ) ? array_map( 'absint', (array) wp_unslash( $_GET['exclude'] ) ) : array();
+
 		$term       = isset( $_GET['term'] ) ? (string) wc_clean( wp_unslash( $_GET['term'] ) ) : '';
 		$data_store = WC_Data_Store::load( 'product' );
-		$ids        = $data_store->search_products( $term, 'downloadable', true );
-
-		if ( ! empty( $_GET['exclude'] ) ) {
-			$ids = array_diff( $ids, array_map( 'absint', (array) wp_unslash( $_GET['exclude'] ) ) );
-		}
-
-		if ( ! empty( $_GET['include'] ) ) {
-			$ids = array_intersect( $ids, array_map( 'absint', (array) wp_unslash( $_GET['include'] ) ) );
-		}
-
-		if ( ! empty( $_GET['limit'] ) ) {
-			$ids = array_slice( $ids, 0, absint( $_GET['limit'] ) );
-		}
+		$ids        = $data_store->search_products( $term, 'downloadable', true, false, $limit );
 
 		$product_objects = array_filter( array_map( 'wc_get_product', $ids ), 'wc_products_array_filter_readable' );
 		$products        = array();

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1422,14 +1422,16 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	/**
 	 * Search product data for a term and return ids.
 	 *
-	 * @param  string   $term Search term.
-	 * @param  string   $type Type of product.
-	 * @param  bool     $include_variations Include variations in search or not.
-	 * @param  bool     $all_statuses Should we search all statuses or limit to published.
-	 * @param  null|int $limit Limit returned results. @since 3.5.0.
+	 * @param  string     $term Search term.
+	 * @param  string     $type Type of product.
+	 * @param  bool       $include_variations Include variations in search or not.
+	 * @param  bool       $all_statuses Should we search all statuses or limit to published.
+	 * @param  null|int   $limit Limit returned results. @since 3.5.0.
+	 * @param  null|array $include Keep specific results. @since 3.6.0.
+	 * @param  null|array $exclude Discard specific results. @since 3.6.0.
 	 * @return array of ids
 	 */
-	public function search_products( $term, $type = '', $include_variations = false, $all_statuses = false, $limit = null ) {
+	public function search_products( $term, $type = '', $include_variations = false, $all_statuses = false, $limit = null, $include = null, $exclude = null ) {
 		global $wpdb;
 
 		$custom_results = apply_filters( 'woocommerce_product_pre_search_products', false, $term, $type, $include_variations, $all_statuses, $limit );
@@ -1484,7 +1486,15 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		}
 
 		if ( ! empty( $search_queries ) ) {
-			$search_where = 'AND (' . implode( ') OR (', $search_queries ) . ')';
+			$search_where = ' AND (' . implode( ') OR (', $search_queries ) . ') ';
+		}
+
+		if ( ! empty( $include ) && is_array( $include ) ) {
+			$search_where .= ' AND posts.ID IN(' . implode( ',', array_map( 'absint', $include ) ) . ') ';
+		}
+
+		if ( ! empty( $exclude ) && is_array( $exclude ) ) {
+			$search_where .= " AND posts.ID NOT IN('" . implode( "','", array_map( 'absint', $exclude ) ) . "') ";
 		}
 
 		if ( 'virtual' === $type ) {

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1494,7 +1494,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		}
 
 		if ( ! empty( $exclude ) && is_array( $exclude ) ) {
-			$search_where .= " AND posts.ID NOT IN('" . implode( "','", array_map( 'absint', $exclude ) ) . "') ";
+			$search_where .= ' AND posts.ID NOT IN(' . implode( ',', array_map( 'absint', $exclude ) ) . ') ';
 		}
 
 		if ( 'virtual' === $type ) {

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -806,7 +806,7 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$this->assertNotContains( $product4->get_id(), $results );
 
 		$results = $data_store->search_products( 'green', '', true, true, 1 );
-		$this->assertEquals( 1, sizeof( array_diff( $results, array( 0 ) ) ) );
+		$this->assertEquals( 1, count( array_diff( $results, array( 0 ) ) ) );
 
 		$results = $data_store->search_products( 'green', '', true, true, null, array( $product3->get_id() ) );
 		$this->assertNotContains( $product->get_id(), $results );

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -804,5 +804,8 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$this->assertContains( $product2->get_id(), $results );
 		$this->assertNotContains( $product3->get_id(), $results );
 		$this->assertNotContains( $product4->get_id(), $results );
+
+		$results = $data_store->search_products( 'green', '', true, true, 1 );
+		$this->assertEquals( 1, sizeof( array_diff( $results, array( 0 ) ) ) );
 	}
 }

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -813,5 +813,11 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$this->assertNotContains( $product2->get_id(), $results );
 		$this->assertContains( $product3->get_id(), $results );
 		$this->assertNotContains( $product4->get_id(), $results );
+
+		$results = $data_store->search_products( 'green', '', true, true, null, null, array( $product3->get_id() ) );
+		$this->assertNotContains( $product->get_id(), $results );
+		$this->assertNotContains( $product2->get_id(), $results );
+		$this->assertNotContains( $product3->get_id(), $results );
+		$this->assertContains( $product4->get_id(), $results );
 	}
 }

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -807,5 +807,11 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 
 		$results = $data_store->search_products( 'green', '', true, true, 1 );
 		$this->assertEquals( 1, sizeof( array_diff( $results, array( 0 ) ) ) );
+
+		$results = $data_store->search_products( 'green', '', true, true, null, array( $product3->get_id() ) );
+		$this->assertNotContains( $product->get_id(), $results );
+		$this->assertNotContains( $product2->get_id(), $results );
+		$this->assertContains( $product3->get_id(), $results );
+		$this->assertNotContains( $product4->get_id(), $results );
 	}
 }


### PR DESCRIPTION
Closes #23245

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Introduce `include` and `exclude` parameters in `WC_Product_Data_Store_CPT::search_products`
* Use them to populate `IN` and `NOT IN` clauses.
* Pass `WC_AJAX::json_search_products` incl/excl parameters into `WC_Product_Data_Store_CPT::search_products`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: Product search may fail to return valid results when using the 'include' flag to search within a limited set.
