### PR TITLE
NL postcode validation update

### DIFF
--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -94,7 +94,7 @@ class WC_Validation {
 				$valid = (bool) preg_match( '/^([0-9]{3})(\s?)([0-9]{2})$/', $postcode );
 				break;
 			case 'NL':
-				$valid = (bool) preg_match( '/^[1-9][0-9]{3}\s(?!SA|SD|SS)[A-Z]{2}$/', $postcode );
+				$valid = (bool) preg_match( '/^[1-9][0-9]{3}\s?(?!SA|SD|SS)[A-Z]{2}$/', $postcode );
 				break;
 
 			default:

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -774,6 +774,10 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
 		// JP postcode.
 		$this->assertEquals( '999-9999', wc_format_postcode( '9999999', 'JP' ) );
+
+		// NL postcodes.
+		$this->assertSame( '1073 LP', wc_format_postcode( '1073LP', 'NL' ) );
+		$this->assertSame( '1073 LP', wc_format_postcode( '1073 LP', 'NL' ) );
 	}
 
 	/**

--- a/tests/unit-tests/util/validation.php
+++ b/tests/unit-tests/util/validation.php
@@ -98,7 +98,19 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 			array( false, WC_Validation::is_postcode( '0A0A0A', 'CA' ) ),
 		);
 
-		return array_merge( $it, $gb, $us, $ch, $br, $ca );
+		$nl = array(
+			array( true, WC_Validation::is_postcode( '1073LP', 'NL' ) ),
+			array( true, WC_Validation::is_postcode( '1073 LP', 'NL' ) ),
+			array( false, WC_Validation::is_postcode( '0073LP', 'NL' ) ),
+			array( false, WC_Validation::is_postcode( '0073 LP', 'NL' ) ),
+			array( false, WC_Validation::is_postcode( '107 3LP', 'NL' ) ),
+			array( false, WC_Validation::is_postcode( 'A073LP', 'NL' ) ),
+			array( false, WC_Validation::is_postcode( '1073SA', 'NL' ) ),
+			array( false, WC_Validation::is_postcode( '1073SD', 'NL' ) ),
+			array( false, WC_Validation::is_postcode( '1073SS', 'NL' ) ),
+		);
+
+		return array_merge( $it, $gb, $us, $ch, $br, $ca, $nl );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR alters the postal code validation for NL to allow for the space to be optional inbetween the postal code. Currently we enforce the space however as pointed out in #23901 the space is omitted on the country's postal service site.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23901 

### How to test the changes in this Pull Request:

1. Checkout branch
2. Test checkout using a combination of these valid postal codes 1073LP, 1073 LP
3. Test checkout using a combination of these invalid postal codes 0073LP, 0073 LP, 007 3LP

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - NL postal code, allow 4th char to be optional space.
