### PR TITLE
Tracks: Fix OBW scripts

### DIFF
--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -50,6 +50,7 @@ class WC_Admin_Setup_Wizard_Tracking {
 	public function add_footer_scripts() {
 		wp_print_scripts();
 		WC_Site_Tracking::add_tracking_function();
+		wc_print_js();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ensure enqueued scripts actually get printed on the page via `wc_print_js`;

### How to test the changes in this Pull Request:

1. Go to `/wp-admin/index.php?page=wc-setup&step=next_steps`.
2. View page source and ensure that relevant js is printed to the page. You can search for `obw_ready_next_step` to accomplish this. There will be one instance of this string in text that looks like `window.wcTracks.recordEvent( 'obw_ready_next_step', properties );`
