### PR TITLE
add filter to check image attachment exist!

### DIFF
--- a/includes/api/class-wc-rest-products-controller.php
+++ b/includes/api/class-wc-rest-products-controller.php
@@ -234,6 +234,8 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			foreach ( $images as $index => $image ) {
 				$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
 
+				$attachment_id = apply_filters( 'woocommerce_rest_check_product_image_attachment_exist', $attachment_id,  $image );
+				
 				if ( 0 === $attachment_id && isset( $image['src'] ) ) {
 					$upload = wc_rest_upload_image_from_url( esc_url_raw( $image['src'] ) );
 


### PR DESCRIPTION
This filter has two arguments.
second argument `$image` is useful to find the filename from `src`, to get product image is available or not.
if yes than no upload is needed, just assign id of that attachment. (performance improvement)
upload all process otherwise.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This filter is useful for third party plugins, to check image existence!

Closes # .

### How to test the changes in this Pull Request:

1. no need to write test. (this is just filter to apply)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Add filter to check image is exist or not.