### PR TITLE
Added validation for Italian postcodes

### DIFF
--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -64,6 +64,7 @@ class WC_Validation {
 				break;
 			case 'ES':
 			case 'FR':
+			case 'IT':
 				$valid = (bool) preg_match( '/^([0-9]{5})$/i', $postcode );
 				break;
 			case 'GB':

--- a/tests/unit-tests/util/validation.php
+++ b/tests/unit-tests/util/validation.php
@@ -1,8 +1,12 @@
 <?php
+/**
+ * Unit tests for validation.
+ *
+ * @package WooCommerce\Tests\Util
+ */
 
 /**
- * Class Validation.
- * @package WooCommerce\Tests\Util
+ * Class WC_Tests_Validation.
  * @since 2.3
  */
 class WC_Tests_Validation extends WC_Unit_Test_Case {
@@ -34,6 +38,9 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 
 	/**
 	 * Test is_phone().
+	 *
+	 * @param mixed $assert
+	 * @param mixed $values
 	 *
 	 * @dataProvider data_provider_test_is_phone
 	 * @since 2.3
@@ -97,6 +104,9 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 	/**
 	 * Test is_postcode().
 	 *
+	 * @param mixed $assert
+	 * @param mixed $values
+	 *
 	 * @dataProvider data_provider_test_is_postcode
 	 * @since 2.4
 	 */
@@ -128,6 +138,9 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 	/**
 	 * Test is_gb_postcode().
 	 *
+	 * @param mixed $assert
+	 * @param mixed $values
+	 *
 	 * @dataProvider data_provider_test_is_gb_postcode
 	 * @since 2.4
 	 */
@@ -153,6 +166,9 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 
 	/**
 	 * Test format_postcode().
+	 *
+	 * @param mixed $assert
+	 * @param mixed $values
 	 *
 	 * @dataProvider data_provider_test_format_postcode
 	 * @since 2.4

--- a/tests/unit-tests/util/validation.php
+++ b/tests/unit-tests/util/validation.php
@@ -48,12 +48,11 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 	 * @since 2.4
 	 */
 	public function data_provider_test_is_postcode() {
-		$generic = array(
+		$it = array(
 			array( true, WC_Validation::is_postcode( '99999', 'IT' ) ),
-			array( true, WC_Validation::is_postcode( '99999', 'IT' ) ),
-			array( true, WC_Validation::is_postcode( '9999', 'IT' ) ),
-			array( true, WC_Validation::is_postcode( 'ABC 999', 'IT' ) ),
-			array( true, WC_Validation::is_postcode( 'ABC-999', 'IT' ) ),
+			array( false, WC_Validation::is_postcode( '9999', 'IT' ) ),
+			array( false, WC_Validation::is_postcode( 'ABC 999', 'IT' ) ),
+			array( false, WC_Validation::is_postcode( 'ABC-999', 'IT' ) ),
 			array( false, WC_Validation::is_postcode( 'ABC_123', 'IT' ) ),
 		);
 
@@ -92,7 +91,7 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 			array( false, WC_Validation::is_postcode( '0A0A0A', 'CA' ) ),
 		);
 
-		return array_merge( $generic, $gb, $us, $ch, $br, $ca );
+		return array_merge( $it, $gb, $us, $ch, $br, $ca );
 	}
 
 	/**

--- a/tests/unit-tests/util/validation.php
+++ b/tests/unit-tests/util/validation.php
@@ -39,8 +39,8 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 	/**
 	 * Test is_phone().
 	 *
-	 * @param mixed $assert
-	 * @param mixed $values
+	 * @param mixed $assert Expected value.
+	 * @param mixed $values Actual value.
 	 *
 	 * @dataProvider data_provider_test_is_phone
 	 * @since 2.3
@@ -104,8 +104,8 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 	/**
 	 * Test is_postcode().
 	 *
-	 * @param mixed $assert
-	 * @param mixed $values
+	 * @param mixed $assert Expected value.
+	 * @param mixed $values Actual value.
 	 *
 	 * @dataProvider data_provider_test_is_postcode
 	 * @since 2.4
@@ -138,8 +138,8 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 	/**
 	 * Test is_gb_postcode().
 	 *
-	 * @param mixed $assert
-	 * @param mixed $values
+	 * @param mixed $assert Expected value.
+	 * @param mixed $values Actual value.
 	 *
 	 * @dataProvider data_provider_test_is_gb_postcode
 	 * @since 2.4
@@ -167,8 +167,8 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 	/**
 	 * Test format_postcode().
 	 *
-	 * @param mixed $assert
-	 * @param mixed $values
+	 * @param mixed $assert Expected value.
+	 * @param mixed $values Actual value.
 	 *
 	 * @dataProvider data_provider_test_format_postcode
 	 * @since 2.4


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Similarly to what was done in #22316 for Dutch postcodes, this Pull request aims to provide validation for Italian postcodes. The format (5 digits) is exactly the same which is already in place for France and Spain, so it was sufficient to simply add a new case.

### How to test the changes in this Pull Request:

1. During checkout select Italy as country
2. The validation should ensure that the postcode is a string consisting of exactly 5 digits (it may include leading 0s) and not an arbitrary string

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Added validation for Italian postcodes
