### PR TITLE
[REST API] Stop orders being created if invalid data is sent

### DIFF
--- a/includes/api/class-wc-rest-orders-controller.php
+++ b/includes/api/class-wc-rest-orders-controller.php
@@ -144,6 +144,8 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	 * @return WC_Data|WP_Error
 	 */
 	protected function save_object( $request, $creating = false ) {
+		$object = null;
+
 		try {
 			$object = $this->prepare_object_for_database( $request, $creating );
 
@@ -196,10 +198,27 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 			return $this->get_object( $object->get_id() );
 		} catch ( WC_Data_Exception $e ) {
+			$this->purge( $object, $creating );
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), $e->getErrorData() );
 		} catch ( WC_REST_Exception $e ) {
+			$this->purge( $object, $creating );
 			return new WP_Error( $e->getErrorCode(), $e->getMessage(), array( 'status' => $e->getCode() ) );
 		}
+	}
+
+	/**
+	 * Purge object when creating.
+	 *
+	 * @param WC_Data $object  Object data.
+	 * @param bool    $creating If is creating a new object.
+	 * @return bool
+	 */
+	protected function purge( $object, $creating ) {
+		if ( $object instanceof WC_Data && $creating ) {
+			return $object->delete( true );
+		}
+
+		return false;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Prevents orders of being created if a WC_Data_Exception or a WC_REST_Exception was throwed.

Closes #23316.

### How to test the changes in this Pull Request:

Steps to reproduce in #23316.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - REST API - Stop orders of been created if invalid data is sent.
