### PR TITLE
Fix Top rated shortcode results

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -397,6 +397,18 @@ class WC_Shortcode_Products {
 		$query_args['order']    = 'DESC';
 		$query_args['orderby']  = 'meta_value_num';
 	}
+	
+	/**
+	 * Set top rated products query args.
+	 *
+	 * @since 3.6.4
+	 * @param array $query_args Query args.
+	 */
+	protected function set_top_rated_products_query_args( &$query_args ) {
+		$query_args['meta_key'] = '_wc_average_rating'; // @codingStandardsIgnoreLine
+		$query_args['order']    = 'DESC';
+		$query_args['orderby']  = 'meta_value_num';
+	}
 
 	/**
 	 * Set visibility as hidden.
@@ -562,13 +574,7 @@ class WC_Shortcode_Products {
 		if ( isset( $transient_value['value'], $transient_value['version'] ) && $transient_value['version'] === $transient_version ) {
 			$results = $transient_value['value'];
 		} else {
-			if ( 'top_rated_products' === $this->type ) {
-				add_filter( 'posts_clauses', array( __CLASS__, 'order_by_rating_post_clauses' ) );
-				$query = new WP_Query( $this->query_args );
-				remove_filter( 'posts_clauses', array( __CLASS__, 'order_by_rating_post_clauses' ) );
-			} else {
-				$query = new WP_Query( $this->query_args );
-			}
+			$query = new WP_Query( $this->query_args );	
 
 			$paginated = ! $query->get( 'no_found_rows' );
 
@@ -673,23 +679,5 @@ class WC_Shortcode_Products {
 		}
 
 		return '<div class="' . esc_attr( implode( ' ', $classes ) ) . '">' . ob_get_clean() . '</div>';
-	}
-
-	/**
-	 * Order by rating.
-	 *
-	 * @since  3.2.0
-	 * @param  array $args Query args.
-	 * @return array
-	 */
-	public static function order_by_rating_post_clauses( $args ) {
-		global $wpdb;
-
-		$args['where']  .= " AND $wpdb->commentmeta.meta_key = 'rating' ";
-		$args['join']   .= "LEFT JOIN $wpdb->comments ON($wpdb->posts.ID = $wpdb->comments.comment_post_ID) LEFT JOIN $wpdb->commentmeta ON($wpdb->comments.comment_ID = $wpdb->commentmeta.comment_id)";
-		$args['orderby'] = "$wpdb->commentmeta.meta_value DESC";
-		$args['groupby'] = "$wpdb->posts.ID";
-
-		return $args;
 	}
 }

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -195,20 +195,18 @@ class WC_Shortcode_Products {
 			$this->attributes['limit'] = $this->attributes['columns'] * $this->attributes['rows'];
 		}
 
-		// @codingStandardsIgnoreStart
-		$ordering_args                = WC()->query->get_catalog_ordering_args( $query_args['orderby'], $query_args['order'] );
-		$query_args['orderby']        = $ordering_args['orderby'];
-		$query_args['order']          = $ordering_args['order'];
+		$ordering_args         = WC()->query->get_catalog_ordering_args( $query_args['orderby'], $query_args['order'] );
+		$query_args['orderby'] = $ordering_args['orderby'];
+		$query_args['order']   = $ordering_args['order'];
 		if ( $ordering_args['meta_key'] ) {
-			$query_args['meta_key']       = $ordering_args['meta_key'];
+			$query_args['meta_key'] = $ordering_args['meta_key']; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		}
 		$query_args['posts_per_page'] = intval( $this->attributes['limit'] );
 		if ( 1 < $this->attributes['page'] ) {
-			$query_args['paged']          = absint( $this->attributes['page'] );
+			$query_args['paged'] = absint( $this->attributes['page'] );
 		}
-		$query_args['meta_query']     = WC()->query->get_meta_query();
-		$query_args['tax_query']      = array();
-		// @codingStandardsIgnoreEnd
+		$query_args['meta_query'] = WC()->query->get_meta_query(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+		$query_args['tax_query']  = array(); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 
 		// Visibility.
 		$this->set_visibility_query_args( $query_args );
@@ -482,9 +480,7 @@ class WC_Shortcode_Products {
 	 * @param array $query_args Query args.
 	 */
 	protected function set_visibility_featured_query_args( &$query_args ) {
-		// @codingStandardsIgnoreStart
-		$query_args['tax_query'] = array_merge( $query_args['tax_query'], WC()->query->get_tax_query() );
-		// @codingStandardsIgnoreEnd
+		$query_args['tax_query'] = array_merge( $query_args['tax_query'], WC()->query->get_tax_query() ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 
 		$query_args['tax_query'][] = array(
 			'taxonomy'         => 'product_visibility',
@@ -505,9 +501,7 @@ class WC_Shortcode_Products {
 		if ( method_exists( $this, 'set_visibility_' . $this->attributes['visibility'] . '_query_args' ) ) {
 			$this->{'set_visibility_' . $this->attributes['visibility'] . '_query_args'}( $query_args );
 		} else {
-			// @codingStandardsIgnoreStart
-			$query_args['tax_query'] = array_merge( $query_args['tax_query'], WC()->query->get_tax_query() );
-			// @codingStandardsIgnoreEnd
+			$query_args['tax_query'] = array_merge( $query_args['tax_query'], WC()->query->get_tax_query() ); // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 		}
 	}
 

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -397,7 +397,7 @@ class WC_Shortcode_Products {
 		$query_args['order']    = 'DESC';
 		$query_args['orderby']  = 'meta_value_num';
 	}
-	
+
 	/**
 	 * Set top rated products query args.
 	 *
@@ -574,7 +574,7 @@ class WC_Shortcode_Products {
 		if ( isset( $transient_value['value'], $transient_value['version'] ) && $transient_value['version'] === $transient_version ) {
 			$results = $transient_value['value'];
 		} else {
-			$query = new WP_Query( $this->query_args );	
+			$query = new WP_Query( $this->query_args );
 
 			$paginated = ! $query->get( 'no_found_rows' );
 
@@ -679,5 +679,23 @@ class WC_Shortcode_Products {
 		}
 
 		return '<div class="' . esc_attr( implode( ' ', $classes ) ) . '">' . ob_get_clean() . '</div>';
+	}
+
+	/**
+	 * Order by rating.
+	 *
+	 * @since  3.2.0
+	 * @param  array $args Query args.
+	 * @return array
+	 */
+	public static function order_by_rating_post_clauses( $args ) {
+		global $wpdb;
+
+		$args['where']  .= " AND $wpdb->commentmeta.meta_key = 'rating' ";
+		$args['join']   .= "LEFT JOIN $wpdb->comments ON($wpdb->posts.ID = $wpdb->comments.comment_post_ID) LEFT JOIN $wpdb->commentmeta ON($wpdb->comments.comment_ID = $wpdb->commentmeta.comment_id)";
+		$args['orderby'] = "$wpdb->commentmeta.meta_value DESC";
+		$args['groupby'] = "$wpdb->posts.ID";
+
+		return $args;
 	}
 }

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -125,7 +125,7 @@ class WC_Shortcode_Products {
 				'terms'          => '',        // Comma separated term slugs or ids.
 				'terms_operator' => 'IN',      // Operator to compare terms. Possible values are 'IN', 'NOT IN', 'AND'.
 				'tag'            => '',        // Comma separated tag slugs.
-				'visibility'     => 'visible', // Possible values are 'visible', 'catalog', 'search', 'hidden'.
+				'visibility'     => 'visible', // Product visibility setting. Possible values are 'visible', 'catalog', 'search', 'hidden'.
 				'class'          => '',        // HTML class.
 				'page'           => 1,         // Page for pagination.
 				'paginate'       => false,     // Should results be paginated.
@@ -178,7 +178,7 @@ class WC_Shortcode_Products {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => false === wc_string_to_bool( $this->attributes['paginate'] ),
-			'orderby'             => empty( $_GET['orderby'] ) ? $this->attributes['orderby'] : wc_clean( wp_unslash( $_GET['orderby'] ) ),
+			'orderby'             => empty( $_GET['orderby'] ) ? $this->attributes['orderby'] : wc_clean( wp_unslash( $_GET['orderby'] ) ), // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 		);
 
 		$orderby_value         = explode( '-', $query_args['orderby'] );
@@ -333,7 +333,7 @@ class WC_Shortcode_Products {
 			$field      = 'slug';
 
 			if ( is_numeric( $categories[0] ) ) {
-				$field = 'term_id';
+				$field      = 'term_id';
 				$categories = array_map( 'absint', $categories );
 				// Check numeric slugs.
 				foreach ( $categories as $cat ) {
@@ -393,7 +393,7 @@ class WC_Shortcode_Products {
 	 * @param array $query_args Query args.
 	 */
 	protected function set_best_selling_products_query_args( &$query_args ) {
-		$query_args['meta_key'] = 'total_sales'; // @codingStandardsIgnoreLine
+		$query_args['meta_key'] = 'total_sales'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		$query_args['order']    = 'DESC';
 		$query_args['orderby']  = 'meta_value_num';
 	}
@@ -405,7 +405,7 @@ class WC_Shortcode_Products {
 	 * @param array $query_args Query args.
 	 */
 	protected function set_top_rated_products_query_args( &$query_args ) {
-		$query_args['meta_key'] = '_wc_average_rating'; // @codingStandardsIgnoreLine
+		$query_args['meta_key'] = '_wc_average_rating'; // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		$query_args['order']    = 'DESC';
 		$query_args['orderby']  = 'meta_value_num';
 	}
@@ -552,7 +552,7 @@ class WC_Shortcode_Products {
 
 		if ( 'rand' === $this->query_args['orderby'] ) {
 			// When using rand, we'll cache a number of random queries and pull those to avoid querying rand on each page load.
-			$rand_index      = rand( 0, max( 1, absint( apply_filters( 'woocommerce_product_query_max_rand_cache_count', 5 ) ) ) );
+			$rand_index      = wp_rand( 0, max( 1, absint( apply_filters( 'woocommerce_product_query_max_rand_cache_count', 5 ) ) ) );
 			$transient_name .= $rand_index;
 		}
 

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -1,9 +1,12 @@
 <?php
-
 /**
- * Class WC_Shortcode_Products.
+ * Test WC_Shortcode_Products
  *
  * @package WooCommerce\Tests\Shortcodes
+ */
+
+/**
+ * Class WC_Test_Shortcode_Products.
  */
 class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 
@@ -80,8 +83,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => '-1',
-			'meta_query'          => $meta_query,
-			'tax_query'           => $tax_query,
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'fields'              => 'ids',
 		);
 		$this->assertEquals( $expected, $shortcode->get_query_args() );
@@ -101,8 +104,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'ID',
 			'order'               => 'DESC',
 			'posts_per_page'      => '-1',
-			'meta_query'          => $meta_query,
-			'tax_query'           => $tax_query,
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'fields'              => 'ids',
 		);
 		$this->assertEquals( $expected2, $shortcode2->get_query_args() );
@@ -121,8 +124,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => '-1',
-			'meta_query'          => $meta_query,
-			'tax_query'           => $tax_query,
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'post__in'            => array( '1', '2', '3' ),
 			'fields'              => 'ids',
 		);
@@ -154,8 +157,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => '12',
-			'meta_query'          => $meta_query,
-			'tax_query'           => $tax_query,
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'fields'              => 'ids',
 		);
 		$expected4['tax_query'][] = array(
@@ -188,8 +191,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => '12',
-			'meta_query'          => $meta_query,
-			'tax_query'           => $tax_query,
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'fields'              => 'ids',
 		);
 		$expected4_id['tax_query'][] = array(
@@ -222,8 +225,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'date ID',
 			'order'               => 'DESC',
 			'posts_per_page'      => '12',
-			'meta_query'          => $meta_query,
-			'tax_query'           => $tax_query,
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'fields'              => 'ids',
 		);
 
@@ -245,8 +248,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => '1',
-			'meta_query'          => $meta_query,
-			'tax_query'           => $tax_query,
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'p'                   => '1',
 			'fields'              => 'ids',
 		);
@@ -273,8 +276,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => 12,
-			'meta_query'          => $meta_query,
-			'tax_query'           => $tax_query,
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'post__in'            => array_merge( array( 0 ), wc_get_product_ids_on_sale() ),
 			'fields'              => 'ids',
 		);
@@ -299,9 +302,9 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'meta_value_num',
 			'order'               => 'DESC',
 			'posts_per_page'      => 12,
-			'meta_query'          => $meta_query,
-			'tax_query'           => $tax_query,
-			'meta_key'            => 'total_sales',
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
+			'meta_key'            => 'total_sales', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 			'fields'              => 'ids',
 		);
 
@@ -324,12 +327,13 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => true,
-			'orderby'             => 'title',
-			'order'               => 'ASC',
+			'orderby'             => 'meta_value_num',
+			'order'               => 'DESC',
 			'posts_per_page'      => 12,
-			'meta_query'          => $meta_query,
-			'tax_query'           => $tax_query,
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'fields'              => 'ids',
+			'meta_key'            => '_wc_average_rating', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 		);
 
 		$this->assertEquals( $expected9, $shortcode9->get_query_args() );
@@ -354,8 +358,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'date ID',
 			'order'               => 'DESC',
 			'posts_per_page'      => 12,
-			'meta_query'          => $meta_query,
-			'tax_query'           => array_merge(
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => array_merge( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				$tax_query,
 				array(
 					array(
@@ -392,8 +396,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => 12,
-			'meta_query'          => $meta_query,
-			'tax_query'           => array_merge(
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => array_merge( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				$tax_query,
 				array(
 					array(
@@ -429,8 +433,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => 12,
-			'meta_query'          => $meta_query,
-			'tax_query'           => array_merge(
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => array_merge( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				$tax_query,
 				array(
 					array(
@@ -460,8 +464,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
-			'meta_query'          => $meta_query,
-			'tax_query'           => array(
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				array(
 					'taxonomy'         => 'product_visibility',
 					'terms'            => array( 'exclude-from-catalog', 'exclude-from-search' ),
@@ -488,8 +492,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
-			'meta_query'          => $meta_query,
-			'tax_query'           => array(
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				array(
 					'taxonomy'         => 'product_visibility',
 					'terms'            => 'exclude-from-search',
@@ -523,8 +527,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
-			'meta_query'          => $meta_query,
-			'tax_query'           => array(
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				array(
 					'taxonomy'         => 'product_visibility',
 					'terms'            => 'exclude-from-catalog',
@@ -560,8 +564,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
-			'meta_query'          => $meta_query,
-			'tax_query'           => array_merge(
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => array_merge( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				$tax_query,
 				array(
 					array(
@@ -593,8 +597,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'orderby'             => 'title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
-			'meta_query'          => $meta_query,
-			'tax_query'           => array_merge(
+			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+			'tax_query'           => array_merge( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 				$tax_query,
 				array(
 					array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This make the results returned by top rated shortcode the same as blocks and the widget.

Closes #23756.

### How to test the changes in this Pull Request:

See #23756 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed query of top rated products shortcode.