### PR TITLE
#23232 Moved accessibility labels for checkout after woocommerce_checkout_fi…

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -267,6 +267,14 @@ class WC_Checkout {
 		foreach ( $this->fields as $field_type => $fields ) {
 			// Sort each of the checkout field sections based on priority.
 			uasort( $this->fields[ $field_type ], 'wc_checkout_fields_uasort_comparison' );
+            
+            //add accessibility labels to fields that have placeholders
+            foreach ( $fields as $single_field_type => $field) {
+                if ( empty( $field[ 'label' ] ) && !empty( $field[ 'placeholder' ] )) {
+                    $this->fields[ $field_type ][ $single_field_type ][ 'label' ]       = $field[ 'placeholder' ];
+                    $this->fields[ $field_type ][ $single_field_type ][ 'label_class' ] = 'screen-reader-text';
+                }
+            }
 		}
 
 		return $fieldset ? $this->fields[ $fieldset ] : $this->fields;

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -664,8 +664,6 @@ class WC_Countries {
 				'priority'     => 50,
 			),
 			'address_2'  => array(
-				'label'        => __( 'Apartment, suite, unit etc.', 'woocommerce' ),
-				'label_class'  => array( 'screen-reader-text' ),
 				'placeholder'  => esc_attr( $address_2_placeholder ),
 				'class'        => array( 'form-row-wide', 'address-field' ),
 				'autocomplete' => 'address-line2',


### PR DESCRIPTION
…elds filter

### All Submissions:

* [ X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23232 .

### How to test the changes in this Pull Request:

1. Go to checkout
2. Without using a screen reader - view source and check whether the fields without a label have extra hidden label for accessibility purposes (e.g. Address2 field)
3. With a screen reader - read all fields on checkout - Address2 field should be read

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ X ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
