### PR TITLE
Force delete rather than trash variations on product type change

### DIFF
--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -129,7 +129,7 @@ class WC_Post_Data {
 		if ( 'variable' === $from && 'variable' !== $to ) {
 			// If the product is no longer variable, we should ensure all variations are removed.
 			$data_store = WC_Data_Store::load( 'product-variable' );
-			$data_store->delete_variations( $product->get_id() );
+			$data_store->delete_variations( $product->get_id(), true );
 		}
 	}
 


### PR DESCRIPTION
When product type changes away from variable, variations are trashed.

This should force delete them instead, so they cannot return if trashing/untrashing is performed later on.

To test, change a variable product to simple and save. Check the variation posts are no longer in the DB (force deleted).

> * Tweak - When cleaning up variations due to product type change, force delete them instead of trashing.