### PR TITLE
Init the blocks package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "require": {
     "composer/installers": "1.6.0",
     "woocommerce/woocommerce-rest-api": "dev-test/jetpack-autoloader",
-    "woocommerce/woocommerce-blocks": "dev-refactor/php-classes",
+    "woocommerce/woocommerce-blocks": "dev-build/2.2.0-dev",
     "automattic/jetpack-autoloader": "^1"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "require": {
     "composer/installers": "1.6.0",
     "woocommerce/woocommerce-rest-api": "dev-test/jetpack-autoloader",
-    "woocommerce/woocommerce-blocks": "dev-add/build-config",
+    "woocommerce/woocommerce-blocks": "dev-refactor/php-classes",
     "automattic/jetpack-autoloader": "^1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b26e3ab11a27accf12e540dc6cb540a4",
+    "content-hash": "f269789179494befeb7caf0cb7bb29eb",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -164,16 +164,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "dev-add/build-config",
+            "version": "dev-refactor/php-classes",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "be2a243d0e999af6f4318f7b242cdac2565d36d8"
+                "reference": "52e2cd8ba1462c40febd5408994996872e2610d5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/be2a243d0e999af6f4318f7b242cdac2565d36d8",
-                "reference": "be2a243d0e999af6f4318f7b242cdac2565d36d8",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/52e2cd8ba1462c40febd5408994996872e2610d5",
+                "reference": "52e2cd8ba1462c40febd5408994996872e2610d5",
                 "shasum": ""
             },
             "require": {
@@ -184,9 +184,16 @@
                 "woocommerce/woocommerce-sniffs": "0.0.6"
             },
             "type": "wordpress-plugin",
+            "extra": {
+                "scripts-description": {
+                    "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
+                    "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier"
+                }
+            },
             "autoload": {
                 "psr-4": {
-                    "WooCommerce\\Blocks\\": "src/"
+                    "WooCommerce\\Blocks\\": "src/",
+                    "WooCommerce\\Blocks\\Tests\\": "tests/php/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -195,7 +202,7 @@
             ],
             "description": "Feature plugin for the WooCommerce Gutenberg Products block",
             "homepage": "https://woocommerce.com/",
-            "time": "2019-06-20T14:53:51+00:00"
+            "time": "2019-06-20T09:39:04+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f269789179494befeb7caf0cb7bb29eb",
+    "content-hash": "bd3583eea7bbf9c0401e52371ae1baf9",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -164,19 +164,20 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "dev-refactor/php-classes",
+            "version": "dev-build/2.2.0-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "52e2cd8ba1462c40febd5408994996872e2610d5"
+                "reference": "64fdbe613ee66d5444696428567f3b683b1a2b06"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/52e2cd8ba1462c40febd5408994996872e2610d5",
-                "reference": "52e2cd8ba1462c40febd5408994996872e2610d5",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/64fdbe613ee66d5444696428567f3b683b1a2b06",
+                "reference": "64fdbe613ee66d5444696428567f3b683b1a2b06",
                 "shasum": ""
             },
             "require": {
+                "automattic/jetpack-autoloader": "^1",
                 "composer/installers": "1.6.0"
             },
             "require-dev": {
@@ -192,8 +193,7 @@
             },
             "autoload": {
                 "psr-4": {
-                    "WooCommerce\\Blocks\\": "src/",
-                    "WooCommerce\\Blocks\\Tests\\": "tests/php/"
+                    "Automattic\\WooCommerce\\Blocks\\": "src/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -202,7 +202,7 @@
             ],
             "description": "Feature plugin for the WooCommerce Gutenberg Products block",
             "homepage": "https://woocommerce.com/",
-            "time": "2019-06-20T09:39:04+00:00"
+            "time": "2019-06-21T18:08:00+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",
@@ -210,12 +210,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-rest-api.git",
-                "reference": "46453550e8d7468f6a1f46b47fefd2fdc482c801"
+                "reference": "2943708bb12f70b845f32e5f26893436a926a1ee"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/46453550e8d7468f6a1f46b47fefd2fdc482c801",
-                "reference": "46453550e8d7468f6a1f46b47fefd2fdc482c801",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/2943708bb12f70b845f32e5f26893436a926a1ee",
+                "reference": "2943708bb12f70b845f32e5f26893436a926a1ee",
                 "shasum": ""
             },
             "require": {
@@ -243,7 +243,7 @@
             ],
             "description": "The WooCommerce core REST API.",
             "homepage": "https://github.com/woocommerce/woocommerce-rest-api",
-            "time": "2019-06-21T09:40:39+00:00"
+            "time": "2019-06-21T13:57:26+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * WooCommerce API class loader.
+ * WC-API endpoint handler.
  *
- * This handles APIs in WooCommerce. These include:
+ * This handles API related functionality in WooCommerce.
  * - wc-api endpoint - Commonly used by Payment gateways for callbacks.
  * - Legacy REST API - Deprecated in 2.6.0. @see class-wc-legacy-api.php
  * - WP REST API - The main REST API in WooCommerce which is built on top of the WP REST API.
@@ -24,22 +24,9 @@ class WC_API extends WC_Legacy_API {
 	public function init() {
 		parent::init();
 		add_action( 'init', array( $this, 'add_endpoint' ), 0 );
-		add_action( 'init', array( $this, 'rest_api_init' ) );
 		add_filter( 'query_vars', array( $this, 'add_query_vars' ), 0 );
 		add_action( 'parse_request', array( $this, 'handle_api_requests' ), 0 );
 		add_action( 'rest_api_init', array( $this, 'register_wp_admin_settings' ) );
-	}
-
-	/**
-	 * Call the Server class from the Rest API package.
-	 *
-	 * @see \Automattic\WooCommerce\RestApi\Server
-	 */
-	public function rest_api_init() {
-		if ( $this->is_rest_api_loaded() || version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
-			return;
-		}
-		\Automattic\WooCommerce\RestApi\Server::instance()->init();
 	}
 
 	/**
@@ -82,7 +69,7 @@ class WC_API extends WC_Legacy_API {
 	 */
 	public function get_endpoint_data( $endpoint, $params = array() ) {
 		if ( ! $this->is_rest_api_loaded() ) {
-			$this->rest_api_init();
+			return new WP_Error( 'rest_api_unavailable', __( 'The Rest API is unavailable.', 'woocommerce' ) );
 		}
 		$request = new \WP_REST_Request( 'GET', $endpoint );
 		if ( $params ) {

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -33,10 +33,13 @@ class WC_API extends WC_Legacy_API {
 	 * Get the version of the REST API package being ran.
 	 *
 	 * @since 3.7.0
-	 * @return int|null
+	 * @return string|null
 	 */
 	public function get_rest_api_package_version() {
-		return null;
+		if ( ! $this->is_rest_api_loaded() ) {
+			return null;
+		}
+		return \Automattic\WooCommerce\RestApi\Package::get_version();
 	}
 
 	/**
@@ -46,7 +49,10 @@ class WC_API extends WC_Legacy_API {
 	 * @return string
 	 */
 	public function get_rest_api_package_path() {
-		return '';
+		if ( ! $this->is_rest_api_loaded() ) {
+			return null;
+		}
+		return \Automattic\WooCommerce\RestApi\Package::get_path();
 	}
 
 	/**
@@ -56,7 +62,7 @@ class WC_API extends WC_Legacy_API {
 	 * @return boolean
 	 */
 	protected function is_rest_api_loaded() {
-		return class_exists( '\Automattic\WooCommerce\RestApi\Server', false );
+		return class_exists( '\Automattic\WooCommerce\RestApi\Package', false );
 	}
 
 	/**

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -203,8 +203,8 @@ final class WooCommerce {
 		if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
 			return;
 		}
-		\Automattic\WooCommerce\Blocks\Library::instance()->init();
-		\Automattic\WooCommerce\RestApi\Server::instance()->init();
+		\Automattic\WooCommerce\Blocks\Package::init();
+		\Automattic\WooCommerce\RestApi\Package::init();
 	}
 
 	/**

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -180,6 +180,7 @@ final class WooCommerce {
 		register_shutdown_function( array( $this, 'log_errors' ) );
 
 		add_action( 'plugins_loaded', array( $this, 'on_plugins_loaded' ), -1 );
+		add_action( 'plugins_loaded', array( $this, 'init_packages' ) );
 		add_action( 'after_setup_theme', array( $this, 'setup_environment' ) );
 		add_action( 'after_setup_theme', array( $this, 'include_template_functions' ), 11 );
 		add_action( 'init', array( $this, 'init' ), 0 );
@@ -189,6 +190,21 @@ final class WooCommerce {
 		add_action( 'switch_blog', array( $this, 'wpdb_table_fix' ), 0 );
 		add_action( 'activated_plugin', array( $this, 'activated_plugin' ) );
 		add_action( 'deactivated_plugin', array( $this, 'deactivated_plugin' ) );
+	}
+
+	/**
+	 * Load any WooCommerce packages.
+	 *
+	 * Most packages will have their own init routines, so this is used early once plugins are loaded.
+	 *
+	 * @since 3.7.0
+	 */
+	public function init_packages() {
+		if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
+			return;
+		}
+		\Automattic\WooCommerce\Blocks\Library::instance()->init();
+		\Automattic\WooCommerce\RestApi\Server::instance()->init();
 	}
 
 	/**
@@ -539,11 +555,6 @@ final class WooCommerce {
 		$this->structured_data                     = new WC_Structured_Data();
 		$this->deprecated_hook_handlers['actions'] = new WC_Deprecated_Action_Hooks();
 		$this->deprecated_hook_handlers['filters'] = new WC_Deprecated_Filter_Hooks();
-
-		// Init any packages.
-		if ( version_compare( PHP_VERSION, '5.6.0', '>=' ) ) {
-			\Automattic\WooCommerce\Blocks\Library::instance()->init();
-		}
 
 		// Classes/actions loaded for the frontend and for ajax requests.
 		if ( $this->is_request( 'frontend' ) ) {

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -540,6 +540,11 @@ final class WooCommerce {
 		$this->deprecated_hook_handlers['actions'] = new WC_Deprecated_Action_Hooks();
 		$this->deprecated_hook_handlers['filters'] = new WC_Deprecated_Filter_Hooks();
 
+		// Init any packages.
+		if ( version_compare( PHP_VERSION, '5.6.0', '>=' ) ) {
+			\Automattic\WooCommerce\Blocks\Library::instance()->init();
+		}
+
 		// Classes/actions loaded for the frontend and for ajax requests.
 		if ( $this->is_request( 'frontend' ) ) {
 			wc_load_cart();

--- a/includes/legacy/class-wc-legacy-api.php
+++ b/includes/legacy/class-wc-legacy-api.php
@@ -272,6 +272,13 @@ class WC_Legacy_API {
 	}
 
 	/**
+	 * Rest API Init.
+	 *
+	 * @deprecated since 3.7.0 - REST API clases autoload.
+	 */
+	public function rest_api_init() {}
+
+	/**
 	 * Include REST API classes.
 	 *
 	 * @deprecated since 3.7.0 - REST API clases autoload.

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
   "license": "GPL-3.0+",
   "main": "Gruntfile.js",
   "scripts": {
-    "prebuild": "npm install && composer install --no-dev",
     "build": "grunt",
     "build-watch": "grunt watch",
     "lint:js": "eslint assets/js --ext=js",


### PR DESCRIPTION
Simply inits the block library. The class is found via the autoloader.

_This series of PRs target the [Feature Plugin Package](https://github.com/woocommerce/woocommerce/pull/23957) branch where all related functionality will be grouped, and stack on top of one another. If reviewed, please mark as approved to merge, but leave the merging until last since other PRs will target this one._

To test, run `composer update` and ensure there are not errors and blocks are available in the editor.