### PR TITLE
Update class-wc-regenerate-images.php

### DIFF
--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -263,19 +263,14 @@ class WC_Regenerate_Images {
 	private static function get_full_size_image_dimensions( $attachment_id ) {
 		$imagedata = wp_get_attachment_metadata( $attachment_id );
 
-		if ( ! $imagedata ) {
-			return array();
-		}
+        if ( $imagedata && ! isset( $imagedata['file'] ) && isset( $imagedata['sizes']['full'] ) ) {
+            return array(
+                'width' => $imagedata['sizes']['full']['width'],
+                'height' => $imagedata['sizes']['full']['height'],
+            );
+        }
 
-		if ( ! isset( $imagedata['file'] ) && isset( $imagedata['sizes']['full'] ) ) {
-			$imagedata['height'] = $imagedata['sizes']['full']['height'];
-			$imagedata['width']  = $imagedata['sizes']['full']['width'];
-		}
-
-		return array(
-			'width'  => $imagedata['width'],
-			'height' => $imagedata['height'],
-		);
+        return array();
 	}
 
 	/**


### PR DESCRIPTION
Using svg image "$imagedata['sizes']['full']" not set, so php display warning "Undefined index: width" and "Undefined index: height"

### All Submissions:

* [+] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [+] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [+] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

/includes/class-wc-regenerate-images.php
