### PR TITLE
Add support for namespaced Jetpack tracks_get_identity

### DIFF
--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -139,11 +139,16 @@ class WC_Tracks_Client {
 	public static function get_identity( $user_id ) {
 		$jetpack_lib = '/tracks/client.php';
 
-		if ( class_exists( 'Jetpack' ) && file_exists( jetpack_require_lib_dir() . $jetpack_lib ) ) {
-			include_once jetpack_require_lib_dir() . $jetpack_lib;
-
-			if ( function_exists( 'jetpack_tracks_get_identity' ) ) {
-				return jetpack_tracks_get_identity( $user_id );
+		if ( class_exists( 'Jetpack' ) && defined( JETPACK__VERSION ) ) {
+			if ( version_compare( JETPACK__VERSION, '7.5', '<' ) ) {
+				if ( file_exists( jetpack_require_lib_dir() . $jetpack_lib ) ) {
+					include_once jetpack_require_lib_dir() . $jetpack_lib;
+					if ( function_exists( 'jetpack_tracks_get_identity' ) ) {
+						return jetpack_tracks_get_identity( $user_id );
+					}
+				}
+			} else {
+				Automattic\Jetpack\Tracking::tracks_get_identity( $user_id );
 			}
 		}
 

--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -148,7 +148,7 @@ class WC_Tracks_Client {
 					}
 				}
 			} else {
-				Automattic\Jetpack\Tracking::tracks_get_identity( $user_id );
+				return Automattic\Jetpack\Tracking::tracks_get_identity( $user_id );
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #23930 

### How to test the changes in this Pull Request:

1. Install Jetpack 7.4 installed and test that no notices are given on tracking requests
2. Install Jetpack 7.5 and test that no notices are given on tracking requests.
3. More details in #23930

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Tracking compatibility with Jetpack 7.5
