### PR TITLE
#23768 Fixed - ajax call reloads after every Ajax Add to cart call

### DIFF
--- a/assets/js/frontend/add-to-cart.js
+++ b/assets/js/frontend/add-to-cart.js
@@ -13,7 +13,6 @@ jQuery( function( $ ) {
 			.on( 'click', '.add_to_cart_button', this.onAddToCart )
 			.on( 'click', '.remove_from_cart_button', this.onRemoveFromCart )
 			.on( 'added_to_cart', this.updateButton )
-			.on( 'added_to_cart', this.updateCartPage )
 			.on( 'added_to_cart removed_from_cart', this.updateFragments );
 	};
 
@@ -111,21 +110,6 @@ jQuery( function( $ ) {
 
 			$( document.body ).trigger( 'wc_cart_button_updated', [ $button ] );
 		}
-	};
-
-	/**
-	 * Update cart page elements after add to cart events.
-	 */
-	AddToCartHandler.prototype.updateCartPage = function() {
-		var page = window.location.toString().replace( 'add-to-cart', 'added-to-cart' );
-
-		$.get( page, function( data ) {
-			$( '.shop_table.cart:eq(0)' ).replaceWith( $( data ).find( '.shop_table.cart:eq(0)' ) );
-			$( '.cart_totals:eq(0)' ).replaceWith( $( data ).find( '.cart_totals:eq(0)' ) );
-			$( '.cart_totals, .shop_table.cart' ).stop( true ).css( 'opacity', '1' ).unblock();
-			$( document.body ).trigger( 'cart_page_refreshed' );
-			$( document.body ).trigger( 'cart_totals_refreshed' );
-		} );
 	};
 
 	/**


### PR DESCRIPTION
I have fixed #23768 . Please check it and let me know.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
