### PR TITLE
Dashboard stock queries should only include published products

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -229,7 +229,13 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			if ( false === $outofstock_count ) {
 				$outofstock_count = (int) $wpdb->get_var(
 					$wpdb->prepare(
-						"SELECT COUNT( product_id ) FROM {$wpdb->wc_product_meta_lookup} WHERE stock_quantity <= %d",
+						"SELECT COUNT( product_id )
+						FROM {$wpdb->wc_product_meta_lookup} AS lookup
+						INNER JOIN {$wpdb->posts} as posts ON lookup.product_id = posts.ID
+						WHERE 1=1
+						AND stock_quantity <= %d
+						AND posts.post_type IN ( 'product', 'product_variation' )
+						AND posts.post_status = 'publish'",
 						$nostock
 					)
 				);

--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -232,9 +232,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 						"SELECT COUNT( product_id )
 						FROM {$wpdb->wc_product_meta_lookup} AS lookup
 						INNER JOIN {$wpdb->posts} as posts ON lookup.product_id = posts.ID
-						WHERE 1=1
-						AND stock_quantity <= %d
-						AND posts.post_type IN ( 'product', 'product_variation' )
+						WHERE stock_quantity <= %d
 						AND posts.post_status = 'publish'",
 						$nostock
 					)

--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -215,7 +215,12 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			if ( false === $lowinstock_count ) {
 				$lowinstock_count = (int) $wpdb->get_var(
 					$wpdb->prepare(
-						"SELECT COUNT( product_id ) FROM {$wpdb->wc_product_meta_lookup} WHERE stock_quantity <= %d AND stock_quantity > %d",
+						"SELECT COUNT( product_id )
+						FROM {$wpdb->wc_product_meta_lookup} AS lookup
+						INNER JOIN {$wpdb->posts} as posts ON lookup.product_id = posts.ID
+						WHERE stock_quantity <= %d
+						AND stock_quantity > %d
+						AND posts.post_status = 'publish'",
 						$stock,
 						$nostock
 					)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes an issue with the number of out of stock and low in stock products in the WooCommerce Status widget in the admin dashboard. Both queries were not checking the status of the product when counting resulting in trashed products being included in the results and inconsistent behavior when compared to the out of stock and low in stock reports. To fix it, this PR includes a check for the post status to both queries.

Closes #23676
Supersedes #23685
### How to test the changes in this Pull Request:

1. Mark a few products as out of stock and a few as low in stock (by default, stock equal to 1), set some of those products in draft status or trash them.
2. Clear the `wc_outofstock_count` and `wc_low_stock_count` transients (`wp transient delete --all`)
3. Load the dashboard in wp-admin and check that the numbers under out of stock and low in stock only reflects published products.

### Changelog entry

> Fix - Dashboard stats widget including unpublished products in out of stock and low in stock counts.