### PR TITLE
[3.6] More useful update notices if cron is disabled

### DIFF
--- a/includes/admin/views/html-notice-regenerating-lookup-table.php
+++ b/includes/admin/views/html-notice-regenerating-lookup-table.php
@@ -7,20 +7,27 @@
 
 defined( 'ABSPATH' ) || exit;
 
+$pending_actions_url = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=wc_update_product_lookup_tables&status=pending' );
+$cron_disabled       = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON;
 ?>
 <div id="message" class="updated woocommerce-message">
 	<p>
-		<strong><?php esc_html_e( 'WooCommerce is updating product data in the background.', 'woocommerce' ); ?></strong>&nbsp;
+		<strong><?php esc_html_e( 'WooCommerce is updating product data in the background.', 'woocommerce' ); ?></strong><br/>
 		<?php
-		echo wp_kses_post(
-			sprintf(
-				/* Translators: 1: Link, 2: link close. */
-				__( 'Some queries and reports may not show accurate results until this finishes. It will take a few minutes and this notice will disappear when complete.', 'woocommerce' ),
-				'<a href="' . esc_url( admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=wc_update_product_lookup_tables' ) ) . '">',
-				'</a>'
-			)
-		);
+		esc_html_e( 'Product display, sorting, and reports may not be accurate until this finishes. It will take a few minutes and this notice will disappear when complete.', 'woocommerce' );
+
+		if ( $cron_disabled ) {
+			echo '<br><span style="color:red;">' . esc_html__( 'Warning: WP CRON has been disabled on your install which may prevent this update from completing.', 'woocommerce' ) . '</span>';
+		}
 		?>
-		&nbsp;<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=wc_update_product_lookup_tables&status=pending' ) ); ?>"><?php esc_html_e( 'View progress &rarr;', 'woocommerce' ); ?></a>
+		&nbsp;<a href="<?php echo esc_url( $pending_actions_url ); ?>">
+			<?php
+			if ( $cron_disabled ) {
+				esc_html_e( 'You can manually run queued updates here.', 'woocommerce' );
+			} else {
+				esc_html_e( 'View progress &rarr;', 'woocommerce' );
+			}
+			?>
+		</a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-regenerating-lookup-table.php
+++ b/includes/admin/views/html-notice-regenerating-lookup-table.php
@@ -13,12 +13,12 @@ $cron_cta            = $cron_disabled ? __( 'You can manually run queued updates
 ?>
 <div id="message" class="updated woocommerce-message">
 	<p>
-		<strong><?php esc_html_e( 'WooCommerce is updating product data in the background.', 'woocommerce' ); ?></strong><br/>
+		<strong><?php esc_html_e( 'WooCommerce is updating product data in the background', 'woocommerce' ); ?></strong><br>
 		<?php
 		esc_html_e( 'Product display, sorting, and reports may not be accurate until this finishes. It will take a few minutes and this notice will disappear when complete.', 'woocommerce' );
 
 		if ( $cron_disabled ) {
-			echo '<br><span style="color:red;">' . esc_html__( 'Warning: WP CRON has been disabled on your install which may prevent this update from completing.', 'woocommerce' ) . '</span>';
+			echo '<br>' . esc_html__( 'Note: WP CRON has been disabled on your install which may prevent this update from completing.', 'woocommerce' );
 		}
 		?>
 		&nbsp;<a href="<?php echo esc_url( $pending_actions_url ); ?>"><?php echo esc_html( $cron_cta ); ?></a>

--- a/includes/admin/views/html-notice-regenerating-lookup-table.php
+++ b/includes/admin/views/html-notice-regenerating-lookup-table.php
@@ -9,6 +9,7 @@ defined( 'ABSPATH' ) || exit;
 
 $pending_actions_url = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=wc_update_product_lookup_tables&status=pending' );
 $cron_disabled       = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON;
+$cron_cta            = $cron_disabled ? __( 'You can manually run queued updates here.', 'woocommerce' ) : __( 'View progress &rarr;', 'woocommerce' );
 ?>
 <div id="message" class="updated woocommerce-message">
 	<p>
@@ -20,14 +21,6 @@ $cron_disabled       = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON;
 			echo '<br><span style="color:red;">' . esc_html__( 'Warning: WP CRON has been disabled on your install which may prevent this update from completing.', 'woocommerce' ) . '</span>';
 		}
 		?>
-		&nbsp;<a href="<?php echo esc_url( $pending_actions_url ); ?>">
-			<?php
-			if ( $cron_disabled ) {
-				esc_html_e( 'You can manually run queued updates here.', 'woocommerce' );
-			} else {
-				esc_html_e( 'View progress &rarr;', 'woocommerce' );
-			}
-			?>
-		</a>
+		&nbsp;<a href="<?php echo esc_url( $pending_actions_url ); ?>"><?php echo esc_html( $cron_cta ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-regenerating-lookup-table.php
+++ b/includes/admin/views/html-notice-regenerating-lookup-table.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Admin View: Notice - Regenerating thumbnails.
+ * Admin View: Notice - Regenerating product lookup table.
  *
  * @package WooCommerce/admin
  */

--- a/includes/admin/views/html-notice-updating.php
+++ b/includes/admin/views/html-notice-updating.php
@@ -8,9 +8,26 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+$pending_actions_url = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=woocommerce_run_update&status=pending' );
+$cron_disabled       = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON;
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p>
 		<strong><?php esc_html_e( 'WooCommerce database update', 'woocommerce' ); ?></strong> &#8211; <?php esc_html_e( 'WooCommerce is updating the database in the background. The database update process may take a little while, so please be patient.', 'woocommerce' ); ?>
+		<?php
+		if ( $cron_disabled ) {
+			echo '<br><span style="color:red;">' . esc_html__( 'Warning: WP CRON has been disabled on your install which may prevent this update from completing.', 'woocommerce' ) . '</span>';
+		}
+		?>
+		&nbsp;<a href="<?php echo esc_url( $pending_actions_url ); ?>">
+			<?php
+			if ( $cron_disabled ) {
+				esc_html_e( 'You can manually run queued updates here.', 'woocommerce' );
+			} else {
+				esc_html_e( 'View progress &rarr;', 'woocommerce' );
+			}
+			?>
+		</a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-updating.php
+++ b/includes/admin/views/html-notice-updating.php
@@ -11,6 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 $pending_actions_url = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=woocommerce_run_update&status=pending' );
 $cron_disabled       = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON;
+$cron_cta            = $cron_disabled ? __( 'You can manually run queued updates here.', 'woocommerce' ) : __( 'View progress &rarr;', 'woocommerce' );
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p>
@@ -20,14 +21,6 @@ $cron_disabled       = defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON;
 			echo '<br><span style="color:red;">' . esc_html__( 'Warning: WP CRON has been disabled on your install which may prevent this update from completing.', 'woocommerce' ) . '</span>';
 		}
 		?>
-		&nbsp;<a href="<?php echo esc_url( $pending_actions_url ); ?>">
-			<?php
-			if ( $cron_disabled ) {
-				esc_html_e( 'You can manually run queued updates here.', 'woocommerce' );
-			} else {
-				esc_html_e( 'View progress &rarr;', 'woocommerce' );
-			}
-			?>
-		</a>
+		&nbsp;<a href="<?php echo esc_url( $pending_actions_url ); ?>"><?php echo esc_html( $cron_cta ); ?></a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-updating.php
+++ b/includes/admin/views/html-notice-updating.php
@@ -15,10 +15,11 @@ $cron_cta            = $cron_disabled ? __( 'You can manually run queued updates
 ?>
 <div id="message" class="updated woocommerce-message wc-connect">
 	<p>
-		<strong><?php esc_html_e( 'WooCommerce database update', 'woocommerce' ); ?></strong> &#8211; <?php esc_html_e( 'WooCommerce is updating the database in the background. The database update process may take a little while, so please be patient.', 'woocommerce' ); ?>
+		<strong><?php esc_html_e( 'WooCommerce database update', 'woocommerce' ); ?></strong><br>
+		<?php esc_html_e( 'WooCommerce is updating the database in the background. The database update process may take a little while, so please be patient.', 'woocommerce' ); ?>
 		<?php
 		if ( $cron_disabled ) {
-			echo '<br><span style="color:red;">' . esc_html__( 'Warning: WP CRON has been disabled on your install which may prevent this update from completing.', 'woocommerce' ) . '</span>';
+			echo '<br>' . esc_html__( 'Note: WP CRON has been disabled on your install which may prevent this update from completing.', 'woocommerce' );
 		}
 		?>
 		&nbsp;<a href="<?php echo esc_url( $pending_actions_url ); ?>"><?php echo esc_html( $cron_cta ); ?></a>


### PR DESCRIPTION
This PR tweaks both the update notice and the product lookup table regeneration notice to include a link to the scheduled actions screen, and a warning if WP Cron has been disabled which may impact the jobs completing.

To test the update notice, set woocommerce_db_version to 3.5 and refresh
To test the lookup data notice, go to WC > Status > Tools > Regenerate.

Regular notices:

![Orders ‹ WC Dev — WordPress 2019-04-18 19-55-51](https://user-images.githubusercontent.com/90977/56384982-bdd1f680-6215-11e9-9045-9080c3d99095.png)
![Orders ‹ WC Dev — WordPress 2019-04-18 20-02-09](https://user-images.githubusercontent.com/90977/56384989-c0345080-6215-11e9-8d4d-74a22f9c89f4.png)

WP Cron disabled:

![Orders ‹ WC Dev — WordPress 2019-04-18 20-02-55](https://user-images.githubusercontent.com/90977/56384997-c75b5e80-6215-11e9-91ee-02d916424e2d.png)
![Orders ‹ WC Dev — WordPress 2019-04-18 19-55-18](https://user-images.githubusercontent.com/90977/56385002-cc201280-6215-11e9-81c0-baa4a6d42279.png)

@timmyc @peterfabian 