### PR TITLE
Remove inputmode from quantity inputs as it is not listed in WHATWG or W3C HTML 5.2 specs

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1675,7 +1675,6 @@ if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 			'min_value'    => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),
 			'step'         => apply_filters( 'woocommerce_quantity_input_step', 1, $product ),
 			'pattern'      => apply_filters( 'woocommerce_quantity_input_pattern', has_filter( 'woocommerce_stock_amount', 'intval' ) ? '[0-9]*' : '' ),
-			'inputmode'    => apply_filters( 'woocommerce_quantity_input_inputmode', has_filter( 'woocommerce_stock_amount', 'intval' ) ? 'numeric' : '' ),
 			'product_name' => $product ? $product->get_title() : '',
 		);
 

--- a/templates/global/quantity-input.php
+++ b/templates/global/quantity-input.php
@@ -41,7 +41,6 @@ if ( $max_value && $min_value === $max_value ) {
 			value="<?php echo esc_attr( $input_value ); ?>"
 			title="<?php echo esc_attr_x( 'Qty', 'Product quantity input tooltip', 'woocommerce' ); ?>"
 			size="4"
-			inputmode="<?php echo esc_attr( $inputmode ); ?>" />
 		<?php do_action( 'woocommerce_after_quantity_input_field' ); ?>
 	</div>
 	<?php


### PR DESCRIPTION
### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

The W3C HTML 5.2 spec and the WHATWG spec don't list inputmode as an attribute for input tags.  The W3C validator throws an error every time it sees this.  If you remove the lines as I have the quantity inputs still do NOT allow users to type in letters or anything else as the type attribute is still set to "number" on line 34 of quantity-input.php

Closes # .


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
See above

* [x] Have you written new tests for your changes, as applicable?
See above

* [x] Have you successfully run tests with your changes locally?
yes

<!-- Mark completed items with an [x] -->

### Changelog entry

Removes inputmode attribute on quantity inputs