### PR TITLE
Fix attribute matching in `get_attribute_taxonomy_name`

### DIFF
--- a/includes/api/v2/class-wc-rest-products-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-products-v2-controller.php
@@ -457,13 +457,21 @@ class WC_REST_Products_V2_Controller extends WC_REST_Legacy_Products_Controller 
 	 * @return string
 	 */
 	protected function get_attribute_taxonomy_name( $slug, $product ) {
+		// Format slug so it matches attributes of the product.
+		$slug       = wc_attribute_taxonomy_slug( $slug );
 		$attributes = $product->get_attributes();
+		$attribute  = false;
 
-		if ( ! isset( $attributes[ $slug ] ) ) {
-			return wc_attribute_taxonomy_slug( $slug );
+		// pa_ attributes.
+		if ( isset( $attributes[ wc_attribute_taxonomy_name( $slug ) ] ) ) {
+			$attribute = $attributes[ wc_attribute_taxonomy_name( $slug ) ];
+		} elseif ( isset( $attributes[ $slug ] ) ) {
+			$attribute = $attributes[ $slug ];
 		}
 
-		$attribute = $attributes[ $slug ];
+		if ( ! $attribute ) {
+			return $slug;
+		}
 
 		// Taxonomy attribute name.
 		if ( $attribute->is_taxonomy() ) {


### PR DESCRIPTION
To test, view hoodie sample product in REST API. e.g. 

```
https://local.wordpress.test/wp-json/wc/v3/products/88
```

(it was 88 on my test install). See the 'logo' attribute shows as lowercase instead of 'Logo' as defined in admin. 3.5.x shows 'Logo'.

This PR fixes the matching so that is first compares pa_ prefixed attributes and then non-prefixed attributes in order to find the correct attribute match. When a match is found, the correct name is returned instead of a lowercase 'slug'.

> * Fix - REST API - Return custom attribute with defined name instead of lowercase name.