### PR TITLE
Switch to subquery for sale product query

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -864,19 +864,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$outofstock_where = ' AND exclude_join.object_id IS NULL';
 		}
 
-		// Fetch a list of non-published parent products and exlude them, quicker than joining in the main query below.
-		$non_published_products = $wpdb->get_col(
-			"
-			SELECT posts.ID as id FROM `$wpdb->posts` AS posts
-			WHERE posts.post_type = 'product'
-			AND posts.post_parent = 0
-			AND posts.post_status != 'publish'
-			"
-		);
-		if ( 0 < count( $non_published_products ) ) {
-			$non_published_where = ' AND posts.post_parent NOT IN ( ' . implode( ',', $non_published_products ) . ')';
-		}
-
 		return $wpdb->get_results(
 			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 			"
@@ -888,7 +875,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			AND posts.post_status = 'publish'
 			AND lookup.onsale = 1
 			$outofstock_where
-			$non_published_where
+			AND posts.post_parent NOT IN (
+				SELECT ID FROM `$wpdb->posts`
+				WHERE posts.post_type = 'product'
+				AND posts.post_parent = 0
+				AND posts.post_status != 'publish'
+			)
 			GROUP BY posts.ID
 			"
 			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -876,7 +876,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			AND lookup.onsale = 1
 			$outofstock_where
 			AND posts.post_parent NOT IN (
-				SELECT ID FROM `$wpdb->posts`
+				SELECT ID FROM `$wpdb->posts` as posts
 				WHERE posts.post_type = 'product'
 				AND posts.post_parent = 0
 				AND posts.post_status != 'publish'

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -562,12 +562,14 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	 * @expectedIncorrectUsage wc_get_template
 	 */
 	public function test_wc_get_template_invalid_action_args() {
+		ob_start();
 		wc_get_template(
 			'global/wrapper-start.php',
 			array(
 				'action_args' => 'this is bad',
 			)
 		);
+		$template = ob_get_clean();
 	}
 
 	/**


### PR DESCRIPTION
Prevents really really long queries on stores with lots of non-published products.

To test, you can run this in CLI:

```
wp profile eval "WC_Data_Store::load('product')->get_on_sale_products();"
```

Or check results with:

```
wp eval "var_dump(WC_Data_Store::load('product')->get_on_sale_products());"
```