### PR TITLE
Delete guest cart session if user logs in, solves #23686

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -235,9 +235,11 @@ class WC_Session_Handler extends WC_Session {
 	}
 
 	/**
-	 * Save data.
+	 * Save data and delete guest session.
+	 *
+	 * @param int $old_session_key session ID before user logs in.
 	 */
-	public function save_data( $old_session_key ) {
+	public function save_data( $old_session_key = 0 ) {
 		// Dirty if something changed - prevents saving nothing new.
 		if ( $this->_dirty && $this->has_session() ) {
 			global $wpdb;

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -256,7 +256,7 @@ class WC_Session_Handler extends WC_Session {
 
 			wp_cache_set( $this->get_cache_prefix() . $this->_customer_id, $this->_data, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
 			$this->_dirty = false;
-			if ( get_current_user_id() != $old_session_key && !is_object( get_user_by( 'id', $old_session_key ) ) ) {
+			if ( get_current_user_id() != $old_session_key && ! is_object( get_user_by( 'id', $old_session_key ) ) ) {
 				$this->delete_session( $old_session_key );
 			}
 		}

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -239,7 +239,7 @@ class WC_Session_Handler extends WC_Session {
 	 *
 	 * @param int $old_session_key session ID before user logs in.
 	 */
-	public function save_data( $old_session_key ) {
+	public function save_data( $old_session_key = 0 ) {
 		// Dirty if something changed - prevents saving nothing new.
 		if ( $this->_dirty && $this->has_session() ) {
 			global $wpdb;
@@ -256,7 +256,7 @@ class WC_Session_Handler extends WC_Session {
 
 			wp_cache_set( $this->get_cache_prefix() . $this->_customer_id, $this->_data, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
 			$this->_dirty = false;
-			if ( get_current_user_id() != $old_session_key ) {
+			if ( get_current_user_id() != $old_session_key && !is_object( get_user_by( 'id', $old_session_key ) ) ) {
 				$this->delete_session( $old_session_key );
 			}
 		}

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -239,7 +239,7 @@ class WC_Session_Handler extends WC_Session {
 	 *
 	 * @param int $old_session_key session ID before user logs in.
 	 */
-	public function save_data( $old_session_key = 0 ) {
+	public function save_data( $old_session_key ) {
 		// Dirty if something changed - prevents saving nothing new.
 		if ( $this->_dirty && $this->has_session() ) {
 			global $wpdb;
@@ -256,8 +256,7 @@ class WC_Session_Handler extends WC_Session {
 
 			wp_cache_set( $this->get_cache_prefix() . $this->_customer_id, $this->_data, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
 			$this->_dirty = false;
-			$allow_guest_session_removal = apply_filters( 'woocommerce_persistent_cart_enabled', true ) ? true : (bool) get_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login', true );
-			if ( $allow_guest_session_removal && get_current_user_id() !== $old_session_key ) {
+			if ( get_current_user_id() != $old_session_key ) {
 				$this->delete_session( $old_session_key );
 			}
 		}

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -237,7 +237,7 @@ class WC_Session_Handler extends WC_Session {
 	/**
 	 * Save data.
 	 */
-	public function save_data($old_session_key = false) {
+	public function save_data( $old_session_key ) {
 		// Dirty if something changed - prevents saving nothing new.
 		if ( $this->_dirty && $this->has_session() ) {
 			global $wpdb;

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -256,7 +256,8 @@ class WC_Session_Handler extends WC_Session {
 
 			wp_cache_set( $this->get_cache_prefix() . $this->_customer_id, $this->_data, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
 			$this->_dirty = false;
-			if ( (bool) get_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login', true ) && get_current_user_id() !== $old_session_key ) {
+			$allow_guest_session_removal = apply_filters( 'woocommerce_persistent_cart_enabled', true ) ? true : (bool) get_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login', true );
+			if ( $allow_guest_session_removal && get_current_user_id() !== $old_session_key ) {
 				$this->delete_session( $old_session_key );
 			}
 		}

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -94,9 +94,10 @@ class WC_Session_Handler extends WC_Session {
 
 			// If the user logs in, update session.
 			if ( is_user_logged_in() && get_current_user_id() !== $this->_customer_id ) {
+				$guest_session_id = $this->_customer_id;
 				$this->_customer_id = get_current_user_id();
 				$this->_dirty       = true;
-				$this->save_data();
+				$this->save_data($guest_session_id);
 				$this->set_customer_session_cookie( true );
 			}
 
@@ -236,7 +237,7 @@ class WC_Session_Handler extends WC_Session {
 	/**
 	 * Save data.
 	 */
-	public function save_data() {
+	public function save_data($old_session_key = false) {
 		// Dirty if something changed - prevents saving nothing new.
 		if ( $this->_dirty && $this->has_session() ) {
 			global $wpdb;
@@ -253,6 +254,9 @@ class WC_Session_Handler extends WC_Session {
 
 			wp_cache_set( $this->get_cache_prefix() . $this->_customer_id, $this->_data, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
 			$this->_dirty = false;
+			if (get_current_user_id() !== $old_session_key) {
+				$this->delete_session( $old_session_key );
+			}
 		}
 	}
 

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -256,7 +256,7 @@ class WC_Session_Handler extends WC_Session {
 
 			wp_cache_set( $this->get_cache_prefix() . $this->_customer_id, $this->_data, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
 			$this->_dirty = false;
-			if ( get_current_user_id() !== $old_session_key ) {
+			if ( (bool) get_user_meta( get_current_user_id(), '_woocommerce_load_saved_cart_after_login', true ) && get_current_user_id() !== $old_session_key ) {
 				$this->delete_session( $old_session_key );
 			}
 		}

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -97,7 +97,7 @@ class WC_Session_Handler extends WC_Session {
 				$guest_session_id = $this->_customer_id;
 				$this->_customer_id = get_current_user_id();
 				$this->_dirty       = true;
-				$this->save_data($guest_session_id);
+				$this->save_data( $guest_session_id );
 				$this->set_customer_session_cookie( true );
 			}
 
@@ -254,7 +254,7 @@ class WC_Session_Handler extends WC_Session {
 
 			wp_cache_set( $this->get_cache_prefix() . $this->_customer_id, $this->_data, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
 			$this->_dirty = false;
-			if (get_current_user_id() !== $old_session_key) {
+			if ( get_current_user_id() !== $old_session_key ) {
 				$this->delete_session( $old_session_key );
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This code changes the session handler behaviour so that if a guest user who has products in cart later logs in the cart content is moved to the now logged in user user session and the guest session is deleted after login. Previously in woocommerce_sessions table would exist both the guest session and the logged in session. This would cause confusion as the same cart items would show up twice in calculations where one would check cart content from different sessions.

Closes #23686 .

### How to test the changes in this Pull Request:

1. Add products to cart while not logged in to user account. Check woocommerce_sessions table which shows the guest user session
2. Now log in to the user account
3. View the woocommerce_sessions table to see that now the guest session is removed and only logged in user session exists. Cart content has carried over correctly. Without this fix there would exist both the guest and logged in session.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Changes the session handler behavior to delete the guest session after successful login.