### PR TITLE
add filter to allow disabling endpoint 404 behavior, per #23622

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -43,7 +43,7 @@ function wc_template_redirect() {
 	}
 
 	// Trigger 404 if trying to access an endpoint on wrong page.
-	if ( is_wc_endpoint_url() && ! is_account_page() && ! is_checkout() && apply_filters( 'woocommerce_account_endpoints_on_wrong_page_not_found', true ) ) {
+	if ( is_wc_endpoint_url() && ! is_account_page() && ! is_checkout() && apply_filters( 'woocommerce_account_endpoint_page_not_found', true ) ) {
 		$wp_query->set_404();
 		status_header( 404 );
 		include( get_query_template( '404' ) );

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -43,7 +43,7 @@ function wc_template_redirect() {
 	}
 
 	// Trigger 404 if trying to access an endpoint on wrong page.
-	if ( is_wc_endpoint_url() && ! is_account_page() && ! is_checkout() ) {
+	if ( is_wc_endpoint_url() && ! is_account_page() && ! is_checkout() && apply_filters( 'woocommerce_account_endpoints_on_wrong_page_not_found', true ) ) {
 		$wp_query->set_404();
 		status_header( 404 );
 		include( get_query_template( '404' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added a filter to allow developers to easily disable the 404 behavior for endpoints accessed outside of the account page, per #23622 

### How to test the changes in this Pull Request:

1. Created a page with a child page that has the slug "downloads"
2. Prior to this change that page will 404 (confirming that the 404 status works as expected
3. After this change the 404 still occurs
4. Adding the following code to the functions.php file of a theme causes the page to be accessible (with no 404): `add_filter( 'woocommerce_account_endpoints_on_wrong_page_not_found', '__return_false' );`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them? See #23622
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Feature: Add filter woocommerce_account_endpoints_on_wrong_page_not_found to disable endpoint 404s when accessed outside the account page.