### PR TITLE
Calculate tax before applying coupon so that it uses correct tax values

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1139,15 +1139,12 @@ class WC_AJAX {
 				$order->set_billing_email( $user_email_arg );
 			}
 
+			$order->calculate_taxes( $calculate_tax_args );
 			$result = $order->apply_coupon( wc_format_coupon_code( wp_unslash( $_POST['coupon'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 			if ( is_wp_error( $result ) ) {
 				throw new Exception( html_entity_decode( wp_strip_all_tags( $result->get_error_message() ) ) );
 			}
-
-			$order->calculate_taxes( $calculate_tax_args );
-			$order->calculate_totals( false );
-
 			ob_start();
 			include 'admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When creating "New order" from admin menu, if a new coupon is applies, and "Recalculate" button has not clicked on before, then the discount and total will be slightly inaccurate. This commit adds "calculate_tax" call before calculating discount to remove the inaccuracies.

Also removed a call for "calculate_total" because its already being called by "apply_coupon" method.

Towards #23802

### How to test the changes in this Pull Request:

1.  (From 23802) Add following settings in a new install:

(General) Enable tax rates and calculations
(General) Enable the use of coupon codes
(Tax) Yes, I will enter prices inclusive of tax
(Tax > Standard rates) Rate % 24.0000 

2. Create a new percentage coupon with 10% discount
3. Create a product with price 39 
4. Create a new order in WooCommerce Admin 
5. Add product created in step 3
6. Add coupon created in step 2

You will see that calculated prices are correct.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
