### PR TITLE
Tracks: fix blog ID retrieval from Jetpack options.

### DIFF
--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -37,7 +37,7 @@ class WC_Tracks {
 			$blog_details = array(
 				'url'            => home_url(),
 				'blog_lang'      => get_user_locale( $user_id ),
-				'blog_id'        => ( class_exists( 'Jetpack' ) && Jetpack_Options::get_option( 'id' ) ) || null,
+				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
 				'products_count' => self::get_products_count(),
 			);
 			set_transient( 'wc_tracks_blog_details', $blog_details, DAY_IN_SECONDS );


### PR DESCRIPTION
JavaScripty syntax is resulting in boolean values being sent.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix the check for Jetpack and the `id` option retrieval. We want to send the blog ID, not a boolean representing Jetpack's status.

### How to test the changes in this Pull Request:

1. Ensure that Jetpack is connected
1. Trigger a Tracks event (can just be viewing a WooCommerce settings page)
1. Verify that the `blog_id` parameter is a proper looking ID, like `123456789`

### Changelog entry

Fix: Tracks blog ID retrieval from Jetpack options.

_cc: @justinshreve_
