### PR TITLE
Tweak: update paying customer information on payment complete

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -247,8 +247,11 @@ function wc_paying_customer( $order_id ) {
 
 	if ( $customer_id > 0 && 'shop_order_refund' !== $order->get_type() ) {
 		$customer = new WC_Customer( $customer_id );
-		$customer->set_is_paying_customer( true );
-		$customer->save();
+
+		if ( ! $customer->get_is_paying_customer() ) {
+			$customer->set_is_paying_customer( true );
+			$customer->save();
+		}
 	}
 }
 add_action( 'woocommerce_payment_complete', 'wc_paying_customer' );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -252,6 +252,7 @@ function wc_paying_customer( $order_id ) {
 	}
 }
 add_action( 'woocommerce_payment_complete', 'wc_paying_customer' );
+add_action( 'woocommerce_order_status_completed', 'wc_paying_customer' );
 
 /**
  * Checks if a user (by email or ID or both) has bought an item.

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -237,7 +237,7 @@ function wc_update_new_customer_past_orders( $customer_id ) {
 }
 
 /**
- * Order Status completed - This is a paying customer.
+ * Order payment completed - This is a paying customer.
  *
  * @param int $order_id Order ID.
  */
@@ -251,7 +251,7 @@ function wc_paying_customer( $order_id ) {
 		$customer->save();
 	}
 }
-add_action( 'woocommerce_order_status_completed', 'wc_paying_customer' );
+add_action( 'woocommerce_payment_complete', 'wc_paying_customer' );
 
 /**
  * Checks if a user (by email or ID or both) has bought an item.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The [`wc_paying_customer()` method](https://github.com/woocommerce/woocommerce/blob/0cd54b67c7653171a73759e8d7e229ffdfa4cd6a/includes/wc-user-functions.php#L189-L199) sets the paying customer meta. However, when setting the customer total spent value, [all paid statuses are used](https://github.com/woocommerce/woocommerce/blob/master/includes/data-stores/class-wc-customer-data-store.php#L379-L422). Setting the paying customer information, including money spent an order count, therefore seems more appropriate to do on `woocommerce_payment_complete` instead of scoping this only to `completed` orders.

### How to test the changes in this Pull Request:

1. Submit an order for an existing paying customer, but ensure it requires shipping so the order status changes to "processing".
2. Observe no `customer.updated` webhooks are sent, as the customer information is not updated at this point, even though the order has been paid for.
3. Complete the order, then observe customer webhooks are fired.
4. Repeat with these changes, and see that the customer is updated immediately with the paid order.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update customer order and lifetime spend totals upon `payment_complete` to trigger customer.updated webhooks for paid orders.