### PR TITLE
Wrap wc_terms_clauses query in brackets to group meta_key where clause

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -100,7 +100,7 @@ function wc_terms_clauses( $clauses, $taxonomies, $args ) {
 	// For sorting, force left join in case order meta is missing.
 	if ( ! empty( $args['force_menu_order_sort'] ) ) {
 		$clauses['join']    = str_replace( "INNER JOIN {$wpdb->termmeta} ON ( t.term_id = {$wpdb->termmeta}.term_id )", "LEFT JOIN {$wpdb->termmeta} ON ( t.term_id = {$wpdb->termmeta}.term_id AND {$wpdb->termmeta}.meta_key='order')", $clauses['join'] );
-		$clauses['where']   = str_replace( "{$wpdb->termmeta}.meta_key = 'order'", "{$wpdb->termmeta}.meta_key = 'order' OR {$wpdb->termmeta}.meta_key IS NULL", $clauses['where'] );
+		$clauses['where']   = str_replace( "{$wpdb->termmeta}.meta_key = 'order'", "( {$wpdb->termmeta}.meta_key = 'order' OR {$wpdb->termmeta}.meta_key IS NULL )", $clauses['where'] );
 		$clauses['orderby'] = 'DESC' === $args['order'] ? str_replace( 'meta_value+0', 'meta_value+0 DESC, t.name', $clauses['orderby'] ) : str_replace( 'meta_value+0', 'meta_value+0 ASC, t.name', $clauses['orderby'] );
 	}
 


### PR DESCRIPTION
Wraps the IS NULL query in `wc_terms_clauses` in brackets so that it doesn't affect additional where clauses added to the query.

If you sort your product categories and then show categories on the shop page, you can test this by confirming the categories are in your defined order.

`* Fix - Prevent term ordering queries inserted by wc_terms_clauses from conflicting with custom where clauses`