### PR TITLE
Improved batching for _wc_rating_count lookup table

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1343,35 +1343,27 @@ function wc_update_product_lookup_tables() {
 	}
 
 	// Rating counts are serialised so they have to be unserialised before populating the lookup table.
-	$rating_count_rows = $wpdb->get_results(
-		"
-		SELECT post_id, meta_value FROM {$wpdb->postmeta}
-		WHERE meta_key = '_wc_rating_count'
-		AND meta_value != ''
-		AND meta_value != 'a:0:{}'
-		",
-		ARRAY_A
-	);
-
-	if ( $rating_count_rows ) {
-		if ( $is_cli ) {
-			wc_update_product_lookup_tables_rating_count( $rating_count_rows );
-		} else {
-			$rating_count_rows = array_chunk( $rating_count_rows, 50 );
-			$index             = count( $columns ) + 1;
-
-			foreach ( $rating_count_rows as $rows ) {
-				WC()->queue()->schedule_single(
-					time() + $index,
-					'wc_update_product_lookup_tables_rating_count',
-					array(
-						'rows' => $rows,
-					),
-					'wc_update_product_lookup_tables'
-				);
-				$index ++;
-			}
-		}
+	if ( $is_cli ) {
+		$rating_count_rows = $wpdb->get_results(
+			"
+			SELECT post_id, meta_value FROM {$wpdb->postmeta}
+			WHERE meta_key = '_wc_rating_count'
+			AND meta_value != ''
+			AND meta_value != 'a:0:{}'
+			",
+			ARRAY_A
+		);
+		wc_update_product_lookup_tables_rating_count( $rating_count_rows );
+	} else {
+		WC()->queue()->schedule_single(
+			time() + 10,
+			'wc_update_product_lookup_tables_rating_count_batch',
+			array(
+				'offset' => 0,
+				'limit'  => 50,
+			),
+			'wc_update_product_lookup_tables'
+		);
 	}
 }
 
@@ -1507,4 +1499,48 @@ function wc_update_product_lookup_tables_rating_count( $rows ) {
 		);
 	}
 }
-add_action( 'wc_update_product_lookup_tables_rating_count', 'wc_update_product_lookup_tables_rating_count' );
+
+/**
+ * Populate a batch of rating count lookup table data for products.
+ *
+ * @since 3.6.2
+ * @param array $offset Offset to query.
+ * @param array $limit  Limit to query.
+ */
+function wc_update_product_lookup_tables_rating_count_batch( $offset = 0, $limit = 0 ) {
+	global $wpdb;
+
+	if ( ! $limit ) {
+		return;
+	}
+
+	$rating_count_rows = $wpdb->get_results(
+		$wpdb->prepare(
+			"
+			SELECT post_id, meta_value FROM {$wpdb->postmeta}
+			WHERE meta_key = '_wc_rating_count'
+			AND meta_value != ''
+			AND meta_value != 'a:0:{}'
+			ORDER BY post_id ASC
+			LIMIT %d, %d
+			",
+			$offset,
+			$limit
+		),
+		ARRAY_A
+	);
+
+	if ( $rating_count_rows ) {
+		wc_update_product_lookup_tables_rating_count( $rating_count_rows );
+		WC()->queue()->schedule_single(
+			time() + 1,
+			'wc_update_product_lookup_tables_rating_count_batch',
+			array(
+				'offset' => $offset + $limit,
+				'limit'  => $limit,
+			),
+			'wc_update_product_lookup_tables'
+		);
+	}
+}
+add_action( 'wc_update_product_lookup_tables_rating_count_batch', 'wc_update_product_lookup_tables_rating_count_batch', 10, 2 );


### PR DESCRIPTION
The current lookup table generation for wc_rating_count passes IDs to the queue which is not supported by AS. See #23475 

This new logic instead keeps working through the products until there are none left by passing around the offset and limit until no rows are found. This also prevents memory issues if dealing with a lot of posts.

To test, you need a product catalog with ratings > 50 (or you can edit the code). You should see one job initially when regenerating lookup table data, and another job queued once the first has run. This should continue until all products have been processed.

> Fix - Improve wc_rating_count lookup table generation.

cc @kloon 

Fixes #23475