### PR TITLE
Allow notice type changes when updating cart contents

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -657,7 +657,7 @@ class WC_Form_Handler {
 				wp_safe_redirect( wc_get_checkout_url() );
 				exit;
 			} elseif ( $cart_updated ) {
-				wc_add_notice( __( 'Cart updated.', 'woocommerce' ), apply_filters( 'woocommerce_update_cart_notice_type', 'success' ) );
+				wc_add_notice( __( 'Cart updated.', 'woocommerce' ), apply_filters( 'woocommerce_cart_updated_notice_type', 'success' ) );
 				$referer = remove_query_arg( array( 'remove_coupon', 'add-to-cart' ), ( wp_get_referer() ? wp_get_referer() : wc_get_cart_url() ) );
 				wp_safe_redirect( $referer );
 				exit;

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -1052,7 +1052,7 @@ class WC_Form_Handler {
 
 			if ( in_array( $field, array( 'password_1', 'password_2' ) ) ) {
 				// Don't unslash password fields
-				// @see https://github.com/woocommerce/woocommerce/issues/23922
+				// @see https://github.com/woocommerce/woocommerce/issues/23922.
 				$posted_fields[ $field ] = $_POST[ $field ]; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.ValidatedSanitizedInput.MissingUnslash
 			} else {
 				$posted_fields[ $field ] = wp_unslash( $_POST[ $field ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -586,7 +586,7 @@ class WC_Form_Handler {
 					$removed_notice = sprintf( __( '%s removed.', 'woocommerce' ), $item_removed_title );
 				}
 
-				wc_add_notice( $removed_notice );
+				wc_add_notice( $removed_notice, apply_filters( 'woocommerce_cart_item_removed_notice_type', 'success' ) );
 			}
 
 			$referer = wp_get_referer() ? remove_query_arg( array( 'remove_item', 'add-to-cart', 'added-to-cart', 'order_again', '_wpnonce' ), add_query_arg( 'removed_item', '1', wp_get_referer() ) ) : wc_get_cart_url();
@@ -657,7 +657,7 @@ class WC_Form_Handler {
 				wp_safe_redirect( wc_get_checkout_url() );
 				exit;
 			} elseif ( $cart_updated ) {
-				wc_add_notice( __( 'Cart updated.', 'woocommerce' ) );
+				wc_add_notice( __( 'Cart updated.', 'woocommerce' ), apply_filters( 'woocommerce_update_cart_notice_type', 'success' ) );
 				$referer = remove_query_arg( array( 'remove_coupon', 'add-to-cart' ), ( wp_get_referer() ? wp_get_referer() : wc_get_cart_url() ) );
 				wp_safe_redirect( $referer );
 				exit;

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -133,7 +133,7 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 	if ( $return ) {
 		return $message;
 	} else {
-		wc_add_notice( $message );
+		wc_add_notice( $message, apply_filters( 'wc_add_to_cart_notice_type', 'success' ) );
 	}
 }
 

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -133,7 +133,7 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 	if ( $return ) {
 		return $message;
 	} else {
-		wc_add_notice( $message, apply_filters( 'wc_add_to_cart_notice_type', 'success' ) );
+		wc_add_notice( $message, apply_filters( 'woocommerce_add_to_cart_notice_type', 'success' ) );
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On add to cart, remove from cart or update cart, allow notice type to be changed from default 'success'.

Use case: I want to change the status of cart notifications from default 'success' notice type in order to apply a different style to the notification. You can already add a new notice_type 'added' using the `woocommerce_notice_types` filter, but you can't then use this new notice_type on cart notifications.


### How to test the changes in this Pull Request:

1. Add this to functions.php

```
function theme_notice_types() {
	return array(
		'error',
		'success',
		'notice',
		'added',
	);
}
add_filter( 'woocommerce_notice_types', 'theme_notice_types' );

function theme_add_to_cart_notice_type() {
	return 'added';
}
add_filter( 'wc_add_to_cart_notice_type', 'theme_add_to_cart_notice_type' );
```

2. Add the following to `wp-content/themes/mytheme/woocommerce/notices/added.php`

```
<?php foreach ( $messages as $message ) : ?>
	<div class="woocommerce-added" role="alert">
		<?php
			echo wc_kses_notice( $message );
		?>
	</div>
<?php endforeach; ?>
```

3. Add to cart and you should see a notice with the class of `woocommerce-added`


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? N/A
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

> Dev - New woocommerce_cart_item_removed_notice_type, woocommerce_cart_updated_notice_type and woocommerce_add_to_cart_notice_type filters for changing the default notice types for cart notices.
