### PR TITLE
Allow display multiple error messages through registration validation

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -1095,11 +1095,17 @@ class WC_Form_Handler {
 			$email    = wp_unslash( $_POST['email'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 			try {
-				$validation_error = new WP_Error();
-				$validation_error = apply_filters( 'woocommerce_process_registration_errors', $validation_error, $username, $password, $email );
+				$validation_error  = new WP_Error();
+				$validation_error  = apply_filters( 'woocommerce_process_registration_errors', $validation_error, $username, $password, $email );
+				$validation_errors = $validation_error->get_error_messages();
 
-				if ( $validation_error->get_error_code() ) {
+				if ( 1 === count( $validation_errors ) ) {
 					throw new Exception( $validation_error->get_error_message() );
+				} elseif ( $validation_errors ) {
+					foreach ( $validation_errors as $message ) {
+						wc_add_notice( '<strong>' . __( 'Error:', 'woocommerce' ) . '</strong> ' . $message, 'error' );
+					}
+					throw new Exception();
 				}
 
 				$new_customer = wc_create_new_customer( sanitize_email( $email ), wc_clean( $username ), $password );
@@ -1130,7 +1136,9 @@ class WC_Form_Handler {
 					exit;
 				}
 			} catch ( Exception $e ) {
-				wc_add_notice( '<strong>' . __( 'Error:', 'woocommerce' ) . '</strong> ' . $e->getMessage(), 'error' );
+				if ( $e->getMessage() ) {
+					wc_add_notice( '<strong>' . __( 'Error:', 'woocommerce' ) . '</strong> ' . $e->getMessage(), 'error' );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

At this moment is not possible to throw more than one error message while validating the registration form, this PR intend to fix it.

Closes #23954.

### How to test the changes in this Pull Request:

1. Apply the follow code somewhere on your installation:
```php
add_filter(
    'woocommerce_process_registration_errors',
    function( $errors ) {
        $errors->add( 'message_1', 'Something going wrong!' );
        $errors->add( 'message_2', 'Help me!!' );
        $errors->add( 'message_3', 'Game over!' );
        return $errors;
    }
);
```
2. Enable Registration in the My Account page in `/wp-admin/admin.php?page=wc-settings&tab=account`, and check "Allow customers to create an account on the "My account" page ".
3. Logout, and go to the My Account page in your installation.
4. Click in the "Register" button (no need to fill any field, since we already have 3 errors registered).
5. Check that only the first message shows up.
6. Apply this patch, and hit the button again, now see that all messages are there.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Allow display multiple error messages through registration validation
