### PR TITLE
Fixed incorrect sprintf specifier which caused missing closing <a> tag.

### DIFF
--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -95,7 +95,7 @@ if ( ! comments_open() ) {
 				$account_page_url = wc_get_page_permalink( 'myaccount' );
 				if ( $account_page_url ) {
 					/* translators: %s opening and closing link tags respectively */
-					$comment_form['must_log_in'] = '<p class="must-log-in">' . sprintf( esc_html__( 'You must be %slogged in%S to post a review.', 'woocommerce' ), '<a href="' . esc_url( $account_page_url ) . '">', '</a>' ) . '</p>';
+					$comment_form['must_log_in'] = '<p class="must-log-in">' . sprintf( esc_html__( 'You must be %1$slogged in%2$s to post a review.', 'woocommerce' ), '<a href="' . esc_url( $account_page_url ) . '">', '</a>' ) . '</p>';
 				}
 
 				if ( wc_review_ratings_enabled() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23415  .

Funny thing is that the <a> link around Related product was not present in 'view source', only in 'inspect element'. I was trying to find JS code that adds the link, but then noticed missing </a> above 🤦‍♂️

### How to test the changes in this Pull Request:

1. General settings > Dscussion settings > set Users must be registered and logged in to comment to true.
2. Log out
3. Go to product page and notice Related products is a link to my account.
4. Apply branch and notice it's no longer a link.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed missing closing tag for logging in for reviews.
