### PR TITLE
Avoid attempting to cache expired sessions

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -325,7 +325,7 @@ class WC_Session_Handler extends WC_Session {
 			}
 
 			$cache_duration = $this->_session_expiration - time();
-			if ($cache_duration > 0){
+			if ( 0 < $cache_duration ) {
 				wp_cache_add( $this->get_cache_prefix() . $customer_id, $value, WC_SESSION_CACHE_GROUP, $cache_duration );
 			}
 		}

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -324,7 +324,10 @@ class WC_Session_Handler extends WC_Session {
 				$value = $default;
 			}
 
-			wp_cache_add( $this->get_cache_prefix() . $customer_id, $value, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );
+			$cache_duration = $this->_session_expiration - time();
+			if ($cache_duration > 0){
+				wp_cache_add( $this->get_cache_prefix() . $customer_id, $value, WC_SESSION_CACHE_GROUP, $cache_duration );
+			}
 		}
 
 		return maybe_unserialize( $value );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currrently get_session() attempts to cache a session even if it is already expired.
The current code used passes negative expiry seconds to wp_cache_add() if the session expired in the past:
`wp_cache_add( $this->get_cache_prefix() . $customer_id, $value, WC_SESSION_CACHE_GROUP, $this->_session_expiration - time() );`

Depending on the caching layers used this will give errors in the logs such as:
ERR invalid expire time in setex in /var/www/html/wp-content/plugins/redis-cache/includes/predis/src/Client.php:370
as reported on: https://wordpress.org/support/topic/error-when-trying-to-get-a-get-a-cache-not-available/

The solution proposed here is to not cache sessions which are expired by testing if the cache expiry seconds would be negative.


### How to test the changes in this Pull Request:

It can be tested that the change proposed is harmless.
What is more difficult is to reproduce the original error condition which is along the lines of:
1.  never clear sessions so there is a build up of expired sessions..
2. this error may start to appear in the logs

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Avoid caching expired sessions (negative expiry causing errors in some caching modules).