### PR TITLE
Check isset rather than empty so cart title can be removed

### DIFF
--- a/includes/widgets/class-wc-widget-cart.php
+++ b/includes/widgets/class-wc-widget-cart.php
@@ -58,7 +58,7 @@ class WC_Widget_Cart extends WC_Widget {
 
 		$hide_if_empty = empty( $instance['hide_if_empty'] ) ? 0 : 1;
 
-		if ( empty( $instance['title'] ) ) {
+		if ( ! isset( $instance['title'] ) ) {
 			$instance['title'] = __( 'Cart', 'woocommerce' );
 		}
 


### PR DESCRIPTION
So new widgets in the customizer get a title, we set the default of `cart` when empty.

This however prevents you from having no title.

The fix is to check isset rather than empty.

To test:

- Add widget via customiser. Ensure 'cart' title is shown.
- Clear the title and publish changes. Ensure no title is shown.

Fixes #23368