### PR TITLE
Fix #23870 - State field editing for orders in admin

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -39,10 +39,11 @@ jQuery( function ( $ ) {
 			var $this = $( this ),
 				country = $this.val(),
 				$state = $this.parents( 'div.edit_address' ).find( ':input.js_field-state' ),
+				$stateValue = $state.val(),
 				$parent = $state.parent(),
 				input_name = $state.attr( 'name' ),
 				input_id = $state.attr( 'id' ),
-				value = $this.data( 'woocommerce.stickState-' + country ) ? $this.data( 'woocommerce.stickState-' + country ) : $state.val(),
+				value = $this.data( 'woocommerce.stickState-' + country ) ? $this.data( 'woocommerce.stickState-' + country ) : $stateValue,
 				placeholder = $state.attr( 'placeholder' ),
 				$newstate;
 
@@ -83,7 +84,7 @@ jQuery( function ( $ ) {
 					.prop( 'name', input_name )
 					.prop( 'placeholder', placeholder )
 					.addClass( 'js_field-state' )
-					.val( '' );
+					.val( $stateValue );
 				$state.replaceWith( $newstate );
 			}
 


### PR DESCRIPTION
Fixed #23870
This PR will fix the state name issue.  

Please review it and let me know if any changes are required.

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23870 .

### How to test the changes in this Pull Request:

1. Go to your shop page, add product to the cart and check out using any shipping / payment method
2. Once the order has been placed, go to WooCommerce > Orders > YOUR ORDER
3. For the shipping address, notice the presense of the County/State field
4. Click on the "edit" button
5. Earlier the State/County field was empty. After these changes, the State/County will be filled with the correct value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Changed assets/js/admin/meta-boxes-order.js file to fill the state/county field value using jquery
