### PR TITLE
Add different new hooks for mini cart and cart

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2083,6 +2083,16 @@ if ( ! function_exists( 'woocommerce_widget_shopping_cart_proceed_to_checkout' )
 	}
 }
 
+if ( ! function_exists( 'woocommerce_widget_shopping_cart_subtotal' ) ) {
+
+	/**
+	 * Output to view cart subtotal.
+	 */
+	function woocommerce_widget_shopping_cart_subtotal() {
+		echo '<strong>' . __( 'Subtotal', 'woocommerce' ) . ':</strong> ' . WC()->cart->get_cart_subtotal();
+	}
+}
+
 /** Mini-Cart */
 
 if ( ! function_exists( 'woocommerce_mini_cart' ) ) {

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -220,7 +220,7 @@ add_action( 'woocommerce_checkout_terms_and_conditions', 'wc_terms_and_condition
  */
 add_action( 'woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_button_view_cart', 10 );
 add_action( 'woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_proceed_to_checkout', 20 );
-add_action( 'woocommerce_widget_shopping_cart_total', 'woocommerce_widget_shopping_cart_subtotal', 20 );
+add_action( 'woocommerce_widget_shopping_cart_total', 'woocommerce_widget_shopping_cart_subtotal', 10 );
 
 /**
  * Cart.

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -220,6 +220,7 @@ add_action( 'woocommerce_checkout_terms_and_conditions', 'wc_terms_and_condition
  */
 add_action( 'woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_button_view_cart', 10 );
 add_action( 'woocommerce_widget_shopping_cart_buttons', 'woocommerce_widget_shopping_cart_proceed_to_checkout', 20 );
+add_action( 'woocommerce_widget_shopping_cart_total', 'woocommerce_widget_shopping_cart_subtotal', 20 );
 
 /**
  * Cart.

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -152,6 +152,8 @@ do_action( 'woocommerce_before_cart' ); ?>
 	<?php do_action( 'woocommerce_after_cart_table' ); ?>
 </form>
 
+<?php do_action( 'woocommerce_before_cart_collaterals' ); ?>
+
 <div class="cart-collaterals">
 	<?php
 		/**

--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -67,11 +67,13 @@ do_action( 'woocommerce_before_mini_cart' ); ?>
 		?>
 	</ul>
 
-	<p class="woocommerce-mini-cart__total total"><strong><?php _e( 'Subtotal', 'woocommerce' ); ?>:</strong> <?php echo WC()->cart->get_cart_subtotal(); ?></p>
+	<p class="woocommerce-mini-cart__total total"><?php do_action( 'woocommerce_widget_shopping_cart_total' ); ?></p>
 
 	<?php do_action( 'woocommerce_widget_shopping_cart_before_buttons' ); ?>
 
 	<p class="woocommerce-mini-cart__buttons buttons"><?php do_action( 'woocommerce_widget_shopping_cart_buttons' ); ?></p>
+
+	<?php do_action( 'woocommerce_widget_shopping_cart_after_buttons' ); ?>
 
 <?php else : ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23545 .

### Changelog entry

New template hooks

cart/cart.php:
> woocommerce_before_cart_collaterals 

cart/mini-cart.php
> woocommerce_widget_shopping_cart_total
> woocommerce_widget_shopping_cart_after_buttons