### PR TITLE
Clear notices when calling cart-errors.php template

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -272,6 +272,7 @@ class WC_Shortcode_Checkout {
 		if ( empty( $_POST ) && wc_notice_count( 'error' ) > 0 ) { // WPCS: input var ok, CSRF ok.
 
 			wc_get_template( 'checkout/cart-errors.php', array( 'checkout' => $checkout ) );
+			wc_clear_notices();
 
 		} else {
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR fixes a bug where on checkout before calling cart-errors.php notices are queued up but never printed in the template resulting in it not being cleared, when you then navigate back to the cart page the notices are enqueued again resulting in duplicate notices being displayed.

Closes #23630 

### How to test the changes in this Pull Request:

1. Load a product that is in stock and add to cart and view the cart page
2. Go to wp-admin and set the product out of stock
3. Load the cart page again and see the message that the product is out of stock
4. Click to proceed to checkout and see the general issue with items in your cart message
5. Go back to the cart page, there should now only be one notice about product being out of stock. Prior to this patch there would have been two messages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Duplicate out of stock notices when navigating from cart to checkout and back to cart.