### PR TITLE
fix#23722 Signature mismatch of get_formatted_order_total

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1668,9 +1668,11 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	/**
 	 * Gets order total - formatted for display.
 	 *
+	 * @param string $tax_display Excl or incl tax display mode.
+	 *
 	 * @return string
 	 */
-	public function get_formatted_order_total() {
+	public function get_formatted_order_total( $tax_display ) {
 		$formatted_total = wc_price( $this->get_total(), array( 'currency' => $this->get_currency() ) );
 		return apply_filters( 'woocommerce_get_formatted_order_total', $formatted_total, $this );
 	}

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1668,11 +1668,12 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	/**
 	 * Gets order total - formatted for display.
 	 *
-	 * @param string $tax_display Excl or incl tax display mode.
+	 * @param string $tax_display      Type of tax display.
+	 * @param bool   $display_refunded If should include refunded value.
 	 *
 	 * @return string
 	 */
-	public function get_formatted_order_total( $tax_display ) {
+	public function get_formatted_order_total( $tax_display = '', $display_refunded = true ) {
 		$formatted_total = wc_price( $this->get_total(), array( 'currency' => $this->get_currency() ) );
 		return apply_filters( 'woocommerce_get_formatted_order_total', $formatted_total, $this );
 	}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23722 .

### How to test the changes in this Pull Request:

1. Go to 'plugins\woocommerce\includes\abstracts\abstract-wc-order.php'
2. Find the method call get_formatted_order_total and method signature.

> updated the get_formatted_order_total method signature.
