### PR TITLE
Display line breaks of customer notes in emails, and order details.

### DIFF
--- a/templates/emails/email-order-details.php
+++ b/templates/emails/email-order-details.php
@@ -77,7 +77,7 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 				?>
 				<tr>
 					<th class="td" scope="row" colspan="2" style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
-					<td class="td" style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php echo wp_kses_post( wptexturize( $order->get_customer_note() ) ); ?></td>
+					<td class="td" style="text-align:<?php echo esc_attr( $text_align ); ?>;"><?php echo wp_kses_post( nl2br( wptexturize( $order->get_customer_note() ) ) ); ?></td>
 				</tr>
 				<?php
 			}

--- a/templates/emails/email-order-details.php
+++ b/templates/emails/email-order-details.php
@@ -15,9 +15,7 @@
  * @version 3.7.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 $text_align = is_rtl() ? 'right' : 'left';
 
@@ -48,22 +46,25 @@ do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plai
 		</thead>
 		<tbody>
 			<?php
-			echo wc_get_email_order_items( $order, array( // WPCS: XSS ok.
-				'show_sku'      => $sent_to_admin,
-				'show_image'    => false,
-				'image_size'    => array( 32, 32 ),
-				'plain_text'    => $plain_text,
-				'sent_to_admin' => $sent_to_admin,
-			) );
+			echo wc_get_email_order_items( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+				$order,
+				array(
+					'show_sku'      => $sent_to_admin,
+					'show_image'    => false,
+					'image_size'    => array( 32, 32 ),
+					'plain_text'    => $plain_text,
+					'sent_to_admin' => $sent_to_admin,
+				)
+			);
 			?>
 		</tbody>
 		<tfoot>
 			<?php
-			$totals = $order->get_order_item_totals();
+			$item_totals = $order->get_order_item_totals();
 
-			if ( $totals ) {
+			if ( $item_totals ) {
 				$i = 0;
-				foreach ( $totals as $total ) {
+				foreach ( $item_totals as $total ) {
 					$i++;
 					?>
 					<tr>

--- a/templates/emails/email-order-details.php
+++ b/templates/emails/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates/Emails
- * @version 3.3.1
+ * @version 3.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/plain/email-order-details.php
+++ b/templates/emails/plain/email-order-details.php
@@ -15,28 +15,29 @@
  * @version 3.7.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
+defined( 'ABSPATH' ) || exit;
 
 do_action( 'woocommerce_email_before_order_table', $order, $sent_to_admin, $plain_text, $email );
 
 /* translators: %1$s: Order ID. %2$s: Order date */
 echo wp_kses_post( wc_strtoupper( sprintf( __( '[Order #%1$s] (%2$s)', 'woocommerce' ), $order->get_order_number(), wc_format_datetime( $order->get_date_created() ) ) ) ) . "\n";
-echo "\n" . wc_get_email_order_items( $order, array( // WPCS: XSS ok.
-	'show_sku'      => $sent_to_admin,
-	'show_image'    => false,
-	'image_size'    => array( 32, 32 ),
-	'plain_text'    => true,
-	'sent_to_admin' => $sent_to_admin,
-) );
+echo "\n" . wc_get_email_order_items( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	$order,
+	array(
+		'show_sku'      => $sent_to_admin,
+		'show_image'    => false,
+		'image_size'    => array( 32, 32 ),
+		'plain_text'    => true,
+		'sent_to_admin' => $sent_to_admin,
+	)
+);
 
 echo "==========\n\n";
 
-$totals = $order->get_order_item_totals();
+$item_totals = $order->get_order_item_totals();
 
-if ( $totals ) {
-	foreach ( $totals as $total ) {
+if ( $item_totals ) {
+	foreach ( $item_totals as $total ) {
 		echo wp_kses_post( $total['label'] . "\t " . $total['value'] ) . "\n";
 	}
 }

--- a/templates/emails/plain/email-order-details.php
+++ b/templates/emails/plain/email-order-details.php
@@ -43,7 +43,7 @@ if ( $item_totals ) {
 }
 
 if ( $order->get_customer_note() ) {
-	echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses_post( nl2br( wptexturize( $order->get_customer_note() ) ) ) . "\n";
+	echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses_post( wptexturize( $order->get_customer_note() ) ) . "\n";
 }
 
 if ( $sent_to_admin ) {

--- a/templates/emails/plain/email-order-details.php
+++ b/templates/emails/plain/email-order-details.php
@@ -42,7 +42,7 @@ if ( $totals ) {
 }
 
 if ( $order->get_customer_note() ) {
-	echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses_post( wptexturize( $order->get_customer_note() ) ) . "\n";
+	echo esc_html__( 'Note:', 'woocommerce' ) . "\t " . wp_kses_post( nl2br( wptexturize( $order->get_customer_note() ) ) ) . "\n";
 }
 
 if ( $sent_to_admin ) {

--- a/templates/emails/plain/email-order-details.php
+++ b/templates/emails/plain/email-order-details.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates/Emails
- * @version 3.5.0
+ * @version 3.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -81,7 +81,7 @@ if ( $show_downloads ) {
 			<?php if ( $order->get_customer_note() ) : ?>
 				<tr>
 					<th><?php _e( 'Note:', 'woocommerce' ); ?></th>
-					<td><?php echo wptexturize( $order->get_customer_note() ); ?></td>
+					<td><?php echo nl2br( wptexturize( $order->get_customer_note() ) ); ?></td>
 				</tr>
 			<?php endif; ?>
 		</tfoot>

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -10,15 +10,16 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	https://docs.woocommerce.com/document/template-structure/
+ * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
  * @version 3.7.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-if ( ! $order = wc_get_order( $order_id ) ) {
+defined( 'ABSPATH' ) || exit;
+
+$order = wc_get_order( $order_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited
+
+if ( ! $order ) {
 	return;
 }
 
@@ -29,20 +30,26 @@ $downloads             = $order->get_downloadable_items();
 $show_downloads        = $order->has_downloadable_item() && $order->is_download_permitted();
 
 if ( $show_downloads ) {
-	wc_get_template( 'order/order-downloads.php', array( 'downloads' => $downloads, 'show_title' => true ) );
+	wc_get_template(
+		'order/order-downloads.php',
+		array(
+			'downloads'  => $downloads,
+			'show_title' => true,
+		)
+	);
 }
 ?>
 <section class="woocommerce-order-details">
 	<?php do_action( 'woocommerce_order_details_before_order_table', $order ); ?>
 
-	<h2 class="woocommerce-order-details__title"><?php _e( 'Order details', 'woocommerce' ); ?></h2>
+	<h2 class="woocommerce-order-details__title"><?php esc_html_e( 'Order details', 'woocommerce' ); ?></h2>
 
 	<table class="woocommerce-table woocommerce-table--order-details shop_table order_details">
 
 		<thead>
 			<tr>
-				<th class="woocommerce-table__product-name product-name"><?php _e( 'Product', 'woocommerce' ); ?></th>
-				<th class="woocommerce-table__product-table product-total"><?php _e( 'Total', 'woocommerce' ); ?></th>
+				<th class="woocommerce-table__product-name product-name"><?php esc_html_e( 'Product', 'woocommerce' ); ?></th>
+				<th class="woocommerce-table__product-table product-total"><?php esc_html_e( 'Total', 'woocommerce' ); ?></th>
 			</tr>
 		</thead>
 
@@ -53,14 +60,17 @@ if ( $show_downloads ) {
 			foreach ( $order_items as $item_id => $item ) {
 				$product = $item->get_product();
 
-				wc_get_template( 'order/order-details-item.php', array(
-					'order'			     => $order,
-					'item_id'		     => $item_id,
-					'item'			     => $item,
-					'show_purchase_note' => $show_purchase_note,
-					'purchase_note'	     => $product ? $product->get_purchase_note() : '',
-					'product'	         => $product,
-				) );
+				wc_get_template(
+					'order/order-details-item.php',
+					array(
+						'order'              => $order,
+						'item_id'            => $item_id,
+						'item'               => $item,
+						'show_purchase_note' => $show_purchase_note,
+						'purchase_note'      => $product ? $product->get_purchase_note() : '',
+						'product'            => $product,
+					)
+				);
 			}
 
 			do_action( 'woocommerce_order_details_after_order_table_items', $order );
@@ -69,19 +79,19 @@ if ( $show_downloads ) {
 
 		<tfoot>
 			<?php
-				foreach ( $order->get_order_item_totals() as $key => $total ) {
-					?>
+			foreach ( $order->get_order_item_totals() as $key => $total ) {
+				?>
 					<tr>
-						<th scope="row"><?php echo $total['label']; ?></th>
-						<td><?php echo ( 'payment_method' === $key ) ? esc_html( $total['value'] ) : $total['value']; ?></td>
+						<th scope="row"><?php echo esc_html( $total['label'] ); ?></th>
+						<td><?php echo ( 'payment_method' === $key ) ? esc_html( $total['value'] ) : wp_kses_post( $total['value'] ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></td>
 					</tr>
 					<?php
-				}
+			}
 			?>
 			<?php if ( $order->get_customer_note() ) : ?>
 				<tr>
-					<th><?php _e( 'Note:', 'woocommerce' ); ?></th>
-					<td><?php echo nl2br( wptexturize( $order->get_customer_note() ) ); ?></td>
+					<th><?php esc_html_e( 'Note:', 'woocommerce' ); ?></th>
+					<td><?php echo wp_kses_post( nl2br( wptexturize( $order->get_customer_note() ) ) ); ?></td>
 				</tr>
 			<?php endif; ?>
 		</tfoot>

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -12,7 +12,7 @@
  *
  * @see 	https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.5.2
+ * @version 3.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We don't convert line breaks to `<br>` inside emails or in the order details screen.

Closes #23956.

### How to test the changes in this Pull Request:

1. Place an order (or editing an existing order), and enter a some customer note with line breaks. Placing an order should already trigger emails, but if editing, you may want to select "Resend new order notification" before save.
2. See the line breaks are there in the source code, but doesn't display any `<br>`.
3. Apply this patch, and resend the email, now see that there's `<br>`, and the message display properly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Display line breaks of customer notes in emails, and order details.
