### PR TITLE
Add wc-admin notice.

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -34,6 +34,7 @@ class WC_Admin_Notices {
 		'regenerating_thumbnails'   => 'regenerating_thumbnails_notice',
 		'regenerating_lookup_table' => 'regenerating_lookup_table_notice',
 		'no_secure_connection'      => 'secure_connection_notice',
+		'wc_admin'                  => 'wc_admin_feature_plugin_notice',
 	);
 
 	/**
@@ -82,6 +83,7 @@ class WC_Admin_Notices {
 		if ( ! self::is_ssl() ) {
 			self::add_notice( 'no_secure_connection' );
 		}
+		self::add_wc_admin_feature_plugin_notice();
 		self::add_notice( 'template_files' );
 	}
 
@@ -339,6 +341,36 @@ class WC_Admin_Notices {
 		}
 
 		include dirname( __FILE__ ) . '/views/html-notice-regenerating-lookup-table.php';
+	}
+
+
+	/**
+	 * If on WordPress 5.0 or greater, inform users of WooCommerce Admin feature plugin.
+	 *
+	 * @since 3.6.4
+	 * @todo  Remove this notice and associated code once the feature plugin has been merged into core.
+	 */
+	public static function add_wc_admin_feature_plugin_notice() {
+		$wordpress_version            = get_bloginfo( 'version' );
+
+		if ( version_compare( $wordpress_version, '4.9.9', '>' ) ) {
+			self::add_notice( 'wc_admin' );
+		}
+	}
+
+	/**
+	 * Notice to try WooCommerce Admin
+	 *
+	 * @since 3.6.4
+	 * @todo  Remove this notice and associated code once the feature plugin has been merged into core.
+	 */
+	public static function wc_admin_feature_plugin_notice() {
+		if ( get_user_meta( get_current_user_id(), 'dismissed_wc_admin_notice', true ) || self::is_plugin_active( 'woocommerce-admin/woocommerce-admin.php' ) ) {
+			self::remove_notice( 'wc_admin' );
+			return;
+		}
+
+		include dirname( __FILE__ ) . '/views/html-notice-wc-admin.php';
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -353,7 +353,7 @@ class WC_Admin_Notices {
 	public static function add_wc_admin_feature_plugin_notice() {
 		$wordpress_version            = get_bloginfo( 'version' );
 
-		if ( version_compare( $wordpress_version, '4.9.9', '>' ) ) {
+		if ( version_compare( $wordpress_version, '5.0', '>=' ) ) {
 			self::add_notice( 'wc_admin' );
 		}
 	}

--- a/includes/admin/views/html-notice-wc-admin.php
+++ b/includes/admin/views/html-notice-wc-admin.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Admin View: Notice - WooCommerce Admin Feature Plugin
+ *
+ * @package admin.
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+?>
+<div id="message" class="updated woocommerce-message woocommerce-admin-promo-messages">
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'wc_admin' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
+
+	<p>
+		<?php echo wp_kses_post( __( 'Test drive the future of WooCommerce. A quicker, javascript powered interface with exciting new features and reports.', 'woocommerce' ) ); ?>
+	</p>
+	<?php if ( file_exists( WP_PLUGIN_DIR . '/woocommerce-admin/woocommerce-admin.php' ) && ! is_plugin_active( 'woocommerce-admin/woocommerce-admin.php' ) && current_user_can( 'activate_plugin', 'woocommerce-admin/woocommerce-admin.php' ) ) : ?>
+		<p>
+			<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'plugins.php?action=activate&plugin=woocommerce-admin/woocommerce-admin.php&plugin_status=active' ), 'activate-plugin_woocommerce-admin/woocommerce-admin.php' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Activate WooCommerce Admin', 'woocommerce' ); ?></a>
+		</p>
+	<?php else : ?>
+		<?php
+		if ( current_user_can( 'install_plugins' ) ) {
+			$url = wp_nonce_url( self_admin_url( 'update.php?action=install-plugin&plugin=woocommerce-admin' ), 'install-plugin_woocommerce-admin' );
+		} else {
+			$url = 'https://wordpress.org/plugins/woocommerce-admin/';
+		}
+		?>
+		<p>
+			<a href="<?php echo esc_url( $url ); ?>" class="button button-primary"><?php esc_html_e( 'Install WooCommerce Admin', 'woocommerce' ); ?></a>
+		</p>
+	<?php endif; ?>
+</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This branch adds in a notice/nudge to checkout the WC Admin feature plugin. The code was 💯 based off of the same logic that was in place for the same nudge for the Blocks feature plugin. Just verbiage, and plugin slug changes really.

**Please Don't Cherry Pick This** Until we have released the next version of wc-admin. We have a few changes that we would like live in the .org repo prior to encouraging users to install.


Closes https://github.com/woocommerce/woocommerce-admin/issues/2174

### How to test the changes in this Pull Request:

1. Activate this branch on a site running less than WP 5.0 - verify no nudge is shown
2. Activate this branch on a site running 5.0 or greater. Switch themes to trigger the `reset_admin_notices` - verify the notif is shown.
3. Click the link to install the plugin, verify the plugin is installed
4. Navigate to a WooCommerce page **without activating** the plugin
5. Verify the notif changes to prompt you to activate the plugin
6. Click the link to activate and verify wc-admin is now active
7. Start over, delete wc-admin, change your theme
8. Test dismissing the notif and verify it is no longer shown

![not-installed](https://user-images.githubusercontent.com/22080/57417185-583fad00-71b8-11e9-8e12-99ceaa4bd503.png)

### Changelog entry

Feature: Add notice to install WooCommerce Admin
