### PR TITLE
#23850 Fixed the coupon usage limit issue when apply coupon from admin panel

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -969,7 +969,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( 0 === $this->get_customer_id() ) {
 			$data_store  = $coupon->get_data_store();
 			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
-			if ( !empty( $usage_count ) && $usage_count >= $coupon->get_usage_limit_per_user() ) {
+			if ( ! empty( $usage_count ) && $usage_count >= $coupon->get_usage_limit_per_user() ) {
 				return new WP_Error(
 					'invalid_coupon',
 					$coupon->get_coupon_error( 106 ),

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -969,7 +969,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( 0 === $this->get_customer_id() ) {
 			$data_store  = $coupon->get_data_store();
 			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
-			if ( ! empty( $usage_count ) && $usage_count >= $coupon->get_usage_limit_per_user() ) {
+			if ( 0 < $coupon->get_usage_limit_per_user() && $usage_count >= $coupon->get_usage_limit_per_user() ) {
 				return new WP_Error(
 					'invalid_coupon',
 					$coupon->get_coupon_error( 106 ),

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -969,7 +969,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( 0 === $this->get_customer_id() ) {
 			$data_store  = $coupon->get_data_store();
 			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
-			if ( $usage_count > $coupon->get_usage_limit_per_user() ) {
+			if ( !empty( $usage_count ) && $usage_count >= $coupon->get_usage_limit_per_user() ) {
 				return new WP_Error(
 					'invalid_coupon',
 					$coupon->get_coupon_error( 106 ),

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -969,7 +969,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		if ( 0 === $this->get_customer_id() ) {
 			$data_store  = $coupon->get_data_store();
 			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
-			if ( $usage_count >= $coupon->get_usage_limit_per_user() ) {
+			if ( $usage_count > $coupon->get_usage_limit_per_user() ) {
 				return new WP_Error(
 					'invalid_coupon',
 					$coupon->get_coupon_error( 106 ),


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23850 .

### How to test the changes in this Pull Request:

1 Create an order on wp-admin backend.
2 Set it to Pending payment or On hold status. The other statuses do not allow applying a coupon code. 
3 Create a coupon code with a percentage discount, say 10% off.
4 Open the On hold order.
5 Apply the coupon code.

It's working as expected now.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed the usage limit issue when applying coupon for the order from admin panel.