### PR TITLE
 Fix: parameter values should be converted back as well when building form fields

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -705,7 +705,7 @@ function wc_query_string_form_fields( $values = null, $exclude = array(), $curre
 		$values    = array();
 
 		if ( ! empty( $url_parts['query'] ) ) {
-			// This is to preserve full-stops and spaces in the query string when ran through parse_str.
+			// This is to preserve full-stops, pluses and spaces in the query string when ran through parse_str.
 			$replace_chars = array(
 				'.'   => '{dot}',
 				'+'   => '{plus}',
@@ -717,9 +717,11 @@ function wc_query_string_form_fields( $values = null, $exclude = array(), $curre
 			// Parse the string.
 			parse_str( $query_string, $parsed_query_string );
 
-			// Convert the full-stops back and add to values array.
+			// Convert the full-stops, pluses and spaces back and add to values array.
 			foreach ( $parsed_query_string as $key => $value ) {
-				$values[ str_replace( array_values( $replace_chars ), array_keys( $replace_chars ), $key ) ] = $value;
+				$new_key            = str_replace( array_values( $replace_chars ), array_keys( $replace_chars ), $key );
+				$new_value          = str_replace( array_values( $replace_chars ), array_keys( $replace_chars ), $value );
+				$values[ $new_key ] = $new_value;
 			}
 		}
 	}

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -124,22 +124,22 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 	public function test_wc_query_string_form_fields() {
 		$actual_html   = wc_query_string_form_fields( '?test=1', array(), '', true );
 		$expected_html = '<input type="hidden" name="test" value="1" />';
-		$this->assertEquals( $expected_html, $actual_html, var_export( $actual_html, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		$this->assertEquals( $expected_html, $actual_html );
 
 		$actual_html   = wc_query_string_form_fields( '?test=1&test2=something', array(), '', true );
 		$expected_html = '<input type="hidden" name="test" value="1" /><input type="hidden" name="test2" value="something" />';
-		$this->assertEquals( $expected_html, $actual_html, var_export( $actual_html, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		$this->assertEquals( $expected_html, $actual_html );
 
 		$actual_html   = wc_query_string_form_fields( '?test.something=something', array(), '', true );
 		$expected_html = '<input type="hidden" name="test.something" value="something" />';
-		$this->assertEquals( $expected_html, $actual_html, var_export( $actual_html, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		$this->assertEquals( $expected_html, $actual_html );
 
 		$actual_html   = wc_query_string_form_fields( '?test+something=something', array(), '', true );
 		$expected_html = '<input type="hidden" name="test+something" value="something" />';
-		$this->assertEquals( $expected_html, $actual_html, var_export( $actual_html, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		$this->assertEquals( $expected_html, $actual_html );
 
 		$actual_html   = wc_query_string_form_fields( '?test%20something=something', array(), '', true );
 		$expected_html = '<input type="hidden" name="test%20something" value="something" />';
-		$this->assertEquals( $expected_html, $actual_html, var_export( $actual_html, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		$this->assertEquals( $expected_html, $actual_html );
 	}
 }

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -130,16 +130,16 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$expected_html = '<input type="hidden" name="test" value="1" /><input type="hidden" name="test2" value="something" />';
 		$this->assertEquals( $expected_html, $actual_html );
 
-		$actual_html   = wc_query_string_form_fields( '?test.something=something', array(), '', true );
-		$expected_html = '<input type="hidden" name="test.something" value="something" />';
+		$actual_html   = wc_query_string_form_fields( '?test.something=something.else', array(), '', true );
+		$expected_html = '<input type="hidden" name="test.something" value="something.else" />';
 		$this->assertEquals( $expected_html, $actual_html );
 
-		$actual_html   = wc_query_string_form_fields( '?test+something=something', array(), '', true );
-		$expected_html = '<input type="hidden" name="test+something" value="something" />';
+		$actual_html   = wc_query_string_form_fields( '?test+something=something+else', array(), '', true );
+		$expected_html = '<input type="hidden" name="test+something" value="something+else" />';
 		$this->assertEquals( $expected_html, $actual_html );
 
-		$actual_html   = wc_query_string_form_fields( '?test%20something=something', array(), '', true );
-		$expected_html = '<input type="hidden" name="test%20something" value="something" />';
+		$actual_html   = wc_query_string_form_fields( '?test%20something=something%20else', array(), '', true );
+		$expected_html = '<input type="hidden" name="test%20something" value="something%20else" />';
 		$this->assertEquals( $expected_html, $actual_html );
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PR #23196 added a workaround to `parse_str()` limitation when dealing with full-stops, pluses, and spaces in the parameter key. This workaround involved temporarily replacing those three characters with placeholders before calling `parse_str()` and then replacing back to the original form. This commit fixes a bug in this logic that was replacing back only parameters keys and not parameters values.

For example, if the query string is `?query.parameter=foo.bar`, the resulting <input> field contained `foo{dot}bar`, instead of the expected `foo.bar`.

Besides changing a unit test to cover the case fixed in this PR, in a separate commit, I also modified the same unit test and removed the third parameter from the calls to `assertEquals()`. As far as I can tell, passing the actual value to the third parameter of `assertEquals()` is not necessary as this function will display the actual value anyway when there is an error and is also subverting the purpose of this parameter which is to display a message to the user identifying the error (cc @mikejolley in case I missed something, and there is a reason to keep the third parameter in this case).

Related #23518.

### How to test the changes in this Pull Request:

1. Add the following URL to an external product: `https://woocommerce.com/?first.parameter=foo.bar`.
2. Go to the product page and make sure that the hidden input field with the name `first.parameter` contains the value `foo.bar`. Before the change proposed in this PR, it contained `first{dot}parameter`.

### Changelog entry

>  Fix: error in the logic used to build <input> fields for external products when the query string contained full-stops, pluses or spaces in the values of the parameters