### PR TITLE
Return WP_Error messages from wp_insert_user()

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -99,7 +99,7 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 		$customer_id = wp_insert_user( $new_customer_data );
 
 		if ( is_wp_error( $customer_id ) ) {
-			return new WP_Error( 'registration-error', __( 'Couldn&#8217;t register you&hellip; please contact us if you continue to have problems.', 'woocommerce' ) );
+			return $customer_id;
 		}
 
 		do_action( 'woocommerce_created_customer', $customer_id, $new_customer_data, $password_generated );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Our current message is too generic, not covering all error messages that `wp_insert_user()` may throw, see: https://core.trac.wordpress.org/browser/tags/5.1.1/src/wp-includes/user.php#L1519

Also this ensure that new features should work properly, like the new `illegal_user_logins` that should display a correct error message now.

Closes #23395.

### How to test the changes in this Pull Request:

1. Include the follow filter:
```php
add_filter( 'illegal_user_logins', function( $logins ) {
    $logins[] = 'woo';
    return $logins;
} );
```
2. Try create a user called `woo` (you can use `wp shell` and then `wc_create_new_customer( 'example@mail.com', 'woo' )`)
3. Check the error message
4. Now apply this patch and try again to see the correct error message.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Improve user registration validation messages. 
