### PR TITLE
Check `get_plugin_data` exists in `WC_REST_System_Status_V2_Controller`

### DIFF
--- a/includes/api/v2/class-wc-rest-system-status-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-v2-controller.php
@@ -801,6 +801,12 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 	 * @return array
 	 */
 	public function get_active_plugins() {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+
+		if ( ! function_exists( 'get_plugin_data' ) ) {
+			return array();
+		}
+
 		$active_plugins = (array) get_option( 'active_plugins', array() );
 		if ( is_multisite() ) {
 			$network_activated_plugins = array_keys( get_site_option( 'active_sitewide_plugins', array() ) );


### PR DESCRIPTION
Fixes #23291

The `/wp-json/wc/v2/system_status` endpoint threw an error because `get_plugin_data` is not included. It's part of `wp-admin/includes/plugin.php`.

To test, simply call `/wp-json/wc/v2/system_status` endpoint and check results are returned in your client.