### PR TITLE
Tracks: set cookie on admin_init insead of wp_loaded

### DIFF
--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -34,7 +34,7 @@ class WC_Tracks_Client {
 	 */
 	public static function init() {
 		// Use wp hook for setting the identity cookie to avoid headers already sent warnings.
-		add_action( 'wp_loaded', array( __CLASS__, 'maybe_set_identity_cookie' ) );
+		add_action( 'admin_init', array( __CLASS__, 'maybe_set_identity_cookie' ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fire the `maybe_set_identity_cookie` function on `admin_init` instead of `wp_loaded`. As is now, the function is only called on admin screens because the files are loaded via `WC_Admin`. For transparency and clarity, its best to convey that by changing the action to match the intent.

### How to test the changes in this Pull Request:

1. Navigate about Woo admin screens
2. Make sure the `maybe_set_identity_cookie` function is called before events are fired via `error_log` calls.
