### PR TITLE
Revise update stock logic

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -631,21 +631,17 @@ class WC_Admin_Post_Types {
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
 			$change_stock = absint( $_REQUEST['change_stock'] );
-			// Product is re-read in wc_update_product_stock twice, so it needs to be synced before calling the function.
-			$product->save();
 			switch ( $change_stock ) {
 				case 2:
-					$new_qty = wc_update_product_stock( $product, $stock_amount, 'increase' );
+					$new_qty = wc_update_product_stock( $product, $stock_amount, 'increase', true );
 					break;
 				case 3:
-					$new_qty = wc_update_product_stock( $product, $stock_amount, 'decrease' );
+					$new_qty = wc_update_product_stock( $product, $stock_amount, 'decrease', true );
 					break;
 				default:
-					$new_qty = wc_update_product_stock( $product, $stock_amount, 'set' );
+					$new_qty = wc_update_product_stock( $product, $stock_amount, 'set', true );
 					break;
 			}
-			// Need to update the stock quantity on this copy of product so that further functions adjust the object correctly when saving.
-			$product->set_stock_quantity( $new_qty );
 		}
 
 		// Apply product type constraints to stock status.

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -633,13 +633,13 @@ class WC_Admin_Post_Types {
 			$change_stock = absint( $_REQUEST['change_stock'] );
 			switch ( $change_stock ) {
 				case 2:
-					$new_qty = wc_update_product_stock( $product, $stock_amount, 'increase', true );
+					wc_update_product_stock( $product, $stock_amount, 'increase', true );
 					break;
 				case 3:
-					$new_qty = wc_update_product_stock( $product, $stock_amount, 'decrease', true );
+					wc_update_product_stock( $product, $stock_amount, 'decrease', true );
 					break;
 				default:
-					$new_qty = wc_update_product_stock( $product, $stock_amount, 'set', true );
+					wc_update_product_stock( $product, $stock_amount, 'set', true );
 					break;
 			}
 		}

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -631,17 +631,21 @@ class WC_Admin_Post_Types {
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
 			$change_stock = absint( $_REQUEST['change_stock'] );
+			// Product is re-read in wc_update_product_stock twice, so it needs to be synced before calling the function.
+			$product->save();
 			switch ( $change_stock ) {
 				case 2:
-					wc_update_product_stock( $product, $stock_amount, 'increase' );
+					$new_qty = wc_update_product_stock( $product, $stock_amount, 'increase' );
 					break;
 				case 3:
-					wc_update_product_stock( $product, $stock_amount, 'decrease' );
+					$new_qty = wc_update_product_stock( $product, $stock_amount, 'decrease' );
 					break;
 				default:
-					wc_update_product_stock( $product, $stock_amount, 'set' );
+					$new_qty = wc_update_product_stock( $product, $stock_amount, 'set' );
 					break;
 			}
+			// Need to update the stock quantity on this copy of product so that further functions adjust the object correctly when saving.
+			$product->set_stock_quantity( $new_qty );
 		}
 
 		// Apply product type constraints to stock status.

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -555,9 +555,10 @@ class WC_Data_Store_WP {
 	 * @since 3.6.0
 	 * @param int    $id ID of object to update.
 	 * @param string $table Lookup table name.
+	 * @param bool   $ignore_manage_stock If set to true, stock quantity will be returned regardless of _manage_stock meta value on the product.
 	 * @return array
 	 */
-	protected function get_data_for_lookup_table( $id, $table ) {
+	protected function get_data_for_lookup_table( $id, $table, $ignore_manage_stock = false ) {
 		return array();
 	}
 
@@ -578,8 +579,11 @@ class WC_Data_Store_WP {
 	 * @since 3.6.0
 	 * @param int    $id ID of object to update.
 	 * @param string $table Lookup table name.
+	 * @param bool   $force_qty_update If set to true, stock quantity for update of lookup table will be read from the database regardless of manage stock setting on the product.
+	 *
+	 * @return NULL
 	 */
-	protected function update_lookup_table( $id, $table ) {
+	protected function update_lookup_table( $id, $table, $force_qty_update = false ) {
 		global $wpdb;
 
 		$id    = absint( $id );
@@ -590,7 +594,7 @@ class WC_Data_Store_WP {
 		}
 
 		$existing_data = wp_cache_get( 'lookup_table', 'object_' . $id );
-		$update_data   = $this->get_data_for_lookup_table( $id, $table );
+		$update_data   = $this->get_data_for_lookup_table( $id, $table, $force_qty_update );
 
 		if ( ! empty( $update_data ) && $update_data !== $existing_data ) {
 			$wpdb->replace(

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -555,10 +555,9 @@ class WC_Data_Store_WP {
 	 * @since 3.6.0
 	 * @param int    $id ID of object to update.
 	 * @param string $table Lookup table name.
-	 * @param bool   $ignore_manage_stock If set to true, stock quantity will be returned regardless of _manage_stock meta value on the product.
 	 * @return array
 	 */
-	protected function get_data_for_lookup_table( $id, $table, $ignore_manage_stock = false ) {
+	protected function get_data_for_lookup_table( $id, $table ) {
 		return array();
 	}
 
@@ -579,11 +578,10 @@ class WC_Data_Store_WP {
 	 * @since 3.6.0
 	 * @param int    $id ID of object to update.
 	 * @param string $table Lookup table name.
-	 * @param bool   $force_qty_update If set to true, stock quantity for update of lookup table will be read from the database regardless of manage stock setting on the product.
 	 *
 	 * @return NULL
 	 */
-	protected function update_lookup_table( $id, $table, $force_qty_update = false ) {
+	protected function update_lookup_table( $id, $table ) {
 		global $wpdb;
 
 		$id    = absint( $id );
@@ -594,7 +592,7 @@ class WC_Data_Store_WP {
 		}
 
 		$existing_data = wp_cache_get( 'lookup_table', 'object_' . $id );
-		$update_data   = $this->get_data_for_lookup_table( $id, $table, $force_qty_update );
+		$update_data   = $this->get_data_for_lookup_table( $id, $table );
 
 		if ( ! empty( $update_data ) && $update_data !== $existing_data ) {
 			$wpdb->replace(

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1957,13 +1957,14 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @since 3.6.0
 	 * @param int    $id ID of object to update.
 	 * @param string $table Lookup table name.
+	 * @param bool   $ignore_manage_stock If set to true, stock quantity will be returned regardless of _manage_stock meta value on the product.
 	 * @return array
 	 */
-	protected function get_data_for_lookup_table( $id, $table ) {
+	protected function get_data_for_lookup_table( $id, $table, $ignore_manage_stock = false ) {
 		if ( 'wc_product_meta_lookup' === $table ) {
 			$price_meta   = (array) get_post_meta( $id, '_price', false );
-			$manage_stock = get_post_meta( $id, '_manage_stock', true );
-			$stock        = 'yes' === $manage_stock ? wc_stock_amount( get_post_meta( $id, '_stock', true ) ) : null;
+			$manage_stock = get_post_meta( $id, '_manage_stock', true ); // while product is being modified, manage stock could be 'no' in the db, but we want to change the stock qty anyway.
+			$stock        = 'yes' === $manage_stock || $ignore_manage_stock ? wc_stock_amount( get_post_meta( $id, '_stock', true ) ) : null;
 			$price        = wc_format_decimal( get_post_meta( $id, '_price', true ) );
 			$sale_price   = wc_format_decimal( get_post_meta( $id, '_sale_price', true ) );
 			return array(

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1374,7 +1374,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		// Generate SQL.
 		$sql = $wpdb->prepare(
 			"UPDATE {$wpdb->postmeta} SET meta_value = %f WHERE post_id = %d AND meta_key='_stock'",
-			$stock_quantity,
+			$new_stock,
 			$product_id_with_stock
 		);
 

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1996,7 +1996,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	protected function get_data_for_lookup_table( $id, $table ) {
 		if ( 'wc_product_meta_lookup' === $table ) {
 			$price_meta   = (array) get_post_meta( $id, '_price', false );
-			$stock        = wc_stock_amount( get_post_meta( $id, '_stock', true ) );
+			$manage_stock = get_post_meta( $id, '_manage_stock', true );
+			$stock        = 'yes' === $manage_stock ? wc_stock_amount( get_post_meta( $id, '_stock', true ) ) : null;
 			$price        = wc_format_decimal( get_post_meta( $id, '_price', true ) );
 			$sale_price   = wc_format_decimal( get_post_meta( $id, '_sale_price', true ) );
 			return array(

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1324,8 +1324,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		// Sometimes I wonder if it shouldn't be part of update_lookup_table.
 		wp_cache_delete( $product_id_with_stock, 'post_meta' );
 
-		// Stock qty in lookup table might not be set to the same value here due to manage_stock not being set to true, thus using force update.
-		$this->update_lookup_table( $product_id_with_stock, 'wc_product_meta_lookup', true );
+		$this->update_lookup_table( $product_id_with_stock, 'wc_product_meta_lookup' );
 	}
 
 	/**
@@ -1998,14 +1997,12 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	 * @since 3.6.0
 	 * @param int    $id ID of object to update.
 	 * @param string $table Lookup table name.
-	 * @param bool   $ignore_manage_stock If set to true, stock quantity will be returned regardless of _manage_stock meta value on the product.
 	 * @return array
 	 */
-	protected function get_data_for_lookup_table( $id, $table, $ignore_manage_stock = false ) {
+	protected function get_data_for_lookup_table( $id, $table ) {
 		if ( 'wc_product_meta_lookup' === $table ) {
 			$price_meta   = (array) get_post_meta( $id, '_price', false );
-			$manage_stock = get_post_meta( $id, '_manage_stock', true ); // while product is being modified, manage stock could be 'no' in the db, but we want to change the stock qty anyway.
-			$stock        = 'yes' === $manage_stock || $ignore_manage_stock ? wc_stock_amount( get_post_meta( $id, '_stock', true ) ) : null;
+			$stock        = wc_stock_amount( get_post_meta( $id, '_stock', true ) );
 			$price        = wc_format_decimal( get_post_meta( $id, '_price', true ) );
 			$sale_price   = wc_format_decimal( get_post_meta( $id, '_sale_price', true ) );
 			return array(

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -364,6 +364,19 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	}
 
 	/**
+	 * Re-reads stock from the DB ignoring changes.
+	 *
+	 * @param WC_Product $product Product object.
+	 * @param int|float  $new_stock New stock level if already read.
+	 */
+	public function read_stock_quantity( &$product, $new_stock = null ) {
+		$object_read = $product->get_object_read();
+		$product->set_object_read( false );
+		$product->set_stock_quantity( is_null( $new_stock ) ? get_post_meta( $product->get_id(), '_stock', true ) : $new_stock );
+		$product->set_object_read( $object_read );
+	}
+
+	/**
 	 * Read extra data associated with the product, like button text or product URL for external products.
 	 *
 	 * @param WC_Product $product Product object.

--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -39,11 +39,9 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
 		$data_store            = WC_Data_Store::load( 'product' );
 
 		// Update the database.
-		// This can fail, i.e. not update stock level if the record is locked and will then return 'old' stock level.
 		$new_stock = $data_store->update_product_stock( $product_id_with_stock, $stock_quantity, $operation );
 
 		// Update the product object.
-		// Force product object stock level to be updated to the value we just persisted (or the value from the db, if not persisted due to lock).
 		$data_store->read_stock_quantity( $product_with_stock, $new_stock );
 
 		// If this is not being called during an update routine, save the product so stock status etc is in sync, and caches are cleared.

--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -20,11 +20,13 @@ defined( 'ABSPATH' ) || exit;
  * @param  int|WC_Product $product        Product ID or product instance.
  * @param  int|null       $stock_quantity Stock quantity.
  * @param  string         $operation      Type of opertion, allows 'set', 'increase' and 'decrease'.
- *
+ * @param  bool           $updating       If true, the product object won't be saved here as it will be updated later.
  * @return bool|int|null
  */
-function wc_update_product_stock( $product, $stock_quantity = null, $operation = 'set' ) {
-	$product = wc_get_product( $product );
+function wc_update_product_stock( $product, $stock_quantity = null, $operation = 'set', $updating = false ) {
+	if ( ! is_a( $product, 'WC_Product' ) ) {
+		$product = wc_get_product( $product );
+	}
 
 	if ( ! $product ) {
 		return false;
@@ -33,18 +35,20 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
 	if ( ! is_null( $stock_quantity ) && $product->managing_stock() ) {
 		// Some products (variations) can have their stock managed by their parent. Get the correct ID to reduce here.
 		$product_id_with_stock = $product->get_stock_managed_by_id();
+		$product_with_stock    = $product_id_with_stock !== $product->get_id() ? wc_get_product( $product_id_with_stock ) : $product;
 		$data_store            = WC_Data_Store::load( 'product' );
-		$data_store->update_product_stock( $product_id_with_stock, $stock_quantity, $operation );
-		delete_transient( 'wc_low_stock_count' );
-		delete_transient( 'wc_outofstock_count' );
-		delete_transient( 'wc_product_children_' . ( $product->is_type( 'variation' ) ? $product->get_parent_id() : $product->get_id() ) );
-		wp_cache_delete( 'product-' . $product_id_with_stock, 'products' );
+		$new_stock             = $data_store->update_product_stock( $product_id_with_stock, $stock_quantity, $operation );
 
-		// Re-read product data after updating stock, then have stock status calculated and saved.
-		$product_with_stock = wc_get_product( $product_id_with_stock );
-		$product_with_stock->set_stock_status();
-		$product_with_stock->save();
+		// Force product object stock level to be updated to the value we just persisted.
+		$data_store->read_stock_quantity( $product_with_stock, $new_stock );
 
+		// If this is not being called during an update routine, save the product so stock status etc is in sync, and caches are cleared.
+		if ( ! $updating ) {
+			$product_with_stock->set_stock_status();
+			$product_with_stock->save();
+		}
+
+		// Fire actions to let 3rd parties know the stock changed.
 		if ( $product_with_stock->is_type( 'variation' ) ) {
 			do_action( 'woocommerce_variation_set_stock', $product_with_stock );
 		} else {


### PR DESCRIPTION
Continuing with #23510 

The current update stock routines mix DB updates and CRUD based saves, so when used within things like bulk update (introduced in https://github.com/woocommerce/woocommerce/commit/6b211ab25bab939ea10752cbc006f293ae5326a9) all havoc breaks loose.

This PR makes some changes to make this more reliable.

- Made the `update_product_stock` routine in the datastore return the new stock amount as well as read then update. The SELECT..FOR UPDATE here might need some feedback from @kloon and @rodrigoprimo 
- The datastore new method `read_stock_quantity` forces a read so we can keep product objects in sync with each other.
- Made `wc_update_product_stock` avoid reads if given a product object
- Allow `wc_update_product_stock` to skip saving if the calling function says it's running updates
- Removed cache clearing from `wc_update_product_stock` since it's done during CRUD save().

Some tests you can do:
- Try the instructions in https://github.com/woocommerce/woocommerce/issues/23388
- Try setting stock to 0 for a bunch of in stock products in bulk. They become out of stock.

@peterfabian If this needs more work or testing (please feel free to take over as I go on leave) it might be better to revert https://github.com/woocommerce/woocommerce/commit/6b211ab25bab939ea10752cbc006f293ae5326a9 instead of rolling out some hacky fixes like in #23510 as those could cause more issues.

Hope it helps :)
