### PR TITLE
Calculate base store taxes including the store's zip and city

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1316,9 +1316,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		// Default to base.
 		if ( 'base' === $tax_based_on || empty( $args['country'] ) ) {
-			$default          = wc_get_base_location();
-			$args['country']  = $default['country'];
-			$args['state']    = $default['state'];
+			$args['country']  = WC()->countries->get_base_country();
+			$args['state']    = WC()->countries->get_base_state();
 			$args['postcode'] = WC()->countries->get_base_postcode();
 			$args['city']     = WC()->countries->get_base_city();
 		}

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1319,8 +1319,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$default          = wc_get_base_location();
 			$args['country']  = $default['country'];
 			$args['state']    = $default['state'];
-			$args['postcode'] = '';
-			$args['city']     = '';
+			$args['postcode'] = WC()->countries->get_base_postcode();
+			$args['city']     = WC()->countries->get_base_city();
 		}
 
 		return $args;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR ensures that calculating order totals includes the store's postcode and city when taxes are calculated from the store's base address.

This is already the case when calculating taxes in other places, including [`WC_Tax::get_tax_location()`](https://github.com/woocommerce/woocommerce/blob/3.6.2/includes/class-wc-tax.php#L470-L471), [`WC_Customer::get_taxable_address()`](https://github.com/woocommerce/woocommerce/blob/3.6.2/includes/class-wc-customer.php#L194-L198), and [`WC_Tax::get_base_tax_rates()`](https://github.com/woocommerce/woocommerce/blob/3.6.2/includes/class-wc-tax.php#L517-L521)

All of these other cases use all the individual `WC()->countries` getters rather than `wc_get_base_location()` which `WC_order::get_tax_location()` uses. I wasn't sure if I should replace the `wc_get_base_location()` here or not. `wc_get_base_location()` is filterable so I figured I'd leave it but let me know if this should be consistant. 

### How to test the changes in this Pull Request:

1. Under **WooCommerce > Settings > Taxes > Tax Options** set _Calculate tax based on - Shop base address_: https://cl.ly/3184f24ff884
1. Set your shop base address: https://cl.ly/af760142cb92
1. Create a **Standard tax rate** that matches your shop base address criteria: https://cl.ly/4306f1a202cf. **Be sure to include a postcode and city.** 
1. Go to **WooCommerce > Orders > Add Order**
1. Create an order
1. Add a taxable product
1. Click **recalculate**:
   - on `master` or `3.6.2` no tax is added.
   - on this branch, taxes are added.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Include the store's base postcode and city when calculating order taxes.