### PR TITLE
Correctly handle images in v3 api

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -226,7 +226,9 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @return WC_Product
 	 */
 	protected function set_product_images( $product, $images ) {
-		if ( is_array( $images ) ) {
+		$images = is_array( $images ) ? array_filter( $images ) : array();
+
+		if ( ! empty( $images ) ) {
 			$gallery = array();
 
 			foreach ( $images as $index => $image ) {


### PR DESCRIPTION
If an empty array is passed to the API for `images`, images should be unset.

This code exists in v2 API but is missing from v3 API.

Fixes #23337

Instructions in #23337