### PR TITLE
Remove slash from currency code string

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -484,7 +484,7 @@ class WC_Admin_Setup_Wizard {
 							echo esc_html( sprintf( __( '%1$s (%2$s)', 'woocommerce' ), $name, $code ) );
 						} else {
 							/* translators: 1: currency name 2: currency symbol, 3: currency code */
-							echo esc_html( sprintf( __( '%1$s (%2$s / %3$s)', 'woocommerce' ), $name, get_woocommerce_currency_symbol( $code ), $code ) );
+							echo esc_html( sprintf( __( '%1$s (%2$s %3$s)', 'woocommerce' ), $name, get_woocommerce_currency_symbol( $code ), $code ) );
 						}
 						?>
 					</option>


### PR DESCRIPTION
This is a quick workaround for #23328 to prevent the slash being escaped to html on display.

This will be fixed by https://github.com/woocommerce/woocommerce/pull/23334

To test, view first screen of the setup wizard. No HTML should be shown in the currency dropdown.