### PR TITLE
Marketplace queue handling - avoid recurring event

### DIFF
--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
@@ -188,12 +188,22 @@ class WC_Marketplace_Suggestions {
 	}
 
 	/**
-	 * Pull suggestion data from remote endpoint & cache in a transient.
+	 * Pull suggestion data from options. This is retrieved from a remote endpoint.
 	 *
 	 * @return array of json API data
 	 */
 	public static function get_suggestions_api_data() {
 		$data = get_option( 'woocommerce_marketplace_suggestions', array() );
+
+		// If the options have never been updated, or were updated over a week ago, queue update.
+		if ( empty( $data['updated'] ) || ( time() - WEEK_IN_SECONDS ) > $data['updated'] ) {
+			$next = WC()->queue()->get_next( 'woocommerce_update_marketplace_suggestions' );
+			if ( ! $next ) {
+				WC()->queue()->cancel( 'woocommerce_update_marketplace_suggestions' );
+				WC()->queue()->schedule_single( time(), 'woocommerce_update_marketplace_suggestions' );
+			}
+		}
+
 		return ! empty( $data['suggestions'] ) ? $data['suggestions'] : array();
 	}
 }

--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-suggestions.php
@@ -199,7 +199,7 @@ class WC_Marketplace_Suggestions {
 		if ( empty( $data['updated'] ) || ( time() - WEEK_IN_SECONDS ) > $data['updated'] ) {
 			$next = WC()->queue()->get_next( 'woocommerce_update_marketplace_suggestions' );
 			if ( ! $next ) {
-				WC()->queue()->cancel( 'woocommerce_update_marketplace_suggestions' );
+				WC()->queue()->cancel_all( 'woocommerce_update_marketplace_suggestions' );
 				WC()->queue()->schedule_single( time(), 'woocommerce_update_marketplace_suggestions' );
 			}
 		}

--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -72,7 +72,7 @@ class WC_Marketplace_Updater {
 	 * Re-schedules the job earlier than the main weekly one.
 	 */
 	public static function retry() {
-		WC()->queue()->cancel( 'woocommerce_update_marketplace_suggestions' );
+		WC()->queue()->cancel_all( 'woocommerce_update_marketplace_suggestions' );
 		WC()->queue()->schedule_single( time() + DAY_IN_SECONDS, 'woocommerce_update_marketplace_suggestions' );
 	}
 }

--- a/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
+++ b/includes/admin/marketplace-suggestions/class-wc-marketplace-updater.php
@@ -26,12 +26,6 @@ class WC_Marketplace_Updater {
 	 * Schedule events and hook appropriate actions.
 	 */
 	public static function init() {
-		$queue = WC()->queue();
-		$next  = $queue->get_next( 'woocommerce_update_marketplace_suggestions' );
-		if ( ! $next ) {
-			$queue->schedule_recurring( time(), WEEK_IN_SECONDS, 'woocommerce_update_marketplace_suggestions' );
-		}
-
 		add_action( 'woocommerce_update_marketplace_suggestions', array( __CLASS__, 'update_marketplace_suggestions' ) );
 	}
 


### PR DESCRIPTION
This PR removes the need for a recurring event by scheduling a single update event when:

- There is no marketplace suggestion data
- The current data is > 1 week old.

Since this is a single event, it prevents jobs being re-queued instantly if running them manually.

Also, since this is only queued as needed, it prevents a job being added if suggestions are disabled.

To test, delete the `woocommerce_marketplace_suggestions` option from your DB.
Visit the products screen when the queue option may be read.
View Tools > Scheduled actions. There will be a single event pending which will run the next time cron is triggered.

cc @peterfabian This is an alternative to #23396