### PR TITLE
Fixed database update tool, fixing System Status, REST API and CLI

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -137,6 +137,7 @@ class WC_Install {
 	 */
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
+		add_action( 'init', array( __CLASS__, 'manual_database_update' ), 20 );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
 		add_action( 'admin_init', array( __CLASS__, 'install_actions' ) );
 		add_filter( 'plugin_action_links_' . WC_PLUGIN_BASENAME, array( __CLASS__, 'plugin_action_links' ) );
@@ -155,6 +156,24 @@ class WC_Install {
 			self::install();
 			do_action( 'woocommerce_updated' );
 		}
+	}
+
+	/**
+	 * Performan manual database update when triggered by WooCommerce System Tools.
+	 *
+	 * @since 3.6.5
+	 */
+	public static function manual_database_update() {
+		$blog_id = get_current_blog_id();
+
+		add_action( 'wp_' . $blog_id . '_wc_updater_cron', array( __CLASS__, 'run_manual_database_update' ) );
+	}
+
+	/**
+	 * Run manual database update.
+	 */
+	public static function run_manual_database_update() {
+		self::update();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since WooCommerce 3.6 the button in WooCommerce > Status > Tools to perform a manual update in the database stopped to work, there's no more functions hooking into `wp_{$blog_id}_wc_updater_cron`, so to keep backwards compatibility, and still allow it works via REST API and CLI, It was introduced new methods to `WC_Install` keep triggering database updates when that hook is triggered.

Closes #23946.

### How to test the changes in this Pull Request:

1. Open your terminal, and run `wp eval "WC_Install::update_db_version( '3.5.0' );"`
2. Go to WooCommerce > Status > Tools and click in "Update database" at the bottom of the screen.
3. Check that no database routine is scheduled, visit `/wp-admin/admin.php?page=wc-status&tab=action-scheduler&status=pending`, see that there's no `woocommerce_run_update_callback` entries.
4. Apply this patch and run the tool again, now is scheduled. Check again in `/wp-admin/admin.php?page=wc-status&tab=action-scheduler&status=pending`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed manual database update.
