### PR TITLE
Reviews: Respect "Comment author must fill out name and email" setting

### DIFF
--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -105,7 +105,7 @@ if ( ! comments_open() ) {
 
 				foreach ( $fields as $key => $field ) {
 					$field_html  = '<p class="comment-form-' . esc_attr( $key ) . '">';
-					$field_html .= '<label for="author">' . esc_html( $field['label'] );
+					$field_html .= '<label for="' . esc_attr( $key ) . '">' . esc_html( $field['label'] );
 
 					if ( $field['required'] ) {
 						$field_html .= '&nbsp;<span class="required">*</span>';

--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -71,8 +71,7 @@ if ( ! comments_open() ) {
 		<div id="review_form_wrapper">
 			<div id="review_form">
 				<?php
-				$commenter = wp_get_current_commenter();
-
+				$commenter    = wp_get_current_commenter();
 				$comment_form = array(
 					/* translators: %s is product title */
 					'title_reply'         => have_comments() ? __( 'Add a review', 'woocommerce' ) : sprintf( __( 'Be the first to review &ldquo;%s&rdquo;', 'woocommerce' ), get_the_title() ),
@@ -81,16 +80,41 @@ if ( ! comments_open() ) {
 					'title_reply_before'  => '<span id="reply-title" class="comment-reply-title">',
 					'title_reply_after'   => '</span>',
 					'comment_notes_after' => '',
-					'fields'              => array(
-						'author' => '<p class="comment-form-author"><label for="author">' . esc_html__( 'Name', 'woocommerce' ) . '&nbsp;<span class="required">*</span></label> ' .
-									'<input id="author" name="author" type="text" value="' . esc_attr( $commenter['comment_author'] ) . '" size="30" required /></p>',
-						'email'  => '<p class="comment-form-email"><label for="email">' . esc_html__( 'Email', 'woocommerce' ) . '&nbsp;<span class="required">*</span></label> ' .
-									'<input id="email" name="email" type="email" value="' . esc_attr( $commenter['comment_author_email'] ) . '" size="30" required /></p>',
-					),
 					'label_submit'        => __( 'Submit', 'woocommerce' ),
 					'logged_in_as'        => '',
 					'comment_field'       => '',
 				);
+
+				$name_email_required = (bool) get_option( 'require_name_email', 1 );
+				$fields              = array(
+					'author' => array(
+						'label'    => __( 'Name', 'woocommerce' ),
+						'type'     => 'text',
+						'value'    => $commenter['comment_author'],
+						'required' => $name_email_required,
+					),
+					'email' => array(
+						'label'    => __( 'Email', 'woocommerce' ),
+						'type'     => 'email',
+						'value'    => $commenter['comment_author_email'],
+						'required' => $name_email_required,
+					),
+				);
+
+				$comment_form['fields'] = array();
+
+				foreach ( $fields as $key => $field ) {
+					$field_html  = '<p class="comment-form-' . esc_attr( $key ) . '">';
+					$field_html .= '<label for="author">' . esc_html( $field['label'] );
+
+					if ( $field['required'] ) {
+						$field_html .= '&nbsp;<span class="required">*</span>';
+					}
+
+					$field_html .= '</label><input id="' . esc_attr( $key ) . '" name="' . esc_attr( $key ) . '" type="' . esc_attr( $field['type'] ) . '" value="' . esc_attr( $field['value'] ) . '" size="30" ' . ( $field['required'] ? 'required' : '' ) . ' /></p>';
+
+					$comment_form['fields'][ $key ] = $field_html;
+				}
 
 				$account_page_url = wc_get_page_permalink( 'myaccount' );
 				if ( $account_page_url ) {


### PR DESCRIPTION
The review/comment form on products was not respecting the WP core setting `require_name_email`. If this is false (0) the name and email fields are not required.

This PR creates those 2 fields dynamically and only adds required/* marks if that setting is true. Validation is unchanged (handled by WP).

Fixes #23120

To test, 

1. go to Settings > Discussion > "Comment author must fill out name and email" unchecked.
2. View product whist logged out
3. Confirm review form does not show * asterisks for name + email