### PR TITLE
List plugins already compatible with next WooCommerce version

### DIFF
--- a/includes/admin/plugin-updates/class-wc-plugin-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugin-updates.php
@@ -213,7 +213,7 @@ class WC_Plugin_Updates {
 					$plugin_version .= '.' . $plugin_version_parts[1];
 				}
 
-				if ( version_compare( $plugin_version, $version, '<' ) ) {
+				if ( version_compare( $plugin_version, $version, '<=' ) ) {
 					$untested[ $file ] = $plugin;
 				}
 			} else {

--- a/tests/unit-tests/util/plugin-updates.php
+++ b/tests/unit-tests/util/plugin-updates.php
@@ -1,9 +1,13 @@
 <?php
+/**
+ * Test WC_Plugin_Updates class
+ *
+ * @package WooCommerce\Tests\Util
+ * @since 3.2.0
+ */
 
 /**
  * Class WC_Plugin_Updates.
- * @package WooCommerce\Tests\Util
- * @since 3.2.0
  */
 class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 
@@ -23,10 +27,10 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 
 		if ( ! class_exists( 'WC_Plugin_Updates' ) ) {
 			$bootstrap = WC_Unit_Tests_Bootstrap::instance();
-			include_once( $bootstrap->plugin_dir . '/includes/admin/plugin-updates/class-wc-plugin-updates.php' );
+			include_once $bootstrap->plugin_dir . '/includes/admin/plugin-updates/class-wc-plugin-updates.php';
 		}
 
-		$this->updates = new WC_Plugin_Updates;
+		$this->updates = new WC_Plugin_Updates();
 		$this->plugins = array();
 
 		add_filter( 'woocommerce_get_plugins_with_header', array( $this, 'populate_untested_plugins' ), 10, 2 );
@@ -35,7 +39,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 	/**
 	 * Allow this test suite to easily define plugin results to test for the version tested header.
 	 *
-	 * @param array $plugins array of plugin data in same format as get_plugins.
+	 * @param array  $plugins array of plugin data in same format as get_plugins.
 	 * @param string $header plugin header results matched on.
 	 * @return array modified $plugins.
 	 * @since 3.2.0
@@ -57,7 +61,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		$release = 'major';
 
 		$this->plugins = array(
-			'test/test.php' => array(
+			'test/test.php'   => array(
 				'Name'                                   => 'Test plugin',
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.0.0',
 			),
@@ -74,29 +78,29 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.0.1',
 			),
 		);
-		$new_version = '4.0.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$new_version   = '4.0.0';
+		$untested      = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '3.9.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayNotHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '4.3.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '4.0.2';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayHasKey( 'test3/test3.php', $untested );
@@ -112,7 +116,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		$release = 'major';
 
 		$this->plugins = array(
-			'test/test.php' => array(
+			'test/test.php'   => array(
 				'Name'                                   => 'Test plugin',
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '3.0.0',
 			),
@@ -125,18 +129,18 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '3.0',
 			),
 		);
-		$plugin_keys = array_keys( $this->plugins );
+		$plugin_keys   = array_keys( $this->plugins );
 
 		$new_version = '4.0.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertEquals( $plugin_keys, array_intersect( $plugin_keys, array_keys( $untested ) ) );
 
 		$new_version = '4.3.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertEquals( $plugin_keys, array_intersect( $plugin_keys, array_keys( $untested ) ) );
 
 		$new_version = '4.0.2';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertEquals( $plugin_keys, array_intersect( $plugin_keys, array_keys( $untested ) ) );
 	}
 
@@ -149,7 +153,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		$release = 'minor';
 
 		$this->plugins = array(
-			'test/test.php' => array(
+			'test/test.php'   => array(
 				'Name'                                   => 'Test plugin',
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.1.0',
 			),
@@ -166,22 +170,22 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.2.1',
 			),
 		);
-		$new_version = '4.1.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$new_version   = '4.1.0';
+		$untested      = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '4.2.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '4.1.5';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayHasKey( 'test3/test3.php', $untested );
@@ -197,7 +201,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		$release = 'minor';
 
 		$this->plugins = array(
-			'test/test.php' => array(
+			'test/test.php'   => array(
 				'Name'                                   => 'Test plugin',
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.1.0',
 			),
@@ -210,14 +214,14 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.2',
 			),
 		);
-		$plugin_keys = array_keys( $this->plugins );
+		$plugin_keys   = array_keys( $this->plugins );
 
 		$new_version = '4.3.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertEquals( $plugin_keys, array_intersect( $plugin_keys, array_keys( $untested ) ) );
 
 		$new_version = '4.3.1';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertEquals( $plugin_keys, array_intersect( $plugin_keys, array_keys( $untested ) ) );
 
 		$new_version = '4.1.0';
@@ -237,7 +241,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		$release = 'minor';
 
 		$this->plugins = array(
-			'test/test.php' => array(
+			'test/test.php'   => array(
 				'Name'                                   => 'Test plugin',
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4',
 			),
@@ -255,13 +259,13 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 			),
 		);
 
-		$release = 'major';
+		$release     = 'major';
 		$new_version = '5.0.0';
 		$this->assertArrayHasKey( 'test/test.php', $this->updates->get_untested_plugins( $new_version, $release ) );
 
-		$release = 'minor';
+		$release     = 'minor';
 		$new_version = '4.1.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayNotHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );

--- a/tests/unit-tests/util/plugin-updates.php
+++ b/tests/unit-tests/util/plugin-updates.php
@@ -76,10 +76,10 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		);
 		$new_version = '4.0.0';
 		$untested = $this->updates->get_untested_plugins( $new_version, $release );
-		$this->assertArrayNotHasKey( 'test/test.php', $untested );
+		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
-		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
-		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
+		$this->assertArrayHasKey( 'test3/test3.php', $untested );
+		$this->assertArrayHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '3.9.0';
 		$untested = $this->updates->get_untested_plugins( $new_version, $release );
@@ -90,17 +90,17 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 
 		$new_version = '4.3.0';
 		$untested = $this->updates->get_untested_plugins( $new_version, $release );
-		$this->assertArrayNotHasKey( 'test/test.php', $untested );
+		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
-		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
-		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
+		$this->assertArrayHasKey( 'test3/test3.php', $untested );
+		$this->assertArrayHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '4.0.2';
 		$untested = $this->updates->get_untested_plugins( $new_version, $release );
-		$this->assertArrayNotHasKey( 'test/test.php', $untested );
+		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
-		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
-		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
+		$this->assertArrayHasKey( 'test3/test3.php', $untested );
+		$this->assertArrayHasKey( 'test4/test4.php', $untested );
 	}
 
 	/**
@@ -168,9 +168,9 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		);
 		$new_version = '4.1.0';
 		$untested = $this->updates->get_untested_plugins( $new_version, $release );
-		$this->assertArrayNotHasKey( 'test/test.php', $untested );
+		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
-		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
+		$this->assertArrayHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '4.2.0';
@@ -178,13 +178,13 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayHasKey( 'test3/test3.php', $untested );
-		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
+		$this->assertArrayHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '4.1.5';
 		$untested = $this->updates->get_untested_plugins( $new_version, $release );
-		$this->assertArrayNotHasKey( 'test/test.php', $untested );
+		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
-		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
+		$this->assertArrayHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

If you are running WooCommerce 3.5.8 and already have updated some plugins that declares support for WooCommerce 3.6, those should not be listed, see:

![Screenshot from 2019-04-23 13-37-28](https://user-images.githubusercontent.com/1264099/56599773-a5732a80-65cd-11e9-9279-280eef51f5c6.png)

This Pull Request fixes it:

![Screenshot from 2019-04-23 13-37-17](https://user-images.githubusercontent.com/1264099/56610724-8339d680-65e6-11e9-84f8-1acddf581085.png)

I found it debugging: https://github.com/woocommerce/woocommerce/issues/23458

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Checkout to a old tag, like `git checkout tags/3.5.8`
2. Create or edit any plugin with the follow header: `WC tested up to: 3.5.0`
3. Note that it will display properly, but if you change to `3.6.0` will hide the plugin name from the list.
4. Apply this patch and check that now `3.6.0` works.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Display plugins that already supports new version of WooCommerce in the update notice.
