### PR TITLE
 Plain text email: check if product exists before calling get_sku()

### DIFF
--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @package 	WooCommerce/Templates/Emails/Plain
- * @version     3.6.4
+ * @version     3.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,6 +22,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 foreach ( $items as $item_id => $item ) :
 	if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
 		$product = $item->get_product();
+		$sku           = '';
+		$purchase_note = '';
 		
 		if ( is_object( $product ) ) {
 			$sku           = $product->get_sku();
@@ -29,7 +31,7 @@ foreach ( $items as $item_id => $item ) :
 		}
 
 		echo apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false );
-		if ( $show_sku && ! empty( $sku ) ) {
+		if ( $show_sku && $sku ) {
 			echo ' (#' . $sku . ')';
 		}
 		echo ' X ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
@@ -49,7 +51,7 @@ foreach ( $items as $item_id => $item ) :
 		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );
 	}
 	// Note
-	if ( $show_purchase_note && ! empty( $purchase_note ) ) {
+	if ( $show_purchase_note && $purchase_note ) {
 		echo "\n" . do_shortcode( wp_kses_post( $purchase_note ) );
 	}
 	echo "\n\n";

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -12,7 +12,7 @@
  *
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @package 	WooCommerce/Templates/Emails/Plain
- * @version     3.2.0
+ * @version     3.6.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,9 +22,15 @@ if ( ! defined( 'ABSPATH' ) ) {
 foreach ( $items as $item_id => $item ) :
 	if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
 		$product = $item->get_product();
+		
+		if ( is_object( $product ) ) {
+			$sku           = $product->get_sku();
+			$purchase_note = $product->get_purchase_note();
+		}
+
 		echo apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false );
-		if ( $show_sku && $product->get_sku() ) {
-			echo ' (#' . $product->get_sku() . ')';
+		if ( $show_sku && !empty( $sku ) ) {
+			echo ' (#' . $sku . ')';
 		}
 		echo ' X ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
 		echo ' = ' . $order->get_formatted_line_subtotal( $item ) . "\n";
@@ -43,7 +49,7 @@ foreach ( $items as $item_id => $item ) :
 		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );
 	}
 	// Note
-	if ( $show_purchase_note && is_object( $product ) && ( $purchase_note = $product->get_purchase_note() ) ) {
+	if ( $show_purchase_note && !empty( $purchase_note ) ) ) {
 		echo "\n" . do_shortcode( wp_kses_post( $purchase_note ) );
 	}
 	echo "\n\n";

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -29,7 +29,7 @@ foreach ( $items as $item_id => $item ) :
 		}
 
 		echo apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false );
-		if ( $show_sku && !empty( $sku ) ) {
+		if ( $show_sku && ! empty( $sku ) ) {
 			echo ' (#' . $sku . ')';
 		}
 		echo ' X ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
@@ -49,7 +49,7 @@ foreach ( $items as $item_id => $item ) :
 		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );
 	}
 	// Note
-	if ( $show_purchase_note && !empty( $purchase_note ) ) {
+	if ( $show_purchase_note && ! empty( $purchase_note ) ) {
 		echo "\n" . do_shortcode( wp_kses_post( $purchase_note ) );
 	}
 	echo "\n\n";

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -49,7 +49,7 @@ foreach ( $items as $item_id => $item ) :
 		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );
 	}
 	// Note
-	if ( $show_purchase_note && !empty( $purchase_note ) ) ) {
+	if ( $show_purchase_note && !empty( $purchase_note ) ) {
 		echo "\n" . do_shortcode( wp_kses_post( $purchase_note ) );
 	}
 	echo "\n\n";


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Following the same logic in the HTML template, checking if the product exists before calling `get_sku()` to prevent fatal errors

### How to test the changes in this Pull Request:

Send an email, with show_sku enabled of an order with products that have been removed from the WC catalog in plain text.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: fatal error on emails from orders with non-catalog products
