### PR TITLE
[3.6] Fix product class name theme conflict due to missing global

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -453,7 +453,9 @@ function wc_get_product_cat_class( $class = '', $category = null ) {
 }
 
 /**
- * Adds extra post classes for products.
+ * Adds extra post classes for products via the WordPress post_class hook, if used.
+ *
+ * Note: For performance reasons we instead recommend using wc_product_class/wc_get_product_class instead.
  *
  * @since 2.1.0
  * @param array        $classes Current classes.
@@ -468,41 +470,43 @@ function wc_product_post_class( $classes, $class = '', $post_id = 0 ) {
 
 	$product = wc_get_product( $post_id );
 
-	if ( $product ) {
-		$classes[] = 'product';
-		$classes[] = wc_get_loop_class();
-		$classes[] = $product->get_stock_status();
+	if ( ! $product ) {
+		return $classes;
+	}
 
-		if ( $product->is_on_sale() ) {
-			$classes[] = 'sale';
-		}
-		if ( $product->is_featured() ) {
-			$classes[] = 'featured';
-		}
-		if ( $product->is_downloadable() ) {
-			$classes[] = 'downloadable';
-		}
-		if ( $product->is_virtual() ) {
-			$classes[] = 'virtual';
-		}
-		if ( $product->is_sold_individually() ) {
-			$classes[] = 'sold-individually';
-		}
-		if ( $product->is_taxable() ) {
-			$classes[] = 'taxable';
-		}
-		if ( $product->is_shipping_taxable() ) {
-			$classes[] = 'shipping-taxable';
-		}
-		if ( $product->is_purchasable() ) {
-			$classes[] = 'purchasable';
-		}
-		if ( $product->get_type() ) {
-			$classes[] = 'product-type-' . $product->get_type();
-		}
-		if ( $product->is_type( 'variable' ) && $product->get_default_attributes() ) {
-			$classes[] = 'has-default-attributes';
-		}
+	$classes[] = 'product';
+	$classes[] = wc_get_loop_class();
+	$classes[] = $product->get_stock_status();
+
+	if ( $product->is_on_sale() ) {
+		$classes[] = 'sale';
+	}
+	if ( $product->is_featured() ) {
+		$classes[] = 'featured';
+	}
+	if ( $product->is_downloadable() ) {
+		$classes[] = 'downloadable';
+	}
+	if ( $product->is_virtual() ) {
+		$classes[] = 'virtual';
+	}
+	if ( $product->is_sold_individually() ) {
+		$classes[] = 'sold-individually';
+	}
+	if ( $product->is_taxable() ) {
+		$classes[] = 'taxable';
+	}
+	if ( $product->is_shipping_taxable() ) {
+		$classes[] = 'shipping-taxable';
+	}
+	if ( $product->is_purchasable() ) {
+		$classes[] = 'purchasable';
+	}
+	if ( $product->get_type() ) {
+		$classes[] = 'product-type-' . $product->get_type();
+	}
+	if ( $product->is_type( 'variable' ) && $product->get_default_attributes() ) {
+		$classes[] = 'has-default-attributes';
 	}
 
 	$key = array_search( 'hentry', $classes, true );
@@ -551,10 +555,7 @@ function wc_get_product_taxonomy_class( $term_ids, $taxonomy ) {
  * Retrieves the classes for the post div as an array.
  *
  * This method was modified from WordPress's get_post_class() to allow the removal of taxonomies
- * (for performance reasons).
- *
- * Previously wc_product_post_class was hooked into post_class. That still happens, but this function
- * negates the need for it and thus unhooks it when running the post_class hook. @since 3.6.0
+ * (for performance reasons). Previously wc_product_post_class was hooked into post_class. @since 3.6.0
  *
  * @since 3.4.0
  * @param string|array           $class      One or more classes to add to the class list.
@@ -573,11 +574,7 @@ function wc_get_product_class( $class = '', $product = null ) {
 	}
 
 	// Make sure we have an array.
-	if ( ! is_array( $class ) ) {
-		$classes = preg_split( '#\s+#', $class );
-	} else {
-		$classes = $class;
-	}
+	$classes = is_array( $class ) ? $class : preg_split( '#\s+#', $class );
 
 	if ( ! $product ) {
 		return array_map( 'esc_attr', $classes );
@@ -665,7 +662,7 @@ function wc_get_product_class( $class = '', $product = null ) {
  * @param int|WP_Post|WC_Product $product_id Product ID or product object.
  */
 function wc_product_class( $class = '', $product_id = null ) {
-	echo 'class="' . esc_attr( join( ' ', wc_get_product_class( $class, $product_id ) ) ) . '"';
+	echo 'class="' . esc_attr( implode( ' ', wc_get_product_class( $class, $product_id ) ) ) . '"';
 }
 
 /**

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -558,15 +558,18 @@ function wc_get_product_taxonomy_class( $term_ids, $taxonomy ) {
  *
  * @since 3.4.0
  * @param string|array           $class      One or more classes to add to the class list.
- * @param int|WP_Post|WC_Product $product_id Product ID or product object.
+ * @param int|WP_Post|WC_Product $product Product ID or product object.
  * @return array
  */
-function wc_get_product_class( $class = '', $product_id = null ) {
-	if ( is_a( $product_id, 'WC_Product' ) ) {
-		$product    = $product_id;
-		$product_id = $product_id->get_id();
-	} else {
-		$product = wc_get_product( $product_id );
+function wc_get_product_class( $class = '', $product = null ) {
+	if ( is_null( $product ) && ! empty( $GLOBALS['product'] ) ) {
+		// Product was null so pull from global.
+		$product = $GLOBALS['product'];
+	}
+
+	if ( $product && ! is_a( $product, 'WC_Product' ) ) {
+		// Make sure we have a valid product, or set to false.
+		$product = wc_get_product( $product );
 	}
 
 	if ( ! is_array( $class ) ) {

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -572,6 +572,7 @@ function wc_get_product_class( $class = '', $product = null ) {
 		$product = wc_get_product( $product );
 	}
 
+	// Make sure we have an array.
 	if ( ! is_array( $class ) ) {
 		$classes = preg_split( '#\s+#', $class );
 	} else {
@@ -644,20 +645,16 @@ function wc_get_product_class( $class = '', $product = null ) {
 		}
 	}
 
-	// If using `wc_get_product_class` instead of `get_post_class`, we don't need to hook `wc_product_post_class` function.
-	$filtered = has_filter( 'post_class', 'wc_product_post_class' );
+	/**
+	 * WooCommerce Post Class filter.
+	 *
+	 * @since 3.6.2
+	 * @param array      $class Array of CSS classes.
+	 * @param WC_Product $product Product object.
+	 */
+	$classes = apply_filters( 'woocommerce_post_class', $classes, $product );
 
-	if ( $filtered ) {
-		remove_filter( 'post_class', 'wc_product_post_class', 20, 3 );
-	}
-
-	$classes = apply_filters( 'post_class', $classes, $class, $product->get_id() );
-
-	if ( $filtered ) {
-		add_filter( 'post_class', 'wc_product_post_class', 20, 3 );
-	}
-
-	return array_filter( array_map( 'esc_attr', array_unique( $classes ) ) );
+	return array_map( 'esc_attr', array_filter( array_unique( $classes ) ) );
 }
 
 /**

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -593,7 +593,7 @@ function wc_get_product_class( $class = '', $product = null ) {
 	$filtered = has_filter( 'post_class', 'wc_product_post_class' );
 
 	if ( $filtered ) {
-		remove_filter( 'post_class', 'wc_product_post_class', 20, 3 );
+		remove_filter( 'post_class', 'wc_product_post_class', 20 );
 	}
 
 	$post_classes = apply_filters( 'post_class', $post_classes, $class, $product->get_id() );

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -574,7 +574,7 @@ function wc_get_product_class( $class = '', $product = null ) {
 	}
 
 	if ( $class ) {
-		if ( ! is_array() ) {
+		if ( ! is_array( $class ) ) {
 			$class = preg_split( '#\s+#', $class );
 		}
 	} else {


### PR DESCRIPTION
Fixes #23374 

In 3.5.x `wc_get_product_class` used get_post when grabbing the post/product objects. `get_post` pulls the global $post if null (https://developer.wordpress.org/reference/functions/get_post/).

In 3.6.x this was switched to just `wc_get_product` which does not use the global.

This lead to themes which uses `wc_product_class` without passing a product object to have missing CSS class names. Core is unaffected because it passes the $product object to this function.

To test, try the theme zip in #23374. On the shop page, results should be styled correctly and have classes such as 'product type-product' in the markup.

> * Fix - [3.6.x] Fix CSS classname conflict with themes due to missing product object global.