### PR TITLE
Migrate Admin Notices to WooCommerce Admin Store Alerts and Inbox Panel

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -571,7 +571,36 @@ class WC_Admin_Notices {
 			return;
 		}
 
-		include dirname( __FILE__ ) . '/views/html-notice-secure-connection.php';
+		if ( class_exists( 'WC_Admin_Note' ) ) {
+			// First, see if we've already created this kind of note so we don't do it again.
+			$data_store = WC_Data_Store::load( 'admin-note' );
+			$note_ids   = $data_store->get_notes_with_name( 'wc-secure-connection' );
+
+			if ( ! empty( $note_ids ) ) {
+				return;
+			}
+
+			$note = new WC_Admin_Note();
+			$note->set_title( __( 'Your store does not appear to be using a secure connection.', 'woocommerce' ) );
+			$note->set_content( __( 'We highly recommend serving your entire website over an HTTPS connection to help keep customer data secure.', 'woocommerce' ) );
+			$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+			$note->set_icon( 'lock' );
+			$note->set_name( 'wc-secure-connection' );
+			$note->set_content_data( (object) array() );
+			$note->set_source( 'woocommerce' );
+
+			$note->add_action(
+				'secure-connection-learn-more',
+				__( 'Learn more', 'woocommerce' ),
+				'https://docs.woocommerce.com/document/ssl-and-https/',
+				'actioned',
+				true
+			);
+
+			$note->save();
+		} else {
+			include dirname( __FILE__ ) . '/views/html-notice-secure-connection.php';
+		}
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -283,23 +283,18 @@ class WC_Admin_Notices {
 			$note->set_content_data( (object) array() );
 			$note->set_source( 'woocommerce' );
 
-			$update_url = wp_nonce_url(
-				add_query_arg( 'do_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ),
-				'wc_db_update',
-				'wc_db_update_nonce'
-			);
-
 			$note->add_action(
 				'update-database',
 				__( 'Update WooCommerce Database', 'woocommerce' ),
-				$update_url,
+				'',
 				'actioned',
 				true
 			);
 			$note->add_action(
 				'update-learn-more',
 				__( 'Learn more about updates', 'woocommerce' ),
-				'https://docs.woocommerce.com/document/how-to-update-woocommerce/'
+				'https://docs.woocommerce.com/document/how-to-update-woocommerce/',
+				'unactioned'
 			);
 
 			$note->save();
@@ -313,6 +308,7 @@ class WC_Admin_Notices {
 	 */
 	public static function update_notice_updated() {
 		if ( class_exists( 'WC_Admin_Note' ) ) {
+			WC_Admin_Notes::delete_notes_with_name( 'wc-update' );
 			WC_Admin_Notes::delete_notes_with_name( 'wc-updating' );
 			// First, see if we've already created this kind of note so we don't do it again.
 			$data_store = WC_Data_Store::load( 'admin-note' );
@@ -334,7 +330,7 @@ class WC_Admin_Notices {
 			$note->add_action(
 				'dismiss-database-updated',
 				__( 'Dismiss', 'woocommerce' ),
-				'#',
+				'',
 				'actioned',
 				true
 			);
@@ -399,7 +395,7 @@ class WC_Admin_Notices {
 			$note->add_action(
 				'skip-setup',
 				__( 'Skip setup', 'woocommerce' ),
-				wp_nonce_url( add_query_arg( 'wc-hide-notice', 'install' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ),
+				'',
 				'actioned'
 			);
 

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -483,12 +483,6 @@ class WC_Admin_Notices {
 					'unactioned',
 					true
 				);
-				$note->add_action(
-					'template-check-dismiss',
-					__( 'Dismiss', 'woocommerce' ),
-					'#',
-					'actioned'
-				);
 
 				$note->save();
 			} else {

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -550,7 +550,35 @@ class WC_Admin_Notices {
 	 * Notice shown when regenerating thumbnails background process is running.
 	 */
 	public static function regenerating_thumbnails_notice() {
-		include dirname( __FILE__ ) . '/views/html-notice-regenerating-thumbnails.php';
+		if ( class_exists( 'WC_Admin_Note' ) ) {
+			// First, see if we've already created this kind of note so we don't do it again.
+			$data_store = WC_Data_Store::load( 'admin-note' );
+			$note_ids   = $data_store->get_notes_with_name( 'wc-regen-thumbnails' );
+
+			if ( ! empty( $note_ids ) ) {
+				return;
+			}
+
+			$note->set_title( __( 'Thumbnail regeneration is running in the background.', 'woocommerce' ) );
+			$note->set_content( __( 'Depending on the amount of images in your store this may take a while.', 'woocommerce' ) );
+			$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+			$note->set_icon( 'image' );
+			$note->set_name( 'wc-regen-thumbnails' );
+			$note->set_content_data( (object) array() );
+			$note->set_source( 'woocommerce' );
+
+			$note->add_action(
+				'regen-thumbnails-cancel',
+				__( 'Cancel thumbnail regeneration', 'woocommerce' ),
+				'',
+				'actioned',
+				true
+			);
+
+			$note->save();
+		} else {
+			include dirname( __FILE__ ) . '/views/html-notice-regenerating-thumbnails.php';
+		}
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -138,11 +138,11 @@ class WC_Install {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
-		add_action( 'admin_init', array( __CLASS__, 'install_actions' ) );
 		add_filter( 'plugin_action_links_' . WC_PLUGIN_BASENAME, array( __CLASS__, 'plugin_action_links' ) );
 		add_filter( 'plugin_row_meta', array( __CLASS__, 'plugin_row_meta' ), 10, 2 );
 		add_filter( 'wpmu_drop_tables', array( __CLASS__, 'wpmu_drop_tables' ) );
 		add_filter( 'cron_schedules', array( __CLASS__, 'cron_schedules' ) );
+		add_action( 'woocommerce_admin_note_action_update-database', array( __CLASS__, 'update' ) );
 	}
 
 	/**
@@ -199,19 +199,6 @@ class WC_Install {
 				),
 				'woocommerce-db-updates'
 			);
-		}
-	}
-
-	/**
-	 * Install actions when a update button is clicked within the admin area.
-	 *
-	 * This function is hooked into admin_init to affect admin only.
-	 */
-	public static function install_actions() {
-		if ( ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok.
-			check_admin_referer( 'wc_db_update', 'wc_db_update_nonce' );
-			self::update();
-			WC_Admin_Notices::add_notice( 'update' );
 		}
 	}
 
@@ -353,7 +340,7 @@ class WC_Install {
 	/**
 	 * Push all needed DB updates to the queue for processing.
 	 */
-	private static function update() {
+	public static function update() {
 		$current_db_version = get_option( 'woocommerce_db_version' );
 		$loop               = 0;
 

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -49,7 +49,7 @@ class WC_Regenerate_Images {
 			self::$background_process = new WC_Regenerate_Images_Request();
 
 			add_action( 'admin_init', array( __CLASS__, 'regenerating_notice' ) );
-			add_action( 'woocommerce_hide_regenerating_thumbnails_notice', array( __CLASS__, 'dismiss_regenerating_notice' ) );
+			add_action( 'woocommerce_admin_note_action_regen-thumbnails-cancel', array( __CLASS__, 'dismiss_regenerating_notice' ) );
 
 			// Regenerate thumbnails in the background after settings changes. Not ran on multisite to avoid multiple simultanious jobs.
 			if ( ! is_multisite() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce-admin/issues/2268.

This PR uses the new WooCommerce Admin `<StoreAlert>` and Inbox Panel to reimplement WooCommerce admin notices. Notices that were dismissible are found in the Inbox, others will get "high priority" treatment and will display at the top of WooCommerce Admin pages.

### How to test the changes in this Pull Request:

These changes rely on several tweaks to the WooCommerce Admin plugin:
* https://github.com/woocommerce/woocommerce-admin/pull/2324
* https://github.com/woocommerce/woocommerce-admin/pull/2344
* https://github.com/woocommerce/woocommerce-admin/pull/2327
* https://github.com/woocommerce/woocommerce-admin/pull/2325

1. Ensure you have WooCommerce Admin enabled
1. Trigger conditions to add each core notice (these will vary)
1. Verify that each notice content is displayed correctly and that the actions work
1. Verify that the behavior of the notices is maintained (notices clearing after pending actions, etc)
