### PR TITLE
Deprecate get_used_coupons in favor of get_coupon_codes

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -771,23 +771,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
-	 * Get coupon codes only.
-	 *
-	 * @deprecated 3.7.0 - Replaced with better named method to reflect the actual data being returned.
-	 * @return array
-	 */
-	public function get_used_coupons() {
-		wc_deprecated_function( 'get_used_coupons', '3.7', 'WC_Abstract_Order::get_used_coupon_codes' );
-		return $this->get_used_coupon_codes();
-	}
-
-	/**
 	 * Get used coupon codes only.
 	 *
 	 * @since 3.7.0
 	 * @return array
 	 */
-	public function get_used_coupon_codes() {
+	public function get_coupon_codes() {
 		$coupon_codes = array();
 		$coupons      = $this->get_items( 'coupon' );
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -773,9 +773,21 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	/**
 	 * Get coupon codes only.
 	 *
+	 * @deprecated 3.7.0 - Replaced with better named method to reflect the actual data being returned.
 	 * @return array
 	 */
 	public function get_used_coupons() {
+		wc_deprecated_function( 'get_used_coupons', '3.7', 'WC_Abstract_Order::get_used_coupon_codes' );
+		return $this->get_used_coupon_codes();
+	}
+
+	/**
+	 * Get used coupon codes only.
+	 *
+	 * @since 3.7.0
+	 * @return array
+	 */
+	public function get_used_coupon_codes() {
 		$coupon_codes = array();
 		$coupons      = $this->get_items( 'coupon' );
 

--- a/includes/legacy/abstract-wc-legacy-order.php
+++ b/includes/legacy/abstract-wc-legacy-order.php
@@ -599,6 +599,17 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	}
 
 	/**
+	 * Get coupon codes only.
+	 *
+	 * @deprecated 3.7.0 - Replaced with better named method to reflect the actual data being returned.
+	 * @return array
+	 */
+	public function get_used_coupons() {
+		wc_deprecated_function( 'get_used_coupons', '3.7', 'WC_Abstract_Order::get_coupon_codes' );
+		return $this->get_coupon_codes();
+	}
+
+	/**
 	 * Expand item meta into the $item array.
 	 * @deprecated 3.0.0 Item meta no longer expanded due to new order item
 	 *		classes. This function now does nothing to avoid data breakage.

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -854,8 +854,8 @@ function wc_update_coupon_usage_counts( $order_id ) {
 		return;
 	}
 
-	if ( count( $order->get_used_coupons() ) > 0 ) {
-		foreach ( $order->get_used_coupons() as $code ) {
+	if ( count( $order->get_used_coupon_codes() ) > 0 ) {
+		foreach ( $order->get_used_coupon_codes() as $code ) {
 			if ( ! $code ) {
 				continue;
 			}

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -854,8 +854,8 @@ function wc_update_coupon_usage_counts( $order_id ) {
 		return;
 	}
 
-	if ( count( $order->get_used_coupon_codes() ) > 0 ) {
-		foreach ( $order->get_used_coupon_codes() as $code ) {
+	if ( count( $order->get_coupon_codes() ) > 0 ) {
+		foreach ( $order->get_coupon_codes() as $code ) {
 			if ( ! $code ) {
 				continue;
 			}

--- a/tests/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-crud-orders.php
@@ -452,9 +452,9 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test: get_used_coupons
+	 * Test: get_used_coupon_codes
 	 */
-	public function test_get_used_coupons() {
+	public function test_get_used_coupon_codes() {
 		$object = new WC_Order();
 		$item   = new WC_Order_Item_Coupon();
 		$item->set_props(
@@ -466,7 +466,7 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		);
 		$object->add_item( $item );
 		$object->save();
-		$this->assertCount( 1, $object->get_used_coupons() );
+		$this->assertCount( 1, $object->get_used_coupon_codes() );
 	}
 
 	/**

--- a/tests/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-crud-orders.php
@@ -452,9 +452,9 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test: get_used_coupon_codes
+	 * Test: get_coupon_codes
 	 */
-	public function test_get_used_coupon_codes() {
+	public function test_get_coupon_codes() {
 		$object = new WC_Order();
 		$item   = new WC_Order_Item_Coupon();
 		$item->set_props(
@@ -466,7 +466,7 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		);
 		$object->add_item( $item );
 		$object->save();
-		$this->assertCount( 1, $object->get_used_coupon_codes() );
+		$this->assertCount( 1, $object->get_coupon_codes() );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR introduces WC_Abstract_Order::get_coupon_codes which replaces WC_Abstract_Order::get_used_coupons. The name of the later just does not make sense since only codes are returned and not the actual coupon objects. This also paves way for #23663 which introduces a new get_coupons method same as we have for other line item types already.

### How to test the changes in this Pull Request:

1. Make sure unit tests pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Add WC_Abstract_Order::get_coupon_codes method to replace deprecated WC_Abstract_Order::get_used_coupons