### PR TITLE
[3.6] Fix logic in link all variations

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -728,7 +728,7 @@ class WC_AJAX {
 			wp_die( -1 );
 		}
 
-		wc_maybe_define_constant( 'WC_MAX_LINKED_VARIATIONS', 49 );
+		wc_maybe_define_constant( 'WC_MAX_LINKED_VARIATIONS', 50 );
 		wc_set_time_limit( 0 );
 
 		$post_id = isset( $_POST['post_id'] ) ? intval( $_POST['post_id'] ) : 0;
@@ -738,39 +738,14 @@ class WC_AJAX {
 		}
 
 		$product    = wc_get_product( $post_id );
-		$attributes = wc_list_pluck( array_filter( $product->get_attributes(), 'wc_attributes_array_filter_variation' ), 'get_slugs' );
+		$data_store = $product->get_data_store();
 
-		if ( ! empty( $attributes ) ) {
-			// Get existing variations so we don't create duplicates.
-			$existing_variations = array_map( 'wc_get_product', $product->get_children() );
-			$existing_attributes = array();
-
-			foreach ( $existing_variations as $existing_variation ) {
-				$existing_attributes[] = $existing_variation->get_attributes();
-			}
-
-			$added               = 0;
-			$possible_attributes = array_reverse( wc_array_cartesian( $attributes ) );
-
-			foreach ( $possible_attributes as $possible_attribute ) {
-				if ( in_array( $possible_attribute, $existing_attributes, true ) ) {
-					continue;
-				}
-				$variation = new WC_Product_Variation();
-				$variation->set_parent_id( $post_id );
-				$variation->set_attributes( $possible_attribute );
-
-				do_action( 'product_variation_linked', $variation->save() );
-
-				if ( ( $added ++ ) > WC_MAX_LINKED_VARIATIONS ) {
-					break;
-				}
-			}
-
-			echo esc_html( $added );
+		if ( ! is_callable( array( $data_store, 'create_all_product_variations' ) ) ) {
+			wp_die();
 		}
 
-		$data_store = $product->get_data_store();
+		echo esc_html( $data_store->create_all_product_variations( $product, WC_MAX_LINKED_VARIATIONS ) );
+
 		$data_store->sort_all_product_variations( $product->get_id() );
 		wp_die();
 	}

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1134,6 +1134,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * Creates all possible combinations of variations from the attributes, without creating duplicates.
 	 *
 	 * @since  3.6.0
+	 * @todo   Add to interface in 4.0.
 	 * @param  WC_Product $product Variable product.
 	 * @param  int        $limit Limit the number of created variations.
 	 * @return int        Number of created variations.
@@ -1162,7 +1163,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$possible_attributes = array_reverse( wc_array_cartesian( $attributes ) );
 
 		foreach ( $possible_attributes as $possible_attribute ) {
-			if ( in_array( $possible_attribute, $existing_attributes, true ) ) {
+			// Allow any order if key/values -- do not use strict mode.
+			if ( in_array( $possible_attribute, $existing_attributes ) ) { // phpcs:ignore WordPress.PHP.StrictInArray.MissingTrueStrict
 				continue;
 			}
 			$variation = new WC_Product_Variation();

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -805,4 +805,94 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		$this->assertNotContains( $product3->get_id(), $results );
 		$this->assertNotContains( $product4->get_id(), $results );
 	}
+
+	/**
+	 * Test WC_Product_Data_Store_CPT::create_all_product_variations
+	 */
+	public function test_variable_create_all_product_variations() {
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Test Variable Product' );
+
+		$attribute_1 = new WC_Product_Attribute();
+		$attribute_1->set_name( 'color' );
+		$attribute_1->set_visible( true );
+		$attribute_1->set_variation( true );
+		$attribute_1->set_options( array( 'red', 'green', 'blue' ) );
+
+		$attribute_2 = new WC_Product_Attribute();
+		$attribute_2->set_name( 'size' );
+		$attribute_2->set_visible( true );
+		$attribute_2->set_variation( true );
+		$attribute_2->set_options( array( 'small', 'medium', 'large' ) );
+
+		$attribute_3 = new WC_Product_Attribute();
+		$attribute_3->set_name( 'pattern' );
+		$attribute_3->set_visible( true );
+		$attribute_3->set_variation( true );
+		$attribute_3->set_options( array( 'striped', 'polka-dot', 'plain' ) );
+
+		$attributes = array(
+			$attribute_1,
+			$attribute_2,
+			$attribute_3,
+		);
+
+		$product->set_attributes( $attributes );
+		$product_id = $product->save();
+
+		// Test all variations get linked.
+		$data_store = WC_Data_Store::load( 'product' );
+		$count      = $data_store->create_all_product_variations( wc_get_product( $product_id ) );
+		$this->assertEquals( 27, $count );
+
+		// Test duplicates are not created.
+		$count = $data_store->create_all_product_variations( wc_get_product( $product_id ) );
+		$this->assertEquals( 0, $count );
+	}
+
+	/**
+	 * Test WC_Product_Data_Store_CPT::create_all_product_variations
+	 */
+	public function test_variable_create_all_product_variations_limits() {
+		$product = new WC_Product_Variable();
+		$product->set_name( 'Test Variable Product' );
+
+		$attribute_1 = new WC_Product_Attribute();
+		$attribute_1->set_name( 'color' );
+		$attribute_1->set_visible( true );
+		$attribute_1->set_variation( true );
+		$attribute_1->set_options( array( 'red', 'green', 'blue' ) );
+
+		$attribute_2 = new WC_Product_Attribute();
+		$attribute_2->set_name( 'size' );
+		$attribute_2->set_visible( true );
+		$attribute_2->set_variation( true );
+		$attribute_2->set_options( array( 'small', 'medium', 'large' ) );
+
+		$attribute_3 = new WC_Product_Attribute();
+		$attribute_3->set_name( 'pattern' );
+		$attribute_3->set_visible( true );
+		$attribute_3->set_variation( true );
+		$attribute_3->set_options( array( 'striped', 'polka-dot', 'plain' ) );
+
+		$attributes = array(
+			$attribute_1,
+			$attribute_2,
+			$attribute_3,
+		);
+
+		$product->set_attributes( $attributes );
+		$product_id = $product->save();
+
+		// Test creation with a limit of 10.
+		$data_store = WC_Data_Store::load( 'product' );
+		$count      = $data_store->create_all_product_variations( wc_get_product( $product_id ), 10 );
+		$this->assertEquals( 10, $count );
+
+		$count = $data_store->create_all_product_variations( wc_get_product( $product_id ), 10 );
+		$this->assertEquals( 10, $count );
+
+		$count = $data_store->create_all_product_variations( wc_get_product( $product_id ), 10 );
+		$this->assertEquals( 7, $count );
+	}
 }


### PR DESCRIPTION
Some phpcs changes in 3.6 caused link_all_variations to create duplicates. It seems PHP strict mode for in_array checks the order of elements.

To fix this I wrote some tests first to identify the problem, had to move some code to new data-store methods to make it testable, then applied the fix.

To test this manually, create a variable and use the 'create all variations from attributes' function. Then repeat to ensure it does not create duplicates.

This now has test coverage anyhow.

cc @Braintelligence @timmyc 