### PR TITLE
Remove administrative message from refund reason

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -772,11 +772,13 @@ function wc_order_fully_refunded( $order_id ) {
 	wc_create_refund(
 		array(
 			'amount'     => $max_refund,
-			'reason'     => __( 'Order status set to refunded. To return funds to the customer you will need to issue a refund through your payment gateway.', 'woocommerce' ),
+			'reason'     => __( 'Order fully refunded.', 'woocommerce' ),
 			'order_id'   => $order_id,
 			'line_items' => array(),
 		)
 	);
+
+	$order->add_order_note( __( 'Order status set to refunded. To return funds to the customer you will need to issue a refund through your payment gateway.', 'woocommerce' ) );
 }
 add_action( 'woocommerce_order_status_refunded', 'wc_order_fully_refunded' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Refund reasons are public, can be visualized on emails, and shall not contain any sensitive data or administration information. Since 3.6 we are including the follow message (https://github.com/woocommerce/woocommerce/pull/23149):

> Order status set to refunded. To return funds to the customer you will need to issue a refund through your payment gateway.

I just moved it into an order note, so still target https://github.com/woocommerce/woocommerce/issues/23144

Closes https://github.com/woocommerce/woocommerce/issues/23737.

### How to test the changes in this Pull Request:

1. Place an order with any payment method.
2. Change the order status to refunded.
3. See email, and information on the admin screen.
4. Apply this patch and try again, now all messages about refund is now an internal order note.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Removed sensitive information when manually refunded an order changing status, and moved information into order notes.
