### PR TITLE
DB received `ENGINE` instead of `engine`, so PHP notices appear

### DIFF
--- a/includes/api/v2/class-wc-rest-system-status-v2-controller.php
+++ b/includes/api/v2/class-wc-rest-system-status-v2-controller.php
@@ -700,7 +700,7 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			$wpdb->prepare(
 				"SELECT
 				    table_name AS 'name',
-					engine,
+					engine AS 'engine',
 				    round( ( data_length / 1024 / 1024 ), 2 ) 'data',
 				    round( ( index_length / 1024 / 1024 ), 2 ) 'index'
 				FROM information_schema.TABLES


### PR DESCRIPTION
See the following screenshots:

<img width="889" alt="Screen Shot 2019-06-27 at 17 34 59" src="https://user-images.githubusercontent.com/1620929/60279773-f969fa80-9901-11e9-8223-7567a0b08a02.png">
<img width="1343" alt="Screen Shot 2019-06-27 at 17 35 24" src="https://user-images.githubusercontent.com/1620929/60279774-f969fa80-9901-11e9-98a4-7a2ca7eb74b2.png">
