### PR TITLE
Add another unique identifier for template cachekey (#23751)

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -157,7 +157,12 @@ function wc_update_order( $args ) {
  * @param string $name Template name (default: '').
  */
 function wc_get_template_part( $slug, $name = '' ) {
-	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name, WC_VERSION ) ) );
+	if ( isset( $_SERVER['SERVER_NAME'] ) ) {
+		$uniquepath = sanitize_key( $_SERVER['SERVER_NAME'] );
+	} else {
+		$uniquepath = '';
+	}
+	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name, WC_VERSION, $uniquepath ) ) );
 	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {
@@ -205,7 +210,12 @@ function wc_get_template_part( $slug, $name = '' ) {
  * @param string $default_path  Default path. (default: '').
  */
 function wc_get_template( $template_name, $args = array(), $template_path = '', $default_path = '' ) {
-	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path, WC_VERSION ) ) );
+	if ( isset( $_SERVER['SERVER_NAME'] ) ) {
+		$uniquepath = sanitize_key( $_SERVER['SERVER_NAME'] );
+	} else {
+		$uniquepath = '';
+	}
+	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path, WC_VERSION, $uniquepath ) ) );
 	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -157,12 +157,8 @@ function wc_update_order( $args ) {
  * @param string $name Template name (default: '').
  */
 function wc_get_template_part( $slug, $name = '' ) {
-	if ( isset( $_SERVER['SERVER_NAME'] ) ) {
-		$uniquepath = sanitize_key( $_SERVER['SERVER_NAME'] );
-	} else {
-		$uniquepath = '';
-	}
-	$cache_key = sanitize_key( implode( '-', array( 'template-part', $slug, $name, WC_VERSION, $uniquepath ) ) );
+	$server_name = isset( $_SERVER['SERVER_NAME'] ) ? sanitize_key( $_SERVER['SERVER_NAME'] ) : '';
+	$cache_key = sanitize_key( apply_filters( 'woocommerce_get_template_part_cache_key', implode( '-', array( 'template-part', $slug, $name, WC_VERSION, $server_name ) ), $slug, $name, WC_VERSION, $server_name ) );
 	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {
@@ -210,12 +206,8 @@ function wc_get_template_part( $slug, $name = '' ) {
  * @param string $default_path  Default path. (default: '').
  */
 function wc_get_template( $template_name, $args = array(), $template_path = '', $default_path = '' ) {
-	if ( isset( $_SERVER['SERVER_NAME'] ) ) {
-		$uniquepath = sanitize_key( $_SERVER['SERVER_NAME'] );
-	} else {
-		$uniquepath = '';
-	}
-	$cache_key = sanitize_key( implode( '-', array( 'template', $template_name, $template_path, $default_path, WC_VERSION, $uniquepath ) ) );
+	$server_name = isset( $_SERVER['SERVER_NAME'] ) ? sanitize_key( $_SERVER['SERVER_NAME'] ) : '';
+	$cache_key = sanitize_key( apply_filters( 'woocommerce_get_template_cache_key', implode( '-', array( 'template', $template_name, $template_path, $default_path, WC_VERSION, $server_name ) ) ) );
 	$template  = (string) wp_cache_get( $cache_key, 'woocommerce' );
 
 	if ( ! $template ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In relation to #23751, this PR includes the proposed solution `2` which will create a cache key for each server and using the server variable `$_SERVER['SERVER_NAME']` as another layer of unique identifier for the $cachekey as there are no other elegant way to do this via native functions like `WC()->template_path()` and `WC()->plugin_path()` because it will always still use the full server path

Closes #23751 .

### How to test the changes in this Pull Request:

1. Can be reproduced on servers that have multiple containers. ( Pantheon is an example and in Performance medium and above plans, I can share access) The setup of multiple application servers behind a load balancer where there are different root path for each app server e.g.
Server 1 path - /svr/bindings/serverpathxxxxxxxxx1/
Server 2 path - /svr/bindings/serverpathxxxxxxxxx2/

Based from the wc_get_template_part function, it stores the full path in the cache in the $template variable eg. /svr/bindings/serverpathxxxxxxxxx1/wp-content/plugins/woocommerce

Similar code happens in wc_get_template function in same file.

What happens in a load balanced environment, where full paths on each server are different, is when the event happens that the 2nd server is called and the cache for the $template is called for 1st server resulting a failed to open stream: No such file or directory in /svr/bindings/serverpathxxxxxxxxx1/wp-content/plugins/woocommerce warning and not rendering all relevant WooCommerce templates.

2. When the patch is applied, error encountered in the previous step is eliminated

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

Improved the naming of template path cache keys in `wc_get_template_part` and `wc_get_template` function so it can also properly cache file paths that are unique in each container in a load balanced environment

