### PR TITLE
Tracker: fix review count

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -349,14 +349,14 @@ class WC_Tracker {
 	 */
 	private static function get_review_counts() {
 		global $wpdb;
-		$review_count    = array( 'total' => 0 );
-		$status_map      = array(
+		$review_count = array( 'total' => 0 );
+		$status_map   = array(
 			'0'     => 'pending',
 			'1'     => 'approved',
 			'trash' => 'trash',
 			'spam'  => 'spam',
-			);
-		$counts          = $wpdb->get_results(
+		);
+		$counts       = $wpdb->get_results(
 			"
 			SELECT comment_approved, COUNT(*) AS num_reviews
 			FROM {$wpdb->comments}

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -349,8 +349,14 @@ class WC_Tracker {
 	 */
 	private static function get_review_counts() {
 		global $wpdb;
-		$review_count = array();
-		$counts       = $wpdb->get_results(
+		$review_count    = array( 'total' => 0 );
+		$status_map      = array(
+			'0'     => 'pending',
+			'1'     => 'approved',
+			'trash' => 'trash',
+			'spam'  => 'spam',
+			);
+		$counts          = $wpdb->get_results(
 			"
 			SELECT comment_approved, COUNT(*) AS num_reviews
 			FROM {$wpdb->comments}
@@ -359,15 +365,19 @@ class WC_Tracker {
 			",
 			ARRAY_A
 		);
-		if ( $counts ) {
-			foreach ( $counts as $count ) {
-				if ( 1 === $count['comment_approved'] ) {
-					$review_count['approved'] = $count['num_reviews'];
-				} else {
-					$review_count['pending'] = $count['num_reviews'];
-				}
-			}
+
+		if ( ! $counts ) {
+			return $review_count;
 		}
+
+		foreach ( $counts as $count ) {
+			$status = $count['comment_approved'];
+			if ( array_key_exists( $status, $status_map ) ) {
+				$review_count[ $status_map[ $status ] ] = $count['num_reviews'];
+			}
+			$review_count['total'] += $count['num_reviews'];
+		}
+
 		return $review_count;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
`WC_Tracker::get_review_counts()` bug fixes:
* The approved review count is now included if it is non-zero.
* The pending review count will only include the pending reviews. The value used to some times get replaced by the count of approved, spam, or trashed reviews.)

`WC_Tracker::get_review_counts()` new features:
* Total reviews count is included. (new feature)
* Counts of spam or trash reviews are now included if they are non-zero. (new feature)

Closes #23848.

### How to test the changes in this Pull Request:

1. Set up a WooCommerce store with reviews in various statuses.
2. Modify `WC_Tracker::get_review_counts()` to be public.
3. Run the method with something like `wp eval "print_r( WC_Tracker::get_review_counts() );"`.

The function should return something like the below, but with correct counts for your store. The "total" key will always be included. The other keys that might be included are: "pending", "spam", "approved", and "trash".
```
Array
(   
    [total] => 3
    [pending] => 2
    [spam] => 1
)
```

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix WC Tracker review count.
