### PR TITLE
[3.6] Blocker - remove total revenue from Tracks events.

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -66,7 +66,6 @@ class WC_Site_Tracking {
 				var eventProperties = properties || {};
 				eventProperties.url = '<?php echo esc_html( home_url() ); ?>'
 				eventProperties.products_count = '<?php echo intval( WC_Tracks::get_products_count() ); ?>';
-				eventProperties.orders_gross = '<?php echo floatval( WC_Tracks::get_total_revenue() ); ?>';
 				window._tkq = window._tkq || [];
 				window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
 			}

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -16,45 +16,6 @@ class WC_Tracks {
 	const PREFIX = 'wcadmin_';
 
 	/**
-	 * Option name for total store revenue.
-	 */
-	const REVENUE_CACHE_OPTION = 'woocommerce_tracker_orders_totals';
-
-	/**
-	 * Initialize necessary hooks.
-	 */
-	public static function init() {
-		add_action( 'woocommerce_new_order', array( __CLASS__, 'update_revenue_cache' ) );
-		add_action( 'woocommerce_update_order', array( __CLASS__, 'update_revenue_cache' ) );
-		add_action( 'woocommerce_delete_order', array( __CLASS__, 'update_revenue_cache' ) );
-		add_action( 'woocommerce_order_refunded', array( __CLASS__, 'update_revenue_cache' ) );
-	}
-
-	/**
-	 * Recalculate store gross revenue and update cache.
-	 */
-	public static function update_revenue_cache() {
-		update_option( self::REVENUE_CACHE_OPTION, WC_Tracker::get_order_totals() );
-	}
-
-	/**
-	 * Get the (cached) store gross revenue total.
-	 *
-	 * @return null|string Store gross revenue, or null if cache error.
-	 */
-	public static function get_total_revenue() {
-		$total_revenue = get_option( self::REVENUE_CACHE_OPTION, false );
-
-		if ( false === $total_revenue ) {
-			$total_revenue = WC_Tracker::get_order_totals();
-
-			update_option( self::REVENUE_CACHE_OPTION, $total_revenue );
-		}
-
-		return empty( $total_revenue['gross'] ) ? null : $total_revenue['gross'];
-	}
-
-	/**
 	 * Get total product counts.
 	 *
 	 * @return int Number of products.
@@ -78,7 +39,6 @@ class WC_Tracks {
 				'blog_lang'      => get_user_locale( $user_id ),
 				'blog_id'        => ( class_exists( 'Jetpack' ) && Jetpack_Options::get_option( 'id' ) ) || null,
 				'products_count' => self::get_products_count(),
-				'orders_gross'   => self::get_total_revenue(),
 			);
 			set_transient( 'wc_tracks_blog_details', $blog_details, DAY_IN_SECONDS );
 		}
@@ -149,5 +109,3 @@ class WC_Tracks {
 		return $event_obj->record();
 	}
 }
-
-WC_Tracks::init();


### PR DESCRIPTION
Query to calculate is far too expensive and doesn’t seem to ever get cached with large datasets.

Props @kovshenin for bug discovery.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Removes the `orders_gross` property from Tracks events and the associated hooks to update the cached value when orders are processed. The calculation is just too expensive on large stores and delays order processing. We do not want to impact sales.

### How to test the changes in this Pull Request:

1. Verify that Tracks events no longer have the `orders_gross` property
2. Verify that no PHP warnings or errors occur when creating or updating Orders

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->