### PR TITLE
Fix for get categories endpoint

### DIFF
--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -34,10 +34,10 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		// Get category display type.
-		$display_type = get_term_meta( $item->term_id, 'display_type' );
+		$display_type = get_term_meta( $item->term_id, 'display_type', true );
 
 		// Get category order.
-		$menu_order = get_term_meta( $item->term_id, 'order' );
+		$menu_order = get_term_meta( $item->term_id, 'order', true );
 
 		$data = array(
 			'id'          => (int) $item->term_id,
@@ -52,7 +52,7 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 		);
 
 		// Get category image.
-		$image_id = get_term_meta( $item->term_id, 'thumbnail_id' );
+		$image_id = get_term_meta( $item->term_id, 'thumbnail_id', true );
 		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 

--- a/includes/api/v1/class-wc-rest-product-categories-controller.php
+++ b/includes/api/v1/class-wc-rest-product-categories-controller.php
@@ -52,10 +52,10 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		// Get category display type.
-		$display_type = get_term_meta( $item->term_id, 'display_type' );
+		$display_type = get_term_meta( $item->term_id, 'display_type', true );
 
 		// Get category order.
-		$menu_order = get_term_meta( $item->term_id, 'order' );
+		$menu_order = get_term_meta( $item->term_id, 'order', true );
 
 		$data = array(
 			'id'          => (int) $item->term_id,
@@ -70,7 +70,7 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 		);
 
 		// Get category image.
-		$image_id = get_term_meta( $item->term_id, 'thumbnail_id' );
+		$image_id = get_term_meta( $item->term_id, 'thumbnail_id', true );
 		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 

--- a/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
@@ -34,10 +34,10 @@ class WC_REST_Product_Categories_V2_Controller extends WC_REST_Product_Categorie
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		// Get category display type.
-		$display_type = get_term_meta( $item->term_id, 'display_type' );
+		$display_type = get_term_meta( $item->term_id, 'display_type', true );
 
 		// Get category order.
-		$menu_order = get_term_meta( $item->term_id, 'order' );
+		$menu_order = get_term_meta( $item->term_id, 'order', true );
 
 		$data = array(
 			'id'          => (int) $item->term_id,
@@ -52,7 +52,7 @@ class WC_REST_Product_Categories_V2_Controller extends WC_REST_Product_Categorie
 		);
 
 		// Get category image.
-		$image_id = get_term_meta( $item->term_id, 'thumbnail_id' );
+		$image_id = get_term_meta( $item->term_id, 'thumbnail_id', true );
 		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 


### PR DESCRIPTION
Fix to get proper display mode, image and order

issue
https://github.com/woocommerce/woocommerce/issues/23407

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. /wp-json/wc/v3/products/categories/
2. check if you dont have   
`"image": { "src":  false,`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
