### PR TITLE
Add Filter for wc_prices_include_tax() function return

### DIFF
--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -361,7 +361,7 @@ if ( ! function_exists( 'wc_prices_include_tax' ) ) {
 	 * @return bool
 	 */
 	function wc_prices_include_tax() {
-		return wc_tax_enabled() && apply_filters( 'wc_prices_include_tax', get_option( 'woocommerce_prices_include_tax' ) === 'yes' );
+		return wc_tax_enabled() && apply_filters( 'woocommerce_prices_include_tax', get_option( 'woocommerce_prices_include_tax' ) === 'yes' );
 	}
 }
 

--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -361,7 +361,7 @@ if ( ! function_exists( 'wc_prices_include_tax' ) ) {
 	 * @return bool
 	 */
 	function wc_prices_include_tax() {
-		return wc_tax_enabled() && 'yes' === get_option( 'woocommerce_prices_include_tax' );
+		return wc_tax_enabled() && apply_filters( 'wc_prices_include_tax', get_option( 'woocommerce_prices_include_tax' ) === 'yes' );
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This PR allows use filter `wc_prices_include_tax` create custom logic for displaying prices based on some cases. 

### Other information:
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry
> Add filter for return wc_prices_include_tax function