### PR TITLE
Allow filtering formatted shipping address

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -882,13 +882,11 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_formatted_shipping_address( $empty_content = '' ) {
-		$address = '';
+		$address = apply_filters( 'woocommerce_order_formatted_shipping_address', $this->get_address( 'shipping' ), $this );
 
 		if ( $this->has_shipping_address() ) {
-			$address = WC()->countries->get_formatted_address( $this->get_address( 'shipping' ) );
+			$address = WC()->countries->get_formatted_address( $address );
 		}
-
-		$address = apply_filters( 'woocommerce_order_formatted_shipping_address', $address, $this );
 
 		return $address ? $address : $empty_content;
 	}

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -885,9 +885,10 @@ class WC_Order extends WC_Abstract_Order {
 		$address = '';
 
 		if ( $this->has_shipping_address() ) {
-			$address = apply_filters( 'woocommerce_order_formatted_shipping_address', $this->get_address( 'shipping' ), $this );
-			$address = WC()->countries->get_formatted_address( $address );
+			$address = WC()->countries->get_formatted_address( $this->get_address( 'shipping' ) );
 		}
+
+		$address = apply_filters( 'woocommerce_order_formatted_shipping_address', $address, $this );
 
 		return $address ? $address : $empty_content;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently `WC_Order::get_formatted_billing_address()` has a filter `woocommerce_order_formatted_billing_address` that can be hooked into no matter what the address value is, but the similar filter in `WC_Order::get_formatted_shipping_address()` (`woocommerce_order_formatted_shipping_address`) can be hooked into only when there's any kind of shipping address available.

This change will allow to hook into the shipping address no matter what the address is, just like with billing.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog Entry
> Update - Move woocommerce_order_formatted_shipping_address filter outside the has_shipping() check.
