### PR TITLE
OBW: Fix event recording in OBW

### DIFF
--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -93,11 +93,10 @@ class WC_Admin_Setup_Wizard_Tracking {
 
 		wc_enqueue_js(
 			"
-			var form = $( '.newsletter-form-email' ).closest( 'form' );
-			$( document ).on( 'submit', form, function() {
+			jQuery( '#mc-embedded-subscribe' ).click( function() {
 				window.wcTracks.recordEvent( 'obw_marketing_signup' );
 			} );
-			$( '.wc-setup-content a' ).click( function trackNextScreen( e ) {
+			jQuery( '.wc-setup-content a' ).click( function trackNextScreen( e ) {
 				var properties = {
 					next_url: e.target.href,
 					button: e.target.textContent && e.target.textContent.trim()

--- a/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
+++ b/includes/tracks/events/class-wc-admin-setup-wizard-tracking.php
@@ -111,6 +111,11 @@ class WC_Admin_Setup_Wizard_Tracking {
 	 * Track various events when a step is saved.
 	 */
 	public function add_step_save_events() {
+		// Always record a track on this page view.
+		if ( 'next_steps' === $this->get_current_step() ) {
+			add_action( 'admin_init', array( $this, 'track_next_steps' ), 1 );
+		}
+
 		if ( empty( $_POST['save_step'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 			return;
 		}
@@ -239,6 +244,15 @@ class WC_Admin_Setup_Wizard_Tracking {
 	 */
 	public function track_jetpack_activate() {
 		WC_Tracks::record_event( 'obw_activate' );
+	}
+
+	/**
+	 * Tracks when last next_steps screen is viewed in the OBW.
+	 *
+	 * @return void
+	 */
+	public function track_next_steps() {
+		WC_Tracks::record_event( 'obw_ready_view' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

See https://github.com/woocommerce/woocommerce-admin/issues/2549

This branch fixes two events that were not recording properly in the OBW. Since this branch records tracks via PHP, it is helpful to add the following in an active plugin on your site:

```
add_filter( 'http_request_args', function( $r, $url ) {
       error_log( $r['method'] . ' ' . $url );
       return $r;
},10, 2 );
```

### How to test the changes in this Pull Request:

1. Launch the OBW via `/wp-admin/admin.php?page=wc-setup`
2. Be sure to opt-in for tracking on the first page ( it defaults to on )
3. Skip through to the last step `/wp-admin/admin.php?page=wc-setup&step=next_steps`
4. Click the 'Yes Please!' button on the email signup form, verify a `t.gif` is recorded in your network tab in the browser console with an event name of `wcadmin_obw_marketing_signup`
5. Also when viewing this step, you should see a request to t.gif logged if you enabled logging as outlined above for `wcadmin_obw_ready_view`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix: Event logging in the onboarding wizard.

/cc @pmcpinto 
