### PR TITLE
Update Action Scheduler library to 2.2.4

### DIFF
--- a/action-scheduler.php
+++ b/action-scheduler.php
@@ -5,7 +5,7 @@
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Prospress
  * Author URI: http://prospress.com/
- * Version: 2.2.3
+ * Version: 2.2.4
  * License: GPLv3
  *
  * Copyright 2019 Prospress, Inc.  (email : freedoms@prospress.com)
@@ -25,21 +25,21 @@
  *
  */
 
-if ( ! function_exists( 'action_scheduler_register_2_dot_2_dot_3' ) ) {
+if ( ! function_exists( 'action_scheduler_register_2_dot_2_dot_4' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_2_dot_3', 0, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_2_dot_4', 0, 0 );
 
-	function action_scheduler_register_2_dot_2_dot_3() {
+	function action_scheduler_register_2_dot_2_dot_4() {
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '2.2.3', 'action_scheduler_initialize_2_dot_2_dot_3' );
+		$versions->register( '2.2.4', 'action_scheduler_initialize_2_dot_2_dot_4' );
 	}
 
-	function action_scheduler_initialize_2_dot_2_dot_3() {
+	function action_scheduler_initialize_2_dot_2_dot_4() {
 		require_once( 'classes/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}

--- a/classes/ActionScheduler_AdminView.php
+++ b/classes/ActionScheduler_AdminView.php
@@ -40,7 +40,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 
 	public function system_status_report() {
 		$table = new ActionScheduler_wcSystemStatus( ActionScheduler::store() );
-		$table->print();
+		$table->render();
 	}
 
 	/**

--- a/classes/ActionScheduler_wcSystemStatus.php
+++ b/classes/ActionScheduler_wcSystemStatus.php
@@ -21,7 +21,7 @@ class ActionScheduler_wcSystemStatus {
 	 *
 	 * Helpful to identify issues, like a clogged queue.
 	 */
-	public function print() {
+	public function render() {
 		$action_counts     = $this->store->action_counts();
 		$status_labels     = $this->store->get_status_labels();
 		$oldest_and_newest = $this->get_oldest_and_newest( array_keys( $status_labels ) );
@@ -126,4 +126,22 @@ class ActionScheduler_wcSystemStatus {
 		<?php
 	}
 
+	/**
+	 * is triggered when invoking inaccessible methods in an object context.
+	 *
+	 * @param $name      string
+	 * @param $arguments array
+	 *
+	 * @return mixed
+	 * @link https://php.net/manual/en/language.oop5.overloading.php#language.oop5.overloading.methods
+	 */
+	public function __call( $name, $arguments ) {
+		switch ( $name ) {
+			case 'print':
+				_deprecated_function( __CLASS__ . '::print()', '2.2.4', __CLASS__ . '::render()' );
+				return call_user_func_array( array( $this, 'render' ), $arguments );
+		}
+
+		return null;
+	}
 }

--- a/license.txt
+++ b/license.txt
@@ -1,7 +1,7 @@
                     GNU GENERAL PUBLIC LICENSE
                        Version 3, 29 June 2007
 
- Copyright (C) 2007 Free Software Foundation, Inc. <http://fsf.org/>
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
  Everyone is permitted to copy and distribute verbatim copies
  of this license document, but changing it is not allowed.
 
@@ -645,7 +645,7 @@ the "copyright" line and a pointer to where the full notice is found.
     GNU General Public License for more details.
 
     You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
 
 Also add information on how to contact you by electronic and paper mail.
 
@@ -664,11 +664,11 @@ might be different; for a GUI interface, you would use an "about box".
   You should also get your employer (if you work as a programmer) or school,
 if any, to sign a "copyright disclaimer" for the program, if necessary.
 For more information on this, and how to apply and follow the GNU GPL, see
-<http://www.gnu.org/licenses/>.
+<https://www.gnu.org/licenses/>.
 
   The GNU General Public License does not permit incorporating your program
 into proprietary programs.  If your program is a subroutine library, you
 may consider it more useful to permit linking proprietary applications with
 the library.  If this is what you want to do, use the GNU Lesser General
 Public License instead of this License.  But first, please read
-<http://www.gnu.org/philosophy/why-not-lgpl.html>.
+<https://www.gnu.org/licenses/why-not-lgpl.html>.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Updates the Action Scheduler library to `2.2.4`.

Closes #23305.

### How to test the changes in this Pull Request:

1. Use PHP < 7.0
1. In the admin area, go to WooCommerce > Status
1. Scroll down to the bottom of the page
1. The Action Scheduler section should be visible, with no error message.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Dev: Update Action Scheduler library to `2.2.4`