### PR TITLE
Correct singular form usage in class-wc-admin-report.php

### DIFF
--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -20,7 +20,7 @@ class WC_Admin_Report {
 	 * @var array List of transients name that have been updated and need persisting.
 	 */
 	protected static $transients_to_update = array();
-	
+
 	/**
 	 * @var array The list of transients.
 	 */
@@ -333,8 +333,8 @@ class WC_Admin_Report {
 			$query['limit'] = "LIMIT {$limit}";
 		}
 
-		$query          = apply_filters( 'woocommerce_reports_get_order_report_query', $query );
-		$query          = implode( ' ', $query );
+		$query = apply_filters( 'woocommerce_reports_get_order_report_query', $query );
+		$query = implode( ' ', $query );
 
 		if ( $debug ) {
 			echo '<pre>';
@@ -348,7 +348,7 @@ class WC_Admin_Report {
 			$result = apply_filters( 'woocommerce_reports_get_order_report_data', $wpdb->$query_type( $query ), $data );
 		} else {
 			$query_hash = md5( $query_type . $query );
-			$result = $this->get_cached_query( $query_hash );
+			$result     = $this->get_cached_query( $query_hash );
 			if ( $result === null ) {
 				self::enable_big_selects();
 
@@ -368,7 +368,7 @@ class WC_Admin_Report {
 			add_action( 'shutdown', array( 'WC_Admin_Report', 'maybe_update_transients' ) );
 		}
 	}
-	
+
 	/**
 	 * Enables big mysql selects for reports, just once for this session.
 	 */
@@ -392,11 +392,11 @@ class WC_Admin_Report {
 	 */
 	protected function get_cached_query( $query_hash ) {
 		$class = strtolower( get_class( $this ) );
-		
+
 		if ( ! isset( self::$cached_results[ $class ] ) ) {
 			self::$cached_results[ $class ] = get_transient( strtolower( get_class( $this ) ) );
 		}
-		
+
 		if ( isset( self::$cached_results[ $class ][ $query_hash ] ) ) {
 			return self::$cached_results[ $class ][ $query_hash ];
 		}
@@ -412,13 +412,13 @@ class WC_Admin_Report {
 	 */
 	protected function set_cached_query( $query_hash, $data ) {
 		$class = strtolower( get_class( $this ) );
-		
+
 		if ( ! isset( self::$cached_results[ $class ] ) ) {
 			self::$cached_results[ $class ] = get_transient( strtolower( get_class( $this ) ) );
 		}
-		
+
 		self::add_update_transients_hook();
-		
+
 		self::$transients_to_update[ $class ]          = $class;
 		self::$cached_results[ $class ][ $query_hash ] = $data;
 	}

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -593,7 +593,7 @@ class WC_Admin_Report {
 			$tooltip = sprintf( __( 'Sold %1$s worth in the last %2$d days', 'woocommerce' ), strip_tags( wc_price( $total ) ), $days );
 		} else {
 			/* translators: 1: total items sold 2: days */
-			$tooltip = sprintf( _n( 'Sold 1 item in the last %2$d days', 'Sold %1$d items in the last %2$d days', $total, 'woocommerce' ), $total, $days );
+			$tooltip = sprintf( _n( 'Sold %1$d item in the last %2$d days', 'Sold %1$d items in the last %2$d days', $total, 'woocommerce' ), $total, $days );
 		}
 
 		$sparkline_data = array_values( $this->prepare_chart_data( $data, 'post_date', 'sparkline_value', $days - 1, strtotime( 'midnight -' . ( $days - 1 ) . ' days', current_time( 'timestamp' ) ), 'day' ) );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the singular form string inside a call to `_n()` to accommodate languages that use the singular form for numbers other than 1. For more information see #24004. Thanks @SergeyBiryukov for reporting this problem. I have searched WooCommerce code base for other places where `_n()` and the one fixed in this PR is the only issue that I found.

This PR also includes a separate commit that uses PHPCBF to fix some of the PHPCS violations in the modified file. Violations that need to be fixed manually were not addressed.