### PR TITLE
Implement Package Manager class

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -459,6 +459,8 @@ final class WooCommerce {
 		}
 
 		$this->theme_support_includes();
+
+		\WooCommerce\Core\PackageManager::init();
 		$this->query = new WC_Query();
 		$this->api   = new WC_API();
 		$this->api->init();

--- a/includes/legacy/class-wc-legacy-api.php
+++ b/includes/legacy/class-wc-legacy-api.php
@@ -270,4 +270,23 @@ class WC_Legacy_API {
 		// Fire off the request.
 		$this->server->serve_request();
 	}
+
+	/**
+	 * Include REST API classes.
+	 *
+	 * @deprecated since 3.7.0 - REST API clases autoload.
+	 */
+	public function rest_api_includes() {
+		$this->rest_api_init();
+	}
+
+	/**
+	 * Register REST API routes.
+	 *
+	 * @deprecated since 3.7.0 - Not used.
+	 */
+	public function register_rest_routes() {
+		// Register settings to the REST API.
+		$this->register_wp_admin_settings();
+	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,7 +16,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="4.7" />
-	<config name="testVersion" value="5.2-" />
+	<config name="testVersion" value="5.6-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -34,6 +34,7 @@
 	<rule ref="WordPress.Files.FileName.InvalidClassFileName">
 		<exclude-pattern>includes/**/abstract-*.php</exclude-pattern>
 		<exclude-pattern>tests/*</exclude-pattern>
+		<exclude-pattern>src/*</exclude-pattern>
 	</rule>
 
 	<rule ref="Generic.Commenting">
@@ -46,5 +47,6 @@
 
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
 		<exclude-pattern>i18n/</exclude-pattern>
+		<exclude-pattern>src/*</exclude-pattern>
 	</rule>
 </ruleset>

--- a/src/Package.php
+++ b/src/Package.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * WooCommerce Package class.
+ *
+ * Stores information about a core/external package, such as it's version and init callback.
+ *
+ * @package WooCommerce/Core
+ * @since   3.7.0
+ */
+
+namespace WooCommerce\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Package class.
+ */
+class Package {
+
+	/**
+	 * Version string for package.
+	 *
+	 * @var string
+	 */
+	public $version = '0';
+
+	/**
+	 * Callback to init this package.
+	 *
+	 * @var callable
+	 */
+	public $callback = '__return_null';
+
+	/**
+	 * Path to the package.
+	 *
+	 * @var string
+	 */
+	public $path = '';
+
+}

--- a/src/PackageManager.php
+++ b/src/PackageManager.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * WooCommerce package class loader.
+ *
+ * Loads external packages which are home to core functionality.
+ *
+ * @package WooCommerce/Core
+ * @since   3.7.0
+ */
+
+namespace WooCommerce\Core;
+
+defined( 'ABSPATH' ) || exit;
+
+use \WooCommerce\Core\Package;
+
+/**
+ * PackageManager class.
+ */
+final class PackageManager {
+
+	/**
+	 * List of packages to load, found in the /packages/ directory.
+	 *
+	 * @var array
+	 */
+	private static $packages = [
+		'woocommerce-rest-api',
+	];
+
+	/**
+	 * List of registered package versions.
+	 *
+	 * @var array
+	 */
+	private static $package_versions = [];
+
+	/**
+	 * Setup class.
+	 */
+	public static function init() {
+		if ( empty( self::$package_versions ) ) {
+			self::register_core_packages();
+		}
+	}
+
+	/**
+	 * Register a version of a package available to load.
+	 *
+	 * @since 3.7.0
+	 * @param string $package Package name.
+	 * @param string $version Version of the REST API being registered.
+	 * @param mixed  $callback Callback function to load the REST API.
+	 * @param string $path Path to package.
+	 * @return bool
+	 */
+	public static function register( $package, $version, $callback, $path ) {
+		if ( isset( self::$package_versions[ $package ][ $version ] ) ) {
+			return false; // This version is already registered.
+		}
+
+		$registered_package           = new Package();
+		$registered_package->version  = $version;
+		$registered_package->callback = $callback;
+		$registered_package->path     = $path;
+
+		self::$package_versions[ $package ][ $version ] = $registered_package;
+
+		return true;
+	}
+
+	/**
+	 * Returns the latest version of a package.
+	 *
+	 * @param string $package Package name.
+	 * @return Package
+	 */
+	public static function get_package( $package ) {
+		if ( ! in_array( $package, self::$packages, true ) ) {
+			return new Package();
+		}
+		$package_versions = self::$package_versions[ $package ];
+
+		uksort( $package_versions, 'version_compare' );
+
+		return end( $package_versions );
+	}
+
+	/**
+	 * Show a build notice in admin if files are missing.
+	 */
+	public static function show_build_notice() {
+		add_action(
+			'admin_notices',
+			function() {
+				echo '<div class="error"><p>';
+				printf(
+					/* Translators: %1$s WooCommerce plugin directory, %2$s is the install command, %3$s is the build command. */
+					esc_html__( 'The development version of WooCommerce requires a build step to function correctly. From the plugin directory (%1$s), run %2$s to install dependencies and %3$s to build assets.', 'woocommerce' ),
+					'<code>' . esc_html( str_replace( ABSPATH, '', WC_ABSPATH ) ) . '</code>',
+					'<code>npm install</code>',
+					'<code>npm run build</code>'
+				);
+				echo '</p></div>';
+			}
+		);
+	}
+
+	/**
+	 * Register each package so we know which versions are available to load.
+	 */
+	private static function register_core_packages() {
+		foreach ( self::$packages as $package ) {
+			self::register_core_package( $package );
+		}
+	}
+
+	/**
+	 * Register a package included in core.
+	 *
+	 * Packages MUST include a valid version.php and init.php file so core knows
+	 * which version to load, should the same package exist in multiple places.
+	 *
+	 * Packages are found in the /packages/ directory and are pulled in using
+	 * composer during the build process.
+	 *
+	 * Packags also contain their own custom autoloader. This ensures that if
+	 * multiple same-packages exist, only the chosen/latest one is used.
+	 *
+	 * @param string $package Package to load.
+	 */
+	private static function register_core_package( $package ) {
+		$version  = '0';
+		$callback = array( __CLASS__, 'show_build_notice' );
+		$path     = WC_ABSPATH . 'packages/' . $package;
+
+		if ( file_exists( $path . '/init.php' ) ) {
+			$version  = include $path . '/version.php';
+			$callback = include $path . '/init.php';
+		}
+		self::register( $package, $version, $callback, $path );
+	}
+}


### PR DESCRIPTION
This PR implements a `PackageManager` where packages/plugins can register versions of a core package with WooCommerce. The API package is registered here, and the fallback callback shows a notice that build is required.

In testing, only the notice will render. A future PR will implement retrieval of the package.

Since this is a new class, I've used `\WooCommerce\Core\` namespace with psr4 class naming under a new `src` directory. Autoloader has been updated to handle this namespace with minimal effort.

I'm not sure what the plans are around this and how we plan on updating existing code so if this is not accepted I'll revert to old style class naming without a namespace. This just affects how packages need to register themselves since at present with this PR they would use:

```
\WooCommerce\Core\PackageManager::register( $package, $version, $callback, $path );
```

cc @kloon 

_This series of PRs target the [Feature Plugin Package](https://github.com/woocommerce/woocommerce/pull/23957) branch where all related functionality will be grouped, and stack on top of one another. If reviewed, please mark as approved to merge, but leave the merging until last since other PRs will target this one._