### PR TITLE
[3.6] Move suggestions/tracks settings to new Advanced | WooCommerce.com page.

### DIFF
--- a/includes/admin/settings/class-wc-settings-accounts.php
+++ b/includes/admin/settings/class-wc-settings-accounts.php
@@ -36,8 +36,6 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 			$erasure_text = sprintf( '<a href="%s">%s</a>', esc_url( admin_url( 'tools.php?page=remove_personal_data' ) ), $erasure_text );
 		}
 
-		$tracking_info_text = sprintf( '<a href="%s" target="_blank">%s</a>', 'https://woocommerce.com/usage-tracking', esc_html__( 'WooCommerce.com Usage Tracking Documentation', 'woocommerce' ) );
-
 		$account_settings = array(
 			array(
 				'title' => '',
@@ -232,55 +230,7 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'type' => 'sectionend',
 				'id'   => 'personal_data_retention',
 			),
-			array(
-				'title' => esc_html__( 'Usage Tracking', 'woocommerce' ),
-				'type'  => 'title',
-				'id'    => 'tracking_options',
-				'desc'  => __( 'Gathering usage data allows us to make WooCommerce better — your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense.', 'woocommerce' ),
-			),
-			array(
-				'title'         => __( 'Enable tracking', 'woocommerce' ),
-				'desc'          => __( 'Allow usage of WooCommerce to be tracked', 'woocommerce' ),
-				/* Translators: %s URL to tracking info screen. */
-				'desc_tip'      => sprintf( esc_html__( 'To opt-out, leave this box unticked. Your store remains untracked, and no data will be collected. Read about what usage data is tracked at: %s.', 'woocommerce' ), $tracking_info_text ),
-				'id'            => 'woocommerce_allow_tracking',
-				'type'          => 'checkbox',
-				'checkboxgroup' => 'start',
-				'default'       => 'no',
-				'autoload'      => false,
-			),
-			array(
-				'type' => 'sectionend',
-				'id'   => 'tracking_options',
-			),
 		);
-
-		// Only display Marketplace Suggestions opt-out if current user can actually see suggestions.
-		if ( current_user_can( 'install_plugins' ) ) {
-			$marketplace_suggestion_settings = array(
-				array(
-					'title' => esc_html__( 'Marketplace suggestions', 'woocommerce' ),
-					'type'  => 'title',
-					'id'    => 'marketplace_suggestions',
-					'desc'  => __( 'We show contextual suggestions for official extensions that may be helpful to your store.', 'woocommerce' ),
-				),
-				array(
-					'title'         => __( 'Show Suggestions', 'woocommerce' ),
-					'desc'          => __( 'Display suggestions within WooCommerce', 'woocommerce' ),
-					'desc_tip'      => esc_html__( 'Leave this box unchecked if you do not want to see suggested extensions.', 'woocommerce' ),
-					'id'            => 'woocommerce_show_marketplace_suggestions',
-					'type'          => 'checkbox',
-					'checkboxgroup' => 'start',
-					'default'       => 'yes',
-					'autoload'      => false,
-				),
-				array(
-					'type' => 'sectionend',
-					'id'   => 'marketplace_suggestions',
-				),
-			);
-			$account_settings = array_merge( $account_settings, $marketplace_suggestion_settings );
-		}
 
 		$settings = apply_filters(
 			'woocommerce_' . $this->id . '_settings',

--- a/includes/admin/settings/class-wc-settings-advanced.php
+++ b/includes/admin/settings/class-wc-settings-advanced.php
@@ -58,7 +58,8 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 
 		if ( '' === $current_section ) {
 			$settings = apply_filters(
-				'woocommerce_settings_pages', array(
+				'woocommerce_settings_pages',
+				array(
 
 					array(
 						'title' => __( 'Page setup', 'woocommerce' ),
@@ -303,7 +304,8 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 			$tracking_info_text = sprintf( '<a href="%s" target="_blank">%s</a>', 'https://woocommerce.com/usage-tracking', esc_html__( 'WooCommerce.com Usage Tracking Documentation', 'woocommerce' ) );
 
 			$settings = apply_filters(
-				'woocommerce_com_integration_settings', array(
+				'woocommerce_com_integration_settings', 
+				array(
 					array(
 						'title' => esc_html__( 'Usage Tracking', 'woocommerce' ),
 						'type'  => 'title',
@@ -349,7 +351,8 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 			);
 		} elseif ( 'legacy_api' === $current_section ) {
 			$settings = apply_filters(
-				'woocommerce_settings_rest_api', array(
+				'woocommerce_settings_rest_api',
+				array(
 					array(
 						'title' => '',
 						'type'  => 'title',

--- a/includes/admin/settings/class-wc-settings-advanced.php
+++ b/includes/admin/settings/class-wc-settings-advanced.php
@@ -304,7 +304,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 			$tracking_info_text = sprintf( '<a href="%s" target="_blank">%s</a>', 'https://woocommerce.com/usage-tracking', esc_html__( 'WooCommerce.com Usage Tracking Documentation', 'woocommerce' ) );
 
 			$settings = apply_filters(
-				'woocommerce_com_integration_settings', 
+				'woocommerce_com_integration_settings',
 				array(
 					array(
 						'title' => esc_html__( 'Usage Tracking', 'woocommerce' ),

--- a/includes/admin/settings/class-wc-settings-advanced.php
+++ b/includes/admin/settings/class-wc-settings-advanced.php
@@ -37,10 +37,11 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 	 */
 	public function get_sections() {
 		$sections = array(
-			''           => __( 'Page setup', 'woocommerce' ),
-			'keys'       => __( 'REST API', 'woocommerce' ),
-			'webhooks'   => __( 'Webhooks', 'woocommerce' ),
-			'legacy_api' => __( 'Legacy API', 'woocommerce' ),
+			''                => __( 'Page setup', 'woocommerce' ),
+			'keys'            => __( 'REST API', 'woocommerce' ),
+			'webhooks'        => __( 'Webhooks', 'woocommerce' ),
+			'legacy_api'      => __( 'Legacy API', 'woocommerce' ),
+			'woocommerce_com' => __( 'WooCommerce.com', 'woocommerce' ),
 		);
 
 		return apply_filters( 'woocommerce_get_sections_' . $this->id, $sections );
@@ -298,6 +299,54 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 			if ( wc_site_is_https() ) {
 				unset( $settings['unforce_ssl_checkout'], $settings['force_ssl_checkout'] );
 			}
+		} elseif ( 'woocommerce_com' === $current_section ) {
+			$tracking_info_text = sprintf( '<a href="%s" target="_blank">%s</a>', 'https://woocommerce.com/usage-tracking', esc_html__( 'WooCommerce.com Usage Tracking Documentation', 'woocommerce' ) );
+
+			$settings = apply_filters(
+				'woocommerce_com_integration_settings', array(
+					array(
+						'title' => esc_html__( 'Usage Tracking', 'woocommerce' ),
+						'type'  => 'title',
+						'id'    => 'tracking_options',
+						'desc'  => __( 'Gathering usage data allows us to make WooCommerce better — your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense.', 'woocommerce' ),
+					),
+					array(
+						'title'         => __( 'Enable tracking', 'woocommerce' ),
+						'desc'          => __( 'Allow usage of WooCommerce to be tracked', 'woocommerce' ),
+						/* Translators: %s URL to tracking info screen. */
+						'desc_tip'      => sprintf( esc_html__( 'To opt out, leave this box unticked. Your store remains untracked, and no data will be collected. Read about what usage data is tracked at: %s.', 'woocommerce' ), $tracking_info_text ),
+						'id'            => 'woocommerce_allow_tracking',
+						'type'          => 'checkbox',
+						'checkboxgroup' => 'start',
+						'default'       => 'no',
+						'autoload'      => false,
+					),
+					array(
+						'type' => 'sectionend',
+						'id'   => 'tracking_options',
+					),
+					array(
+						'title' => esc_html__( 'Marketplace suggestions', 'woocommerce' ),
+						'type'  => 'title',
+						'id'    => 'marketplace_suggestions',
+						'desc'  => __( 'We show contextual suggestions for official extensions that may be helpful to your store.', 'woocommerce' ),
+					),
+					array(
+						'title'         => __( 'Show Suggestions', 'woocommerce' ),
+						'desc'          => __( 'Display suggestions within WooCommerce', 'woocommerce' ),
+						'desc_tip'      => esc_html__( 'Leave this box unchecked if you do not want to see suggested extensions.', 'woocommerce' ),
+						'id'            => 'woocommerce_show_marketplace_suggestions',
+						'type'          => 'checkbox',
+						'checkboxgroup' => 'start',
+						'default'       => 'yes',
+						'autoload'      => false,
+					),
+					array(
+						'type' => 'sectionend',
+						'id'   => 'marketplace_suggestions',
+					),
+				)
+			);
 		} elseif ( 'legacy_api' === $current_section ) {
 			$settings = apply_filters(
 				'woocommerce_settings_rest_api', array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

After chatting with @mikejolley - we decided to do this PR as a follow-up to #23218

This branch moves the settings that control Usage Tracking and Marketplace Suggestions to a new tab under "Advanced" settings called "WooCommerce.com". This keeps these two settings which are fully about store-level settings and WooCommerce.com integrations in one spot, and away from other Store settings where they didn't seem as logical.

I also removed the hyphen from `opt-out` per @californiakat's request - sorry for shipping an error there Kat!

### How to test the changes in this Pull Request:

1. Visit `wp-admin/admin.php?page=wc-settings&tab=account`, verify Usage Tracking & Suggestions options are no longer shown.
2. Visit `wp-admin/admin.php?page=wc-settings&tab=advanced`, note the new "WooCommerce.com" sub tab, select that, verify the Usage Tracking & Suggestion options are shown.
3. Enable both options ( check them on )
4. Visit a product add page, verify you see the "Get More Options" tab, and check your network traffic to verify that usage was recorded via t.gif:

![tracking-enabled](https://user-images.githubusercontent.com/22080/55818669-ff430300-5aab-11e9-822a-86fbf44bde90.png)

5. Revisit the WooCommerce.com settings, disable usage tracking.
6. Reload the add product page, verify no usage tracks were recorded ( no t.gif )
7. Revisit the WooCommerce.com settings page, disable suggestions
8. Reload the add product page, verify no suggestions are shown

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
