### PR TITLE
Update direct usage of REST API controllers

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1061,10 +1061,6 @@ class WC_Admin_Setup_Wizard {
 	public function wc_setup_shipping_save() {
 		check_admin_referer( 'wc-setup' );
 
-		if ( ! did_action( 'rest_api_init' ) ) {
-			WC()->api->rest_api_includes();
-		}
-
 		// @codingStandardsIgnoreStart
 		$setup_domestic   = isset( $_POST['shipping_zones']['domestic']['enabled'] ) && ( 'yes' === $_POST['shipping_zones']['domestic']['enabled'] );
 		$domestic_method  = isset( $_POST['shipping_zones']['domestic']['method'] ) ? sanitize_text_field( wp_unslash( $_POST['shipping_zones']['domestic']['method'] ) ) : '';
@@ -1110,44 +1106,42 @@ class WC_Admin_Setup_Wizard {
 		 * store is located in, with the selected method preconfigured.
 		 */
 		if ( $setup_domestic ) {
-			$country = WC()->countries->get_base_country();
-
 			$zone = new WC_Shipping_Zone( null );
 			$zone->set_zone_order( 0 );
-			$zone->add_location( $country, 'country' );
-			$instance_id = $zone->add_shipping_method( $domestic_method );
-			$zone->save();
+			$zone->add_location( WC()->countries->get_base_country(), 'country' );
+			$zone_id = $zone->save();
 
 			// Save chosen shipping method settings (using REST controller for convenience).
-			if ( isset( $instance_id ) && ! empty( $_POST['shipping_zones']['domestic'][ $domestic_method ] ) ) { // WPCS: input var ok.
-				$method_controller = new WC_REST_Shipping_Zone_Methods_Controller();
-				// @codingStandardsIgnoreStart
-				$method_controller->update_item( array(
-					'zone_id'     => $zone->get_id(),
-					'instance_id' => $instance_id,
-					'settings'    => wp_unslash( $_POST['shipping_zones']['domestic'][ $domestic_method ] ),
-				) );
-				// @codingStandardsIgnoreEnd
+			if ( ! empty( $_POST['shipping_zones']['domestic'][ $domestic_method ] ) ) { // WPCS: input var ok.
+				$request = new WP_REST_Request( 'POST', "/wc/v3/shipping/zones/{$zone_id}/methods" );
+				$request->add_header( 'Content-Type', 'application/json' );
+				$request->set_body(
+					wp_json_encode(
+						array(
+							'method_id' => $domestic_method,
+							'settings'  => wc_clean( wp_unslash( $_POST['shipping_zones']['domestic'][ $domestic_method ] ) ),
+						)
+					)
+				);
+				rest_do_request( $request );
 			}
 		}
 
 		// If enabled, set the selected method for the "rest of world" zone.
 		if ( $setup_intl ) {
-			$zone        = new WC_Shipping_Zone( 0 );
-			$instance_id = $zone->add_shipping_method( $intl_method );
-
-			$zone->save();
-
 			// Save chosen shipping method settings (using REST controller for convenience).
-			if ( isset( $instance_id ) && ! empty( $_POST['shipping_zones']['intl'][ $intl_method ] ) ) { // WPCS: input var ok.
-				$method_controller = new WC_REST_Shipping_Zone_Methods_Controller();
-				// @codingStandardsIgnoreStart
-				$method_controller->update_item( array(
-					'zone_id'     => $zone->get_id(),
-					'instance_id' => $instance_id,
-					'settings'    => wp_unslash( $_POST['shipping_zones']['intl'][ $intl_method ] ),
-				) );
-				// @codingStandardsIgnoreEnd
+			if ( ! empty( $_POST['shipping_zones']['intl'][ $intl_method ] ) ) { // WPCS: input var ok.
+				$request = new WP_REST_Request( 'POST', '/wc/v3/shipping/zones/0/methods' );
+				$request->add_header( 'Content-Type', 'application/json' );
+				$request->set_body(
+					wp_json_encode(
+						array(
+							'method_id' => $intl_method,
+							'settings'  => wc_clean( wp_unslash( $_POST['shipping_zones']['intl'][ $intl_method ] ) ),
+						)
+					)
+				);
+				rest_do_request( $request );
 			}
 		}
 

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -31,12 +31,7 @@ class WC_Admin_Status {
 	 * Handles output of tools.
 	 */
 	public static function status_tools() {
-		// This screen requires classes from the REST API.
-		if ( ! did_action( 'rest_api_init' ) ) {
-			WC()->api->rest_api_includes();
-		}
-
-		if ( ! class_exists( 'WC_REST_System_Status_Tools_Controller', false ) ) {
+		if ( ! class_exists( 'WC_REST_System_Status_Tools_Controller' ) ) {
 			wp_die( 'Cannot load the REST API to access WC_REST_System_Status_Tools_Controller.' );
 		}
 

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -9,26 +9,16 @@ defined( 'ABSPATH' ) || exit;
 
 global $wpdb;
 
-// This screen requires classes from the REST API.
-if ( ! did_action( 'rest_api_init' ) ) {
-	WC()->api->rest_api_includes();
-}
-
-if ( ! class_exists( 'WC_REST_System_Status_Controller', false ) ) {
-	wp_die( 'Cannot load the REST API to access WC_REST_System_Status_Controller.' );
-}
-
-$system_status      = new WC_REST_System_Status_Controller();
-$environment        = $system_status->get_environment_info();
-$database           = $system_status->get_database_info();
-$post_type_counts   = $system_status->get_post_type_counts();
-$active_plugins     = $system_status->get_active_plugins();
-$inactive_plugins   = $system_status->get_inactive_plugins();
-$dropins_mu_plugins = $system_status->get_dropins_mu_plugins();
-$theme              = $system_status->get_theme_info();
-$security           = $system_status->get_security_info();
-$settings           = $system_status->get_settings();
-$wp_pages           = $system_status->get_pages();
+$report             = wc()->api->get_endpoint_data( '/wc/v3/system_status' );
+$environment        = $report['environment'];
+$database           = $report['database'];
+$active_plugins     = $report['active_plugins'];
+$inactive_plugins   = $report['inactive_plugins'];
+$dropins_mu_plugins = $report['dropins_mu_plugins'];
+$theme              = $report['theme'];
+$security           = $report['security'];
+$settings           = $report['settings'];
+$wp_pages           = $report['pages'];
 $plugin_updates     = new WC_Plugin_Updates();
 $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'minor' );
 ?>
@@ -510,26 +500,6 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 				</td>
 			</tr>
 		<?php } ?>
-	</tbody>
-</table>
-<table class="wc_status_table widefat" cellspacing="0">
-	<thead>
-	<tr>
-		<th colspan="3" data-export-label="Post Type Counts"><h2><?php esc_html_e( 'Post Type Counts', 'woocommerce' ); ?></h2></th>
-	</tr>
-	</thead>
-	<tbody>
-		<?php
-		foreach ( $post_type_counts as $ptype ) {
-			?>
-			<tr>
-				<td><?php echo esc_html( $ptype->type ); ?></td>
-				<td class="help">&nbsp;</td>
-				<td><?php echo absint( $ptype->count ); ?></td>
-			</tr>
-			<?php
-		}
-		?>
 	</tbody>
 </table>
 <table class="wc_status_table widefat" cellspacing="0">

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -73,6 +73,28 @@ class WC_API extends WC_Legacy_API {
 	}
 
 	/**
+	 * Get data from a WooCommerce API endpoint.
+	 *
+	 * @since 3.7.0
+	 * @param string $endpoint Endpoint.
+	 * @param array  $params Params to passwith request.
+	 * @return array|\WP_Error
+	 */
+	public function get_endpoint_data( $endpoint, $params = array() ) {
+		if ( ! $this->is_rest_api_loaded() ) {
+			$this->rest_api_init();
+		}
+		$request = new \WP_REST_Request( 'GET', $endpoint );
+		if ( $params ) {
+			$request->set_query_params( $params );
+		}
+		$response = rest_do_request( $request );
+		$server   = rest_get_server();
+		$json     = wp_json_encode( $server->response_to_data( $response, false ) );
+		return json_decode( $json, true );
+	}
+
+	/**
 	 * Add new query vars.
 	 *
 	 * @since 2.0

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -388,31 +388,18 @@ class WC_Webhook extends WC_Legacy_Webhook {
 	 * @return array
 	 */
 	private function get_wp_api_payload( $resource, $resource_id, $event ) {
-		$rest_api_versions = wc_get_webhook_rest_api_versions();
-		$version_suffix    = end( $rest_api_versions ) !== $this->get_api_version() ? strtoupper( str_replace( 'wp_api', '', $this->get_api_version() ) ) : '';
-
-		// Load REST API endpoints to generate payload.
-		if ( ! did_action( 'rest_api_init' ) ) {
-			WC()->api->rest_api_includes();
-		}
-
 		switch ( $resource ) {
 			case 'coupon':
 			case 'customer':
 			case 'order':
 			case 'product':
-				$class      = 'WC_REST_' . ucfirst( $resource ) . 's' . $version_suffix . '_Controller';
-				$request    = new WP_REST_Request( 'GET' );
-				$controller = new $class();
-
 				// Bulk and quick edit action hooks return a product object instead of an ID.
 				if ( 'product' === $resource && 'updated' === $event && is_a( $resource_id, 'WC_Product' ) ) {
 					$resource_id = $resource_id->get_id();
 				}
 
-				$request->set_param( 'id', $resource_id );
-				$result  = $controller->get_item( $request );
-				$payload = isset( $result->data ) ? $result->data : array();
+				$version = str_replace( 'wp_api_', '', $this->get_api_version() );
+				$payload = wc()->api->get_endpoint_data( "/wc/{$version}/{$resource}s/{$resource_id}" );
 				break;
 
 			// Custom topics include the first hook argument.


### PR DESCRIPTION
This PR updates existing REST API usage to avoid using REST API Controllers directly. A `get_endpoint_data` method is added to make look-ups simpler.

_This series of PRs target the [Feature Plugin Package](https://github.com/woocommerce/woocommerce/pull/23957) branch where all related functionality will be grouped, and stack on top of one another. If reviewed, please mark as approved to merge, but leave the merging until last since other PRs will target this one._

To test:

- Run composer update.
- Run through setup wizard and confirm domestic/international shipping settings save correctly.
- View system status report.
- Run a system status tool.
- Fire some webhooks and ensure payloads are sent.