### PR TITLE
CSV Import - check if sku or id column exists when updating products from csv

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -976,7 +976,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				continue;
 			}
 
-			if ( $update_existing && ( $id || $sku ) && ! $id_exists && ! $sku_exists ) {
+			if ( $update_existing && ( isset( $parsed_data['id'] ) || isset( $parsed_data['sku'] ) ) && ! $id_exists && ! $sku_exists ) {
 				$data['skipped'][] = new WP_Error(
 					'woocommerce_product_importer_error',
 					esc_html__( 'No matching product exists to update.', 'woocommerce' ),

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -112,6 +112,36 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test import should update product price and skip products with empty SKU
+	 * (see https://github.com/woocommerce/woocommerce/issues/23257).
+	 */
+	public function test_import_should_update_product() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_price( 15 );
+		$product->set_sku( 'wp-pennant' );
+		$product->save();
+
+		$args = array(
+			'mapping'         => $this->get_csv_mapped_items(),
+			'parse'           => true,
+			'update_existing' => true,
+		);
+
+		$csv_file = dirname( __FILE__ ) . '/sample_update_product.csv';
+
+		$importer = new WC_Product_CSV_Importer( $csv_file, $args );
+		$results  = $importer->import();
+
+		$this->assertEquals( 0, count( $results['imported'] ) );
+		$this->assertEquals( 0, count( $results['failed'] ) );
+		$this->assertEquals( 1, count( $results['updated'] ) );
+		$this->assertEquals( 2, count( $results['skipped'] ) );
+
+		$updated_product = wc_get_product( $product->get_id() );
+		$this->assertEquals( 20, $updated_product->get_price() );
+	}
+
+	/**
 	 * Test importing file located on another location on server.
 	 *
 	 * @return void

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -1,8 +1,12 @@
 <?php
+/**
+ * Class WC_Product_CSV_Importer unit tests.
+ *
+ * @package WooCommerce\Tests\Importer
+ */
 
 /**
- * Meta
- * @package WooCommerce\Tests\Importer
+ * Test class for WC_Product_CSV_Importer.
  */
 class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 
@@ -599,7 +603,7 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	 *
 	 * This function is called by WP_HTTP_TestCase::http_request_listner().
 	 *
-	 * @param array $request Request arguments.
+	 * @param array  $request Request arguments.
 	 * @param string $url URL of the request.
 	 *
 	 * @return array|false mocked response or false to let WP perform a regular request.

--- a/tests/unit-tests/importer/sample_update_product.csv
+++ b/tests/unit-tests/importer/sample_update_product.csv
@@ -1,0 +1,4 @@
+Name,SKU,Regular price
+WordPress Pennant,wp-pennant,20
+0,,something invalid
+0,,something invalid


### PR DESCRIPTION
When the CSV importer updates products, if the SKU or ID is defined and no matches exist the row is skipped ✅

If there is no SKU or ID it does an import instead ✅

However, if the SKU is left blank it imports and assumes SKU was defined.

This PR makes it check if the column was set/exists rather than basing this on the value.

Test with this CSV: 
[23257.csv.zip](https://github.com/woocommerce/woocommerce/files/3063230/23257.csv.zip)

It should skip 2 products which have no SKU match.

> Fix - CSV Importer - Skip rows during update if a SKU column exists, but the value is empty.