### PR TITLE
Set register_rest_route override to TRUE in Blocks REST API

### DIFF
--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-attribute-terms-controller.php
@@ -41,7 +41,8 @@ class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_
 					'args'                => $this->get_collection_params(),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
-			)
+			),
+			true
 		);
 
 		register_rest_route(
@@ -67,7 +68,8 @@ class WC_REST_Blocks_Product_Attribute_Terms_Controller extends WC_REST_Product_
 					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
-			)
+			),
+			true
 		);
 	}
 

--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-attributes-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-attributes-controller.php
@@ -41,7 +41,8 @@ class WC_REST_Blocks_Product_Attributes_Controller extends WC_REST_Product_Attri
 					'args'                => $this->get_collection_params(),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
-			)
+			),
+			true
 		);
 
 		register_rest_route(
@@ -67,7 +68,8 @@ class WC_REST_Blocks_Product_Attributes_Controller extends WC_REST_Product_Attri
 					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
-			)
+			),
+			true
 		);
 	}
 

--- a/includes/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-product-categories-controller.php
@@ -41,7 +41,8 @@ class WC_REST_Blocks_Product_Categories_Controller extends WC_REST_Product_Categ
 					'args'                => $this->get_collection_params(),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
-			)
+			),
+			true
 		);
 
 		register_rest_route(
@@ -67,7 +68,8 @@ class WC_REST_Blocks_Product_Categories_Controller extends WC_REST_Product_Categ
 					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
-			)
+			),
+			true
 		);
 	}
 

--- a/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
+++ b/includes/api/wc-blocks/class-wc-rest-blocks-products-controller.php
@@ -41,7 +41,8 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 					'args'                => $this->get_collection_params(),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
-			)
+			),
+			true
 		);
 
 		register_rest_route(
@@ -67,7 +68,8 @@ class WC_REST_Blocks_Products_Controller extends WC_REST_Products_Controller {
 					),
 				),
 				'schema' => array( $this, 'get_public_item_schema' ),
-			)
+			),
+			true
 		);
 	}
 


### PR DESCRIPTION
`register_rest_route` has an `override` option which defaults to `false`.

https://developer.wordpress.org/reference/functions/register_rest_route/

When this is true, any existing routes will be replaced with the new route. I think in our case this is more desirable. In my use-case, I extended one of these endpoints, replaced the class in `wc()->api` and then called `register_routes`. Without extending `register_routes` too in my class, this did not work because override was false.

See https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/554 where I had to add this as a workaround.

@claudiosanches What do you think of this for other endpoints too?
