### PR TITLE
[Setup] Make PostCode optional as few countries don't use them

### DIFF
--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -51,6 +51,25 @@ jQuery( function( $ ) {
 		$( '#currency_code' ).val( wc_setup_currencies[ country ] ).change();
 	} );
 
+	/* Setup postcode field and validations */
+	$( '#store_country' ).on( 'change', function() {
+		if ( ! wc_setup_params.postcodes ) {
+			return;
+		}
+
+		var $this                 = $( this ),
+			country               = $this.val(),
+			$store_postcode_input = $( '#store_postcode' ),
+			country_postcode_obj  = wc_setup_params.postcodes[ country ];
+
+		// Default to required, if its unknown whether postcode is required or not.
+		if ( $.isEmptyObject( country_postcode_obj ) || country_postcode_obj.required  ) {
+			$store_postcode_input.attr( 'required', 'true' );
+		} else {
+			$store_postcode_input.removeAttr( 'required' );
+		}
+	} );
+
 	$( '#store_country' ).change();
 
 	$( '.wc-wizard-services' ).on( 'change', '.wc-wizard-service-enable input', function() {

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -211,7 +211,7 @@ class WC_Admin_Setup_Wizard {
 			array(
 				'pending_jetpack_install' => $pending_jetpack ? 'yes' : 'no',
 				'states'                  => WC()->countries->get_states(),
-				'postcodes'               => wp_list_pluck( WC()->countries->get_country_locale(), 'postcode' ),
+				'postcodes'               => $this->get_postcodes(),
 				'current_step'            => isset( $this->steps[ $this->step ] ) ? $this->step : false,
 				'i18n'                    => array(
 					'extra_plugins' => array(
@@ -224,6 +224,23 @@ class WC_Admin_Setup_Wizard {
 				),
 			)
 		);
+	}
+
+	/**
+	 * Helper method to get postcode configurations from `WC()->countries->get_country_locale()`.
+	 * We don't use `wp_list_pluck` because it will throw notices when postcode configuration is not defined for a country.
+	 *
+	 * @return array
+	 */
+	private function get_postcodes() {
+		$locales   = WC()->countries->get_country_locale();
+		$postcodes = array();
+		foreach ( $locales as $country_code => $locale ) {
+			if ( isset( $locale['postcode'] ) ) {
+				$postcodes[ $country_code ] = $locale['postcode'];
+			}
+		}
+		return $postcodes;
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -211,6 +211,7 @@ class WC_Admin_Setup_Wizard {
 			array(
 				'pending_jetpack_install' => $pending_jetpack ? 'yes' : 'no',
 				'states'                  => WC()->countries->get_states(),
+				'postcodes'               => wp_list_pluck( WC()->countries->get_country_locale(), 'postcode' ),
 				'current_step'            => isset( $this->steps[ $this->step ] ) ? $this->step : false,
 				'i18n'                    => array(
 					'extra_plugins' => array(


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some countries like Hong Kong, UAE etc don't use post codes. This commitswill make the Postcode / Zip field optional in setup wizard if this is the case.
If its not known whether a country uses postcode or not, default behavior would be to require the postcode.
Closes #23544 .

### How to test the changes in this Pull Request:

1. Go to WooCommerce Setup wizard: `wp-admin/index.php?page=wc-setup&step=store_setup`
2. Select a country with post code required like `India`. Leave the PostCode field empty and click on `Let's Go` button. An error message will be displayed informing that post code field is required.
3. Select a country with post code not required, like `United Arab Emirates`. Leave the `PostCode` field empty and click on `Let's Go` button. No error message will be shown and you will be able to proceed.

### Other information:
This increases the setup page size from 22.25KB to 22.91KB because of added locale data on frontend

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
