### PR TITLE
Fix phone number format to accept "(", and ")"

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -976,7 +976,7 @@ function wc_format_phone_number( $phone ) {
 	if ( ! WC_Validation::is_phone( $phone ) ) {
 		return '';
 	}
-	return preg_replace( '/[^0-9\+\-\s]/', '-', preg_replace( '/[\x00-\x1F\x7F-\xFF]/', '', $phone ) );
+	return preg_replace( '/[^0-9\+\-\(\)\s]/', '-', preg_replace( '/[\x00-\x1F\x7F-\xFF]/', '', $phone ) );
 }
 
 /**

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -792,6 +792,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_format_phone_number() {
 		$this->assertEquals( '1-610-385-0000', wc_format_phone_number( '1.610.385.0000' ) );
+		$this->assertEquals( '(32) 3212-2345', wc_format_phone_number( '(32) 3212-2345' ) );
 		// This number contains non-visible unicode chars at the beginning and end of string, which makes it invalid phone number.
 		$this->assertEquals( '', wc_format_phone_number( '‭+47 0000 00003‬' ) );
 		$this->assertEquals( '27 00 00 0000', wc_format_phone_number( '27 00 00 0000' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

A phone number may contains `(`, and `)` characters, we also test for it in [`WC_Validation::is_phone`](https://github.com/woocommerce/woocommerce/blob/6c6785c844863f8dfcafaca4ba12dad6aae7fa68/includes/class-wc-validation.php#L26-L38), but the problem is that `wc_format_phone_number()` converts to `-`.

Closes #23947.

### How to test the changes in this Pull Request:

1. Run `wc_format_phone_number( '(32) 3212-2345' )` and see the output: `-32- 3212-2345`
2. Apply this patch, and check that now the output is `(32) 3212-2345`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed support to brackets in phone numbers.
