### PR TITLE
Round late when rounding at subtotal to reduce rounding error.

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -591,7 +591,6 @@ final class WC_Cart_Totals {
 				$taxes[ $rate_id ] += $this->round_line_tax( $rate );
 			}
 		}
-		$taxes = $this->round_merged_taxes( $taxes );
 
 		return $in_cents ? $taxes : wc_remove_number_precision_deep( $taxes );
 	}
@@ -682,7 +681,13 @@ final class WC_Cart_Totals {
 			$this->cart->cart_contents[ $item_key ]['line_tax']               = wc_remove_number_precision( $item->total_tax );
 		}
 
-		$this->set_total( 'items_total', array_sum( array_map( 'round', array_values( wp_list_pluck( $this->items, 'total' ) ) ) ) );
+		$items_total = array_sum(
+			array_map(
+				array( $this, 'round_item_subtotal' ),
+				array_values( wp_list_pluck( $this->items, 'total' ) )
+			)
+		);
+		$this->set_total( 'items_total', round( $items_total ) );
 		$this->set_total( 'items_total_tax', array_sum( array_values( wp_list_pluck( $this->items, 'total_tax' ) ) ) );
 
 		$this->cart->set_cart_contents_total( $this->get_total( 'items_total' ) );
@@ -740,8 +745,14 @@ final class WC_Cart_Totals {
 			$this->cart->cart_contents[ $item_key ]['line_subtotal_tax'] = wc_remove_number_precision( $item->subtotal_tax );
 		}
 
-		$this->set_total( 'items_subtotal', array_sum( array_map( 'round', array_values( wp_list_pluck( $this->items, 'subtotal' ) ) ) ) );
-		$this->set_total( 'items_subtotal_tax', array_sum( $this->round_merged_taxes( $merged_subtotal_taxes ) ) );
+		$items_subtotal = array_sum(
+			array_map(
+				array( $this, 'round_item_subtotal' ),
+				array_values( wp_list_pluck( $this->items, 'subtotal' ) )
+			)
+		);
+		$this->set_total( 'items_subtotal', round( $items_subtotal ) );
+		$this->set_total( 'items_subtotal_tax', wc_round_tax_total( array_sum( $merged_subtotal_taxes ), 0 ) );
 
 		$this->cart->set_subtotal( $this->get_total( 'items_subtotal' ) );
 		$this->cart->set_subtotal_tax( $this->get_total( 'items_subtotal_tax' ) );
@@ -873,6 +884,20 @@ final class WC_Cart_Totals {
 	protected function round_line_tax( $value ) {
 		if ( ! $this->round_at_subtotal() ) {
 			$value = wc_round_tax_total( $value, 0 );
+		}
+		return $value;
+	}
+
+	/**
+	 * Apply rounding to item subtotal before summing.
+	 *
+	 * @since 3.7.0
+	 * @param float $value Item subtotal value.
+	 * @return float
+	 */
+	protected function round_item_subtotal( $value ) {
+		if ( ! $this->round_at_subtotal() ) {
+			$value = round( $value );
 		}
 		return $value;
 	}

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -188,6 +188,53 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test for subtotal when multiple tax slabs are present and round at subtotal is enabled.
+	 *
+	 * Ticket: @link https://github.com/woocommerce/woocommerce/issues/23917
+	 */
+	public function test_cart_calculate_total_rounding_23917() {
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+
+		$tax_rate    = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '24.0000',
+			'tax_rate_name'     => 'CGST',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '0',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => 'tax_1',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate );
+
+		$tax_rate   = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '24.0000',
+			'tax_rate_name'     => 'SGST',
+			'tax_rate_priority' => '2',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '0',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => 'tax_2',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate );
+
+		// Create a product with price 599.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 599 );
+		$product->save();
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->calculate_totals();
+		$this->assertEquals( 599, WC()->cart->subtotal );
+		$this->assertEquals( 599, WC()->cart->total );
+	}
+
+	/**
 	 * Test some discount logic which has caused issues in the past.
 	 * Ticket:
 	 *  https://github.com/woocommerce/woocommerce/issues/10963


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This experiments with approach suggested in https://github.com/woocommerce/woocommerce/issues/23917#issuecomment-505033366 . When the setting "Round at subtotal" is selected, we will round as late as possible. This means that there could be a 0.01 difference between sum of individual lines and the actual total value, when prices are inclusive of taxes, but that total will the same as the price that author entered. 

This should not affect anything when the setting "round at subtotal" is disabled. More explanation in commit message.

Closes #23917  .

### How to test the changes in this Pull Request:

1. Enable settings:
a. Round at subtotal
b. Prices are inclusive of taxes
2. Add a product with price `599`
3. Add two tax rows for 24% with priority 1 and 2 respectively
4. Add the product in the card. You will notice that the sum is now `599`, instead of `599.01` without this commit.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Round tax late when rounding at subtotal setting is enabled to reduce rounding error.
