### PR TITLE
Update find matching variation method inner query

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1079,19 +1079,21 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		// Get the attributes of the variations.
 		$query = $wpdb->prepare(
 			"
-			SELECT post_id, meta_key, meta_value FROM {$wpdb->postmeta}
-			WHERE post_id IN (
+			SELECT postmeta.post_id, postmeta.meta_key, postmeta.meta_value, posts.menu_order FROM {$wpdb->postmeta} as postmeta
+			LEFT JOIN {$wpdb->posts} as posts ON postmeta.post_id=posts.ID
+			WHERE postmeta.post_id IN (
 				SELECT ID FROM {$wpdb->posts}
 				WHERE {$wpdb->posts}.post_parent = %d
 				AND {$wpdb->posts}.post_status = 'publish'
 				AND {$wpdb->posts}.post_type = 'product_variation'
-				ORDER BY menu_order ASC, ID ASC
 			)
 			",
 			$product->get_id()
 		);
 
-		$query .= ' AND meta_key IN ( "' . implode( '","', array_map( 'esc_sql', $meta_attribute_names ) ) . '" );';
+		$query .= ' AND postmeta.meta_key IN ( "' . implode( '","', array_map( 'esc_sql', $meta_attribute_names ) ) . '" )';
+
+		$query.=' ORDER BY posts.menu_order ASC, postmeta.post_id ASC;';
 
 		$attributes = $wpdb->get_results( $query ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 


### PR DESCRIPTION
Fix variation query to prevent the ORDER BY being ignored in some mysql
and mariadb versions. The order by has been moved outside and a left
join was added.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The query that fetches the variations does not respect the menu order, this is due to the subquery orderby getting ignored in some mysql and mariadb engines. The fix is to move the order by out of the subquery, and a join is required as the menu order is only on the posts table. 

Closes #23872  .

### How to test the changes in this Pull Request:

1. Create a variable product with 2 variations. Make one variations specific while the other has an any clause
2. Set different images for the variations
3. You should get the image for the variation that is first in order when the selected attributes match multiple variations

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix variation query to prevent the ORDER BY being ignored in some mysql
and mariadb versions. The order by has been moved outside and a left
join was added.