### PR TITLE
Deletes plain text section

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -37,16 +37,6 @@ WooCommerce is built to allow store managers to run an eCommerce site themselves
 
 WooCommerce is developed and supported by Automattic, the creators of Jetpack and WordPress.com, along with independent contributors. The [official extension marketplace](https://woocommerce.com/product-category/woocommerce-extensions/?utm_source=wp%20org%20repo%20listing&utm_content=3.6) is on WooCommerce.com.
 
-= Screenshots =
-
-- WC-Admin to show off new central dashboard
-- WooCommerce products admin.
-- Product data panel.
-- (New) WooCommerce sales reports.
-- A single product page.
-- A product archive (grid).
-- Blocks in action
-
 = From subscriptions to gym classes to luxury cars =
 With WooCommerce, you can sell both physical and digital goods in all shapes and sizes, offer product variations, complex configurations, and instant downloads to shoppers; and even sell affiliate goods from online marketplaces.
 


### PR DESCRIPTION
The section deletes a plain text duplicate of the _actual_ screenshot album lower down. So, this bit will no longer appear:

<img width="452" alt="Screen Shot 2019-04-25 at 10 46 10 PM" src="https://user-images.githubusercontent.com/8245590/56771464-9b5c5200-67ae-11e9-8b0d-4f3b95d37589.png">


### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
