### PR TITLE
Fix-23987, Now auditory data will updated on metadata changes

### DIFF
--- a/includes/api/v2/class-wc-rest-coupons-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-coupons-v2-controller.php
@@ -293,6 +293,8 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_Legacy_Coupons_Controller {
 							foreach ( $value as $meta ) {
 								$coupon->update_meta_data( $meta['key'], $meta['value'], isset( $meta['id'] ) ? $meta['id'] : '' );
 							}
+							$date_modified_gmt = current_time( 'mysql', 1 );
+							$coupon->set_date_modified( $date_modified_gmt );
 						}
 						break;
 					case 'description':
@@ -301,6 +303,8 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_Legacy_Coupons_Controller {
 					default:
 						if ( is_callable( array( $coupon, "set_{$key}" ) ) ) {
 							$coupon->{"set_{$key}"}( $value );
+							$date_modified_gmt = current_time( 'mysql', 1 );
+							$coupon->set_date_modified( $date_modified_gmt );
 						}
 						break;
 				}


### PR DESCRIPTION
#23987 I have tested this one and found as a bug, Which I resolved by this PR. Kindly review and let me know if there are any changes required.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #23987 