### PR TITLE
Fix #23784 Shipping zonde UI issue

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3270,6 +3270,10 @@ table.wc_shipping {
 	margin-top: 0;
 }
 
+.wc-shipping-zone-settings tbody {
+	display: inherit;
+}
+
 table {
 
 	tr,


### PR DESCRIPTION
### All Submissions:

As Issue is facing due to the Grammarly extension I have fixed this by updating the some of the css code in admin.scss 

Kindly review it and let me know your feedback about the same.

Thanks, 

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23784 .


### Changelog entry

> Fix the Shipping Zone UI issue when Grammarly browser extension active.