### PR TITLE
Add WC_Abstract_Order::get_coupons()

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -731,6 +731,16 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
+	 * Return an array of coupons within this order.
+	 *
+	 * @since  3.7.0
+	 * @return WC_Order_Item_Coupon[]
+	 */
+	public function get_coupons() {
+		return $this->get_items( 'coupon' );
+	}
+
+	/**
 	 * Return an array of fees within this order.
 	 *
 	 * @return WC_Order_item_Fee[]

--- a/tests/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-crud-orders.php
@@ -313,6 +313,24 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test: get_coupons
+	 */
+	public function test_get_coupons() {
+		$object = new WC_Order();
+		$item   = new WC_Order_Item_Coupon();
+		$item->set_props(
+			array(
+				'code'         => '12345',
+				'discount'     => 10,
+				'discount_tax' => 5,
+			)
+		);
+		$object->add_item( $item );
+		$object->save();
+		$this->assertCount( 1, $object->get_coupons() );
+	}
+
+	/**
 	 * Test: get_fees
 	 */
 	public function test_get_fees() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add WC_Abstract_Order::get_coupons() method to improve code hinting. 
I propose adding this to 3.7.0. If this changes the `@since` tag will need to be modified.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Dev - Introduce new WC_Abstract_Order::get_coupons() method for returning all coupon line items on an order.