### PR TITLE
WC Update CLI DB Version

### DIFF
--- a/includes/cli/class-wc-cli-update-command.php
+++ b/includes/cli/class-wc-cli-update-command.php
@@ -49,6 +49,8 @@ class WC_CLI_Update_Command {
 		}
 
 		if ( empty( $callbacks_to_run ) ) {
+			// Ensure DB version is set to the current WC version to match WP-Admin update routine.
+			WC_Install::update_db_version();
 			/* translators: %s Database version number */
 			WP_CLI::success( sprintf( __( 'No updates required. Database version is %s', 'woocommerce' ), get_option( 'woocommerce_db_version' ) ) );
 			return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR mimics the functionality of WC_Admin_Notice::update_notice for the WooCommerce WP CLI update command. When no DB updates are found it should call WC_Install::update_db_version without a parameter to ensure the version is updated to the currently installed version.

### How to test the changes in this Pull Request:

1. Install WC 3.6.0 and run the DB upgrade routine via WP-CLI
2. Check DB version is set to 3.6.0
3. Upgrade WooCommerce to 3.6.2 and run the DB upgrade routine via WP-CLI again
4. You should see a message stating no updates found, and then the DB version should be 3.6.2 and not stay at 3.6.0.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - WP-CLI upgrade routine not updating to current DB version when no updates available, now mimics WP-Admin upgrade routine functionality.