### PR TITLE
Version template caching

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -157,7 +157,7 @@ function wc_update_order( $args ) {
  * @param string $name Template name (default: '').
  */
 function wc_get_template_part( $slug, $name = '' ) {
-	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name, WC()->version ) ) );
+	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name, WC_VERSION ) ) );
 	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {
@@ -205,7 +205,7 @@ function wc_get_template_part( $slug, $name = '' ) {
  * @param string $default_path  Default path. (default: '').
  */
 function wc_get_template( $template_name, $args = array(), $template_path = '', $default_path = '' ) {
-	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path, WC()->version ) ) );
+	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path, WC_VERSION ) ) );
 	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -158,7 +158,13 @@ function wc_update_order( $args ) {
  */
 function wc_get_template_part( $slug, $name = '' ) {
 	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name ) ) );
-	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
+	$template  = wp_cache_get( $cache_key, 'woocommerce' );
+
+	if ( isset( $template['version'], $template['value'] ) && WC()->version === $template['version'] ) {
+		$template = (string) $template['value'];
+	} else {
+		$template = false;
+	}
 
 	if ( ! $template ) {
 		if ( $name ) {
@@ -185,7 +191,11 @@ function wc_get_template_part( $slug, $name = '' ) {
 			);
 		}
 
-		wp_cache_set( $cache_key, $template, 'woocommerce' );
+		$template_cache_value = array(
+			'version' => WC()->version,
+			'value'   => $template,
+		);
+		wp_cache_set( $cache_key, $template_cache_value, 'woocommerce' );
 	}
 
 	// Allow 3rd party plugins to filter template file from their plugin.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -157,7 +157,7 @@ function wc_update_order( $args ) {
  * @param string $name Template name (default: '').
  */
 function wc_get_template_part( $slug, $name = '' ) {
-	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name ) ) . '_' . WC()->version );
+	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name, WC()->version ) ) );
 	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {
@@ -205,7 +205,7 @@ function wc_get_template_part( $slug, $name = '' ) {
  * @param string $default_path  Default path. (default: '').
  */
 function wc_get_template( $template_name, $args = array(), $template_path = '', $default_path = '' ) {
-	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path ) ) . '_' . WC()->version );
+	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path, WC()->version ) ) );
 	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -157,14 +157,8 @@ function wc_update_order( $args ) {
  * @param string $name Template name (default: '').
  */
 function wc_get_template_part( $slug, $name = '' ) {
-	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name ) ) );
-	$template  = wp_cache_get( $cache_key, 'woocommerce' );
-
-	if ( isset( $template['version'], $template['value'] ) && WC()->version === $template['version'] ) {
-		$template = (string) $template['value'];
-	} else {
-		$template = false;
-	}
+	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name ) ) ) . '_' . WC()->version;
+	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {
 		if ( $name ) {
@@ -191,11 +185,7 @@ function wc_get_template_part( $slug, $name = '' ) {
 			);
 		}
 
-		$template_cache_value = array(
-			'version' => WC()->version,
-			'value'   => $template,
-		);
-		wp_cache_set( $cache_key, $template_cache_value, 'woocommerce' );
+		wp_cache_set( $cache_key, $template, 'woocommerce' );
 	}
 
 	// Allow 3rd party plugins to filter template file from their plugin.
@@ -215,23 +205,12 @@ function wc_get_template_part( $slug, $name = '' ) {
  * @param string $default_path  Default path. (default: '').
  */
 function wc_get_template( $template_name, $args = array(), $template_path = '', $default_path = '' ) {
-	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path ) ) );
-	$template  = wp_cache_get( $cache_key, 'woocommerce' );
-
-	if ( isset( $template['version'], $template['value'] ) && WC()->version === $template['version'] ) {
-		$template = (string) $template['value'];
-	} else {
-		$template = false;
-	}
+	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path ) ) ) . '_' . WC()->version;
+	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {
 		$template = wc_locate_template( $template_name, $template_path, $default_path );
-
-		$template_cache_value = array(
-			'version' => WC()->version,
-			'value'   => $template,
-		);
-		wp_cache_set( $cache_key, $template_cache_value, 'woocommerce' );
+		wp_cache_set( $cache_key, $template, 'woocommerce' );
 	}
 
 	// Allow 3rd party plugin filter template file from their plugin.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -216,11 +216,22 @@ function wc_get_template_part( $slug, $name = '' ) {
  */
 function wc_get_template( $template_name, $args = array(), $template_path = '', $default_path = '' ) {
 	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path ) ) );
-	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
+	$template  = wp_cache_get( $cache_key, 'woocommerce' );
+
+	if ( isset( $template['version'], $template['value'] ) && WC()->version === $template['version'] ) {
+		$template = (string) $template['value'];
+	} else {
+		$template = false;
+	}
 
 	if ( ! $template ) {
 		$template = wc_locate_template( $template_name, $template_path, $default_path );
-		wp_cache_set( $cache_key, $template, 'woocommerce' );
+
+		$template_cache_value = array(
+			'version' => WC()->version,
+			'value'   => $template,
+		);
+		wp_cache_set( $cache_key, $template_cache_value, 'woocommerce' );
 	}
 
 	// Allow 3rd party plugin filter template file from their plugin.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -157,7 +157,7 @@ function wc_update_order( $args ) {
  * @param string $name Template name (default: '').
  */
 function wc_get_template_part( $slug, $name = '' ) {
-	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name ) ) ) . '_' . WC()->version;
+	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name ) ) . '_' . WC()->version );
 	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {
@@ -205,7 +205,7 @@ function wc_get_template_part( $slug, $name = '' ) {
  * @param string $default_path  Default path. (default: '').
  */
 function wc_get_template( $template_name, $args = array(), $template_path = '', $default_path = '' ) {
-	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path ) ) ) . '_' . WC()->version;
+	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path ) ) . '_' . WC()->version );
 	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
https://github.com/woocommerce/woocommerce/commit/d167cb0a9593b8038f510435aa1bd706b7d762cd Introduced template caching to avoid multiple file exist checks on a single page load. However due to symlinks and how you can have multiple versions of a plugin under different folder this caused issues on some hosts which were symlinking WooCommerce based on the version.

This PR adds a version to the template caching which corresponds to the WooCommerce current woocommerce version, if the WooCommerce version changes the cache will be invalid causing it to find the new path.

Another alternative would be to use the plugin file path as the version key and do the validation against that, but templates should not changes in the current version so do not see the need to go that route, just another alternative should we want to.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23533 

### How to test the changes in this Pull Request:

1. Ensure you have memcache active on your site
2. Load the shop page
3. Rename the WooCommerce plugin folder and change the $version variable in class-woocommerce.php to something else
4. Activate WooCommerce again
5. Load shop page and check error log for any fatal errors, there should be none. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - Version template caching to avoid fatal errors on symlinked plugins.