### PR TITLE
OBW: Adjust size of plugin install highlight to avoid overlap

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1393,15 +1393,15 @@ p.jetpack-terms {
 
 .wc-setup-content .recommended-item {
 	list-style: none;
+	margin-bottom: 1.5em;
 
-	&:last-child label {
+	&:last-child {
 		margin-bottom: 0; // Avoid extra space at the end of the list.
 	}
 
 	label {
 		display: flex;
 		align-items: center;
-		margin-bottom: 1.5em;
 
 		&::before,
 		&::after {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix regression in size of highlighted area in the Recommended step, when hovering links for plugins that will be installed (behavior originally introduced in https://github.com/woocommerce/woocommerce/pull/19952).

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`master` | this branch
-- | --
<img width="662" alt="master" src="https://user-images.githubusercontent.com/1867547/60063273-5aa78900-96ca-11e9-8efd-ca8dfeef32f5.png"> | <img width="661" alt="this branch" src="https://user-images.githubusercontent.com/1867547/60063277-6004d380-96ca-11e9-8542-ecf57a421e68.png">