### PR TITLE
Change location of github-contributors-list in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6131,6 +6131,7 @@
     "github-contributors-list": {
       "version": "https://github.com/woocommerce/github-contributors-list/tarball/master",
       "integrity": "sha512-B2yGehx2B1Fg0ooPCxcbq2fRE+YvAh1Yssa6Kp/sGMCRgDD9+yR6Fa5urn+cOqMbOvuAVZElVqQx+4wVm4JWgw==",
+      "dev": true,
       "requires": {
         "marked": "~0.3.1",
         "merge": "^1.2.0",
@@ -9007,7 +9008,8 @@
     "marked": {
       "version": "0.3.19",
       "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha1-XUf3CcTJ/Dwha21GEnKA9As515A="
+      "integrity": "sha1-XUf3CcTJ/Dwha21GEnKA9As515A=",
+      "dev": true
     },
     "matcher": {
       "version": "1.1.1",
@@ -9132,7 +9134,8 @@
     "merge": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
-      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ=="
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
+      "dev": true
     },
     "merge2": {
       "version": "1.2.3",
@@ -9195,7 +9198,8 @@
     "minimist": {
       "version": "0.0.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
     },
     "minimist-options": {
       "version": "3.0.2",
@@ -11039,7 +11043,8 @@
     "q": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/q/-/q-1.4.1.tgz",
-      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4="
+      "integrity": "sha1-VXBbzZPF82c1MMLCy8DCs63cKG4=",
+      "dev": true
     },
     "qs": {
       "version": "6.5.2",
@@ -12580,7 +12585,8 @@
     "sprintf-js": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-0.0.7.tgz",
-      "integrity": "sha1-8A14/RYBMICbSrNAwDEPqnElPb0="
+      "integrity": "sha1-8A14/RYBMICbSrNAwDEPqnElPb0=",
+      "dev": true
     },
     "sshpk": {
       "version": "1.16.1",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
     "test:single": "cross-env NODE_CONFIG_DIR='./tests/e2e-tests/config' BABEL_ENV=commonjs mocha --require babel-register",
     "git:update-hooks": "rm -r .git/hooks && mkdir -p .git/hooks && node ./node_modules/husky/husky.js install"
   },
+  "dependencies": {
+    "@woocommerce/block-library": "2.0.1"
+  },
   "devDependencies": {
     "autoprefixer": "9.5.1",
     "babel": "6.23.0",
@@ -65,9 +68,6 @@
   "engines": {
     "node": ">=10.15.0",
     "npm": ">=6.4.1"
-  },
-  "dependencies": {
-    "@woocommerce/block-library": "2.0.1"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -59,15 +59,15 @@
     "prettier": "github:automattic/calypso-prettier#c56b4251",
     "stylelint": "10.0.1",
     "stylelint-config-wordpress": "14.0.0",
-    "wc-e2e-page-objects": "0.10.0"
+    "wc-e2e-page-objects": "0.10.0",
+    "github-contributors-list": "https://github.com/woocommerce/github-contributors-list/tarball/master"
   },
   "engines": {
     "node": ">=10.15.0",
     "npm": ">=6.4.1"
   },
   "dependencies": {
-    "@woocommerce/block-library": "2.0.1",
-    "github-contributors-list": "https://github.com/woocommerce/github-contributors-list/tarball/master"
+    "@woocommerce/block-library": "2.0.1"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
This PR moves `github-contributors-list` in package.json from the `dependencies` section to the `devDependencies` section. This package is used to generate the list of WC contributors for each release, and it is not needed to run WC.

This PR also moves the `dependencies` to appear before `devDependencies` as the former is more important than the latter and this seems to be the standard for other package.json files.

cc @claudiosanches 