### PR TITLE
Updated the meta_key for average rating when generating lookup tables.

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1425,7 +1425,13 @@ function wc_update_product_lookup_tables_column( $column ) {
 		case 'stock_status':
 		case 'average_rating':
 		case 'total_sales':
-			$meta_key = 'total_sales' === $column ? $column : '_' . $column;
+			if ( 'total_sales' === $column ) {
+				$meta_key = 'total_sales';
+			} elseif ( 'average_rating' === $column ) {
+				$meta_key = '_wc_average_rating';
+			} else {
+				$meta_key = '_' . $column;
+			}
 			$column   = esc_sql( $column );
 			$wpdb->query(
 				$wpdb->prepare(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23403  .

### How to test the changes in this Pull Request:

1. On a fresh site, install WC 3.5.7, add upload sample products, rate a few of them.
2. Upgrade to WC 3.6, see the average rating is not reflected in the lookup table.
3. Apply the change, run the db upgrade again (or start from step 1)
4. Average rating column should now be populated correctly. 
5. Test that adding another rating correctly updates the rating in lookup table.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed average_rating in the db upgrade routine for lookup table.
