### PR TITLE
Update/23558 Related product order

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1160,6 +1160,8 @@ function wc_products_array_orderby( $products, $orderby = 'date', $order = 'desc
 		case 'price':
 			usort( $products, 'wc_products_array_orderby_' . $orderby );
 			break;
+		case 'none':
+			break;
 		default:
 			shuffle( $products );
 			break;

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -886,7 +886,9 @@ function wc_get_related_products( $product_id, $limit = 5, $exclude_ids = array(
 		)
 	);
 
-	shuffle( $related_posts );
+	if ( apply_filters( 'woocommerce_product_related_posts_shuffle', true ) ) {
+		shuffle( $related_posts );
+	}
 
 	return array_slice( $related_posts, 0, $limit );
 }


### PR DESCRIPTION
This pull request allows overriding of some of the default random ordering (not filterable) that happens when getting a products' related posts.

It allows you to display related products in a specific custom order, either from a custom query or by creating an array of post IDs in a specific order.

The first change allows the disabling of a hardcoded `shuffle()` using the new `woocommerce_product_related_posts_shuffle` filter which maintains backwards compatibility,

The second change allows a products array to be ordered by "none" (which is also a parameter available to `WP_Query`) to override the default random order, which maintains backwards compatibility.

Closes #23558.

### How to test the changes in this Pull Request:

1. Use the `woocommerce_related_products` filter to return some custom related products in a specific order. For example, you may keep the default related post IDs but prepend a specific product ID at the front of the array.

2. At this point you will find as you refresh the page your related products appear in a random changing order.

3. Use the `woocommerce_product_related_posts_shuffle` and return `false` to disable the shuffle.

4. Use the `woocommerce_output_related_products_args` filter to set the "orderby" arg to "none" and the "order" arg to "asc".

5. You related products should now appear in your own custom order.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Add filters to allow related products to be ordered in a custom order instead of randomly.