### PR TITLE
Added confirmation before saving empty list of countries to sell to.

### DIFF
--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -161,9 +161,12 @@
 				lastRow  = $( this ).find( 'tbody tr:last' ),
 				firstRow = $( this ).find( 'tbody tr:first' );
 
-			table.find( '.wc-item-reorder-nav .wc-move-disabled' ).removeClass( 'wc-move-disabled' ).attr( { 'tabindex': '0', 'aria-hidden': 'false' } );
-			firstRow.find( '.wc-item-reorder-nav .wc-move-up' ).addClass( 'wc-move-disabled' ).attr( { 'tabindex': '-1', 'aria-hidden': 'true' } );
-			lastRow.find( '.wc-item-reorder-nav .wc-move-down' ).addClass( 'wc-move-disabled' ).attr( { 'tabindex': '-1', 'aria-hidden': 'true' } );
+			table.find( '.wc-item-reorder-nav .wc-move-disabled' ).removeClass( 'wc-move-disabled' )
+				.attr( { 'tabindex': '0', 'aria-hidden': 'false' } );
+			firstRow.find( '.wc-item-reorder-nav .wc-move-up' ).addClass( 'wc-move-disabled' )
+				.attr( { 'tabindex': '-1', 'aria-hidden': 'true' } );
+			lastRow.find( '.wc-item-reorder-nav .wc-move-down' ).addClass( 'wc-move-disabled' )
+				.attr( { 'tabindex': '-1', 'aria-hidden': 'true' } );
 		} );
 
 		$( '.wc-item-reorder-nav').closest( 'table' ).trigger( 'updateMoveButtons' );

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -171,5 +171,16 @@
 
 		$( '.wc-item-reorder-nav').closest( 'table' ).trigger( 'updateMoveButtons' );
 
+
+		$( '.submit button' ).on( 'click', function() {
+			if ( $( 'select#woocommerce_allowed_countries' ).val() === 'specific'
+				&& ! $("[name='woocommerce_specific_allowed_countries[]']").val() ) {
+				if ( window.confirm( woocommerce_settings_params.i18n_no_specific_countries_selected ) ) {
+					return true;
+				};
+				return false;
+			}
+		} );
+
 	});
 })( jQuery, woocommerce_settings_params, wp );

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -173,11 +173,13 @@
 
 
 		$( '.submit button' ).on( 'click', function() {
-			if ( $( 'select#woocommerce_allowed_countries' ).val() === 'specific'
-				&& ! $("[name='woocommerce_specific_allowed_countries[]']").val() ) {
+			if (
+				$( 'select#woocommerce_allowed_countries' ).val() === 'specific' &&
+				! $( '[name="woocommerce_specific_allowed_countries[]"]' ).val()
+			) {
 				if ( window.confirm( woocommerce_settings_params.i18n_no_specific_countries_selected ) ) {
 					return true;
-				};
+				}
 				return false;
 			}
 		} );

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -135,7 +135,9 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 			wp_enqueue_script( 'woocommerce_settings', WC()->plugin_url() . '/assets/js/admin/settings' . $suffix . '.js', array( 'jquery', 'wp-util', 'jquery-ui-datepicker', 'jquery-ui-sortable', 'iris', 'selectWoo' ), WC()->version, true );
 
 			wp_localize_script(
-				'woocommerce_settings', 'woocommerce_settings_params', array(
+				'woocommerce_settings',
+				'woocommerce_settings_params',
+				array(
 					'i18n_nav_warning' => __( 'The changes you made will be lost if you navigate away from this page.', 'woocommerce' ),
 					'i18n_moved_up'    => __( 'Item moved up', 'woocommerce' ),
 					'i18n_moved_down'  => __( 'Item moved down', 'woocommerce' ),
@@ -391,7 +393,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 												selected( $option_value, (string) $key );
 											}
 
-										?>
+											?>
 										><?php echo esc_html( $val ); ?></option>
 										<?php
 									}
@@ -494,7 +496,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						<?php
 
 						if ( ! isset( $value['checkboxgroup'] ) || 'end' === $value['checkboxgroup'] ) {
-										?>
+							?>
 										</fieldset>
 									</td>
 								</tr>

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -138,9 +138,10 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 				'woocommerce_settings',
 				'woocommerce_settings_params',
 				array(
-					'i18n_nav_warning' => __( 'The changes you made will be lost if you navigate away from this page.', 'woocommerce' ),
-					'i18n_moved_up'    => __( 'Item moved up', 'woocommerce' ),
-					'i18n_moved_down'  => __( 'Item moved down', 'woocommerce' ),
+					'i18n_nav_warning'                    => __( 'The changes you made will be lost if you navigate away from this page.', 'woocommerce' ),
+					'i18n_moved_up'                       => __( 'Item moved up', 'woocommerce' ),
+					'i18n_moved_down'                     => __( 'Item moved down', 'woocommerce' ),
+					'i18n_no_specific_countries_selected' => __( 'Selecting no country to sell to prevents from completing the checkout. Continue anyway?', 'woocommerce' ),
 				)
 			);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23509 .

### How to test the changes in this Pull Request:

1. Go to WC general settings.
2. Set Selling location(s) to `Sell to specific countries` and pick no States.
3. Try to save, OK should save anyway, Cancel should stop from saving. 
4. Add one or two countries, confirmation should not be displayed.
5. On other setting screens, all should work fine.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - added confirm dialogue when saving setting for selling to no countries.
