### PR TITLE
Product list table shipping class tax_query

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -338,7 +338,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 			?>
 			<select class="wc-category-search" name="product_cat" data-placeholder="<?php esc_attr_e( 'Filter by category', 'woocommerce' ); ?>" data-allow_clear="true">
 				<?php if ( $current_category_slug && $current_category ) : ?>
-					<option value="<?php echo esc_attr( $current_category_slug ); ?>" selected="selected"><?php echo htmlspecialchars( wp_kses_post( $current_category->name ) ); ?><option>
+					<option value="<?php echo esc_attr( $current_category_slug ); ?>" selected="selected"><?php echo esc_html( htmlspecialchars( wp_kses_post( $current_category->name ) ) ); ?><option>
 				<?php endif; ?>
 			</select>
 			<?php
@@ -487,9 +487,9 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		if ( ! empty( $_GET['product_shipping_class'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 			$query_vars['tax_query'][] = array(
 				'taxonomy' => 'product_shipping_class',
-				'field'    => 'id',
-				'terms'    => get_terms( 'product_shipping_class', array( 'fields' => 'ids' ) ),
-				'operator' => 'NOT IN',
+				'field'    => 'slug',
+				'terms'    => sanitize_title( wp_unslash( $_GET['product_shipping_class'] ) ),
+				'operator' => 'IN',
 			);
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The shipping class filter functionality on the product list table in wp-admin was doing some strange things, this PR fixes the behavior so it return the correct products when you pass the product_shipping_class parameter filter.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23439 

### How to test the changes in this Pull Request:

1. Create a shipping class under WooCommerce -> Settings -> Shipping
2. Assign a product to the shipping class
3. Go back to WooCommerce -> Settings -> Shipping and click the count icon next to the shipping class, it should load the product list page with the selected product displaying on screen.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Product list view shipping class filter display correct products.