### PR TITLE
Fix woocommerce_output_all_notices bug

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3597,9 +3597,9 @@ function wc_get_cart_undo_url( $cart_item_key ) {
  * @since 3.5.0
  */
 function woocommerce_output_all_notices() {
-	$notices = wc_print_notices(true);
+	$notices = wc_print_notices( true );
 	
-	if(strlen($notices) > 0) {
+	if ( strlen( $notices ) > 0 ) {
 		echo '<div class="woocommerce-notices-wrapper">'.$notices.'</div>';
 	}
 }

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3600,9 +3600,7 @@ function woocommerce_output_all_notices() {
 	$notices = wc_print_notices(true);
 	
 	if(strlen($notices) > 0) {
-		echo '<div class="woocommerce-notices-wrapper">';
-		echo $notices;
-		echo '</div>';
+		echo '<div class="woocommerce-notices-wrapper">'.$notices.'</div>';
 	}
 }
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3598,7 +3598,7 @@ function wc_get_cart_undo_url( $cart_item_key ) {
  */
 function woocommerce_output_all_notices() {
 	$notices = wc_print_notices( true );
-	
+
 	if ( strlen( $notices ) > 0 ) {
 		echo '<div class="woocommerce-notices-wrapper">' . $notices . '</div>';
 	}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3600,7 +3600,7 @@ function woocommerce_output_all_notices() {
 	$notices = wc_print_notices( true );
 	
 	if ( strlen( $notices ) > 0 ) {
-		echo '<div class="woocommerce-notices-wrapper">'.$notices.'</div>';
+		echo '<div class="woocommerce-notices-wrapper">' . $notices . '</div>';
 	}
 }
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3597,9 +3597,13 @@ function wc_get_cart_undo_url( $cart_item_key ) {
  * @since 3.5.0
  */
 function woocommerce_output_all_notices() {
-	echo '<div class="woocommerce-notices-wrapper">';
-	wc_print_notices();
-	echo '</div>';
+	$notices = wc_print_notices(true);
+	
+	if(strlen($notices) > 0) {
+		echo '<div class="woocommerce-notices-wrapper">';
+		echo $notices;
+		echo '</div>';
+	}
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes woocommerce_output_all_notices bug, the div was always triggered even in error `500` returing invalid input (only div, no html).

### How to test the changes in this Pull Request:

1. Force any error and see proper output
2. Use any JSON api and json will be malformed due to `divs`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

- Add extra check on the current implementation, it will avoid to return a string if the list of notices is empty.
- Code cleanup
