### PR TITLE
WC_Comments: Add action_log to excluded types in wp_count_comments

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -238,7 +238,7 @@ class WC_Comments {
 					"
 					SELECT comment_approved, COUNT(*) AS num_comments
 					FROM {$wpdb->comments}
-					WHERE comment_type NOT IN ('order_note', 'webhook_delivery')
+					WHERE comment_type NOT IN ('action_log', 'order_note', 'webhook_delivery')
 					GROUP BY comment_approved
 					",
 					ARRAY_A


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

From testing on woocommerce.com with wc-admin, there has been a notable slower response in the wp_count_comments() query as the number of comments present in the db created by ActionScheduler has grown. Per the suggestion from @thenbrent - this branch adds `action_log` to the list of excluded comment types in the query.

Longer-term with the plan to move ActionScheduler to custom tables, this will no longer be a problem, but seems like we should implement this fix as more extensions are utilizing ActionScheduler - so this will prevent them from encountering slower responses in this query.

@kloon this would be great to get in 3.7 if possible.

### Changelog entry

> Tweak: Add action_log to excluded comment types in WC_Comments::wp_count_comments()
