### PR TITLE
[#23839] Do not throw autoloader notice if following notice instructions

### DIFF
--- a/includes/class-wc-autoloader.php
+++ b/includes/class-wc-autoloader.php
@@ -91,7 +91,7 @@ class WC_Autoloader {
 		}
 
 		// Prevent plugins from breaking if they extend the rest API early.
-		if ( 0 === strpos( $class, 'wc_rest_' ) && ! class_exists( $class ) && ! did_action( 'rest_api_init' ) ) {
+		if ( 0 === strpos( $class, 'wc_rest_' ) && ! class_exists( $class, false ) && ! did_action( 'rest_api_init' ) ) {
 			wc_doing_it_wrong( $class, __( 'Classes that extend the WooCommerce/WordPress REST API should only be loaded during the rest_api_init action, or should call WC()->api->rest_api_includes() manually.', 'woocommerce' ), '3.6' );
 			WC()->api->rest_api_includes();
 		}

--- a/includes/class-wc-autoloader.php
+++ b/includes/class-wc-autoloader.php
@@ -91,7 +91,7 @@ class WC_Autoloader {
 		}
 
 		// Prevent plugins from breaking if they extend the rest API early.
-		if ( 0 === strpos( $class, 'wc_rest_' ) && ! did_action( 'rest_api_init' ) ) {
+		if ( 0 === strpos( $class, 'wc_rest_' ) && ! class_exists( $class ) && ! did_action( 'rest_api_init' ) ) {
 			wc_doing_it_wrong( $class, __( 'Classes that extend the WooCommerce/WordPress REST API should only be loaded during the rest_api_init action, or should call WC()->api->rest_api_includes() manually.', 'woocommerce' ), '3.6' );
 			WC()->api->rest_api_includes();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds an `! class_exist( $class )` check in autoloader, so if someone included the rest api handlers correctly as suggested by the notice, the notice is not produced.

Closes #23839.

### How to test the changes in this Pull Request:

1. Attempt to load some handler based on the rest api classes before `rest_api_init`
2. Notice is produced by WooCommerce 3.6.0 that rest api includes are called too early
3. Manually include `WC()->api->rest_api_includes();` in your code: no PHP error occurs, no notice is thrown. Before this PR: a notice would still be thrown, even if you followed its own advice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

 * Fix: Do not throw a PHP notice if including the rest API handlers manually