### PR TITLE
Better iconv support handling in wc_ascii_uasort_comparison 

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1624,8 +1624,8 @@ function wc_uasort_comparison( $a, $b ) {
  */
 function wc_ascii_uasort_comparison( $a, $b ) {
 	if ( function_exists( 'iconv' ) && defined( 'ICONV_IMPL' ) && @strcasecmp( ICONV_IMPL, 'unknown' ) !== 0 ) {
-		$a = iconv( 'UTF-8', 'ASCII//IGNORE//TRANSLIT', $a );
-		$b = iconv( 'UTF-8', 'ASCII//IGNORE//TRANSLIT', $b );
+		$a = @iconv( 'UTF-8', 'ASCII//TRANSLIT//IGNORE', $a );
+		$b = @iconv( 'UTF-8', 'ASCII//TRANSLIT//IGNORE', $b );
 	}
 	return strcmp( $a, $b );
 }

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1623,9 +1623,9 @@ function wc_uasort_comparison( $a, $b ) {
  * @return int
  */
 function wc_ascii_uasort_comparison( $a, $b ) {
-	if ( function_exists( 'iconv' ) ) {
-		$a = iconv( 'UTF-8', 'ASCII//IGNORE', $a );
-		$b = iconv( 'UTF-8', 'ASCII//IGNORE', $b );
+	if ( function_exists( 'iconv' ) && defined( 'ICONV_IMPL' ) && @strcasecmp( ICONV_IMPL, 'unknown' ) !== 0 ) {
+		$a = iconv( 'UTF-8', 'ASCII//IGNORE//TRANSLIT', $a );
+		$b = iconv( 'UTF-8', 'ASCII//IGNORE//TRANSLIT', $b );
 	}
 	return strcmp( $a, $b );
 }

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1624,8 +1624,8 @@ function wc_uasort_comparison( $a, $b ) {
  */
 function wc_ascii_uasort_comparison( $a, $b ) {
 	if ( function_exists( 'iconv' ) ) {
-		$a = iconv( 'UTF-8', 'ASCII//TRANSLIT', $a );
-		$b = iconv( 'UTF-8', 'ASCII//TRANSLIT', $b );
+		$a = iconv( 'UTF-8', 'ASCII//IGNORE', $a );
+		$b = iconv( 'UTF-8', 'ASCII//IGNORE', $b );
 	}
 	return strcmp( $a, $b );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Per the PHP manual:
> Caution
If and how //TRANSLIT works exactly depends on the system's iconv() implementation (cf. ICONV_IMPL). Some implementations are known to ignore //TRANSLIT, so the conversion is likely to fail for characters which are illegal for the out_charset.

So it seem server config plays a role in how the TRANSLIT flag is handled, and is likely to fail causing notices, so this PR adds the IGNORE flag, introduces better iconv server support checks and also surpresses notices on the iconv usage in wc_ascii_uasort_comparison

Closes #23361 
Another issue: #23348 

### How to test the changes in this Pull Request:

1. Setup the PHP constant ICONV_IMPL to 'unknow'
2. Load a page where the countries are listed in the dropdown, ie Checkout
3. Check the ordering is alphabetical correct

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - wc_ascii_uasort_comparison throwing notices in some server configs.