### PR TITLE
Remove call to header_register_callback and revert to 3.5 cookie handling

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -53,13 +53,9 @@ final class WC_Cart_Session {
 		add_action( 'woocommerce_cart_updated', array( $this, 'persistent_cart_update' ) );
 
 		// Cookie events - cart cookies need to be set before headers are sent.
-		if ( function_exists( 'header_register_callback' ) ) {
-			header_register_callback( array( $this, 'maybe_set_cart_cookies' ) ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctions.header_register_callbackFound
-		} else {
-			add_action( 'woocommerce_add_to_cart', array( $this, 'maybe_set_cart_cookies' ) );
-			add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 );
-			add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 );
-		}
+		add_action( 'woocommerce_add_to_cart', array( $this, 'maybe_set_cart_cookies' ) );
+		add_action( 'wp', array( $this, 'maybe_set_cart_cookies' ), 99 );
+		add_action( 'shutdown', array( $this, 'maybe_set_cart_cookies' ), 0 );
 	}
 
 	/**


### PR DESCRIPTION
Fixes #23352 and #23353

'header_register_callback' was introduced in https://github.com/woocommerce/woocommerce/pull/22666 to make cookie setting more efficient, but we're seeing conflicts with some hosts/php versions and other issues which means we should pull it for now.

This basically reverts to the way 3.5.x set cookies by listening to certain events and seeing if a cookie is needed.

> Fix - Remove calls to 'header_register_callback' to prevent conflicts with some hosting providers and PHP versions. If you are using WP Engine and seeing 50x errors when logging in, this will resolve your problems.