### PR TITLE
Fixes #23578 - Check taxes enabled before adding totals row to order

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1848,7 +1848,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	protected function add_order_item_totals_tax_rows( &$total_rows, $tax_display ) {
 		// Tax for tax exclusive prices.
-		if ( 'excl' === $tax_display ) {
+		if ( 'excl' === $tax_display && wc_tax_enabled() ) {
 			if ( 'itemized' === get_option( 'woocommerce_tax_total_display' ) ) {
 				foreach ( $this->get_tax_totals() as $code => $tax ) {
 					$total_rows[ sanitize_title( $code ) ] = array(


### PR DESCRIPTION
While this resolves the issue in WooCommerce core, I am concerned there are extensions that have taken a similar approach and will need to apply a fix. I first discovered the bug when testing the "WooCommerce Subscriptions" extension which added tax rows to the cart/checkout pages even though we had taxes disabled.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prevent a tax row from appearing under order totals when taxes have been disabled and the user has previously changed the tax display type from 'Itemized' to "As a single total".

Closes #23578 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Check taxes are enabled when displaying tax rows in order totals.
