### PR TITLE
Remove / hide / disable the Install WooCommerce Admin message from da…

### DIFF
--- a/includes/admin/views/html-notice-wc-admin.php
+++ b/includes/admin/views/html-notice-wc-admin.php
@@ -9,8 +9,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if ( ! current_user_can( 'shop_manager' ) ) {
-	?>
+if (! current_user_can( 'shop_manager' ))
+{
+?>
 <div id="message" class="updated woocommerce-message woocommerce-admin-promo-messages">
 	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'wc_admin' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 
@@ -34,6 +35,6 @@ if ( ! current_user_can( 'shop_manager' ) ) {
 		</p>
 	<?php endif; ?>
 </div>
-	<?php
+<?php
 }
 ?>

--- a/includes/admin/views/html-notice-wc-admin.php
+++ b/includes/admin/views/html-notice-wc-admin.php
@@ -9,6 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+if (! current_user_can( 'shop_manager' ))
+{
 ?>
 <div id="message" class="updated woocommerce-message woocommerce-admin-promo-messages">
 	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'wc_admin' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
@@ -33,3 +35,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</p>
 	<?php endif; ?>
 </div>
+<?php
+}
+?>

--- a/includes/admin/views/html-notice-wc-admin.php
+++ b/includes/admin/views/html-notice-wc-admin.php
@@ -9,9 +9,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-if (! current_user_can( 'shop_manager' ))
-{
-?>
+if ( ! current_user_can( 'shop_manager' ) ) {
+	?>
 <div id="message" class="updated woocommerce-message woocommerce-admin-promo-messages">
 	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'wc_admin' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 
@@ -35,6 +34,6 @@ if (! current_user_can( 'shop_manager' ))
 		</p>
 	<?php endif; ?>
 </div>
-<?php
+	<?php
 }
 ?>

--- a/includes/data-stores/abstract-wc-order-item-type-data-store.php
+++ b/includes/data-stores/abstract-wc-order-item-type-data-store.php
@@ -44,7 +44,8 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 		global $wpdb;
 
 		$wpdb->insert(
-			$wpdb->prefix . 'woocommerce_order_items', array(
+			$wpdb->prefix . 'woocommerce_order_items',
+			array(
 				'order_item_name' => $item->get_name(),
 				'order_item_type' => $item->get_type(),
 				'order_id'        => $item->get_order_id(),
@@ -72,11 +73,13 @@ abstract class Abstract_WC_Order_Item_Type_Data_Store extends WC_Data_Store_WP i
 
 		if ( array_intersect( array( 'name', 'order_id' ), array_keys( $changes ) ) ) {
 			$wpdb->update(
-				$wpdb->prefix . 'woocommerce_order_items', array(
+				$wpdb->prefix . 'woocommerce_order_items',
+				array(
 					'order_item_name' => $item->get_name(),
 					'order_item_type' => $item->get_type(),
 					'order_id'        => $item->get_order_id(),
-				), array( 'order_item_id' => $item->get_id() )
+				),
+				array( 'order_item_id' => $item->get_id() )
 			);
 		}
 


### PR DESCRIPTION
…shboard for Shop Manager users #23890

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Create user from Wordpress admin which has role of store-manager.
2. Login to created user from Wordpress admin.
3. Install WooCommerce Admin notice should not be get displayed.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
