### PR TITLE
Added cleanup of marketplace scheduled actions queue when the checkbox value changes.

### DIFF
--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
@@ -198,5 +198,5 @@ class WC_Marketplace_Suggestions {
 	}
 }
 
-WC_Marketplace_Suggestions::init();
+add_action( 'init', array( 'WC_Marketplace_Suggestions', 'init' ) );
 

--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -26,13 +26,13 @@ class WC_Marketplace_Updater {
 	 * Schedule events and hook appropriate actions.
 	 */
 	public static function init() {
-		$queue = WC()->queue();
-		$next  = $queue->get_next( 'woocommerce_update_marketplace_suggestions' );
-		if ( ! $next ) {
-			$queue->schedule_recurring( time(), WEEK_IN_SECONDS, 'woocommerce_update_marketplace_suggestions' );
+		if ( WC_Marketplace_Suggestions::allow_suggestions() ) {
+			self::schedule_next_action();
 		}
-
 		add_action( 'woocommerce_update_marketplace_suggestions', array( __CLASS__, 'update_marketplace_suggestions' ) );
+
+		// Removes scheduled tasks when suggestions are inactive, add scheduled action if suggestions are enabled.
+		add_filter( 'update_option_woocommerce_show_marketplace_suggestions', array( __CLASS__, 'update_scheduled_actions' ), 10, 3 );
 	}
 
 	/**
@@ -80,6 +80,42 @@ class WC_Marketplace_Updater {
 	public static function retry() {
 		WC()->queue()->cancel( 'woocommerce_update_marketplace_suggestions' );
 		WC()->queue()->schedule_single( time() + DAY_IN_SECONDS, 'woocommerce_update_marketplace_suggestions' );
+	}
+
+	/**
+	 * Schedules a recurring marketplace suggestion update, if there isn't one already.
+	 */
+	public static function schedule_next_action() {
+		$queue = WC()->queue();
+		$next  = $queue->get_next( 'woocommerce_update_marketplace_suggestions' );
+		if ( ! $next ) {
+			$queue->schedule_recurring( time(), WEEK_IN_SECONDS, 'woocommerce_update_marketplace_suggestions' );
+		}
+	}
+
+	/**
+	 * Updates marketplace suggestions actions when admin option is updated.
+	 *
+	 * @param mixed  $old_value Previous value of option being changed.
+	 * @param mixed  $value New value of option being changed.
+	 * @param string $option Option name.
+	 *
+	 * @return mixed Same value as receive on the input.
+	 */
+	public static function update_scheduled_actions( $old_value, $value, $option ) {
+		if ( 'woocommerce_show_marketplace_suggestions' !== $option ) {
+			return;
+		}
+		if ( 'yes' === $value ) {
+			self::schedule_next_action();
+		} else {
+			$queue = WC()->queue();
+			$next  = $queue->get_next( 'woocommerce_update_marketplace_suggestions' );
+			while ( $next ) {
+				$queue->cancel( 'woocommerce_update_marketplace_suggestions' );
+				$next = $queue->get_next( 'woocommerce_update_marketplace_suggestions' );
+			}
+		}
 	}
 }
 

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -371,6 +371,7 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/class-wc-logger.php';
 		include_once WC_ABSPATH . 'includes/queue/class-wc-action-queue.php';
 		include_once WC_ABSPATH . 'includes/queue/class-wc-queue.php';
+		include_once WC_ABSPATH . 'includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php';
 		include_once WC_ABSPATH . 'includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php';
 
 		/**


### PR DESCRIPTION
Reused static method from WC_Marketplace_Suggestions for checking whether marketplace suggestions should appear, so had to modify the init of the class WC_Marketplace_Suggestions as well.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23386  .

### How to test the changes in this Pull Request:

1. Disable marketplace suggestions.
2. Check Pending queue, it should be empty.
3. Enable marketplace suggestions back.
4. Pending queue should include 1 recurring update task.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Action Scheduler queue cleanup of marketplace suggestions when the checkbox value changes.
