### PR TITLE
Corrects WC Tracker's order total calculation.

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -509,7 +509,7 @@ class WC_Tracker {
 			FROM {$wpdb->prefix}posts AS orders
 			LEFT JOIN {$wpdb->prefix}postmeta AS order_meta ON order_meta.post_id = orders.ID
 			WHERE order_meta.meta_key =  '_order_total'
-				AND orders.post_status =  'wc-completed'
+				AND orders.post_status in ( 'wc-completed', 'wc-refunded' )
 			GROUP BY order_meta.meta_key
 		"
 		);


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes problem that was causing refunds to be subtracted from order totals twice. See #23669 for more details about the issue.

Closes #23669.

### How to test the changes in this Pull Request:

1. Set up a new WooCommerce site with no orders
2. Create a completed order for $N
3. Fully refund the order
4. Check the calculation with something like wp eval "print_r( WC_Tracker::get_order_totals() );"

Before this fix, the result is -$N. After the fix, it is $0.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix WC Tracker order total calculation.