### PR TITLE
Correct plural forms usage in loop/result-count.php

### DIFF
--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -23,14 +23,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <p class="woocommerce-result-count">
 	<?php
-	if ( $total <= $per_page || -1 === $per_page ) {
+	if ( 1 === $total ) {
+		_e( 'Showing the single result', 'woocommerce' );
+	} elseif ( $total <= $per_page || -1 === $per_page ) {
 		/* translators: %d: total results */
-		printf( _n( 'Showing the single result', 'Showing all %d results', $total, 'woocommerce' ), $total );
+		printf( _n( 'Showing all %d result', 'Showing all %d results', $total, 'woocommerce' ), $total );
 	} else {
 		$first = ( $per_page * $current ) - $per_page + 1;
 		$last  = min( $total, $per_page * $current );
 		/* translators: 1: first result 2: last result 3: total results */
-		printf( _nx( 'Showing the single result', 'Showing %1$d&ndash;%2$d of %3$d results', $total, 'with first and last result', 'woocommerce' ), $first, $last, $total );
+		printf( _nx( 'Showing %1$d&ndash;%2$d of %3$d result', 'Showing %1$d&ndash;%2$d of %3$d results', $total, 'with first and last result', 'woocommerce' ), $first, $last, $total );
 	}
 	?>
 </p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24004.

` _n()` should only be used for the same string with different numbers, not for different strings.

### How to test the changes in this Pull Request:

1. Switch the site language to Russian, Ukrainian, or any other Slavic language.
2. Create 21 products.
3. Go to the products' category.
4. Make sure the `Showing %1$d–%2$d of %3$d results` message is displayed instead of `Showing the single result`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Correct plural forms usage in Result Count template.