### PR TITLE
Trigger input change when deleting download file on variations

### DIFF
--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -328,7 +328,8 @@ jQuery( function( $ ) {
 			$( '#variable_product_options' )
 				.on( 'click', 'button.save-variation-changes', this.save_variations )
 				.on( 'click', 'button.cancel-variation-changes', this.cancel_variations )
-				.on( 'click', '.remove_variation', this.remove_variation );
+				.on( 'click', '.remove_variation', this.remove_variation )
+				.on( 'click','.downloadable_files a.delete', this.input_changed );
 
 			$( document.body )
 				.on( 'change', '#variable_product_options .woocommerce_variations :input', this.input_changed )

--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -118,11 +118,12 @@ jQuery( function( $ ) {
 			// Init TipTip
 			$( '#tiptip_holder' ).removeAttr( 'style' );
 			$( '#tiptip_arrow' ).removeAttr( 'style' );
-			$( '.woocommerce_variations .tips, .woocommerce_variations .help_tip, .woocommerce_variations .woocommerce-help-tip', wrapper ).tipTip({
-				'attribute': 'data-tip',
-				'fadeIn':    50,
-				'fadeOut':   50,
-				'delay':     200
+			$( '.woocommerce_variations .tips, .woocommerce_variations .help_tip, .woocommerce_variations .woocommerce-help-tip', wrapper )
+				.tipTip({
+					'attribute': 'data-tip',
+					'fadeIn':    50,
+					'fadeOut':   50,
+					'delay':     200
 			});
 
 			// Datepicker fields
@@ -195,7 +196,10 @@ jQuery( function( $ ) {
 				offset       = parseInt( ( current_page - 1 ) * woocommerce_admin_meta_boxes_variations.variations_per_page, 10 );
 
 			$( '.woocommerce_variations .woocommerce_variation' ).each( function ( index, el ) {
-				$( '.variation_menu_order', el ).val( parseInt( $( el ).index( '.woocommerce_variations .woocommerce_variation' ), 10 ) + 1 + offset ).change();
+				$( '.variation_menu_order', el )
+					.val( parseInt( $( el )
+					.index( '.woocommerce_variations .woocommerce_variation' ), 10 ) + 1 + offset )
+					.change();
 			});
 		}
 	};
@@ -259,14 +263,16 @@ jQuery( function( $ ) {
 			if ( $button.is( '.remove' ) ) {
 
 				$( '.upload_image_id', wc_meta_boxes_product_variations_media.setting_variation_image ).val( '' ).change();
-				wc_meta_boxes_product_variations_media.setting_variation_image.find( 'img' ).eq( 0 ).attr( 'src', woocommerce_admin_meta_boxes_variations.woocommerce_placeholder_img_src );
+				wc_meta_boxes_product_variations_media.setting_variation_image.find( 'img' ).eq( 0 )
+					.attr( 'src', woocommerce_admin_meta_boxes_variations.woocommerce_placeholder_img_src );
 				wc_meta_boxes_product_variations_media.setting_variation_image.find( '.upload_image_button' ).removeClass( 'remove' );
 
 			} else {
 
 				// If the media frame already exists, reopen it.
 				if ( wc_meta_boxes_product_variations_media.variable_image_frame ) {
-					wc_meta_boxes_product_variations_media.variable_image_frame.uploader.uploader.param( 'post_id', wc_meta_boxes_product_variations_media.setting_variation_image_id );
+					wc_meta_boxes_product_variations_media.variable_image_frame.uploader.uploader
+						.param( 'post_id', wc_meta_boxes_product_variations_media.setting_variation_image_id );
 					wc_meta_boxes_product_variations_media.variable_image_frame.open();
 					return;
 				} else {
@@ -291,7 +297,8 @@ jQuery( function( $ ) {
 				// When an image is selected, run a callback.
 				wc_meta_boxes_product_variations_media.variable_image_frame.on( 'select', function () {
 
-					var attachment = wc_meta_boxes_product_variations_media.variable_image_frame.state().get( 'selection' ).first().toJSON(),
+					var attachment = wc_meta_boxes_product_variations_media.variable_image_frame.state()
+						.get( 'selection' ).first().toJSON(),
 						url = attachment.sizes && attachment.sizes.thumbnail ? attachment.sizes.thumbnail.url : attachment.url;
 
 					$( '.upload_image_id', wc_meta_boxes_product_variations_media.setting_variation_image ).val( attachment.id ).change();
@@ -554,7 +561,8 @@ jQuery( function( $ ) {
 		cancel_variations: function() {
 			var current = parseInt( $( '#variable_product_options' ).find( '.woocommerce_variations' ).attr( 'data-page' ), 10 );
 
-			$( '#variable_product_options' ).find( '.woocommerce_variations .variation-needs-update' ).removeClass( 'variation-needs-update' );
+			$( '#variable_product_options' ).find( '.woocommerce_variations .variation-needs-update' )
+				.removeClass( 'variation-needs-update' );
 			$( '.variations-defaults select' ).each( function() {
 				$( this ).val( $( this ).attr( 'data-current' ) );
 			});
@@ -618,7 +626,9 @@ jQuery( function( $ ) {
 					$.post( woocommerce_admin_meta_boxes_variations.ajax_url, data, function() {
 						var wrapper      = $( '#variable_product_options' ).find( '.woocommerce_variations' ),
 							current_page = parseInt( wrapper.attr( 'data-page' ), 10 ),
-							total_pages  = Math.ceil( ( parseInt( wrapper.attr( 'data-total' ), 10 ) - 1 ) / woocommerce_admin_meta_boxes_variations.variations_per_page ),
+							total_pages  = Math.ceil( (
+								parseInt( wrapper.attr( 'data-total' ), 10 ) - 1
+							) / woocommerce_admin_meta_boxes_variations.variations_per_page ),
 							page         = 1;
 
 						$( '#woocommerce-product-data' ).trigger( 'woocommerce_variations_removed' );
@@ -727,7 +737,8 @@ jQuery( function( $ ) {
 					if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_delete_all_variations ) ) {
 						if ( window.confirm( woocommerce_admin_meta_boxes_variations.i18n_last_warning ) ) {
 							data.allowed = true;
-							changes      = parseInt( $( '#variable_product_options' ).find( '.woocommerce_variations' ).attr( 'data-total' ), 10 ) * -1;
+							changes      = parseInt( $( '#variable_product_options' ).find( '.woocommerce_variations' )
+								.attr( 'data-total' ), 10 ) * -1;
 						}
 					}
 					break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR ties the deletion of download files on variations to an input change event to ensure the `Save variations` button is activated when you delete a file from a variation.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23683 

### How to test the changes in this Pull Request:

1. See issue for steps to replicate.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Unable to save variations when deleting a downloadable file.
