### PR TITLE
get_formatted_line_subtotal takes Item object instead of an array

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1642,7 +1642,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	/**
 	 * Gets line subtotal - formatted for display.
 	 *
-	 * @param array  $item Item to get total from.
+	 * @param object $item Item to get total from.
 	 * @param string $tax_display Incl or excl tax display mode.
 	 * @return string
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Change the PHPDoc for `WC_Abstract_Order::get_formatted_line_subtotal`, as it takes the `WC_Order_Item` object for the `$item` param instead of an array. 

It passes the `$item` to the `WC_Abstract_Order::get_line_subtotal`, which takes the object as well.

It confuses the IDEs.

### How to test the changes in this Pull Request:

Not applicable.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] ~Have you written new tests for your changes, as applicable?~
* [ ] ~Have you successfully run tests with your changes locally?~

<!-- Mark completed items with an [x] -->

### Changelog entry

> Changed the PHPDoc for `WC_Abstract_Order::get_formatted_line_subtotal`, the `$item` param is an object and not an array