### PR TITLE
Make NL postcode validation more flexible

### DIFF
--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -94,7 +94,7 @@ class WC_Validation {
 				$valid = (bool) preg_match( '/^([0-9]{3})(\s?)([0-9]{2})$/', $postcode );
 				break;
 			case 'NL':
-				$valid = (bool) preg_match( '/^([1-9][0-9]{3})(\s?)(?!SA|SD|SS|sa|sd|ss)[A-Za-z]{2}$/', $postcode );
+				$valid = (bool) preg_match( '/^([1-9][0-9]{3})(\s?)(?!SA|SD|SS)[A-Z]{2}$/i', $postcode );
 				break;
 
 			default:

--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -94,7 +94,7 @@ class WC_Validation {
 				$valid = (bool) preg_match( '/^([0-9]{3})(\s?)([0-9]{2})$/', $postcode );
 				break;
 			case 'NL':
-				$valid = (bool) preg_match( '/^[1-9][0-9]{3}\s(?!SA|SD|SS)[A-Z]{2}$/', $postcode );
+				$valid = (bool) preg_match( '/^([1-9][0-9]{3})(\s?)(?!SA|SD|SS|sa|sd|ss)[A-Za-z]{2}$/', $postcode );
 				break;
 
 			default:

--- a/tests/unit-tests/util/validation.php
+++ b/tests/unit-tests/util/validation.php
@@ -98,7 +98,16 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 			array( false, WC_Validation::is_postcode( '0A0A0A', 'CA' ) ),
 		);
 
-		return array_merge( $it, $gb, $us, $ch, $br, $ca );
+		$nl = array(
+			array( true, WC_Validation::is_postcode( '3852GC', 'NL' ) ),
+			array( true, WC_Validation::is_postcode( '3852 GC', 'NL' ) ),
+			array( true, WC_Validation::is_postcode( '3852 gc', 'NL' ) ),
+			array( false, WC_Validation::is_postcode( '3852SA', 'NL' ) ),
+			array( false, WC_Validation::is_postcode( '3852 SA', 'NL' ) ),
+			array( false, WC_Validation::is_postcode( '3852 sa', 'NL' ) ),
+		);
+
+		return array_merge( $it, $gb, $us, $ch, $br, $ca, $nl );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Allows postcode without spaces and in lowercase.

Closes #23834.

### How to test the changes in this Pull Request:

See #23834

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Made NL postcode validation more flexible, allowing lowercase and missing space.
