### PR TITLE
Update table name in WC_Data_Store_WP::update_lookup_table

### DIFF
--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -594,7 +594,7 @@ class WC_Data_Store_WP {
 
 		if ( ! empty( $update_data ) && $update_data !== $existing_data ) {
 			$wpdb->replace(
-				$wpdb->$table,
+				$wpdb->prefix.$table,
 				$update_data
 			);
 			wp_cache_set( 'lookup_table', $update_data, 'object_' . $id );


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I've updated the table name in the function `update_lookup_table` to use the actual lookup table name. It was coming up blank and throwing a silent WordPress Database error in my logs. It was also failing to add any data to the `wp_wc_product_meta_lookup` table. Here is the error I was receiving

```
WordPress database error Incorrect table name '' for query SHOW FULL COLUMNS FROM `` made by require('wp-blog-header.php'), require_once('wp-includes/template-loader.php'), include('/themes/cut00117/page-member-dashboard.php'), HM_Reservation->charge, WC_Gateway_Stripe->process_payment, WC_Stripe_Payment_Gateway->process_response, WC_Order->payment_complete, WC_Order->save, WC_Order->status_transition, do_action('woocommerce_order_status_processing'), WP_Hook->do_action, WP_Hook->apply_filters, wc_update_total_sales_counts, WC_Data_Store->__call, WC_Product_Data_Store_CPT->update_product_sales, WC_Data_Store_WP->update_lookup_table
```

### How to test the changes in this Pull Request:

1. Create an instance of the class `WC_Gateway_Stripe`
2. Run the function process_payment() and pass in an order ID
3. Review the DB and you should successfully see data in the `wp_wc_product_meta_lookup` table

### Changelog entry

> Update `$wpdb->$table` to `$wpdb->prefix.$table` to successfully pass in the correct table name when adding to/updting the `wp_wc_product_meta_lookup` table on payment processing.
