### PR TITLE
Set Tracks image position to fixed

### DIFF
--- a/includes/tracks/class-wc-tracks-footer-pixel.php
+++ b/includes/tracks/class-wc-tracks-footer-pixel.php
@@ -90,7 +90,7 @@ class WC_Tracks_Footer_Pixel {
 				continue;
 			}
 
-			echo '<img src="', esc_url( $pixel ), '" />';
+			echo '<img style="position: fixed;" src="', esc_url( $pixel ), '" />';
 		}
 
 		$this->events = array();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Sets the position of the tracking image to fixed, so it doesn't affect page layout. Having it statically positioned was making a scrollbar to appear if the contents rendered on top occupied exactly 100% of the height:

Before<br>screenshot | After<br>screenshot
:--------:|:--------:
![image](https://user-images.githubusercontent.com/3616980/59677534-624ac780-91ca-11e9-85a0-f0108bba300f.png) | ![image](https://user-images.githubusercontent.com/3616980/59677579-78588800-91ca-11e9-9c4d-5ec3161fa2af.png)
(notice the scrollbar) | (notice there is no scrollbar)

That was visible in the plugin WooCommerce Admin, for example. I think it makes sense fixing it in core since it might affect other plugins as well.

### How to test the changes in this Pull Request:

1. Install [WooCommerce Admin](https://wordpress.org/plugins/woocommerce-admin/).
2. Go to a page that doesn't fill all the page, so there is blank space at the bottom.
3. Verify there are no scrollbars/page can't be scrolled.
4. In your browser _Network_ devtools, verify `pixel.wp.com/t.gif` is still being loaded.

@jeffstieler tagging you for review since it looks you were the last one to modify that file. But feel free to tag somebody else if you think it would be better. :slightly_smiling_face: 