### PR TITLE
Disable export of scheduled action posts

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -30,6 +30,9 @@ class WC_Admin {
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ), 1 );
 		add_action( 'wp_ajax_setup_wizard_check_jetpack', array( $this, 'setup_wizard_check_jetpack' ) );
 		add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
+
+		// Disable WXR export of schedule action posts.
+		add_filter( 'action_scheduler_post_type_args', array( $this, 'disable_webhook_post_export' ) );
 	}
 
 	/**
@@ -287,6 +290,20 @@ class WC_Admin {
 				'is_active' => $jetpack_active ? 'yes' : 'no',
 			)
 		);
+	}
+
+	/**
+	 * Disable WXR export of scheduled action posts.
+	 *
+	 * @since 3.6.2
+	 *
+	 * @param array $args Scehduled action post type registration args.
+	 *
+	 * @return array
+	 */
+	public function disable_webhook_post_export( $args ) {
+		$args['can_export'] = false;
+		return $args;
 	}
 }
 

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -72,8 +72,8 @@ class WC_Admin {
 		}
 
 		// Setup/welcome.
-		if ( ! empty( $_GET['page'] ) ) {
-			switch ( $_GET['page'] ) {
+		if ( ! empty( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+			switch ( $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 				case 'wc-setup':
 					include_once dirname( __FILE__ ) . '/class-wc-admin-setup-wizard.php';
 					break;
@@ -254,7 +254,7 @@ class WC_Admin {
 		$wc_pages = array_diff( $wc_pages, array( 'profile', 'user-edit' ) );
 
 		// Check to make sure we're on a WooCommerce admin page.
-		if ( isset( $current_screen->id ) && apply_filters( 'woocommerce_display_admin_footer_text', in_array( $current_screen->id, $wc_pages ) ) ) {
+		if ( isset( $current_screen->id ) && apply_filters( 'woocommerce_display_admin_footer_text', in_array( $current_screen->id, $wc_pages, true ) ) ) {
 			// Change the footer text.
 			if ( ! get_option( 'woocommerce_admin_footer_text_rated' ) ) {
 				$footer_text = sprintf(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The serialized schedule objects in the post meta of recurring scheduled action posts exported to WXR contain null characters to delimit object variables. These meta rows cause fatal errors in the WP WXR importer with some versions of PHP.

This filter would not work in the WC_Admin_Post_Types because both the AS post type registration and the WC_Admin_Post_Types class load are hooked into `init` at the default priority. The AS hook is registered first. To use WC_Admin_Post_Types we would need to change the priority on one of the two hooks. This implementation is less intrusive.

Closes #23447 .

### How to test the changes in this Pull Request:

1. Go to the Tools -> Export
2. Scheduled Actions should not be in the list of post types available for export
3. Export all content
4. Edit the exported XML file
5. Searching for `scheduled` should return no results

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Disable the export of scheduled action posts.
