### PR TITLE
Fixes #23626 - PayPal gateway captures on completed with custom order…

### DIFF
--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -71,7 +71,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		add_action( 'admin_enqueue_scripts', array( $this, 'admin_scripts' ) );
 		add_action( 'woocommerce_update_options_payment_gateways_' . $this->id, array( $this, 'process_admin_options' ) );
 		add_action( 'woocommerce_order_status_on-hold_to_processing', array( $this, 'capture_payment' ) );
-		add_action( 'woocommerce_order_status_on-hold_to_completed', array( $this, 'capture_payment' ) );
+		add_action( 'woocommerce_order_status_completed', array( $this, 'capture_payment' ) );
 
 		if ( ! $this->is_valid_for_use() ) {
 			$this->enabled = 'no';


### PR DESCRIPTION
Fixes an issue where custom order status' cause the PayPal gateway to not capture previously verified transactions when the order status is changed to completed.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23626. Fixes an issue where custom order status' stopped the PayPal gateway from capturing previously authorized orders when the status is changed to completed.

### How to test the changes in this Pull Request:

1. Add a custom order status.
2. Set the PayPal gateway to authorize only.
3. Create an order and change the order status to the custom order status.
4. Change the order status to completed, and check in PayPal if the transaction has been captured.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
-Fixed an issue where custom order status' stopped the PayPal gateway from capturing orders when the status is changed to completed.