### PR TITLE
Force string comparison for customer_id

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -93,8 +93,8 @@ class WC_Session_Handler extends WC_Session {
 			$this->_data               = $this->get_session_data();
 
 			// If the user logs in, update session.
-			if ( is_user_logged_in() && get_current_user_id() !== $this->_customer_id ) {
-				$this->_customer_id = get_current_user_id();
+			if ( is_user_logged_in() && strval( get_current_user_id() ) !== $this->_customer_id ) {
+				$this->_customer_id = strval( get_current_user_id() );
 				$this->_dirty       = true;
 				$this->save_data();
 				$this->set_customer_session_cookie( true );
@@ -172,7 +172,7 @@ class WC_Session_Handler extends WC_Session {
 		$customer_id = '';
 
 		if ( is_user_logged_in() ) {
-			$customer_id = get_current_user_id();
+			$customer_id = strval( get_current_user_id() );
 		}
 
 		if ( empty( $customer_id ) ) {


### PR DESCRIPTION
In 203dba5a a check against the current user id was introduced.

This check is always failing because of a type mismatch causing an unnecessary insert/update query against the database.

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When trying to use W3 Total Cache database caching on a site with WooCommerce most queries are not cached because they come after the initialisation of the WooCommerce session which for a logged in user is always making an INSERT/UPDATE query.  This is because `_customer_id` is a string (having come from splitting a cookie value) but `get_current_user_id()` returns an integer that is then compared with `!==` and so fails.

This change casts all returns from `get_current_user_id()` to a string before comparing or assigning to 
`_customer_id`.

### Changelog entry

> Avoid some unnecessary session database updates for logged in users