### PR TITLE
Add generate coupon code button

### DIFF
--- a/assets/js/admin/meta-boxes-coupon.js
+++ b/assets/js/admin/meta-boxes-coupon.js
@@ -12,6 +12,12 @@ jQuery(function( $ ) {
 			$( 'select#discount_type' )
 				.on( 'change', this.type_options )
 				.change();
+
+			// Add buttons to coupon screen
+			var $coupon_screen = $( '.post-new-php.post-type-shop_coupon' ),
+			$code_action       = $coupon_screen.find( '#title' );
+			$code_action.after( '<a href="#" class="button generate-coupon-code">Generate code</a>' );
+			$( '.button.generate-coupon-code' ).on( 'click', this.generate_coupon_code );
 		},
 
 		/**
@@ -32,6 +38,24 @@ jQuery(function( $ ) {
 			} else {
 				$( '.limit_usage_to_x_items_field' ).hide();
 			}
+		},
+
+		/**
+		 * Generate a random coupon code
+		 */
+		generate_coupon_code: function( e ) {
+			e.preventDefault();
+			var $coupon_code_field = $( '#title' ),
+				$coupon_code_label = $( '#title-prompt-text' ),
+			    $result = '';
+			for ( var i = 0; i < woocommerce_admin_meta_boxes_coupon.char_limit; i++ ) {
+				$result += woocommerce_admin_meta_boxes_coupon.characters.charAt(
+					Math.floor( Math.random() * woocommerce_admin_meta_boxes_coupon.characters.length )
+				);
+			}
+			$result = woocommerce_admin_meta_boxes_coupon.prefix + $result + woocommerce_admin_meta_boxes_coupon.postfix;
+			$coupon_code_field.focus().val( $result );
+			$coupon_code_label.addClass( 'screen-reader-text' );
 		}
 	};
 

--- a/assets/js/admin/meta-boxes-coupon.js
+++ b/assets/js/admin/meta-boxes-coupon.js
@@ -1,3 +1,4 @@
+/* global woocommerce_admin_meta_boxes_coupon */
 jQuery(function( $ ) {
 
 	/**
@@ -13,12 +14,7 @@ jQuery(function( $ ) {
 				.on( 'change', this.type_options )
 				.change();
 
-			// Add buttons to coupon screen
-			var $coupon_screen = $( '.post-new-php.post-type-shop_coupon' ),
-			$code_action       = $coupon_screen.find( '#title' );
-			$code_action.after(
-				'<a href="#" class="button generate-coupon-code">' + woocommerce_admin_meta_boxes_coupon.generate_button_text + '</a>'
-			);
+            this.insert_generate_coupon_code_button();
 			$( '.button.generate-coupon-code' ).on( 'click', this.generate_coupon_code );
 		},
 
@@ -40,7 +36,16 @@ jQuery(function( $ ) {
 			} else {
 				$( '.limit_usage_to_x_items_field' ).hide();
 			}
-		},
+        },
+
+        /**
+         * Insert generate coupon code buttom HTML.
+         */
+        insert_generate_coupon_code_button: function() {
+			$( '.post-type-shop_coupon' ).find( '#title' ).after(
+				'<a href="#" class="button generate-coupon-code">' + woocommerce_admin_meta_boxes_coupon.generate_button_text + '</a>'
+			);
+        },
 
 		/**
 		 * Generate a random coupon code
@@ -50,7 +55,7 @@ jQuery(function( $ ) {
 			var $coupon_code_field = $( '#title' ),
 				$coupon_code_label = $( '#title-prompt-text' ),
 			    $result = '';
-			for ( var i = 0; i < woocommerce_admin_meta_boxes_coupon.char_limit; i++ ) {
+			for ( var i = 0; i < woocommerce_admin_meta_boxes_coupon.char_length; i++ ) {
 				$result += woocommerce_admin_meta_boxes_coupon.characters.charAt(
 					Math.floor( Math.random() * woocommerce_admin_meta_boxes_coupon.characters.length )
 				);

--- a/assets/js/admin/meta-boxes-coupon.js
+++ b/assets/js/admin/meta-boxes-coupon.js
@@ -16,7 +16,9 @@ jQuery(function( $ ) {
 			// Add buttons to coupon screen
 			var $coupon_screen = $( '.post-new-php.post-type-shop_coupon' ),
 			$code_action       = $coupon_screen.find( '#title' );
-			$code_action.after( '<a href="#" class="button generate-coupon-code">Generate code</a>' );
+			$code_action.after(
+				'<a href="#" class="button generate-coupon-code">' + woocommerce_admin_meta_boxes_coupon.generate_button_text + '</a>'
+			);
 			$( '.button.generate-coupon-code' ).on( 'click', this.generate_coupon_code );
 		},
 

--- a/assets/js/admin/meta-boxes-coupon.js
+++ b/assets/js/admin/meta-boxes-coupon.js
@@ -55,7 +55,7 @@ jQuery(function( $ ) {
 					Math.floor( Math.random() * woocommerce_admin_meta_boxes_coupon.characters.length )
 				);
 			}
-			$result = woocommerce_admin_meta_boxes_coupon.prefix + $result + woocommerce_admin_meta_boxes_coupon.postfix;
+			$result = woocommerce_admin_meta_boxes_coupon.prefix + $result + woocommerce_admin_meta_boxes_coupon.suffix;
 			$coupon_code_field.focus().val( $result );
 			$coupon_code_label.addClass( 'screen-reader-text' );
 		}

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -275,6 +275,16 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			}
 			if ( in_array( $screen_id, array( 'shop_coupon', 'edit-shop_coupon' ) ) ) {
 				wp_enqueue_script( 'wc-admin-coupon-meta-boxes', WC()->plugin_url() . '/assets/js/admin/meta-boxes-coupon' . $suffix . '.js', array( 'wc-admin-meta-boxes' ), WC_VERSION );
+				wp_localize_script(
+					'wc-admin-coupon-meta-boxes',
+					'woocommerce_admin_meta_boxes_coupon',
+					array(
+						'characters' => apply_filters( 'woocommerce_coupon_code_generator_characters', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345678' ),
+						'char_limit' => apply_filters( 'woocommerce_coupon_code_generator_character_limit', 8 ),
+						'prefix'     => apply_filters( 'woocommerce_coupon_code_generator_prefix', '' ),
+						'postfix'    => apply_filters( 'woocommerce_coupon_code_generator_postfix', '' ),
+					)
+				);
 			}
 			if ( in_array( str_replace( 'edit-', '', $screen_id ), array_merge( array( 'shop_coupon', 'product' ), wc_get_order_types( 'order-meta-boxes' ) ) ) ) {
 				$post_id            = isset( $post->ID ) ? $post->ID : '';

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -2,8 +2,8 @@
 /**
  * Load assets
  *
- * @package     WooCommerce/Admin
- * @version     2.1.0
+ * @package WooCommerce/Admin
+ * @version 3.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -279,9 +279,9 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'wc-admin-coupon-meta-boxes',
 					'woocommerce_admin_meta_boxes_coupon',
 					array(
-						'generate_button_text' => esc_html__( 'Generate coupon', 'woocommerce' ),
+						'generate_button_text' => esc_html__( 'Generate coupon code', 'woocommerce' ),
 						'characters'           => apply_filters( 'woocommerce_coupon_code_generator_characters', 'ABCDEFGHJKMNPQRSTUVWXYZ23456789' ),
-						'char_limit'           => apply_filters( 'woocommerce_coupon_code_generator_character_limit', 8 ),
+						'char_length'          => apply_filters( 'woocommerce_coupon_code_generator_character_length', 8 ),
 						'prefix'               => apply_filters( 'woocommerce_coupon_code_generator_prefix', '' ),
 						'suffix'               => apply_filters( 'woocommerce_coupon_code_generator_suffix', '' ),
 					)

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -280,7 +280,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'woocommerce_admin_meta_boxes_coupon',
 					array(
 						'generate_button_text' => esc_html__( 'Generate coupon', 'woocommerce' ),
-						'characters'           => apply_filters( 'woocommerce_coupon_code_generator_characters', 'ABCDEFGHJKMNPQRSTUVWXYZ2345678' ),
+						'characters'           => apply_filters( 'woocommerce_coupon_code_generator_characters', 'ABCDEFGHJKMNPQRSTUVWXYZ23456789' ),
 						'char_limit'           => apply_filters( 'woocommerce_coupon_code_generator_character_limit', 8 ),
 						'prefix'               => apply_filters( 'woocommerce_coupon_code_generator_prefix', '' ),
 						'postfix'              => apply_filters( 'woocommerce_coupon_code_generator_postfix', '' ),

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -280,7 +280,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'woocommerce_admin_meta_boxes_coupon',
 					array(
 						'generate_button_text' => esc_html__( 'Generate coupon', 'woocommerce' ),
-						'characters'           => apply_filters( 'woocommerce_coupon_code_generator_characters', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345678' ),
+						'characters'           => apply_filters( 'woocommerce_coupon_code_generator_characters', 'ABCDEFGHJKMNPQRSTUVWXYZ2345678' ),
 						'char_limit'           => apply_filters( 'woocommerce_coupon_code_generator_character_limit', 8 ),
 						'prefix'               => apply_filters( 'woocommerce_coupon_code_generator_prefix', '' ),
 						'postfix'              => apply_filters( 'woocommerce_coupon_code_generator_postfix', '' ),

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -279,10 +279,11 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'wc-admin-coupon-meta-boxes',
 					'woocommerce_admin_meta_boxes_coupon',
 					array(
-						'characters' => apply_filters( 'woocommerce_coupon_code_generator_characters', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345678' ),
-						'char_limit' => apply_filters( 'woocommerce_coupon_code_generator_character_limit', 8 ),
-						'prefix'     => apply_filters( 'woocommerce_coupon_code_generator_prefix', '' ),
-						'postfix'    => apply_filters( 'woocommerce_coupon_code_generator_postfix', '' ),
+						'generate_button_text' => esc_html__( 'Generate coupon', 'woocommerce' ),
+						'characters'           => apply_filters( 'woocommerce_coupon_code_generator_characters', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ012345678' ),
+						'char_limit'           => apply_filters( 'woocommerce_coupon_code_generator_character_limit', 8 ),
+						'prefix'               => apply_filters( 'woocommerce_coupon_code_generator_prefix', '' ),
+						'postfix'              => apply_filters( 'woocommerce_coupon_code_generator_postfix', '' ),
 					)
 				);
 			}

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -283,7 +283,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'characters'           => apply_filters( 'woocommerce_coupon_code_generator_characters', 'ABCDEFGHJKMNPQRSTUVWXYZ23456789' ),
 						'char_limit'           => apply_filters( 'woocommerce_coupon_code_generator_character_limit', 8 ),
 						'prefix'               => apply_filters( 'woocommerce_coupon_code_generator_prefix', '' ),
-						'postfix'              => apply_filters( 'woocommerce_coupon_code_generator_postfix', '' ),
+						'suffix'               => apply_filters( 'woocommerce_coupon_code_generator_suffix', '' ),
 					)
 				);
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR adds a button underneath the coupon code field on new coupon pages. When clicked this button will generate a coupon code via javascript. The code length defaults to 8 characters but can be adjusted via a filter and you can also add prefix and postfix data to the generated coupon via the filters and adjust the characters used for generating the coupon via a filter.

![](https://cld.wthms.co/OrOcIm+)

### How to test the changes in this Pull Request:

1. Head to the `WooCommerce -> Coupons` click the `Add new` option
2. See the new button underneath the coupon code field
3. Click the button and see auto-generated coupon code added.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - Coupon code generator button on new coupon page.