### PR TITLE
Fix fatal error when applying a virtual coupon to an order placed by a guest

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -965,9 +965,10 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			return $applied;
 		}
 
+		$data_store = $coupon->get_data_store();
+
 		// Check specific for guest checkouts here as well since WC_Cart handles that seperately in check_customer_coupons.
-		if ( 0 === $this->get_customer_id() ) {
-			$data_store  = $coupon->get_data_store();
+		if ( $data_store && 0 === $this->get_customer_id() ) {
 			$usage_count = $data_store->get_usage_by_email( $coupon, $this->get_billing_email() );
 			if ( 0 < $coupon->get_usage_limit_per_user() && $usage_count >= $coupon->get_usage_limit_per_user() ) {
 				return new WP_Error(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Recent changes in 3.6.4 [here](https://github.com/woocommerce/woocommerce/commit/7fe80b82bd8961d9c6d2b5163d06da9e9a0d4cc6#diff-9b4164165828b26c4b7aec01c7b17884) are causing a fatal error when trying to apply virtual coupons to a guest order in the WC admin. Since virtual coupons don't have a data store, [this line](https://github.com/woocommerce/woocommerce/blob/9eca72849dba6c3c491e5822dee7a3b47c8bead4/includes/abstracts/abstract-wc-order.php#L971) causes the following error: `CRITICAL Uncaught Error: Call to a member function get_usage_by_email() on null`

This breaks virtual coupons being added to any guest orders - I was alerted to this because it also breaks redeeming vouchers with PDF Product Vouchers for guest orders via the 'Apply coupon' button.

This PR simply adds a check for the existence of `$coupon->data_store` before attempting to access it.

### How to test the changes in this Pull Request:

1. Create an order for a guest
2. Add the following snippet to create a virtual coupon for testing:
```php
add_filter( 'woocommerce_get_shop_coupon_data', function( $coupon_data, $coupon_code ) {
  
  if ( 'test-coupon-fatal' === $coupon_code ) {
	
	$coupon_data = array(
	  'amount' => 5,
	);
  }
  
  return $coupon_data;
}, 10, 2 );
```
3. Click 'Apply coupon' and enter 'test-coupon-fatal'

On `master`, this will give a fatal error in the logs and will cause the order screen to become unresponsive.

In this PR, the virtual coupon is applied normally.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix fatal error when trying to apply virtual coupons to guest orders
