### PR TITLE
Introduce wc_load_cart to dynamically load the cart

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -546,17 +546,7 @@ final class WooCommerce {
 
 		// Classes/actions loaded for the frontend and for ajax requests.
 		if ( $this->is_request( 'frontend' ) ) {
-			// Session class, handles session data for users - can be overwritten if custom handler is needed.
-			$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
-			$this->session = new $session_class();
-			$this->session->init();
-
-			$this->customer = new WC_Customer( get_current_user_id(), true );
-			// Cart needs the customer info.
-			$this->cart = new WC_Cart();
-
-			// Customer should be saved during shutdown.
-			add_action( 'shutdown', array( $this->customer, 'save' ), 10 );
+			wc_load_cart();
 		}
 
 		$this->load_webhooks();
@@ -723,6 +713,39 @@ final class WooCommerce {
 		$limit = apply_filters( 'woocommerce_load_webhooks_limit', null );
 
 		wc_load_webhooks( 'active', $limit );
+	}
+
+	/**
+	 * Initialize the customer and cart objects and setup customer saving on shutdown.
+	 *
+	 * @since 3.6.4
+	 * @return void
+	 */
+	public function initialize_cart() {
+		// Cart needs customer info.
+		if ( is_null( $this->customer ) || ! $this->customer instanceof WC_Customer ) {
+			$this->customer = new WC_Customer( get_current_user_id(), true );
+			// Customer should be saved during shutdown.
+			add_action( 'shutdown', array( $this->customer, 'save' ), 10 );
+		}
+		if ( is_null( $this->cart ) || ! $this->cart instanceof WC_Cart ) {
+			$this->cart = new WC_Cart();
+		}
+	}
+
+	/**
+	 * Initialize the session class.
+	 *
+	 * @since 3.6.4
+	 * @return void
+	 */
+	public function initialize_session() {
+		// Session class, handles session data for users - can be overwritten if custom handler is needed.
+		$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
+		if ( is_null( $this->session ) || ! $this->session instanceof $session_class ) {
+			$this->session = new $session_class();
+			$this->session->init();
+		}
 	}
 
 	/**

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2255,3 +2255,14 @@ function wc_get_server_database_version() {
 		'number' => preg_replace( '/([^\d.]+).*/', '', $server_info ),
 	);
 }
+
+/**
+ * Initialize and load the cart functionality.
+ *
+ * @since 3.6.4
+ * @return void
+ */
+function wc_load_cart() {
+	WC()->initialize_session();
+	WC()->initialize_cart();
+}

--- a/tests/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/unit-tests/util/class-wc-tests-core-functions.php
@@ -10,6 +10,17 @@
  * Core function unit tests.
  */
 class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up test
+	 *
+	 * @return void
+	 */
+	public function setUp() {
+		parent::setUp();
+		$this->wc = WC();
+	}
+
 	/**
 	 * Test get_woocommerce_currency().
 	 *
@@ -931,5 +942,27 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 		// Now test the new wc_ascii_uasort_comparison function which sorts the strings correctly.
 		uasort( $sorted_values, 'wc_ascii_uasort_comparison' );
 		$this->assertSame( array( 'Bélgica', 'Benin' ), array_values( $sorted_values ) );
+	}
+
+	/**
+	 * Test wc_load_cart function.
+	 *
+	 * @return void
+	 */
+	public function test_wc_load_cart() {
+		$this->assertInstanceOf( 'WC_Cart', $this->wc->cart );
+		$this->assertInstanceOf( 'WC_Customer', $this->wc->customer );
+		$this->assertInstanceOf( 'WC_Session', $this->wc->session );
+
+		$this->wc->cart = $this->wc->customer = $this->wc->session = null;
+		$this->assertNull( $this->wc->cart );
+		$this->assertNull( $this->wc->customer );
+		$this->assertNull( $this->wc->session );
+
+		wc_load_cart();
+		$this->assertInstanceOf( 'WC_Cart', $this->wc->cart );
+		$this->assertInstanceOf( 'WC_Customer', $this->wc->customer );
+		$this->assertInstanceOf( 'WC_Session', $this->wc->session );
+
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR introduced a new function called wc_load_cart which will dynamically load the cart and all the required classes for cart handling and then initialize them.

This is being introduced to give users that relied on the cart object being present in certain circumstances before we introduced the change to only load the cart on the frontend for performance.

With this function, the cart can now be accessed in certain hooks or even the REST API after calling it.

Closes #23792 

### How to test the changes in this Pull Request:

1. Check unit tests as passing
2. Check that cart loads on normal operations like adding to cart, visiting the cart page and checking out.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduce new wc_load_cart function for dynamically loading and initializing the cart.
