### PR TITLE
Add WooCommerce Admin Build Process

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -19,3 +19,4 @@
 /assets/js/stupidtable/**
 /assets/js/zeroclipboard/**
 /assets/js/zoom/**
+/assets/js/wc-admin/**

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -446,6 +446,10 @@ final class WooCommerce {
 
 		if ( $this->is_request( 'admin' ) ) {
 			include_once WC_ABSPATH . 'includes/admin/class-wc-admin.php';
+
+			if ( file_exists( WC_ABSPATH . 'includes/wc-admin/class-wc-admin-library.php' ) ) {
+				include_once WC_ABSPATH . 'includes/wc-admin/class-wc-admin-library.php';
+			}
 		}
 
 		if ( $this->is_request( 'frontend' ) ) {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "git:update-hooks": "rm -r .git/hooks && mkdir -p .git/hooks && node ./node_modules/husky/husky.js install"
   },
   "dependencies": {
-    "@woocommerce/block-library": "2.0.1"
+    "@woocommerce/block-library": "2.0.1",
+    "@woocommerce/admin-library": "./woocommerce-admin-library-0.12.0.tgz"
   },
   "devDependencies": {
     "autoprefixer": "9.6.0",


### PR DESCRIPTION
This PR adds the WooCommerce Admin build process to the `feature/woocommerce-admin` branch, which continues the work started in https://github.com/woocommerce/woocommerce-admin/pull/1863.

It copies over PHP files located in the `includes/features/` section of WooCommerce Admin package, as well as all JS and CSS assets. It contains a loader to make it all work.

I think we can merge this and continue work, since it is going in a feature branch. Here are some TODOs I know about:

* All PHP from `includes/features/` is currently included in `npm pack` on the WooCommere Admin side. We should only ship 'core' ready features like we do with the JavaScript.
* This currently requires you to manually copy over the build core package. We will want to actually publish releases to npm so they can be consumed.
* Features that require the REST API, or other PHP files not in `includes/features/` will need manually merged.

To Test:
* Disable the `WooCommerce Admin` plugin.
* Pull down `fix/core-publish-process` of `WooCommere Admin`. https://github.com/woocommerce/woocommerce-admin/pull/2391/
* Reset your onboarding profile setting, to get the wizard to show. `update_option( 'wc_onboarding_profile', array() );`
* Make the following changes:.
    * in `config/core.json`
        * Mark `dashboard` and `onboarding` as true.
* Run `npm pack`
* Copy the `woocommerce-admin-library-0.12.0.tgz` file over to your core installation folder (same directory as core's `package.json`).
* From your WooCommerce core directory, run `npm install`.
* From your WooCommerce core directory, run `grunt`.
* Visit `/wp-admin/admin.php?page=wc-admin` and you should see the onboarding wizard start screen