### PR TITLE
Add missing post_type=product query var in url

### DIFF
--- a/includes/admin/class-wc-admin-taxonomies.php
+++ b/includes/admin/class-wc-admin-taxonomies.php
@@ -393,7 +393,7 @@ class WC_Admin_Taxonomies {
 		if ( $default_category_id !== $term->term_id && current_user_can( 'edit_term', $term->term_id ) ) {
 			$actions['make_default'] = sprintf(
 				'<a href="%s" aria-label="%s">%s</a>',
-				wp_nonce_url( 'edit-tags.php?action=make_default&amp;taxonomy=product_cat&amp;tag_ID=' . absint( $term->term_id ), 'make_default_' . absint( $term->term_id ) ),
+				wp_nonce_url( 'edit-tags.php?action=make_default&amp;taxonomy=product_cat&amp;post_type=product&amp;tag_ID=' . absint( $term->term_id ), 'make_default_' . absint( $term->term_id ) ),
 				/* translators: %s: taxonomy term name */
 				esc_attr( sprintf( __( 'Make &#8220;%s&#8221; the default category', 'woocommerce' ), $term->name ) ),
 				__( 'Make default', 'woocommerce' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Make Products->Categories active when clicked on "Make Default" link under any product category and fix #23923.

### How to test the changes in this Pull Request:

1. Visit Products->Categories.
2. Under any category, click on "Make Default" link which can be shown on hover.
3. See the active link of Products->Categories in admin sidebar menu.
