### PR TITLE
Remove tags from product titles when building PayPal request URL

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -492,7 +492,7 @@ class WC_Gateway_Paypal_Request {
 		$item = apply_filters(
 			'woocommerce_paypal_line_item',
 			array(
-				'item_name'   => html_entity_decode( wc_trim_string( $item_name ? $item_name : __( 'Item', 'woocommerce' ), 127 ), ENT_NOQUOTES, 'UTF-8' ),
+				'item_name'   => html_entity_decode( wc_trim_string( $item_name ? wp_strip_all_tags( $item_name ) : __( 'Item', 'woocommerce' ), 127 ), ENT_NOQUOTES, 'UTF-8' ),
 				'quantity'    => (int) $quantity,
 				'amount'      => wc_float_to_string( (float) $amount ),
 				'item_number' => $item_number,

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -397,6 +397,7 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 			// Many items in order -> forced to use one line item -> shipping tax included.
             $this->check_large_order( true, $testmode );
             
+            // Test removing tags from line item name
             $this->check_product_title_containing_html( $testmode );
 
 			// Test amount < 0.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Strip HTML tags from product title when building request URL

Closes #23296 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Applies `wp_strip_all_tags()` to the line item name when building PayPal request URL
