### PR TITLE
Fixes #23440 : # symbol in Product Category name breaks Reports CSV e…

### DIFF
--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -138,7 +138,7 @@ jQuery(function( $ ) {
 		var groupby       = $( this ) .data( 'groupby' );
 		var index_type    = $( this ).data( 'index_type' );
 		var export_format = $( this ).data( 'export' );
-		var csv_data      = 'data:text/csv;charset=utf-8,\uFEFF';
+		var csv_data      = '';
 		var s, series_data, d;
 
 		if ( 'table' === export_format ) {
@@ -243,8 +243,9 @@ jQuery(function( $ ) {
 			} );
 		}
 
+		csv_data = 'data:text/csv;charset=utf-8,\uFEFF' + encodeURIComponent( csv_data );
 		// Set data as href and return
-		$( this ).attr( 'href', encodeURI( csv_data ) );
+		$( this ).attr( 'href', csv_data );
 		return true;
 	});
 });


### PR DESCRIPTION
fixes : #23440 

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

I have fixed the CSV export issue for categories having name with # symbol. Please check it and let me know if any modifications are required.
