### PR TITLE
Non int value handling in wc_let_to_num

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -608,26 +608,22 @@ function wc_price( $price, $args = array() ) {
 function wc_let_to_num( $size ) {
 	$l    = substr( $size, -1 );
 	$ret  = (int) substr( $size, 0, -1 );
-	if ( is_int( $ret ) ) {
-		switch ( strtoupper( $l ) ) {
-			case 'P':
-				$ret *= 1024;
-				// No break.
-			case 'T':
-				$ret *= 1024;
-				// No break.
-			case 'G':
-				$ret *= 1024;
-				// No break.
-			case 'M':
-				$ret *= 1024;
-				// No break.
-			case 'K':
-				$ret *= 1024;
-				// No break.
-		}
-	} else {
-		$ret = 0;
+	switch ( strtoupper( $l ) ) {
+		case 'P':
+			$ret *= 1024;
+			// No break.
+		case 'T':
+			$ret *= 1024;
+			// No break.
+		case 'G':
+			$ret *= 1024;
+			// No break.
+		case 'M':
+			$ret *= 1024;
+			// No break.
+		case 'K':
+			$ret *= 1024;
+			// No break.
 	}
 	return $ret;
 }

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -607,25 +607,27 @@ function wc_price( $price, $args = array() ) {
  */
 function wc_let_to_num( $size ) {
 	$l    = substr( $size, -1 );
-	$ret  = substr( $size, 0, -1 );
-	$byte = 1024;
-
-	switch ( strtoupper( $l ) ) {
-		case 'P':
-			$ret *= 1024;
-			// No break.
-		case 'T':
-			$ret *= 1024;
-			// No break.
-		case 'G':
-			$ret *= 1024;
-			// No break.
-		case 'M':
-			$ret *= 1024;
-			// No break.
-		case 'K':
-			$ret *= 1024;
-			// No break.
+	$ret  = (int) substr( $size, 0, -1 );
+	if ( is_int( $ret ) ) {
+		switch ( strtoupper( $l ) ) {
+			case 'P':
+				$ret *= 1024;
+				// No break.
+			case 'T':
+				$ret *= 1024;
+				// No break.
+			case 'G':
+				$ret *= 1024;
+				// No break.
+			case 'M':
+				$ret *= 1024;
+				// No break.
+			case 'K':
+				$ret *= 1024;
+				// No break.
+		}
+	} else {
+		$ret = 0;
 	}
 	return $ret;
 }

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -606,8 +606,8 @@ function wc_price( $price, $args = array() ) {
  * @return int
  */
 function wc_let_to_num( $size ) {
-	$l    = substr( $size, -1 );
-	$ret  = (int) substr( $size, 0, -1 );
+	$l   = substr( $size, -1 );
+	$ret = (int) substr( $size, 0, -1 );
 	switch ( strtoupper( $l ) ) {
 		case 'P':
 			$ret *= 1024;

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -602,14 +602,18 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 * @since 2.2
 	 */
 	public function test_wc_let_to_num() {
-		$this->assertEquals(
-			array( 10240, 10485760, 10737418240, 10995116277760, 11258999068426240 ),
+		$this->assertSame(
+			array( 10240, 10485760, 10737418240, 10995116277760, 11258999068426240, 0, 0, 0, 0 ),
 			array(
 				wc_let_to_num( '10K' ),
 				wc_let_to_num( '10M' ),
 				wc_let_to_num( '10G' ),
 				wc_let_to_num( '10T' ),
 				wc_let_to_num( '10P' ),
+				wc_let_to_num( false ),
+				wc_let_to_num( true ),
+				wc_let_to_num( '' ),
+				wc_let_to_num( 'ABC' ),
 			)
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
`wc_let_to_num` relies on a valid format to work correctly, however ini_get could return false or empty trings resulting in warnings. This PR adds some logic to wc_let_to_num to handle non int values, if a non valid size is passed to wc_let_to_num it will simply return 0

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23327 

### How to test the changes in this Pull Request:

1. Check that unit tests pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->