### PR TITLE
Avoid outputting a rating of zero when product has comments without a review rating.

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -268,7 +268,7 @@ class WC_Structured_Data {
 			$markup['offers'] = array( apply_filters( 'woocommerce_structured_data_product_offer', $markup_offer, $product ) );
 		}
 
-		if ( $product->get_review_count() && wc_review_ratings_enabled() ) {
+		if ( $product->get_rating_count() && wc_review_ratings_enabled() ) {
 			$markup['aggregateRating'] = array(
 				'@type'       => 'AggregateRating',
 				'ratingValue' => $product->get_average_rating(),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

If rating is not mandatory on comments, generate_product_data() produces incorrect output when a product only has comments without a rating.
For example items with comments but no reviews are output with rating of zero which is getting flagged in google webmasters tools under the heading "Rating is missing required best and/or worst values".

The output google is objecting to is eg:
"aggregateRating":{"@type":"AggregateRating","ratingValue":"0","reviewCount":1}}

postmeta in this case is:
_wc_average_rating 0
_wc_rating_count 0.0
_wc_review_count 1

product lookup table is reporting
rating_count 0
average_rating 0.00

the meta is correct and reflected in the product object, it is the test that is wrong since
if $product->get_review_count() 
may be true even if there are no ratings.

This is solved by substituting get_rating_count() which has the correct number of ratings.


### How to test the changes in this Pull Request:

1. in WooCommerce settings, enable star ratings but leave them optional ( leave unchecked the box Star ratings should be required, not optional ) 
2. go to a product with no reviews and add a comment
3. without this change the output like "aggregateRating":{"@type":"AggregateRating","ratingValue":"0","reviewCount":1}} can be seen.  After the change this section does not appear for this product.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Avoid outputting a rating of zero when product has comments without a review rating.