### PR TITLE
Replace call to deprecated function delete_woocommerce_term_meta()

### DIFF
--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -262,7 +262,7 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 					);
 				}
 			} else {
-				delete_woocommerce_term_meta( $id, 'thumbnail_id' );
+				delete_term_meta( $id, 'thumbnail_id' );
 			}
 		}
 

--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -223,11 +223,11 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 		$id = (int) $term->term_id;
 
 		if ( isset( $request['display'] ) ) {
-			update_woocommerce_term_meta( $id, 'display_type', 'default' === $request['display'] ? '' : $request['display'] );
+			update_term_meta( $id, 'display_type', 'default' === $request['display'] ? '' : $request['display'] );
 		}
 
 		if ( isset( $request['menu_order'] ) ) {
-			update_woocommerce_term_meta( $id, 'order', $request['menu_order'] );
+			update_term_meta( $id, 'order', $request['menu_order'] );
 		}
 
 		if ( isset( $request['image'] ) ) {
@@ -245,7 +245,7 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 
 			// Check if image_id is a valid image attachment before updating the term meta.
 			if ( $image_id && wp_attachment_is_image( $image_id ) ) {
-				update_woocommerce_term_meta( $id, 'thumbnail_id', $image_id );
+				update_term_meta( $id, 'thumbnail_id', $image_id );
 
 				// Set the image alt.
 				if ( ! empty( $request['image']['alt'] ) ) {


### PR DESCRIPTION
This commit replaces a call to deprecated function `delete_woocommerce_term_meta()` with its replacement `delete_term_meta()`. `delete_woocommerce_term_meta()` was deprecated by https://github.com/woocommerce/woocommerce/commit/32ae0192e5a100a598f9358a283212bb572ebc82 and all calls removed, but PR #22553 that was created about the same time added a new call to this function.

Related to #23308