### PR TITLE
Fix WP version to 5.1.1, last one that supports PHP < 5.6.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,10 @@ matrix:
   include:
   - php: 5.3
     dist: precise
+    env: WP_VERSION=5.1.1 WP_MULTISITE=0 RUN_PHPCS=0
   - php: 5.2
     dist: precise
+    env: WP_VERSION=5.1.1 WP_MULTISITE=0 RUN_PHPCS=0
   - name: "Coding standard check"
     php: 7.2
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1


### PR DESCRIPTION
Attempt to fix failing unit tests for PHP 5.2 and 5.3 by requiring WP 5.1.1 in the unit tests for old PHP versions. Could be used for 3.6.x fix versions until we merge #23924 to master for 3.7.