### PR TITLE
Change the link of the "Report a bug" button

### DIFF
--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -66,7 +66,7 @@ class WC_Admin_Help {
 					'<h2>' . __( 'Found a bug?', 'woocommerce' ) . '</h2>' .
 					/* translators: 1: GitHub issues URL 2: GitHub contribution guide URL 3: System status report URL */
 					'<p>' . sprintf( __( 'If you find a bug within WooCommerce core you can create a ticket via <a href="%1$s">Github issues</a>. Ensure you read the <a href="%2$s">contribution guide</a> prior to submitting your report. To help us solve your issue, please be as descriptive as possible and include your <a href="%3$s">system status report</a>.', 'woocommerce' ), 'https://github.com/woocommerce/woocommerce/issues?state=open', 'https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md', admin_url( 'admin.php?page=wc-status' ) ) . '</p>' .
-					'<p><a href="https://github.com/woocommerce/woocommerce/issues?state=open" class="button button-primary">' . __( 'Report a bug', 'woocommerce' ) . '</a> <a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button">' . __( 'System status', 'woocommerce' ) . '</a></p>',
+					'<p><a href="https://github.com/woocommerce/woocommerce/issues/new?template=Bug_report.md" class="button button-primary">' . __( 'Report a bug', 'woocommerce' ) . '</a> <a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button">' . __( 'System status', 'woocommerce' ) . '</a></p>',
 
 			)
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the link of the "Report a bug" button from https://github.com/woocommerce/woocommerce/issues?state=open to https://github.com/woocommerce/woocommerce/issues/new?template=Bug_report.md. When users click on this button, they should go directly to the new issue page, instead of the page that lists issues.

### How to test the changes in this Pull Request:

1. On the admin, open any WooCommerce page.
2. Click "Help" on the top right corner and then click "Found a bug?"
3. Check that the link of the "Report a bug" button points to the new issue page on GitHub.