### PR TITLE
Enqueue free shipping JS only on the respective settings page.

### DIFF
--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -454,6 +454,34 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 				wp_enqueue_script( 'marketplace-suggestions' );
 			}
 
+			if ( $wc_screen_id . '_page_wc-settings' === $screen_id && isset( $_GET['tab'] ) && 'shipping' == $_GET['tab'] ) {
+				wc_enqueue_js(
+					"jQuery( function( $ ) {
+						function wcFreeShippingShowHideMinAmountField( el ) {
+							var form = $( el ).closest( 'form' );
+							var minAmountField = $( '#woocommerce_free_shipping_min_amount', form ).closest( 'tr' );
+							if ( 'coupon' === $( el ).val() || '' === $( el ).val() ) {
+								minAmountField.hide();
+							} else {
+								minAmountField.show();
+							}
+						}
+	
+						$( document.body ).on( 'change', '#woocommerce_free_shipping_requires', function() {
+							wcFreeShippingShowHideMinAmountField( this );
+						});
+	
+						// Change while load.
+						$( '#woocommerce_free_shipping_requires' ).change();
+						$( document.body ).on( 'wc_backbone_modal_loaded', function( evt, target ) {
+							if ( 'wc-modal-shipping-method-settings' === target ) {
+								wcFreeShippingShowHideMinAmountField( $( '#wc-backbone-modal-dialog #woocommerce_free_shipping_requires', evt.currentTarget ) );
+							}
+						} );
+					});"
+				);
+			}
+
 		}
 
 	}

--- a/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -112,34 +112,6 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 	 * @return array
 	 */
 	public function get_instance_form_fields() {
-		if ( is_admin() ) {
-			wc_enqueue_js(
-				"jQuery( function( $ ) {
-					function wcFreeShippingShowHideMinAmountField( el ) {
-						var form = $( el ).closest( 'form' );
-						var minAmountField = $( '#woocommerce_free_shipping_min_amount', form ).closest( 'tr' );
-						if ( 'coupon' === $( el ).val() || '' === $( el ).val() ) {
-							minAmountField.hide();
-						} else {
-							minAmountField.show();
-						}
-					}
-
-					$( document.body ).on( 'change', '#woocommerce_free_shipping_requires', function() {
-						wcFreeShippingShowHideMinAmountField( this );
-					});
-
-					// Change while load.
-					$( '#woocommerce_free_shipping_requires' ).change();
-					$( document.body ).on( 'wc_backbone_modal_loaded', function( evt, target ) {
-						if ( 'wc-modal-shipping-method-settings' === target ) {
-							wcFreeShippingShowHideMinAmountField( $( '#wc-backbone-modal-dialog #woocommerce_free_shipping_requires', evt.currentTarget ) );
-						}
-					} );
-				});"
-			);
-		}
-
 		return parent::get_instance_form_fields();
 	}
 


### PR DESCRIPTION
Previsouly the JS was enqueued on all admin pages where shipping classes were constructed, but that is unnecessary, as it's only used for shipping settings.

To prevent the JS from being enqueued multiple times, I first moved it to a static method of the same class. 

However, looking at the JS code itself, I think a better option is to move it to the `WC_Admin_Assets` class. Other option would be to create a standalone file and enqueue it as the rest of the JS code. 

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23699 .

### How to test the changes in this Pull Request:

1. Have a free shipping option active/set up on the site.
2. Make an order.
3. Inspect HTML source for edit order screen, you should find multiple instances of the same code `wcFreeShippingShowHideMinAmountField `.
4. Apply branch, check that there is no instance of the code on Edit order screen, just on the Settings > Shipping screen. Check that you can set up free shipping including minimum amount correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enqueue free shipping JS only on the respective settings page.
