### PR TITLE
Stop using update_woocommerce_term_meta on class-wc-rest-product-categories-controller.php

### DIFF
--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -223,11 +223,11 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 		$id = (int) $term->term_id;
 
 		if ( isset( $request['display'] ) ) {
-			update_woocommerce_term_meta( $id, 'display_type', 'default' === $request['display'] ? '' : $request['display'] );
+			update_term_meta( $id, 'display_type', 'default' === $request['display'] ? '' : $request['display'] );
 		}
 
 		if ( isset( $request['menu_order'] ) ) {
-			update_woocommerce_term_meta( $id, 'order', $request['menu_order'] );
+			update_term_meta( $id, 'order', $request['menu_order'] );
 		}
 
 		if ( isset( $request['image'] ) ) {
@@ -245,7 +245,7 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 
 			// Check if image_id is a valid image attachment before updating the term meta.
 			if ( $image_id && wp_attachment_is_image( $image_id ) ) {
-				update_woocommerce_term_meta( $id, 'thumbnail_id', $image_id );
+				update_term_meta( $id, 'thumbnail_id', $image_id );
 
 				// Set the image alt.
 				if ( ! empty( $request['image']['alt'] ) ) {


### PR DESCRIPTION
Stop using the update_woocommerce_term_meta helper function on includes/api/class-wc-rest-product-categories-controller.php as it has been deprecated on 3.6.0

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Replace `update_woocommerce_term_meta` with `update_term_meta`

Closes #23307 
