### PR TITLE
Manual orders coupon usage limits by email

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -400,15 +400,17 @@ jQuery( function ( $ ) {
 			if ( value != null ) {
 				wc_meta_boxes_order_items.block();
 
-				var user_id = $( '#customer_user' ).val();
+				var user_id    = $( '#customer_user' ).val();
+				var user_email = $( '#_billing_email' ).val();
 
 				var data = $.extend( {}, wc_meta_boxes_order_items.get_taxable_address(), {
-					action   : 'woocommerce_add_coupon_discount',
-					dataType : 'json',
-					order_id : woocommerce_admin_meta_boxes.post_id,
-					security : woocommerce_admin_meta_boxes.order_item_nonce,
-					coupon   : value,
-					user_id  : user_id
+					action     : 'woocommerce_add_coupon_discount',
+					dataType   : 'json',
+					order_id   : woocommerce_admin_meta_boxes.post_id,
+					security   : woocommerce_admin_meta_boxes.order_item_nonce,
+					coupon     : value,
+					user_id    : user_id,
+					user_email : user_email,
 				} );
 
 				$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -966,16 +966,18 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		// Check specific for guest checkouts here as well since WC_Cart handles that seperately in check_customer_coupons.
-		$data_store  = $coupon->get_data_store();
-		$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
-		if ( $usage_count >= $coupon->get_usage_limit_per_user() ) {
-			return new WP_Error(
-				'invalid_coupon',
-				$coupon->get_coupon_error( 106 ),
-				array(
-					'status' => 400,
-				)
-			);
+		if ( 0 === $this->get_customer_id() ) {
+			$data_store  = $coupon->get_data_store();
+			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
+			if ( $usage_count >= $coupon->get_usage_limit_per_user() ) {
+				return new WP_Error(
+					'invalid_coupon',
+					$coupon->get_coupon_error( 106 ),
+					array(
+						'status' => 400,
+					)
+				);
+			}
 		}
 
 		$this->set_coupon_discount_amounts( $discounts );

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -965,6 +965,19 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			return $applied;
 		}
 
+		// Check specific for guest checkouts here as well since WC_Cart handles that seperately in check_customer_coupons.
+		$data_store  = $coupon->get_data_store();
+		$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
+		if ( $usage_count >= $coupon->get_usage_limit_per_user() ) {
+			return new WP_Error(
+				'invalid_coupon',
+				$coupon->get_coupon_error( 106 ),
+				array(
+					'status' => 400,
+				)
+			);
+		}
+
 		$this->set_coupon_discount_amounts( $discounts );
 		$this->save();
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1128,11 +1128,15 @@ class WC_AJAX {
 				throw new Exception( __( 'Invalid coupon', 'woocommerce' ) );
 			}
 
-			// Add user ID so validation for coupon limits works.
-			$user_id_arg = isset( $_POST['user_id'] ) ? absint( $_POST['user_id'] ) : 0;
+			// Add user ID and/or email so validation for coupon limits works.
+			$user_id_arg    = isset( $_POST['user_id'] ) ? absint( $_POST['user_id'] ) : 0;
+			$user_email_arg = isset( $_POST['user_email'] ) ? sanitize_email( wp_unslash( $_POST['user_email'] ) ) : '';
 
 			if ( $user_id_arg ) {
 				$order->set_customer_id( $user_id_arg );
+			}
+			if ( $user_email_arg ) {
+				$order->set_billing_email( $user_email_arg );
 			}
 
 			$result = $order->apply_coupon( wc_format_coupon_code( wp_unslash( $_POST['coupon'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -369,6 +369,19 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	}
 
 	/**
+	 * Get the number of uses for a coupon by email address
+	 *
+	 * @since 3.6.4
+	 * @param WC_Coupon $coupon Coupon object.
+	 * @param string    $email Email address.
+	 * @return int
+	 */
+	public function get_usage_by_email( &$coupon, $email ) {
+		global $wpdb;
+		return $wpdb->get_var( $wpdb->prepare( "SELECT COUNT( meta_id ) FROM {$wpdb->postmeta} WHERE post_id = %d AND meta_key = '_used_by' AND meta_value = %s;", $coupon->get_id(), $email ) );
+	}
+
+	/**
 	 * Return a coupon code for a specific ID.
 	 *
 	 * @since 3.0.0

--- a/tests/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-crud-orders.php
@@ -1839,6 +1839,37 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test the coupon usage limit based on guest orders with emails only.
+	 *
+	 * @return void
+	 */
+	public function test_coupon_email_usage_limit() {
+		// Orders.
+		$order1 = WC_Helper_Order::create_order();
+		$order2 = WC_Helper_Order::create_order();
+
+		// Setup coupon.
+		$coupon = new WC_Coupon();
+		$coupon->set_code( 'usage-limit-coupon' );
+		$coupon->set_amount( 100 );
+		$coupon->set_discount_type( 'percent' );
+		$coupon->set_usage_limit_per_user( 1 );
+		$coupon->save();
+
+		// Set as guest users with the same email.
+		$order1->set_customer_id( 0 );
+		$order1->set_billing_email( 'coupontest@example.com' );
+		$order1->set_customer_id( 0 );
+		$order2->set_billing_email( 'coupontest@example.com' );
+
+		$order1->apply_coupon( 'usage-limit-coupon' );
+		$this->assertEquals( 1, count( $order1->get_coupons() ) );
+
+		$order2->apply_coupon( 'usage-limit-coupon' );
+		$this->assertEquals( 0, count( $order2->get_coupons() ) );
+	}
+
+	/**
 	 * Test removing and adding items + recalculation.
 	 *
 	 * @since 3.2.0

--- a/tests/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-crud-orders.php
@@ -1859,7 +1859,7 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 		// Set as guest users with the same email.
 		$order1->set_customer_id( 0 );
 		$order1->set_billing_email( 'coupontest@example.com' );
-		$order1->set_customer_id( 0 );
+		$order2->set_customer_id( 0 );
 		$order2->set_billing_email( 'coupontest@example.com' );
 
 		$order1->apply_coupon( 'usage-limit-coupon' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR applies the same logic as is done in WC_Cart where coupon usage limits for emails are done separately outside the discounts class. This resulted in manual orders not applying the check to usage limits based on emails because that was all done in WC_Cart only.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23760 

### How to test the changes in this Pull Request:

1. See instructions in #23760

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Coupon usage limit checks based on email never ran when orders are created via wp-admin.
