### PR TITLE
Default category sorting order should be overwritten if defined by get_terms

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -32,16 +32,13 @@ function wc_change_get_terms_defaults( $defaults, $taxonomies ) {
 		$orderby = 'menu_order';
 	}
 
+	// Change defaults. Invalid values will be changed later @see wc_change_pre_get_terms.
+	// These are in place so we know if a specific order was requested.
 	switch ( $orderby ) {
 		case 'menu_order':
-			$defaults['force_menu_order_sort'] = true;
-			break;
 		case 'name_num':
-			$defaults['orderby']            = 'name';
-			$defaults['force_numeric_name'] = true;
-			break;
 		case 'parent':
-			$defaults['orderby'] = 'parent';
+			$defaults['orderby'] = $orderby;
 			break;
 	}
 
@@ -58,11 +55,23 @@ add_filter( 'get_terms_defaults', 'wc_change_get_terms_defaults', 10, 2 );
 function wc_change_pre_get_terms( $terms_query ) {
 	$args = &$terms_query->query_vars;
 
+	// Put back valid orderby values.
+	if ( 'menu_order' === $args['orderby'] ) {
+		$args['orderby']               = 'name';
+		$args['force_menu_order_sort'] = true;
+	}
+
+	if ( 'name_num' === $args['orderby'] ) {
+		$args['orderby']            = 'name';
+		$args['force_numeric_name'] = true;
+	}
+
 	// When COUNTING, disable custom sorting.
 	if ( 'count' === $args['fields'] ) {
 		return;
 	}
 
+	// Support menu_order arg used in previous versions.
 	if ( ! empty( $args['menu_order'] ) ) {
 		$args['order']                 = 'DESC' === strtoupper( $args['menu_order'] ) ? 'DESC' : 'ASC';
 		$args['force_menu_order_sort'] = true;

--- a/tests/unit-tests/core/taxonomies.php
+++ b/tests/unit-tests/core/taxonomies.php
@@ -9,25 +9,17 @@
  * WC_Test_Taxonomies class.
  */
 class WC_Test_Taxonomies extends WC_Unit_Test_Case {
-
-	/**
-	 * Setup test.
-	 */
-	public function setUp() {
-		parent::setUp();
-		$category_1 = wp_insert_term( 'Zulu Category', 'product_cat' );
-		$category_2 = wp_insert_term( 'Alpha Category', 'product_cat' );
-		$category_3 = wp_insert_term( 'Beta Category', 'product_cat' );
-		update_term_meta( $category_1['term_id'], 'order', 2 );
-		update_term_meta( $category_2['term_id'], 'order', 1 );
-		update_term_meta( $category_3['term_id'], 'order', 3 );
-	}
-
 	/**
 	 * Test get_terms sorting.
 	 */
 	public function test_get_terms_orderby() {
 		$default_category_id = absint( get_option( 'default_product_cat', 0 ) );
+		$category_1          = wp_insert_term( 'Zulu Category', 'product_cat' );
+		$category_2          = wp_insert_term( 'Alpha Category', 'product_cat' );
+		$category_3          = wp_insert_term( 'Beta Category', 'product_cat' );
+		update_term_meta( $category_1['term_id'], 'order', 2 );
+		update_term_meta( $category_2['term_id'], 'order', 1 );
+		update_term_meta( $category_3['term_id'], 'order', 3 );
 
 		// Default sort (menu_order).
 		$terms = array_values(
@@ -95,6 +87,85 @@ class WC_Test_Taxonomies extends WC_Unit_Test_Case {
 				'Zulu Category',
 				'Alpha Category',
 				'Beta Category',
+			),
+			$terms,
+			print_r( $terms, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		);
+	}
+
+	/**
+	 * Test get_terms sorting for name_num.
+	 */
+	public function test_get_terms_orderby_name_num() {
+		$default_category_id = absint( get_option( 'default_product_cat', 0 ) );
+		wp_insert_term( '1', 'product_cat' );
+		wp_insert_term( '2', 'product_cat' );
+		wp_insert_term( '3', 'product_cat' );
+		wp_insert_term( '4', 'product_cat' );
+		wp_insert_term( '5', 'product_cat' );
+		wp_insert_term( '10', 'product_cat' );
+		wp_insert_term( '9', 'product_cat' );
+		wp_insert_term( '8', 'product_cat' );
+		wp_insert_term( '7', 'product_cat' );
+		wp_insert_term( '6', 'product_cat' );
+
+		// by name.
+		$terms = array_values(
+			wp_list_pluck(
+				get_terms(
+					array(
+						'taxonomy'   => 'product_cat',
+						'hide_empty' => false,
+						'orderby'    => 'name',
+						'exclude'    => $default_category_id,
+					)
+				),
+				'name'
+			)
+		);
+		$this->assertEquals(
+			array(
+				'1',
+				'10',
+				'2',
+				'3',
+				'4',
+				'5',
+				'6',
+				'7',
+				'8',
+				'9',
+			),
+			$terms,
+			print_r( $terms, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		);
+
+		// by numeric name.
+		$terms = array_values(
+			wp_list_pluck(
+				get_terms(
+					array(
+						'taxonomy'   => 'product_cat',
+						'hide_empty' => false,
+						'orderby'    => 'name_num',
+						'exclude'    => $default_category_id,
+					)
+				),
+				'name'
+			)
+		);
+		$this->assertEquals(
+			array(
+				'1',
+				'2',
+				'3',
+				'4',
+				'5',
+				'6',
+				'7',
+				'8',
+				'9',
+				'10',
 			),
 			$terms,
 			print_r( $terms, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r

--- a/tests/unit-tests/core/taxonomies.php
+++ b/tests/unit-tests/core/taxonomies.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Taxonomy tests class.
+ *
+ * @package WooCommerce\Tests\Core
+ */
+
+/**
+ * WC_Test_Taxonomies class.
+ */
+class WC_Test_Taxonomies extends WC_Unit_Test_Case {
+
+	/**
+	 * Setup test.
+	 */
+	public function setUp() {
+		parent::setUp();
+		$category_1 = wp_insert_term( 'Zulu Category', 'product_cat' );
+		$category_2 = wp_insert_term( 'Alpha Category', 'product_cat' );
+		$category_3 = wp_insert_term( 'Beta Category', 'product_cat' );
+		update_term_meta( $category_1['term_id'], 'order', 2 );
+		update_term_meta( $category_2['term_id'], 'order', 1 );
+		update_term_meta( $category_3['term_id'], 'order', 3 );
+	}
+
+	/**
+	 * Test get_terms sorting.
+	 */
+	public function test_get_terms_orderby() {
+		$default_category_id = absint( get_option( 'default_product_cat', 0 ) );
+
+		// Default sort (menu_order).
+		$terms = array_values(
+			wp_list_pluck(
+				get_terms(
+					array(
+						'taxonomy'   => 'product_cat',
+						'hide_empty' => false,
+						'exclude'    => $default_category_id,
+					)
+				),
+				'name'
+			)
+		);
+		$this->assertEquals(
+			array(
+				'Alpha Category',
+				'Zulu Category',
+				'Beta Category',
+			),
+			$terms,
+			print_r( $terms, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		);
+
+		// Force sort by name.
+		$terms = array_values(
+			wp_list_pluck(
+				get_terms(
+					array(
+						'taxonomy'   => 'product_cat',
+						'orderby'    => 'name',
+						'hide_empty' => false,
+						'exclude'    => $default_category_id,
+					)
+				),
+				'name'
+			)
+		);
+		$this->assertEquals(
+			array(
+				'Alpha Category',
+				'Beta Category',
+				'Zulu Category',
+			),
+			$terms,
+			print_r( $terms, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		);
+
+		// Force sort by ID.
+		$terms = array_values(
+			wp_list_pluck(
+				get_terms(
+					array(
+						'taxonomy'   => 'product_cat',
+						'orderby'    => 'term_id',
+						'hide_empty' => false,
+						'exclude'    => $default_category_id,
+					)
+				),
+				'name'
+			)
+		);
+		$this->assertEquals(
+			array(
+				'Zulu Category',
+				'Alpha Category',
+				'Beta Category',
+			),
+			$terms,
+			print_r( $terms, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		);
+	}
+}

--- a/tests/unit-tests/core/taxonomies.php
+++ b/tests/unit-tests/core/taxonomies.php
@@ -44,6 +44,31 @@ class WC_Test_Taxonomies extends WC_Unit_Test_Case {
 			print_r( $terms, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
 		);
 
+		// Explicit menu_order sort, backwards.
+		$terms = array_values(
+			wp_list_pluck(
+				get_terms(
+					array(
+						'taxonomy'   => 'product_cat',
+						'hide_empty' => false,
+						'orderby'    => 'menu_order',
+						'order'      => 'DESC',
+						'exclude'    => $default_category_id,
+					)
+				),
+				'name'
+			)
+		);
+		$this->assertEquals(
+			array(
+				'Beta Category',
+				'Zulu Category',
+				'Alpha Category',
+			),
+			$terms,
+			print_r( $terms, true ) // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		);
+
 		// Force sort by name.
 		$terms = array_values(
 			wp_list_pluck(


### PR DESCRIPTION
Fixes #23466 

The default orderby being set was taking precedence when defining an orderby when calling get_terms. The revised code sets the default, then only proceeds to use the default if another orderby was not defined.

This now has test coverage. The tests cover menu_order, name_num, default, and regular sorting params for get_terms.

You should also test that:

- The order you sort categories is reflected in the shop when showing categories on the shop page
- The order you sort attributes is reflected in variable product attribute dropdowns

> * Fix - Allow default sorting of WC taxonomies to be overwritten by get_terms orderby.