### PR TITLE
PayPal pass billing address when shipping address option disabled

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -249,7 +249,7 @@ class WC_Gateway_Paypal_Request {
 	 */
 	protected function get_shipping_args( $order ) {
 		$shipping_args = array();
-		if ( $order->has_shipping_method() ) {
+		if ( $order->needs_shipping_address() ) {
 			$shipping_args['address_override'] = $this->gateway->get_option( 'address_override' ) === 'yes' ? 1 : 0;
 			$shipping_args['no_shipping']      = 0;
 			if ( 'yes' === $this->gateway->get_option( 'send_shipping' ) ) {

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -249,24 +249,23 @@ class WC_Gateway_Paypal_Request {
 	 */
 	protected function get_shipping_args( $order ) {
 		$shipping_args = array();
-
-		if ( 'yes' === $this->gateway->get_option( 'send_shipping' ) ) {
+		if ( $order->has_shipping_method() ) {
 			$shipping_args['address_override'] = $this->gateway->get_option( 'address_override' ) === 'yes' ? 1 : 0;
 			$shipping_args['no_shipping']      = 0;
-
-			// If we are sending shipping, send shipping address instead of billing.
-			$shipping_args['first_name'] = $this->limit_length( $order->get_shipping_first_name(), 32 );
-			$shipping_args['last_name']  = $this->limit_length( $order->get_shipping_last_name(), 64 );
-			$shipping_args['address1']   = $this->limit_length( $order->get_shipping_address_1(), 100 );
-			$shipping_args['address2']   = $this->limit_length( $order->get_shipping_address_2(), 100 );
-			$shipping_args['city']       = $this->limit_length( $order->get_shipping_city(), 40 );
-			$shipping_args['state']      = $this->get_paypal_state( $order->get_shipping_country(), $order->get_shipping_state() );
-			$shipping_args['country']    = $this->limit_length( $order->get_shipping_country(), 2 );
-			$shipping_args['zip']        = $this->limit_length( wc_format_postcode( $order->get_shipping_postcode(), $order->get_shipping_country() ), 32 );
+			if ( 'yes' === $this->gateway->get_option( 'send_shipping' ) ) {
+				// If we are sending shipping, send shipping address instead of billing.
+				$shipping_args['first_name'] = $this->limit_length( $order->get_shipping_first_name(), 32 );
+				$shipping_args['last_name']  = $this->limit_length( $order->get_shipping_last_name(), 64 );
+				$shipping_args['address1']   = $this->limit_length( $order->get_shipping_address_1(), 100 );
+				$shipping_args['address2']   = $this->limit_length( $order->get_shipping_address_2(), 100 );
+				$shipping_args['city']       = $this->limit_length( $order->get_shipping_city(), 40 );
+				$shipping_args['state']      = $this->get_paypal_state( $order->get_shipping_country(), $order->get_shipping_state() );
+				$shipping_args['country']    = $this->limit_length( $order->get_shipping_country(), 2 );
+				$shipping_args['zip']        = $this->limit_length( wc_format_postcode( $order->get_shipping_postcode(), $order->get_shipping_country() ), 32 );
+			}
 		} else {
 			$shipping_args['no_shipping'] = 1;
 		}
-
 		return $shipping_args;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes a logic bug where if `Send shipping details to PayPal instead of billing` where enabled it would pass the no_shipping argument to PayPal as true resulting in no address being saved.

This PR adjusts the logic so the no_shipping argument is only set to true when the order actually does not require shipping.

Closes #23744 

### How to test the changes in this Pull Request:

1. See #23744 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Do not pass the no_shipping argument to PayPal when the order contains shippable items.
