### PR TITLE
Fix order parent property in REST item schema and formatted item data

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -82,6 +82,9 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 			if ( ! is_null( $value ) ) {
 				switch ( $key ) {
+					case 'parent':
+						$order->set_parent_id( $value );
+						break;
 					case 'coupon_lines':
 					case 'status':
 						// Change should be done later so transitions have new data.

--- a/includes/api/v2/class-wc-rest-orders-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-orders-v2-controller.php
@@ -245,7 +245,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 
 		return array(
 			'id'                   => $object->get_id(),
-			'parent_id'            => $data['parent_id'],
+			'parent'               => $data['parent_id'],
 			'number'               => $data['number'],
 			'order_key'            => $data['order_key'],
 			'created_via'          => $data['created_via'],
@@ -846,7 +846,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_Legacy_Orders_Controller {
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'parent_id'            => array(
+				'parent'               => array(
 					'description' => __( 'Parent order ID.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

At present `WC_REST_Orders_V2_Controller::get_item_schema` contains `parent_id` in REST item schema property which is incompatible when we try to create an order. According to `WC_REST_CRUD_Controller::prepare_objects_query` we need to pass `parent` instead of `parent_id`. Similar change in this PR inside  `WC_REST_Orders_V2_Controller::get_formatted_item_data` method to match the argument schema defined in `WC_REST_CRUD_Controller::get_collection_params` method. So in a word, we should use `parent` instead of `parent_id` since WC defined the schema in `WC_REST_CRUD_Controller` as `parent` not `parent_id`.

Also, take a look at the `/wp/v2/pages` schema. It uses `parent` not `parent_id`.

### How to test the changes in this Pull Request:

Though for basic purpose parent id is irrelevant in WC order. But for testing purpose if you try to create an order having `parent_id`, it will not use this property data.

Multivendor plugins for WooCommerce like Dokan stores parent order id in a child sub-order object.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix order parent property in REST item schema and formatted item data
