### PR TITLE
During initial product lookup table generation, set an option

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -482,18 +482,18 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 		$children = $product->get_children();
 
 		if ( $children ) {
-			$format               = array_fill( 0, count( $children ), '%d' );
-			$query_in             = '(' . implode( ',', $format ) . ')';
-			$query_args           = array( 'stock_status' => $status ) + $children;
+			$format     = array_fill( 0, count( $children ), '%d' );
+			$query_in   = '(' . implode( ',', $format ) . ')';
+			$query_args = array( 'stock_status' => $status ) + $children;
 			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+			if ( get_option( 'woocommerce_product_lookup_table_is_generating' ) ) {
+				$query = "SELECT COUNT( post_id ) FROM {$wpdb->postmeta} WHERE meta_key = '_stock_status' AND meta_value = %s AND post_id IN {$query_in}";
+			} else {
+				$query = "SELECT COUNT( product_id ) FROM {$wpdb->wc_product_meta_lookup} WHERE stock_status = %s AND product_id IN {$query_in}";
+			}
 			$children_with_status = $wpdb->get_var(
 				$wpdb->prepare(
-					"
-					SELECT COUNT( product_id )
-					FROM {$wpdb->wc_product_meta_lookup}
-					WHERE stock_status = %s
-					AND product_id IN {$query_in}
-					",
+					$query,
 					$query_args
 				)
 			);

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1302,6 +1302,9 @@ function wc_update_product_lookup_tables() {
 		WC_Admin_Notices::add_notice( 'regenerating_lookup_table' );
 	}
 
+	// Note that the table is not yet generated.
+	update_option( 'woocommerce_product_lookup_table_is_generating', true );
+
 	// Make a row per product in lookup table.
 	$wpdb->query(
 		"
@@ -1324,7 +1327,7 @@ function wc_update_product_lookup_tables() {
 		'total_sales',
 		'downloadable',
 		'virtual',
-		'onsale',
+		'onsale', // When last column is updated, woocommerce_product_lookup_table_is_generating is updated.
 	);
 
 	foreach ( $columns as $index => $column ) {
@@ -1476,6 +1479,8 @@ function wc_update_product_lookup_tables_column( $column ) {
 					$decimals
 				)
 			);
+
+			delete_option( 'woocommerce_product_lookup_table_is_generating' ); // Complete.
 			break;
 	}
 	// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared


### PR DESCRIPTION
Fixes #23388

When `wc_update_product_lookup_tables` is called (during updates) this PR sets an option so queries, such as the one inside `WC_Product_Variable_Data_Store_CPT::child_has_stock_status`, can fallback to meta based queries. 

For users updating to 3.6 where the table generation has not yet completed, this will prevent product updates from setting wrong stock status on variable products.

For users already on 3.6, this won't help. They need to wait for lookup table generation to complete or trigger it manually.

To test the original issue, see https://github.com/woocommerce/woocommerce/issues/23388#issuecomment-485786356

> * Fix - When product lookup table is generating for the first time, avoid wrong stock statuses being set for variable products.