### PR TITLE
Send boolean as expected, not string

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -378,7 +378,7 @@ class WC_AJAX {
 			array(
 				'result'    => empty( $messages ) ? 'success' : 'failure',
 				'messages'  => $messages,
-				'reload'    => $reload_checkout ? 'true' : 'false',
+				'reload'    => $reload_checkout,
 				'fragments' => apply_filters(
 					'woocommerce_update_order_review_fragments',
 					array(


### PR DESCRIPTION
Originally checkout.js:336 expected string but changed to boolean
with 4ad370985. Send boolean for `reload` in json and fix #23888.

### Changes proposed in this Pull Request:

Closes #23888 by sending boolean as expected no string. This is my first
pull request, I expect you to be nice to me.

### How to test the changes in this Pull Request:

1. Add in any theme function or custom plugin the code to force refresh cart:
```
add_action('wp', 'my_custom_action')';

function my_custom_action() {
    WC()->session->set( 'reload_checkout' );
}
```
2. Add some product and go to checkout.
3. Checkout should get a infinity loop, because always the response from POST /?wc-ajax=update_order_review should be something like this:
```
{
   "result": "success",
   "message": "",
   "reload": true,
   "fragments": {}
}
```
And in `checkout.js` by strict check, it should reload:
```
if ( data && true === data.reload ) {
   window.location.reload();
   return;
}
```

### Changelog entry
* Fix reload of checkout when POST /?wc-ajax=update_order_review
