### PR TITLE
Fix dismiss button in two WC admin notices

### DIFF
--- a/assets/css/activation.scss
+++ b/assets/css/activation.scss
@@ -66,34 +66,3 @@ p.woocommerce-actions,
 .woocommerce-about-text {
 	margin-bottom: 1em !important;
 }
-
-div.woocommerce-legacy-shipping-notice,
-div.woocommerce-no-shipping-methods-notice {
-	overflow: hidden;
-	padding: 1px 12px;
-
-	p {
-		position: relative;
-		z-index: 1;
-		line-height: 1.5em;
-		margin: 12px 0;
-
-		&.main {
-			font-size: 1.1em;
-		}
-	}
-
-	&::before {
-		content: "\e01b";
-		font-family: "WooCommerce";
-		text-align: center;
-		line-height: 1;
-		color: #f7f1f6;
-		display: block;
-		width: 1em;
-		font-size: 20em;
-		top: 36px;
-		right: 12px;
-		position: absolute;
-	}
-}

--- a/includes/admin/views/html-notice-legacy-shipping.php
+++ b/includes/admin/views/html-notice-legacy-shipping.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Admin View: Notice - Legacy Shipping.
+ *
+ * @package WooCommerce\Admin\Notices
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -8,15 +10,25 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div id="message" class="updated woocommerce-message woocommerce-legacy-shipping-notice">
-	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'legacy_shipping' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php _e( 'Dismiss', 'woocommerce' ); ?></a>
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'legacy_shipping' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>">
+		<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
+	</a>
 
-	<p class="main"><strong><?php _e( 'New:', 'woocommerce' ); ?> <?php _e( 'Shipping zones', 'woocommerce' ); ?></strong> &#8211; <?php _e( 'a group of regions that can be assigned different shipping methods and rates.', 'woocommerce' ); ?></p>
-	<p><?php _e( 'Legacy shipping methods (flat rate, international flat rate, local pickup and delivery, and free shipping) are deprecated but will continue to work as normal for now. <b><em>They will be removed in future versions of WooCommerce</em></b>. We recommend disabling these and setting up new rates within shipping zones as soon as possible.', 'woocommerce' ); ?></p>
+	<p class="main">
+		<strong><?php esc_html_e( 'New:', 'woocommerce' ); ?> <?php esc_html_e( 'Shipping zones', 'woocommerce' ); ?></strong> &#8211; <?php esc_html_e( 'a group of regions that can be assigned different shipping methods and rates.', 'woocommerce' ); ?>
+	</p>
+	<p>
+		<?php esc_html_e( 'Legacy shipping methods (flat rate, international flat rate, local pickup and delivery, and free shipping) are deprecated but will continue to work as normal for now. <b><em>They will be removed in future versions of WooCommerce</em></b>. We recommend disabling these and setting up new rates within shipping zones as soon as possible.', 'woocommerce' ); ?>
+	</p>
 
 	<p class="submit">
 		<?php if ( empty( $_GET['page'] ) || empty( $_GET['tab'] ) || 'wc-settings' !== $_GET['page'] || 'shipping' !== $_GET['tab'] ) : ?>
-			<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) ); ?>"><?php _e( 'Setup shipping zones', 'woocommerce' ); ?></a>
+			<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) ); ?>">
+				<?php esc_html_e( 'Setup shipping zones', 'woocommerce' ); ?>
+			</a>
 		<?php endif; ?>
-		<a class="button-secondary" href="https://docs.woocommerce.com/document/setting-up-shipping-zones/"><?php _e( 'Learn more about shipping zones', 'woocommerce' ); ?></a>
+		<a class="button-secondary" href="https://docs.woocommerce.com/document/setting-up-shipping-zones/">
+			<?php esc_html_e( 'Learn more about shipping zones', 'woocommerce' ); ?>
+		</a>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-legacy-shipping.php
+++ b/includes/admin/views/html-notice-legacy-shipping.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<div id="message" class="updated woocommerce-message woocommerce-legacy-shipping-notice">
+<div id="message" class="updated woocommerce-message">
 	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'legacy_shipping' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>">
 		<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
 	</a>

--- a/includes/admin/views/html-notice-no-shipping-methods.php
+++ b/includes/admin/views/html-notice-no-shipping-methods.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<div id="message" class="updated woocommerce-message woocommerce-no-shipping-methods-notice">
+<div id="message" class="updated woocommerce-message">
 	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'no_shipping_methods' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>">
 		<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
 	</a>

--- a/includes/admin/views/html-notice-no-shipping-methods.php
+++ b/includes/admin/views/html-notice-no-shipping-methods.php
@@ -1,6 +1,8 @@
 <?php
 /**
  * Admin View: Notice - No Shipping methods.
+ *
+ * @package WooCommerce\Admin\Notices
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -8,14 +10,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 ?>
 <div id="message" class="updated woocommerce-message woocommerce-no-shipping-methods-notice">
-	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'no_shipping_methods' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php _e( 'Dismiss', 'woocommerce' ); ?></a>
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'no_shipping_methods' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>">
+		<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
+	</a>
 
-	<p class="main"><strong><?php _e( 'Add shipping methods &amp; zones', 'woocommerce' ); ?></strong></p>
-	<p><?php _e( 'Shipping is currently enabled, but you have not added any shipping methods to your shipping zones.', 'woocommerce' ); ?></p>
-	<p><?php _e( 'Customers will not be able to purchase physical goods from your store until a shipping method is available.', 'woocommerce' ); ?></p>
+	<p class="main">
+		<strong>
+			<?php esc_html_e( 'Add shipping methods &amp; zones', 'woocommerce' ); ?>
+		</strong>
+	</p>
+	<p>
+		<?php esc_html_e( 'Shipping is currently enabled, but you have not added any shipping methods to your shipping zones.', 'woocommerce' ); ?>
+	</p>
+	<p>
+		<?php esc_html_e( 'Customers will not be able to purchase physical goods from your store until a shipping method is available.', 'woocommerce' ); ?>
+	</p>
 
 	<p class="submit">
-		<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) ); ?>"><?php _e( 'Setup shipping zones', 'woocommerce' ); ?></a>
-		<a class="button-secondary" href="https://docs.woocommerce.com/document/setting-up-shipping-zones/"><?php _e( 'Learn more about shipping zones', 'woocommerce' ); ?></a>
+		<a class="button-primary" href="<?php echo esc_url( admin_url( 'admin.php?page=wc-settings&tab=shipping' ) ); ?>">
+			<?php esc_html_e( 'Setup shipping zones', 'woocommerce' ); ?>
+		</a>
+		<a class="button-secondary" href="https://docs.woocommerce.com/document/setting-up-shipping-zones/">
+			<?php esc_html_e( 'Learn more about shipping zones', 'woocommerce' ); ?>
+		</a>
 	</p>
 </div>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The dismiss button in the WC admin notices `legacy_shipping` and `no_shipping_methods` was not fully clickable due to a custom CSS applied to them (see the video showing the problem in #23506). This custom CSS was used to add a background image to those notices. More specifically, the problem was caused by the use of `position: relative` applied to `<p>` elements. I couldn't find an easy way to fix this problem keeping the custom background image, so I opted to remove it to make the design of all notices identical (besides the background image, the custom CSS also added a few other differences to those to notices like the font size of the notice title).

This PR also includes PHPCS fixes to the modified files in a separate commit.

cc @mikejolley as you added the custom background image to those notices in case you think we should keep it.

Closes #23506 

### How to test the changes in this Pull Request:

1. Watch the video in #23506 to see a demonstration of the problem
2. Display the notices `legacy_shipping` and `no_shipping_methods` on a WC admin page like the products page (I did this by adding calls to `WC_Admin_Notices::add_notice()` and them changing the methods `WC_Admin_Notices::legacy_shipping_notice()` and `WC_Admin_Notices::no_shipping_methods_notice()` to force the display of the notices).
3. Confirm that you can dismiss the notice no matter where you click in the dismiss link

### Changelog entry

> Fix dismiss button in Wc admin notices "legacy_shipping" and "no_shipping_methods"
