### PR TITLE
Prevents undefined offset for empty arrays in wc_change_get_terms_defaults

### DIFF
--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -23,7 +23,7 @@ function wc_change_get_terms_defaults( $defaults, $taxonomies ) {
 	if ( is_array( $taxonomies ) && 1 < count( $taxonomies ) ) {
 		return $defaults;
 	}
-	$taxonomy = is_array( $taxonomies ) ? $taxonomies[0] : $taxonomies;
+	$taxonomy = is_array( $taxonomies ) && ! emtpy( $taxonomies[0] ) ? $taxonomies[0] : $taxonomies;
 	$orderby  = 'name';
 
 	if ( taxonomy_is_product_attribute( $taxonomy ) ) {

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -23,7 +23,7 @@ function wc_change_get_terms_defaults( $defaults, $taxonomies ) {
 	if ( is_array( $taxonomies ) && 1 < count( $taxonomies ) ) {
 		return $defaults;
 	}
-	$taxonomy = is_array( $taxonomies ) && ! emtpy( $taxonomies[0] ) ? $taxonomies[0] : $taxonomies;
+	$taxonomy = is_array( $taxonomies ) ? current( $taxonomies ) : $taxonomies;
 	$orderby  = 'name';
 
 	if ( taxonomy_is_product_attribute( $taxonomy ) ) {

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -23,7 +23,7 @@ function wc_change_get_terms_defaults( $defaults, $taxonomies ) {
 	if ( is_array( $taxonomies ) && 1 < count( $taxonomies ) ) {
 		return $defaults;
 	}
-	$taxonomy = is_array( $taxonomies ) ? current( $taxonomies ) : $taxonomies;
+	$taxonomy = is_array( $taxonomies ) ? (string) current( $taxonomies ) : $taxonomies;
 	$orderby  = 'name';
 
 	if ( taxonomy_is_product_attribute( $taxonomy ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Prevents undefined offset PHP warning in `wc_change_get_terms_defaults()`.

Closes #23583.

### How to test the changes in this Pull Request:

See #23583.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Prevent undefined offset error on `wc_change_get_terms_defaults()`
