### PR TITLE
Fix bulk stock update 

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -631,17 +631,21 @@ class WC_Admin_Post_Types {
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
 			$change_stock = absint( $_REQUEST['change_stock'] );
+			// Product is re-read in wc_update_product_stock twice, so it needs to be synced before calling the function.
+			$product->save();
 			switch ( $change_stock ) {
 				case 2:
-					wc_update_product_stock( $product, $stock_amount, 'increase' );
+					$new_qty = wc_update_product_stock( $product, $stock_amount, 'increase' );
 					break;
 				case 3:
-					wc_update_product_stock( $product, $stock_amount, 'decrease' );
+					$new_qty = wc_update_product_stock( $product, $stock_amount, 'decrease' );
 					break;
 				default:
-					wc_update_product_stock( $product, $stock_amount, 'set' );
+					$new_qty = wc_update_product_stock( $product, $stock_amount, 'set' );
 					break;
 			}
+			// Need to update the stock quantity on this copy of product so that further functions adjust the object correctly when saving.
+			$product->set_stock_quantity( $new_qty );
 		}
 
 		// Apply product type constraints to stock status.


### PR DESCRIPTION
Added a save of the product before calling `wc_update_product_stock` to ensure data consistency and seting quantity in local copy after saving it to db in `wc_update_product_stock`.

This is because `wc_update_product_stock` reads product from the db twice, so if it's out of sync, strange things are happening.

Also, changes depending on stock status might get reverted if local copy of `$product` is not updated after `wc_update_product_stock`, so added an update as well.

This seems to fix the problem for me for simple products which had been in stock, then updated to in stock + manage inventory + stock qty = X.

TODO: 
- check if the behaviour for variable products makes sense
- fix bulk increase/decrease by X when initial stock qty value is NULL (NULL + X does not work)

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23388  .

### How to test the changes in this Pull Request:

1. Please see video in the issue.
2. Ideally, please test if it behaves correctly for different types of products (variable, simple) and different stock statuses.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - bulk stock update could result in all products set to out of stock, change ensures consistency between db and Product instance in memory.
