### PR TITLE
Auto generate usernames when a username is blacklisted by WP

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -175,9 +175,18 @@ function wc_create_new_customer_username( $email, $new_user_args, $suffix = '' )
 		 * Filter generated usernames.
 		 *
 		 * @since 3.7.0
-		 * @param string $username Generated username.
+		 * @param string $username      Generated username.
+		 * @param string $email         New customer email address.
+		 * @param array  $new_user_args Array of new user args, maybe including first and last names.
+		 * @param string $suffix        Append string to username to make it unique.
 		 */
-		$new_args['first_name'] = apply_filters( 'wc_create_new_customer_username_generated', 'woo_user_' . zeroise( wp_rand( 0, 9999 ), 4 ) );
+		$new_args['first_name'] = apply_filters(
+			'woocommerce_generated_customer_username',
+			'woo_user_' . zeroise( wp_rand( 0, 9999 ), 4 ),
+			$email,
+			$new_user_args,
+			$suffix
+		);
 
 		return wc_create_new_customer_username( $email, $new_args, $suffix );
 	}

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -121,11 +121,11 @@ function wc_create_new_customer_username( $email, $new_user_args = array(), $suf
 	$username_parts = array();
 
 	if ( isset( $new_user_args['first_name'] ) ) {
-		$username_parts[] = $new_user_args['first_name'];
+		$username_parts[] = sanitize_user( $new_user_args['first_name'], true );
 	}
 
 	if ( isset( $new_user_args['last_name'] ) ) {
-		$username_parts[] = $new_user_args['last_name'];
+		$username_parts[] = sanitize_user( $new_user_args['last_name'], true );
 	}
 
 	// Remove empty parts.
@@ -152,10 +152,10 @@ function wc_create_new_customer_username( $email, $new_user_args = array(), $suf
 			$email_username = $email_parts[1];
 		}
 
-		$username_parts[] = $email_username;
+		$username_parts[] = sanitize_user( $email_username, true );
 	}
 
-	$username = sanitize_user( wc_strtolower( implode( '.', $username_parts ) ), true );
+	$username = wc_strtolower( implode( '.', $username_parts ) );
 
 	if ( $suffix ) {
 		$username .= $suffix;

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -155,7 +155,7 @@ function wc_create_new_customer_username( $email, $new_user_args, $suffix = '' )
 		$username_parts[] = $email_username;
 	}
 
-	$username = sanitize_user( wc_strtolower( implode( '', $username_parts ) ), true );
+	$username = sanitize_user( wc_strtolower( implode( '.', $username_parts ) ), true );
 
 	if ( $suffix ) {
 		$username .= $suffix;

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -121,11 +121,11 @@ function wc_create_new_customer_username( $email, $new_user_args, $suffix = '' )
 	$username_parts = array();
 
 	if ( isset( $new_user_args['first_name'] ) ) {
-		$username_parts[] = sanitize_user( $new_user_args['first_name'], true );
+		$username_parts[] = $new_user_args['first_name'];
 	}
 
 	if ( isset( $new_user_args['last_name'] ) ) {
-		$username_parts[] = sanitize_user( $new_user_args['last_name'], true );
+		$username_parts[] = $new_user_args['last_name'];
 	}
 
 	// Remove empty parts.
@@ -152,10 +152,10 @@ function wc_create_new_customer_username( $email, $new_user_args, $suffix = '' )
 			$email_username = $email_parts[1];
 		}
 
-		$username_parts[] = sanitize_user( $email_username, true );
+		$username_parts[] = $email_username;
 	}
 
-	$username = wc_strtolower( implode( '', $username_parts ) );
+	$username = sanitize_user( wc_strtolower( implode( '', $username_parts ) ), true );
 
 	if ( $suffix ) {
 		$username .= $suffix;
@@ -168,6 +168,8 @@ function wc_create_new_customer_username( $email, $new_user_args, $suffix = '' )
 	 * @param array $usernames Array of blacklisted usernames.
 	 */
 	$illegal_logins = (array) apply_filters( 'illegal_user_logins', array() );
+
+	// Stop illegal logins and generate a new random username.
 	if ( in_array( strtolower( $username ), array_map( 'strtolower', $illegal_logins ), true ) ) {
 		$new_args = array();
 

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -117,7 +117,7 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
  * @param string $suffix Append string to username to make it unique.
  * @return string Generated username.
  */
-function wc_create_new_customer_username( $email, $new_user_args, $suffix = '' ) {
+function wc_create_new_customer_username( $email, $new_user_args = array(), $suffix = '' ) {
 	$username_parts = array();
 
 	if ( isset( $new_user_args['first_name'] ) ) {

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -161,6 +161,27 @@ function wc_create_new_customer_username( $email, $new_user_args, $suffix = '' )
 		$username .= $suffix;
 	}
 
+	/**
+	 * WordPress 4.4 - filters the list of blacklisted usernames.
+	 *
+	 * @since 3.7.0
+	 * @param array $usernames Array of blacklisted usernames.
+	 */
+	$illegal_logins = (array) apply_filters( 'illegal_user_logins', array() );
+	if ( in_array( strtolower( $username ), array_map( 'strtolower', $illegal_logins ), true ) ) {
+		$new_args = array();
+
+		/**
+		 * Filter generated usernames.
+		 *
+		 * @since 3.7.0
+		 * @param string $username Generated username.
+		 */
+		$new_args['first_name'] = apply_filters( 'wc_create_new_customer_username_generated', 'woo_user_' . zeroise( wp_rand( 0, 9999 ), 4 ) );
+
+		return wc_create_new_customer_username( $email, $new_args, $suffix );
+	}
+
 	if ( username_exists( $username ) ) {
 		// Generate something unique to append to the username in case of a conflict with another user.
 		$suffix = '-' . zeroise( wp_rand( 0, 9999 ), 4 );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -172,7 +172,7 @@ function wc_create_new_customer_username( $email, $new_user_args, $suffix = '' )
 		$new_args = array();
 
 		/**
-		 * Filter generated usernames.
+		 * Filter generated customer username.
 		 *
 		 * @since 3.7.0
 		 * @param string $username      Generated username.
@@ -197,7 +197,16 @@ function wc_create_new_customer_username( $email, $new_user_args, $suffix = '' )
 		return wc_create_new_customer_username( $email, $new_user_args, $suffix );
 	}
 
-	return $username;
+	/**
+	 * Filter new customer username.
+	 *
+	 * @since 3.7.0
+	 * @param string $username      Customer username.
+	 * @param string $email         New customer email address.
+	 * @param array  $new_user_args Array of new user args, maybe including first and last names.
+	 * @param string $suffix        Append string to username to make it unique.
+	 */
+	return apply_filters( 'woocommerce_new_customer_username', $username, $email, $new_user_args, $suffix );
 }
 
 /**

--- a/tests/unit-tests/customer/functions.php
+++ b/tests/unit-tests/customer/functions.php
@@ -11,6 +11,16 @@
 class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 
 	/**
+	 * Set illegal login
+	 *
+	 * @param array $logins Array of blacklisted logins.
+	 * @return array
+	 */
+	public function setup_illegal_user_logins( $logins ) {
+		return array( 'test' );
+	}
+
+	/**
 	 * Test wc_create_new_customer.
 	 *
 	 * @since 3.1
@@ -93,7 +103,7 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 
 		// Test first/last name generation.
 		$this->assertEquals(
-			'bobbobson',
+			'bob.bobson',
 			wc_create_new_customer_username(
 				'bob@bobbobson.com',
 				array(
@@ -114,6 +124,16 @@ class WC_Tests_Customer_Functions extends WC_Unit_Test_Case {
 				)
 			)
 		);
+
+		// Test username generation triggered by illegal_user_logins filter.
+		add_filter( 'illegal_user_logins', array( $this, 'setup_illegal_user_logins' ) );
+
+		$this->assertStringStartsWith(
+			'woo_user_',
+			wc_create_new_customer_username( 'test@test.com' )
+		);
+
+		remove_filter( 'illegal_user_logins', array( $this, 'setup_illegal_user_logins' ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This prevents errors in the checkout when generating usernames, WordPress may block a few usernames with the help of `illegal_user_logins` filter, so a new username prefixed with `woo_user_` will be generated instead to avoid any error message.

Closes #23366.

### How to test the changes in this Pull Request:

1. Set `woocommerce_registration_generate_username` to `yes`.
2. Include a few usernames into the blacklist using the `illegal_user_logins` filter.
3. Try create a new user with `wc_create_new_customer()`, you should try with an email like `blacklisted-term@blacklisted-term.com`.
4. See error (For better error messages, see #23468).
5. Apply this patch and try again, an random username prefixed with `woo_user_` will be generated instead of throwing errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Auto generate usernames when a username is blacklisted by WP
