### PR TITLE
make WC_Data_Store update_lookup_table() public

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -268,7 +268,7 @@ class WC_Structured_Data {
 			$markup['offers'] = array( apply_filters( 'woocommerce_structured_data_product_offer', $markup_offer, $product ) );
 		}
 
-		if ( $product->get_rating_count() && wc_review_ratings_enabled() ) {
+		if ( $product->get_review_count() && wc_review_ratings_enabled() ) {
 			$markup['aggregateRating'] = array(
 				'@type'       => 'AggregateRating',
 				'ratingValue' => $product->get_average_rating(),

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -268,7 +268,7 @@ class WC_Structured_Data {
 			$markup['offers'] = array( apply_filters( 'woocommerce_structured_data_product_offer', $markup_offer, $product ) );
 		}
 
-		if ( $product->get_review_count() && wc_review_ratings_enabled() ) {
+		if ( $product->get_rating_count() && wc_review_ratings_enabled() ) {
 			$markup['aggregateRating'] = array(
 				'@type'       => 'AggregateRating',
 				'ratingValue' => $product->get_average_rating(),

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -581,7 +581,7 @@ class WC_Data_Store_WP {
 	 *
 	 * @return NULL
 	 */
-	protected function update_lookup_table( $id, $table ) {
+	public function update_lookup_table( $id, $table ) {
 		global $wpdb;
 
 		$id    = absint( $id );


### PR DESCRIPTION
make update_lookup_table public so it can be called to force updates, for example for compatibility with legacy plugins / other which make updates to post meta leaving the lookup table out of date.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Changes WC_Data_Store_WP update_lookup_table() to public
The reason is to allow resynchronisation of lookup table in cases where it may become out of date, for example where underlying meta data may have been changed by legacy plugins using post meta api rather than product api.

### How to test the changes in this Pull Request:

1. code example
$data_store = \WC_Data_Store::load( $datastoreType );
$data_store->update_lookup_table( $productid, 'wc_product_meta_lookup' );

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
make update_lookup_table public() to allow resynchronisation of lookup table data by other plugins