### PR TITLE
Remove shipping section from helpful message of login form

### DIFF
--- a/templates/checkout/form-login.php
+++ b/templates/checkout/form-login.php
@@ -29,7 +29,7 @@ if ( is_user_logged_in() || 'no' === get_option( 'woocommerce_enable_checkout_lo
 
 woocommerce_login_form(
 	array(
-		'message'  => __( 'If you have shopped with us before, please enter your details below. If you are a new customer, please proceed to the Billing &amp; Shipping section.', 'woocommerce' ),
+		'message'  => __( 'If you have shopped with us before, please enter your details below. If you are a new customer, please proceed to the Billing section.', 'woocommerce' ),
 		'redirect' => wc_get_page_permalink( 'checkout' ),
 		'hidden'   => true,
 	)


### PR DESCRIPTION
Shipping section may not always be present such as in case of only virtual products in cart, so remove it from message shown for the login form.

### Changes proposed in this Pull Request:

Closes #23940 by removing shipping section from message. In case of where shipping section needs to be shown, it is quite obvious for customers to move to shipping section after filling out billing details.

### How to test the changes in this Pull Request:

1. Make sure under WooCommerce->Settings->Accounts & Privacy->Guest Checkout the checkbox "_Allow customers to log into an existing account during checkout_" is checked.
2. Put any product in cart and checkout.
3. Click on link of message "_Returning customer? Click here to login_" shown.
4. See the modified message with mention of only billing section.

### Other information:

The other way to resolve #23940 is to conditionally show " &amp; Shipping" in the message based on condition if shipping section needs to be shown as form-shipping itself does:
https://github.com/woocommerce/woocommerce/blob/aaf789ad64f171ab8b5cec8aee95b98b9932f60d/templates/checkout/form-shipping.php#L22

But I think it will be an overkill for such a simple obvious message and will unnecessarily make the code ugly. The message currently written as:
https://github.com/woocommerce/woocommerce/blob/aaf789ad64f171ab8b5cec8aee95b98b9932f60d/templates/checkout/form-login.php#L32
Let me know if this condition is necessary. I'll make changes. :)