### PR TITLE
Bump default WC API version used when creating webhook

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -38,7 +38,7 @@ class WC_Webhook extends WC_Legacy_Webhook {
 		'event'            => '',
 		'failure_count'    => 0,
 		'user_id'          => 0,
-		'api_version'      => 2,
+		'api_version'      => 3,
 		'pending_delivery' => false,
 	);
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR bumps the default WC API version used when users are creating a new webhook. Before this change, the default version would be v2, and after this change, it is v3 which is the latest API version.

In the future we might want to create a method in WC_API class or somewhere else that returns the latest WC API version and use it in `includes/class-wc-webhook.php` instead of hard-coding the version number.

### How to test the changes in this Pull Request:

1. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=webhooks&edit-webhook=0`
2. Check that the selected value for the field `API Version` is `WP REST API Integration v3` instead of `WP REST API Integration v2`.

### Changelog entry

> Bump default WC API version used when creating webhook to the latest WC API version
