### PR TITLE
Prevent negative prices on products

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -828,7 +828,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param string $price Price.
 	 */
 	public function set_price( $price ) {
-		$this->set_prop( 'price', wc_format_decimal( $price ) );
+		$this->set_prop( 'price', wc_format_decimal( $price, false, false, true ) );
 	}
 
 	/**
@@ -838,7 +838,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param string $price Regular price.
 	 */
 	public function set_regular_price( $price ) {
-		$this->set_prop( 'regular_price', wc_format_decimal( $price ) );
+		$this->set_prop( 'regular_price', wc_format_decimal( $price, false, false, true ) );
 	}
 
 	/**
@@ -848,7 +848,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param string $price sale price.
 	 */
 	public function set_sale_price( $price ) {
-		$this->set_prop( 'sale_price', wc_format_decimal( $price ) );
+		$this->set_prop( 'sale_price', wc_format_decimal( $price, false, false, true ) );
 	}
 
 	/**

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -281,7 +281,7 @@ function wc_format_refund_total( $amount ) {
  * This function does not remove thousands - this should be done before passing a value to the function.
  *
  * @param  float|string $number     Expects either a float or a string with a decimal separator only (no thousands).
- * @param  bool|integer $dp number  Number of decimal points to use, blank to use woocommerce_price_num_decimals, or false to avoid all rounding.
+ * @param  bool|integer $dp         Number of decimal points to use, blank to use woocommerce_price_num_decimals, or false to avoid all rounding.
  * @param  bool         $trim_zeros From end of string.
  * @param  bool         $abs        Converts to absolute value of a number. See PHP abs().
  * @return string

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -281,11 +281,12 @@ function wc_format_refund_total( $amount ) {
  * This function does not remove thousands - this should be done before passing a value to the function.
  *
  * @param  float|string $number     Expects either a float or a string with a decimal separator only (no thousands).
- * @param  mixed        $dp number  Number of decimal points to use, blank to use woocommerce_price_num_decimals, or false to avoid all rounding.
+ * @param  bool|integer $dp number  Number of decimal points to use, blank to use woocommerce_price_num_decimals, or false to avoid all rounding.
  * @param  bool         $trim_zeros From end of string.
+ * @param  bool         $abs        Converts to absolute value of a number. See PHP abs().
  * @return string
  */
-function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
+function wc_format_decimal( $number, $dp = false, $trim_zeros = false, $abs = false ) {
 	$locale   = localeconv();
 	$decimals = array( wc_get_price_decimal_separator(), $locale['decimal_point'], $locale['mon_decimal_point'] );
 
@@ -293,6 +294,11 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 	if ( ! is_float( $number ) ) {
 		$number = str_replace( $decimals, '.', $number );
 		$number = preg_replace( '/[^0-9\.,-]/', '', wc_clean( $number ) );
+	}
+
+	// Convert to absolute number. Avoid empty values to not convert to 0.
+	if ( '' !== $number && $abs ) {
+		$number = abs( $number );
 	}
 
 	if ( false !== $dp ) {

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -311,6 +311,15 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		// Trim zeros and round.
 		$this->assertEquals( '10', wc_format_decimal( 9.9999, '', true ) );
 
+		// Negative values.
+		$this->assertEquals( '-9.9999', wc_format_decimal( -9.9999 ) );
+		$this->assertEquals( '-10.00', wc_format_decimal( -9.9999, '' ) );
+		$this->assertEquals( '-9.991', wc_format_decimal( -9.9912, 3 ) );
+		$this->assertEquals( '-9', wc_format_decimal( -9.00, false, true ) );
+
+		// Convert nevative to absolute value.
+		$this->assertEquals( '9.9999', wc_format_decimal( -9.9999, false, false, true ) );
+
 		// Given string with thousands in german format.
 		update_option( 'woocommerce_price_decimal_sep', ',' );
 		update_option( 'woocommerce_price_thousand_sep', '.' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Trim any `-` in product prices, this also should fix on front end some PHP warnings:

```
[14-May-2019 16:01:08 UTC] PHP Warning:  A non-numeric value encountered in wp-content/plugins/woocommerce/includes/class-wc-cart-totals.php on line 235
[14-May-2019 16:01:08 UTC] PHP Warning:  A non-numeric value encountered in wp-content/plugins/woocommerce/includes/class-wc-discounts.php on line 85
[14-May-2019 16:01:09 UTC] PHP Warning:  A non-numeric value encountered in wp-content/plugins/woocommerce/includes/wc-product-functions.php on line 1017
```

Closes #23696.

### How to test the changes in this Pull Request:

See #23696.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog

> Fix - Prevent negative prices on products
