### PR TITLE
Dashboard stock query should match reports

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -229,7 +229,13 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			if ( false === $outofstock_count ) {
 				$outofstock_count = (int) $wpdb->get_var(
 					$wpdb->prepare(
-						"SELECT COUNT( product_id ) FROM {$wpdb->wc_product_meta_lookup} WHERE stock_quantity <= %d",
+						"SELECT COUNT( product_id )
+						FROM {$wpdb->wc_product_meta_lookup} AS lookup
+						INNER JOIN {$wpdb->posts} as posts ON lookup.product_id = posts.ID
+						WHERE 1=1
+						AND stock_quantity <= %d
+						AND posts.post_type IN ( 'product', 'product_variation' )
+						AND posts.post_status = 'publish'",
 						$nostock
 					)
 				);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes an issue with the out of stock dashboard widget where it was not checking the status of the product when counting the out of stock products. This PR fixes it to make the query match the one used in the reporting, this still maintains the use of the right indexes keeping things fast.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23676 

### How to test the changes in this Pull Request:

1. Mark a few products as out of stock, set some of those products in draft status or trash them.
2. Clear the `wc_outofstock_count` transients
3. Load the dashboard in wp-admin and check that the number under out of stock only reflects published products.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Dashboard stats widget including unpublished products in out of stock counts.
