### PR TITLE
More useful actions in during CRUD save events

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -200,16 +200,32 @@ abstract class WC_Data {
 	 * @return int
 	 */
 	public function save() {
-		if ( $this->data_store ) {
-			// Trigger action before saving to the DB. Allows you to adjust object props before save.
-			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
-
-			if ( $this->get_id() ) {
-				$this->data_store->update( $this );
-			} else {
-				$this->data_store->create( $this );
-			}
+		if ( ! $this->data_store ) {
+			return $this->get_id();
 		}
+
+		/**
+		 * Trigger action before saving to the DB. Allows you to adjust object props before save.
+		 *
+		 * @param WC_Data          $this The object being saved.
+		 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+		 */
+		do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
+		if ( $this->get_id() ) {
+			$this->data_store->update( $this );
+		} else {
+			$this->data_store->create( $this );
+		}
+
+		/**
+		 * Trigger action after saving to the DB.
+		 *
+		 * @param WC_Data          $this The object being saved.
+		 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+		 */
+		do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 		return $this->get_id();
 	}
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -195,19 +195,27 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
 
 		} catch ( Exception $e ) {
-			wc_get_logger()->error(
-				sprintf(
-					'Error saving order #%d',
-					$this->get_id()
-				),
-				array(
-					'order' => $this,
-					'error' => $e,
-				)
-			);
+			$this->handle_exception( $e, __( 'Error saving order.', 'woocommerce' ) );
 		}
 
 		return $this->get_id();
+	}
+
+	/**
+	 * Log an error about this order is exception is encountered.
+	 *
+	 * @param Exception $e Exception object.
+	 * @param string    $message Message regarding exception thrown.
+	 * @since 3.7.0
+	 */
+	protected function handle_exception( $e, $message = 'Error' ) {
+		wc_get_logger()->error(
+			$message,
+			array(
+				'order' => $this,
+				'error' => $e,
+			)
+		);
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1360,19 +1360,36 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	public function save() {
 		$this->validate_props();
 
-		if ( $this->data_store ) {
-			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
-			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
-
-			if ( $this->get_id() ) {
-				$this->data_store->update( $this );
-			} else {
-				$this->data_store->create( $this );
-			}
-			if ( $this->get_parent_id() ) {
-				wc_deferred_product_sync( $this->get_parent_id() );
-			}
+		if ( ! $this->data_store ) {
+			return $this->get_id();
 		}
+
+		/**
+		 * Trigger action before saving to the DB. Allows you to adjust object props before save.
+		 *
+		 * @param WC_Data          $this The object being saved.
+		 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+		 */
+		do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
+		if ( $this->get_id() ) {
+			$this->data_store->update( $this );
+		} else {
+			$this->data_store->create( $this );
+		}
+
+		if ( $this->get_parent_id() ) {
+			wc_deferred_product_sync( $this->get_parent_id() );
+		}
+
+		/**
+		 * Trigger action after saving to the DB.
+		 *
+		 * @param WC_Data          $this The object being saved.
+		 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+		 */
+		do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
+
 		return $this->get_id();
 	}
 

--- a/includes/class-wc-customer-download.php
+++ b/includes/class-wc-customer-download.php
@@ -334,32 +334,6 @@ WHERE permission_id = %d",
 
 	/*
 	|--------------------------------------------------------------------------
-	| CRUD methods
-	|--------------------------------------------------------------------------
-	*/
-
-	/**
-	 * Save data to the database.
-	 *
-	 * @since 3.0.0
-	 * @return int Item ID
-	 */
-	public function save() {
-		if ( $this->data_store ) {
-			// Trigger action before saving to the DB. Use a pointer to adjust object props before save.
-			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
-
-			if ( $this->get_id() ) {
-				$this->data_store->update( $this );
-			} else {
-				$this->data_store->create( $this );
-			}
-		}
-		return $this->get_id();
-	}
-
-	/*
-	|--------------------------------------------------------------------------
 	| ArrayAccess/Backwards compatibility.
 	|--------------------------------------------------------------------------
 	*/

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -128,7 +128,11 @@ class WC_Order extends WC_Abstract_Order {
 			 */
 			$logger = wc_get_logger();
 			$logger->error(
-				sprintf( 'Error completing payment for order #%d', $this->get_id() ), array(
+				sprintf(
+					'Error completing payment for order #%d',
+					$this->get_id()
+				),
+				array(
 					'order' => $this,
 					'error' => $e,
 				)
@@ -175,7 +179,7 @@ class WC_Order extends WC_Abstract_Order {
 		}
 
 		if ( $total_refunded && $display_refunded ) {
-			$formatted_total = '<del>' . strip_tags( $formatted_total ) . '</del> <ins>' . wc_price( $order_total - $total_refunded, array( 'currency' => $this->get_currency() ) ) . $tax_string . '</ins>';
+			$formatted_total = '<del>' . wp_strip_all_tags( $formatted_total ) . '</del> <ins>' . wc_price( $order_total - $total_refunded, array( 'currency' => $this->get_currency() ) ) . $tax_string . '</ins>';
 		} else {
 			$formatted_total .= $tax_string;
 		}
@@ -212,32 +216,9 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return int order ID
 	 */
 	public function save() {
-		try {
-			$this->maybe_set_user_billing_email();
-
-			if ( $this->data_store ) {
-				// Trigger action before saving to the DB. Allows you to adjust object props before save.
-				do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
-
-				if ( $this->get_id() ) {
-					$this->data_store->update( $this );
-				} else {
-					$this->data_store->create( $this );
-				}
-			}
-
-			$this->save_items();
-			$this->status_transition();
-		} catch ( Exception $e ) {
-			$logger = wc_get_logger();
-			$logger->error(
-				sprintf( 'Error saving order #%d', $this->get_id() ), array(
-					'order' => $this,
-					'error' => $e,
-				)
-			);
-			$this->add_order_note( __( 'Error saving order.', 'woocommerce' ) . ' ' . $e->getMessage() );
-		}
+		$this->maybe_set_user_billing_email();
+		parent::save();
+		$this->status_transition();
 
 		return $this->get_id();
 	}
@@ -335,7 +316,11 @@ class WC_Order extends WC_Abstract_Order {
 		} catch ( Exception $e ) {
 			$logger = wc_get_logger();
 			$logger->error(
-				sprintf( 'Error updating status for order #%d', $this->get_id() ), array(
+				sprintf(
+					'Error updating status for order #%d',
+					$this->get_id()
+				),
+				array(
 					'order' => $this,
 					'error' => $e,
 				)
@@ -375,7 +360,11 @@ class WC_Order extends WC_Abstract_Order {
 			} catch ( Exception $e ) {
 				$logger = wc_get_logger();
 				$logger->error(
-					sprintf( 'Status transition of order #%d errored!', $this->get_id() ), array(
+					sprintf(
+						'Status transition of order #%d errored!',
+						$this->get_id()
+					),
+					array(
 						'order' => $this,
 						'error' => $e,
 					)
@@ -1513,7 +1502,8 @@ class WC_Order extends WC_Abstract_Order {
 				array(
 					'pay_for_order' => 'true',
 					'key'           => $this->get_order_key(),
-				), $pay_url
+				),
+				$pay_url
 			);
 		}
 
@@ -1545,15 +1535,18 @@ class WC_Order extends WC_Abstract_Order {
 	 */
 	public function get_cancel_order_url( $redirect = '' ) {
 		return apply_filters(
-			'woocommerce_get_cancel_order_url', wp_nonce_url(
+			'woocommerce_get_cancel_order_url',
+			wp_nonce_url(
 				add_query_arg(
 					array(
 						'cancel_order' => 'true',
 						'order'        => $this->get_order_key(),
 						'order_id'     => $this->get_id(),
 						'redirect'     => $redirect,
-					), $this->get_cancel_endpoint()
-				), 'woocommerce-cancel_order'
+					),
+					$this->get_cancel_endpoint()
+				),
+				'woocommerce-cancel_order'
 			)
 		);
 	}
@@ -1566,14 +1559,16 @@ class WC_Order extends WC_Abstract_Order {
 	 */
 	public function get_cancel_order_url_raw( $redirect = '' ) {
 		return apply_filters(
-			'woocommerce_get_cancel_order_url_raw', add_query_arg(
+			'woocommerce_get_cancel_order_url_raw',
+			add_query_arg(
 				array(
 					'cancel_order' => 'true',
 					'order'        => $this->get_order_key(),
 					'order_id'     => $this->get_id(),
 					'redirect'     => $redirect,
 					'_wpnonce'     => wp_create_nonce( 'woocommerce-cancel_order' ),
-				), $this->get_cancel_endpoint()
+				),
+				$this->get_cancel_endpoint()
 			)
 		);
 	}
@@ -1669,7 +1664,8 @@ class WC_Order extends WC_Abstract_Order {
 			add_comment_meta( $comment_id, 'is_customer_note', 1 );
 
 			do_action(
-				'woocommerce_new_customer_note', array(
+				'woocommerce_new_customer_note',
+				array(
 					'order_id'      => $this->get_id(),
 					'customer_note' => $commentdata['comment_content'],
 				)

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -224,6 +224,24 @@ class WC_Order extends WC_Abstract_Order {
 	}
 
 	/**
+	 * Log an error about this order is exception is encountered.
+	 *
+	 * @param Exception $e Exception object.
+	 * @param string    $message Message regarding exception thrown.
+	 * @since 3.7.0
+	 */
+	protected function handle_exception( $e, $message = 'Error' ) {
+		wc_get_logger()->error(
+			$message,
+			array(
+				'order' => $this,
+				'error' => $e,
+			)
+		);
+		$this->add_order_note( $message . ' ' . $e->getMessage() );
+	}
+
+	/**
 	 * Set order status.
 	 *
 	 * @since 3.0.0

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -325,7 +325,8 @@ class WC_Product_Variable extends WC_Product {
 		$show_variation_price = apply_filters( 'woocommerce_show_variation_price', $variation->get_price() === '' || $this->get_variation_sale_price( 'min' ) !== $this->get_variation_sale_price( 'max' ) || $this->get_variation_regular_price( 'min' ) !== $this->get_variation_regular_price( 'max' ), $this, $variation );
 
 		return apply_filters(
-			'woocommerce_available_variation', array(
+			'woocommerce_available_variation',
+			array(
 				'attributes'            => $variation->get_variation_attributes(),
 				'availability_html'     => wc_get_stock_html( $variation ),
 				'backorders_allowed'    => $variation->backorders_allowed(),
@@ -350,7 +351,9 @@ class WC_Product_Variable extends WC_Product {
 				'variation_is_visible'  => $variation->variation_is_visible(),
 				'weight'                => $variation->get_weight(),
 				'weight_html'           => wc_format_weight( $variation->get_weight() ),
-			), $this, $variation
+			),
+			$this,
+			$variation
 		);
 	}
 
@@ -434,25 +437,41 @@ class WC_Product_Variable extends WC_Product {
 	 */
 	public function save() {
 		$this->validate_props();
-		if ( $this->data_store ) {
-			// Trigger action before saving to the DB. Allows you to adjust object props before save.
-			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
 
-			// Get names before save.
-			$previous_name = $this->data['name'];
-			$new_name      = $this->get_name( 'edit' );
-
-			if ( $this->get_id() ) {
-				$this->data_store->update( $this );
-			} else {
-				$this->data_store->create( $this );
-			}
-
-			$this->data_store->sync_variation_names( $this, $previous_name, $new_name );
-			$this->data_store->sync_managed_variation_stock_status( $this );
-
+		if ( ! $this->data_store ) {
 			return $this->get_id();
 		}
+
+		/**
+		 * Trigger action before saving to the DB. Allows you to adjust object props before save.
+		 *
+		 * @param WC_Data          $this The object being saved.
+		 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+		 */
+		do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
+		// Get names before save.
+		$previous_name = $this->data['name'];
+		$new_name      = $this->get_name( 'edit' );
+
+		if ( $this->get_id() ) {
+			$this->data_store->update( $this );
+		} else {
+			$this->data_store->create( $this );
+		}
+
+		$this->data_store->sync_variation_names( $this, $previous_name, $new_name );
+		$this->data_store->sync_managed_variation_stock_status( $this );
+
+		/**
+		 * Trigger action after saving to the DB.
+		 *
+		 * @param WC_Data          $this The object being saved.
+		 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+		 */
+		do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
+
+		return $this->get_id();
 	}
 
 	/*
@@ -587,10 +606,13 @@ class WC_Product_Variable extends WC_Product {
 			}
 
 			wc_do_deprecated_action(
-				'woocommerce_variable_product_sync', array(
+				'woocommerce_variable_product_sync',
+				array(
 					$product->get_id(),
 					$product->get_visible_children(),
-				), '3.0', 'woocommerce_variable_product_sync_data, woocommerce_new_product or woocommerce_update_product'
+				),
+				'3.0',
+				'woocommerce_variable_product_sync_data, woocommerce_new_product or woocommerce_update_product'
 			);
 		}
 

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -272,7 +272,7 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 		 */
 		do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
 
-		if ( null === $this->get_id() ) {
+		if ( null !== $this->get_id() ) {
 			$this->data_store->update( $this );
 		} else {
 			$this->data_store->create( $this );

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -259,17 +259,34 @@ class WC_Shipping_Zone extends WC_Legacy_Shipping_Zone {
 		if ( ! $this->get_zone_name() ) {
 			$this->set_zone_name( $this->generate_zone_name() );
 		}
-		if ( $this->data_store ) {
-			// Trigger action before saving to the DB. Allows you to adjust object props before save.
-			do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
 
-			if ( null === $this->get_id() ) {
-				$this->data_store->create( $this );
-			} else {
-				$this->data_store->update( $this );
-			}
+		if ( ! $this->data_store ) {
 			return $this->get_id();
 		}
+
+		/**
+		 * Trigger action before saving to the DB. Allows you to adjust object props before save.
+		 *
+		 * @param WC_Data          $this The object being saved.
+		 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+		 */
+		do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
+
+		if ( null === $this->get_id() ) {
+			$this->data_store->update( $this );
+		} else {
+			$this->data_store->create( $this );
+		}
+
+		/**
+		 * Trigger action after saving to the DB.
+		 *
+		 * @param WC_Data          $this The object being saved.
+		 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+		 */
+		do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
+
+		return $this->get_id();
 	}
 
 	/**

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -86,7 +86,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			$coupon->save_meta_data();
 			$coupon->apply_changes();
 			delete_transient( 'rest_api_coupons_type_count' );
-			do_action( 'woocommerce_new_coupon', $coupon_id );
+			do_action( 'woocommerce_new_coupon', $coupon_id, $coupon );
 		}
 	}
 
@@ -179,7 +179,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		$this->update_post_meta( $coupon );
 		$coupon->apply_changes();
 		delete_transient( 'rest_api_coupons_type_count' );
-		do_action( 'woocommerce_update_coupon', $coupon->get_id() );
+		do_action( 'woocommerce_update_coupon', $coupon->get_id(), $coupon );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -132,7 +132,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 		$customer->set_date_modified( get_user_meta( $customer->get_id(), 'last_update', true ) );
 		$customer->save_meta_data();
 		$customer->apply_changes();
-		do_action( 'woocommerce_new_customer', $customer->get_id() );
+		do_action( 'woocommerce_new_customer', $customer->get_id(), $customer );
 	}
 
 	/**
@@ -209,7 +209,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 		$customer->set_date_modified( get_user_meta( $customer->get_id(), 'last_update', true ) );
 		$customer->save_meta_data();
 		$customer->apply_changes();
-		do_action( 'woocommerce_update_customer', $customer->get_id() );
+		do_action( 'woocommerce_update_customer', $customer->get_id(), $customer );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -83,7 +83,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	public function create( &$order ) {
 		$order->set_order_key( wc_generate_order_key() );
 		parent::create( $order );
-		do_action( 'woocommerce_new_order', $order->get_id() );
+		do_action( 'woocommerce_new_order', $order->get_id(), $order );
 	}
 
 	/**
@@ -166,9 +166,9 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		$new_status = $order->get_status( 'edit' );
 
 		if ( $new_status !== $previous_status && in_array( $previous_status, array( 'new', 'auto-draft', 'draft' ), true ) ) {
-			do_action( 'woocommerce_new_order', $order->get_id() );
+			do_action( 'woocommerce_new_order', $order->get_id(), $order );
 		} else {
-			do_action( 'woocommerce_update_order', $order->get_id() );
+			do_action( 'woocommerce_update_order', $order->get_id(), $order );
 		}
 	}
 

--- a/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/includes/data-stores/class-wc-payment-token-data-store.php
@@ -71,7 +71,7 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Payment
 			WC_Payment_Tokens::set_users_default( $token->get_user_id(), $token_id );
 		}
 
-		do_action( 'woocommerce_new_payment_token', $token_id );
+		do_action( 'woocommerce_new_payment_token', $token_id, $token );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -145,7 +145,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$product->save_meta_data();
 			$product->apply_changes();
 
-			do_action( 'woocommerce_new_product', $id );
+			do_action( 'woocommerce_new_product', $id, $product );
 		}
 	}
 
@@ -262,7 +262,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$product->apply_changes();
 
-		do_action( 'woocommerce_update_product', $product->get_id() );
+		do_action( 'woocommerce_update_product', $product->get_id(), $product );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -172,7 +172,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 			$this->clear_caches( $product );
 
-			do_action( 'woocommerce_new_product_variation', $id );
+			do_action( 'woocommerce_new_product_variation', $id, $product );
 		}
 	}
 
@@ -265,7 +265,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		$this->clear_caches( $product );
 
-		do_action( 'woocommerce_update_product_variation', $product->get_id() );
+		do_action( 'woocommerce_update_product_variation', $product->get_id(), $product );
 	}
 
 	/*

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -61,7 +61,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 
 		$this->delete_transients( $webhook->get_status( 'edit' ) );
 		WC_Cache_Helper::incr_cache_prefix( 'webhooks' );
-		do_action( 'woocommerce_new_webhook', $webhook_id );
+		do_action( 'woocommerce_new_webhook', $webhook_id, $webhook );
 	}
 
 	/**


### PR DESCRIPTION
This PR makes some changes to CRUD classes and data stores to consistently fire certain actions for usefulness. Closes #23335 

- Data stores now pass objects to the `woocommerce_new_x` and `woocommerce_update_x` actions.
- CRUD class `save()` methods now fire actions before and after save.
- All CRUD classes are given consistent implementations based on the above.

This has test coverage already.

> * Dev - Introduced `woocommerce_after_X_object_save` actions, and passed objects to `woocommerce_new_x` and `woocommerce_update_x` actions.

