### PR TITLE
Display Status > Logs timestamp with the Y-m-d H:i:s format

### DIFF
--- a/includes/admin/class-wc-admin-log-table-list.php
+++ b/includes/admin/class-wc-admin-log-table-list.php
@@ -126,7 +126,7 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 	public function column_timestamp( $log ) {
 		return esc_html(
 			mysql2date(
-				get_option( 'date_format' ) . ' ' . get_option( 'time_format' ),
+				'Y-m-d H:i:s',
 				$log['timestamp']
 			)
 		);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Display WooCommerce > Status > Logs timestamp, when using WC_Log_Handler_DB, with the Y-m-d H:i:s format instead of the WordPress global date and time format options, because we need more detail on the shown timestamps and that might not be compatible with what we want for our global options.

Closes #23914 

### How to test the changes in this Pull Request:

1. Change the WC_LOG_HANDLER to WC_Log_Handler_DB
2. Check the timestamp format on WooCommerce > Status > Logs

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?