### PR TITLE
Fix PHPCS violations in tests/ using PHPCBF

### DIFF
--- a/tests/framework/class-wc-api-unit-test-case.php
+++ b/tests/framework/class-wc-api-unit-test-case.php
@@ -40,10 +40,10 @@ class WC_API_Unit_Test_Case extends WC_Unit_Test_Case {
 	 * Assert the given response is an API error with a specific code and status.
 	 *
 	 * @since 2.2
-	 * @param string $code error code, e.g. `woocommerce_api_user_cannot_read_orders_count`
+	 * @param string   $code error code, e.g. `woocommerce_api_user_cannot_read_orders_count`
 	 * @param int|null $status HTTP status code associated with error, e.g. 400
 	 * @param WP_Error $response
-	 * @param string $message optional message to render when assertion fails
+	 * @param string   $message optional message to render when assertion fails
 	 */
 	public function assertHasAPIError( $code, $status = null, $response, $message = '' ) {
 

--- a/tests/framework/class-wc-mock-wc-data.php
+++ b/tests/framework/class-wc-mock-wc-data.php
@@ -1,9 +1,9 @@
 <?php
 class WC_Mock_WC_Data_Store extends WC_Data_Store_WP implements WC_Object_Data_Store_Interface {
 
-	protected $meta_type = 'post';
+	protected $meta_type                = 'post';
 	protected $object_id_field_for_meta = '';
-	protected $internal_meta_keys = array();
+	protected $internal_meta_keys       = array();
 
 	/*
 	|--------------------------------------------------------------------------
@@ -75,9 +75,19 @@ class WC_Mock_WC_Data_Store extends WC_Data_Store_WP implements WC_Object_Data_S
 		$content_id = $object->get_id();
 
 		if ( 'user' === $this->meta_type ) {
-			wp_update_user( array( 'ID' => $customer_id, 'user_email' => $object->get_content() ) );
+			wp_update_user(
+				array(
+					'ID'         => $customer_id,
+					'user_email' => $object->get_content(),
+				)
+			);
 		} else {
-			wp_update_post( array( 'ID' => $content_id, 'post_title' => $object->get_content() ) );
+			wp_update_post(
+				array(
+					'ID'         => $content_id,
+					'post_title' => $object->get_content(),
+				)
+			);
 		}
 	}
 
@@ -132,7 +142,7 @@ class WC_Mock_WC_Data extends WC_Data {
 			$this->set_object_read( true );
 		}
 
-		$this->data_store = new WC_Mock_WC_Data_Store;
+		$this->data_store = new WC_Mock_WC_Data_Store();
 
 		if ( $this->get_id() > 0 ) {
 			$this->data_store->read( $this );

--- a/tests/framework/class-wc-rest-unit-test-case.php
+++ b/tests/framework/class-wc-rest-unit-test-case.php
@@ -22,7 +22,7 @@ class WC_REST_Unit_Test_Case extends WC_Unit_Test_Case {
 		do_action( 'rest_api_init' );
 
 		// Reset payment gateways.
-		$gateways = WC_Payment_Gateways::instance();
+		$gateways                   = WC_Payment_Gateways::instance();
 		$gateways->payment_gateways = array();
 		$gateways->init();
 	}

--- a/tests/framework/helpers/class-wc-helper-coupon.php
+++ b/tests/framework/helpers/class-wc-helper-coupon.php
@@ -19,32 +19,37 @@ class WC_Helper_Coupon {
 	 */
 	public static function create_coupon( $coupon_code = 'dummycoupon', $meta = array() ) {
 		// Insert post
-		$coupon_id = wp_insert_post( array(
-			'post_title'   => $coupon_code,
-			'post_type'    => 'shop_coupon',
-			'post_status'  => 'publish',
-			'post_excerpt' => 'This is a dummy coupon',
-		) );
+		$coupon_id = wp_insert_post(
+			array(
+				'post_title'   => $coupon_code,
+				'post_type'    => 'shop_coupon',
+				'post_status'  => 'publish',
+				'post_excerpt' => 'This is a dummy coupon',
+			)
+		);
 
-		$meta = wp_parse_args( $meta, array(
-			'discount_type'              => 'fixed_cart',
-			'coupon_amount'              => '1',
-			'individual_use'             => 'no',
-			'product_ids'                => '',
-			'exclude_product_ids'        => '',
-			'usage_limit'                => '',
-			'usage_limit_per_user'       => '',
-			'limit_usage_to_x_items'     => '',
-			'expiry_date'                => '',
-			'free_shipping'              => 'no',
-			'exclude_sale_items'         => 'no',
-			'product_categories'         => array(),
-			'exclude_product_categories' => array(),
-			'minimum_amount'             => '',
-			'maximum_amount'             => '',
-			'customer_email'             => array(),
-			'usage_count'                => '0',
-		) );
+		$meta = wp_parse_args(
+			$meta,
+			array(
+				'discount_type'              => 'fixed_cart',
+				'coupon_amount'              => '1',
+				'individual_use'             => 'no',
+				'product_ids'                => '',
+				'exclude_product_ids'        => '',
+				'usage_limit'                => '',
+				'usage_limit_per_user'       => '',
+				'limit_usage_to_x_items'     => '',
+				'expiry_date'                => '',
+				'free_shipping'              => 'no',
+				'exclude_sale_items'         => 'no',
+				'product_categories'         => array(),
+				'exclude_product_categories' => array(),
+				'minimum_amount'             => '',
+				'maximum_amount'             => '',
+				'customer_email'             => array(),
+				'usage_count'                => '0',
+			)
+		);
 
 		// Update meta.
 		foreach ( $meta as $key => $value ) {

--- a/tests/framework/helpers/class-wc-helper-customer.php
+++ b/tests/framework/helpers/class-wc-helper-customer.php
@@ -14,25 +14,25 @@ class WC_Helper_Customer {
 	 */
 	public static function create_mock_customer() {
 		$customer_data = array(
-			'id'                     => 0,
-			'date_modified'          => null,
-			'country' 				 => 'US',
-			'state' 				 => 'PA',
-			'postcode' 				 => '19123',
-			'city'					 => 'Philadelphia',
-			'address' 				 => '123 South Street',
-			'address_2' 			 => 'Apt 1',
-			'shipping_country' 		 => 'US',
-			'shipping_state' 		 => 'PA',
-			'shipping_postcode' 	 => '19123',
-			'shipping_city'			 => 'Philadelphia',
-			'shipping_address'		 => '123 South Street',
-			'shipping_address_2'	 => 'Apt 1',
-			'is_vat_exempt' 		 => false,
-			'calculated_shipping'	 => false,
+			'id'                  => 0,
+			'date_modified'       => null,
+			'country'             => 'US',
+			'state'               => 'PA',
+			'postcode'            => '19123',
+			'city'                => 'Philadelphia',
+			'address'             => '123 South Street',
+			'address_2'           => 'Apt 1',
+			'shipping_country'    => 'US',
+			'shipping_state'      => 'PA',
+			'shipping_postcode'   => '19123',
+			'shipping_city'       => 'Philadelphia',
+			'shipping_address'    => '123 South Street',
+			'shipping_address_2'  => 'Apt 1',
+			'is_vat_exempt'       => false,
+			'calculated_shipping' => false,
 		);
 
-		WC_Helper_Customer::set_customer_details( $customer_data );
+		self::set_customer_details( $customer_data );
 
 		$customer = new WC_Customer( 0, true );
 
@@ -70,7 +70,7 @@ class WC_Helper_Customer {
 	 * @return array
 	 */
 	public static function get_expected_store_location() {
-		return array( "GB", "", "", "" );
+		return array( 'GB', '', '', '' );
 	}
 
 	/**

--- a/tests/framework/helpers/class-wc-helper-order.php
+++ b/tests/framework/helpers/class-wc-helper-order.php
@@ -54,16 +54,18 @@ class WC_Helper_Order {
 		);
 
 		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // Required, else wc_create_order throws an exception
-		$order 					= wc_create_order( $order_data );
+		$order                  = wc_create_order( $order_data );
 
 		// Add order products
 		$item = new WC_Order_Item_Product();
-		$item->set_props( array(
-			'product'  => $product,
-			'quantity' => 4,
-			'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => 4 ) ),
-			'total'    => wc_get_price_excluding_tax( $product, array( 'qty' => 4 ) ),
-		) );
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => 4,
+				'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => 4 ) ),
+				'total'    => wc_get_price_excluding_tax( $product, array( 'qty' => 4 ) ),
+			)
+		);
 		$item->save();
 		$order->add_item( $item );
 
@@ -82,14 +84,16 @@ class WC_Helper_Order {
 
 		// Add shipping costs
 		$shipping_taxes = WC_Tax::calc_shipping_tax( '10', WC_Tax::get_shipping_tax_rates() );
-		$rate   = new WC_Shipping_Rate( 'flat_rate_shipping', 'Flat rate shipping', '10', $shipping_taxes, 'flat_rate' );
-		$item   = new WC_Order_Item_Shipping();
-		$item->set_props( array(
-			'method_title' => $rate->label,
-			'method_id'    => $rate->id,
-			'total'        => wc_format_decimal( $rate->cost ),
-			'taxes'        => $rate->taxes,
-		) );
+		$rate           = new WC_Shipping_Rate( 'flat_rate_shipping', 'Flat rate shipping', '10', $shipping_taxes, 'flat_rate' );
+		$item           = new WC_Order_Item_Shipping();
+		$item->set_props(
+			array(
+				'method_title' => $rate->label,
+				'method_id'    => $rate->id,
+				'total'        => wc_format_decimal( $rate->cost ),
+				'taxes'        => $rate->taxes,
+			)
+		);
 		foreach ( $rate->get_meta_data() as $key => $value ) {
 			$item->add_meta_data( $key, $value, true );
 		}

--- a/tests/framework/helpers/class-wc-helper-product.php
+++ b/tests/framework/helpers/class-wc-helper-product.php
@@ -90,8 +90,8 @@ class WC_Helper_Product {
 		$product          = new WC_Product_Grouped();
 		$product->set_props(
 			array(
-				'name'          => 'Dummy Grouped Product',
-				'sku'           => 'DUMMY GROUPED SKU',
+				'name' => 'Dummy Grouped Product',
+				'sku'  => 'DUMMY GROUPED SKU',
 			)
 		);
 		$product->set_children( array( $simple_product_1->get_id(), $simple_product_2->get_id() ) );
@@ -235,7 +235,7 @@ class WC_Helper_Product {
 			$result = term_exists( $term, $attribute->slug );
 
 			if ( ! $result ) {
-				$result = wp_insert_term( $term, $attribute->slug );
+				$result               = wp_insert_term( $term, $attribute->slug );
 				$return['term_ids'][] = $result['term_id'];
 			} else {
 				$return['term_ids'][] = $result['term_id'];

--- a/tests/framework/helpers/class-wc-helper-settings.php
+++ b/tests/framework/helpers/class-wc-helper-settings.php
@@ -40,13 +40,13 @@ class WC_Helper_Settings {
 			'option_key'  => '',
 		);
 		$groups[] = array(
-			'id'    => 'coupon-data',
-			'label' => 'Coupon data',
-			'option_key'  => '',
+			'id'         => 'coupon-data',
+			'label'      => 'Coupon data',
+			'option_key' => '',
 		);
 		$groups[] = array(
-			'id' => 'invalid',
-			'option_key'  => '',
+			'id'         => 'invalid',
+			'option_key' => '',
 		);
 		return $groups;
 	}

--- a/tests/includes/wp-http-testcase.php
+++ b/tests/includes/wp-http-testcase.php
@@ -203,7 +203,7 @@ abstract class WP_HTTP_TestCase extends WP_UnitTestCase {
 	public function http_request_listner( $preempt, $request, $url ) {
 
 		$this->http_requests[] = array(
-			'url' => $url,
+			'url'     => $url,
 			'request' => $request,
 		);
 
@@ -256,7 +256,7 @@ abstract class WP_HTTP_TestCase extends WP_UnitTestCase {
 	 *
 	 * @since 1.1.0
 	 *
-	 * @param array $request The request.
+	 * @param array  $request The request.
 	 * @param string $url The URL the request is for.
 	 *
 	 * @return string|false The cache key for the request. False if not caching.
@@ -315,7 +315,7 @@ abstract class WP_HTTP_TestCase extends WP_UnitTestCase {
 		}
 
 		self::$cache[ $cache_key ] = $response;
-		self::$cache_changed = true;
+		self::$cache_changed       = true;
 	}
 
 	//
@@ -428,7 +428,8 @@ abstract class WP_HTTP_TestCase extends WP_UnitTestCase {
 
 		// phpcs:ignore WordPress.VIP.FileSystemWritesDisallow.file_ops_file_put_contents
 		file_put_contents(
-			self::$cache_dir . '/' . self::$cache_group, serialize( self::$cache )
+			self::$cache_dir . '/' . self::$cache_group,
+			serialize( self::$cache )
 		);
 	}
 }

--- a/tests/unit-tests/account/functions.php
+++ b/tests/unit-tests/account/functions.php
@@ -45,14 +45,17 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_get_account_menu_items() {
-		$this->assertEquals( array(
-			'dashboard'       => 'Dashboard',
-			'orders'          => 'Orders',
-			'downloads'       => 'Downloads',
-			'edit-address'    => 'Addresses',
-			'edit-account'    => 'Account details',
-			'customer-logout' => 'Logout',
-		), wc_get_account_menu_items() );
+		$this->assertEquals(
+			array(
+				'dashboard'       => 'Dashboard',
+				'orders'          => 'Orders',
+				'downloads'       => 'Downloads',
+				'edit-address'    => 'Addresses',
+				'edit-account'    => 'Account details',
+				'customer-logout' => 'Logout',
+			),
+			wc_get_account_menu_items()
+		);
 	}
 
 	/**
@@ -79,13 +82,16 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_get_account_orders_columns() {
-		$this->assertEquals( array(
-			'order-number'  => 'Order',
-			'order-date'    => 'Date',
-			'order-status'  => 'Status',
-			'order-total'   => 'Total',
-			'order-actions' => 'Actions',
-		), wc_get_account_orders_columns() );
+		$this->assertEquals(
+			array(
+				'order-number'  => 'Order',
+				'order-date'    => 'Date',
+				'order-status'  => 'Status',
+				'order-total'   => 'Total',
+				'order-actions' => 'Actions',
+			),
+			wc_get_account_orders_columns()
+		);
 	}
 
 	/**
@@ -94,12 +100,15 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_get_account_downloads_columns() {
-		$this->assertEquals( array(
-			'download-file'      => 'Download',
-			'download-remaining' => 'Downloads remaining',
-			'download-expires'   => 'Expires',
-			'download-product'   => 'Product',
-		), wc_get_account_downloads_columns() );
+		$this->assertEquals(
+			array(
+				'download-file'      => 'Download',
+				'download-remaining' => 'Downloads remaining',
+				'download-expires'   => 'Expires',
+				'download-product'   => 'Product',
+			),
+			wc_get_account_downloads_columns()
+		);
 	}
 
 	/**
@@ -108,11 +117,14 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 	 * @since 3.3.0
 	 */
 	public function test_wc_get_account_payment_methods_columns() {
-		$this->assertEquals( array(
-			'method'  => 'Method',
-			'expires' => 'Expires',
-			'actions' => '&nbsp;',
-		), wc_get_account_payment_methods_columns() );
+		$this->assertEquals(
+			array(
+				'method'  => 'Method',
+				'expires' => 'Expires',
+				'actions' => '&nbsp;',
+			),
+			wc_get_account_payment_methods_columns()
+		);
 	}
 
 	/**
@@ -121,10 +133,13 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 	 * @since 3.3.0
 	 */
 	public function test_wc_get_account_payment_methods_types() {
-		$this->assertEquals( array(
-			'cc'     => 'Credit card',
-			'echeck' => 'eCheck',
-		), wc_get_account_payment_methods_types() );
+		$this->assertEquals(
+			array(
+				'cc'     => 'Credit card',
+				'echeck' => 'eCheck',
+			),
+			wc_get_account_payment_methods_types()
+		);
 	}
 
 	/**
@@ -135,20 +150,23 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 	public function test_wc_get_account_orders_actions() {
 		$order = WC_Helper_Order::create_order();
 
-		$this->assertEquals( array(
-			'view' => array(
-				'url'  => $order->get_view_order_url(),
-				'name' => 'View',
+		$this->assertEquals(
+			array(
+				'view'   => array(
+					'url'  => $order->get_view_order_url(),
+					'name' => 'View',
+				),
+				'pay'    => array(
+					'url'  => $order->get_checkout_payment_url(),
+					'name' => 'Pay',
+				),
+				'cancel' => array(
+					'url'  => $order->get_cancel_order_url( wc_get_page_permalink( 'myaccount' ) ),
+					'name' => 'Cancel',
+				),
 			),
-			'pay' => array(
-				'url'  => $order->get_checkout_payment_url(),
-				'name' => 'Pay',
-			),
-			'cancel' => array(
-				'url'  => $order->get_cancel_order_url( wc_get_page_permalink( 'myaccount' ) ),
-				'name' => 'Cancel',
-			),
-		), wc_get_account_orders_actions( $order->get_id() ) );
+			wc_get_account_orders_actions( $order->get_id() )
+		);
 
 		$order->delete( true );
 	}
@@ -187,25 +205,28 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 		$delete_url = wc_get_endpoint_url( 'delete-payment-method', $token->get_id() );
 		$delete_url = wp_nonce_url( $delete_url, 'delete-payment-method-' . $token->get_id() );
 
-		$this->assertEquals( array(
-			'cc' => array(
-				array(
-					'method'     => array(
-						'gateway' => 'bacs',
-						'last4'   => '1234',
-						'brand'   => 'Mastercard',
-					),
-					'expires'    => '12/20',
-					'is_default' => true,
-					'actions'    => array(
-						'delete' => array(
-							'url'  => $delete_url,
-							'name' => 'Delete',
+		$this->assertEquals(
+			array(
+				'cc' => array(
+					array(
+						'method'     => array(
+							'gateway' => 'bacs',
+							'last4'   => '1234',
+							'brand'   => 'Mastercard',
+						),
+						'expires'    => '12/20',
+						'is_default' => true,
+						'actions'    => array(
+							'delete' => array(
+								'url'  => $delete_url,
+								'name' => 'Delete',
+							),
 						),
 					),
 				),
 			),
-		), wc_get_account_saved_payment_methods_list( array(), $customer->get_id() ) );
+			wc_get_account_saved_payment_methods_list( array(), $customer->get_id() )
+		);
 
 		$customer->delete( true );
 		$token->delete( true );
@@ -226,13 +247,16 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 		$token->set_expiry_year( '2020' );
 		$token->save();
 
-		$this->assertEquals( array(
-			'method' => array(
-				'last4' => '1234',
-				'brand' => 'Mastercard',
+		$this->assertEquals(
+			array(
+				'method'  => array(
+					'last4' => '1234',
+					'brand' => 'Mastercard',
+				),
+				'expires' => '12/20',
 			),
-			'expires' => '12/20',
-		), wc_get_account_saved_payment_methods_list_item_cc( array(), $token ) );
+			wc_get_account_saved_payment_methods_list_item_cc( array(), $token )
+		);
 
 		$token->delete( true );
 	}
@@ -249,12 +273,15 @@ class WC_Tests_Account_Functions extends WC_Unit_Test_Case {
 		$token->set_last4( '1234' );
 		$token->save();
 
-		$this->assertEquals( array(
-			'method' => array(
-				'last4' => '1234',
-				'brand' => 'eCheck',
+		$this->assertEquals(
+			array(
+				'method' => array(
+					'last4' => '1234',
+					'brand' => 'eCheck',
+				),
 			),
-		), wc_get_account_saved_payment_methods_list_item_echeck( array(), $token ) );
+			wc_get_account_saved_payment_methods_list_item_echeck( array(), $token )
+		);
 
 		$token->delete( true );
 	}

--- a/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
+++ b/tests/unit-tests/admin/reports/class-wc-tests-admin-report.php
@@ -31,20 +31,22 @@ class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 	 * Test: get_order_report_data
 	 */
 	public function test_get_order_report_data() {
-		$order  = WC_Helper_Order::create_order();
+		$order = WC_Helper_Order::create_order();
 		$order->set_status( 'completed' );
 		$order->save();
 
 		$report = new WC_Admin_Report();
-		$data   = $report->get_order_report_data( array(
-			'data' => array(
-				'ID' => array(
-					'type'     => 'post_data',
-					'function' => 'COUNT',
-					'name'     => 'total_orders',
+		$data   = $report->get_order_report_data(
+			array(
+				'data' => array(
+					'ID' => array(
+						'type'     => 'post_data',
+						'function' => 'COUNT',
+						'name'     => 'total_orders',
+					),
 				),
-			),
-		) );
+			)
+		);
 
 		$this->assertEquals( 1, $data->total_orders, 'Expected to see one completed order in the report.' );
 		WC_Admin_Report::maybe_update_transients();
@@ -66,20 +68,22 @@ class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 	 * Test: get_order_report_data
 	 */
 	public function test_get_order_report_data_for_post_meta() {
-		$order  = WC_Helper_Order::create_order();
+		$order = WC_Helper_Order::create_order();
 		$order->set_status( 'completed' );
 		$order->save();
 
 		$report = new WC_Admin_Report();
-		$data   = $report->get_order_report_data( array(
-			'data' => array(
-				'_billing_first_name' => array(
-					'type'     => 'meta',
-					'function' => null,
-					'name'     => 'customer_name',
+		$data   = $report->get_order_report_data(
+			array(
+				'data' => array(
+					'_billing_first_name' => array(
+						'type'     => 'meta',
+						'function' => null,
+						'name'     => 'customer_name',
+					),
 				),
-			),
-		) );
+			)
+		);
 
 		$this->assertEquals( $order->get_billing_first_name(), $data->customer_name );
 	}
@@ -89,20 +93,24 @@ class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 	 */
 	public function test_get_order_report_data_for_parent_meta() {
 		$order  = WC_Helper_Order::create_order();
-		$refund = wc_create_refund( array(
-			'order_id' => $order->get_id(),
-		) );
+		$refund = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+			)
+		);
 
 		$report = new WC_Admin_Report();
-		$data   = $report->get_order_report_data( array(
-			'data' => array(
-				'_order_total' => array(
-					'type'     => 'parent_meta',
-					'function' => '',
-					'name'     => 'total_refund',
+		$data   = $report->get_order_report_data(
+			array(
+				'data' => array(
+					'_order_total' => array(
+						'type'     => 'parent_meta',
+						'function' => '',
+						'name'     => 'total_refund',
+					),
 				),
-			),
-		) );
+			)
+		);
 
 		$this->assertEquals( $order->get_total(), $data->total_refund );
 	}
@@ -111,20 +119,22 @@ class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 	 * Test: get_order_report_data
 	 */
 	public function test_get_order_report_data_for_post_data() {
-		$order  = WC_Helper_Order::create_order();
+		$order = WC_Helper_Order::create_order();
 		$order->set_status( 'completed' );
 		$order->save();
 
 		$report = new WC_Admin_Report();
-		$data   = $report->get_order_report_data( array(
-			'data' => array(
-				'post_status' => array(
-					'type'     => 'post_data',
-					'function' => null,
-					'name'     => 'post_status',
+		$data   = $report->get_order_report_data(
+			array(
+				'data' => array(
+					'post_status' => array(
+						'type'     => 'post_data',
+						'function' => null,
+						'name'     => 'post_status',
+					),
 				),
-			),
-		) );
+			)
+		);
 
 		$this->assertEquals( 'wc-completed', $data->post_status );
 	}
@@ -139,15 +149,17 @@ class WC_Tests_Admin_Report extends WC_Unit_Test_Case {
 		$order->save();
 
 		$report = new WC_Admin_Report();
-		$data   = $report->get_order_report_data( array(
-			'data' => array(
-				'order_item_name' => array(
-					'type'     => 'order_item',
-					'function' => null,
-					'name'     => 'name',
+		$data   = $report->get_order_report_data(
+			array(
+				'data' => array(
+					'order_item_name' => array(
+						'type'     => 'order_item',
+						'function' => null,
+						'name'     => 'name',
+					),
 				),
-			),
-		) );
+			)
+		);
 
 		$this->assertEquals( $product->get_name(), $data->name );
 	}

--- a/tests/unit-tests/api/coupons.php
+++ b/tests/unit-tests/api/coupons.php
@@ -15,9 +15,11 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Coupons_Controller();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -43,51 +45,54 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 		$coupon_2 = WC_Helper_Coupon::create_coupon( 'dummycoupon-2' );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/coupons' ) );
-		$coupons = $response->get_data();
+		$coupons  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, count( $coupons ) );
-		$this->assertContains( array(
-			'id'             => $coupon_1->get_id(),
-			'code'           => 'dummycoupon-1',
-			'amount'         => '1.00',
-			'date_created'   => wc_rest_prepare_date_response( $post_1->post_date_gmt, false ),
-			'date_created_gmt'   => wc_rest_prepare_date_response( $post_1->post_date_gmt ),
-			'date_modified'  => wc_rest_prepare_date_response( $post_1->post_modified_gmt, false ),
-			'date_modified_gmt'  => wc_rest_prepare_date_response( $post_1->post_modified_gmt ),
-			'discount_type'  => 'fixed_cart',
-			'description'    => 'This is a dummy coupon',
-			'date_expires'   => '',
-			'date_expires_gmt'   => '',
-			'usage_count'    => 0,
-			'individual_use' => false,
-			'product_ids'    => array(),
-			'excluded_product_ids' => array(),
-			'usage_limit'    => '',
-			'usage_limit_per_user' => '',
-			'limit_usage_to_x_items' => null,
-			'free_shipping' => false,
-			'product_categories' => array(),
-			'excluded_product_categories' => array(),
-			'exclude_sale_items' => false,
-			'minimum_amount' => '0.00',
-			'maximum_amount' => '0.00',
-			'email_restrictions' => array(),
-			'used_by' => array(),
-			'meta_data' => array(),
-			'_links' => array(
-				'self'       => array(
-					array(
-						'href' => rest_url( '/wc/v3/coupons/' . $coupon_1->get_id() ),
+		$this->assertContains(
+			array(
+				'id'                          => $coupon_1->get_id(),
+				'code'                        => 'dummycoupon-1',
+				'amount'                      => '1.00',
+				'date_created'                => wc_rest_prepare_date_response( $post_1->post_date_gmt, false ),
+				'date_created_gmt'            => wc_rest_prepare_date_response( $post_1->post_date_gmt ),
+				'date_modified'               => wc_rest_prepare_date_response( $post_1->post_modified_gmt, false ),
+				'date_modified_gmt'           => wc_rest_prepare_date_response( $post_1->post_modified_gmt ),
+				'discount_type'               => 'fixed_cart',
+				'description'                 => 'This is a dummy coupon',
+				'date_expires'                => '',
+				'date_expires_gmt'            => '',
+				'usage_count'                 => 0,
+				'individual_use'              => false,
+				'product_ids'                 => array(),
+				'excluded_product_ids'        => array(),
+				'usage_limit'                 => '',
+				'usage_limit_per_user'        => '',
+				'limit_usage_to_x_items'      => null,
+				'free_shipping'               => false,
+				'product_categories'          => array(),
+				'excluded_product_categories' => array(),
+				'exclude_sale_items'          => false,
+				'minimum_amount'              => '0.00',
+				'maximum_amount'              => '0.00',
+				'email_restrictions'          => array(),
+				'used_by'                     => array(),
+				'meta_data'                   => array(),
+				'_links'                      => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v3/coupons/' . $coupon_1->get_id() ),
+						),
 					),
-				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v3/coupons' ),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v3/coupons' ),
+						),
 					),
 				),
 			),
-		), $coupons );
+			$coupons
+		);
 	}
 
 	/**
@@ -112,35 +117,38 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array(
-			'id'             => $coupon->get_id(),
-			'code'           => 'dummycoupon-1',
-			'amount'         => '1.00',
-			'date_created'   => wc_rest_prepare_date_response( $post->post_date_gmt, false ),
-			'date_created_gmt' => wc_rest_prepare_date_response( $post->post_date_gmt ),
-			'date_modified'  => wc_rest_prepare_date_response( $post->post_modified_gmt, false ),
-			'date_modified_gmt' => wc_rest_prepare_date_response( $post->post_modified_gmt ),
-			'discount_type'  => 'fixed_cart',
-			'description'    => 'This is a dummy coupon',
-			'date_expires'    => null,
-			'date_expires_gmt' => null,
-			'usage_count'    => 0,
-			'individual_use' => false,
-			'product_ids'    => array(),
-			'excluded_product_ids' => array(),
-			'usage_limit'    => null,
-			'usage_limit_per_user' => null,
-			'limit_usage_to_x_items' => null,
-			'free_shipping' => false,
-			'product_categories' => array(),
-			'excluded_product_categories' => array(),
-			'exclude_sale_items' => false,
-			'minimum_amount' => '0.00',
-			'maximum_amount' => '0.00',
-			'email_restrictions' => array(),
-			'used_by' => array(),
-			'meta_data' => array(),
-		), $data );
+		$this->assertEquals(
+			array(
+				'id'                          => $coupon->get_id(),
+				'code'                        => 'dummycoupon-1',
+				'amount'                      => '1.00',
+				'date_created'                => wc_rest_prepare_date_response( $post->post_date_gmt, false ),
+				'date_created_gmt'            => wc_rest_prepare_date_response( $post->post_date_gmt ),
+				'date_modified'               => wc_rest_prepare_date_response( $post->post_modified_gmt, false ),
+				'date_modified_gmt'           => wc_rest_prepare_date_response( $post->post_modified_gmt ),
+				'discount_type'               => 'fixed_cart',
+				'description'                 => 'This is a dummy coupon',
+				'date_expires'                => null,
+				'date_expires_gmt'            => null,
+				'usage_count'                 => 0,
+				'individual_use'              => false,
+				'product_ids'                 => array(),
+				'excluded_product_ids'        => array(),
+				'usage_limit'                 => null,
+				'usage_limit_per_user'        => null,
+				'limit_usage_to_x_items'      => null,
+				'free_shipping'               => false,
+				'product_categories'          => array(),
+				'excluded_product_categories' => array(),
+				'exclude_sale_items'          => false,
+				'minimum_amount'              => '0.00',
+				'maximum_amount'              => '0.00',
+				'email_restrictions'          => array(),
+				'used_by'                     => array(),
+				'meta_data'                   => array(),
+			),
+			$data
+		);
 	}
 
 	/**
@@ -171,46 +179,51 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 	public function test_create_coupon() {
 		wp_set_current_user( $this->user );
 		$request = new WP_REST_Request( 'POST', '/wc/v3/coupons' );
-		$request->set_body_params( array(
-			'code'          => 'test',
-			'amount'        => '5.00',
-			'discount_type' => 'fixed_product',
-			'description'   => 'Test',
-			'usage_limit'   => 10,
-		) );
+		$request->set_body_params(
+			array(
+				'code'          => 'test',
+				'amount'        => '5.00',
+				'discount_type' => 'fixed_product',
+				'description'   => 'Test',
+				'usage_limit'   => 10,
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals( array(
-			'id'             => $data['id'],
-			'code'           => 'test',
-			'amount'         => '5.00',
-			'date_created'   => $data['date_created'],
-			'date_created_gmt'   => $data['date_created_gmt'],
-			'date_modified'  => $data['date_modified'],
-			'date_modified_gmt'  => $data['date_modified_gmt'],
-			'discount_type'  => 'fixed_product',
-			'description'    => 'Test',
-			'date_expires'    => null,
-			'date_expires_gmt'    => null,
-			'usage_count'    => 0,
-			'individual_use' => false,
-			'product_ids'    => array(),
-			'excluded_product_ids' => array(),
-			'usage_limit'    => 10,
-			'usage_limit_per_user' => null,
-			'limit_usage_to_x_items' => null,
-			'free_shipping' => false,
-			'product_categories' => array(),
-			'excluded_product_categories' => array(),
-			'exclude_sale_items' => false,
-			'minimum_amount' => '0.00',
-			'maximum_amount' => '0.00',
-			'email_restrictions' => array(),
-			'used_by' => array(),
-			'meta_data' => array(),
-		), $data );
+		$this->assertEquals(
+			array(
+				'id'                          => $data['id'],
+				'code'                        => 'test',
+				'amount'                      => '5.00',
+				'date_created'                => $data['date_created'],
+				'date_created_gmt'            => $data['date_created_gmt'],
+				'date_modified'               => $data['date_modified'],
+				'date_modified_gmt'           => $data['date_modified_gmt'],
+				'discount_type'               => 'fixed_product',
+				'description'                 => 'Test',
+				'date_expires'                => null,
+				'date_expires_gmt'            => null,
+				'usage_count'                 => 0,
+				'individual_use'              => false,
+				'product_ids'                 => array(),
+				'excluded_product_ids'        => array(),
+				'usage_limit'                 => 10,
+				'usage_limit_per_user'        => null,
+				'limit_usage_to_x_items'      => null,
+				'free_shipping'               => false,
+				'product_categories'          => array(),
+				'excluded_product_categories' => array(),
+				'exclude_sale_items'          => false,
+				'minimum_amount'              => '0.00',
+				'maximum_amount'              => '0.00',
+				'email_restrictions'          => array(),
+				'used_by'                     => array(),
+				'meta_data'                   => array(),
+			),
+			$data
+		);
 	}
 
 	/**
@@ -222,12 +235,14 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 
 		// test no code...
 		$request = new WP_REST_Request( 'POST', '/wc/v3/coupons' );
-		$request->set_body_params( array(
-			'amount'        => '5.00',
-			'discount_type' => 'fixed_product',
-		) );
+		$request->set_body_params(
+			array(
+				'amount'        => '5.00',
+				'discount_type' => 'fixed_product',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
 	}
@@ -241,13 +256,15 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 
 		// test no code...
 		$request = new WP_REST_Request( 'POST', '/wc/v3/coupons' );
-		$request->set_body_params( array(
-			'code'          => 'fail',
-			'amount'        => '5.00',
-			'discount_type' => 'fixed_product',
-		) );
+		$request->set_body_params(
+			array(
+				'code'          => 'fail',
+				'amount'        => '5.00',
+				'discount_type' => 'fixed_product',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -258,8 +275,8 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_coupon() {
 		wp_set_current_user( $this->user );
-		$coupon   = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
-		$post     = get_post( $coupon->get_id() );
+		$coupon = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
+		$post   = get_post( $coupon->get_id() );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/coupons/' . $coupon->get_id() ) );
 		$data     = $response->get_data();
@@ -268,12 +285,14 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( '1.00', $data['amount'] );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/coupons/' . $coupon->get_id() );
-		$request->set_body_params( array(
-			'amount' => '10.00',
-			'description' => 'New description',
-		) );
+		$request->set_body_params(
+			array(
+				'amount'      => '10.00',
+				'description' => 'New description',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( '10.00', $data['amount'] );
 		$this->assertEquals( 'New description', $data['description'] );
@@ -288,13 +307,15 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/coupons/0' );
-		$request->set_body_params( array(
-			'code'   => 'tester',
-			'amount' => '10.00',
-			'description' => 'New description',
-		) );
+		$request->set_body_params(
+			array(
+				'code'        => 'tester',
+				'amount'      => '10.00',
+				'description' => 'New description',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
 	}
@@ -305,14 +326,16 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_coupon_without_permission() {
 		wp_set_current_user( 0 );
-		$coupon   = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
-		$post     = get_post( $coupon->get_id() );
+		$coupon = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
+		$post   = get_post( $coupon->get_id() );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/coupons/' . $coupon->get_id() );
-		$request->set_body_params( array(
-			'amount' => '10.00',
-			'description' => 'New description',
-		) );
+		$request->set_body_params(
+			array(
+				'amount'      => '10.00',
+				'description' => 'New description',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
@@ -324,7 +347,7 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_coupon() {
 		wp_set_current_user( $this->user );
-		$coupon   = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
+		$coupon  = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
 		$request = new WP_REST_Request( 'DELETE', '/wc/v3/coupons/' . $coupon->get_id() );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
@@ -364,32 +387,34 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 	public function test_batch_coupon() {
 		wp_set_current_user( $this->user );
 
-		$coupon_1   = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
-		$coupon_2   = WC_Helper_Coupon::create_coupon( 'dummycoupon-2' );
-		$coupon_3   = WC_Helper_Coupon::create_coupon( 'dummycoupon-3' );
-		$coupon_4   = WC_Helper_Coupon::create_coupon( 'dummycoupon-4' );
+		$coupon_1 = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
+		$coupon_2 = WC_Helper_Coupon::create_coupon( 'dummycoupon-2' );
+		$coupon_3 = WC_Helper_Coupon::create_coupon( 'dummycoupon-3' );
+		$coupon_4 = WC_Helper_Coupon::create_coupon( 'dummycoupon-4' );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/coupons/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'     => $coupon_1->get_id(),
-					'amount' => '5.15',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'     => $coupon_1->get_id(),
+						'amount' => '5.15',
+					),
 				),
-			),
-			'delete' => array(
-				$coupon_2->get_id(),
-				$coupon_3->get_id(),
-			),
-			'create' => array(
-				array(
-					'code'   => 'new-coupon',
-					'amount' => '11.00',
+				'delete' => array(
+					$coupon_2->get_id(),
+					$coupon_3->get_id(),
 				),
-			),
-		) );
+				'create' => array(
+					array(
+						'code'   => 'new-coupon',
+						'amount' => '11.00',
+					),
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( '5.15', $data['update'][0]['amount'] );
 		$this->assertEquals( '11.00', $data['create'][0]['amount'] );
@@ -397,9 +422,9 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $coupon_2->get_id(), $data['delete'][0]['id'] );
 		$this->assertEquals( $coupon_3->get_id(), $data['delete'][1]['id'] );
 
-		$request = new WP_REST_Request( 'GET', '/wc/v3/coupons' );
+		$request  = new WP_REST_Request( 'GET', '/wc/v3/coupons' );
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
 	}
@@ -410,9 +435,9 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_coupon_schema() {
 		wp_set_current_user( $this->user );
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v3/coupons' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v3/coupons' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
 		$this->assertEquals( 27, count( $properties ) );

--- a/tests/unit-tests/api/payment-gateways.php
+++ b/tests/unit-tests/api/payment-gateways.php
@@ -14,9 +14,11 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Payment_Gateways_Controller();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -42,34 +44,40 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$gateways = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertContains( array(
-			'id'                 => 'cheque',
-			'title'              => 'Check payments',
-			'description'        => 'Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.',
-			'order'              => '',
-			'enabled'            => false,
-			'method_title'       => 'Check payments',
-			'method_description' => 'Take payments in person via checks. This offline gateway can also be useful to test purchases.',
-			'method_supports'    => array(
-				'products',
-			),
-			'settings'           => array_diff_key( $this->get_settings( 'WC_Gateway_Cheque' ), array(
-				'enabled'     => false,
-				'description' => false,
-			) ),
-			'_links' => array(
-				'self'       => array(
+		$this->assertContains(
+			array(
+				'id'                 => 'cheque',
+				'title'              => 'Check payments',
+				'description'        => 'Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.',
+				'order'              => '',
+				'enabled'            => false,
+				'method_title'       => 'Check payments',
+				'method_description' => 'Take payments in person via checks. This offline gateway can also be useful to test purchases.',
+				'method_supports'    => array(
+					'products',
+				),
+				'settings'           => array_diff_key(
+					$this->get_settings( 'WC_Gateway_Cheque' ),
 					array(
-						'href' => rest_url( '/wc/v3/payment_gateways/cheque' ),
+						'enabled'     => false,
+						'description' => false,
+					)
+				),
+				'_links'             => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v3/payment_gateways/cheque' ),
+						),
+					),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v3/payment_gateways' ),
+						),
 					),
 				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v3/payment_gateways' ),
-					),
-				),
 			),
-		), $gateways );
+			$gateways
+		);
 	}
 
 	/**
@@ -95,23 +103,29 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$paypal   = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array(
-			'id'                 => 'paypal',
-			'title'              => 'PayPal',
-			'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
-			'order'              => '',
-			'enabled'            => false,
-			'method_title'       => 'PayPal',
-			'method_description' => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
-			'method_supports'    => array(
-				'products',
-				'refunds',
+		$this->assertEquals(
+			array(
+				'id'                 => 'paypal',
+				'title'              => 'PayPal',
+				'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
+				'order'              => '',
+				'enabled'            => false,
+				'method_title'       => 'PayPal',
+				'method_description' => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
+				'method_supports'    => array(
+					'products',
+					'refunds',
+				),
+				'settings'           => array_diff_key(
+					$this->get_settings( 'WC_Gateway_Paypal' ),
+					array(
+						'enabled'     => false,
+						'description' => false,
+					)
+				),
 			),
-			'settings'           => array_diff_key( $this->get_settings( 'WC_Gateway_Paypal' ), array(
-				'enabled'     => false,
-				'description' => false,
-			) ),
-		), $paypal );
+			$paypal
+		);
 	}
 
 	/**
@@ -154,11 +168,13 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 
 		// test updating single setting
 		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'settings' => array(
-				'email' => 'woo@woo.local',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'email' => 'woo@woo.local',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$paypal   = $response->get_data();
 
@@ -169,12 +185,14 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 
 		// test updating multiple settings
 		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'settings' => array(
-				'testmode' => 'yes',
-				'title'    => 'PayPal - New Title',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'testmode' => 'yes',
+					'title'    => 'PayPal - New Title',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$paypal   = $response->get_data();
 
@@ -185,10 +203,12 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 
 		// Test other parameters, and recheck settings
 		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'enabled' => false,
-			'order'   => 2,
-		) );
+		$request->set_body_params(
+			array(
+				'enabled' => false,
+				'order'   => 2,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$paypal   = $response->get_data();
 
@@ -200,20 +220,24 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 
 		// test bogus
 		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'settings' => array(
-				'paymentaction' => 'afasfasf',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'paymentaction' => 'afasfasf',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'settings' => array(
-				'paymentaction' => 'authorization',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'paymentaction' => 'authorization',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$paypal   = $response->get_data();
 		$this->assertEquals( 'authorization', $paypal['settings']['paymentaction']['value'] );
@@ -227,12 +251,14 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 	public function test_update_payment_gateway_without_permission() {
 		wp_set_current_user( 0 );
 		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'settings' => array(
-				'testmode' => 'yes',
-				'title'    => 'PayPal - New Title',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'testmode' => 'yes',
+					'title'    => 'PayPal - New Title',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -244,10 +270,12 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_payment_gateway_invalid_id() {
 		wp_set_current_user( $this->user );
-		$request  = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/totally_fake_method' );
-		$request->set_body_params( array(
-			'enabled' => true,
-		) );
+		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/totally_fake_method' );
+		$request->set_body_params(
+			array(
+				'enabled' => true,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -260,9 +288,9 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 	public function test_payment_gateway_schema() {
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v3/payment_gateways' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v3/payment_gateways' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
 		$this->assertEquals( 9, count( $properties ) );

--- a/tests/unit-tests/api/product-reviews.php
+++ b/tests/unit-tests/api/product-reviews.php
@@ -80,7 +80,8 @@ class WC_Tests_API_Product_Reviews extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $product_reviews
+			),
+			$product_reviews
 		);
 	}
 
@@ -134,7 +135,8 @@ class WC_Tests_API_Product_Reviews extends WC_REST_Unit_Test_Case {
 				'rating'               => 0,
 				'verified'             => false,
 				'reviewer_avatar_urls' => $data['reviewer_avatar_urls'],
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -198,7 +200,8 @@ class WC_Tests_API_Product_Reviews extends WC_REST_Unit_Test_Case {
 				'rating'               => 5,
 				'verified'             => false,
 				'reviewer_avatar_urls' => $data['reviewer_avatar_urls'],
-			), $data
+			),
+			$data
 		);
 	}
 

--- a/tests/unit-tests/api/reports-coupons-totals.php
+++ b/tests/unit-tests/api/reports-coupons-totals.php
@@ -52,7 +52,8 @@ class WC_Tests_API_Reports_Coupons_Totals extends WC_REST_Unit_Test_Case {
 					FROM $wpdb->postmeta
 					WHERE meta_key = 'discount_type'
 					AND meta_value = %s
-				", $slug
+				",
+					$slug
 				)
 			);
 

--- a/tests/unit-tests/api/settings.php
+++ b/tests/unit-tests/api/settings.php
@@ -15,9 +15,11 @@ class Settings extends WC_REST_Unit_Test_Case {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Setting_Options_Controller();
 		WC_Helper_Settings::register();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -41,39 +43,45 @@ class Settings extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 
-		$this->assertContains( array(
-			'id'          => 'test',
-			'label'       => 'Test extension',
-			'parent_id'   => '',
-			'description' => 'My awesome test settings.',
-			'sub_groups'  => array( 'sub-test' ),
-			'_links'      => array(
-				'options' => array(
-					array(
-						'href' => rest_url( '/wc/v3/settings/test' ),
+		$this->assertContains(
+			array(
+				'id'          => 'test',
+				'label'       => 'Test extension',
+				'parent_id'   => '',
+				'description' => 'My awesome test settings.',
+				'sub_groups'  => array( 'sub-test' ),
+				'_links'      => array(
+					'options' => array(
+						array(
+							'href' => rest_url( '/wc/v3/settings/test' ),
+						),
 					),
 				),
 			),
-		), $data );
+			$data
+		);
 
-		$this->assertContains( array(
-			'id'          => 'sub-test',
-			'label'       => 'Sub test',
-			'parent_id'   => 'test',
-			'description' => '',
-			'sub_groups'  => array(),
-			'_links'      => array(
-				'options' => array(
-					array(
-						'href' => rest_url( '/wc/v3/settings/sub-test' ),
+		$this->assertContains(
+			array(
+				'id'          => 'sub-test',
+				'label'       => 'Sub test',
+				'parent_id'   => 'test',
+				'description' => '',
+				'sub_groups'  => array(),
+				'_links'      => array(
+					'options' => array(
+						array(
+							'href' => rest_url( '/wc/v3/settings/sub-test' ),
+						),
 					),
 				),
 			),
-		), $data );
+			$data
+		);
 	}
 
 	/**
@@ -111,9 +119,9 @@ class Settings extends WC_REST_Unit_Test_Case {
 	 * @since 3.5.0
 	 */
 	public function test_get_group_schema() {
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v3/settings' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v3/settings' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 		$this->assertEquals( 5, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
@@ -129,9 +137,9 @@ class Settings extends WC_REST_Unit_Test_Case {
 	 * @since 3.5.0
 	 */
 	public function test_get_setting_schema() {
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v3/settings/test/woocommerce_shop_page_display' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v3/settings/test/woocommerce_shop_page_display' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 		$this->assertEquals( 10, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
@@ -168,7 +176,7 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		// test getting a valid group with settings attached to it
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/test' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( 1, count( $data ) );
 		$this->assertEquals( 'woocommerce_shop_page_display', $data[0]['id'] );
 		$this->assertEmpty( $data[0]['value'] );
@@ -196,36 +204,42 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		// test defaults first
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/test/woocommerce_shop_page_display' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( '', $data['value'] );
 
 		// test updating shop display setting
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'test', 'woocommerce_shop_page_display' ) );
-		$request->set_body_params( array(
-			'value' => 'both',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'both',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'both', $data['value'] );
 		$this->assertEquals( 'both', get_option( 'woocommerce_shop_page_display' ) );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'test', 'woocommerce_shop_page_display' ) );
-		$request->set_body_params( array(
-			'value' => 'subcategories',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'subcategories',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'subcategories', $data['value'] );
 		$this->assertEquals( 'subcategories', get_option( 'woocommerce_shop_page_display' ) );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'test', 'woocommerce_shop_page_display' ) );
-		$request->set_body_params( array(
-			'value' => '',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => '',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( '', $data['value'] );
 		$this->assertEquals( '', get_option( 'woocommerce_shop_page_display' ) );
@@ -241,37 +255,41 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		// test defaults first
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/test' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( '', $data[0]['value'] );
 
 		// test setting both at once
 		$request = new WP_REST_Request( 'POST', '/wc/v3/settings/test/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'    => 'woocommerce_shop_page_display',
-					'value' => 'both',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'    => 'woocommerce_shop_page_display',
+						'value' => 'both',
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'both', $data['update'][0]['value'] );
 		$this->assertEquals( 'both', get_option( 'woocommerce_shop_page_display' ) );
 
 		// test updating one, but making sure the other value stays the same
 		$request = new WP_REST_Request( 'POST', '/wc/v3/settings/test/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'    => 'woocommerce_shop_page_display',
-					'value' => 'subcategories',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'    => 'woocommerce_shop_page_display',
+						'value' => 'subcategories',
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( 'subcategories', $data['update'][0]['value'] );
 		$this->assertEquals( 'subcategories', get_option( 'woocommerce_shop_page_display' ) );
 	}
@@ -286,17 +304,17 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		// test getting an invalid setting from a group that does not exist
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/not-real/woocommerce_shop_page_display' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( 404, $response->get_status() );
 
 		// test getting an invalid setting from a group that does exist
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/invalid/invalid' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( 404, $response->get_status() );
 
 		// test getting a valid setting
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/test/woocommerce_shop_page_display' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 
@@ -374,9 +392,11 @@ class Settings extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( 0 );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'test', 'woocommerce_shop_page_display' ) );
-		$request->set_body_params( array(
-			'value' => 'subcategories',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'subcategories',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -391,14 +411,16 @@ class Settings extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( 0 );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/settings/test/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'    => 'woocommerce_shop_page_display',
-					'value' => 'subcategories',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'    => 'woocommerce_shop_page_display',
+						'value' => 'subcategories',
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -413,9 +435,11 @@ class Settings extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/settings/test/invalid' );
-		$request->set_body_params( array(
-			'value' => 'test',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'test',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -430,43 +454,48 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		// Make sure the group is properly registered
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/products' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertTrue( is_array( $data ) );
-		$this->assertContains( array(
-			'id'          => 'woocommerce_downloads_require_login',
-			'label'       => 'Access restriction',
-			'description' => 'Downloads require login',
-			'type'        => 'checkbox',
-			'default'     => 'no',
-			'tip'         => 'This setting does not apply to guest purchases.',
-			'value'       => 'no',
-			'_links'      => array(
-				'self' => array(
-					array(
-						'href' => rest_url( '/wc/v3/settings/products/woocommerce_downloads_require_login' ),
+		$this->assertContains(
+			array(
+				'id'          => 'woocommerce_downloads_require_login',
+				'label'       => 'Access restriction',
+				'description' => 'Downloads require login',
+				'type'        => 'checkbox',
+				'default'     => 'no',
+				'tip'         => 'This setting does not apply to guest purchases.',
+				'value'       => 'no',
+				'_links'      => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v3/settings/products/woocommerce_downloads_require_login' ),
+						),
 					),
-				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v3/settings/products' ),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v3/settings/products' ),
+						),
 					),
 				),
 			),
-		), $data );
+			$data
+		);
 
 		// test get single
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/products/woocommerce_dimension_unit' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'cm', $data['default'] );
 
 		// test update
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'products', 'woocommerce_dimension_unit' ) );
-		$request->set_body_params( array(
-			'value' => 'yd',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'yd',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'yd', $data['value'] );
 		$this->assertEquals( 'yd', get_option( 'woocommerce_dimension_unit' ) );
@@ -485,64 +514,75 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 
-		$this->assertContains( array(
-			'id'          => 'recipient',
-			'label'       => 'Recipient(s)',
-			'description' => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
-			'type'        => 'text',
-			'default'     => '',
-			'tip'         => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
-			'value'       => '',
-			'_links'      => array(
-				'self' => array(
-					array(
-						'href' => rest_url( '/wc/v3/settings/email_new_order/recipient' ),
+		$this->assertContains(
+			array(
+				'id'          => 'recipient',
+				'label'       => 'Recipient(s)',
+				'description' => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
+				'type'        => 'text',
+				'default'     => '',
+				'tip'         => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
+				'value'       => '',
+				'_links'      => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v3/settings/email_new_order/recipient' ),
+						),
 					),
-				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v3/settings/email_new_order' ),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v3/settings/email_new_order' ),
+						),
 					),
 				),
 			),
-		), $settings );
+			$settings
+		);
 
 		// test get single
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/settings/email_new_order/subject' ) );
 		$setting  = $response->get_data();
 
-		$this->assertEquals( array(
-			'id'          => 'subject',
-			'label'       => 'Subject',
-			'description' => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
-			'type'        => 'text',
-			'default'     => '',
-			'tip'         => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
-			'value'       => '',
-			'group_id'    => 'email_new_order',
-		), $setting );
+		$this->assertEquals(
+			array(
+				'id'          => 'subject',
+				'label'       => 'Subject',
+				'description' => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
+				'type'        => 'text',
+				'default'     => '',
+				'tip'         => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
+				'value'       => '',
+				'group_id'    => 'email_new_order',
+			),
+			$setting
+		);
 
 		// test update
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'email_new_order', 'subject' ) );
-		$request->set_body_params( array(
-			'value' => 'This is my subject',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'This is my subject',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 
-		$this->assertEquals( array(
-			'id'          => 'subject',
-			'label'       => 'Subject',
-			'description' => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
-			'type'        => 'text',
-			'default'     => '',
-			'tip'         => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
-			'value'       => 'This is my subject',
-			'group_id'    => 'email_new_order',
-		), $setting );
+		$this->assertEquals(
+			array(
+				'id'          => 'subject',
+				'label'       => 'Subject',
+				'description' => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
+				'type'        => 'text',
+				'default'     => '',
+				'tip'         => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
+				'value'       => 'This is my subject',
+				'group_id'    => 'email_new_order',
+			),
+			$setting
+		);
 
 		// test updating another subject and making sure it works with a "similar" id
-		$request = new WP_REST_Request( 'GET', sprintf( '/wc/v3/settings/%s/%s', 'email_customer_new_account', 'subject' ) );
+		$request  = new WP_REST_Request( 'GET', sprintf( '/wc/v3/settings/%s/%s', 'email_customer_new_account', 'subject' ) );
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 
@@ -550,9 +590,11 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		// test update
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'email_customer_new_account', 'subject' ) );
-		$request->set_body_params( array(
-			'value' => 'This is my new subject',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'This is my new subject',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 
@@ -575,25 +617,31 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		// test bogus value
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'email_cancelled_order', 'enabled' ) );
-		$request->set_body_params( array(
-			'value' => 'not_yes_or_no',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'not_yes_or_no',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 
 		// test yes
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'email_cancelled_order', 'enabled' ) );
-		$request->set_body_params( array(
-			'value' => 'yes',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'yes',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 
 		// test no
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'email_cancelled_order', 'enabled' ) );
-		$request->set_body_params( array(
-			'value' => 'no',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'no',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 	}
@@ -608,17 +656,21 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		// not a valid option
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'shipping', 'woocommerce_ship_to_destination' ) );
-		$request->set_body_params( array(
-			'value' => 'billing2',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'billing2',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 
 		// valid
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'shipping', 'woocommerce_ship_to_destination' ) );
-		$request->set_body_params( array(
-			'value' => 'billing',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'billing',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 	}
@@ -636,9 +688,11 @@ class Settings extends WC_REST_Unit_Test_Case {
 		$this->assertEmpty( $setting['value'] );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'general', 'woocommerce_specific_allowed_countries' ) );
-		$request->set_body_params( array(
-			'value' => array( 'AX', 'DZ', 'MMM' ),
-		) );
+		$request->set_body_params(
+			array(
+				'value' => array( 'AX', 'DZ', 'MMM' ),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( array( 'AX', 'DZ' ), $setting['value'] );
@@ -658,17 +712,21 @@ class Settings extends WC_REST_Unit_Test_Case {
 
 		// invalid
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'products', 'woocommerce_weight_unit' ) );
-		$request->set_body_params( array(
-			'value' => 'pounds', // invalid, should be lbs
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'pounds', // invalid, should be lbs
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 
 		// valid
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v3/settings/%s/%s', 'products', 'woocommerce_weight_unit' ) );
-		$request->set_body_params( array(
-			'value' => 'lbs', // invalid, should be lbs
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'lbs', // invalid, should be lbs
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( 'lbs', $setting['value'] );
@@ -705,19 +763,23 @@ class Settings extends WC_REST_Unit_Test_Case {
 		// Repalce the old value with something uniquely new
 		$old_value = $setting['value'];
 		$new_value = $old_value . ' ' . rand( 1000, 9999 );
-		$request = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_address' );
-		$request->set_body_params( array(
-			'value' => $new_value,
-		) );
+		$request   = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_address' );
+		$request->set_body_params(
+			array(
+				'value' => $new_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $new_value, $setting['value'] );
 
 		// Put the original value back
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_address' );
-		$request->set_body_params( array(
-			'value' => $old_value,
-		) );
+		$request->set_body_params(
+			array(
+				'value' => $old_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $old_value, $setting['value'] );
@@ -737,19 +799,23 @@ class Settings extends WC_REST_Unit_Test_Case {
 		// Repalce the old value with something uniquely new
 		$old_value = $setting['value'];
 		$new_value = $old_value . ' ' . rand( 1000, 9999 );
-		$request = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_address_2' );
-		$request->set_body_params( array(
-			'value' => $new_value,
-		) );
+		$request   = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_address_2' );
+		$request->set_body_params(
+			array(
+				'value' => $new_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $new_value, $setting['value'] );
 
 		// Put the original value back
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_address_2' );
-		$request->set_body_params( array(
-			'value' => $old_value,
-		) );
+		$request->set_body_params(
+			array(
+				'value' => $old_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $old_value, $setting['value'] );
@@ -769,19 +835,23 @@ class Settings extends WC_REST_Unit_Test_Case {
 		// Repalce the old value with something uniquely new
 		$old_value = $setting['value'];
 		$new_value = $old_value . ' ' . rand( 1000, 9999 );
-		$request = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_city' );
-		$request->set_body_params( array(
-			'value' => $new_value,
-		) );
+		$request   = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_city' );
+		$request->set_body_params(
+			array(
+				'value' => $new_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $new_value, $setting['value'] );
 
 		// Put the original value back
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_city' );
-		$request->set_body_params( array(
-			'value' => $old_value,
-		) );
+		$request->set_body_params(
+			array(
+				'value' => $old_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $old_value, $setting['value'] );
@@ -801,19 +871,23 @@ class Settings extends WC_REST_Unit_Test_Case {
 		// Repalce the old value with something uniquely new
 		$old_value = $setting['value'];
 		$new_value = $old_value . ' ' . rand( 1000, 9999 );
-		$request = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_postcode' );
-		$request->set_body_params( array(
-			'value' => $new_value,
-		) );
+		$request   = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_postcode' );
+		$request->set_body_params(
+			array(
+				'value' => $new_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $new_value, $setting['value'] );
 
 		// Put the original value back
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/settings/general/woocommerce_store_postcode' );
-		$request->set_body_params( array(
-			'value' => $old_value,
-		) );
+		$request->set_body_params(
+			array(
+				'value' => $old_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $old_value, $setting['value'] );

--- a/tests/unit-tests/api/shipping-methods.php
+++ b/tests/unit-tests/api/shipping-methods.php
@@ -14,9 +14,11 @@ class Shipping_Methods extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Shipping_Methods_Controller();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -39,26 +41,29 @@ class Shipping_Methods extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/shipping_methods' ) );
-		$methods = $response->get_data();
+		$methods  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertContains( array(
-			'id'          => 'free_shipping',
-			'title'       => 'Free shipping',
-			'description' => 'Free shipping is a special method which can be triggered with coupons and minimum spends.',
-			'_links' => array(
-				'self'       => array(
-					array(
-						'href' => rest_url( '/wc/v3/shipping_methods/free_shipping' ),
+		$this->assertContains(
+			array(
+				'id'          => 'free_shipping',
+				'title'       => 'Free shipping',
+				'description' => 'Free shipping is a special method which can be triggered with coupons and minimum spends.',
+				'_links'      => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v3/shipping_methods/free_shipping' ),
+						),
 					),
-				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v3/shipping_methods' ),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v3/shipping_methods' ),
+						),
 					),
 				),
 			),
-		), $methods );
+			$methods
+		);
 	}
 
 	/**
@@ -84,11 +89,14 @@ class Shipping_Methods extends WC_REST_Unit_Test_Case {
 		$method   = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array(
-			'id'          => 'local_pickup',
-			'title'       => 'Local pickup',
-			'description' => 'Allow customers to pick up orders themselves. By default, when using local pickup store base taxes will apply regardless of customer address.',
-		), $method );
+		$this->assertEquals(
+			array(
+				'id'          => 'local_pickup',
+				'title'       => 'Local pickup',
+				'description' => 'Allow customers to pick up orders themselves. By default, when using local pickup store base taxes will apply regardless of customer address.',
+			),
+			$method
+		);
 	}
 
 	/**
@@ -122,9 +130,9 @@ class Shipping_Methods extends WC_REST_Unit_Test_Case {
 	public function test_shipping_method_schema() {
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v3/shipping_methods' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v3/shipping_methods' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
 		$this->assertEquals( 3, count( $properties ) );

--- a/tests/unit-tests/api/shipping-zones.php
+++ b/tests/unit-tests/api/shipping-zones.php
@@ -99,7 +99,8 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 
 		// Create a zone and make sure it's in the response
@@ -132,7 +133,8 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -222,7 +224,8 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -288,7 +291,8 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -391,7 +395,8 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -418,7 +423,9 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 
 		// Create a zone
 		$zone = $this->create_shipping_zone(
-			'Zone 1', 0, array(
+			'Zone 1',
+			0,
+			array(
 				array(
 					'code' => 'US',
 					'type' => 'country',
@@ -449,7 +456,8 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -552,7 +560,8 @@ class WC_Tests_API_Shipping_Zones extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 

--- a/tests/unit-tests/api/v2/coupons.php
+++ b/tests/unit-tests/api/v2/coupons.php
@@ -12,12 +12,14 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 	 * Setup test coupon data.
 	 * @since 3.0.0
 	 */
-	 public function setUp() {
+	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Coupons_Controller();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -43,51 +45,54 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 		$coupon_2 = WC_Helper_Coupon::create_coupon( 'dummycoupon-2' );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/coupons' ) );
-		$coupons = $response->get_data();
+		$coupons  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, count( $coupons ) );
-		$this->assertContains( array(
-			'id'             => $coupon_1->get_id(),
-			'code'           => 'dummycoupon-1',
-			'amount'         => '1.00',
-			'date_created'   => wc_rest_prepare_date_response( $post_1->post_date_gmt, false ),
-			'date_created_gmt'   => wc_rest_prepare_date_response( $post_1->post_date_gmt ),
-			'date_modified'  => wc_rest_prepare_date_response( $post_1->post_modified_gmt, false ),
-			'date_modified_gmt'  => wc_rest_prepare_date_response( $post_1->post_modified_gmt ),
-			'discount_type'  => 'fixed_cart',
-			'description'    => 'This is a dummy coupon',
-			'date_expires'   => '',
-			'date_expires_gmt'   => '',
-			'usage_count'    => 0,
-			'individual_use' => false,
-			'product_ids'    => array(),
-			'excluded_product_ids' => array(),
-			'usage_limit'    => '',
-			'usage_limit_per_user' => '',
-			'limit_usage_to_x_items' => null,
-			'free_shipping' => false,
-			'product_categories' => array(),
-			'excluded_product_categories' => array(),
-			'exclude_sale_items' => false,
-			'minimum_amount' => '0.00',
-			'maximum_amount' => '0.00',
-			'email_restrictions' => array(),
-			'used_by' => array(),
-			'meta_data' => array(),
-			'_links' => array(
-				'self'       => array(
-					array(
-						'href' => rest_url( '/wc/v2/coupons/' . $coupon_1->get_id() ),
+		$this->assertContains(
+			array(
+				'id'                          => $coupon_1->get_id(),
+				'code'                        => 'dummycoupon-1',
+				'amount'                      => '1.00',
+				'date_created'                => wc_rest_prepare_date_response( $post_1->post_date_gmt, false ),
+				'date_created_gmt'            => wc_rest_prepare_date_response( $post_1->post_date_gmt ),
+				'date_modified'               => wc_rest_prepare_date_response( $post_1->post_modified_gmt, false ),
+				'date_modified_gmt'           => wc_rest_prepare_date_response( $post_1->post_modified_gmt ),
+				'discount_type'               => 'fixed_cart',
+				'description'                 => 'This is a dummy coupon',
+				'date_expires'                => '',
+				'date_expires_gmt'            => '',
+				'usage_count'                 => 0,
+				'individual_use'              => false,
+				'product_ids'                 => array(),
+				'excluded_product_ids'        => array(),
+				'usage_limit'                 => '',
+				'usage_limit_per_user'        => '',
+				'limit_usage_to_x_items'      => null,
+				'free_shipping'               => false,
+				'product_categories'          => array(),
+				'excluded_product_categories' => array(),
+				'exclude_sale_items'          => false,
+				'minimum_amount'              => '0.00',
+				'maximum_amount'              => '0.00',
+				'email_restrictions'          => array(),
+				'used_by'                     => array(),
+				'meta_data'                   => array(),
+				'_links'                      => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v2/coupons/' . $coupon_1->get_id() ),
+						),
 					),
-				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/coupons' ),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v2/coupons' ),
+						),
 					),
 				),
 			),
-		), $coupons );
+			$coupons
+		);
 	}
 
 	/**
@@ -112,35 +117,38 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array(
-			'id'             => $coupon->get_id(),
-			'code'           => 'dummycoupon-1',
-			'amount'         => '1.00',
-			'date_created'   => wc_rest_prepare_date_response( $post->post_date_gmt, false ),
-			'date_created_gmt' => wc_rest_prepare_date_response( $post->post_date_gmt ),
-			'date_modified'  => wc_rest_prepare_date_response( $post->post_modified_gmt, false ),
-			'date_modified_gmt' => wc_rest_prepare_date_response( $post->post_modified_gmt ),
-			'discount_type'  => 'fixed_cart',
-			'description'    => 'This is a dummy coupon',
-			'date_expires'    => null,
-			'date_expires_gmt' => null,
-			'usage_count'    => 0,
-			'individual_use' => false,
-			'product_ids'    => array(),
-			'excluded_product_ids' => array(),
-			'usage_limit'    => null,
-			'usage_limit_per_user' => null,
-			'limit_usage_to_x_items' => null,
-			'free_shipping' => false,
-			'product_categories' => array(),
-			'excluded_product_categories' => array(),
-			'exclude_sale_items' => false,
-			'minimum_amount' => '0.00',
-			'maximum_amount' => '0.00',
-			'email_restrictions' => array(),
-			'used_by' => array(),
-			'meta_data' => array(),
-		), $data );
+		$this->assertEquals(
+			array(
+				'id'                          => $coupon->get_id(),
+				'code'                        => 'dummycoupon-1',
+				'amount'                      => '1.00',
+				'date_created'                => wc_rest_prepare_date_response( $post->post_date_gmt, false ),
+				'date_created_gmt'            => wc_rest_prepare_date_response( $post->post_date_gmt ),
+				'date_modified'               => wc_rest_prepare_date_response( $post->post_modified_gmt, false ),
+				'date_modified_gmt'           => wc_rest_prepare_date_response( $post->post_modified_gmt ),
+				'discount_type'               => 'fixed_cart',
+				'description'                 => 'This is a dummy coupon',
+				'date_expires'                => null,
+				'date_expires_gmt'            => null,
+				'usage_count'                 => 0,
+				'individual_use'              => false,
+				'product_ids'                 => array(),
+				'excluded_product_ids'        => array(),
+				'usage_limit'                 => null,
+				'usage_limit_per_user'        => null,
+				'limit_usage_to_x_items'      => null,
+				'free_shipping'               => false,
+				'product_categories'          => array(),
+				'excluded_product_categories' => array(),
+				'exclude_sale_items'          => false,
+				'minimum_amount'              => '0.00',
+				'maximum_amount'              => '0.00',
+				'email_restrictions'          => array(),
+				'used_by'                     => array(),
+				'meta_data'                   => array(),
+			),
+			$data
+		);
 	}
 
 	/**
@@ -171,46 +179,51 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 	public function test_create_coupon() {
 		wp_set_current_user( $this->user );
 		$request = new WP_REST_Request( 'POST', '/wc/v2/coupons' );
-		$request->set_body_params( array(
-			'code'          => 'test',
-			'amount'        => '5.00',
-			'discount_type' => 'fixed_product',
-			'description'   => 'Test',
-			'usage_limit'   => 10,
-		) );
+		$request->set_body_params(
+			array(
+				'code'          => 'test',
+				'amount'        => '5.00',
+				'discount_type' => 'fixed_product',
+				'description'   => 'Test',
+				'usage_limit'   => 10,
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals( array(
-			'id'             => $data['id'],
-			'code'           => 'test',
-			'amount'         => '5.00',
-			'date_created'   => $data['date_created'],
-			'date_created_gmt'   => $data['date_created_gmt'],
-			'date_modified'  => $data['date_modified'],
-			'date_modified_gmt'  => $data['date_modified_gmt'],
-			'discount_type'  => 'fixed_product',
-			'description'    => 'Test',
-			'date_expires'    => null,
-			'date_expires_gmt'    => null,
-			'usage_count'    => 0,
-			'individual_use' => false,
-			'product_ids'    => array(),
-			'excluded_product_ids' => array(),
-			'usage_limit'    => 10,
-			'usage_limit_per_user' => null,
-			'limit_usage_to_x_items' => null,
-			'free_shipping' => false,
-			'product_categories' => array(),
-			'excluded_product_categories' => array(),
-			'exclude_sale_items' => false,
-			'minimum_amount' => '0.00',
-			'maximum_amount' => '0.00',
-			'email_restrictions' => array(),
-			'used_by' => array(),
-			'meta_data' => array(),
-		), $data );
+		$this->assertEquals(
+			array(
+				'id'                          => $data['id'],
+				'code'                        => 'test',
+				'amount'                      => '5.00',
+				'date_created'                => $data['date_created'],
+				'date_created_gmt'            => $data['date_created_gmt'],
+				'date_modified'               => $data['date_modified'],
+				'date_modified_gmt'           => $data['date_modified_gmt'],
+				'discount_type'               => 'fixed_product',
+				'description'                 => 'Test',
+				'date_expires'                => null,
+				'date_expires_gmt'            => null,
+				'usage_count'                 => 0,
+				'individual_use'              => false,
+				'product_ids'                 => array(),
+				'excluded_product_ids'        => array(),
+				'usage_limit'                 => 10,
+				'usage_limit_per_user'        => null,
+				'limit_usage_to_x_items'      => null,
+				'free_shipping'               => false,
+				'product_categories'          => array(),
+				'excluded_product_categories' => array(),
+				'exclude_sale_items'          => false,
+				'minimum_amount'              => '0.00',
+				'maximum_amount'              => '0.00',
+				'email_restrictions'          => array(),
+				'used_by'                     => array(),
+				'meta_data'                   => array(),
+			),
+			$data
+		);
 	}
 
 	/**
@@ -222,12 +235,14 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 
 		// test no code...
 		$request = new WP_REST_Request( 'POST', '/wc/v2/coupons' );
-		$request->set_body_params( array(
-			'amount'        => '5.00',
-			'discount_type' => 'fixed_product',
-		) );
+		$request->set_body_params(
+			array(
+				'amount'        => '5.00',
+				'discount_type' => 'fixed_product',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
 	}
@@ -241,13 +256,15 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 
 		// test no code...
 		$request = new WP_REST_Request( 'POST', '/wc/v2/coupons' );
-		$request->set_body_params( array(
-			'code'          => 'fail',
-			'amount'        => '5.00',
-			'discount_type' => 'fixed_product',
-		) );
+		$request->set_body_params(
+			array(
+				'code'          => 'fail',
+				'amount'        => '5.00',
+				'discount_type' => 'fixed_product',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -258,8 +275,8 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_coupon() {
 		wp_set_current_user( $this->user );
-		$coupon   = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
-		$post     = get_post( $coupon->get_id() );
+		$coupon = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
+		$post   = get_post( $coupon->get_id() );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/coupons/' . $coupon->get_id() ) );
 		$data     = $response->get_data();
@@ -268,12 +285,14 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( '1.00', $data['amount'] );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/coupons/' . $coupon->get_id() );
-		$request->set_body_params( array(
-			'amount' => '10.00',
-			'description' => 'New description',
-		) );
+		$request->set_body_params(
+			array(
+				'amount'      => '10.00',
+				'description' => 'New description',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( '10.00', $data['amount'] );
 		$this->assertEquals( 'New description', $data['description'] );
@@ -288,13 +307,15 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/coupons/0' );
-		$request->set_body_params( array(
-			'code'   => 'tester',
-			'amount' => '10.00',
-			'description' => 'New description',
-		) );
+		$request->set_body_params(
+			array(
+				'code'        => 'tester',
+				'amount'      => '10.00',
+				'description' => 'New description',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
 	}
@@ -305,14 +326,16 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_coupon_without_permission() {
 		wp_set_current_user( 0 );
-		$coupon   = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
-		$post     = get_post( $coupon->get_id() );
+		$coupon = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
+		$post   = get_post( $coupon->get_id() );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/coupons/' . $coupon->get_id() );
-		$request->set_body_params( array(
-			'amount' => '10.00',
-			'description' => 'New description',
-		) );
+		$request->set_body_params(
+			array(
+				'amount'      => '10.00',
+				'description' => 'New description',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 
 		$this->assertEquals( 401, $response->get_status() );
@@ -324,7 +347,7 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_coupon() {
 		wp_set_current_user( $this->user );
-		$coupon   = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
+		$coupon  = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
 		$request = new WP_REST_Request( 'DELETE', '/wc/v2/coupons/' . $coupon->get_id() );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
@@ -364,32 +387,34 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 	public function test_batch_coupon() {
 		wp_set_current_user( $this->user );
 
-		$coupon_1   = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
-		$coupon_2   = WC_Helper_Coupon::create_coupon( 'dummycoupon-2' );
-		$coupon_3   = WC_Helper_Coupon::create_coupon( 'dummycoupon-3' );
-		$coupon_4   = WC_Helper_Coupon::create_coupon( 'dummycoupon-4' );
+		$coupon_1 = WC_Helper_Coupon::create_coupon( 'dummycoupon-1' );
+		$coupon_2 = WC_Helper_Coupon::create_coupon( 'dummycoupon-2' );
+		$coupon_3 = WC_Helper_Coupon::create_coupon( 'dummycoupon-3' );
+		$coupon_4 = WC_Helper_Coupon::create_coupon( 'dummycoupon-4' );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/coupons/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'     => $coupon_1->get_id(),
-					'amount' => '5.15',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'     => $coupon_1->get_id(),
+						'amount' => '5.15',
+					),
 				),
-			),
-			'delete' => array(
-				$coupon_2->get_id(),
-				$coupon_3->get_id(),
-			),
-			'create' => array(
-				array(
-					'code'   => 'new-coupon',
-					'amount' => '11.00',
+				'delete' => array(
+					$coupon_2->get_id(),
+					$coupon_3->get_id(),
 				),
-			),
-		) );
+				'create' => array(
+					array(
+						'code'   => 'new-coupon',
+						'amount' => '11.00',
+					),
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( '5.15', $data['update'][0]['amount'] );
 		$this->assertEquals( '11.00', $data['create'][0]['amount'] );
@@ -397,9 +422,9 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $coupon_2->get_id(), $data['delete'][0]['id'] );
 		$this->assertEquals( $coupon_3->get_id(), $data['delete'][1]['id'] );
 
-		$request = new WP_REST_Request( 'GET', '/wc/v2/coupons' );
+		$request  = new WP_REST_Request( 'GET', '/wc/v2/coupons' );
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
 	}
@@ -410,9 +435,9 @@ class WC_Tests_API_Coupons_V2 extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_coupon_schema() {
 		wp_set_current_user( $this->user );
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v2/coupons' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v2/coupons' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
 		$this->assertEquals( 27, count( $properties ) );

--- a/tests/unit-tests/api/v2/customers.php
+++ b/tests/unit-tests/api/v2/customers.php
@@ -41,68 +41,73 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 		WC_Helper_Customer::create_customer( 'test2', 'test2', 'test2@woo.local' );
 
 		$request = new WP_REST_Request( 'GET', '/wc/v2/customers' );
-		$request->set_query_params( array(
-			'orderby' => 'id',
-		) );
+		$request->set_query_params(
+			array(
+				'orderby' => 'id',
+			)
+		);
 		$response  = $this->server->dispatch( $request );
 		$customers = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, count( $customers ) );
 
-		$this->assertContains( array(
-			'id'                 => $customer_1->get_id(),
-			'date_created'       => wc_rest_prepare_date_response( $customer_1->get_date_created(), false ),
-			'date_created_gmt'   => wc_rest_prepare_date_response( $customer_1->get_date_created() ),
-			'date_modified'      => wc_rest_prepare_date_response( $customer_1->get_date_modified(), false ),
-			'date_modified_gmt'  => wc_rest_prepare_date_response( $customer_1->get_date_modified() ),
-			'email'              => 'test@woo.local',
-			'first_name'         => 'Justin',
-			'last_name'          => '',
-			'role'               => 'customer',
-			'username'           => 'testcustomer',
-			'billing'            => array(
-				'first_name' => '',
-				'last_name'  => '',
-				'company'    => '',
-				'address_1'  => '123 South Street',
-				'address_2'  => 'Apt 1',
-				'city'       => 'Philadelphia',
-				'state'      => 'PA',
-				'postcode'   => '19123',
-				'country'    => 'US',
-				'email'      => '',
-				'phone'      => '',
-			),
-			'shipping'           => array(
-				'first_name' => '',
-				'last_name'  => '',
-				'company'    => '',
-				'address_1'  => '123 South Street',
-				'address_2'  => 'Apt 1',
-				'city'       => 'Philadelphia',
-				'state'      => 'PA',
-				'postcode'   => '19123',
-				'country'    => 'US',
-			),
-			'is_paying_customer' => false,
-			'orders_count'       => 0,
-			'total_spent'        => '0.00',
-			'avatar_url'         => $customer_1->get_avatar_url(),
-			'meta_data'          => array(),
-			'_links'             => array(
-				'self'       => array(
-					array(
-						'href' => rest_url( '/wc/v2/customers/' . $customer_1->get_id() . '' ),
+		$this->assertContains(
+			array(
+				'id'                 => $customer_1->get_id(),
+				'date_created'       => wc_rest_prepare_date_response( $customer_1->get_date_created(), false ),
+				'date_created_gmt'   => wc_rest_prepare_date_response( $customer_1->get_date_created() ),
+				'date_modified'      => wc_rest_prepare_date_response( $customer_1->get_date_modified(), false ),
+				'date_modified_gmt'  => wc_rest_prepare_date_response( $customer_1->get_date_modified() ),
+				'email'              => 'test@woo.local',
+				'first_name'         => 'Justin',
+				'last_name'          => '',
+				'role'               => 'customer',
+				'username'           => 'testcustomer',
+				'billing'            => array(
+					'first_name' => '',
+					'last_name'  => '',
+					'company'    => '',
+					'address_1'  => '123 South Street',
+					'address_2'  => 'Apt 1',
+					'city'       => 'Philadelphia',
+					'state'      => 'PA',
+					'postcode'   => '19123',
+					'country'    => 'US',
+					'email'      => '',
+					'phone'      => '',
+				),
+				'shipping'           => array(
+					'first_name' => '',
+					'last_name'  => '',
+					'company'    => '',
+					'address_1'  => '123 South Street',
+					'address_2'  => 'Apt 1',
+					'city'       => 'Philadelphia',
+					'state'      => 'PA',
+					'postcode'   => '19123',
+					'country'    => 'US',
+				),
+				'is_paying_customer' => false,
+				'orders_count'       => 0,
+				'total_spent'        => '0.00',
+				'avatar_url'         => $customer_1->get_avatar_url(),
+				'meta_data'          => array(),
+				'_links'             => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v2/customers/' . $customer_1->get_id() . '' ),
+						),
+					),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v2/customers' ),
+						),
 					),
 				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/customers' ),
-					),
-				),
 			),
-		), $customers );
+			$customers
+		);
 	}
 
 	/**
@@ -126,129 +131,141 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 
 		// Test just the basics first..
 		$request = new WP_REST_Request( 'POST', '/wc/v2/customers' );
-		$request->set_body_params( array(
-			'username' => 'create_customer_test',
-			'password' => 'test123',
-			'email'    => 'create_customer_test@woo.local',
-		) );
+		$request->set_body_params(
+			array(
+				'username' => 'create_customer_test',
+				'password' => 'test123',
+				'email'    => 'create_customer_test@woo.local',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals( array(
-			'id'                 => $data['id'],
-			'date_created'       => $data['date_created'],
-			'date_created_gmt'   => $data['date_created_gmt'],
-			'date_modified'      => $data['date_modified'],
-			'date_modified_gmt'  => $data['date_modified_gmt'],
-			'email'              => 'create_customer_test@woo.local',
-			'first_name'         => '',
-			'last_name'          => '',
-			'role'               => 'customer',
-			'username'           => 'create_customer_test',
-			'billing'            => array(
-				'first_name' => '',
-				'last_name'  => '',
-				'company'    => '',
-				'address_1'  => '',
-				'address_2'  => '',
-				'city'       => '',
-				'state'      => '',
-				'postcode'   => '',
-				'country'    => '',
-				'email'      => '',
-				'phone'      => '',
+		$this->assertEquals(
+			array(
+				'id'                 => $data['id'],
+				'date_created'       => $data['date_created'],
+				'date_created_gmt'   => $data['date_created_gmt'],
+				'date_modified'      => $data['date_modified'],
+				'date_modified_gmt'  => $data['date_modified_gmt'],
+				'email'              => 'create_customer_test@woo.local',
+				'first_name'         => '',
+				'last_name'          => '',
+				'role'               => 'customer',
+				'username'           => 'create_customer_test',
+				'billing'            => array(
+					'first_name' => '',
+					'last_name'  => '',
+					'company'    => '',
+					'address_1'  => '',
+					'address_2'  => '',
+					'city'       => '',
+					'state'      => '',
+					'postcode'   => '',
+					'country'    => '',
+					'email'      => '',
+					'phone'      => '',
+				),
+				'shipping'           => array(
+					'first_name' => '',
+					'last_name'  => '',
+					'company'    => '',
+					'address_1'  => '',
+					'address_2'  => '',
+					'city'       => '',
+					'state'      => '',
+					'postcode'   => '',
+					'country'    => '',
+				),
+				'is_paying_customer' => false,
+				'meta_data'          => array(),
+				'orders_count'       => 0,
+				'total_spent'        => '0.00',
+				'avatar_url'         => $data['avatar_url'],
 			),
-			'shipping'           => array(
-				'first_name' => '',
-				'last_name'  => '',
-				'company'    => '',
-				'address_1'  => '',
-				'address_2'  => '',
-				'city'       => '',
-				'state'      => '',
-				'postcode'   => '',
-				'country'    => '',
-			),
-			'is_paying_customer' => false,
-			'meta_data'          => array(),
-			'orders_count'       => 0,
-			'total_spent'        => '0.00',
-			'avatar_url'         => $data['avatar_url'],
-		), $data );
+			$data
+		);
 
 		// Test extra data
 		$request = new WP_REST_Request( 'POST', '/wc/v2/customers' );
-		$request->set_body_params( array(
-			'username' => 'create_customer_test2',
-			'password' => 'test123',
-			'email'    => 'create_customer_test2@woo.local',
-			'first_name' => 'Test',
-			'last_name' => 'McTestFace',
-			'billing' => array(
-				'country' => 'US',
-				'state'   => 'WA',
-			),
-			'shipping' => array(
-				'state'   => 'CA',
-				'country' => 'US',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'username'   => 'create_customer_test2',
+				'password'   => 'test123',
+				'email'      => 'create_customer_test2@woo.local',
+				'first_name' => 'Test',
+				'last_name'  => 'McTestFace',
+				'billing'    => array(
+					'country' => 'US',
+					'state'   => 'WA',
+				),
+				'shipping'   => array(
+					'state'   => 'CA',
+					'country' => 'US',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 201, $response->get_status() );
-		$this->assertEquals( array(
-			'id'                 => $data['id'],
-			'date_created'       => $data['date_created'],
-			'date_created_gmt'   => $data['date_created_gmt'],
-			'date_modified'      => $data['date_modified'],
-			'date_modified_gmt'  => $data['date_modified_gmt'],
-			'email'              => 'create_customer_test2@woo.local',
-			'first_name'         => 'Test',
-			'last_name'          => 'McTestFace',
-			'role'               => 'customer',
-			'username'           => 'create_customer_test2',
-			'billing'            => array(
-				'first_name' => '',
-				'last_name'  => '',
-				'company'    => '',
-				'address_1'  => '',
-				'address_2'  => '',
-				'city'       => '',
-				'state'      => 'WA',
-				'postcode'   => '',
-				'country'    => 'US',
-				'email'      => '',
-				'phone'      => '',
+		$this->assertEquals(
+			array(
+				'id'                 => $data['id'],
+				'date_created'       => $data['date_created'],
+				'date_created_gmt'   => $data['date_created_gmt'],
+				'date_modified'      => $data['date_modified'],
+				'date_modified_gmt'  => $data['date_modified_gmt'],
+				'email'              => 'create_customer_test2@woo.local',
+				'first_name'         => 'Test',
+				'last_name'          => 'McTestFace',
+				'role'               => 'customer',
+				'username'           => 'create_customer_test2',
+				'billing'            => array(
+					'first_name' => '',
+					'last_name'  => '',
+					'company'    => '',
+					'address_1'  => '',
+					'address_2'  => '',
+					'city'       => '',
+					'state'      => 'WA',
+					'postcode'   => '',
+					'country'    => 'US',
+					'email'      => '',
+					'phone'      => '',
+				),
+				'shipping'           => array(
+					'first_name' => '',
+					'last_name'  => '',
+					'company'    => '',
+					'address_1'  => '',
+					'address_2'  => '',
+					'city'       => '',
+					'state'      => 'CA',
+					'postcode'   => '',
+					'country'    => 'US',
+				),
+				'is_paying_customer' => false,
+				'meta_data'          => array(),
+				'orders_count'       => 0,
+				'total_spent'        => '0.00',
+				'avatar_url'         => $data['avatar_url'],
 			),
-			'shipping'           => array(
-				'first_name' => '',
-				'last_name'  => '',
-				'company'    => '',
-				'address_1'  => '',
-				'address_2'  => '',
-				'city'       => '',
-				'state'      => 'CA',
-				'postcode'   => '',
-				'country'    => 'US',
-			),
-			'is_paying_customer' => false,
-			'meta_data'          => array(),
-			'orders_count'       => 0,
-			'total_spent'        => '0.00',
-			'avatar_url'         => $data['avatar_url'],
-		), $data );
+			$data
+		);
 
 		// Test without required field
 		$request = new WP_REST_Request( 'POST', '/wc/v2/customers' );
-		$request->set_body_params( array(
-			'username' => 'create_customer_test3',
-			'first_name' => 'Test',
-			'last_name' => 'McTestFace',
-		) );
+		$request->set_body_params(
+			array(
+				'username'   => 'create_customer_test3',
+				'first_name' => 'Test',
+				'last_name'  => 'McTestFace',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 400, $response->get_status() );
 	}
@@ -261,11 +278,13 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 	public function test_create_customer_without_permission() {
 		wp_set_current_user( 0 );
 		$request = new WP_REST_Request( 'POST', '/wc/v2/customers' );
-		$request->set_body_params( array(
-			'username' => 'create_customer_test_without_permission',
-			'password' => 'test123',
-			'email'    => 'create_customer_test_without_permission@woo.local',
-		) );
+		$request->set_body_params(
+			array(
+				'username' => 'create_customer_test_without_permission',
+				'password' => 'test123',
+				'email'    => 'create_customer_test_without_permission@woo.local',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -279,49 +298,52 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( 1 );
 		$customer = WC_Helper_Customer::create_customer( 'get_customer_test', 'test123', 'get_customer_test@woo.local' );
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/customers/' . $customer->get_id() ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
-		$this->assertEquals( array(
-			'id'                 => $data['id'],
-			'date_created'       => $data['date_created'],
-			'date_created_gmt'   => $data['date_created_gmt'],
-			'date_modified'      => $data['date_modified'],
-			'date_modified_gmt'  => $data['date_modified_gmt'],
-			'email'              => 'get_customer_test@woo.local',
-			'first_name'         => 'Justin',
-			'billing'            => array(
-				'first_name' => '',
-				'last_name'  => '',
-				'company'    => '',
-				'address_1'  => '123 South Street',
-				'address_2'  => 'Apt 1',
-				'city'       => 'Philadelphia',
-				'state'      => 'PA',
-				'postcode'   => '19123',
-				'country'    => 'US',
-				'email'      => '',
-				'phone'      => '',
+		$this->assertEquals(
+			array(
+				'id'                 => $data['id'],
+				'date_created'       => $data['date_created'],
+				'date_created_gmt'   => $data['date_created_gmt'],
+				'date_modified'      => $data['date_modified'],
+				'date_modified_gmt'  => $data['date_modified_gmt'],
+				'email'              => 'get_customer_test@woo.local',
+				'first_name'         => 'Justin',
+				'billing'            => array(
+					'first_name' => '',
+					'last_name'  => '',
+					'company'    => '',
+					'address_1'  => '123 South Street',
+					'address_2'  => 'Apt 1',
+					'city'       => 'Philadelphia',
+					'state'      => 'PA',
+					'postcode'   => '19123',
+					'country'    => 'US',
+					'email'      => '',
+					'phone'      => '',
+				),
+				'shipping'           => array(
+					'first_name' => '',
+					'last_name'  => '',
+					'company'    => '',
+					'address_1'  => '123 South Street',
+					'address_2'  => 'Apt 1',
+					'city'       => 'Philadelphia',
+					'state'      => 'PA',
+					'postcode'   => '19123',
+					'country'    => 'US',
+				),
+				'is_paying_customer' => false,
+				'meta_data'          => array(),
+				'last_name'          => '',
+				'role'               => 'customer',
+				'username'           => 'get_customer_test',
+				'orders_count'       => 0,
+				'total_spent'        => '0.00',
+				'avatar_url'         => $data['avatar_url'],
 			),
-			'shipping'           => array(
-				'first_name' => '',
-				'last_name'  => '',
-				'company'    => '',
-				'address_1'  => '123 South Street',
-				'address_2'  => 'Apt 1',
-				'city'       => 'Philadelphia',
-				'state'      => 'PA',
-				'postcode'   => '19123',
-				'country'    => 'US',
-			),
-			'is_paying_customer' => false,
-			'meta_data'          => array(),
-			'last_name'          => '',
-			'role'               => 'customer',
-			'username'           => 'get_customer_test',
-			'orders_count'       => 0,
-			'total_spent'        => '0.00',
-			'avatar_url'         => $data['avatar_url'],
-		), $data );
+			$data
+		);
 	}
 
 	/**
@@ -362,10 +384,12 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'update_customer_test@woo.local', $data['email'] );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/customers/' . $customer->get_id() );
-		$request->set_body_params( array(
-			'email'      => 'updated_email@woo.local',
-			'first_name' => 'UpdatedTest',
-		) );
+		$request->set_body_params(
+			array(
+				'email'      => 'updated_email@woo.local',
+				'first_name' => 'UpdatedTest',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
@@ -418,7 +442,7 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_customer_invalid_id() {
 		wp_set_current_user( 1 );
-		$request  = new WP_REST_Request( 'DELETE', '/wc/v2/customers/0' );
+		$request = new WP_REST_Request( 'DELETE', '/wc/v2/customers/0' );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
@@ -452,27 +476,29 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 		$customer_4 = WC_Helper_Customer::create_customer( 'test_batch_customer4', 'test123', 'test_batch_customer4@woo.local' );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/customers/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'        => $customer_1->get_id(),
-					'last_name' => 'McTest',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'        => $customer_1->get_id(),
+						'last_name' => 'McTest',
+					),
 				),
-			),
-			'delete' => array(
-				$customer_2->get_id(),
-				$customer_3->get_id(),
-			),
-			'create' => array(
-				array(
-					'username' => 'newuser',
-					'password'   => 'test123',
-					'email'  => 'newuser@woo.local',
+				'delete' => array(
+					$customer_2->get_id(),
+					$customer_3->get_id(),
 				),
-			),
-		) );
+				'create' => array(
+					array(
+						'username' => 'newuser',
+						'password' => 'test123',
+						'email'    => 'newuser@woo.local',
+					),
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'McTest', $data['update'][0]['last_name'] );
 		$this->assertEquals( 'newuser', $data['create'][0]['username'] );
@@ -480,9 +506,9 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $customer_2->get_id(), $data['delete'][0]['id'] );
 		$this->assertEquals( $customer_3->get_id(), $data['delete'][1]['id'] );
 
-		$request = new WP_REST_Request( 'GET', '/wc/v2/customers' );
+		$request  = new WP_REST_Request( 'GET', '/wc/v2/customers' );
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 3, count( $data ) );
 	}
@@ -494,9 +520,9 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_customer_schema() {
 		wp_set_current_user( 1 );
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v2/customers' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v2/customers' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
 		$this->assertEquals( 18, count( $properties ) );

--- a/tests/unit-tests/api/v2/orders.php
+++ b/tests/unit-tests/api/v2/orders.php
@@ -120,10 +120,12 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_item_refund_id() {
 		wp_set_current_user( $this->user );
-		$order  = WC_Helper_Order::create_order();
-		$refund = wc_create_refund( array(
-			'order_id' => $order->get_id(),
-		) );
+		$order    = WC_Helper_Order::create_order();
+		$refund   = wc_create_refund(
+			array(
+				'order_id' => $order->get_id(),
+			)
+		);
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/orders/' . $refund->get_id() ) );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -273,7 +275,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 		$request->set_body_params(
 			array(
 				'payment_method'       => 'bacs',
-				'payment_method_title' => '<h1>Sanitize this too <script>alert(1);</script></h1>'
+				'payment_method_title' => '<h1>Sanitize this too <script>alert(1);</script></h1>',
 			)
 		);
 		$response = $this->server->dispatch( $request );

--- a/tests/unit-tests/api/v2/payment-gateways.php
+++ b/tests/unit-tests/api/v2/payment-gateways.php
@@ -14,9 +14,11 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Payment_Gateways_Controller();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -42,31 +44,37 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 		$gateways = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertContains( array(
-			'id'                 => 'cheque',
-			'title'              => 'Check payments',
-			'description'        => 'Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.',
-			'order'              => '',
-			'enabled'            => false,
-			'method_title'       => 'Check payments',
-			'method_description' => 'Take payments in person via checks. This offline gateway can also be useful to test purchases.',
-			'settings'           => array_diff_key( $this->get_settings( 'WC_Gateway_Cheque' ), array(
-				'enabled'     => false,
-				'description' => false,
-			) ),
-			'_links' => array(
-				'self'       => array(
+		$this->assertContains(
+			array(
+				'id'                 => 'cheque',
+				'title'              => 'Check payments',
+				'description'        => 'Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.',
+				'order'              => '',
+				'enabled'            => false,
+				'method_title'       => 'Check payments',
+				'method_description' => 'Take payments in person via checks. This offline gateway can also be useful to test purchases.',
+				'settings'           => array_diff_key(
+					$this->get_settings( 'WC_Gateway_Cheque' ),
 					array(
-						'href' => rest_url( '/wc/v2/payment_gateways/cheque' ),
-					),
+						'enabled'     => false,
+						'description' => false,
+					)
 				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/payment_gateways' ),
+				'_links'             => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v2/payment_gateways/cheque' ),
+						),
+					),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v2/payment_gateways' ),
+						),
 					),
 				),
 			),
-		), $gateways );
+			$gateways
+		);
 	}
 
 	/**
@@ -92,19 +100,25 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 		$paypal   = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( array(
-			'id'                 => 'paypal',
-			'title'              => 'PayPal',
-			'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
-			'order'              => '',
-			'enabled'            => false,
-			'method_title'       => 'PayPal',
-			'method_description' => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
-			'settings'           => array_diff_key( $this->get_settings( 'WC_Gateway_Paypal' ), array(
-				'enabled'     => false,
-				'description' => false,
-			) ),
-		), $paypal );
+		$this->assertEquals(
+			array(
+				'id'                 => 'paypal',
+				'title'              => 'PayPal',
+				'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
+				'order'              => '',
+				'enabled'            => false,
+				'method_title'       => 'PayPal',
+				'method_description' => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
+				'settings'           => array_diff_key(
+					$this->get_settings( 'WC_Gateway_Paypal' ),
+					array(
+						'enabled'     => false,
+						'description' => false,
+					)
+				),
+			),
+			$paypal
+		);
 	}
 
 	/**
@@ -147,11 +161,13 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 
 		// test updating single setting
 		$request = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'settings' => array(
-				'email' => 'woo@woo.local',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'email' => 'woo@woo.local',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$paypal   = $response->get_data();
 
@@ -162,12 +178,14 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 
 		// test updating multiple settings
 		$request = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'settings' => array(
-				'testmode' => 'yes',
-				'title'    => 'PayPal - New Title',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'testmode' => 'yes',
+					'title'    => 'PayPal - New Title',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$paypal   = $response->get_data();
 
@@ -178,10 +196,12 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 
 		// Test other parameters, and recheck settings
 		$request = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'enabled' => false,
-			'order'   => 2,
-		) );
+		$request->set_body_params(
+			array(
+				'enabled' => false,
+				'order'   => 2,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$paypal   = $response->get_data();
 
@@ -193,20 +213,24 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 
 		// test bogus
 		$request = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'settings' => array(
-				'paymentaction' => 'afasfasf',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'paymentaction' => 'afasfasf',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'settings' => array(
-				'paymentaction' => 'authorization',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'paymentaction' => 'authorization',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$paypal   = $response->get_data();
 		$this->assertEquals( 'authorization', $paypal['settings']['paymentaction']['value'] );
@@ -220,12 +244,14 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 	public function test_update_payment_gateway_without_permission() {
 		wp_set_current_user( 0 );
 		$request = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/paypal' );
-		$request->set_body_params( array(
-			'settings' => array(
-				'testmode' => 'yes',
-				'title'    => 'PayPal - New Title',
-			),
-		) );
+		$request->set_body_params(
+			array(
+				'settings' => array(
+					'testmode' => 'yes',
+					'title'    => 'PayPal - New Title',
+				),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -237,10 +263,12 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_payment_gateway_invalid_id() {
 		wp_set_current_user( $this->user );
-		$request  = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/totally_fake_method' );
-		$request->set_body_params( array(
-			'enabled' => true,
-		) );
+		$request = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/totally_fake_method' );
+		$request->set_body_params(
+			array(
+				'enabled' => true,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -253,9 +281,9 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 	public function test_payment_gateway_schema() {
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v2/payment_gateways' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v2/payment_gateways' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
 		$this->assertEquals( 8, count( $properties ) );

--- a/tests/unit-tests/api/v2/product-reviews.php
+++ b/tests/unit-tests/api/v2/product-reviews.php
@@ -80,7 +80,8 @@ class WC_Tests_API_Product_Reviews_V2 extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $product_reviews
+			),
+			$product_reviews
 		);
 	}
 
@@ -134,7 +135,8 @@ class WC_Tests_API_Product_Reviews_V2 extends WC_REST_Unit_Test_Case {
 				'rating'               => 0,
 				'verified'             => false,
 				'reviewer_avatar_urls' => $data['reviewer_avatar_urls'],
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -198,7 +200,8 @@ class WC_Tests_API_Product_Reviews_V2 extends WC_REST_Unit_Test_Case {
 				'rating'               => 5,
 				'verified'             => false,
 				'reviewer_avatar_urls' => $data['reviewer_avatar_urls'],
-			), $data
+			),
+			$data
 		);
 	}
 

--- a/tests/unit-tests/api/v2/settings.php
+++ b/tests/unit-tests/api/v2/settings.php
@@ -15,9 +15,11 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Setting_Options_Controller();
 		WC_Helper_Settings::register();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -41,39 +43,45 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 
-		$this->assertContains( array(
-			'id'          => 'test',
-			'label'       => 'Test extension',
-			'parent_id'   => '',
-			'description' => 'My awesome test settings.',
-			'sub_groups'  => array( 'sub-test' ),
-			'_links'      => array(
-				'options' => array(
-					array(
-						'href' => rest_url( '/wc/v2/settings/test' ),
+		$this->assertContains(
+			array(
+				'id'          => 'test',
+				'label'       => 'Test extension',
+				'parent_id'   => '',
+				'description' => 'My awesome test settings.',
+				'sub_groups'  => array( 'sub-test' ),
+				'_links'      => array(
+					'options' => array(
+						array(
+							'href' => rest_url( '/wc/v2/settings/test' ),
+						),
 					),
 				),
 			),
-		), $data );
+			$data
+		);
 
-		$this->assertContains( array(
-			'id'          => 'sub-test',
-			'label'       => 'Sub test',
-			'parent_id'   => 'test',
-			'description' => '',
-			'sub_groups'  => array(),
-			'_links'      => array(
-				'options' => array(
-					array(
-						'href' => rest_url( '/wc/v2/settings/sub-test' ),
+		$this->assertContains(
+			array(
+				'id'          => 'sub-test',
+				'label'       => 'Sub test',
+				'parent_id'   => 'test',
+				'description' => '',
+				'sub_groups'  => array(),
+				'_links'      => array(
+					'options' => array(
+						array(
+							'href' => rest_url( '/wc/v2/settings/sub-test' ),
+						),
 					),
 				),
 			),
-		), $data );
+			$data
+		);
 	}
 
 	/**
@@ -111,9 +119,9 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_get_group_schema() {
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v2/settings' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v2/settings' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 		$this->assertEquals( 5, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
@@ -129,9 +137,9 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_get_setting_schema() {
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v2/settings/test/woocommerce_shop_page_display' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v2/settings/test/woocommerce_shop_page_display' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 		$this->assertEquals( 9, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
@@ -167,7 +175,7 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		// test getting a valid group with settings attached to it
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/test' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( 1, count( $data ) );
 		$this->assertEquals( 'woocommerce_shop_page_display', $data[0]['id'] );
 		$this->assertEmpty( $data[0]['value'] );
@@ -195,36 +203,42 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		// test defaults first
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/test/woocommerce_shop_page_display' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( '', $data['value'] );
 
 		// test updating shop display setting
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'test', 'woocommerce_shop_page_display' ) );
-		$request->set_body_params( array(
-			'value' => 'both',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'both',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'both', $data['value'] );
 		$this->assertEquals( 'both', get_option( 'woocommerce_shop_page_display' ) );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'test', 'woocommerce_shop_page_display' ) );
-		$request->set_body_params( array(
-			'value' => 'subcategories',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'subcategories',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'subcategories', $data['value'] );
 		$this->assertEquals( 'subcategories', get_option( 'woocommerce_shop_page_display' ) );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'test', 'woocommerce_shop_page_display' ) );
-		$request->set_body_params( array(
-			'value' => '',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => '',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( '', $data['value'] );
 		$this->assertEquals( '', get_option( 'woocommerce_shop_page_display' ) );
@@ -240,37 +254,41 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		// test defaults first
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/test' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( '', $data[0]['value'] );
 
 		// test setting both at once
 		$request = new WP_REST_Request( 'POST', '/wc/v2/settings/test/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'    => 'woocommerce_shop_page_display',
-					'value' => 'both',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'    => 'woocommerce_shop_page_display',
+						'value' => 'both',
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'both', $data['update'][0]['value'] );
 		$this->assertEquals( 'both', get_option( 'woocommerce_shop_page_display' ) );
 
 		// test updating one, but making sure the other value stays the same
 		$request = new WP_REST_Request( 'POST', '/wc/v2/settings/test/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'    => 'woocommerce_shop_page_display',
-					'value' => 'subcategories',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'    => 'woocommerce_shop_page_display',
+						'value' => 'subcategories',
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( 'subcategories', $data['update'][0]['value'] );
 		$this->assertEquals( 'subcategories', get_option( 'woocommerce_shop_page_display' ) );
 	}
@@ -285,17 +303,17 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		// test getting an invalid setting from a group that does not exist
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/not-real/woocommerce_shop_page_display' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( 404, $response->get_status() );
 
 		// test getting an invalid setting from a group that does exist
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/invalid/invalid' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertEquals( 404, $response->get_status() );
 
 		// test getting a valid setting
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/test/woocommerce_shop_page_display' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 
@@ -373,9 +391,11 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( 0 );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'test', 'woocommerce_shop_page_display' ) );
-		$request->set_body_params( array(
-			'value' => 'subcategories',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'subcategories',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -390,14 +410,16 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( 0 );
 
 		$request = new WP_REST_Request( 'POST', '/wc/v2/settings/test/batch' );
-		$request->set_body_params( array(
-			'update' => array(
-				array(
-					'id'    => 'woocommerce_shop_page_display',
-					'value' => 'subcategories',
+		$request->set_body_params(
+			array(
+				'update' => array(
+					array(
+						'id'    => 'woocommerce_shop_page_display',
+						'value' => 'subcategories',
+					),
 				),
-			),
-		) );
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -412,9 +434,11 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/test/invalid' );
-		$request->set_body_params( array(
-			'value' => 'test',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'test',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 404, $response->get_status() );
 	}
@@ -429,43 +453,48 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		// Make sure the group is properly registered
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/products' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 		$this->assertTrue( is_array( $data ) );
-		$this->assertContains( array(
-			'id'          => 'woocommerce_downloads_require_login',
-			'label'       => 'Access restriction',
-			'description' => 'Downloads require login',
-			'type'        => 'checkbox',
-			'default'     => 'no',
-			'tip'         => 'This setting does not apply to guest purchases.',
-			'value'       => 'no',
-			'_links'      => array(
-				'self' => array(
-					array(
-						'href' => rest_url( '/wc/v2/settings/products/woocommerce_downloads_require_login' ),
+		$this->assertContains(
+			array(
+				'id'          => 'woocommerce_downloads_require_login',
+				'label'       => 'Access restriction',
+				'description' => 'Downloads require login',
+				'type'        => 'checkbox',
+				'default'     => 'no',
+				'tip'         => 'This setting does not apply to guest purchases.',
+				'value'       => 'no',
+				'_links'      => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v2/settings/products/woocommerce_downloads_require_login' ),
+						),
 					),
-				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/settings/products' ),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v2/settings/products' ),
+						),
 					),
 				),
 			),
-	), $data );
+			$data
+		);
 
 		// test get single
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/products/woocommerce_dimension_unit' ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'cm', $data['default'] );
 
 		// test update
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'products', 'woocommerce_dimension_unit' ) );
-		$request->set_body_params( array(
-			'value' => 'yd',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'yd',
+			)
+		);
 		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 'yd', $data['value'] );
 		$this->assertEquals( 'yd', get_option( 'woocommerce_dimension_unit' ) );
@@ -484,62 +513,73 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		$this->assertEquals( 200, $response->get_status() );
 
-		$this->assertContains( array(
-			'id'          => 'recipient',
-			'label'       => 'Recipient(s)',
-			'description' => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
-			'type'        => 'text',
-			'default'     => '',
-			'tip'         => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
-			'value'       => '',
-			'_links'      => array(
-				'self' => array(
-					array(
-						'href' => rest_url( '/wc/v2/settings/email_new_order/recipient' ),
+		$this->assertContains(
+			array(
+				'id'          => 'recipient',
+				'label'       => 'Recipient(s)',
+				'description' => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
+				'type'        => 'text',
+				'default'     => '',
+				'tip'         => 'Enter recipients (comma separated) for this email. Defaults to <code>admin@example.org</code>.',
+				'value'       => '',
+				'_links'      => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v2/settings/email_new_order/recipient' ),
+						),
 					),
-				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/settings/email_new_order' ),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v2/settings/email_new_order' ),
+						),
 					),
 				),
 			),
-		), $settings );
+			$settings
+		);
 
 		// test get single
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/settings/email_new_order/subject' ) );
 		$setting  = $response->get_data();
 
-		$this->assertEquals( array(
-			'id'          => 'subject',
-			'label'       => 'Subject',
-			'description' => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
-			'type'        => 'text',
-			'default'     => '',
-			'tip'         => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
-			'value'       => '',
-		), $setting );
+		$this->assertEquals(
+			array(
+				'id'          => 'subject',
+				'label'       => 'Subject',
+				'description' => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
+				'type'        => 'text',
+				'default'     => '',
+				'tip'         => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
+				'value'       => '',
+			),
+			$setting
+		);
 
 		// test update
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'email_new_order', 'subject' ) );
-		$request->set_body_params( array(
-			'value' => 'This is my subject',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'This is my subject',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 
-		$this->assertEquals( array(
-			'id'          => 'subject',
-			'label'       => 'Subject',
-			'description' => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
-			'type'        => 'text',
-			'default'     => '',
-			'tip'         => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
-			'value'       => 'This is my subject',
-		), $setting );
+		$this->assertEquals(
+			array(
+				'id'          => 'subject',
+				'label'       => 'Subject',
+				'description' => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
+				'type'        => 'text',
+				'default'     => '',
+				'tip'         => 'Available placeholders: <code>{site_title}, {order_date}, {order_number}</code>',
+				'value'       => 'This is my subject',
+			),
+			$setting
+		);
 
 		// test updating another subject and making sure it works with a "similar" id
-		$request = new WP_REST_Request( 'GET', sprintf( '/wc/v2/settings/%s/%s', 'email_customer_new_account', 'subject' ) );
+		$request  = new WP_REST_Request( 'GET', sprintf( '/wc/v2/settings/%s/%s', 'email_customer_new_account', 'subject' ) );
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 
@@ -547,9 +587,11 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		// test update
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'email_customer_new_account', 'subject' ) );
-		$request->set_body_params( array(
-			'value' => 'This is my new subject',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'This is my new subject',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 
@@ -572,25 +614,31 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		// test bogus value
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'email_cancelled_order', 'enabled' ) );
-		$request->set_body_params( array(
-			'value' => 'not_yes_or_no',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'not_yes_or_no',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 
 		// test yes
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'email_cancelled_order', 'enabled' ) );
-		$request->set_body_params( array(
-			'value' => 'yes',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'yes',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 
 		// test no
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'email_cancelled_order', 'enabled' ) );
-		$request->set_body_params( array(
-			'value' => 'no',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'no',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 	}
@@ -605,17 +653,21 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		// not a valid option
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'shipping', 'woocommerce_ship_to_destination' ) );
-		$request->set_body_params( array(
-			'value' => 'billing2',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'billing2',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 
 		// valid
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'shipping', 'woocommerce_ship_to_destination' ) );
-		$request->set_body_params( array(
-			'value' => 'billing',
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'billing',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 200, $response->get_status() );
 	}
@@ -633,9 +685,11 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEmpty( $setting['value'] );
 
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'general', 'woocommerce_specific_allowed_countries' ) );
-		$request->set_body_params( array(
-			'value' => array( 'AX', 'DZ', 'MMM' ),
-		) );
+		$request->set_body_params(
+			array(
+				'value' => array( 'AX', 'DZ', 'MMM' ),
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( array( 'AX', 'DZ' ), $setting['value'] );
@@ -655,17 +709,21 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 
 		// invalid
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'products', 'woocommerce_weight_unit' ) );
-		$request->set_body_params( array(
-			'value' => 'pounds', // invalid, should be lbs
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'pounds', // invalid, should be lbs
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$this->assertEquals( 400, $response->get_status() );
 
 		// valid
 		$request = new WP_REST_Request( 'PUT', sprintf( '/wc/v2/settings/%s/%s', 'products', 'woocommerce_weight_unit' ) );
-		$request->set_body_params( array(
-			'value' => 'lbs', // invalid, should be lbs
-		) );
+		$request->set_body_params(
+			array(
+				'value' => 'lbs', // invalid, should be lbs
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( 'lbs', $setting['value'] );
@@ -702,19 +760,23 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 		// Repalce the old value with something uniquely new
 		$old_value = $setting['value'];
 		$new_value = $old_value . ' ' . rand( 1000, 9999 );
-		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_address' );
-		$request->set_body_params( array(
-			'value' => $new_value,
-		) );
+		$request   = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_address' );
+		$request->set_body_params(
+			array(
+				'value' => $new_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $new_value, $setting['value'] );
 
 		// Put the original value back
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_address' );
-		$request->set_body_params( array(
-			'value' => $old_value,
-		) );
+		$request->set_body_params(
+			array(
+				'value' => $old_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $old_value, $setting['value'] );
@@ -734,19 +796,23 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 		// Repalce the old value with something uniquely new
 		$old_value = $setting['value'];
 		$new_value = $old_value . ' ' . rand( 1000, 9999 );
-		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_address_2' );
-		$request->set_body_params( array(
-			'value' => $new_value,
-		) );
+		$request   = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_address_2' );
+		$request->set_body_params(
+			array(
+				'value' => $new_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $new_value, $setting['value'] );
 
 		// Put the original value back
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_address_2' );
-		$request->set_body_params( array(
-			'value' => $old_value,
-		) );
+		$request->set_body_params(
+			array(
+				'value' => $old_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $old_value, $setting['value'] );
@@ -766,19 +832,23 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 		// Repalce the old value with something uniquely new
 		$old_value = $setting['value'];
 		$new_value = $old_value . ' ' . rand( 1000, 9999 );
-		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_city' );
-		$request->set_body_params( array(
-			'value' => $new_value,
-		) );
+		$request   = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_city' );
+		$request->set_body_params(
+			array(
+				'value' => $new_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $new_value, $setting['value'] );
 
 		// Put the original value back
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_city' );
-		$request->set_body_params( array(
-			'value' => $old_value,
-		) );
+		$request->set_body_params(
+			array(
+				'value' => $old_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $old_value, $setting['value'] );
@@ -798,19 +868,23 @@ class Settings_V2 extends WC_REST_Unit_Test_Case {
 		// Repalce the old value with something uniquely new
 		$old_value = $setting['value'];
 		$new_value = $old_value . ' ' . rand( 1000, 9999 );
-		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_postcode' );
-		$request->set_body_params( array(
-			'value' => $new_value,
-		) );
+		$request   = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_postcode' );
+		$request->set_body_params(
+			array(
+				'value' => $new_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $new_value, $setting['value'] );
 
 		// Put the original value back
 		$request = new WP_REST_Request( 'PUT', '/wc/v2/settings/general/woocommerce_store_postcode' );
-		$request->set_body_params( array(
-			'value' => $old_value,
-		) );
+		$request->set_body_params(
+			array(
+				'value' => $old_value,
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$setting  = $response->get_data();
 		$this->assertEquals( $old_value, $setting['value'] );

--- a/tests/unit-tests/api/v2/shipping-methods.php
+++ b/tests/unit-tests/api/v2/shipping-methods.php
@@ -14,9 +14,11 @@ class Shipping_Methods_V2 extends WC_REST_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 		$this->endpoint = new WC_REST_Shipping_Methods_Controller();
-		$this->user = $this->factory->user->create( array(
-			'role' => 'administrator',
-		) );
+		$this->user     = $this->factory->user->create(
+			array(
+				'role' => 'administrator',
+			)
+		);
 	}
 
 	/**
@@ -26,7 +28,7 @@ class Shipping_Methods_V2 extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_register_routes() {
 		$routes = $this->server->get_routes();
-        $this->assertArrayHasKey( '/wc/v2/shipping_methods', $routes );
+		$this->assertArrayHasKey( '/wc/v2/shipping_methods', $routes );
 		$this->assertArrayHasKey( '/wc/v2/shipping_methods/(?P<id>[\w-]+)', $routes );
 	}
 
@@ -39,26 +41,29 @@ class Shipping_Methods_V2 extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/shipping_methods' ) );
-		$methods = $response->get_data();
+		$methods  = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-        $this->assertContains( array(
-			'id'          => 'free_shipping',
-			'title'       => 'Free shipping',
-			'description' => 'Free shipping is a special method which can be triggered with coupons and minimum spends.',
-			'_links' => array(
-				'self'       => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping_methods/free_shipping' ),
+		$this->assertContains(
+			array(
+				'id'          => 'free_shipping',
+				'title'       => 'Free shipping',
+				'description' => 'Free shipping is a special method which can be triggered with coupons and minimum spends.',
+				'_links'      => array(
+					'self'       => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping_methods/free_shipping' ),
+						),
 					),
-				),
-				'collection' => array(
-					array(
-						'href' => rest_url( '/wc/v2/shipping_methods' ),
+					'collection' => array(
+						array(
+							'href' => rest_url( '/wc/v2/shipping_methods' ),
+						),
 					),
 				),
 			),
-		), $methods );
+			$methods
+		);
 	}
 
 	/**
@@ -84,11 +89,14 @@ class Shipping_Methods_V2 extends WC_REST_Unit_Test_Case {
 		$method   = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
-        $this->assertEquals( array(
-            'id'          => 'local_pickup',
-            'title'       => 'Local pickup',
-            'description' => 'Allow customers to pick up orders themselves. By default, when using local pickup store base taxes will apply regardless of customer address.',
-        ), $method );
+		$this->assertEquals(
+			array(
+				'id'          => 'local_pickup',
+				'title'       => 'Local pickup',
+				'description' => 'Allow customers to pick up orders themselves. By default, when using local pickup store base taxes will apply regardless of customer address.',
+			),
+			$method
+		);
 	}
 
 	/**
@@ -122,9 +130,9 @@ class Shipping_Methods_V2 extends WC_REST_Unit_Test_Case {
 	public function test_shipping_method_schema() {
 		wp_set_current_user( $this->user );
 
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v2/shipping_methods' );
-		$response = $this->server->dispatch( $request );
-		$data = $response->get_data();
+		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v2/shipping_methods' );
+		$response   = $this->server->dispatch( $request );
+		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
 
 		$this->assertEquals( 3, count( $properties ) );

--- a/tests/unit-tests/api/v2/shipping-zones.php
+++ b/tests/unit-tests/api/v2/shipping-zones.php
@@ -96,7 +96,8 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 
 		// Create a zone and make sure it's in the response
@@ -129,7 +130,8 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -215,7 +217,8 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -279,7 +282,8 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -377,7 +381,8 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -402,7 +407,9 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 
 		// Create a zone
 		$zone = $this->create_shipping_zone(
-			'Zone 1', 0, array(
+			'Zone 1',
+			0,
+			array(
 				array(
 					'code' => 'US',
 					'type' => 'country',
@@ -433,7 +440,8 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 
@@ -534,7 +542,8 @@ class WC_Tests_API_Shipping_Zones_V2 extends WC_REST_Unit_Test_Case {
 						),
 					),
 				),
-			), $data
+			),
+			$data
 		);
 	}
 

--- a/tests/unit-tests/api/wc-blocks/products-attributes.php
+++ b/tests/unit-tests/api/wc-blocks/products-attributes.php
@@ -51,7 +51,7 @@ class WC_Tests_API_Products_Attributes_Controller extends WC_REST_Unit_Test_Case
 		wp_set_current_user( $this->user );
 		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes' );
 
-		$response       = $this->server->dispatch( $request );
+		$response            = $this->server->dispatch( $request );
 		$response_attributes = $response->get_data();
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, count( $response_attributes ) );
@@ -96,7 +96,7 @@ class WC_Tests_API_Products_Attributes_Controller extends WC_REST_Unit_Test_Case
 		wp_set_current_user( $this->contributor );
 		$request = new WP_REST_Request( 'GET', $this->endpoint . '/products/attributes/' . $this->attr_size['attribute_id'] );
 
-		$response       = $this->server->dispatch( $request );
+		$response  = $this->server->dispatch( $request );
 		$attribute = $response->get_data();
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( $this->attr_size['attribute_id'], $attribute['id'] );

--- a/tests/unit-tests/attributes/functions.php
+++ b/tests/unit-tests/attributes/functions.php
@@ -125,7 +125,7 @@ class WC_Tests_Attributes_Functions extends WC_Unit_Test_Case {
 			'is_variation' => 0,
 			'is_taxonomy'  => 1,
 		);
-		$local_before = isset( $product_meta_before_update['Test Local Attribute'] ) ? $product_meta_before_update['Test Local Attribute'] : $product_meta_before_update['test-local-attribute'];
+		$local_before                   = isset( $product_meta_before_update['Test Local Attribute'] ) ? $product_meta_before_update['Test Local Attribute'] : $product_meta_before_update['test-local-attribute'];
 		$this->assertEquals( $expected_local_attribute_data, $local_before );
 		$this->assertEquals( $expected_global_attribute_data, $product_meta_before_update['pa_test'] );
 

--- a/tests/unit-tests/cart/cart-fees.php
+++ b/tests/unit-tests/cart/cart-fees.php
@@ -18,8 +18,8 @@ class WC_Tests_WC_Cart_Fees extends WC_Unit_Test_Case {
 
 		// Test add_fee.
 		$args = array(
-			'name'      => 'testfee',
-			'amount'    => 10,
+			'name'   => 'testfee',
+			'amount' => 10,
 		);
 		$cart_fees->add_fee( $args );
 		$applied_fees = $cart_fees->get_fees();
@@ -34,14 +34,14 @@ class WC_Tests_WC_Cart_Fees extends WC_Unit_Test_Case {
 		// Test set_fees.
 		$args = array(
 			array(
-				'name'      => 'newfee',
-				'amount'    => -5,
+				'name'   => 'newfee',
+				'amount' => -5,
 			),
 			array(
 				'name'      => 'newfee2',
 				'amount'    => 10,
 				'tax_class' => 'Reduced rate',
-				'taxable'   => true
+				'taxable'   => true,
 			),
 		);
 		$cart_fees->set_fees( $args );

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -109,7 +109,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
 
-		$tax_rate = array(
+		$tax_rate    = array(
 			'tax_rate_country'  => '',
 			'tax_rate_state'    => '',
 			'tax_rate'          => '23.0000',
@@ -122,7 +122,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		);
 		$tax_rate_23 = WC_Tax::_insert_tax_rate( $tax_rate );
 
-		$tax_rate = array(
+		$tax_rate   = array(
 			'tax_rate_country'  => '',
 			'tax_rate_state'    => '',
 			'tax_rate'          => '5.0000',
@@ -196,7 +196,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	 */
 	public function test_cart_get_discounted_price_issue_10963() {
 		// Create dummy coupon - fixed cart, 1 value
-		$coupon  = WC_Helper_Coupon::create_coupon();
+		$coupon = WC_Helper_Coupon::create_coupon();
 
 		// Add coupon
 		WC()->cart->add_discount( $coupon->get_code() );
@@ -290,7 +290,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	 */
 	public function test_cart_get_discounted_price_issue_10573() {
 		// Create dummy coupon - fixed cart, 1 value
-		$coupon  = WC_Helper_Coupon::create_coupon();
+		$coupon = WC_Helper_Coupon::create_coupon();
 
 		// Create dummy product - price will be 10
 		$product = WC_Helper_Product::create_simple_product();
@@ -1580,7 +1580,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	}
 
 	public function test_add_individual_use_coupon_removal() {
-		$coupon = WC_Helper_Coupon::create_coupon();
+		$coupon    = WC_Helper_Coupon::create_coupon();
 		$iu_coupon = WC_Helper_Coupon::create_coupon( 'code1' );
 		$iu_coupon->set_individual_use( true );
 		$iu_coupon->save();
@@ -1649,7 +1649,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		$new_cart = clone $cart;
 
 		// Get the properties from each object.
-		$cart_fees = $cart->fees_api();
+		$cart_fees     = $cart->fees_api();
 		$new_cart_fees = $new_cart->fees_api();
 
 		// Ensure that cloned properties are not identical.

--- a/tests/unit-tests/countries/countries.php
+++ b/tests/unit-tests/countries/countries.php
@@ -27,7 +27,7 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 	 * @since 3.6.0
 	 */
 	public function test_get_shipping_continents() {
-		$countries = new WC_Countries();
+		$countries      = new WC_Countries();
 		$all_continents = $countries->get_continents();
 
 		update_option( 'woocommerce_ship_to_countries', 'all' );
@@ -110,7 +110,7 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_specific_allowed_countries', array( 'US' ) );
 
 		$all_states = $countries->get_allowed_country_states();
-		$us_states = $all_states['US'];
+		$us_states  = $all_states['US'];
 
 		$this->assertEquals( 'Oregon', $us_states['OR'] );
 		$this->assertGreaterThanOrEqual( 50, count( $us_states ) );
@@ -134,7 +134,7 @@ class WC_Tests_Countries extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_specific_ship_to_countries', array( 'US' ) );
 
 		$all_states = $countries->get_shipping_country_states();
-		$us_states = $all_states['US'];
+		$us_states  = $all_states['US'];
 
 		$this->assertEquals( 'Oregon', $us_states['OR'] );
 		$this->assertGreaterThanOrEqual( 50, count( $us_states ) );

--- a/tests/unit-tests/coupon/coupon.php
+++ b/tests/unit-tests/coupon/coupon.php
@@ -235,11 +235,14 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		update_post_meta( $product->get_id(), '_regular_price', '10' );
 
 		// Create coupon
-		$coupon = WC_Helper_Coupon::create_coupon( 'dummycoupon', array(
-			'discount_type'          => 'percent',
-			'coupon_amount'          => '5',
-			'limit_usage_to_x_items' => 1,
-		) );
+		$coupon = WC_Helper_Coupon::create_coupon(
+			'dummycoupon',
+			array(
+				'discount_type'          => 'percent',
+				'coupon_amount'          => '5',
+				'limit_usage_to_x_items' => 1,
+			)
+		);
 
 		// We need this to have the calculate_totals() method calculate totals.
 		if ( ! defined( 'WOOCOMMERCE_CHECKOUT' ) ) {
@@ -265,11 +268,14 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		update_post_meta( $product->get_id(), '_regular_price', '10' );
 
 		// Create coupon
-		$coupon = WC_Helper_Coupon::create_coupon( 'dummycoupon', array(
-			'discount_type'          => __FUNCTION__,
-			'coupon_amount'          => '5',
-			'limit_usage_to_x_items' => 1,
-		) );
+		$coupon = WC_Helper_Coupon::create_coupon(
+			'dummycoupon',
+			array(
+				'discount_type'          => __FUNCTION__,
+				'coupon_amount'          => '5',
+				'limit_usage_to_x_items' => 1,
+			)
+		);
 
 		// Add 4 products and coupon to cart.
 		WC()->cart->add_to_cart( $product->get_id(), 4 );

--- a/tests/unit-tests/coupon/data.php
+++ b/tests/unit-tests/coupon/data.php
@@ -94,24 +94,27 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 	public function test_read_manual_coupon() {
 		$code   = 'manual_coupon_' . time();
 		$coupon = new WC_Coupon( $code );
-		$coupon->read_manual_coupon( $code, array(
-			'id'                         => true,
-			'type'                       => 'fixed_cart',
-			'amount'                     => 0,
-			'individual_use'             => true,
-			'product_ids'                => array(),
-			'exclude_product_ids'        => array(),
-			'usage_limit'                => '',
-			'usage_count'                => '',
-			'expiry_date'                => '',
-			'free_shipping'              => false,
-			'product_categories'         => array(),
-			'exclude_product_categories' => array(),
-			'exclude_sale_items'         => false,
-			'minimum_amount'             => '',
-			'maximum_amount'             => 100,
-			'customer_email'             => '',
-		) );
+		$coupon->read_manual_coupon(
+			$code,
+			array(
+				'id'                         => true,
+				'type'                       => 'fixed_cart',
+				'amount'                     => 0,
+				'individual_use'             => true,
+				'product_ids'                => array(),
+				'exclude_product_ids'        => array(),
+				'usage_limit'                => '',
+				'usage_count'                => '',
+				'expiry_date'                => '',
+				'free_shipping'              => false,
+				'product_categories'         => array(),
+				'exclude_product_categories' => array(),
+				'exclude_sale_items'         => false,
+				'minimum_amount'             => '',
+				'maximum_amount'             => 100,
+				'customer_email'             => '',
+			)
+		);
 		$this->assertEquals( $code, $coupon->get_code() );
 		$this->assertTrue( $coupon->get_individual_use() );
 		$this->assertEquals( 100, $coupon->get_maximum_amount() );
@@ -132,24 +135,27 @@ class WC_Tests_Coupon_Data extends WC_Unit_Test_Case {
 		$this->expected_doing_it_wrong = array_merge( $this->expected_doing_it_wrong, $legacy_keys );
 		$code                          = 'bc_manual_coupon_' . time();
 		$coupon                        = new WC_Coupon( $code );
-		$coupon->read_manual_coupon( $code, array(
-			'id'                         => true,
-			'type'                       => 'fixed_cart',
-			'amount'                     => 0,
-			'individual_use'             => 'yes',
-			'product_ids'                => '',
-			'exclude_product_ids'        => '5,6',
-			'usage_limit'                => '',
-			'usage_count'                => '',
-			'expiry_date'                => '',
-			'free_shipping'              => 'no',
-			'product_categories'         => array(),
-			'exclude_product_categories' => array(),
-			'exclude_sale_items'         => 'no',
-			'minimum_amount'             => '',
-			'maximum_amount'             => 100,
-			'customer_email'             => '',
-		) );
+		$coupon->read_manual_coupon(
+			$code,
+			array(
+				'id'                         => true,
+				'type'                       => 'fixed_cart',
+				'amount'                     => 0,
+				'individual_use'             => 'yes',
+				'product_ids'                => '',
+				'exclude_product_ids'        => '5,6',
+				'usage_limit'                => '',
+				'usage_count'                => '',
+				'expiry_date'                => '',
+				'free_shipping'              => 'no',
+				'product_categories'         => array(),
+				'exclude_product_categories' => array(),
+				'exclude_sale_items'         => 'no',
+				'minimum_amount'             => '',
+				'maximum_amount'             => 100,
+				'customer_email'             => '',
+			)
+		);
 		$this->assertEquals( $code, $coupon->get_code() );
 		$this->assertTrue( $coupon->get_individual_use() );
 		$this->assertFalse( $coupon->get_free_shipping() );

--- a/tests/unit-tests/crud/data-store.php
+++ b/tests/unit-tests/crud/data-store.php
@@ -75,7 +75,7 @@ class WC_Tests_Data_Store extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	function load_dummy_store() {
-		include_once( dirname( dirname( dirname( __FILE__ ) ) ) . '/framework/class-wc-dummy-data-store.php' );
+		include_once dirname( dirname( dirname( __FILE__ ) ) ) . '/framework/class-wc-dummy-data-store.php';
 		add_filter( 'woocommerce_data_stores', array( $this, 'add_dummy_data_store' ) );
 	}
 

--- a/tests/unit-tests/crud/data.php
+++ b/tests/unit-tests/crud/data.php
@@ -9,8 +9,8 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	/**
 	 * Restore UTC on failire.
 	 */
-	 public function tearDown() {
- 		parent::tearDown();
+	public function tearDown() {
+		parent::tearDown();
 		// @codingStandardsIgnoreStart
 		date_default_timezone_set( 'UTC' );
 		// @codingStandardsIgnoreEnd
@@ -63,9 +63,9 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 * Test: delete_meta_data_by_mid
 	 */
 	function test_delete_meta_data_by_mid() {
-		$object = $this->create_test_post();
+		$object    = $this->create_test_post();
 		$object_id = $object->get_id();
-		$meta_id = add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
+		$meta_id   = add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
 		$object->delete_meta_data_by_mid( $meta_id );
 		$this->assertEmpty( $object->get_meta( 'test_meta_key' ) );
 	}
@@ -74,12 +74,12 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 * Test: set_props
 	 */
 	function test_set_props() {
-		$object = new WC_Mock_WC_Data();
+		$object      = new WC_Mock_WC_Data();
 		$data_to_set = array(
 			'content'    => 'I am a fish',
 			'bool_value' => true,
 		);
-		$result = $object->set_props( $data_to_set );
+		$result      = $object->set_props( $data_to_set );
 		$this->assertFalse( is_wp_error( $result ) );
 		$this->assertEquals( 'I am a fish', $object->get_content() );
 		$this->assertTrue( $object->get_bool_value() );
@@ -88,7 +88,7 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 			'content'    => 'I am also a fish',
 			'bool_value' => 'thisisinvalid',
 		);
-		$result = $object->set_props( $data_to_set );
+		$result      = $object->set_props( $data_to_set );
 		$this->assertTrue( is_wp_error( $result ) );
 		$this->assertEquals( 'I am also a fish', $object->get_content() );
 		$this->assertNotEquals( 'thisisinvalid', $object->get_bool_value() );
@@ -119,14 +119,14 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 * Tests that the meta data cache is not shared among instances.
 	 */
 	function test_get_meta_data_shared_bug() {
-		$object  = new WC_Order;
+		$object = new WC_Order();
 		$object->add_meta_data( 'test_meta_key', 'val1', true );
 		$object->add_meta_data( 'test_multi_meta_key', 'val2' );
 		$object->add_meta_data( 'test_multi_meta_key', 'val3' );
 		$object->save();
 
-		$order = new WC_Order( $object->get_id() );
-		$metas = $order->get_meta_data();
+		$order           = new WC_Order( $object->get_id() );
+		$metas           = $order->get_meta_data();
 		$metas[0]->value = 'wrong value';
 
 		$order = new WC_Order( $object->get_id() );
@@ -138,14 +138,14 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 * Tests the cache invalidation after an order is saved
 	 */
 	function test_get_meta_data_cache_invalidation() {
-		$object  = new WC_Order;
+		$object = new WC_Order();
 		$object->add_meta_data( 'test_meta_key', 'val1', true );
 		$object->add_meta_data( 'test_multi_meta_key', 'val2' );
 		$object->add_meta_data( 'test_multi_meta_key', 'val3' );
 		$object->save();
 
-		$order = new WC_Order( $object->get_id() );
-		$metas = $order->get_meta_data();
+		$order           = new WC_Order( $object->get_id() );
+		$metas           = $order->get_meta_data();
 		$metas[0]->value = 'updated value';
 		$order->save();
 
@@ -155,14 +155,14 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	}
 
 	function test_get_meta_data_cache_invalidation_array_to_scalar() {
-		$object  = new WC_Order;
+		$object = new WC_Order();
 		$object->add_meta_data( 'test_meta_key', array( 'val1' ), true );
 		$object->add_meta_data( 'test_multi_meta_key', 'val2' );
 		$object->add_meta_data( 'test_multi_meta_key', 'val3' );
 		$object->save();
 
-		$order = new WC_Order( $object->get_id() );
-		$metas = $order->get_meta_data();
+		$order           = new WC_Order( $object->get_id() );
+		$metas           = $order->get_meta_data();
 		$metas[0]->value = 'updated value';
 		$order->save();
 
@@ -175,7 +175,7 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 * Test getting meta by ID.
 	 */
 	function test_get_meta() {
-		$object = $this->create_test_post();
+		$object    = $this->create_test_post();
 		$object_id = $object->get_id();
 		$object->add_meta_data( 'test_meta_key', 'val1', true );
 		$object->add_meta_data( 'test_multi_meta_key', 'val2' );
@@ -218,11 +218,11 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 * Test getting meta that hasn't been set
 	 */
 	function test_get_meta_no_meta() {
-		$object = $this->create_test_post();
+		$object    = $this->create_test_post();
 		$object_id = $object->get_id();
-		$object = new WC_Mock_WC_Data( $object_id );
+		$object    = new WC_Mock_WC_Data( $object_id );
 
-		$single_on = $object->get_meta( 'doesnt-exist', true );
+		$single_on  = $object->get_meta( 'doesnt-exist', true );
 		$single_off = $object->get_meta( 'also-doesnt-exist', false );
 
 		$this->assertEquals( '', $single_on );
@@ -234,18 +234,23 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 */
 	function test_set_meta_data() {
 		global $wpdb;
-		$object = $this->create_test_post();
+		$object    = $this->create_test_post();
 		$object_id = $object->get_id();
 		add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
 		add_metadata( 'post', $object_id, 'test_meta_key_2', 'val2', true );
 		$object = new WC_Mock_WC_Data( $object_id );
 
 		$metadata     = array();
-		$raw_metadata = $wpdb->get_results( $wpdb->prepare( "
+		$raw_metadata = $wpdb->get_results(
+			$wpdb->prepare(
+				"
 			SELECT meta_id, meta_key, meta_value
 			FROM {$wpdb->prefix}postmeta
 			WHERE post_id = %d ORDER BY meta_id
-		", $object_id ) );
+		",
+				$object_id
+			)
+		);
 
 		foreach ( $raw_metadata as $meta ) {
 			$metadata[] = (object) array(
@@ -270,9 +275,9 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 * Test adding meta data.
 	 */
 	function test_add_meta_data() {
-		$object = $this->create_test_post();
+		$object    = $this->create_test_post();
 		$object_id = $object->get_id();
-		$data = 'add_meta_data_' . time();
+		$data      = 'add_meta_data_' . time();
 		$object->add_meta_data( 'test_new_field', $data );
 		$meta = $object->get_meta( 'test_new_field' );
 		$this->assertEquals( $data, $meta );
@@ -283,19 +288,24 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 */
 	function test_update_meta_data() {
 		global $wpdb;
-		$object = $this->create_test_post();
+		$object    = $this->create_test_post();
 		$object_id = $object->get_id();
 		add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
 		$object = new WC_Mock_WC_Data( $object_id );
 
 		$this->assertEquals( 'val1', $object->get_meta( 'test_meta_key' ) );
 
-		$metadata     = array();
-		$meta_id = $wpdb->get_var( $wpdb->prepare( "
+		$metadata = array();
+		$meta_id  = $wpdb->get_var(
+			$wpdb->prepare(
+				"
 			SELECT meta_id
 			FROM {$wpdb->prefix}postmeta
 			WHERE post_id = %d LIMIT 1
-		", $object_id ) );
+		",
+				$object_id
+			)
+		);
 
 		$object->update_meta_data( 'test_meta_key', 'updated_value', $meta_id );
 		$this->assertEquals( 'updated_value', $object->get_meta( 'test_meta_key' ) );
@@ -305,7 +315,7 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 * Test deleting meta.
 	 */
 	function test_delete_meta_data() {
-		$object = $this->create_test_post();
+		$object    = $this->create_test_post();
 		$object_id = $object->get_id();
 		add_metadata( 'post', $object_id, 'test_meta_key', 'val1', true );
 		$object = new WC_Mock_WC_Data( $object_id );
@@ -323,18 +333,23 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 */
 	function test_save_meta_data() {
 		global $wpdb;
-		$object = $this->create_test_post();
+		$object    = $this->create_test_post();
 		$object_id = $object->get_id();
 		$object->add_meta_data( 'test_meta_key', 'val1', true );
 		$object->add_meta_data( 'test_meta_key_2', 'val2', true );
 		$object->save_meta_data();
 		$object = new WC_Mock_WC_Data( $object_id );
 
-		$raw_metadata = $wpdb->get_results( $wpdb->prepare( "
+		$raw_metadata = $wpdb->get_results(
+			$wpdb->prepare(
+				"
 			SELECT meta_id, meta_key, meta_value
 			FROM {$wpdb->prefix}postmeta
 			WHERE post_id = %d ORDER BY meta_id
-		", $object_id ) );
+		",
+				$object_id
+			)
+		);
 
 		$object->delete_meta_data( 'test_meta_key' );
 		$object->update_meta_data( 'test_meta_key_2', 'updated_value', $raw_metadata[1]->meta_id );
@@ -350,7 +365,7 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 * Test reading/getting user meta data too.
 	 */
 	function test_usermeta() {
-		$object = $this->create_test_user();
+		$object    = $this->create_test_user();
 		$object_id = $object->get_id();
 		$object->add_meta_data( 'test_meta_key', 'val1', true );
 		$object->add_meta_data( 'test_meta_key_2', 'val2', true );
@@ -365,7 +380,7 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 	 * data before a save.
 	 */
 	function test_add_meta_data_overwrite_before_save() {
-		$object = new WC_Mock_WC_Data;
+		$object = new WC_Mock_WC_Data();
 		$object->add_meta_data( 'test_field_0', 'another field', true );
 		$object->add_meta_data( 'test_field_1', 'another field', true );
 		$object->add_meta_data( 'test_field_2', 'val1', true );
@@ -504,12 +519,12 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 			'prop3' => 'value3',
 		);
 
-		$object = new WC_Mock_WC_Data;
+		$object = new WC_Mock_WC_Data();
 		$object->set_data( $data );
 		$object->set_changes( $changes );
 		$object->apply_changes();
 
-		$new_data = $object->get_data();
+		$new_data    = $object->get_data();
 		$new_changes = $object->get_changes();
 
 		$this->assertEquals( 'new_value1', $new_data['prop1'] );
@@ -537,7 +552,7 @@ class WC_Tests_CRUD_Data extends WC_Unit_Test_Case {
 			),
 		);
 
-		$object = new WC_Mock_WC_Data;
+		$object = new WC_Mock_WC_Data();
 		$object->set_data( $data );
 		$object->set_changes( $changes );
 		$object->apply_changes();

--- a/tests/unit-tests/crud/meta.php
+++ b/tests/unit-tests/crud/meta.php
@@ -36,7 +36,7 @@ class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
 	 */
 	function test_disappearing_item_meta() {
 		// Setup for testing by making an item.
-		$item = new WC_Order_Item_Product();
+		$item          = new WC_Order_Item_Product();
 		$this->item_id = $item->save();
 
 		$item = WC_Order_Factory::get_order_item( $this->item_id );
@@ -78,7 +78,7 @@ class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
 	 */
 	function test_disappearing_order_meta() {
 		// Setup for testing by making an item.
-		$order = new WC_Order();
+		$order          = new WC_Order();
 		$this->order_id = $order->save();
 
 		$order = wc_get_order( $this->order_id );
@@ -119,7 +119,7 @@ class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
 	 */
 	function test_get_meta_data_after_update_post_meta() {
 		// Create an object.
-		$object  = new WC_Product;
+		$object = new WC_Product();
 		$object->save();
 
 		// Update a meta value.
@@ -138,8 +138,8 @@ class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
 	 */
 	function test_strings_in_meta() {
 		// Create objects.
-		$object = new WC_Product;
-		$object_to_store = new stdClass();
+		$object                 = new WC_Product();
+		$object_to_store        = new stdClass();
 		$object_to_store->prop1 = 'prop_value';
 		$object_to_store->prop2 = 'prop_value_with_\\\"quotes"';
 
@@ -149,7 +149,7 @@ class WC_Tests_CRUD_Meta_Data extends WC_Unit_Test_Case {
 
 		// Get object and check it.
 		$object = wc_get_product( $object_id );
-		$value = $object->get_meta( 'Test Object', true );
+		$value  = $object->get_meta( 'Test Object', true );
 
 		$this->assertEquals( $object_to_store, $object->get_meta( 'Test Object', true ) );
 		$this->assertEquals( 'Test\slashes', $object->get_meta( 'Test meta with slash', true ) );

--- a/tests/unit-tests/crud/query.php
+++ b/tests/unit-tests/crud/query.php
@@ -26,7 +26,7 @@ class WC_Tests_WC_Object_Query extends WC_Unit_Test_Case {
 	 * @since 3.1.0
 	 */
 	function test_query_with_args() {
-		$args = array(
+		$args  = array(
 			'limit' => 15,
 		);
 		$query = new WC_Mock_WC_Object_Query( $args );

--- a/tests/unit-tests/customer/crud.php
+++ b/tests/unit-tests/customer/crud.php
@@ -29,7 +29,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_update_customer() {
-		$customer = WC_Helper_Customer::create_customer();
+		$customer    = WC_Helper_Customer::create_customer();
 		$customer_id = $customer->get_id();
 		$this->assertEquals( 'test@woo.local', $customer->get_email() );
 		$this->assertEquals( 'Apt 1', $customer->get_billing_address_2() );
@@ -58,7 +58,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 		$this->assertEquals( 0, $customer->get_id() );
 		$customer->save();
 		$customer_id = $customer->get_id();
-		$wp_user = new WP_User( $customer->get_id() );
+		$wp_user     = new WP_User( $customer->get_id() );
 
 		$this->assertNotEquals( 0, $customer->get_id() );
 
@@ -76,7 +76,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_delete_customer() {
-		$customer = WC_Helper_Customer::create_customer();
+		$customer    = WC_Helper_Customer::create_customer();
 		$customer_id = $customer->get_id();
 		$this->assertNotEquals( 0, $customer->get_id() );
 		$customer->delete();
@@ -97,7 +97,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 		$customer->set_last_name( 'Bob' );
 		$customer->set_display_name( 'Billy Bob' );
 		$customer->save();
-		$customer_id = $customer->get_id();
+		$customer_id   = $customer->get_id();
 		$customer_read = new WC_Customer( $customer_id );
 
 		$this->assertEquals( $customer_id, $customer_read->get_id() );
@@ -179,35 +179,35 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_customer_setters_and_getters() {
-		$time = time();
+		$time    = time();
 		$setters = array(
-			'username' => 'test',
-			'email' => 'test@woo.local',
-			'first_name' => 'Bob',
-			'last_name' => 'tester',
-			'display_name' => 'Bob Tester',
-			'role' => 'customer',
-			'date_created' => $time,
-			'date_modified' => $time,
-			'billing_postcode' => 11010,
-			'billing_city' => 'New York',
-			'billing_address' => '123 Main St.',
-			'billing_address_1' => '123 Main St.',
-			'billing_address_2' => 'Apt 2',
-			'billing_state' => 'NY',
-			'billing_country' => 'US',
-			'shipping_state' => 'NY',
-			'shipping_postcode' => 11011,
-			'shipping_city' => 'New York',
-			'shipping_address' => '123 Main St.',
-			'shipping_address_1' => '123 Main St.',
-			'shipping_address_2' => 'Apt 2',
-			'is_vat_exempt' => true,
+			'username'            => 'test',
+			'email'               => 'test@woo.local',
+			'first_name'          => 'Bob',
+			'last_name'           => 'tester',
+			'display_name'        => 'Bob Tester',
+			'role'                => 'customer',
+			'date_created'        => $time,
+			'date_modified'       => $time,
+			'billing_postcode'    => 11010,
+			'billing_city'        => 'New York',
+			'billing_address'     => '123 Main St.',
+			'billing_address_1'   => '123 Main St.',
+			'billing_address_2'   => 'Apt 2',
+			'billing_state'       => 'NY',
+			'billing_country'     => 'US',
+			'shipping_state'      => 'NY',
+			'shipping_postcode'   => 11011,
+			'shipping_city'       => 'New York',
+			'shipping_address'    => '123 Main St.',
+			'shipping_address_1'  => '123 Main St.',
+			'shipping_address_2'  => 'Apt 2',
+			'is_vat_exempt'       => true,
 			'calculated_shipping' => true,
-			'is_paying_customer' => true,
+			'is_paying_customer'  => true,
 		);
 
-		$customer = new WC_Customer;
+		$customer = new WC_Customer();
 
 		foreach ( $setters as $method => $value ) {
 			$customer->{"set_{$method}"}( $value );
@@ -220,7 +220,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 		}
 
 		// Get timestamps from date_created and date_modified.
-		$getters['date_created'] = $getters['date_created']->getOffsetTimestamp();
+		$getters['date_created']  = $getters['date_created']->getOffsetTimestamp();
 		$getters['date_modified'] = $getters['date_modified']->getOffsetTimestamp();
 
 		$this->assertEquals( $setters, $getters );
@@ -231,11 +231,11 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_customer_get_last_order_info() {
-		$customer = WC_Helper_Customer::create_customer();
+		$customer    = WC_Helper_Customer::create_customer();
 		$customer_id = $customer->get_id();
-		$order = WC_Helper_Order::create_order( $customer_id );
-		$customer = new WC_Customer( $customer_id );
-		$last_order = $customer->get_last_order();
+		$order       = WC_Helper_Order::create_order( $customer_id );
+		$customer    = new WC_Customer( $customer_id );
+		$last_order  = $customer->get_last_order();
 		$this->assertEquals( $order->get_id(), $last_order ? $last_order->get_id() : 0 );
 		$this->assertEquals( $order->get_date_created(), $last_order ? $last_order->get_date_created() : 0 );
 		$order->delete();
@@ -246,7 +246,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_customer_get_order_count_read() {
-		$customer = WC_Helper_Customer::create_customer();
+		$customer    = WC_Helper_Customer::create_customer();
 		$customer_id = $customer->get_id();
 		WC_Helper_Order::create_order( $customer_id );
 		WC_Helper_Order::create_order( $customer_id );
@@ -260,10 +260,10 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_customer_get_total_spent_read() {
-		$customer = WC_Helper_Customer::create_customer();
+		$customer    = WC_Helper_Customer::create_customer();
 		$customer_id = $customer->get_id();
-		$order = WC_Helper_Order::create_order( $customer_id );
-		$customer = new WC_Customer( $customer_id );
+		$order       = WC_Helper_Order::create_order( $customer_id );
+		$customer    = new WC_Customer( $customer_id );
 		$this->assertEquals( 0, $customer->get_total_spent() );
 		$order->update_status( 'wc-completed' );
 		$customer = new WC_Customer( $customer_id );
@@ -286,9 +286,9 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_customer_get_date_created_read() {
-		$customer = WC_Helper_Customer::create_customer();
+		$customer    = WC_Helper_Customer::create_customer();
 		$customer_id = $customer->get_id();
-		$user = new WP_User( $customer_id );
+		$user        = new WP_User( $customer_id );
 		$this->assertEquals( strtotime( $user->data->user_registered ), $customer->get_date_created()->getOffsetTimestamp() );
 	}
 
@@ -297,9 +297,9 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_customer_get_date_modified_read() {
-		$customer = WC_Helper_Customer::create_customer();
+		$customer    = WC_Helper_Customer::create_customer();
 		$customer_id = $customer->get_id();
-		$last = get_user_meta( $customer_id, 'last_update', true );
+		$last        = get_user_meta( $customer_id, 'last_update', true );
 		sleep( 1 );
 		$this->assertEquals( $last, $customer->get_date_modified()->getOffsetTimestamp() );
 		$customer->set_billing_address( '1234 Some St.' );
@@ -314,7 +314,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_customer_get_taxable_address() {
-		$customer = WC_Helper_Customer::create_customer();
+		$customer    = WC_Helper_Customer::create_customer();
 		$customer_id = $customer->get_id();
 		$customer->set_shipping_postcode( '11111' );
 		$customer->set_shipping_city( 'Test' );
@@ -348,7 +348,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_customer_get_downloadable_products() {
-		$customer = WC_Helper_Customer::create_customer();
+		$customer    = WC_Helper_Customer::create_customer();
 		$customer_id = $customer->get_id();
 		$this->assertEquals( wc_get_customer_available_downloads( $customer_id ), $customer->get_downloadable_products() );
 	}
@@ -358,7 +358,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_customer_password() {
-		$customer = WC_Helper_Customer::create_customer();
+		$customer    = WC_Helper_Customer::create_customer();
 		$customer_id = $customer->get_id();
 
 		$user = get_user_by( 'id', $customer_id );
@@ -460,7 +460,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 
 		// should still be session ID, not a created row, since we are working with guests/sessions
 		$this->assertFalse( $session->get_id() > 0 );
-		$this->assertEquals( '32191' , $session->get_billing_postcode() );
+		$this->assertEquals( '32191', $session->get_billing_postcode() );
 	}
 
 	/**
@@ -468,12 +468,12 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_get_meta() {
-		$customer = WC_Helper_Customer::create_customer();
-		$customer_id  = $customer->get_id();
-		$meta_value = time() . '-custom-value';
+		$customer    = WC_Helper_Customer::create_customer();
+		$customer_id = $customer->get_id();
+		$meta_value  = time() . '-custom-value';
 		add_user_meta( $customer_id, 'test_field', $meta_value, true );
 		$customer = new WC_Customer( $customer_id );
-		$fields = $customer->get_meta_data();
+		$fields   = $customer->get_meta_data();
 		$this->assertEquals( $meta_value, $customer->get_meta( 'test_field' ) );
 	}
 
@@ -482,9 +482,9 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_set_meta() {
-		$customer = WC_Helper_Customer::create_customer();
-		$customer_id  = $customer->get_id();
-		$meta_value = time() . '-custom-value';
+		$customer    = WC_Helper_Customer::create_customer();
+		$customer_id = $customer->get_id();
+		$meta_value  = time() . '-custom-value';
 		$customer->add_meta_data( 'my-field', $meta_value, true );
 		$customer->save();
 		$customer = new WC_Customer( $customer_id );

--- a/tests/unit-tests/customer/customer-download-log.php
+++ b/tests/unit-tests/customer/customer-download-log.php
@@ -137,9 +137,11 @@ class WC_Tests_Customer_Download_Log extends WC_Unit_Test_Case {
 
 		// Make sure download log was recorded properly.
 		$data_store    = WC_Data_Store::load( 'customer-download-log' );
-		$download_logs = $data_store->get_download_logs( array(
-			'permission_id' => $download_1->get_id(),
-		) );
+		$download_logs = $data_store->get_download_logs(
+			array(
+				'permission_id' => $download_1->get_id(),
+			)
+		);
 
 		$this->assertEquals( 1, count( $download_logs ), 'After single download, permission should have one download log in database.' );
 

--- a/tests/unit-tests/customer/functions.php
+++ b/tests/unit-tests/customer/functions.php
@@ -98,7 +98,7 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 				'bob@bobbobson.com',
 				array(
 					'first_name' => 'Bob',
-					'last_name' => 'Bobson',
+					'last_name'  => 'Bobson',
 				)
 			)
 		);
@@ -110,7 +110,7 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 				'unicode@unicode.com',
 				array(
 					'first_name' => 'こんにちは',
-					'last_name' => 'こんにちは',
+					'last_name'  => 'こんにちは',
 				)
 			)
 		);

--- a/tests/unit-tests/discounts/discounts.php
+++ b/tests/unit-tests/discounts/discounts.php
@@ -59,9 +59,9 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 
-		$this->products = array();
-		$this->coupons = array();
-		$this->orders = array();
+		$this->products       = array();
+		$this->coupons        = array();
+		$this->orders         = array();
 		$this->last_test_data = null;
 	}
 
@@ -159,8 +159,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 	 */
 	public function test_calculations( $test_data ) {
 		$this->last_test_data = $test_data;
-		$discounts = new WC_Discounts();
-		$products = array();
+		$discounts            = new WC_Discounts();
+		$products             = array();
 
 		if ( isset( $test_data['tax_rate'] ) ) {
 			WC_Tax::_insert_tax_rate( $test_data['tax_rate'] );
@@ -209,7 +209,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		return array(
 			array(
 				array(
-					'tax_rate' => array(
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -220,20 +220,20 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'wc_options' => array(
+					'wc_options'              => array(
 						'woocommerce_calc_taxes' => array(
 							'set'    => 'yes',
 							'revert' => 'no',
 						),
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 1,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'          => 'test',
 							'discount_type' => 'percent',
@@ -245,7 +245,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'tax_rate' => array(
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -256,14 +256,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 2,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'          => 'test',
 							'discount_type' => 'fixed_cart',
@@ -275,7 +275,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'tax_rate' => array(
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -286,8 +286,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 1,
@@ -297,7 +297,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 1,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'          => 'test',
 							'discount_type' => 'fixed_cart',
@@ -309,7 +309,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'tax_rate' => array(
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -320,8 +320,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 1,
@@ -335,7 +335,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 1,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'          => 'test',
 							'discount_type' => 'fixed_cart',
@@ -347,7 +347,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'tax_rate' => array(
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -358,8 +358,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 2,
@@ -373,7 +373,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 2,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'          => 'test',
 							'discount_type' => 'fixed_cart',
@@ -385,7 +385,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'tax_rate' => array(
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -396,8 +396,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 1,
@@ -443,7 +443,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 1,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'          => 'test',
 							'discount_type' => 'fixed_cart',
@@ -455,7 +455,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'tax_rate' => array(
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -466,8 +466,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 1,
 							'qty'   => 1,
@@ -481,7 +481,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 1,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'          => 'test',
 							'discount_type' => 'fixed_cart',
@@ -493,7 +493,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'tax_rate' => array(
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -504,14 +504,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 2,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'percent',
@@ -524,7 +524,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'tax_rate' => array(
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -535,8 +535,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 2,
@@ -546,7 +546,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 2,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'percent',
@@ -559,8 +559,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test multiple coupons. No limits. Not discounting sequentially.',
-					'tax_rate' => array(
+					'desc'                    => 'Test multiple coupons. No limits. Not discounting sequentially.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -571,8 +571,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 2,
@@ -582,16 +582,16 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 1,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
-							'code'                   => 'test',
-							'discount_type'          => 'percent',
-							'amount'                 => '10',
+							'code'          => 'test',
+							'discount_type' => 'percent',
+							'amount'        => '10',
 						),
 						array(
-							'code'                   => 'test1',
-							'discount_type'          => 'percent',
-							'amount'                 => '20',
+							'code'          => 'test1',
+							'discount_type' => 'percent',
+							'amount'        => '20',
 						),
 					),
 					'expected_total_discount' => 7.5,
@@ -599,8 +599,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test multiple coupons. One coupon has limit up to one item. Not discounting sequentially.',
-					'tax_rate' => array(
+					'desc'                    => 'Test multiple coupons. One coupon has limit up to one item. Not discounting sequentially.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -611,8 +611,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 2,
@@ -622,7 +622,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 1,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'percent',
@@ -630,9 +630,9 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'limit_usage_to_x_items' => 1,
 						),
 						array(
-							'code'                   => 'test1',
-							'discount_type'          => 'percent',
-							'amount'                 => '20',
+							'code'          => 'test1',
+							'discount_type' => 'percent',
+							'amount'        => '20',
 						),
 					),
 					'expected_total_discount' => 6,
@@ -640,8 +640,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test multiple coupons. No limits. Discounting sequentially.',
-					'tax_rate' => array(
+					'desc'                    => 'Test multiple coupons. No limits. Discounting sequentially.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -652,14 +652,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'wc_options' => array(
+					'prices_include_tax'      => false,
+					'wc_options'              => array(
 						'woocommerce_calc_discounts_sequentially' => array(
 							'set'    => 'yes',
 							'revert' => 'no',
 						),
 					),
-					'cart' => array(
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 2,
@@ -669,16 +669,16 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 1,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
-							'code'                   => 'test',
-							'discount_type'          => 'percent',
-							'amount'                 => '10',
+							'code'          => 'test',
+							'discount_type' => 'percent',
+							'amount'        => '10',
 						),
 						array(
-							'code'                   => 'test1',
-							'discount_type'          => 'percent',
-							'amount'                 => '20',
+							'code'          => 'test1',
+							'discount_type' => 'percent',
+							'amount'        => '20',
 						),
 					),
 					'expected_total_discount' => 7,
@@ -686,8 +686,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test multiple coupons. No limits. Discounting sequentially.',
-					'tax_rate' => array(
+					'desc'                    => 'Test multiple coupons. No limits. Discounting sequentially.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -698,14 +698,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'wc_options' => array(
+					'prices_include_tax'      => false,
+					'wc_options'              => array(
 						'woocommerce_calc_discounts_sequentially' => array(
 							'set'    => 'yes',
 							'revert' => 'no',
 						),
 					),
-					'cart' => array(
+					'cart'                    => array(
 						array(
 							'price' => 1.80,
 							'qty'   => 10,
@@ -715,16 +715,16 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 3,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
-							'code'                   => 'test',
-							'discount_type'          => 'percent',
-							'amount'                 => '10',
+							'code'          => 'test',
+							'discount_type' => 'percent',
+							'amount'        => '10',
 						),
 						array(
-							'code'                   => 'test1',
-							'discount_type'          => 'percent',
-							'amount'                 => '20',
+							'code'          => 'test1',
+							'discount_type' => 'percent',
+							'amount'        => '20',
 						),
 					),
 					'expected_total_discount' => 16.75,
@@ -732,8 +732,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test multiple coupons. One coupon has limit up to 5 item. Discounting non-sequentially.',
-					'tax_rate' => array(
+					'desc'                    => 'Test multiple coupons. One coupon has limit up to 5 item. Discounting non-sequentially.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -744,8 +744,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 3,
@@ -755,7 +755,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 3,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'percent',
@@ -763,9 +763,9 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'limit_usage_to_x_items' => 5,
 						),
 						array(
-							'code'                   => 'test1',
-							'discount_type'          => 'percent',
-							'amount'                 => '20',
+							'code'          => 'test1',
+							'discount_type' => 'percent',
+							'amount'        => '20',
 						),
 					),
 					'expected_total_discount' => 21,
@@ -773,8 +773,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test multiple coupons. One coupon has limit up to 5 item. Discounting sequentially.',
-					'tax_rate' => array(
+					'desc'                    => 'Test multiple coupons. One coupon has limit up to 5 item. Discounting sequentially.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -785,14 +785,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'wc_options' => array(
+					'prices_include_tax'      => false,
+					'wc_options'              => array(
 						'woocommerce_calc_discounts_sequentially' => array(
 							'set'    => 'yes',
 							'revert' => 'no',
 						),
 					),
-					'cart' => array(
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 3,
@@ -802,11 +802,11 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 3,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
-							'code'                   => 'test1',
-							'discount_type'          => 'percent',
-							'amount'                 => '20',
+							'code'          => 'test1',
+							'discount_type' => 'percent',
+							'amount'        => '20',
 						),
 						array(
 							'code'                   => 'test',
@@ -820,8 +820,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test multiple coupons. One coupon has limit up to 5 item. Discounting sequentially. Multiple zero-dollar items.',
-					'tax_rate' => array(
+					'desc'                    => 'Test multiple coupons. One coupon has limit up to 5 item. Discounting sequentially. Multiple zero-dollar items.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -832,14 +832,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'wc_options' => array(
+					'prices_include_tax'      => false,
+					'wc_options'              => array(
 						'woocommerce_calc_discounts_sequentially' => array(
 							'set'    => 'yes',
 							'revert' => 'no',
 						),
 					),
-					'cart' => array(
+					'cart'                    => array(
 						array(
 							'price' => 1.80,
 							'qty'   => 3,
@@ -869,7 +869,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 1,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'percent',
@@ -877,9 +877,9 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'limit_usage_to_x_items' => 5,
 						),
 						array(
-							'code'                   => 'test1',
-							'discount_type'          => 'percent',
-							'amount'                 => '20',
+							'code'          => 'test1',
+							'discount_type' => 'percent',
+							'amount'        => '20',
 						),
 					),
 					'expected_total_discount' => 20.35,
@@ -887,8 +887,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on one item.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on one item.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -899,18 +899,18 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 13.95,
 							'qty'   => 3,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
-							'code'                   => 'test',
-							'discount_type'          => 'fixed_product',
-							'amount'                 => '10',
+							'code'          => 'test',
+							'discount_type' => 'fixed_product',
+							'amount'        => '10',
 						),
 					),
 					'expected_total_discount' => 30,
@@ -918,8 +918,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on one item. Coupon greater than item cost.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on one item. Coupon greater than item cost.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -930,18 +930,18 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 13.95,
 							'qty'   => 3,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
-							'code'                   => 'test',
-							'discount_type'          => 'fixed_product',
-							'amount'                 => '20',
+							'code'          => 'test',
+							'discount_type' => 'fixed_product',
+							'amount'        => '20',
 						),
 					),
 					'expected_total_discount' => 41.85,
@@ -949,8 +949,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on one item. Limit to one item.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on one item. Limit to one item.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -961,14 +961,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 13.95,
 							'qty'   => 3,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'fixed_product',
@@ -981,8 +981,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on one item. Limit to one item. Price greater than product.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on one item. Limit to one item. Price greater than product.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -993,14 +993,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 13.95,
 							'qty'   => 3,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'fixed_product',
@@ -1013,8 +1013,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on one item. Limit to same number of items as product. Price same as product.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on one item. Limit to same number of items as product. Price same as product.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -1025,14 +1025,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 13.95,
 							'qty'   => 3,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'fixed_product',
@@ -1045,8 +1045,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on two items. No limit.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on two items. No limit.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -1057,8 +1057,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 13.95,
 							'qty'   => 3,
@@ -1068,11 +1068,11 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 5,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
-							'code'                   => 'test',
-							'discount_type'          => 'fixed_product',
-							'amount'                 => '10',
+							'code'          => 'test',
+							'discount_type' => 'fixed_product',
+							'amount'        => '10',
 						),
 					),
 					'expected_total_discount' => 39,
@@ -1080,8 +1080,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on two items. Limit to same number of items as first product.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on two items. Limit to same number of items as first product.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -1092,8 +1092,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 13.95,
 							'qty'   => 3,
@@ -1103,7 +1103,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 5,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'fixed_product',
@@ -1116,8 +1116,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on two items. Limit to number greater than first product but less than total quantities.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on two items. Limit to number greater than first product but less than total quantities.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -1128,8 +1128,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 13.95,
 							'qty'   => 3,
@@ -1139,7 +1139,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 5,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'fixed_product',
@@ -1152,8 +1152,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on two items. Limit to number greater than first product but less than total quantities. Amount less than price of either product.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on two items. Limit to number greater than first product but less than total quantities. Amount less than price of either product.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -1164,8 +1164,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 13.95,
 							'qty'   => 3,
@@ -1175,7 +1175,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 5,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'fixed_product',
@@ -1188,8 +1188,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on two items. Limit to number greater than both product quantities combined. Amount less than price of either product.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on two items. Limit to number greater than both product quantities combined. Amount less than price of either product.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -1200,8 +1200,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 13.95,
 							'qty'   => 3,
@@ -1211,7 +1211,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 5,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'fixed_product',
@@ -1224,8 +1224,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on two items. Limit to two items. Testing the products are sorted according to legacy method where first one to apply is the one with greatest price * quantity.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on two items. Limit to two items. Testing the products are sorted according to legacy method where first one to apply is the one with greatest price * quantity.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -1236,8 +1236,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 1.80,
 							'qty'   => 5,
@@ -1247,7 +1247,7 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 							'qty'   => 3,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'test',
 							'discount_type'          => 'fixed_product',
@@ -1260,8 +1260,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test single fixed product coupon on one item to illustrate type conversion precision bug.',
-					'tax_rate' => array(
+					'desc'                    => 'Test single fixed product coupon on one item to illustrate type conversion precision bug.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -1272,18 +1272,18 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 8.95,
 							'qty'   => 1,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
-							'code'                   => 'test',
-							'discount_type'          => 'fixed_product',
-							'amount'                 => '10',
+							'code'          => 'test',
+							'discount_type' => 'fixed_product',
+							'amount'        => '10',
 						),
 					),
 					'expected_total_discount' => 8.95,
@@ -1291,8 +1291,8 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 			),
 			array(
 				array(
-					'desc' => 'Test multiple coupons with limits of 1.',
-					'tax_rate' => array(
+					'desc'                    => 'Test multiple coupons with limits of 1.',
+					'tax_rate'                => array(
 						'tax_rate_country'  => '',
 						'tax_rate_state'    => '',
 						'tax_rate'          => '20.0000',
@@ -1303,14 +1303,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 						'tax_rate_order'    => '1',
 						'tax_rate_class'    => '',
 					),
-					'prices_include_tax' => false,
-					'cart' => array(
+					'prices_include_tax'      => false,
+					'cart'                    => array(
 						array(
 							'price' => 10,
 							'qty'   => 4,
 						),
 					),
-					'coupons' => array(
+					'coupons'                 => array(
 						array(
 							'code'                   => 'one',
 							'discount_type'          => 'fixed_product',
@@ -1338,12 +1338,14 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 
 	public function test_free_shipping_coupon_no_products() {
 		$discounts = new WC_Discounts();
-		$coupon = WC_Helper_Coupon::create_coupon( 'freeshipping' );
-		$coupon->set_props( array(
-			'discount_type' => 'percent',
-			'amount' => '',
-			'free_shipping' => 'yes',
-		));
+		$coupon    = WC_Helper_Coupon::create_coupon( 'freeshipping' );
+		$coupon->set_props(
+			array(
+				'discount_type' => 'percent',
+				'amount'        => '',
+				'free_shipping' => 'yes',
+			)
+		);
 
 		$discounts->apply_coupon( $coupon );
 
@@ -1373,11 +1375,13 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		WC()->cart->add_to_cart( $product2->get_id(), 1 );
 
 		$coupon = WC_Helper_Coupon::create_coupon( 'test' );
-		$coupon->set_props( array(
-			'code'                   => 'test',
-			'discount_type'          => 'percent',
-			'amount'                 => '20',
-		) );
+		$coupon->set_props(
+			array(
+				'code'          => 'test',
+				'discount_type' => 'percent',
+				'amount'        => '20',
+			)
+		);
 
 		$discounts->set_items_from_cart( WC()->cart );
 		$discounts->apply_coupon( $coupon );
@@ -1410,19 +1414,23 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$product_sale->save();
 
 		$coupon_percent = new WC_Coupon();
-		$coupon_percent->set_props( array(
-			'amount'             => 10,
-			'discount_type'      => 'percent',
-			'exclude_sale_items' => false,
-		) );
+		$coupon_percent->set_props(
+			array(
+				'amount'             => 10,
+				'discount_type'      => 'percent',
+				'exclude_sale_items' => false,
+			)
+		);
 		$coupon_percent->save();
 
 		$coupon_percent_no_sale = new WC_Coupon();
-		$coupon_percent_no_sale->set_props( array(
-			'amount'             => 10,
-			'discount_type'      => 'percent',
-			'exclude_sale_items' => true,
-		) );
+		$coupon_percent_no_sale->set_props(
+			array(
+				'amount'             => 10,
+				'discount_type'      => 'percent',
+				'exclude_sale_items' => true,
+			)
+		);
 		$coupon_percent_no_sale->save();
 
 		WC()->cart->empty_cart();
@@ -1467,19 +1475,23 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$product_sale->save();
 
 		$coupon_cart = new WC_Coupon();
-		$coupon_cart->set_props( array(
-			'amount'             => 5,
-			'discount_type'      => 'fixed_cart',
-			'exclude_sale_items' => false,
-		) );
+		$coupon_cart->set_props(
+			array(
+				'amount'             => 5,
+				'discount_type'      => 'fixed_cart',
+				'exclude_sale_items' => false,
+			)
+		);
 		$coupon_cart->save();
 
 		$coupon_cart_no_sale = new WC_Coupon();
-		$coupon_cart_no_sale->set_props( array(
-			'amount'             => 5,
-			'discount_type'      => 'fixed_cart',
-			'exclude_sale_items' => true,
-		) );
+		$coupon_cart_no_sale->set_props(
+			array(
+				'amount'             => 5,
+				'discount_type'      => 'fixed_cart',
+				'exclude_sale_items' => true,
+			)
+		);
 		$coupon_cart_no_sale->save();
 
 		WC()->cart->empty_cart();
@@ -1518,19 +1530,23 @@ class WC_Tests_Discounts extends WC_Unit_Test_Case {
 		$product_sale->save();
 
 		$coupon_product = new WC_Coupon();
-		$coupon_product->set_props( array(
-			'amount'             => 5,
-			'discount_type'      => 'fixed_product',
-			'exclude_sale_items' => false,
-		) );
+		$coupon_product->set_props(
+			array(
+				'amount'             => 5,
+				'discount_type'      => 'fixed_product',
+				'exclude_sale_items' => false,
+			)
+		);
 		$coupon_product->save();
 
 		$coupon_product_no_sale = new WC_Coupon();
-		$coupon_product_no_sale->set_props( array(
-			'amount'             => 5,
-			'discount_type'      => 'fixed_product',
-			'exclude_sale_items' => true,
-		) );
+		$coupon_product_no_sale->set_props(
+			array(
+				'amount'             => 5,
+				'discount_type'      => 'fixed_product',
+				'exclude_sale_items' => true,
+			)
+		);
 		$coupon_product_no_sale->save();
 
 		WC()->cart->empty_cart();

--- a/tests/unit-tests/gateways/paypal/request.php
+++ b/tests/unit-tests/gateways/paypal/request.php
@@ -213,21 +213,21 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 		$this->assertEquals( '_cart', $query_array['cmd'] );
 
 		$this->check_shipping_tax( $query_array, $shipping_tax_included );
-    }
-    
-    /**
-     * Test removing HTML tags from product title and request URL
-     *
-     * @param  bool $testmode Whether to use Paypal sandbox.
-     */
-    protected function check_product_title_containing_html( $testmode ) {
-        $order = WC_Helper_Order::create_order();
+	}
 
-        foreach ( $order->get_items() as $item ) {
+	/**
+	 * Test removing HTML tags from product title and request URL
+	 *
+	 * @param  bool $testmode Whether to use Paypal sandbox.
+	 */
+	protected function check_product_title_containing_html( $testmode ) {
+		$order = WC_Helper_Order::create_order();
+
+		foreach ( $order->get_items() as $item ) {
 			$order->remove_item( $item->get_id() );
-        }
+		}
 
-        $product = new WC_Product_Simple();
+		$product = new WC_Product_Simple();
 		$product->set_props(
 			array(
 				'name'          => 'New Product <a href="#" style="color: red;">Link</a>',
@@ -235,33 +235,35 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 				'price'         => 10,
 			)
 		);
-        $product->save();
-        $product = wc_get_product( $product->get_id() );
+		$product->save();
+		$product = wc_get_product( $product->get_id() );
 
-        $qty = 1;
-        
-        $item = new WC_Order_Item_Product();
-		$item->set_props( array(
-			'product'  => $product,
-			'quantity' => $qty,
-			'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => $qty ) ),
-			'total'    => wc_get_price_excluding_tax( $product, array( 'qty' => $qty ) ),
-		) );
-        $item->save();
-        
-        $order->add_item( $item );
-        $order->save();
+		$qty = 1;
 
-        $request_url = $this->paypal_request->get_request_url( $order, $testmode );
+		$item = new WC_Order_Item_Product();
+		$item->set_props(
+			array(
+				'product'  => $product,
+				'quantity' => $qty,
+				'subtotal' => wc_get_price_excluding_tax( $product, array( 'qty' => $qty ) ),
+				'total'    => wc_get_price_excluding_tax( $product, array( 'qty' => $qty ) ),
+			)
+		);
+		$item->save();
 
-        $query_string = wp_parse_url( $request_url, PHP_URL_QUERY )
+		$order->add_item( $item );
+		$order->save();
+
+		$request_url = $this->paypal_request->get_request_url( $order, $testmode );
+
+		$query_string = wp_parse_url( $request_url, PHP_URL_QUERY )
 			? wp_parse_url( $request_url, PHP_URL_QUERY )
-            : '';
-        $query_array  = array();
-        parse_str( $query_string, $query_array );
+			: '';
+		$query_array  = array();
+		parse_str( $query_string, $query_array );
 
-        $this->assertEquals( $query_array['item_name_1'], 'New Product Link x ' . $qty );
-    }
+		$this->assertEquals( $query_array['item_name_1'], 'New Product Link x ' . $qty );
+	}
 
 	/**
 	 * Return true if value is < 0, false otherwise.
@@ -395,10 +397,10 @@ class WC_Tests_Paypal_Gateway_Request extends WC_Unit_Test_Case {
 
 			// Test order with URL longer than limit.
 			// Many items in order -> forced to use one line item -> shipping tax included.
-            $this->check_large_order( true, $testmode );
-            
-            // Test removing tags from line item name
-            $this->check_product_title_containing_html( $testmode );
+			$this->check_large_order( true, $testmode );
+
+			// Test removing tags from line item name
+			$this->check_product_title_containing_html( $testmode );
 
 			// Test amount < 0.
 			$this->check_negative_amount( $testmode );

--- a/tests/unit-tests/importer/product.php
+++ b/tests/unit-tests/importer/product.php
@@ -599,7 +599,7 @@ class WC_Tests_Product_CSV_Importer extends WC_Unit_Test_Case {
 	 *
 	 * This function is called by WP_HTTP_TestCase::http_request_listner().
 	 *
-	 * @param array $request Request arguments.
+	 * @param array  $request Request arguments.
 	 * @param string $url URL of the request.
 	 *
 	 * @return array|false mocked response or false to let WP perform a regular request.

--- a/tests/unit-tests/integrations/class-wc-tests-integrations.php
+++ b/tests/unit-tests/integrations/class-wc-tests-integrations.php
@@ -33,7 +33,7 @@ class WC_Tests_Integrations extends WC_Unit_Test_Case {
 		$this->assertEquals( array(), $integrations->integrations );
 		$this->assertEquals( array(), $integrations->get_integrations() );
 
-		require_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'class-dummy-integration.php' );
+		require_once dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'class-dummy-integration.php';
 
 		add_filter( 'woocommerce_integrations', array( $this, 'add_dummy_integration' ) );
 		$integrations = new WC_Integrations();

--- a/tests/unit-tests/libraries/wp-background-process.php
+++ b/tests/unit-tests/libraries/wp-background-process.php
@@ -18,12 +18,14 @@ class WC_Tests_Libraries_Background_Process extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_is_queue_empty() {
-		require_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'class-wc-mock-background-process.php' );
+		require_once dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'class-wc-mock-background-process.php';
 		$queue = new WC_Mock_Background_Process();
 		$this->assertEquals( true, $queue->is_queue_empty() );
-		$queue->push_to_queue( array(
-			'mock_key' => 'mock_value',
-		) );
+		$queue->push_to_queue(
+			array(
+				'mock_key' => 'mock_value',
+			)
+		);
 		$queue->save();
 		$this->assertEquals( false, $queue->is_queue_empty() );
 	}
@@ -34,7 +36,7 @@ class WC_Tests_Libraries_Background_Process extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_schedule_cron_healthcheck() {
-		require_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'class-wc-mock-background-process.php' );
+		require_once dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'class-wc-mock-background-process.php';
 		$queue = new WC_Mock_Background_Process();
 		$this->assertArrayHasKey( 'wp_' . get_current_blog_id() . '_wc_mock_background_process_cron_interval', $queue->schedule_cron_healthcheck( array() ) );
 	}
@@ -42,7 +44,7 @@ class WC_Tests_Libraries_Background_Process extends WC_Unit_Test_Case {
 	 * Test prefix & action against identifier.
 	 */
 	public function test_identifier() {
-		require_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'class-wc-mock-background-process.php' );
+		require_once dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'class-wc-mock-background-process.php';
 		$queue = new WC_Mock_Background_Process();
 		$this->assertEquals( 'wp_' . get_current_blog_id() . '_wc_mock_background_process', $queue->get_identifier() );
 	}
@@ -53,11 +55,13 @@ class WC_Tests_Libraries_Background_Process extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_get_batch() {
-		require_once( dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'class-wc-mock-background-process.php' );
+		require_once dirname( __FILE__ ) . DIRECTORY_SEPARATOR . 'class-wc-mock-background-process.php';
 		$queue = new WC_Mock_Background_Process();
-		$queue->push_to_queue( array(
-			'mock_key' => 'mock_value',
-		) );
+		$queue->push_to_queue(
+			array(
+				'mock_key' => 'mock_value',
+			)
+		);
 		$queue->save();
 		$this->assertNotEmpty( $queue->get_batch() );
 	}

--- a/tests/unit-tests/log/log-handler-email.php
+++ b/tests/unit-tests/log/log-handler-email.php
@@ -23,8 +23,8 @@ class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_handle() {
-		$mailer = tests_retrieve_phpmailer_instance();
-		$time = time();
+		$mailer    = tests_retrieve_phpmailer_instance();
+		$time      = time();
 		$site_name = get_bloginfo( 'name' );
 
 		$handler = new WC_Log_Handler_Email();
@@ -82,8 +82,8 @@ class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_email_subject() {
-		$mailer = tests_retrieve_phpmailer_instance();
-		$time = time();
+		$mailer    = tests_retrieve_phpmailer_instance();
+		$time      = time();
 		$site_name = get_bloginfo( 'name' );
 
 		$handler = new WC_Log_Handler_Email( null, WC_Log_Levels::DEBUG );
@@ -114,10 +114,12 @@ class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
 	public function test_multiple_recipients() {
 		$mailer = tests_retrieve_phpmailer_instance();
 
-		$handler = new WC_Log_Handler_Email( array(
-			'first@test.com',
-			'Second Recipient <second@test.com>',
-		) );
+		$handler = new WC_Log_Handler_Email(
+			array(
+				'first@test.com',
+				'Second Recipient <second@test.com>',
+			)
+		);
 		$handler->handle( time(), 'emergency', '', array() );
 		$handler->send_log_email();
 
@@ -141,7 +143,7 @@ class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
 		$handler->handle( time(), 'emergency', '', array() );
 		$handler->send_log_email();
 
-		$recipient  = $mailer->get_recipient( 'to' );
+		$recipient = $mailer->get_recipient( 'to' );
 		$this->assertEquals( 'user@test.com', $recipient->address );
 		$this->assertEquals( 'User', $recipient->name );
 	}
@@ -200,7 +202,7 @@ class WC_Tests_Log_Handler_Email extends WC_Unit_Test_Case {
 		$mailer = tests_retrieve_phpmailer_instance();
 
 		$handler = new WC_Log_Handler_Email();
-		$time = time();
+		$time    = time();
 		$handler->handle( $time, 'emergency', 'message 1', array() );
 		$handler->send_log_email();
 		$handler->handle( $time, 'emergency', 'message 2', array() );

--- a/tests/unit-tests/log/log-handler-file.php
+++ b/tests/unit-tests/log/log-handler-file.php
@@ -47,10 +47,15 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 	public function test_legacy_format() {
 		$handler = new WC_Log_Handler_File( array( 'threshold' => 'debug' ) );
 
-		$handler->handle( time(), 'info', 'this is a message', array(
-			'source' => 'unit-tests',
-			'_legacy' => true,
-		) );
+		$handler->handle(
+			time(),
+			'info',
+			'this is a message',
+			array(
+				'source'  => 'unit-tests',
+				'_legacy' => true,
+			)
+		);
 
 		$this->assertStringMatchesFormat( '%d-%d-%d @ %d:%d:%d - %s', $this->read_content( 'unit-tests' ) );
 		$this->assertStringEndsWith( ' - this is a message' . PHP_EOL, $this->read_content( 'unit-tests' ) );
@@ -62,7 +67,7 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_clear() {
-		$handler = new WC_Log_Handler_File();
+		$handler  = new WC_Log_Handler_File();
 		$log_name = '_test_clear';
 		$handler->handle( time(), 'debug', 'debug', array( 'source' => $log_name ) );
 		$handler->clear( $log_name );
@@ -75,7 +80,7 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_remove() {
-		$handler = new WC_Log_Handler_File();
+		$handler  = new WC_Log_Handler_File();
 		$log_name = '_test_remove';
 		$handler->handle( time(), 'debug', 'debug', array( 'source' => $log_name ) );
 		$handler->remove( wc_get_log_file_name( $log_name ) );
@@ -89,7 +94,7 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 	 */
 	public function test_writes_file() {
 		$handler = new WC_Log_Handler_File();
-		$time = time();
+		$time    = time();
 
 		$handler->handle( $time, 'debug', 'debug', array() );
 		$handler->handle( $time, 'info', 'info', array() );
@@ -110,8 +115,8 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_log_file_source() {
-		$handler = new WC_Log_Handler_File();
-		$time = time();
+		$handler        = new WC_Log_Handler_File();
+		$time           = time();
 		$context_source = array( 'source' => 'unit-tests' );
 
 		$handler->handle( $time, 'debug', 'debug', $context_source );
@@ -133,9 +138,9 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_multiple_handlers() {
-		$handler_a = new WC_Log_Handler_File();
-		$handler_b = new WC_Log_Handler_File();
-		$time = time();
+		$handler_a      = new WC_Log_Handler_File();
+		$handler_b      = new WC_Log_Handler_File();
+		$time           = time();
 		$context_source = array( 'source' => 'unit-tests' );
 
 		// Different loggers should not conflict.
@@ -162,9 +167,9 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 	public function test_log_rotate() {
 
 		// Handler with log size limit of 5mb
-		$handler = new WC_Log_Handler_File( 5 * 1024 * 1024 );
-		$time = time();
-		$log_name = '_test_log_rotate';
+		$handler       = new WC_Log_Handler_File( 5 * 1024 * 1024 );
+		$time          = time();
+		$log_name      = '_test_log_rotate';
 		$base_log_file = WC_Log_Handler_File::get_log_file_path( $log_name );
 
 		// Create log file larger than 5mb to ensure log is rotated
@@ -199,9 +204,9 @@ class WC_Tests_Log_Handler_File extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_get_log_file_path() {
-		$log_dir   = trailingslashit( WC_LOG_DIR );
+		$log_dir     = trailingslashit( WC_LOG_DIR );
 		$date_suffix = date( 'Y-m-d', current_time( 'timestamp', true ) );
-		$hash_name = sanitize_file_name( wp_hash( 'unit-tests' ) );
+		$hash_name   = sanitize_file_name( wp_hash( 'unit-tests' ) );
 		$this->assertEquals( $log_dir . 'unit-tests-' . $date_suffix . '-' . $hash_name . '.log', WC_Log_Handler_File::get_log_file_path( 'unit-tests' ) );
 	}
 

--- a/tests/unit-tests/log/log-levels.php
+++ b/tests/unit-tests/log/log-levels.php
@@ -13,7 +13,7 @@ class WC_Tests_Log_Levels extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	public function test_get_level_severity() {
-		$this->assertEquals( 0,   WC_Log_Levels::get_level_severity( 'unrecognized level' ) );
+		$this->assertEquals( 0, WC_Log_Levels::get_level_severity( 'unrecognized level' ) );
 		$this->assertEquals( 100, WC_Log_Levels::get_level_severity( 'debug' ) );
 		$this->assertEquals( 200, WC_Log_Levels::get_level_severity( 'info' ) );
 		$this->assertEquals( 300, WC_Log_Levels::get_level_severity( 'notice' ) );

--- a/tests/unit-tests/log/logger.php
+++ b/tests/unit-tests/log/logger.php
@@ -13,7 +13,7 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 	 * @since 2.4
 	 */
 	public function test_add() {
-		$time = time();
+		$time    = time();
 		$handler = $this
 			->getMockBuilder( 'WC_Log_Handler_Interface' )
 			->setMethods( array( 'handle' ) )
@@ -25,10 +25,12 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 				$this->greaterThanOrEqual( $time ),
 				$this->equalTo( 'notice' ),
 				$this->equalTo( 'this is a message' ),
-				$this->equalTo( array(
-					'source' => 'unit-tests',
-					'_legacy' => true,
-				) )
+				$this->equalTo(
+					array(
+						'source'  => 'unit-tests',
+						'_legacy' => true,
+					)
+				)
 			);
 		$log = new WC_Logger( array( $handler ), 'debug' );
 
@@ -66,7 +68,7 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 	 */
 	public function test_log() {
 		$handler = $this->create_mock_handler();
-		$log = new WC_Logger( array( $handler ), 'debug' );
+		$log     = new WC_Logger( array( $handler ), 'debug' );
 		$log->log( 'debug', 'debug message' );
 		$log->log( 'info', 'info message' );
 		$log->log( 'notice', 'notice message' );
@@ -120,7 +122,7 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 	 */
 	public function test_level_methods() {
 		$handler = $this->create_mock_handler();
-		$log = new WC_Logger( array( $handler ), 'debug' );
+		$log     = new WC_Logger( array( $handler ), 'debug' );
 		$log->debug( 'debug message' );
 		$log->info( 'info message' );
 		$log->notice( 'notice message' );
@@ -242,7 +244,7 @@ class WC_Tests_Logger extends WC_Unit_Test_Case {
 	 * @return WC_Log_Handler mock object
 	 */
 	public function create_mock_handler() {
-		$time = time();
+		$time    = time();
 		$handler = $this
 			->getMockBuilder( 'WC_Log_Handler_Interface' )
 			->setMethods( array( 'handle' ) )

--- a/tests/unit-tests/order-items/class-wc-tests-order-item-product.php
+++ b/tests/unit-tests/order-items/class-wc-tests-order-item-product.php
@@ -146,10 +146,12 @@ class WC_Tests_Order_Item_Product extends WC_Unit_Test_Case {
 		$variation_product = new WC_Product_Variation();
 		$variation_product->set_name( 'Test Variation' );
 		$variation_product->set_parent_id( $parent_product->get_id() );
-		$variation_product->set_attributes( array(
-			'color' => 'Green',
-			'size'  => 'Large',
-		) );
+		$variation_product->set_attributes(
+			array(
+				'color' => 'Green',
+				'size'  => 'Large',
+			)
+		);
 		$variation_product->save();
 
 		$product_item = new WC_Order_Item_Product();
@@ -158,7 +160,7 @@ class WC_Tests_Order_Item_Product extends WC_Unit_Test_Case {
 		$product_item->save();
 
 		// Test with show_all on.
-		$formatted = $product_item->get_formatted_meta_data( '_', true );
+		$formatted          = $product_item->get_formatted_meta_data( '_', true );
 		$formatted_as_array = array();
 		foreach ( $formatted as $f ) {
 			$formatted_as_array[] = (array) $f;
@@ -188,7 +190,7 @@ class WC_Tests_Order_Item_Product extends WC_Unit_Test_Case {
 		);
 
 		// Test with show_all off.
-		$formatted = $product_item->get_formatted_meta_data( '_', false );
+		$formatted          = $product_item->get_formatted_meta_data( '_', false );
 		$formatted_as_array = array();
 		foreach ( $formatted as $f ) {
 			$formatted_as_array[] = (array) $f;
@@ -267,7 +269,7 @@ class WC_Tests_Order_Item_Product extends WC_Unit_Test_Case {
 		$this->assertTrue( isset( $item['item_meta_array'] ) );
 		$item['item_meta_array'] = array(
 			0 => (object) array(
-				'key' => 'test',
+				'key'   => 'test',
 				'value' => 'val',
 			),
 		);

--- a/tests/unit-tests/order-items/functions.php
+++ b/tests/unit-tests/order-items/functions.php
@@ -22,10 +22,12 @@ class WC_Tests_Order_Item_Functions extends WC_Unit_Test_Case {
 
 		$order  = new WC_Order();
 		$item_1 = new WC_Order_Item_Product();
-		$item_1->set_props( array(
-			'product'  => WC_Helper_Product::create_simple_product(),
-			'quantity' => 4,
-		) );
+		$item_1->set_props(
+			array(
+				'product'  => WC_Helper_Product::create_simple_product(),
+				'quantity' => 4,
+			)
+		);
 		$order->add_item( $item_1 );
 		$order->save();
 

--- a/tests/unit-tests/order-items/order-item-coupon.php
+++ b/tests/unit-tests/order-items/order-item-coupon.php
@@ -13,7 +13,7 @@ class WC_Tests_Order_Item_Coupon extends WC_Unit_Test_Case {
 	 * @since 3.2.0
 	 */
 	public function test_setters_getters() {
-		$coupon = new WC_Order_Item_Coupon;
+		$coupon = new WC_Order_Item_Coupon();
 
 		$coupon->set_name( 'testcoupon' );
 		$this->assertTrue( 'testcoupon' === $coupon->get_name() && $coupon->get_name() === $coupon->get_code() );

--- a/tests/unit-tests/order-items/order-item-tax.php
+++ b/tests/unit-tests/order-items/order-item-tax.php
@@ -14,17 +14,17 @@ class WC_Tests_Order_Item_Tax extends WC_Unit_Test_Case {
 	 */
 	function test_set_get_tax_totals() {
 
-		$item = new WC_Order_Item_Tax;
+		$item = new WC_Order_Item_Tax();
 		$this->assertEquals( 0, $item->get_tax_total() );
 
-		$item->set_tax_total( "1.50" );
-		$this->assertEquals( "1.50", $item->get_tax_total() );
+		$item->set_tax_total( '1.50' );
+		$this->assertEquals( '1.50', $item->get_tax_total() );
 
-		$item->set_tax_total( "" );
+		$item->set_tax_total( '' );
 		$this->assertEquals( 0, $item->get_tax_total() );
 
 		$item->set_tax_total( 10.99 );
-		$this->assertEquals( "10.99", $item->get_tax_total() );
+		$this->assertEquals( '10.99', $item->get_tax_total() );
 	}
 
 	/**
@@ -34,16 +34,16 @@ class WC_Tests_Order_Item_Tax extends WC_Unit_Test_Case {
 	 */
 	function test_set_get_shipping_tax_totals() {
 
-		$item = new WC_Order_Item_Tax;
+		$item = new WC_Order_Item_Tax();
 		$this->assertEquals( 0, $item->get_shipping_tax_total() );
 
-		$item->set_shipping_tax_total( "1.50" );
-		$this->assertEquals( "1.50", $item->get_shipping_tax_total() );
+		$item->set_shipping_tax_total( '1.50' );
+		$this->assertEquals( '1.50', $item->get_shipping_tax_total() );
 
-		$item->set_shipping_tax_total( "" );
+		$item->set_shipping_tax_total( '' );
 		$this->assertEquals( 0, $item->get_shipping_tax_total() );
 
 		$item->set_shipping_tax_total( 10.99 );
-		$this->assertEquals( "10.99", $item->get_shipping_tax_total() );
+		$this->assertEquals( '10.99', $item->get_shipping_tax_total() );
 	}
 }

--- a/tests/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/unit-tests/order/class-wc-tests-order-functions.php
@@ -21,7 +21,8 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	public function test_wc_get_order_statuses() {
 
 		$order_statuses = apply_filters(
-			'wc_order_statuses', array(
+			'wc_order_statuses',
+			array(
 				'wc-pending'    => _x( 'Pending payment', 'Order status', 'woocommerce' ),
 				'wc-processing' => _x( 'Processing', 'Order status', 'woocommerce' ),
 				'wc-on-hold'    => _x( 'On hold', 'Order status', 'woocommerce' ),

--- a/tests/unit-tests/order/coupons.php
+++ b/tests/unit-tests/order/coupons.php
@@ -39,12 +39,14 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$coupon2->set_discount_type( 'percent' );
 		$coupon2->save();
 
-		$order = wc_create_order( array(
-			'status'        => 'pending',
-			'customer_id'   => 1,
-			'customer_note' => '',
-			'total'         => '',
-		) );
+		$order = wc_create_order(
+			array(
+				'status'        => 'pending',
+				'customer_id'   => 1,
+				'customer_note' => '',
+				'total'         => '',
+			)
+		);
 
 		// Add order products
 		$product_item  = new WC_Order_Item_Product();
@@ -52,39 +54,51 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$coupon_item_2 = new WC_Order_Item_Coupon();
 
 		if ( get_option( 'woocommerce_prices_include_tax', 'no' ) === 'yes' && get_option( 'woocommerce_calc_taxes', 'no' ) === 'yes' ) {
-			$product_item->set_props( array(
-				'product'  => $product,
-				'quantity' => 1,
-				'subtotal' => 909.09, // Ex tax.
-				'total'    => 726.36,
-			) );
-			$coupon_item_1->set_props( array(
-				'code'         => 'test-coupon-1',
-				'discount'     => 0.91,
-				'discount_tax' => 0.09,
-			) );
-			$coupon_item_2->set_props( array(
-				'code'         => 'this-is-a-virtal-coupon',
-				'discount'     => 181.82,
-				'discount_tax' => 18.18,
-			) );
+			$product_item->set_props(
+				array(
+					'product'  => $product,
+					'quantity' => 1,
+					'subtotal' => 909.09, // Ex tax.
+					'total'    => 726.36,
+				)
+			);
+			$coupon_item_1->set_props(
+				array(
+					'code'         => 'test-coupon-1',
+					'discount'     => 0.91,
+					'discount_tax' => 0.09,
+				)
+			);
+			$coupon_item_2->set_props(
+				array(
+					'code'         => 'this-is-a-virtal-coupon',
+					'discount'     => 181.82,
+					'discount_tax' => 18.18,
+				)
+			);
 		} else {
-			$product_item->set_props( array(
-				'product'  => $product,
-				'quantity' => 1,
-				'subtotal' => 1000, // Ex tax.
-				'total'    => 799,
-			) );
-			$coupon_item_1->set_props( array(
-				'code'         => 'test-coupon-1',
-				'discount'     => 1,
-				'discount_tax' => get_option( 'woocommerce_calc_taxes', 'no' ) === 'yes' ? 0.1 : 0,
-			) );
-			$coupon_item_2->set_props( array(
-				'code'         => 'this-is-a-virtal-coupon',
-				'discount'     => 200,
-				'discount_tax' => get_option( 'woocommerce_calc_taxes', 'no' ) === 'yes' ? 20 : 0,
-			) );
+			$product_item->set_props(
+				array(
+					'product'  => $product,
+					'quantity' => 1,
+					'subtotal' => 1000, // Ex tax.
+					'total'    => 799,
+				)
+			);
+			$coupon_item_1->set_props(
+				array(
+					'code'         => 'test-coupon-1',
+					'discount'     => 1,
+					'discount_tax' => get_option( 'woocommerce_calc_taxes', 'no' ) === 'yes' ? 0.1 : 0,
+				)
+			);
+			$coupon_item_2->set_props(
+				array(
+					'code'         => 'this-is-a-virtal-coupon',
+					'discount'     => 200,
+					'discount_tax' => get_option( 'woocommerce_calc_taxes', 'no' ) === 'yes' ? 20 : 0,
+				)
+			);
 		}
 
 		$product_item->save();
@@ -99,17 +113,19 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$this->objects['coupons'][]      = $coupon2;
 		$this->objects['products'][]     = $product;
 		$this->objects['order']          = $order;
-		$this->objects['tax_rate_ids'][] = WC_Tax::_insert_tax_rate( array(
-			'tax_rate_country'  => '',
-			'tax_rate_state'    => '',
-			'tax_rate'          => '10.0000',
-			'tax_rate_name'     => 'VAT',
-			'tax_rate_priority' => '1',
-			'tax_rate_compound' => '0',
-			'tax_rate_shipping' => '1',
-			'tax_rate_order'    => '1',
-			'tax_rate_class'    => '',
-		) );
+		$this->objects['tax_rate_ids'][] = WC_Tax::_insert_tax_rate(
+			array(
+				'tax_rate_country'  => '',
+				'tax_rate_state'    => '',
+				'tax_rate'          => '10.0000',
+				'tax_rate_name'     => 'VAT',
+				'tax_rate_priority' => '1',
+				'tax_rate_compound' => '0',
+				'tax_rate_shipping' => '1',
+				'tax_rate_order'    => '1',
+				'tax_rate_class'    => '',
+			)
+		);
 
 		$order->calculate_totals( true );
 		$order->save();

--- a/tests/unit-tests/order/query.php
+++ b/tests/unit-tests/order/query.php
@@ -34,7 +34,7 @@ class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 		$order2->save();
 
 		// Just get some orders.
-		$query = new WC_Order_Query();
+		$query   = new WC_Order_Query();
 		$results = $query->get_orders();
 		$this->assertEquals( 2, count( $results ) );
 
@@ -67,45 +67,53 @@ class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_order_query_date_queries() {
-		$now = current_time( 'mysql', true );
-		$now_stamp = strtotime( $now );
-		$now_date = date( 'Y-m-d', $now_stamp );
-		$past_stamp = $now_stamp - DAY_IN_SECONDS;
-		$past = date( 'Y-m-d', $past_stamp );
+		$now          = current_time( 'mysql', true );
+		$now_stamp    = strtotime( $now );
+		$now_date     = date( 'Y-m-d', $now_stamp );
+		$past_stamp   = $now_stamp - DAY_IN_SECONDS;
+		$past         = date( 'Y-m-d', $past_stamp );
 		$future_stamp = $now_stamp + DAY_IN_SECONDS;
-		$future = date( 'Y-m-d', $future_stamp );
+		$future       = date( 'Y-m-d', $future_stamp );
 
 		$order = new WC_Order();
 		$order->set_date_completed( $now_stamp );
 		$order->save();
 
 		// Check WC_DateTime support.
-		$query = new WC_Order_Query( array(
-			'date_created' => $order->get_date_created(),
-		) );
+		$query  = new WC_Order_Query(
+			array(
+				'date_created' => $order->get_date_created(),
+			)
+		);
 		$orders = $query->get_orders();
 		$this->assertEquals( 1, count( $orders ) );
 
 		// Check date support.
-		$query = new WC_Order_Query( array(
-			'date_created' => $now_date,
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_created' => $now_date,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_created', $past );
 		$this->assertEquals( 0, count( $query->get_orders() ) );
 
 		// Check timestamp support.
-		$query = new WC_Order_Query( array(
-			'date_created' => $order->get_date_created()->getTimestamp(),
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_created' => $order->get_date_created()->getTimestamp(),
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_created', $future_stamp );
 		$this->assertEquals( 0, count( $query->get_orders() ) );
 
 		// Check comparison support.
-		$query = new WC_Order_Query( array(
-			'date_created' => '>' . $past,
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_created' => '>' . $past,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_created', '<' . $past );
 		$this->assertEquals( 0, count( $query->get_orders() ) );
@@ -113,18 +121,22 @@ class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 
 		// Check timestamp comparison support.
-		$query = new WC_Order_Query( array(
-			'date_created' => '<' . $future_stamp,
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_created' => '<' . $future_stamp,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_created', '<' . $past_stamp );
 		$this->assertEquals( 0, count( $query->get_orders() ) );
 		$query->set( 'date_created', '>=' . $now_stamp );
 
 		// Check date range support.
-		$query = new WC_Order_Query( array(
-			'date_created' => $past . '...' . $future,
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_created' => $past . '...' . $future,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_created', $past . '...' . $now_date );
 		$this->assertEquals( 1, count( $query->get_orders() ) );
@@ -132,9 +144,11 @@ class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 		$this->assertEquals( 0, count( $query->get_orders() ) );
 
 		// Check timestamp range support.
-		$query = new WC_Order_Query( array(
-			'date_created' => $past_stamp . '...' . $future_stamp,
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_created' => $past_stamp . '...' . $future_stamp,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_created', $now_stamp . '...' . $future_stamp );
 		$this->assertEquals( 1, count( $query->get_orders() ) );
@@ -148,45 +162,53 @@ class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_order_query_meta_date_queries() {
-		$now = current_time( 'mysql', true );
-		$now_stamp = strtotime( $now );
-		$now_date = date( 'Y-m-d', $now_stamp );
-		$past_stamp = $now_stamp - DAY_IN_SECONDS;
-		$past = date( 'Y-m-d', $past_stamp );
+		$now          = current_time( 'mysql', true );
+		$now_stamp    = strtotime( $now );
+		$now_date     = date( 'Y-m-d', $now_stamp );
+		$past_stamp   = $now_stamp - DAY_IN_SECONDS;
+		$past         = date( 'Y-m-d', $past_stamp );
 		$future_stamp = $now_stamp + DAY_IN_SECONDS;
-		$future = date( 'Y-m-d', $future_stamp );
+		$future       = date( 'Y-m-d', $future_stamp );
 
 		$order = new WC_Order();
 		$order->set_date_completed( $now_stamp );
 		$order->save();
 
 		// Check WC_DateTime support.
-		$query = new WC_Order_Query( array(
-			'date_completed' => $order->get_date_completed(),
-		) );
+		$query  = new WC_Order_Query(
+			array(
+				'date_completed' => $order->get_date_completed(),
+			)
+		);
 		$orders = $query->get_orders();
 		$this->assertEquals( 1, count( $orders ) );
 
 		// Check date support.
-		$query = new WC_Order_Query( array(
-			'date_completed' => $now_date,
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_completed' => $now_date,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_completed', $past );
 		$this->assertEquals( 0, count( $query->get_orders() ) );
 
 		// Check timestamp support.
-		$query = new WC_Order_Query( array(
-			'date_completed' => $order->get_date_completed()->getTimestamp(),
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_completed' => $order->get_date_completed()->getTimestamp(),
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_completed', $future_stamp );
 		$this->assertEquals( 0, count( $query->get_orders() ) );
 
 		// Check comparison support.
-		$query = new WC_Order_Query( array(
-			'date_completed' => '>' . $past,
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_completed' => '>' . $past,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_completed', '<' . $past );
 		$this->assertEquals( 0, count( $query->get_orders() ) );
@@ -194,18 +216,22 @@ class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 
 		// Check timestamp comparison support.
-		$query = new WC_Order_Query( array(
-			'date_completed' => '<' . $future_stamp,
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_completed' => '<' . $future_stamp,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_completed', '<' . $past_stamp );
 		$this->assertEquals( 0, count( $query->get_orders() ) );
 		$query->set( 'date_completed', '>=' . $now_stamp );
 
 		// Check date range support.
-		$query = new WC_Order_Query( array(
-			'date_completed' => $past . '...' . $future,
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_completed' => $past . '...' . $future,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_completed', $now_date . '...' . $future );
 		$this->assertEquals( 1, count( $query->get_orders() ) );
@@ -213,9 +239,11 @@ class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 		$this->assertEquals( 0, count( $query->get_orders() ) );
 
 		// Check timestamp range support.
-		$query = new WC_Order_Query( array(
-			'date_completed' => $past_stamp . '...' . $future_stamp,
-		) );
+		$query = new WC_Order_Query(
+			array(
+				'date_completed' => $past_stamp . '...' . $future_stamp,
+			)
+		);
 		$this->assertEquals( 1, count( $query->get_orders() ) );
 		$query->set( 'date_completed', $now_stamp . '...' . $future_stamp );
 		$this->assertEquals( 1, count( $query->get_orders() ) );
@@ -229,19 +257,23 @@ class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 	 * @since 3.1
 	 */
 	public function test_order_query_key_mapping() {
-		$user_id = wp_insert_user( array(
-			'user_login' => 'testname',
-			'user_pass' => 'testpass',
-			'user_email' => 'email@testmail.com',
-		) );
+		$user_id = wp_insert_user(
+			array(
+				'user_login' => 'testname',
+				'user_pass'  => 'testpass',
+				'user_email' => 'email@testmail.com',
+			)
+		);
 
 		$order = new WC_Order();
 		$order->set_customer_id( $user_id );
 		$order->save();
 
-		$query = new WC_Order_Query( array(
-			'customer_id' => $user_id,
-		) );
+		$query   = new WC_Order_Query(
+			array(
+				'customer_id' => $user_id,
+			)
+		);
 		$results = $query->get_orders();
 
 		$this->assertEquals( 1, count( $results ) );
@@ -249,18 +281,22 @@ class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 
 	public function test_order_query_search_by_customers() {
 		$user_email_1 = 'email@testmail.com';
-		$user_id_1    = wp_insert_user( array(
-			'user_login' => 'testname',
-			'user_pass'  => 'testpass',
-			'user_email' => $user_email_1,
-		) );
+		$user_id_1    = wp_insert_user(
+			array(
+				'user_login' => 'testname',
+				'user_pass'  => 'testpass',
+				'user_email' => $user_email_1,
+			)
+		);
 
 		$user_email_2 = 'email2@testmail.com';
-		$user_id_2    = wp_insert_user( array(
-			'user_login' => 'testname2',
-			'user_pass'  => 'testpass2',
-			'user_email' => $user_email_2,
-		) );
+		$user_id_2    = wp_insert_user(
+			array(
+				'user_login' => 'testname2',
+				'user_pass'  => 'testpass2',
+				'user_email' => $user_email_2,
+			)
+		);
 
 		$order1 = new WC_Order();
 		$order1->set_customer_id( $user_id_1 );
@@ -275,30 +311,38 @@ class WC_Tests_WC_Order_Query extends WC_Unit_Test_Case {
 		$order3->save();
 
 		// Searching for both users IDs should return all orders.
-		$query   = new WC_Order_Query( array(
-			'customer' => array( $user_id_1, $user_id_2 ),
-		) );
+		$query   = new WC_Order_Query(
+			array(
+				'customer' => array( $user_id_1, $user_id_2 ),
+			)
+		);
 		$results = $query->get_orders();
 		$this->assertEquals( 3, count( $results ) );
 
 		// Searching for user 1 email and user 2 ID should return all orders.
-		$query   = new WC_Order_Query( array(
-			'customer' => array( $user_email_1, $user_id_2 ),
-		) );
+		$query   = new WC_Order_Query(
+			array(
+				'customer' => array( $user_email_1, $user_id_2 ),
+			)
+		);
 		$results = $query->get_orders();
 		$this->assertEquals( 3, count( $results ) );
 
 		// Searching for orders that match the first user email AND ID should return only a single order
-		$query   = new WC_Order_Query( array(
-			'customer' => array( array( $user_email_1, $user_id_1 ) ),
-		) );
+		$query   = new WC_Order_Query(
+			array(
+				'customer' => array( array( $user_email_1, $user_id_1 ) ),
+			)
+		);
 		$results = $query->get_orders();
 		$this->assertEquals( 1, count( $results ) );
 
 		// Searching for orders that match the first user email AND the second user ID should return no orders.
-		$query   = new WC_Order_Query( array(
-			'customer' => array( array( $user_email_1, $user_id_2 ) ),
-		) );
+		$query   = new WC_Order_Query(
+			array(
+				'customer' => array( array( $user_email_1, $user_id_2 ) ),
+			)
+		);
 		$results = $query->get_orders();
 		$this->assertEquals( 0, count( $results ) );
 	}

--- a/tests/unit-tests/payment-tokens/cc.php
+++ b/tests/unit-tests/payment-tokens/cc.php
@@ -90,8 +90,8 @@ class WC_Tests_Payment_Token_CC extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_payment_token_cc_read_pulls_meta() {
-		$token = WC_Helper_Payment_Token::create_cc_token();
-		$token_id = $token->get_id();
+		$token      = WC_Helper_Payment_Token::create_cc_token();
+		$token_id   = $token->get_id();
 		$token_read = new WC_Payment_Token_CC( $token_id );
 		$this->assertEquals( '1234', $token_read->get_last4() );
 	}

--- a/tests/unit-tests/payment-tokens/echeck.php
+++ b/tests/unit-tests/payment-tokens/echeck.php
@@ -33,7 +33,7 @@ class WC_Tests_Payment_Token_eCheck extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_payment_token_echeck_read_pulls_meta() {
-		$token = WC_Helper_Payment_Token::create_eCheck_token();
+		$token    = WC_Helper_Payment_Token::create_eCheck_token();
 		$token_id = $token->get_id();
 
 		$token_read = new WC_Payment_Token_ECheck( $token_id );

--- a/tests/unit-tests/payment-tokens/payment-token.php
+++ b/tests/unit-tests/payment-tokens/payment-token.php
@@ -20,7 +20,7 @@ class WC_Tests_Payment_Token extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_payment_token_token() {
 		$raw_token = time() . ' ' . __FUNCTION__;
-		$token = new WC_Payment_Token_Stub();
+		$token     = new WC_Payment_Token_Stub();
 		$token->set_token( $raw_token );
 		$this->assertEquals( $raw_token, $token->get_token() );
 	}
@@ -73,7 +73,7 @@ class WC_Tests_Payment_Token extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_payment_token_get_data() {
 		$raw_token = time() . ' ' . __FUNCTION__;
-		$token = new WC_Payment_Token_Stub();
+		$token     = new WC_Payment_Token_Stub();
 		$token->set_token( $raw_token );
 		$token->set_gateway_id( 'paypal' );
 		$token->set_extra( 'woocommerce' );
@@ -105,7 +105,7 @@ class WC_Tests_Payment_Token extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_payment_token_read() {
-		$token = WC_Helper_Payment_Token::create_stub_token( __FUNCTION__ );
+		$token    = WC_Helper_Payment_Token::create_stub_token( __FUNCTION__ );
 		$token_id = $token->get_id();
 
 		$token_read = new WC_Payment_Token_Stub( $token_id );
@@ -150,7 +150,7 @@ class WC_Tests_Payment_Token extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	public function test_wc_payment_token_delete() {
-		$token = WC_Helper_Payment_Token::create_stub_token( __FUNCTION__ );
+		$token    = WC_Helper_Payment_Token::create_stub_token( __FUNCTION__ );
 		$token_id = $token->get_id();
 		$token->delete();
 		$get_token = WC_Payment_Tokens::get( $token_id );
@@ -176,7 +176,7 @@ class WC_Tests_Payment_Token extends WC_Unit_Test_Case {
 	 * @expectedDeprecated WC_Payment_Token::update
 	 */
 	public function test_wc_payment_token_legacy() {
-		$token = WC_Helper_Payment_Token::create_stub_token( __FUNCTION__ );
+		$token    = WC_Helper_Payment_Token::create_stub_token( __FUNCTION__ );
 		$token_id = $token->get_id();
 
 		$token_read = new WC_Payment_Token_Stub();

--- a/tests/unit-tests/payment-tokens/payment-tokens.php
+++ b/tests/unit-tests/payment-tokens/payment-tokens.php
@@ -119,8 +119,8 @@ class WC_Tests_Payment_Tokens extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	function test_wc_payment_tokens_get() {
-		$token = WC_Helper_Payment_Token::create_cc_token();
-		$token_id = $token->get_id();
+		$token     = WC_Helper_Payment_Token::create_cc_token();
+		$token_id  = $token->get_id();
 		$get_token = WC_Payment_Tokens::get( $token_id );
 		$this->assertEquals( $token->get_token(), $get_token->get_token() );
 	}
@@ -130,7 +130,7 @@ class WC_Tests_Payment_Tokens extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	function test_wc_payment_tokens_delete() {
-		$token = WC_Helper_Payment_Token::create_cc_token();
+		$token    = WC_Helper_Payment_Token::create_cc_token();
 		$token_id = $token->get_id();
 
 		WC_Payment_Tokens::delete( $token_id );
@@ -144,7 +144,7 @@ class WC_Tests_Payment_Tokens extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	function test_wc_payment_tokens_get_type_by_id() {
-		$token = WC_Helper_Payment_Token::create_cc_token();
+		$token    = WC_Helper_Payment_Token::create_cc_token();
 		$token_id = $token->get_id();
 		$this->assertEquals( 'CC', WC_Payment_Tokens::get_token_type_by_id( $token_id ) );
 	}
@@ -154,11 +154,11 @@ class WC_Tests_Payment_Tokens extends WC_Unit_Test_Case {
 	 * @since 2.6.0
 	 */
 	function test_wc_payment_tokens_set_users_default() {
-		$token = WC_Helper_Payment_Token::create_cc_token( $this->user_id );
+		$token    = WC_Helper_Payment_Token::create_cc_token( $this->user_id );
 		$token_id = $token->get_id();
 		$token->save();
 
-		$token2 = WC_Helper_Payment_Token::create_cc_token( $this->user_id );
+		$token2     = WC_Helper_Payment_Token::create_cc_token( $this->user_id );
 		$token_id_2 = $token2->get_id();
 		$token2->save();
 

--- a/tests/unit-tests/product/data.php
+++ b/tests/unit-tests/product/data.php
@@ -273,7 +273,7 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 	 * Test: test_get_image_should_return_product_image.
 	 */
 	public function test_get_image_should_return_product_image() {
-		$product = new WC_Product();
+		$product   = new WC_Product();
 		$image_url = $this->set_product_image( $product );
 
 		$this->assertEquals(
@@ -297,9 +297,9 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 	 */
 	public function test_get_image_should_return_parent_product_image() {
 		$variable_product = WC_Helper_Product::create_variation_product();
-		$variations = $variable_product->get_children();
-		$variation_1 = wc_get_product( $variations[0] );
-		$image_url = $this->set_product_image( $variable_product );
+		$variations       = $variable_product->get_children();
+		$variation_1      = wc_get_product( $variations[0] );
+		$image_url        = $this->set_product_image( $variable_product );
 
 		$this->assertEquals(
 			'<img width="186" height="144" src="' . $image_url . '" class="attachment-woocommerce_thumbnail size-woocommerce_thumbnail" alt="" />',

--- a/tests/unit-tests/product/factory.php
+++ b/tests/unit-tests/product/factory.php
@@ -12,9 +12,9 @@ class WC_Tests_Product_Factory extends WC_Unit_Test_Case {
 	 * @since 3.0.0
 	 */
 	function test_get_product_type() {
-		$simple = WC_Helper_Product::create_simple_product();
+		$simple   = WC_Helper_Product::create_simple_product();
 		$external = WC_Helper_Product::create_external_product();
-		$grouped = WC_Helper_Product::create_grouped_product();
+		$grouped  = WC_Helper_Product::create_grouped_product();
 		$variable = WC_Helper_Product::create_variation_product();
 		$children = $variable->get_children();
 		$child_id = $children[0];
@@ -51,7 +51,7 @@ class WC_Tests_Product_Factory extends WC_Unit_Test_Case {
 	 */
 	function test_get_product() {
 		$test_product = WC_Helper_Product::create_simple_product();
- 		$get_product  = WC()->product_factory->get_product( $test_product->get_id() );
+		$get_product  = WC()->product_factory->get_product( $test_product->get_id() );
 		$this->assertEquals( $test_product->get_data(), $get_product->get_data() );
 	}
 

--- a/tests/unit-tests/product/product-variation.php
+++ b/tests/unit-tests/product/product-variation.php
@@ -19,11 +19,11 @@ class WC_Tests_Product_Variation extends WC_Unit_Test_Case {
 	 */
 	public function test_is_sold_individually() {
 		// Create a variable product with sold individually.
-		$product = new WC_Product_Variable;
+		$product = new WC_Product_Variable();
 		$product->set_sold_individually( true );
 		$product->save();
 
-		$variation = new WC_Product_Variation;
+		$variation = new WC_Product_Variation();
 		$variation->set_parent_id( $product->get_id() );
 		$variation->save();
 
@@ -35,11 +35,11 @@ class WC_Tests_Product_Variation extends WC_Unit_Test_Case {
 	 * Check get_tax_class against different parent child scenarios
 	 */
 	public function test_get_tax_class() {
-		$product = new WC_Product_Variable;
+		$product = new WC_Product_Variable();
 		$product->set_tax_class( 'standard' );
 		$product->save();
 
-		$variation = new WC_Product_Variation;
+		$variation = new WC_Product_Variation();
 		$variation->set_parent_id( $product->get_id() );
 		$variation->set_tax_class( 'parent' );
 		$variation->save();

--- a/tests/unit-tests/session/class-wc-tests-session-handler.php
+++ b/tests/unit-tests/session/class-wc-tests-session-handler.php
@@ -62,7 +62,7 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 
 	public function test_get_session_should_return_default_value() {
 		$default_session = array( 'session' => 'default' );
-		$session = $this->handler->get_session( 'non-existent key', $default_session );
+		$session         = $this->handler->get_session( 'non-existent key', $default_session );
 		$this->assertEquals( $default_session, $session );
 	}
 
@@ -106,7 +106,7 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 		wp_set_current_user( 1 );
 		$this->handler->set( 'cart', 'fake cart' );
 		$this->handler->save_data();
-		$this->session_key = $this->handler->get_customer_id();
+		$this->session_key  = $this->handler->get_customer_id();
 		$this->cache_prefix = WC_Cache_Helper::get_cache_prefix( WC_SESSION_CACHE_GROUP );
 	}
 

--- a/tests/unit-tests/settings/register-wp-admin-settings.php
+++ b/tests/unit-tests/settings/register-wp-admin-settings.php
@@ -67,7 +67,7 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 				'label' => $this->page->get_label(),
 			),
 		);
-		$actual = $settings->register_page_group( $initial );
+		$actual   = $settings->register_page_group( $initial );
 
 		$this->assertEquals( $expected, $actual );
 	}
@@ -109,11 +109,11 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 			// Boolean 'desc_tip' defaulting to 'desc' value
 			array(
 				array(
-					'id'        => 'setting-id',
-					'type'      => 'select',
-					'title'     => 'Setting Name',
-					'desc'      => 'Setting Description',
-					'desc_tip'  => true,
+					'id'         => 'setting-id',
+					'type'       => 'select',
+					'title'      => 'Setting Name',
+					'desc'       => 'Setting Description',
+					'desc_tip'   => true,
 					'option_key' => '',
 				),
 				array(
@@ -211,18 +211,18 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 
 		$settings = array(
 			array(
-				'id'          => 'setting-1',
-				'type'        => 'text',
-				'option_key'  => '',
+				'id'         => 'setting-1',
+				'type'       => 'text',
+				'option_key' => '',
 			),
 			array(
-				'type'        => 'no-id',
-				'option_key'  => '',
+				'type'       => 'no-id',
+				'option_key' => '',
 			),
 			array(
-				'id'          => 'setting-2',
-				'type'        => 'textarea',
-				'option_key'  => '',
+				'id'         => 'setting-2',
+				'type'       => 'textarea',
+				'option_key' => '',
 			),
 		);
 
@@ -249,7 +249,7 @@ class WC_Tests_Register_WP_Admin_Settings extends WC_Unit_Test_Case {
 				'option_key'  => 'setting-2',
 			),
 		);
-		$actual = $settings->register_page_settings( array() );
+		$actual   = $settings->register_page_settings( array() );
 
 		$this->assertEquals( $expected, $actual );
 	}

--- a/tests/unit-tests/setup/functions.php
+++ b/tests/unit-tests/setup/functions.php
@@ -25,45 +25,63 @@ class WC_Tests_Setup_Functions extends WC_Unit_Test_Case {
 		// non-admin user
 		$this->user_id = $this->factory->user->create( array( 'role' => 'shop_manager' ) );
 		wp_set_current_user( $this->user_id );
-		$this->assertEquals( gateways( $setup_wizard ), array(
-			'paypal' => false,
-		) );
+		$this->assertEquals(
+			gateways( $setup_wizard ),
+			array(
+				'paypal' => false,
+			)
+		);
 
 		// set admin user
 		$this->user_id = $this->factory->user->create( array( 'role' => 'administrator' ) );
 		wp_set_current_user( $this->user_id );
 
 		update_option( 'woocommerce_default_country', 'US' );
-		$this->assertEquals( gateways( $setup_wizard ), array(
-			'stripe' => true,
-			'ppec_paypal' => true,
-		) );
+		$this->assertEquals(
+			gateways( $setup_wizard ),
+			array(
+				'stripe'      => true,
+				'ppec_paypal' => true,
+			)
+		);
 
 		update_option( 'woocommerce_default_country', 'CN' );
-		$this->assertEquals( gateways( $setup_wizard ), array(
-			'ppec_paypal' => true,
-		) );
+		$this->assertEquals(
+			gateways( $setup_wizard ),
+			array(
+				'ppec_paypal' => true,
+			)
+		);
 
 		update_option( 'woocommerce_default_country', 'SE' );
-		$this->assertEquals( gateways( $setup_wizard ), array(
-			'klarna_checkout' => true,
-			'ppec_paypal' => true,
-			'stripe' => false,
-		) );
+		$this->assertEquals(
+			gateways( $setup_wizard ),
+			array(
+				'klarna_checkout' => true,
+				'ppec_paypal'     => true,
+				'stripe'          => false,
+			)
+		);
 
 		update_option( 'woocommerce_default_country', 'DE' );
-		$this->assertEquals( gateways( $setup_wizard ), array(
-			'klarna_payments' => true,
-			'ppec_paypal' => true,
-			'stripe' => false,
-		) );
+		$this->assertEquals(
+			gateways( $setup_wizard ),
+			array(
+				'klarna_payments' => true,
+				'ppec_paypal'     => true,
+				'stripe'          => false,
+			)
+		);
 
 		update_option( 'woocommerce_default_country', 'GB' );
 		update_option( 'woocommerce_sell_in_person', 'yes' );
-		$this->assertEquals( gateways( $setup_wizard ), array(
-			'square' => true,
-			'ppec_paypal' => true,
-			'stripe' => false,
-		) );
-    }
+		$this->assertEquals(
+			gateways( $setup_wizard ),
+			array(
+				'square'      => true,
+				'ppec_paypal' => true,
+				'stripe'      => false,
+			)
+		);
+	}
 }

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -34,10 +34,12 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected, $shortcode->get_attributes() );
 
-		$shortcode2 = new WC_Shortcode_Products( array(
-			'orderby' => 'id',
-			'order'   => 'DESC',
-		) );
+		$shortcode2 = new WC_Shortcode_Products(
+			array(
+				'orderby' => 'id',
+				'order'   => 'DESC',
+			)
+		);
 		$expected2  = array(
 			'limit'          => '-1',
 			'columns'        => '4',
@@ -85,10 +87,12 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected, $shortcode->get_query_args() );
 
 		// products shortcode with attributes.
-		$shortcode2 = new WC_Shortcode_Products( array(
-			'orderby' => 'ID',
-			'order'   => 'DESC',
-		) );
+		$shortcode2 = new WC_Shortcode_Products(
+			array(
+				'orderby' => 'ID',
+				'order'   => 'DESC',
+			)
+		);
 		$expected2  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -103,11 +107,13 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		);
 		$this->assertEquals( $expected2, $shortcode2->get_query_args() );
 
-		$shortcode3 = new WC_Shortcode_Products( array(
-			'ids'  => '1,2,3',
-			'skus' => 'foo,bar',
-		) );
-		$expected3  = array(
+		$shortcode3                = new WC_Shortcode_Products(
+			array(
+				'ids'  => '1,2,3',
+				'skus' => 'foo,bar',
+			)
+		);
+		$expected3                 = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
@@ -129,15 +135,18 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected3, $shortcode3->get_query_args() );
 
 		// product_category shortcode.
-		$shortcode4 = new WC_Shortcode_Products( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'orderby'  => 'title',
-			'order'    => 'ASC',
-			'category' => 'clothing',
-			'operator' => 'IN',
-		), 'product_category' );
-		$expected4  = array(
+		$shortcode4               = new WC_Shortcode_Products(
+			array(
+				'per_page' => '12',
+				'columns'  => '4',
+				'orderby'  => 'title',
+				'order'    => 'ASC',
+				'category' => 'clothing',
+				'operator' => 'IN',
+			),
+			'product_category'
+		);
+		$expected4                = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
@@ -160,15 +169,18 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected4, $shortcode4->get_query_args() );
 
 		// product_category shortcode using category ids.
-		$shortcode4_id = new WC_Shortcode_Products( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'orderby'  => 'title',
-			'order'    => 'ASC',
-			'category' => '123',
-			'operator' => 'IN',
-		), 'product_category' );
-		$expected4_id  = array(
+		$shortcode4_id               = new WC_Shortcode_Products(
+			array(
+				'per_page' => '12',
+				'columns'  => '4',
+				'orderby'  => 'title',
+				'order'    => 'ASC',
+				'category' => '123',
+				'operator' => 'IN',
+			),
+			'product_category'
+		);
+		$expected4_id                = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
@@ -191,14 +203,17 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected4_id, $shortcode4_id->get_query_args() );
 
 		// recent_products shortcode.
-		$shortcode5 = new WC_Shortcode_Products( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'orderby'  => 'date',
-			'order'    => 'DESC',
-			'category' => '',
-			'operator' => 'IN',
-		), 'recent_products' );
+		$shortcode5 = new WC_Shortcode_Products(
+			array(
+				'per_page' => '12',
+				'columns'  => '4',
+				'orderby'  => 'date',
+				'order'    => 'DESC',
+				'category' => '',
+				'operator' => 'IN',
+			),
+			'recent_products'
+		);
 		$expected5  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -215,10 +230,13 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected5, $shortcode5->get_query_args() );
 
 		// product shortcode.
-		$shortcode6 = new WC_Shortcode_Products( array(
-			'ids'      => '1',
-			'per_page' => '1',
-		), 'product' );
+		$shortcode6 = new WC_Shortcode_Products(
+			array(
+				'ids'      => '1',
+				'per_page' => '1',
+			),
+			'product'
+		);
 		$expected6  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -236,14 +254,17 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected6, $shortcode6->get_query_args() );
 
 		// sale_products shortcode.
-		$shortcode7 = new WC_Shortcode_Products( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'orderby'  => 'title',
-			'order'    => 'ASC',
-			'category' => '',
-			'operator' => 'IN',
-		), 'sale_products' );
+		$shortcode7 = new WC_Shortcode_Products(
+			array(
+				'per_page' => '12',
+				'columns'  => '4',
+				'orderby'  => 'title',
+				'order'    => 'ASC',
+				'category' => '',
+				'operator' => 'IN',
+			),
+			'sale_products'
+		);
 		$expected7  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -261,12 +282,15 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected7, $shortcode7->get_query_args() );
 
 		// best_selling_products shortcode.
-		$shortcode8 = new WC_Shortcode_Products( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'category' => '',
-			'operator' => 'IN',
-		), 'best_selling_products' );
+		$shortcode8 = new WC_Shortcode_Products(
+			array(
+				'per_page' => '12',
+				'columns'  => '4',
+				'category' => '',
+				'operator' => 'IN',
+			),
+			'best_selling_products'
+		);
 		$expected8  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -284,14 +308,17 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected8, $shortcode8->get_query_args() );
 
 		// top_rated_products shortcode.
-		$shortcode9 = new WC_Shortcode_Products( array(
-			'per_page' => '12',
-			'columns'  => '4',
-			'orderby'  => 'title',
-			'order'    => 'ASC',
-			'category' => '',
-			'operator' => 'IN',
-		), 'top_rated_products' );
+		$shortcode9 = new WC_Shortcode_Products(
+			array(
+				'per_page' => '12',
+				'columns'  => '4',
+				'orderby'  => 'title',
+				'order'    => 'ASC',
+				'category' => '',
+				'operator' => 'IN',
+			),
+			'top_rated_products'
+		);
 		$expected9  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -308,15 +335,17 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected9, $shortcode9->get_query_args() );
 
 		// featured_products shortcode.
-		$shortcode10 = new WC_Shortcode_Products( array(
-			'per_page'   => '12',
-			'columns'    => '4',
-			'orderby'    => 'date',
-			'order'      => 'DESC',
-			'category'   => '',
-			'operator'   => 'IN',
-			'visibility' => 'featured',
-		) );
+		$shortcode10 = new WC_Shortcode_Products(
+			array(
+				'per_page'   => '12',
+				'columns'    => '4',
+				'orderby'    => 'date',
+				'order'      => 'DESC',
+				'category'   => '',
+				'operator'   => 'IN',
+				'visibility' => 'featured',
+			)
+		);
 		$expected10  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -326,29 +355,35 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'order'               => 'DESC',
 			'posts_per_page'      => 12,
 			'meta_query'          => $meta_query,
-			'tax_query'           => array_merge( $tax_query, array(
+			'tax_query'           => array_merge(
+				$tax_query,
 				array(
-					'taxonomy'         => 'product_visibility',
-					'terms'            => 'featured',
-					'field'            => 'name',
-					'operator'         => 'IN',
-					'include_children' => false,
-				),
-			) ),
+					array(
+						'taxonomy'         => 'product_visibility',
+						'terms'            => 'featured',
+						'field'            => 'name',
+						'operator'         => 'IN',
+						'include_children' => false,
+					),
+				)
+			),
 			'fields'              => 'ids',
 		);
 
 		$this->assertEquals( $expected10, $shortcode10->get_query_args() );
 
 		// product_attribute shortcode.
-		$shortcode11 = new WC_Shortcode_Products( array(
-			'per_page'  => '12',
-			'columns'   => '4',
-			'orderby'   => 'title',
-			'order'     => 'asc',
-			'attribute' => 'color',
-			'filter'    => 'black',
-		), 'product_attribute' );
+		$shortcode11 = new WC_Shortcode_Products(
+			array(
+				'per_page'  => '12',
+				'columns'   => '4',
+				'orderby'   => 'title',
+				'order'     => 'asc',
+				'attribute' => 'color',
+				'filter'    => 'black',
+			),
+			'product_attribute'
+		);
 		$expected11  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -358,28 +393,34 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'order'               => 'ASC',
 			'posts_per_page'      => 12,
 			'meta_query'          => $meta_query,
-			'tax_query'           => array_merge( $tax_query, array(
+			'tax_query'           => array_merge(
+				$tax_query,
 				array(
-					'taxonomy' => 'pa_color',
-					'terms'    => array( 'black' ),
-					'field'    => 'slug',
-					'operator' => 'IN',
-				),
-			) ),
+					array(
+						'taxonomy' => 'pa_color',
+						'terms'    => array( 'black' ),
+						'field'    => 'slug',
+						'operator' => 'IN',
+					),
+				)
+			),
 			'fields'              => 'ids',
 		);
 
 		$this->assertEquals( $expected11, $shortcode11->get_query_args() );
 
 		// product_attribute shortcode using term ids.
-		$shortcode11_id = new WC_Shortcode_Products( array(
-			'per_page'  => '12',
-			'columns'   => '4',
-			'orderby'   => 'title',
-			'order'     => 'asc',
-			'attribute' => 'color',
-			'terms'     => '123',
-		), 'product_attribute' );
+		$shortcode11_id = new WC_Shortcode_Products(
+			array(
+				'per_page'  => '12',
+				'columns'   => '4',
+				'orderby'   => 'title',
+				'order'     => 'asc',
+				'attribute' => 'color',
+				'terms'     => '123',
+			),
+			'product_attribute'
+		);
 		$expected11_id  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -389,23 +430,28 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'order'               => 'ASC',
 			'posts_per_page'      => 12,
 			'meta_query'          => $meta_query,
-			'tax_query'           => array_merge( $tax_query, array(
+			'tax_query'           => array_merge(
+				$tax_query,
 				array(
-					'taxonomy' => 'pa_color',
-					'terms'    => array( 123 ),
-					'field'    => 'term_id',
-					'operator' => 'IN',
-				),
-			) ),
+					array(
+						'taxonomy' => 'pa_color',
+						'terms'    => array( 123 ),
+						'field'    => 'term_id',
+						'operator' => 'IN',
+					),
+				)
+			),
 			'fields'              => 'ids',
 		);
 
 		$this->assertEquals( $expected11_id, $shortcode11_id->get_query_args() );
 
 		// Check for visibility shortcode.
-		$shortcode12 = new WC_Shortcode_Products( array(
-			'visibility' => 'hidden',
-		) );
+		$shortcode12 = new WC_Shortcode_Products(
+			array(
+				'visibility' => 'hidden',
+			)
+		);
 		$expected12  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -429,9 +475,11 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $expected12, $shortcode12->get_query_args() );
 
-		$shortcode13 = new WC_Shortcode_Products( array(
-			'visibility' => 'catalog',
-		) );
+		$shortcode13 = new WC_Shortcode_Products(
+			array(
+				'visibility' => 'catalog',
+			)
+		);
 		$expected13  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -462,9 +510,11 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $expected13, $shortcode13->get_query_args() );
 
-		$shortcode14 = new WC_Shortcode_Products( array(
-			'visibility' => 'search',
-		) );
+		$shortcode14 = new WC_Shortcode_Products(
+			array(
+				'visibility' => 'search',
+			)
+		);
 		$expected14  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -496,10 +546,12 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected14, $shortcode14->get_query_args() );
 
 		// products shortcode -- select multiple categories using AND operator.
-		$shortcode15 = new WC_Shortcode_Products( array(
-			'category'     => 'cat1,cat2',
-			'cat_operator' => 'AND',
-		) );
+		$shortcode15 = new WC_Shortcode_Products(
+			array(
+				'category'     => 'cat1,cat2',
+				'cat_operator' => 'AND',
+			)
+		);
 		$expected15  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -509,25 +561,30 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
 			'meta_query'          => $meta_query,
-			'tax_query'           => array_merge( $tax_query, array(
+			'tax_query'           => array_merge(
+				$tax_query,
 				array(
-					'taxonomy'         => 'product_cat',
-					'terms'            => array( 'cat1', 'cat2' ),
-					'field'            => 'slug',
-					'operator'         => 'AND',
-					'include_children' => false,
-				),
-			) ),
+					array(
+						'taxonomy'         => 'product_cat',
+						'terms'            => array( 'cat1', 'cat2' ),
+						'field'            => 'slug',
+						'operator'         => 'AND',
+						'include_children' => false,
+					),
+				)
+			),
 			'fields'              => 'ids',
 		);
 
 		$this->assertEquals( $expected15, $shortcode15->get_query_args() );
 
 		// products shortcode -- exclude multiple categories using NOT IN operator.
-		$shortcode16 = new WC_Shortcode_Products( array(
-			'category'     => 'cat1,cat2',
-			'cat_operator' => 'NOT IN',
-		) );
+		$shortcode16 = new WC_Shortcode_Products(
+			array(
+				'category'     => 'cat1,cat2',
+				'cat_operator' => 'NOT IN',
+			)
+		);
 		$expected16  = array(
 			'post_type'           => 'product',
 			'post_status'         => 'publish',
@@ -537,15 +594,18 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
 			'meta_query'          => $meta_query,
-			'tax_query'           => array_merge( $tax_query, array(
+			'tax_query'           => array_merge(
+				$tax_query,
 				array(
-					'taxonomy'         => 'product_cat',
-					'terms'            => array( 'cat1', 'cat2' ),
-					'field'            => 'slug',
-					'operator'         => 'NOT IN',
-					'include_children' => true,
-				),
-			) ),
+					array(
+						'taxonomy'         => 'product_cat',
+						'terms'            => array( 'cat1', 'cat2' ),
+						'field'            => 'slug',
+						'operator'         => 'NOT IN',
+						'include_children' => true,
+					),
+				)
+			),
 			'fields'              => 'ids',
 		);
 
@@ -579,9 +639,11 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$shortcode = new WC_Shortcode_Products();
 		$this->assertFalse( $shortcode->set_product_as_visible( false ) );
 
-		$shortcode2 = new WC_Shortcode_Products( array(
-			'visibility' => 'hidden',
-		) );
+		$shortcode2 = new WC_Shortcode_Products(
+			array(
+				'visibility' => 'hidden',
+			)
+		);
 		$this->assertTrue( $shortcode2->set_product_as_visible( false ) );
 	}
 
@@ -598,9 +660,14 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'groupby' => "$wpdb->posts.ID",
 		);
 
-		$this->assertEquals( $expected, WC_Shortcode_Products::order_by_rating_post_clauses( array(
-			'where' => '',
-			'join' => '',
-		) ) );
+		$this->assertEquals(
+			$expected,
+			WC_Shortcode_Products::order_by_rating_post_clauses(
+				array(
+					'where' => '',
+					'join'  => '',
+				)
+			)
+		);
 	}
 }

--- a/tests/unit-tests/tax/tax.php
+++ b/tests/unit-tests/tax/tax.php
@@ -28,7 +28,8 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$tax_rates = WC_Tax::get_rates();
 
 		$this->assertSame(
-			$tax_rates, array(
+			$tax_rates,
+			array(
 				$tax_rate_id => array(
 					'rate'     => 20.0,
 					'label'    => 'VAT',
@@ -56,7 +57,8 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 
 		$tax_rates = WC_Tax::get_rates();
 		$this->assertSame(
-			$tax_rates, array(
+			$tax_rates,
+			array(
 				$tax_rate_catch_all_id => array(
 					'rate'     => 0.0,
 					'label'    => 'VAT',
@@ -89,14 +91,16 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$tax_rates = WC_Tax::get_shipping_tax_rates();
 
 		$this->assertEquals(
-			$tax_rates, array(
+			$tax_rates,
+			array(
 				$tax_rate_id => array(
 					'rate'     => '20.0000',
 					'label'    => 'VAT',
 					'shipping' => 'yes',
 					'compound' => 'no',
 				),
-			), print_r( $tax_rates, true )
+			),
+			print_r( $tax_rates, true )
 		);
 	}
 
@@ -121,7 +125,8 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$tax_rates = WC_Tax::get_base_tax_rates();
 
 		$this->assertEquals(
-			$tax_rates, array(
+			$tax_rates,
+			array(
 				$tax_rate_id => array(
 					'rate'     => '20.0000',
 					'label'    => 'VAT',
@@ -161,7 +166,8 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals(
-			$tax_rates, array(
+			$tax_rates,
+			array(
 				$tax_rate_id => array(
 					'rate'     => '20.0000',
 					'label'    => 'VAT',
@@ -201,7 +207,8 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals(
-			$tax_rates, array(
+			$tax_rates,
+			array(
 				$tax_rate_id => array(
 					'rate'     => '20.0000',
 					'label'    => 'VAT',
@@ -296,7 +303,8 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		// prices exclusive of tax
 		$calced_tax = WC_Tax::calc_tax( '100', $tax_rates, false, false );
 		$this->assertEquals(
-			$calced_tax, array(
+			$calced_tax,
+			array(
 				$tax_rate_1_id => '5.0000',
 				$tax_rate_2_id => '8.925',
 			)

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -44,7 +44,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 			'purchasable',
 			'product-type-simple',
 		);
-		$actual = array_values( wc_get_product_class( 'foo', $product ) );
+		$actual   = array_values( wc_get_product_class( 'foo', $product ) );
 
 		$this->assertEquals( $expected, $actual, print_r( $actual, true ) );
 
@@ -63,7 +63,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 			'purchasable',
 			'product-type-simple',
 		);
-		$actual = array_values( wc_get_product_class( 'foo', $product ) );
+		$actual   = array_values( wc_get_product_class( 'foo', $product ) );
 
 		$this->assertEquals( $expected, $actual, print_r( $actual, true ) );
 		add_filter( 'woocommerce_get_product_class_include_taxonomies', '__return_false' );
@@ -91,7 +91,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 
 		wc_dropdown_variation_attribute_options(
 			array(
-				'product' => $product,
+				'product'   => $product,
 				'attribute' => 'pa_size',
 			)
 		);
@@ -101,14 +101,14 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 	 * Test: test_wc_dropdown_variation_attribute_options_should_return_attributes_list_and_selected_element.
 	 */
 	public function test_wc_dropdown_variation_attribute_options_should_return_attributes_list_and_selected_element() {
-		$product = WC_Helper_Product::create_variation_product();
+		$product                       = WC_Helper_Product::create_variation_product();
 		$_REQUEST['attribute_pa_size'] = 'large';
 
 		$this->expectOutputString( '<select id="pa_size" class="" name="attribute_pa_size" data-attribute_name="attribute_pa_size" data-show_option_none="yes"><option value="">Choose an option</option><option value="large"  selected=\'selected\'>large</option><option value="small" >small</option></select>' );
 
 		wc_dropdown_variation_attribute_options(
 			array(
-				'product' => $product,
+				'product'   => $product,
 				'attribute' => 'pa_size',
 			)
 		);

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -167,7 +167,7 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 	public function test_cart_totals() {
 		WC()->customer->set_is_vat_exempt( false );
 		$this->totals = new WC_Cart_Totals( WC()->cart );
-		$cart = WC()->cart;
+		$cart         = WC()->cart;
 
 		$this->assertEquals( 40.00, $cart->get_fee_total() );
 		$this->assertEquals( 36.00, $cart->get_cart_contents_total() );
@@ -201,7 +201,7 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 	public function test_cart_totals_tax_exempt_customer() {
 		WC()->customer->set_is_vat_exempt( true );
 		$this->totals = new WC_Cart_Totals( WC()->cart );
-		$cart = WC()->cart;
+		$cart         = WC()->cart;
 
 		$this->assertEquals( 40.00, $cart->get_fee_total() );
 		$this->assertEquals( 36.00, $cart->get_cart_contents_total() );

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -900,10 +900,10 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 			'billing_first_name' => array(
 				'priority' => 10,
 			),
-			'billing_last_name' => array(
+			'billing_last_name'  => array(
 				'priority' => 20,
 			),
-			'billing_email' => array(
+			'billing_email'      => array(
 				'priority' => 1,
 			),
 		);

--- a/tests/unit-tests/util/class-wc-tests-user-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-user-functions.php
@@ -19,26 +19,32 @@ class WC_Tests_User_Functions extends WC_Unit_Test_Case {
 	public function test_wc_modify_editable_roles() {
 		$password = wp_generate_password();
 
-		$admin_id = wp_insert_user( array(
-			'user_login' => 'test_admin',
-			'user_pass'  => $password,
-			'user_email' => 'admin@example.com',
-			'role'       => 'administrator',
-		) );
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => $password,
+				'user_email' => 'admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
 
-		$editor_id = wp_insert_user( array(
-			'user_login' => 'test_editor',
-			'user_pass'  => $password,
-			'user_email' => 'editor@example.com',
-			'role'       => 'editor',
-		) );
+		$editor_id = wp_insert_user(
+			array(
+				'user_login' => 'test_editor',
+				'user_pass'  => $password,
+				'user_email' => 'editor@example.com',
+				'role'       => 'editor',
+			)
+		);
 
-		$manager_id = wp_insert_user( array(
-			'user_login' => 'test_manager',
-			'user_pass'  => $password,
-			'user_email' => 'manager@example.com',
-			'role'       => 'shop_manager',
-		) );
+		$manager_id = wp_insert_user(
+			array(
+				'user_login' => 'test_manager',
+				'user_pass'  => $password,
+				'user_email' => 'manager@example.com',
+				'role'       => 'shop_manager',
+			)
+		);
 
 		// Admins should be able to edit anyone.
 		wp_set_current_user( $admin_id );
@@ -70,33 +76,41 @@ class WC_Tests_User_Functions extends WC_Unit_Test_Case {
 	public function test_wc_modify_map_meta_cap() {
 		$password = wp_generate_password();
 
-		$admin_id = wp_insert_user( array(
-			'user_login' => 'test_admin',
-			'user_pass'  => $password,
-			'user_email' => 'admin@example.com',
-			'role'       => 'administrator',
-		) );
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => 'test_admin',
+				'user_pass'  => $password,
+				'user_email' => 'admin@example.com',
+				'role'       => 'administrator',
+			)
+		);
 
-		$editor_id = wp_insert_user( array(
-			'user_login' => 'test_editor',
-			'user_pass'  => $password,
-			'user_email' => 'editor@example.com',
-			'role'       => 'editor',
-		) );
+		$editor_id = wp_insert_user(
+			array(
+				'user_login' => 'test_editor',
+				'user_pass'  => $password,
+				'user_email' => 'editor@example.com',
+				'role'       => 'editor',
+			)
+		);
 
-		$manager_id = wp_insert_user( array(
-			'user_login' => 'test_manager',
-			'user_pass'  => $password,
-			'user_email' => 'manager@example.com',
-			'role'       => 'shop_manager',
-		) );
+		$manager_id = wp_insert_user(
+			array(
+				'user_login' => 'test_manager',
+				'user_pass'  => $password,
+				'user_email' => 'manager@example.com',
+				'role'       => 'shop_manager',
+			)
+		);
 
-		$customer_id = wp_insert_user( array(
-			'user_login' => 'test_customer',
-			'user_pass'  => $password,
-			'user_email' => 'customer@example.com',
-			'role'       => 'customer',
-		) );
+		$customer_id = wp_insert_user(
+			array(
+				'user_login' => 'test_customer',
+				'user_pass'  => $password,
+				'user_email' => 'customer@example.com',
+				'role'       => 'customer',
+			)
+		);
 
 		// Admins should be able to edit or promote anyone.
 		wp_set_current_user( $admin_id );
@@ -123,21 +137,25 @@ class WC_Tests_User_Functions extends WC_Unit_Test_Case {
 	public function test_wc_shop_manager_has_capability() {
 		$password = wp_generate_password();
 
-		$manager_id = wp_insert_user( array(
-			'user_login' => 'test_manager',
-			'user_pass'  => $password,
-			'user_email' => 'manager@example.com',
-			'role'       => 'shop_manager',
-		) );
-		$manager = new WP_User( $manager_id );
+		$manager_id = wp_insert_user(
+			array(
+				'user_login' => 'test_manager',
+				'user_pass'  => $password,
+				'user_email' => 'manager@example.com',
+				'role'       => 'shop_manager',
+			)
+		);
+		$manager    = new WP_User( $manager_id );
 
-		$editor_id = wp_insert_user( array(
-			'user_login' => 'test_editor',
-			'user_pass'  => $password,
-			'user_email' => 'editor@example.com',
-			'role'       => 'editor',
-		) );
-		$editor = new WP_User( $editor_id );
+		$editor_id = wp_insert_user(
+			array(
+				'user_login' => 'test_editor',
+				'user_pass'  => $password,
+				'user_email' => 'editor@example.com',
+				'role'       => 'editor',
+			)
+		);
+		$editor    = new WP_User( $editor_id );
 
 		// Test capabilities translation is working correctly and only gives shop managers capabilities.
 		$this->assertTrue( $manager->has_cap( 'edit_users' ) );

--- a/tests/unit-tests/util/class-wc-tests-wc-query.php
+++ b/tests/unit-tests/util/class-wc-tests-wc-query.php
@@ -108,7 +108,7 @@ class WC_Tests_WC_Query extends WC_Unit_Test_Case {
 	public function test_add_query_vars() {
 		WC()->query->init_query_vars();
 
-		$vars = array(
+		$vars  = array(
 			'test1',
 			'test2',
 		);

--- a/tests/unit-tests/util/conditional-functions.php
+++ b/tests/unit-tests/util/conditional-functions.php
@@ -51,11 +51,11 @@ class WC_Tests_Conditional_Functions extends WC_Unit_Test_Case {
 			array( false, wc_is_valid_url( 'https://google.com/test invalid' ) ),
 
 			// Test some valid URLs
-			array( true,  wc_is_valid_url( 'http://google.com' ) ),
-			array( true,  wc_is_valid_url( 'https://google.com' ) ),
-			array( true,  wc_is_valid_url( 'https://google.com/test%20valid' ) ),
-			array( true,  wc_is_valid_url( 'https://google.com/test-valid/?query=test' ) ),
-			array( true,  wc_is_valid_url( 'https://google.com/test-valid/#hash' ) ),
+			array( true, wc_is_valid_url( 'http://google.com' ) ),
+			array( true, wc_is_valid_url( 'https://google.com' ) ),
+			array( true, wc_is_valid_url( 'https://google.com/test%20valid' ) ),
+			array( true, wc_is_valid_url( 'https://google.com/test-valid/?query=test' ) ),
+			array( true, wc_is_valid_url( 'https://google.com/test-valid/#hash' ) ),
 		);
 	}
 
@@ -86,6 +86,6 @@ class WC_Tests_Conditional_Functions extends WC_Unit_Test_Case {
 	 * @since 2.3.0
 	 */
 	public function test_wc_is_valid_url( $assert, $values ) {
-		$this->assertEquals( $assert,  $values );
+		$this->assertEquals( $assert, $values );
 	}
 }

--- a/tests/unit-tests/util/deprecated-hooks.php
+++ b/tests/unit-tests/util/deprecated-hooks.php
@@ -88,8 +88,8 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	function test_handle_deprecated_hook_filter() {
 		$new_hook = 'wc_new_hook';
 		$old_hook = 'wc_old_hook';
-		$args = array( false );
-		$return = -1;
+		$args     = array( false );
+		$return   = -1;
 
 		add_filter( $old_hook, array( $this, 'toggle_value' ) );
 
@@ -103,11 +103,11 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	 * @since 3.0
 	 */
 	function test_handle_deprecated_hook_action() {
-		$new_hook = 'wc_new_hook';
-		$old_hook = 'wc_old_hook';
+		$new_hook   = 'wc_new_hook';
+		$old_hook   = 'wc_old_hook';
 		$test_value = false;
-		$args = array( &$test_value );
-		$return = -1;
+		$args       = array( &$test_value );
+		$return     = -1;
 
 		add_filter( $old_hook, array( $this, 'toggle_value_by_ref' ) );
 
@@ -135,18 +135,18 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	 * @since 3.0
 	 */
 	function test_action_handler() {
-		$test_product = WC_Helper_Product::create_simple_product();
-		$test_order = WC_Helper_Order::create_order( 1, $test_product );
+		$test_product  = WC_Helper_Product::create_simple_product();
+		$test_order    = WC_Helper_Order::create_order( 1, $test_product );
 		$test_order_id = $test_order->get_id();
-		$test_items = $test_order->get_items();
-		$test_item = reset( $test_items );
-		$test_item_id = $test_item->get_id();
+		$test_items    = $test_order->get_items();
+		$test_item     = reset( $test_items );
+		$test_item_id  = $test_item->get_id();
 
 		add_action( 'woocommerce_order_edit_product', array( $this, 'set_meta' ), 10, 2 );
 		do_action( 'woocommerce_update_order_item', $test_item_id, $test_item, $test_order_id );
 
 		$order_update_worked = (bool) get_post_meta( $test_order_id, 'wc_deprecated_hook_test_item1_meta', 1 );
-		$item_update_worked = (bool) get_post_meta( $test_item_id, 'wc_deprecated_hook_test_item2_meta', 2 );
+		$item_update_worked  = (bool) get_post_meta( $test_item_id, 'wc_deprecated_hook_test_item2_meta', 2 );
 
 		$this->assertTrue( $order_update_worked );
 		$this->assertTrue( $item_update_worked );
@@ -164,7 +164,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 		$token = WC_Helper_Payment_Token::create_stub_token( __FUNCTION__ );
 		$token->save();
 
-		$product = new WC_Product_Variation;
+		$product = new WC_Product_Variation();
 		$product->save();
 
 		$this->assertEquals( 1, did_action( 'woocommerce_payment_token_created' ) );

--- a/tests/unit-tests/util/dummy-wc-logger.php
+++ b/tests/unit-tests/util/dummy-wc-logger.php
@@ -23,7 +23,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 *
 	 * @param string $level
 	 * @param string $message
-	 * @param array $context
+	 * @param array  $context
 	 */
 	public function log( $level, $message, $context = array() ) {
 	}
@@ -32,7 +32,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * Do nothing.
 	 *
 	 * @param string $message
-	 * @param array $context
+	 * @param array  $context
 	 */
 	public function emergency( $message, $context = array() ) {
 	}
@@ -41,7 +41,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * Do nothing.
 	 *
 	 * @param string $message
-	 * @param array $context
+	 * @param array  $context
 	 */
 	public function alert( $message, $context = array() ) {
 	}
@@ -50,7 +50,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * Do nothing.
 	 *
 	 * @param string $message
-	 * @param array $context
+	 * @param array  $context
 	 */
 	public function critical( $message, $context = array() ) {
 	}
@@ -59,7 +59,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * Do nothing.
 	 *
 	 * @param string $message
-	 * @param array $context
+	 * @param array  $context
 	 */
 	public function error( $message, $context = array() ) {
 	}
@@ -68,7 +68,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * Do nothing.
 	 *
 	 * @param string $message
-	 * @param array $context
+	 * @param array  $context
 	 */
 	public function warning( $message, $context = array() ) {
 	}
@@ -77,7 +77,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * Do nothing.
 	 *
 	 * @param string $message
-	 * @param array $context
+	 * @param array  $context
 	 */
 	public function notice( $message, $context = array() ) {
 	}
@@ -86,7 +86,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * Do nothing.
 	 *
 	 * @param string $message
-	 * @param array $context
+	 * @param array  $context
 	 */
 	public function info( $message, $context = array() ) {
 	}
@@ -95,7 +95,7 @@ class Dummy_WC_Logger implements WC_Logger_Interface {
 	 * Do nothing.
 	 *
 	 * @param string $message
-	 * @param array $context
+	 * @param array  $context
 	 */
 	public function debug( $message, $context = array() ) {
 	}

--- a/tests/unit-tests/util/plugin-updates.php
+++ b/tests/unit-tests/util/plugin-updates.php
@@ -23,10 +23,10 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 
 		if ( ! class_exists( 'WC_Plugin_Updates' ) ) {
 			$bootstrap = WC_Unit_Tests_Bootstrap::instance();
-			include_once( $bootstrap->plugin_dir . '/includes/admin/plugin-updates/class-wc-plugin-updates.php' );
+			include_once $bootstrap->plugin_dir . '/includes/admin/plugin-updates/class-wc-plugin-updates.php';
 		}
 
-		$this->updates = new WC_Plugin_Updates;
+		$this->updates = new WC_Plugin_Updates();
 		$this->plugins = array();
 
 		add_filter( 'woocommerce_get_plugins_with_header', array( $this, 'populate_untested_plugins' ), 10, 2 );
@@ -35,7 +35,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 	/**
 	 * Allow this test suite to easily define plugin results to test for the version tested header.
 	 *
-	 * @param array $plugins array of plugin data in same format as get_plugins.
+	 * @param array  $plugins array of plugin data in same format as get_plugins.
 	 * @param string $header plugin header results matched on.
 	 * @return array modified $plugins.
 	 * @since 3.2.0
@@ -57,7 +57,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		$release = 'major';
 
 		$this->plugins = array(
-			'test/test.php' => array(
+			'test/test.php'   => array(
 				'Name'                                   => 'Test plugin',
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.0.0',
 			),
@@ -74,29 +74,29 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.0.1',
 			),
 		);
-		$new_version = '4.0.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$new_version   = '4.0.0';
+		$untested      = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayNotHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '3.9.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayNotHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '4.3.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayNotHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '4.0.2';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayNotHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
@@ -112,7 +112,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		$release = 'major';
 
 		$this->plugins = array(
-			'test/test.php' => array(
+			'test/test.php'   => array(
 				'Name'                                   => 'Test plugin',
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '3.0.0',
 			),
@@ -125,18 +125,18 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '3.0',
 			),
 		);
-		$plugin_keys = array_keys( $this->plugins );
+		$plugin_keys   = array_keys( $this->plugins );
 
 		$new_version = '4.0.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertEquals( $plugin_keys, array_intersect( $plugin_keys, array_keys( $untested ) ) );
 
 		$new_version = '4.3.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertEquals( $plugin_keys, array_intersect( $plugin_keys, array_keys( $untested ) ) );
 
 		$new_version = '4.0.2';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertEquals( $plugin_keys, array_intersect( $plugin_keys, array_keys( $untested ) ) );
 	}
 
@@ -149,7 +149,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		$release = 'minor';
 
 		$this->plugins = array(
-			'test/test.php' => array(
+			'test/test.php'   => array(
 				'Name'                                   => 'Test plugin',
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.1.0',
 			),
@@ -166,22 +166,22 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.2.1',
 			),
 		);
-		$new_version = '4.1.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$new_version   = '4.1.0';
+		$untested      = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayNotHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '4.2.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayHasKey( 'test3/test3.php', $untested );
 		$this->assertArrayNotHasKey( 'test4/test4.php', $untested );
 
 		$new_version = '4.1.5';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayNotHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );
@@ -197,7 +197,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		$release = 'minor';
 
 		$this->plugins = array(
-			'test/test.php' => array(
+			'test/test.php'   => array(
 				'Name'                                   => 'Test plugin',
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.1.0',
 			),
@@ -210,14 +210,14 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4.2',
 			),
 		);
-		$plugin_keys = array_keys( $this->plugins );
+		$plugin_keys   = array_keys( $this->plugins );
 
 		$new_version = '4.3.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertEquals( $plugin_keys, array_intersect( $plugin_keys, array_keys( $untested ) ) );
 
 		$new_version = '4.3.1';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertEquals( $plugin_keys, array_intersect( $plugin_keys, array_keys( $untested ) ) );
 
 		$new_version = '4.1.0';
@@ -237,7 +237,7 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 		$release = 'minor';
 
 		$this->plugins = array(
-			'test/test.php' => array(
+			'test/test.php'   => array(
 				'Name'                                   => 'Test plugin',
 				WC_Plugin_Updates::VERSION_TESTED_HEADER => '4',
 			),
@@ -255,13 +255,13 @@ class WC_Tests_Plugin_Updates extends WC_Unit_Test_Case {
 			),
 		);
 
-		$release = 'major';
+		$release     = 'major';
 		$new_version = '5.0.0';
 		$this->assertArrayHasKey( 'test/test.php', $this->updates->get_untested_plugins( $new_version, $release ) );
 
-		$release = 'minor';
+		$release     = 'minor';
 		$new_version = '4.1.0';
-		$untested = $this->updates->get_untested_plugins( $new_version, $release );
+		$untested    = $this->updates->get_untested_plugins( $new_version, $release );
 		$this->assertArrayNotHasKey( 'test/test.php', $untested );
 		$this->assertArrayNotHasKey( 'test2/test2.php', $untested );
 		$this->assertArrayNotHasKey( 'test3/test3.php', $untested );

--- a/tests/unit-tests/widgets/class-dummy-widget.php
+++ b/tests/unit-tests/widgets/class-dummy-widget.php
@@ -17,7 +17,7 @@ class Dummy_Widget extends WC_Widget {
 	/**
 	 * Output widget.
 	 *
-	 * @param mixed $args Arguments.
+	 * @param mixed     $args Arguments.
 	 * @param WP_Widget $instance Intance of WP_Widget.
 	 * @return void
 	 */

--- a/tests/unit-tests/widgets/class-wc-tests-widget.php
+++ b/tests/unit-tests/widgets/class-wc-tests-widget.php
@@ -35,7 +35,7 @@ class WC_Tests_Widget extends WC_Unit_Test_Case {
 		// Uncached widget.
 		ob_start();
 		$cache_hit = $dummy_widget->get_cached_widget( array( 'widget_id' => $dummy_widget->widget_id ) );
-		$output = ob_get_clean();
+		$output    = ob_get_clean();
 		$this->assertFalse( $cache_hit );
 		$this->assertEmpty( $output );
 
@@ -47,7 +47,7 @@ class WC_Tests_Widget extends WC_Unit_Test_Case {
 		// Cached widget.
 		ob_start();
 		$cache_hit = $dummy_widget->get_cached_widget( array( 'widget_id' => $dummy_widget->widget_id ) );
-		$output = ob_get_clean();
+		$output    = ob_get_clean();
 		$this->assertTrue( $cache_hit );
 		$this->assertEquals( 'Dummy', $output );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes all 1533 PHPCS errors that PHPCBF can fix automatically in the tests/ directory. Before this change, there was a total of 3106 PHPCS errors in the WooCommerce repository and now there are 1573 errors.

Since all the modified files are in the tests/ directory, this shouldn't cause any issues.

### How to test the changes in this Pull Request:

1. Skim through the changes to check if they make sense
2. Check that the tests are still passing