### PR TITLE
CSV Import: Search for 'number' anywhere in cell, not just the end

### DIFF
--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -644,7 +644,7 @@ class WC_Product_CSV_Importer_Controller {
 		// Get index for special column names.
 		$index = $item;
 
-		if ( preg_match( '/\d+$/', $item, $matches ) ) {
+		if ( preg_match( '/\d+/', $item, $matches ) ) {
 			$index = $matches[0];
 		}
 


### PR DESCRIPTION
The importer did not correct map fields such as `option1 name` because the `1` was not the end of the string. This fixes it.

See #23239 and test CSV there. Attributes will be imported after this fix.

> * Fix - Correctly map attributes in CSV when the number is not at the end of the cell.