### PR TITLE
Avoid post update in `wc_update_product_stock`

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -43,7 +43,6 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
 		// Re-read product data after updating stock, then have stock status calculated and saved.
 		$product_with_stock = wc_get_product( $product_id_with_stock );
 		$product_with_stock->set_stock_status();
-		$product_with_stock->set_date_modified( current_time( 'timestamp', true ) );
 		$product_with_stock->save();
 
 		if ( $product_with_stock->is_type( 'variation' ) ) {
@@ -195,7 +194,7 @@ function wc_reduce_stock_levels( $order_id ) {
  *
  * @since 3.5.0
  * @param WC_Order $order order object.
- * @param array $changes Array of changes.
+ * @param array    $changes Array of changes.
  */
 function wc_trigger_stock_change_notifications( $order, $changes ) {
 	if ( empty( $changes ) ) {
@@ -216,7 +215,8 @@ function wc_trigger_stock_change_notifications( $order, $changes ) {
 
 		if ( $change['to'] < 0 ) {
 			do_action(
-				'woocommerce_product_on_backorder', array(
+				'woocommerce_product_on_backorder',
+				array(
 					'product'  => wc_get_product( $change['product']->get_id() ),
 					'order_id' => $order->get_id(),
 					'quantity' => abs( $change['from'] - $change['to'] ),
@@ -320,7 +320,7 @@ function wc_get_held_stock_quantity( $product, $exclude_order_id = 0 ) {
 /**
  * Return low stock amount to determine if notification needs to be sent
  *
- * @param  WC_Product $product
+ * @param  WC_Product $product Product to get data from.
  * @since  3.5.0
  * @return int
  */


### PR DESCRIPTION
Since only admin users can save HTML to post fields (unfiltered_html cap) if a product post object gets updated whilst a logged out user is active via `wp_update_post`, HTML is removed.

I could not find a way around this so to mitigate the issue we can just avoid setting the post_modified field. This data is updated for us anyway via data store which does a direct DB query.

Fixes #23247 <-- test instructions in there also.