### PR TITLE
woocommerce_product_post_type_link_parent_category_only filter

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -216,7 +216,11 @@ function wc_product_post_type_link( $permalink, $post ) {
 			$ancestors = get_ancestors( $category_object->term_id, 'product_cat' );
 			foreach ( $ancestors as $ancestor ) {
 				$ancestor_object = get_term( $ancestor, 'product_cat' );
-				$product_cat     = $ancestor_object->slug . '/' . $product_cat;
+				if ( apply_filters( 'woocommerce_product_post_type_link_parent_category_only', false ) ) {
+					$product_cat = $ancestor_object->slug;
+				} else {
+					$product_cat = $ancestor_object->slug . '/' . $product_cat;
+				}
 			}
 		}
 	} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR adds an option via a new filter called `woocommerce_product_post_type_link_parent_category_only` that allows you to only use the parent category in the slug when you have parent/child hierarchy in the selected category. A bug prior to 3.6 resulted in this as the default behavior most of the times, but since the fix stores now all of a sudden has parent/child slugs in their URLs where previously they only had parent slugs.

Closes #23632 

### How to test the changes in this Pull Request:

1. Setup product permalinks to include %product_cat%
2. Create two categories that has a parent child relationship.
3. Assign the child category to the product and view the URL it should contain both the parent and child slugs in the url.
4. Add `add_filter( 'woocommerce_product_post_type_link_parent_category_only', '__return_true' )` to your themes function code, reload the product page and ensure the child category is now missing from the URL.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - New woocommerce_product_post_type_link_parent_category_only filter to hide child category slugs from urls.
