### PR TITLE
Add package version and path in status report

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -67,6 +67,18 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 			<td><?php echo esc_html( $environment['version'] ); ?></td>
 		</tr>
 		<tr>
+			<td data-export-label="WC Version"><?php esc_html_e( 'WooCommerce REST API package', 'woocommerce' ); ?>:</td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'The WooCommerce REST API package version running on your site.', 'woocommerce' ) ); ?></td>
+			<td>
+				<?php
+				$package = wc()->api->get_latest_rest_api_package();
+
+				echo esc_html( $package->version );
+				echo '<code class="private">' . esc_html( $package->path ) . '</code>';
+				?>
+			</td>
+		</tr>
+		<tr>
 			<td data-export-label="Log Directory Writable"><?php esc_html_e( 'Log directory writable', 'woocommerce' ); ?>:</td>
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'Several WooCommerce extensions can write logs which makes debugging problems easier. The directory must be writable for this to happen.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>


### PR DESCRIPTION
Adds the package version and path to the system status report.

_This series of PRs target the [Feature Plugin Package](https://github.com/woocommerce/woocommerce/pull/23957) branch where all related functionality will be grouped, and stack on top of one another. If reviewed, please mark as approved to merge, but leave the merging until last since other PRs will target this one._

To test:

- Go to system status
- Look for the `WooCommerce REST API package` item
