### PR TITLE
Array handling in `get_catalog_ordering_args` to prevent notices

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -454,8 +454,9 @@ class WC_Query {
 			$order         = ! empty( $orderby_value[1] ) ? $orderby_value[1] : $order;
 		}
 
-		$orderby = strtolower( $orderby );
-		$order   = strtoupper( $order );
+		// Convert to correct format.
+		$orderby = strtolower( is_array( $orderby ) ? (string) current( $orderby ) : (string) $orderby );
+		$order   = strtoupper( is_array( $order ) ? (string) current( $order ) : (string) $order );
 		$args    = array(
 			'orderby'  => $orderby,
 			'order'    => ( 'DESC' === $order ) ? 'DESC' : 'ASC',

--- a/tests/unit-tests/util/class-wc-tests-wc-query.php
+++ b/tests/unit-tests/util/class-wc-tests-wc-query.php
@@ -282,6 +282,20 @@ class WC_Tests_WC_Query extends WC_Unit_Test_Case {
 					'meta_key' => '',
 				),
 			),
+			array(
+				'orderby'  => array(
+					'price',
+					'date',
+				),
+				'order'    => array(
+					'DESC',
+				),
+				'expected' => array(
+					'orderby'  => 'price',
+					'order'    => 'DESC',
+					'meta_key' => '',
+				),
+			),
 		);
 
 		foreach ( $data as $test ) {


### PR DESCRIPTION
This PR prevents notices in `get_catalog_ordering_args` if called incorrectly with arrays rather than strings by casting them before using strtolower.

Adds a unit test which is all that is needed to test.

> * Fix - Prevent plugins causing notices by calling `get_catalog_ordering_args` incorrectly.