### PR TITLE
Bug - Fix for network orders widget when WooCommerce is network active.

### DIFF
--- a/includes/api/v2/class-wc-rest-network-orders-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-network-orders-v2-controller.php
@@ -119,8 +119,11 @@ class WC_REST_Network_Orders_V2_Controller extends WC_REST_Orders_V2_Controller 
 		$blog_id = $request->get_param( 'blog_id' );
 		$blog_id = ! empty( $blog_id ) ? $blog_id : get_current_blog_id();
 		$active_plugins = get_blog_option( $blog_id, 'active_plugins', array() );
+		$network_active_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );
+
+		$plugins = array_merge( $active_plugins, $network_active_plugins );
 		$wc_active = false;
-		foreach ( $active_plugins as $plugin ) {
+		foreach ( $plugins as $plugin ) {
 			if ( substr_compare( $plugin, '/woocommerce.php', strlen( $plugin ) - strlen( '/woocommerce.php' ), strlen( '/woocommerce.php' ) ) === 0 ) {
 				$wc_active = true;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Network orders makes most sense when WooCommerce is installed as a
network wide plugin. This change fixes the widget when it is network
active.

Closes #23215

### How to test the changes in this Pull Request:

1. Install WooCommerce as a network plugin
2. Create orders across multiple sites
3. Before: Network orders widget would remain empty
4. After: Network orders now contains orders across the network

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Fix - Network orders widget not showing orders when installed as a network plugin.
