### PR TITLE
update action scheduler to version 2.2.5

### DIFF
--- a/includes/libraries/action-scheduler/action-scheduler.php
+++ b/includes/libraries/action-scheduler/action-scheduler.php
@@ -4,8 +4,8 @@
  * Plugin URI: https://actionscheduler.org
  * Description: A robust scheduling library for use in WordPress plugins.
  * Author: Prospress
- * Author URI: http://prospress.com/
- * Version: 2.2.4
+ * Author URI: https://prospress.com/
+ * Version: 2.2.5
  * License: GPLv3
  *
  * Copyright 2019 Prospress, Inc.  (email : freedoms@prospress.com)
@@ -25,21 +25,21 @@
  *
  */
 
-if ( ! function_exists( 'action_scheduler_register_2_dot_2_dot_4' ) ) {
+if ( ! function_exists( 'action_scheduler_register_2_dot_2_dot_5' ) ) {
 
 	if ( ! class_exists( 'ActionScheduler_Versions' ) ) {
 		require_once( 'classes/ActionScheduler_Versions.php' );
 		add_action( 'plugins_loaded', array( 'ActionScheduler_Versions', 'initialize_latest_version' ), 1, 0 );
 	}
 
-	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_2_dot_4', 0, 0 );
+	add_action( 'plugins_loaded', 'action_scheduler_register_2_dot_2_dot_5', 0, 0 );
 
-	function action_scheduler_register_2_dot_2_dot_4() {
+	function action_scheduler_register_2_dot_2_dot_5() {
 		$versions = ActionScheduler_Versions::instance();
-		$versions->register( '2.2.4', 'action_scheduler_initialize_2_dot_2_dot_4' );
+		$versions->register( '2.2.5', 'action_scheduler_initialize_2_dot_2_dot_5' );
 	}
 
-	function action_scheduler_initialize_2_dot_2_dot_4() {
+	function action_scheduler_initialize_2_dot_2_dot_5() {
 		require_once( 'classes/ActionScheduler.php' );
 		ActionScheduler::init( __FILE__ );
 	}

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_Logger.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_Logger.php
@@ -55,6 +55,7 @@ abstract class ActionScheduler_Logger {
 		add_action( 'action_scheduler_unexpected_shutdown', array( $this, 'log_unexpected_shutdown' ), 10, 2 );
 		add_action( 'action_scheduler_reset_action', array( $this, 'log_reset_action' ), 10, 1 );
 		add_action( 'action_scheduler_execution_ignored', array( $this, 'log_ignored_action' ), 10, 1 );
+		add_action( 'action_scheduler_failed_fetch_action', array( $this, 'log_failed_fetch_action' ), 10, 1 );
 	}
 
 	public function log_stored_action( $action_id ) {
@@ -94,5 +95,8 @@ abstract class ActionScheduler_Logger {
 	public function log_ignored_action( $action_id ) {
 		$this->log( $action_id, __( 'action ignored', 'action-scheduler' ) );
 	}
+
+	public function log_failed_fetch_action( $action_id ) {
+		$this->log( $action_id, __( 'There was a failure fetching this action', 'action-scheduler' ) );
+	}
 }
- 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Update Action Scheduler to version 2.2.5.
 
Closes #23414 .
Closes #23373 .

### How to test the changes in this Pull Request:

- Start with a WC 3.5.7 install
- Disable the SA queue runner by installing https://github.com/Prospress/action-scheduler-disable-default-runner
- Update WC to 3.6.1
- Go to WC -> Status -> Tools -> Scheduled Actions -> Pending
- Check that the `woocommerce_update_marketplace_suggestions` scheduled action is pending
- Click the `Run` Action link on the scheduled action
- Check that pending `woocommerce_update_marketplace_suggestions` scheduled action is scheduled 1 week in the future

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update Action Scheduler to version 2.2.5.
