### PR TITLE
Tracks: Add check for OBW is-opting-in

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -18,17 +18,21 @@ class WC_Site_Tracking {
 	 */
 	public static function is_tracking_enabled() {
 		/**
-		 * Don't track users who haven't opted-in to tracking or if a filter
-		 * has been applied to turn it off.
+		 * Don't track users if a filter has been applied to turn it off.
+		 * `woocommerce_apply_tracking` will be deprecated. Please use
+		 * `woocommerce_apply_user_tracking` instead.
 		 */
-
-		if ( ! apply_filters( 'woocommerce_apply_user_tracking', true ) ) {
+		if ( ! apply_filters( 'woocommerce_apply_user_tracking', true ) && ! apply_filters( 'woocommerce_apply_tracking', true ) ) {
 			return false;
 		}
 
 		// Check if tracking is actively being opted into.
 		$is_obw_opting_in = isset( $_POST['wc_tracker_checkbox'] ) && 'yes' === sanitize_text_field( $_POST['wc_tracker_checkbox'] ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
 
+		/**
+		 * Don't track users who haven't opted-in to tracking or aren't in
+		 * the process of opting-in.
+		 */
 		if ( 'yes' !== get_option( 'woocommerce_allow_tracking' ) && ! $is_obw_opting_in ) {
 			return false;
 		}

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -22,7 +22,7 @@ class WC_Site_Tracking {
 		 * `woocommerce_apply_tracking` will be deprecated. Please use
 		 * `woocommerce_apply_user_tracking` instead.
 		 */
-		if ( ! apply_filters( 'woocommerce_apply_user_tracking', true ) && ! apply_filters( 'woocommerce_apply_tracking', true ) ) {
+		if ( ! apply_filters( 'woocommerce_apply_user_tracking', true ) || ! apply_filters( 'woocommerce_apply_tracking', true ) ) {
 			return false;
 		}
 

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -74,13 +74,9 @@ class WC_Tracks {
 	 */
 	public static function record_event( $event_name, $properties = array() ) {
 		/**
-		 * Don't track users who haven't opted-in to tracking or if a filter
-		 * has been applied to turn it off.
+		 * Don't track users who don't have tracking enabled.
 		 */
-		if (
-			'yes' !== get_option( 'woocommerce_allow_tracking' ) ||
-			! apply_filters( 'woocommerce_apply_tracking', true )
-		) {
+		if ( ! WC_Site_Tracking::is_tracking_enabled() ) {
 			return false;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

`WC_Tracks::record_event` had its own check to see if tracking is enabled. This PR replaces that check with `WC_Site_Tracking::is_tracking_enabled()`, which is more comprehensive and includes a check for a unique instance where tracking is disabled, but the user is in the process of enabling it.

### How to test the changes in this Pull Request:

1. Turn off tracking here `/wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com`
2. Add an error log to see Tracks requests made:
```php

add_filter( 'http_request_args', function( $r, $url ) {
	error_log( $r['method'] . ' ' . $url );
	return $r;
},10, 2 );
```
3. Go store setup `/wp-admin/admin.php?page=wc-setup&step=store_setup` and enable tracking.
4. Click "Let's go!"
5. See the event being fired.

