### PR TITLE
WC_Structured_Data::generate_product_data() no more hooked in to woommerce_shop_loop  action, which has been removed in #22912

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -178,7 +178,6 @@ class WC_Structured_Data {
 	 * Generates Product structured data.
 	 *
 	 * Hooked into `woocommerce_single_product_summary` action hook.
-	 * Hooked into `woocommerce_shop_loop` action hook.
 	 *
 	 * @param WC_Product $product Product data (default: null).
 	 */

--- a/templates/archive-product.php
+++ b/templates/archive-product.php
@@ -64,8 +64,6 @@ if ( woocommerce_product_loop() ) {
 
 			/**
 			 * Hook: woocommerce_shop_loop.
-			 *
-			 * @hooked WC_Structured_Data::generate_product_data() - 10
 			 */
 			do_action( 'woocommerce_shop_loop' );
 


### PR DESCRIPTION
WC_Structured_Data::generate_product_data() no more hooked in to woommerce_shop_loop action, which has been removed in #22912

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix #22912 .

### Changelog entry

templates/archive-product.php
> remove old command for woommerce_shop_loop action

includes/class-wc-structured-data.php
> remove old command for woommerce_shop_loop action