### PR TITLE
OBW: Switch shipping labels and shipping zones placement

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1,3 +1,4 @@
+/* stylelint-disable no-descending-specificity */
 body {
 	margin: 65px auto 24px;
 	box-shadow: none;
@@ -27,6 +28,14 @@ body {
 	.hidden {
 		display: none;
 	}
+
+	#tiptip_content {
+		background: #5f6973;
+	}
+
+	#tiptip_holder.tip_top #tiptip_arrow_inner {
+		border-top-color: #5f6973;
+	}
 }
 
 .wc-setup-content {
@@ -53,13 +62,13 @@ body {
 	p {
 		margin: 20px 0;
 		font-size: 1em;
-		line-height: 1.75em;
+		line-height: 1.75;
 		color: #666;
 	}
 
 	table {
 		font-size: 1em;
-		line-height: 1.75em;
+		line-height: 1.75;
 		color: #666;
 	}
 
@@ -77,7 +86,7 @@ body {
 		th {
 			width: 35%;
 			vertical-align: top;
-			font-weight: normal;
+			font-weight: 400;
 		}
 
 		td {
@@ -94,7 +103,7 @@ body {
 			}
 
 			.description {
-				line-height: 1.5em;
+				line-height: 1.5;
 				display: block;
 				margin-top: 0.25em;
 				color: #999;
@@ -167,7 +176,7 @@ body {
 
 				&::before {
 					content: "\f333";
-					font-family: "dashicons";
+					font-family: dashicons; /* stylelint-disable-line font-family-no-missing-generic-family-keyword */
 				}
 			}
 
@@ -178,7 +187,7 @@ body {
 
 		.add {
 			padding: 1em 0 0 1em;
-			line-height: 1em;
+			line-height: 1;
 			font-size: 1em;
 			width: 0;
 			margin: 6px 0 0;
@@ -189,7 +198,7 @@ body {
 
 			&::before {
 				content: "\f502";
-				font-family: "dashicons";
+				font-family: dashicons; /* stylelint-disable-line font-family-no-missing-generic-family-keyword */
 				position: absolute;
 				left: 0;
 				top: 0;
@@ -198,7 +207,7 @@ body {
 
 		.remove {
 			padding: 1em 0 0 1em;
-			line-height: 1em;
+			line-height: 1;
 			font-size: 1em;
 			width: 0;
 			margin: 0;
@@ -209,7 +218,7 @@ body {
 
 			&::before {
 				content: "\f182";
-				font-family: "dashicons";
+				font-family: dashicons; /* stylelint-disable-line font-family-no-missing-generic-family-keyword */
 				position: absolute;
 				left: 0;
 				top: 0;
@@ -227,7 +236,7 @@ body {
 
 		.page-name {
 			width: 30%;
-			font-weight: bold;
+			font-weight: 700;
 		}
 
 		th,
@@ -249,14 +258,14 @@ body {
 			p {
 				color: #777;
 				margin: 6px 0 0 24px;
-				line-height: 1.75em;
+				line-height: 1.75;
 
 				input {
 					vertical-align: middle;
 					margin: 1px 0 0;
 					height: 1.75em;
 					width: 1.75em;
-					line-height: 1.75em;
+					line-height: 1.75;
 				}
 
 				label {
@@ -324,7 +333,7 @@ body {
 					text-shadow: 1px 0 1px #eee, 0 1px 1px #eee;
 					font-size: 1em;
 					height: auto;
-					line-height: 1.75em;
+					line-height: 1.75;
 					margin: 0 0 0.75em;
 					opacity: 1;
 					padding: 1em;
@@ -358,7 +367,7 @@ body {
 
 			li a::before {
 				color: #82878c;
-				font: normal 20px/1 "dashicons";
+				font: 400 20px/1 dashicons; /* stylelint-disable-line font-family-no-missing-generic-family-keyword */
 				speak: none;
 				display: inline-block;
 				padding: 0 10px 0 0;
@@ -409,7 +418,7 @@ body {
 
 		p {
 			font-size: 14px;
-			line-height: 1.5em;
+			line-height: 1.5;
 		}
 
 		.checkbox {
@@ -499,7 +508,7 @@ body {
 		text-align: center;
 		position: relative;
 		border-bottom: 4px solid #ccc;
-		line-height: 1.4em;
+		line-height: 1.4;
 
 		a {
 			color: #a16696;
@@ -534,7 +543,7 @@ body {
 	li.active {
 		border-color: #a16696;
 		color: #a16696;
-		font-weight: bold;
+		font-weight: 700;
 
 		&::before {
 			border-color: #a16696;
@@ -556,16 +565,6 @@ body {
 	overflow: hidden;
 	margin: 20px 0 0;
 	position: relative;
-
-	.button {
-		font-size: 1.25em;
-		padding: 0.5em 1em;
-		line-height: 1em;
-		margin-right: 0.5em;
-		margin-bottom: 2px;
-		height: auto;
-		border-radius: 4px;
-	}
 
 	.button-primary {
 		background-color: #bb77ae;
@@ -681,7 +680,7 @@ body {
 		margin: 0 0 1em 0;
 		padding: 0;
 		font-size: 1em;
-		line-height: 1.5em;
+		line-height: 1.5;
 	}
 }
 
@@ -707,7 +706,7 @@ body {
 		flex-basis: 0;
 		min-width: 160px;
 		text-align: center;
-		font-weight: bold;
+		font-weight: 700;
 		padding: 2em 0;
 		align-self: stretch;
 		display: flex;
@@ -790,7 +789,7 @@ body {
 		border-radius: 10em;
 		position: relative;
 
-		input[type=checkbox] {
+		input[type="checkbox"] {
 			display: none;
 		}
 
@@ -850,8 +849,7 @@ body {
 
 	.wc-wizard-service-enable::before {
 		content: "\f343"; // up chevron
-		font-family: "dashicons";
-		visibility: initial;
+		font-family: dashicons; /* stylelint-disable-line font-family-no-missing-generic-family-keyword */
 		color: #666;
 		font-size: 25px;
 		margin-top: -7px;
@@ -882,7 +880,7 @@ body {
 	margin: 0;
 
 	.wc-wizard-service-name {
-		font-weight: normal;
+		font-weight: 400;
 		text-align: left;
 		align-items: center;
 		max-height: 5em;
@@ -966,7 +964,7 @@ body {
 .wc-setup-shipping-units {
 
 	p {
-		line-height: 1.5em;
+		line-height: 1.5;
 		font-size: 13px;
 		margin-bottom: 0.25em;
 		text-align: center;
@@ -1021,7 +1019,7 @@ body {
 	p.wc-wizard-feature-name,
 	p.wc-wizard-feature-description {
 		margin: 0;
-		line-height: 1.5em;
+		line-height: 1.5;
 	}
 }
 
@@ -1061,8 +1059,12 @@ h3.jetpack-reasons {
 	padding: 1em 2em;
 	box-shadow: none;
 	min-width: 12em;
-	min-width: auto;
 	margin-top: 10px;
+	line-height: 1;
+	margin-right: 0.5em;
+	margin-bottom: 2px;
+	height: auto;
+	border-radius: 4px;
 
 	&:focus,
 	&:hover,
@@ -1076,7 +1078,7 @@ h3.jetpack-reasons {
 	font-style: italic;
 	color: #999;
 	font-size: 14px;
-	line-height: 1.5em;
+	line-height: 1.5;
 	margin: 5px 0;
 
 	& > * {
@@ -1292,10 +1294,6 @@ h3.jetpack-reasons {
 				font-size: 15px;
 				margin: 1em 0 1em 1.5em;
 			}
-
-			.button::last-child {
-				margin-right: 1.5em;
-			}
 		}
 	}
 }
@@ -1312,7 +1310,7 @@ p.jetpack-terms {
 	text-align: center;
 	max-width: 480px;
 	margin: 0 auto;
-	line-height: 1.5em;
+	line-height: 1.5;
 }
 
 .woocommerce-error {
@@ -1455,14 +1453,14 @@ p.jetpack-terms {
 
 		h3 {
 			font-size: 15px;
-			font-weight: bold;
+			font-weight: 700;
 			letter-spacing: 0.5px;
 			margin-bottom: 0;
 		}
 
 		p {
 			margin-top: 0;
-			line-height: 1.5em;
+			line-height: 1.5;
 		}
 	}
 }
@@ -1474,17 +1472,6 @@ p.jetpack-terms {
 
 .help_tip {
 	text-decoration: underline dotted;
-}
-
-.wc-setup {
-
-	#tiptip_content {
-		background: #5f6973;
-	}
-
-	#tiptip_holder.tip_top #tiptip_arrow_inner {
-		border-top-color: #5f6973;
-	}
 }
 
 .wc-setup-shipping-recommended {
@@ -1568,3 +1555,4 @@ p.jetpack-terms {
 		}
 	}
 }
+/* stylelint-enable */

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1474,12 +1474,6 @@ p.jetpack-terms {
 	text-decoration: underline dotted;
 }
 
-.wc-setup-shipping-recommended {
-	border-bottom: 1px solid #eee;
-	margin-top: 0;
-	padding: 30px 0;
-}
-
 @media only screen and (max-width: 400px) {
 
 	#wc-logo img {

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -917,6 +917,41 @@ class WC_Admin_Setup_Wizard {
 			<p><?php echo wp_kses_post( $intro_text ); ?></p>
 		<?php endif; ?>
 		<form method="post">
+			<?php if ( $is_wcs_labels_supported || $is_shipstation_supported ) : ?>
+				<ul class="wc-setup-shipping-recommended">
+				<?php
+				if ( $is_wcs_labels_supported ) :
+					$this->display_recommended_item(
+						array(
+							'type'        => 'woocommerce_services',
+							'title'       => __( 'Print shipping labels at home', 'woocommerce' ),
+							'description' => __( 'We recommend WooCommerce Services & Jetpack. These plugins will save you time at the Post Office by enabling you to print your shipping labels at home.', 'woocommerce' ),
+							'img_url'     => WC()->plugin_url() . '/assets/images/obw-woocommerce-services-icon.png',
+							'img_alt'     => __( 'WooCommerce Services icon', 'woocommerce' ),
+							'plugins'     => $this->get_wcs_requisite_plugins(),
+						)
+					);
+				elseif ( $is_shipstation_supported ) :
+					$this->display_recommended_item(
+						array(
+							'type'        => 'shipstation',
+							'title'       => __( 'Print shipping labels at home', 'woocommerce' ),
+							'description' => __( 'We recommend using ShipStation to save time at the Post Office by printing your shipping labels at home. Try ShipStation free for 30 days.', 'woocommerce' ),
+							'img_url'     => WC()->plugin_url() . '/assets/images/obw-shipstation-icon.png',
+							'img_alt'     => __( 'ShipStation icon', 'woocommerce' ),
+							'plugins'     => array(
+								array(
+									'name' => __( 'ShipStation', 'woocommerce' ),
+									'slug' => 'woocommerce-shipstation-integration',
+								),
+							),
+						)
+					);
+				endif;
+				?>
+				</ul>
+			<?php endif; ?>
+
 			<?php if ( empty( $existing_zones ) ) : ?>
 				<ul class="wc-wizard-services shipping">
 					<li class="wc-wizard-service-item">
@@ -981,41 +1016,6 @@ class WC_Admin_Setup_Wizard {
 					</li>
 				</ul>
 			<?php endif; ?>
-
-		<?php if ( $is_wcs_labels_supported || $is_shipstation_supported ) : ?>
-			<ul class="wc-setup-shipping-recommended">
-			<?php
-			if ( $is_wcs_labels_supported ) :
-				$this->display_recommended_item(
-					array(
-						'type'        => 'woocommerce_services',
-						'title'       => __( 'Print shipping labels at home', 'woocommerce' ),
-						'description' => __( 'We recommend WooCommerce Services & Jetpack. These plugins will save you time at the Post Office by enabling you to print your shipping labels at home.', 'woocommerce' ),
-						'img_url'     => WC()->plugin_url() . '/assets/images/obw-woocommerce-services-icon.png',
-						'img_alt'     => __( 'WooCommerce Services icon', 'woocommerce' ),
-						'plugins'     => $this->get_wcs_requisite_plugins(),
-					)
-				);
-			elseif ( $is_shipstation_supported ) :
-				$this->display_recommended_item(
-					array(
-						'type'        => 'shipstation',
-						'title'       => __( 'Print shipping labels at home', 'woocommerce' ),
-						'description' => __( 'We recommend using ShipStation to save time at the Post Office by printing your shipping labels at home. Try ShipStation free for 30 days.', 'woocommerce' ),
-						'img_url'     => WC()->plugin_url() . '/assets/images/obw-shipstation-icon.png',
-						'img_alt'     => __( 'ShipStation icon', 'woocommerce' ),
-						'plugins'     => array(
-							array(
-								'name' => __( 'ShipStation', 'woocommerce' ),
-								'slug' => 'woocommerce-shipstation-integration',
-							),
-						),
-					)
-				);
-			endif;
-			?>
-			</ul>
-		<?php endif; ?>
 
 			<div class="wc-setup-shipping-units">
 				<p>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1013,9 +1013,9 @@ class WC_Admin_Setup_Wizard {
 					)
 				);
 			endif;
-		endif;
-		?>
+			?>
 			</ul>
+		<?php endif; ?>
 
 			<div class="wc-setup-shipping-units">
 				<p>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -924,8 +924,8 @@ class WC_Admin_Setup_Wizard {
 					$this->display_recommended_item(
 						array(
 							'type'        => 'woocommerce_services',
-							'title'       => __( 'Print shipping labels at home', 'woocommerce' ),
-							'description' => __( 'We recommend WooCommerce Services & Jetpack. These plugins will save you time at the Post Office by enabling you to print your shipping labels at home.', 'woocommerce' ),
+							'title'       => __( 'Did you know you can print shipping labels at home?', 'woocommerce' ),
+							'description' => __( 'Use WooCommerce Shipping (powered by WooCommerce Services & Jetpack) to save time at the post office by printing your shipping labels at home.', 'woocommerce' ),
 							'img_url'     => WC()->plugin_url() . '/assets/images/obw-woocommerce-services-icon.png',
 							'img_alt'     => __( 'WooCommerce Services icon', 'woocommerce' ),
 							'plugins'     => $this->get_wcs_requisite_plugins(),
@@ -935,8 +935,8 @@ class WC_Admin_Setup_Wizard {
 					$this->display_recommended_item(
 						array(
 							'type'        => 'shipstation',
-							'title'       => __( 'Print shipping labels at home', 'woocommerce' ),
-							'description' => __( 'We recommend using ShipStation to save time at the Post Office by printing your shipping labels at home. Try ShipStation free for 30 days.', 'woocommerce' ),
+							'title'       => __( 'Did you know you can print shipping labels at home?', 'woocommerce' ),
+							'description' => __( 'We recommend using ShipStation to save time at the post office by printing your shipping labels at home. Try ShipStation free for 30 days.', 'woocommerce' ),
 							'img_url'     => WC()->plugin_url() . '/assets/images/obw-shipstation-icon.png',
 							'img_alt'     => __( 'ShipStation icon', 'woocommerce' ),
 							'plugins'     => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updated the shipping section, and the label recommendation wording. The it now looks like this:

<img width="729" alt="Screen Shot 2019-05-23 at 10 18 51 PM" src="https://user-images.githubusercontent.com/11487924/58298438-84a71c00-7da9-11e9-8e99-4b9e1646976a.png">

### How to test the changes in this Pull Request:

1. Go to the shipping page in the OBW

### Other information:

- fixed most of the linting errors in the related scss file
- did not add strings or css file changes - let me know if you'd like it done as part of this PR (iirc this is done at plugin release time)

cc @bmccotter @alanabweinstein @MechielCouvaras  

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

OBW: Update the shipping page