### PR TITLE
Fix to show WC plugin updates in System status report

### DIFF
--- a/includes/api/v2/class-wc-rest-system-status-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-v2-controller.php
@@ -878,8 +878,8 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		$version_latest = $data['Version'];
 
 		// Find latest version.
-		if ( isset( $available_updates[ $plugin ]->update->new_version ) ) {
-			$version_latest = $available_updates[ $plugin ]->update->new_version;
+		if ( isset( $this->available_updates[ $plugin ]->update->new_version ) ) {
+			$version_latest = $this->available_updates[ $plugin ]->update->new_version;
 		}
 
 		return array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23547  .

### How to test the changes in this Pull Request:

1. Install old WC extension, e.g. bookings
2. Check System status report, it should show update info after applying the fix


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix -- show update info about WC extensions in System status report.
