### PR TITLE
Set tracks cookie on wp hook instead on when calling record event.

### DIFF
--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -54,6 +54,7 @@ class WC_Tracks_Client {
 		if ( $user instanceof WP_User && 'wptests_capabilities' === $user->cap_key ) {
 			return false;
 		}
+		$user_id = $user->ID;
 		$anon_id = get_user_meta( $user_id, '_woocommerce_tracks_anon_id', true );
 
 		// If an id is still not found, create one and save it.

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -34,7 +34,7 @@ class WC_Tracks_Client {
 	 */
 	public static function init() {
 		// Use wp hook for setting the identity cookie to avoid headers already sent warnings.
-		add_action( 'wp', array( __CLASS__, 'maybe_set_identity_cookie' ) );
+		add_action( 'wp_loaded', array( __CLASS__, 'maybe_set_identity_cookie' ) );
 	}
 
 	/**

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -62,7 +62,13 @@ class WC_Tracks_Client {
 			update_user_meta( $user_id, '_woocommerce_tracks_anon_id', $anon_id );
 		}
 
-		wc_setcookie( 'tk_ai', $anon_id );
+		// Don't set cookie on API requests.
+		if (
+			! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) &&
+			! ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
+		) {
+			wc_setcookie( 'tk_ai', $anon_id );
+		}
 	}
 
 	/**
@@ -185,14 +191,6 @@ class WC_Tracks_Client {
 				}
 
 				$anon_id = 'woo:' . base64_encode( $binary );
-
-				// Don't set cookie on API requests.
-				if (
-					! ( defined( 'REST_REQUEST' ) && REST_REQUEST ) &&
-					! ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST )
-				) {
-					wc_setcookie( 'tk_ai', $anon_id );
-				}
 			}
 		}
 

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -28,6 +28,44 @@ class WC_Tracks_Client {
 	const USER_AGENT_SLUG = 'tracks-client';
 
 	/**
+	 * Initialize tracks client class
+	 *
+	 * @return void
+	 */
+	public static function init() {
+		// Use wp hook for setting the identity cookie to avoid headers already sent warnings.
+		add_action( 'wp', array( self, 'maybe_set_identity_cookie' ) );
+	}
+
+	/**
+	 * Check if identiy cookie is set, if not set it.
+	 *
+	 * @return void
+	 */
+	public static function maybe_set_identity_cookie() {
+		// Bail if cookie already set.
+		if ( isset( $_COOKIE['tk_ai'] ) ) {
+			return;
+		}
+
+		$user = wp_get_current_user();
+
+		// We don't want to track user events during unit tests/CI runs.
+		if ( $user instanceof WP_User && 'wptests_capabilities' === $user->cap_key ) {
+			return false;
+		}
+		$anon_id = get_user_meta( $user_id, '_woocommerce_tracks_anon_id', true );
+
+		// If an id is still not found, create one and save it.
+		if ( ! $anon_id ) {
+			$anon_id = self::get_anon_id();
+			update_user_meta( $user_id, '_woocommerce_tracks_anon_id', $anon_id );
+		}
+
+		wc_setcookie( 'tk_ai', $anon_id );
+	}
+
+	/**
 	 * Record a Tracks event
 	 *
 	 * @param  array $event Array of event properties.
@@ -117,10 +155,6 @@ class WC_Tracks_Client {
 			update_user_meta( $user_id, '_woocommerce_tracks_anon_id', $anon_id );
 		}
 
-		if ( ! isset( $_COOKIE['tk_ai'] ) ) {
-			wc_setcookie( 'tk_ai', $anon_id );
-		}
-
 		return array(
 			'_ut' => 'anon',
 			'_ui' => $anon_id,
@@ -165,3 +199,5 @@ class WC_Tracks_Client {
 		return $anon_id;
 	}
 }
+
+WC_Tracks_Client::init();

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -34,7 +34,7 @@ class WC_Tracks_Client {
 	 */
 	public static function init() {
 		// Use wp hook for setting the identity cookie to avoid headers already sent warnings.
-		add_action( 'wp', array( self, 'maybe_set_identity_cookie' ) );
+		add_action( 'wp', array( __CLASS__, 'maybe_set_identity_cookie' ) );
 	}
 
 	/**

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -32,7 +32,7 @@ class WC_Admin_Setup_Wizard_Tracking {
 		add_action( 'admin_init', array( $this, 'track_ready_next_steps' ), 1 );
 		add_action( 'wp_print_scripts', array( $this, 'dequeue_non_whitelisted_scripts' ) );
 		$this->add_step_save_events();
-		$this->add_footer_scripts();
+		add_action( 'woocommerce_setup_footer', array( $this, 'add_footer_scripts' ) );
 	}
 
 	/**
@@ -45,11 +45,9 @@ class WC_Admin_Setup_Wizard_Tracking {
 	}
 
 	/**
-	 * Add footer scripts to OBW since it does not contain hooks for
-	 * wp_footer to allow the default methods of enqueuing scripts.
+	 * Add footer scripts to OBW via woocommerce_setup_footer
 	 */
 	public function add_footer_scripts() {
-		wp_print_scripts();
 		WC_Site_Tracking::add_tracking_function();
 	}
 

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -48,6 +48,7 @@ class WC_Admin_Setup_Wizard_Tracking {
 	 * Add footer scripts to OBW via woocommerce_setup_footer
 	 */
 	public function add_footer_scripts() {
+		wp_print_scripts();
 		WC_Site_Tracking::add_tracking_function();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The tracks client generates a cookie which keeps an identity string of the current user, this cookie is set when a event is recorded. Since events can be fired after headers has already been sent this PR moves the cookie setting to the wp hook instead to avoid headers already sent warnings when you have no cookie and an event fires after headers was sent.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23327 

### How to test the changes in this Pull Request:

1. Start with a clean install, clear all browser cookies
2. Go through setup wizard being sure to enable tracking, proceed to the next page, it should load without issues and afterwards a new tk_id cookie should be set in your browser.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->