### PR TITLE
Track more events on the edit order screen for future design validation.

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -403,6 +403,12 @@ jQuery( function ( $ ) {
 		add_line_item: function() {
 			$( 'div.wc-order-add-item' ).slideDown();
 			$( 'div.wc-order-data-row-toggle' ).not( 'div.wc-order-add-item' ).slideUp();
+
+			window.wcTracks.recordEvent( 'order_edit_add_items_click', {
+				order_id: woocommerce_admin_meta_boxes.post_id,
+				status: $( '#order_status' ).val()
+			} );
+
 			return false;
 		},
 

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -125,7 +125,8 @@ jQuery( function ( $ ) {
 				$edit_address  = $wrapper.find( 'div.edit_address' ),
 				$address       = $wrapper.find( 'div.address' ),
 				$country_input = $edit_address.find( '.js_field-country' ),
-				$state_input   = $edit_address.find( '.js_field-state' );
+				$state_input   = $edit_address.find( '.js_field-state' ),
+				is_billing     = Boolean( $edit_address.find( 'input[name^="_billing_"]' ).length );
 
 			$address.hide();
 			$this.parent().find( 'a' ).toggle();
@@ -136,6 +137,12 @@ jQuery( function ( $ ) {
 			}
 
 			$edit_address.show();
+
+			var event_name = is_billing ? 'order_edit_billing_address_click' : 'order_edit_shipping_address_click';
+			window.wcTracks.recordEvent( event_name, {
+				order_id: data.order_id,
+				status: $( '#order_status' ).val(),
+			} );
 		},
 
 		change_customer_user: function() {

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -407,7 +407,7 @@ jQuery( function ( $ ) {
 		},
 
 		add_coupon: function() {
-			window.wcTracks.recordEvent( 'order_add_coupon_click', {
+			window.wcTracks.recordEvent( 'order_edit_add_coupon_click', {
 				order_id: woocommerce_admin_meta_boxes.post_id,
 				status: $( '#order_status' ).val()
 			} );
@@ -415,7 +415,7 @@ jQuery( function ( $ ) {
 			var value = window.prompt( woocommerce_admin_meta_boxes.i18n_apply_coupon );
 
 			if ( null == value ) {
-				window.wcTracks.recordEvent( 'order_add_coupon_cancel', {
+				window.wcTracks.recordEvent( 'order_edit_add_coupon_cancel', {
 					order_id: woocommerce_admin_meta_boxes.post_id,
 					status: $( '#order_status' ).val()
 				} );
@@ -451,7 +451,7 @@ jQuery( function ( $ ) {
 						wc_meta_boxes_order_items.unblock();
 					},
 					complete: function() {
-						window.wcTracks.recordEvent( 'order_added_coupon', {
+						window.wcTracks.recordEvent( 'order_edit_added_coupon', {
 							order_id: data.order_id,
 							status: $( '#order_status' ).val()
 						} );
@@ -493,7 +493,7 @@ jQuery( function ( $ ) {
 			$( '#woocommerce-order-items' ).find( 'div.refund' ).show();
 			$( '.wc-order-edit-line-item .wc-order-edit-line-item-actions' ).hide();
 
-			window.wcTracks.recordEvent( 'order_refund_button_click', {
+			window.wcTracks.recordEvent( 'order_edit_refund_button_click', {
 				order_id: woocommerce_admin_meta_boxes.post_id,
 				status: $( '#order_status' ).val()
 			} );
@@ -519,7 +519,7 @@ jQuery( function ( $ ) {
 		},
 
 		track_cancel: function() {
-			window.wcTracks.recordEvent( 'order_refund_cancel', {
+			window.wcTracks.recordEvent( 'order_edit_refund_cancel', {
 				order_id: woocommerce_admin_meta_boxes.post_id,
 				status: $( '#order_status' ).val()
 			} );
@@ -681,14 +681,14 @@ jQuery( function ( $ ) {
 						wc_meta_boxes_order_items.unblock();
 					},
 					complete: function() {
-						window.wcTracks.recordEvent( 'order_delete_tax', {
+						window.wcTracks.recordEvent( 'order_edit_delete_tax', {
 							order_id: data.order_id,
 							status: $( '#order_status' ).val()
 						} );
 					}
 				});
 			} else {
-				window.wcTracks.recordEvent( 'order_delete_tax_cancel', {
+				window.wcTracks.recordEvent( 'order_edit_delete_tax_cancel', {
 					order_id: woocommerce_admin_meta_boxes.post_id,
 					status: $( '#order_status' ).val()
 				} );
@@ -878,7 +878,7 @@ jQuery( function ( $ ) {
 							}
 						},
 						complete: function() {
-							window.wcTracks.recordEvent( 'order_refunded', {
+							window.wcTracks.recordEvent( 'order_edit_refunded', {
 								order_id: data.order_id,
 								status: $( '#order_status' ).val(),
 								api_refund: data.api_refund,

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -513,6 +513,8 @@ jQuery( function ( $ ) {
 				wc_meta_boxes_order_items.reload_items();
 			}
 
+			window.wcTracks.recordEvent( 'order_edit_add_items_cancelled' );
+
 			return false;
 		},
 
@@ -551,6 +553,7 @@ jQuery( function ( $ ) {
 							$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
 							wc_meta_boxes_order_items.reloaded_items();
 							wc_meta_boxes_order_items.unblock();
+							window.wcTracks.recordEvent( 'order_edit_add_fee' );
 					} else {
 						window.alert( response.data.error );
 					}
@@ -573,6 +576,7 @@ jQuery( function ( $ ) {
 			$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
 				if ( response.success ) {
 					$( 'table.woocommerce_order_items tbody#order_shipping_line_items' ).append( response.data.html );
+					window.wcTracks.recordEvent( 'order_edit_add_shipping' );
 				} else {
 					window.alert( response.data.error );
 				}
@@ -1118,6 +1122,9 @@ jQuery( function ( $ ) {
 							window.alert( response.data.error );
 						}
 					},
+					complete: function() {
+						window.wcTracks.recordEvent( 'order_edit_add_products' );
+					},
 					dataType: 'json'
 				});
 			},
@@ -1160,6 +1167,9 @@ jQuery( function ( $ ) {
 								window.alert( response.data.error );
 							}
 							wc_meta_boxes_order_items.unblock();
+						},
+						complete: function() {
+							window.wcTracks.recordEvent( 'order_edit_add_tax' );
 						}
 					});
 				} else {

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -556,7 +556,7 @@ jQuery( function ( $ ) {
 							$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
 							wc_meta_boxes_order_items.reloaded_items();
 							wc_meta_boxes_order_items.unblock();
-							window.wcTracks.recordEvent( 'order_edit_add_fee', {
+							window.wcTracks.recordEvent( 'order_edit_added_fee', {
 								order_id: data.post_id,
 								status: $( '#order_status' ).val()
 							} );

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -513,7 +513,10 @@ jQuery( function ( $ ) {
 				wc_meta_boxes_order_items.reload_items();
 			}
 
-			window.wcTracks.recordEvent( 'order_edit_add_items_cancelled' );
+			window.wcTracks.recordEvent( 'order_edit_add_items_cancelled',{
+				order_id: woocommerce_admin_meta_boxes.post_id,
+				status: $( '#order_status' ).val()
+			} );
 
 			return false;
 		},
@@ -553,7 +556,10 @@ jQuery( function ( $ ) {
 							$( '#woocommerce-order-items' ).find( '.inside' ).append( response.data.html );
 							wc_meta_boxes_order_items.reloaded_items();
 							wc_meta_boxes_order_items.unblock();
-							window.wcTracks.recordEvent( 'order_edit_add_fee' );
+							window.wcTracks.recordEvent( 'order_edit_add_fee', {
+								order_id: data.post_id,
+								status: $( '#order_status' ).val()
+							} );
 					} else {
 						window.alert( response.data.error );
 					}
@@ -576,7 +582,10 @@ jQuery( function ( $ ) {
 			$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
 				if ( response.success ) {
 					$( 'table.woocommerce_order_items tbody#order_shipping_line_items' ).append( response.data.html );
-					window.wcTracks.recordEvent( 'order_edit_add_shipping' );
+					window.wcTracks.recordEvent( 'order_edit_add_shipping', {
+						order_id: data.post_id,
+						status: $( '#order_status' ).val()
+					} );
 				} else {
 					window.alert( response.data.error );
 				}
@@ -599,7 +608,10 @@ jQuery( function ( $ ) {
 			$( this ).hide();
 			$( 'button.add-line-item' ).click();
 			$( 'button.cancel-action' ).attr( 'data-reload', true );
-			window.wcTracks.recordEvent( 'order_edit_edit_item_click' );
+			window.wcTracks.recordEvent( 'order_edit_edit_item_click', {
+				order_id: woocommerce_admin_meta_boxes.post_id,
+				status: $( '#order_status' ).val()
+			} );
 			return false;
 		},
 
@@ -647,7 +659,10 @@ jQuery( function ( $ ) {
 						wc_meta_boxes_order_items.unblock();
 					},
 					complete: function() {
-						window.wcTracks.recordEvent( 'order_edit_remove_item' );
+						window.wcTracks.recordEvent( 'order_edit_remove_item', {
+							order_id: data.post_id,
+							status: $( '#order_status' ).val()
+						} );
 					}
 				});
 			}
@@ -753,13 +768,17 @@ jQuery( function ( $ ) {
 						$( document.body ).trigger( 'order-totals-recalculate-complete', response );
 
 						window.wcTracks.recordEvent( 'order_edit_recalc_totals', {
-							OK_cancel: 'OK'
+							order_id: data.post_id,
+							OK_cancel: 'OK',
+							status: $( '#order_status' ).val()
 						} );
 					}
 				});
 			} else {
 				window.wcTracks.recordEvent( 'order_edit_recalc_totals', {
-					OK_cancel: 'cancel'
+					order_id: woocommerce_admin_meta_boxes.post_id,
+					OK_cancel: 'cancel',
+					status: $( '#order_status' ).val()
 				} );
 			}
 
@@ -799,7 +818,10 @@ jQuery( function ( $ ) {
 					}
 				},
 				complete: function() {
-					window.wcTracks.recordEvent( 'order_edit_save_line_items' );
+					window.wcTracks.recordEvent( 'order_edit_save_line_items', {
+						order_id: data.post_id,
+						status: $( '#order_status' ).val()
+					} );
 				}
 			});
 
@@ -1123,7 +1145,10 @@ jQuery( function ( $ ) {
 						}
 					},
 					complete: function() {
-						window.wcTracks.recordEvent( 'order_edit_add_products' );
+						window.wcTracks.recordEvent( 'order_edit_add_products', {
+							order_id: data.post_id,
+							status: $( '#order_status' ).val()
+						} );
 					},
 					dataType: 'json'
 				});
@@ -1169,7 +1194,10 @@ jQuery( function ( $ ) {
 							wc_meta_boxes_order_items.unblock();
 						},
 						complete: function() {
-							window.wcTracks.recordEvent( 'order_edit_add_tax' );
+							window.wcTracks.recordEvent( 'order_edit_add_tax', {
+								order_id: data.post_id,
+								status: $( '#order_status' ).val()
+							} );
 						}
 					});
 				} else {

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -560,6 +560,7 @@ jQuery( function ( $ ) {
 			$( this ).hide();
 			$( 'button.add-line-item' ).click();
 			$( 'button.cancel-action' ).attr( 'data-reload', true );
+			window.wcTracks.recordEvent( 'order_edit_edit_item_click' );
 			return false;
 		},
 
@@ -605,6 +606,9 @@ jQuery( function ( $ ) {
 							window.alert( response.data.error );
 						}
 						wc_meta_boxes_order_items.unblock();
+					},
+					complete: function() {
+						window.wcTracks.recordEvent( 'order_edit_remove_item' );
 					}
 				});
 			}
@@ -708,8 +712,16 @@ jQuery( function ( $ ) {
 					},
 					complete: function( response ) {
 						$( document.body ).trigger( 'order-totals-recalculate-complete', response );
+
+						window.wcTracks.recordEvent( 'order_edit_recalc_totals', {
+							OK_cancel: 'OK'
+						} );
 					}
 				});
+			} else {
+				window.wcTracks.recordEvent( 'order_edit_recalc_totals', {
+					OK_cancel: 'cancel'
+				} );
 			}
 
 			return false;
@@ -746,6 +758,9 @@ jQuery( function ( $ ) {
 						wc_meta_boxes_order_items.unblock();
 						window.alert( response.data.error );
 					}
+				},
+				complete: function() {
+					window.wcTracks.recordEvent( 'order_edit_save_line_items' );
 				}
 			});
 

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -513,7 +513,7 @@ jQuery( function ( $ ) {
 				wc_meta_boxes_order_items.reload_items();
 			}
 
-			window.wcTracks.recordEvent( 'order_edit_add_items_cancelled',{
+			window.wcTracks.recordEvent( 'order_edit_add_items_cancelled', {
 				order_id: woocommerce_admin_meta_boxes.post_id,
 				status: $( '#order_status' ).val()
 			} );

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -140,8 +140,8 @@ jQuery( function ( $ ) {
 
 			var event_name = is_billing ? 'order_edit_billing_address_click' : 'order_edit_shipping_address_click';
 			window.wcTracks.recordEvent( event_name, {
-				order_id: data.order_id,
-				status: $( '#order_status' ).val(),
+				order_id: woocommerce_admin_meta_boxes.post_id,
+				status: $( '#order_status' ).val()
 			} );
 		},
 
@@ -474,7 +474,7 @@ jQuery( function ( $ ) {
 
 			window.wcTracks.recordEvent( 'order_refund_button_click', {
 				order_id: woocommerce_admin_meta_boxes.post_id,
-				status: $( '#order_status' ).val(),
+				status: $( '#order_status' ).val()
 			} );
 
 			return false;
@@ -498,7 +498,7 @@ jQuery( function ( $ ) {
 		track_cancel: function() {
 			window.wcTracks.recordEvent( 'order_refund_cancel', {
 				order_id: woocommerce_admin_meta_boxes.post_id,
-				status: $( '#order_status' ).val(),
+				status: $( '#order_status' ).val()
 			} );
 		},
 
@@ -658,14 +658,14 @@ jQuery( function ( $ ) {
 					complete: function() {
 						window.wcTracks.recordEvent( 'order_delete_tax', {
 							order_id: data.order_id,
-							status: $( '#order_status' ).val(),
+							status: $( '#order_status' ).val()
 						} );
 					}
 				});
 			} else {
 				window.wcTracks.recordEvent( 'order_delete_tax_cancel', {
 					order_id: woocommerce_admin_meta_boxes.post_id,
-					status: $( '#order_status' ).val(),
+					status: $( '#order_status' ).val()
 				} );
 			}
 			return false;
@@ -858,7 +858,7 @@ jQuery( function ( $ ) {
 								status: $( '#order_status' ).val(),
 								api_refund: data.api_refund,
 								has_reason: Boolean( data.refund_reason.length ),
-								restock: 'true' === data.restock_refunded_items,
+								restock: 'true' === data.restock_refunded_items
 							} );
 						}
 					} );

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -537,9 +537,19 @@ jQuery( function ( $ ) {
 		},
 
 		add_fee: function() {
+			window.wcTracks.recordEvent( 'order_edit_add_fee_click', {
+				order_id: woocommerce_admin_meta_boxes.post_id,
+				status: $( '#order_status' ).val()
+			} );
+
 			var value = window.prompt( woocommerce_admin_meta_boxes.i18n_add_fee );
 
-			if ( value != null ) {
+			if ( null == value ) {
+				window.wcTracks.recordEvent( 'order_edit_add_fee_cancel', {
+					order_id: woocommerce_admin_meta_boxes.post_id,
+					status: $( '#order_status' ).val()
+				} );
+			} else {
 				wc_meta_boxes_order_items.block();
 
 				var data = $.extend( {}, wc_meta_boxes_order_items.get_taxable_address(), {

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1,6 +1,10 @@
 /*global woocommerce_admin_meta_boxes, woocommerce_admin, accounting, woocommerce_admin_meta_boxes_order, wcSetClipboard, wcClearClipboard */
 jQuery( function ( $ ) {
 
+	// Stand-in wcTracks.recordEvent in case tracks is not available (for any reason).
+	window.wcTracks = window.wcTracks || {};
+	window.wcTracks.recordEvent = window.wcTracks.recordEvent  || function() { };
+
 	/**
 	 * Order Data Panel
 	 */
@@ -625,8 +629,19 @@ jQuery( function ( $ ) {
 							window.alert( response.data.error );
 						}
 						wc_meta_boxes_order_items.unblock();
+					},
+					complete: function() {
+						window.wcTracks.recordEvent( 'order_delete_tax', {
+							order_id: data.order_id,
+							status: $( '#order_status' ).val(),
+						} );
 					}
 				});
+			} else {
+				window.wcTracks.recordEvent( 'order_delete_tax_cancel', {
+					order_id: woocommerce_admin_meta_boxes.post_id,
+					status: $( '#order_status' ).val(),
+				} );
 			}
 			return false;
 		},

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1230,6 +1230,11 @@ jQuery( function ( $ ) {
 				$( 'ul.order_notes' ).prepend( response );
 				$( '#woocommerce-order-notes' ).unblock();
 				$( '#add_order_note' ).val( '' );
+				window.wcTracks.recordEvent( 'order_edit_add_order_note', {
+					order_id: data.post_id,
+					note_type: data.note_type || 'private',
+					status: $( '#order_status' ).val()
+				} );
 			});
 
 			return false;

--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -110,7 +110,7 @@ class WC_Orders_Tracking {
 				'action'   => $action,
 			);
 
-			WC_Tracks::record_event( 'orders_edit_order_action', $properties );
+			WC_Tracks::record_event( 'order_edit_order_action', $properties );
 		}
 		// phpcs:enable
 	}
@@ -140,7 +140,7 @@ class WC_Orders_Tracking {
 					isset( $referring_args['post'] ) &&
 					'shop_order' === get_post_type( $referring_args['post'] )
 				) {
-					WC_Tracks::record_event( 'orders_add_order_from_edit' );
+					WC_Tracks::record_event( 'order_edit_add_order' );
 				}
 			}
 		}

--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -20,6 +20,7 @@ class WC_Orders_Tracking {
 		add_action( 'pre_post_update', array( $this, 'track_created_date_change' ), 10 );
 		// WC_Meta_Box_Order_Actions::save() hooks in at priority 50.
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'track_order_action' ), 51 );
+		add_action( 'load-post-new.php', array( $this, 'track_add_order_from_edit' ), 10 );
 	}
 
 	/**
@@ -112,5 +113,36 @@ class WC_Orders_Tracking {
 			WC_Tracks::record_event( 'orders_edit_order_action', $properties );
 		}
 		// phpcs:enable
+	}
+
+	/**
+	 * Track "add order" button on the Edit Order screen.
+	 */
+	public function track_add_order_from_edit() {
+		// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( isset( $_GET['post_type'] ) && 'shop_order' === wp_unslash( $_GET['post_type'] ) ) {
+			$referer = wp_get_referer();
+
+			if ( $referer ) {
+				$referring_page = parse_url( $referer );
+				$referring_args = array();
+				$post_edit_page = parse_url( admin_url( 'post.php' ) );
+
+				if ( ! empty( $referring_page['query'] ) ) {
+					parse_str( $referring_page['query'], $referring_args );
+				}
+
+				// Determine if we arrived from an Order Edit screen.
+				if (
+					$post_edit_page['path'] === $referring_page['path'] &&
+					isset( $referring_args['action'] ) &&
+					'edit' === $referring_args['action'] &&
+					isset( $referring_args['post'] ) &&
+					'shop_order' === get_post_type( $referring_args['post'] )
+				) {
+					WC_Tracks::record_event( 'orders_add_order_from_edit' );
+				}
+			}
+		}
 	}
 }

--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -17,6 +17,7 @@ class WC_Orders_Tracking {
 	public function init() {
 		add_action( 'woocommerce_order_status_changed', array( $this, 'track_order_status_change' ), 10, 3 );
 		add_action( 'load-edit.php', array( $this, 'track_orders_view' ), 10 );
+		add_action( 'pre_post_update', array( $this, 'track_created_date_change' ), 10 );
 	}
 
 	/**
@@ -54,5 +55,39 @@ class WC_Orders_Tracking {
 		);
 
 		WC_Tracks::record_event( 'orders_edit_status_change', $properties );
+	}
+
+	/**
+	 * Send a Tracks event when an order date is changed.
+	 *
+	 * @param int $id Order id.
+	 */
+	public function track_created_date_change( $id ) {
+		$post_type = get_post_type( $id );
+
+		if ( 'shop_order' !== $post_type ) {
+			return;
+		}
+
+		$order        = wc_get_order( $id );
+		$date_created = $order->get_date_created()->date( 'Y-m-d H:i:s' );
+		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		$new_date     = sprintf(
+			'%s %2d:%2d:%2d',
+			isset( $_POST['order_date'] ) ? wc_clean( wp_unslash( $_POST['order_date'] ) ) : '',
+			isset( $_POST['order_date_hour'] ) ? wc_clean( wp_unslash( $_POST['order_date_hour'] ) ) : '',
+			isset( $_POST['order_date_minute'] ) ? wc_clean( wp_unslash( $_POST['order_date_minute'] ) ) : '',
+			isset( $_POST['order_date_second'] ) ? wc_clean( wp_unslash( $_POST['order_date_second'] ) ) : ''
+		);
+		// phpcs:enable
+
+		if ( $new_date !== $date_created ) {
+			$properties = array(
+				'order_id'   => $id,
+				'status'     => $order->get_status(),
+			);
+
+			WC_Tracks::record_event( 'order_edit_date_created', $properties );
+		}
 	}
 }

--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -55,6 +55,7 @@ class WC_Orders_Tracking {
 			'next_status'     => $next_status,
 			'previous_status' => $previous_status,
 			'date_created'    => $date->date( 'Y-m-d' ),
+			'payment_method'  => $order->get_payment_method(),
 		);
 
 		WC_Tracks::record_event( 'orders_edit_status_change', $properties );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR seeks to collect more usage data relevant to how users manage their orders. The hope is to use it to better inform any improvements made to these workflows.

### How to test the changes in this Pull Request:

For each event in the table, perform the triggering action and verify the event fired either using the Network tab in your browser and inspecting outbound HTTP requests from your web server

|Event name|How to trigger|
|---|---|
wcadmin_order_edit_billing_address_click|When a user clicks the edit icon for billing address
wcadmin_order_edit_shipping_address_click|When a user clicks the edit icon for billing address
wcadmin_order_edit_add_coupon_click|When a user clicks the "add coupon" button
wcadmin_order_edit_add_coupon_cancel|When a user cancels the "add coupon" flow
wcadmin_order_edit_added_coupon|When a user adds a coupon to an order
wcadmin_order_edit_refund_button_click|When a user clicks the "refund" button
wcadmin_order_edit_refund_cancel|When a user cancels the "refund" flow
wcadmin_order_edit_refunded|When a user completes the "refund" flow
wcadmin_order_edit_added_fee|When a user adds a fee to an order
wcadmin_order_edit_add_fee_click|When a user clicks the "Add fee" button
wcadmin_order_edit_add_fee_cancel|When a user cancels the "Add fee" flow
wcadmin_order_edit_add_items_click|When a user clicks the "Add item(s)" button
wcadmin_order_edit_add_items_cancelled|When a user cancels the "add item(s)" flow
wcadmin_order_edit_add_shipping|When a user adds a shipping item
wcadmin_order_edit_edit_item_click|When a user clicks the edit icon for an order item
wcadmin_order_edit_remove_item|When a user clicks the remove icon for an order item
wcadmin_order_edit_delete_tax|When a user deletes a tax column from order items
wcadmin_order_edit_delete_tax_cancel|When a user cancels the tax deletion flow
wcadmin_order_edit_recalc_totals|When a user clicks to recalculate order totals
wcadmin_order_edit_save_line_items|When a user clicks to save added order items
wcadmin_order_edit_add_products|When a user clicks to add products to order items
wcadmin_order_edit_add_tax|When a user clicks to add tax to order items
wcadmin_order_edit_add_order_note|When a user adds an order note
wcadmin_order_edit_date_created|When a user edits the order's creation date
wcadmin_order_edit_order_action|When a user triggers an order action
wcadmin_order_edit_add_order|When a user clicks to "add order" while editing another
