### PR TITLE
Fixed use of get_term_meta in REST API endpoints

### DIFF
--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -34,10 +34,10 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		// Get category display type.
-		$display_type = get_term_meta( $item->term_id, 'display_type' );
+		$display_type = get_term_meta( $item->term_id, 'display_type', true );
 
 		// Get category order.
-		$menu_order = get_term_meta( $item->term_id, 'order' );
+		$menu_order = get_term_meta( $item->term_id, 'order', true );
 
 		$data = array(
 			'id'          => (int) $item->term_id,
@@ -52,7 +52,7 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 		);
 
 		// Get category image.
-		$image_id = get_term_meta( $item->term_id, 'thumbnail_id' );
+		$image_id = get_term_meta( $item->term_id, 'thumbnail_id', true );
 		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 

--- a/includes/api/class-wc-rest-product-categories-controller.php
+++ b/includes/api/class-wc-rest-product-categories-controller.php
@@ -34,10 +34,10 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		// Get category display type.
-		$display_type = get_term_meta( $item->term_id, 'display_type', true );
+		$display_type = get_term_meta( $item->term_id, 'display_type' );
 
 		// Get category order.
-		$menu_order = get_term_meta( $item->term_id, 'order', true );
+		$menu_order = get_term_meta( $item->term_id, 'order' );
 
 		$data = array(
 			'id'          => (int) $item->term_id,
@@ -52,7 +52,7 @@ class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V
 		);
 
 		// Get category image.
-		$image_id = get_term_meta( $item->term_id, 'thumbnail_id', true );
+		$image_id = get_term_meta( $item->term_id, 'thumbnail_id' );
 		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 

--- a/includes/api/legacy/v2/class-wc-api-products.php
+++ b/includes/api/legacy/v2/class-wc-api-products.php
@@ -607,11 +607,11 @@ class WC_API_Products extends WC_API_Resource {
 			$term_id = intval( $term->term_id );
 
 			// Get category display type
-			$display_type = get_term_meta( $term_id, 'display_type' );
+			$display_type = get_term_meta( $term_id, 'display_type', true );
 
 			// Get category image
 			$image = '';
-			if ( $image_id = get_term_meta( $term_id, 'thumbnail_id' ) ) {
+			if ( $image_id = get_term_meta( $term_id, 'thumbnail_id', true ) ) {
 				$image = wp_get_attachment_url( $image_id );
 			}
 

--- a/includes/api/legacy/v3/class-wc-api-products.php
+++ b/includes/api/legacy/v3/class-wc-api-products.php
@@ -666,11 +666,11 @@ class WC_API_Products extends WC_API_Resource {
 			$term_id = intval( $term->term_id );
 
 			// Get category display type
-			$display_type = get_term_meta( $term_id, 'display_type' );
+			$display_type = get_term_meta( $term_id, 'display_type', true );
 
 			// Get category image
 			$image = '';
-			if ( $image_id = get_term_meta( $term_id, 'thumbnail_id' ) ) {
+			if ( $image_id = get_term_meta( $term_id, 'thumbnail_id', true ) ) {
 				$image = wp_get_attachment_url( $image_id );
 			}
 

--- a/includes/api/v1/class-wc-rest-product-attribute-terms-controller.php
+++ b/includes/api/v1/class-wc-rest-product-attribute-terms-controller.php
@@ -134,7 +134,7 @@ class WC_REST_Product_Attribute_Terms_V1_Controller extends WC_REST_Terms_Contro
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		// Get term order.
-		$menu_order = get_term_meta( $item->term_id, 'order_' . $this->taxonomy );
+		$menu_order = get_term_meta( $item->term_id, 'order_' . $this->taxonomy, true );
 
 		$data = array(
 			'id'          => (int) $item->term_id,

--- a/includes/api/v1/class-wc-rest-product-categories-controller.php
+++ b/includes/api/v1/class-wc-rest-product-categories-controller.php
@@ -52,10 +52,10 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		// Get category display type.
-		$display_type = get_term_meta( $item->term_id, 'display_type' );
+		$display_type = get_term_meta( $item->term_id, 'display_type', true );
 
 		// Get category order.
-		$menu_order = get_term_meta( $item->term_id, 'order' );
+		$menu_order = get_term_meta( $item->term_id, 'order', true );
 
 		$data = array(
 			'id'          => (int) $item->term_id,
@@ -70,7 +70,7 @@ class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller 
 		);
 
 		// Get category image.
-		$image_id = get_term_meta( $item->term_id, 'thumbnail_id' );
+		$image_id = get_term_meta( $item->term_id, 'thumbnail_id', true );
 		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 

--- a/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-product-categories-v2-controller.php
@@ -34,10 +34,10 @@ class WC_REST_Product_Categories_V2_Controller extends WC_REST_Product_Categorie
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		// Get category display type.
-		$display_type = get_term_meta( $item->term_id, 'display_type' );
+		$display_type = get_term_meta( $item->term_id, 'display_type', true );
 
 		// Get category order.
-		$menu_order = get_term_meta( $item->term_id, 'order' );
+		$menu_order = get_term_meta( $item->term_id, 'order', true );
 
 		$data = array(
 			'id'          => (int) $item->term_id,
@@ -52,7 +52,7 @@ class WC_REST_Product_Categories_V2_Controller extends WC_REST_Product_Categorie
 		);
 
 		// Get category image.
-		$image_id = get_term_meta( $item->term_id, 'thumbnail_id' );
+		$image_id = get_term_meta( $item->term_id, 'thumbnail_id', true );
 		if ( $image_id ) {
 			$attachment = get_post( $image_id );
 


### PR DESCRIPTION
This pull request is intended to correct what was missing in #23408.
