### PR TITLE
Stock sorting issue when Yoast installed

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -520,9 +520,10 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	/**
 	 * Remove ordering queries.
 	 *
-	 * @return void
+	 * @param array $posts Posts array, keeping this for backwards compatibility defaulting to empty array.
+	 * @return array
 	 */
-	public function remove_ordering_args() {
+	public function remove_ordering_args( $posts = array() ) {
 		remove_filter( 'posts_clauses', array( $this, 'order_by_price_asc_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'order_by_price_desc_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'order_by_sku_asc_post_clauses' ) );
@@ -530,6 +531,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		remove_filter( 'posts_clauses', array( $this, 'filter_downloadable_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'filter_virtual_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'filter_stock_status_post_clauses' ) );
+		return $posts; // Keeping this here for backward compatibility.
 	}
 
 	/**

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -40,7 +40,6 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		add_filter( 'views_edit-product', array( $this, 'product_views' ) );
 		add_filter( 'get_search_query', array( $this, 'search_label' ) );
 		add_filter( 'posts_clauses', array( $this, 'posts_clauses' ), 10, 2 );
-		add_filter( 'the_posts', array( $this, 'remove_ordering_args' ) );
 	}
 
 	/**
@@ -451,6 +450,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	 * @return array
 	 */
 	protected function query_filters( $query_vars ) {
+		$this->remove_ordering_args();
 		// Custom order by arguments.
 		if ( isset( $query_vars['orderby'] ) ) {
 			$orderby = strtolower( $query_vars['orderby'] );
@@ -520,10 +520,9 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	/**
 	 * Remove ordering queries.
 	 *
-	 * @param array $posts Posts from WP Query.
-	 * @return array
+	 * @return void
 	 */
-	public function remove_ordering_args( $posts ) {
+	public function remove_ordering_args() {
 		remove_filter( 'posts_clauses', array( $this, 'order_by_price_asc_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'order_by_price_desc_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'order_by_sku_asc_post_clauses' ) );
@@ -531,7 +530,6 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		remove_filter( 'posts_clauses', array( $this, 'filter_downloadable_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'filter_virtual_post_clauses' ) );
 		remove_filter( 'posts_clauses', array( $this, 'filter_stock_status_post_clauses' ) );
-		return $posts;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR fixes an issue where you cannot sort by stock status when you have Yoast active. Hat tip @m1tk00 for the fix.

Closes #23587 

### How to test the changes in this Pull Request:

1. Activate Yoast plugin on store
2. Use the sort by stock dropdown and check that products are sorted correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Product sorting issue caused by Yoast plugin conflict.
