### PR TITLE
Textdomain replacement for packages

### DIFF
--- a/bin/package-update.sh
+++ b/bin/package-update.sh
@@ -15,15 +15,38 @@ output() {
   echo "$(tput setaf "$1")$2$(tput sgr0)"
 }
 
+updating=false
+
+# Script args.
+while [ ! $# -eq 0 ]
+do
+	case "$1" in
+		--updating | -u)
+			updating=true
+			;;
+	esac
+	shift
+done
+
+# Autoloader
+output 3 "Updating autoloader classmaps..."
+composer dump-autoload --no-dev
+output 2 "Done"
+
+# Convert textdomains
 output 3 "Updating package textdomains..."
 
-# Find woo-gutenberg-products-block textdomain and replace with woocommerce
+# Replace text domains within packages with woocommerce
 find ./packages/woocommerce-blocks -iname '*.php' -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" {} \;
-
-# Find woocommerce-rest-api textdomain and replace with woocommerce
 find ./packages/woocommerce-rest-api -iname '*.php' -exec sed -i.bak -e "s/'woocommerce-rest-api'/'woocommerce'/g" {} \;
 
 # Cleanup backup files
 find ./packages -name "*.bak" -type f -delete
-
 output 2 "Done"
+
+if ( $updating ); then
+	# Update POT file
+	output 3 "Updating POT file..."
+	grunt makepot
+	output 2 "Done"
+fi

--- a/bin/package-update.sh
+++ b/bin/package-update.sh
@@ -37,8 +37,8 @@ output 2 "Done"
 output 3 "Updating package textdomains..."
 
 # Replace text domains within packages with woocommerce
-find ./packages/woocommerce-blocks -iname '*.php' -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" {} \;
-find ./packages/woocommerce-rest-api -iname '*.php' -exec sed -i.bak -e "s/'woocommerce-rest-api'/'woocommerce'/g" {} \;
+find ./packages/woocommerce-blocks -iname '*.php' -exec sed -i.bak -e "s/, 'woo-gutenberg-products-block'/, 'woocommerce'/g" {} \;
+find ./packages/woocommerce-rest-api -iname '*.php' -exec sed -i.bak -e "s/, 'woocommerce-rest-api'/, 'woocommerce'/g" {} \;
 
 # Cleanup backup files
 find ./packages -name "*.bak" -type f -delete

--- a/bin/replace-package-textdomains.sh
+++ b/bin/replace-package-textdomains.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+
+# Output colorized strings
+#
+# Color codes:
+# 0 - black
+# 1 - red
+# 2 - green
+# 3 - yellow
+# 4 - blue
+# 5 - magenta
+# 6 - cian
+# 7 - white
+output() {
+  echo "$(tput setaf "$1")$2$(tput sgr0)"
+}
+
+output 3 "Updating package textdomains..."
+
+# Find woo-gutenberg-products-block textdomain and replace with woocommerce
+find ./packages -iname '*.php' -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" {} \;
+
+# Cleanup backup files
+find ./packages -name "*.bak" -type f -delete
+
+output 2 "Done"

--- a/bin/replace-package-textdomains.sh
+++ b/bin/replace-package-textdomains.sh
@@ -18,7 +18,10 @@ output() {
 output 3 "Updating package textdomains..."
 
 # Find woo-gutenberg-products-block textdomain and replace with woocommerce
-find ./packages -iname '*.php' -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" {} \;
+find ./packages/woocommerce-blocks -iname '*.php' -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" {} \;
+
+# Find woocommerce-rest-api textdomain and replace with woocommerce
+find ./packages/woocommerce-rest-api -iname '*.php' -exec sed -i.bak -e "s/'woocommerce-rest-api'/'woocommerce'/g" {} \;
 
 # Cleanup backup files
 find ./packages -name "*.bak" -type f -delete

--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,10 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "composer dump-autoload --no-dev",
-      "sh ./bin/replace-package-textdomains.sh"
+      "sh ./bin/package-update.sh"
     ],
     "post-update-cmd": [
-      "composer dump-autoload --no-dev",
-      "sh ./bin/replace-package-textdomains.sh"
+      "sh ./bin/package-update.sh --updating"
     ],
     "test": [
       "phpunit"

--- a/composer.json
+++ b/composer.json
@@ -32,10 +32,12 @@
   },
   "scripts": {
     "post-install-cmd": [
-      "composer dump-autoload --no-dev"
+      "composer dump-autoload --no-dev",
+      "sh ./bin/replace-package-textdomains.sh"
     ],
     "post-update-cmd": [
-      "composer dump-autoload --no-dev"
+      "composer dump-autoload --no-dev",
+      "sh ./bin/replace-package-textdomains.sh"
     ],
     "test": [
       "phpunit"
@@ -52,8 +54,8 @@
   },
   "extra": {
     "installer-paths": {
-      "vendor/woocommerce-rest-api": ["woocommerce/woocommerce-rest-api"],
-      "vendor/woocommerce-blocks": ["woocommerce/woocommerce-blocks"]
+      "packages/woocommerce-rest-api": ["woocommerce/woocommerce-rest-api"],
+      "packages/woocommerce-blocks": ["woocommerce/woocommerce-blocks"]
     },
     "scripts-description": {
       "test": "Run unit tests",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bd3583eea7bbf9c0401e52371ae1baf9",
+    "content-hash": "e52a74aadbfa3411e205ffd3295a9045",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -168,12 +168,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "64fdbe613ee66d5444696428567f3b683b1a2b06"
+                "reference": "d17885ea1fff530ab6bd79d57e8ab4224600ec43"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/64fdbe613ee66d5444696428567f3b683b1a2b06",
-                "reference": "64fdbe613ee66d5444696428567f3b683b1a2b06",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/d17885ea1fff530ab6bd79d57e8ab4224600ec43",
+                "reference": "d17885ea1fff530ab6bd79d57e8ab4224600ec43",
                 "shasum": ""
             },
             "require": {
@@ -202,7 +202,7 @@
             ],
             "description": "Feature plugin for the WooCommerce Gutenberg Products block",
             "homepage": "https://woocommerce.com/",
-            "time": "2019-06-21T18:08:00+00:00"
+            "time": "2019-06-24T11:20:32+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",
@@ -210,12 +210,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-rest-api.git",
-                "reference": "2943708bb12f70b845f32e5f26893436a926a1ee"
+                "reference": "a518b9cfd1dec42a59aa10240a31782bc1d43d13"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/2943708bb12f70b845f32e5f26893436a926a1ee",
-                "reference": "2943708bb12f70b845f32e5f26893436a926a1ee",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/a518b9cfd1dec42a59aa10240a31782bc1d43d13",
+                "reference": "a518b9cfd1dec42a59aa10240a31782bc1d43d13",
                 "shasum": ""
             },
             "require": {
@@ -243,7 +243,7 @@
             ],
             "description": "The WooCommerce core REST API.",
             "homepage": "https://github.com/woocommerce/woocommerce-rest-api",
-            "time": "2019-06-21T13:57:26+00:00"
+            "time": "2019-06-21T18:58:20+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
After updating/installing via composer, this runs a script which finds/replaces textdomains for `woocommerce`.

Moved packages back to `/packages` so only those are targeted. Seems my changes to the autoloader fixed this :)

_This series of PRs target the [Feature Plugin Package](https://github.com/woocommerce/woocommerce/pull/23957) branch where all related functionality will be grouped, and stack on top of one another. If reviewed, please mark as approved to merge, but leave the merging until last since other PRs will target this one._