### PR TITLE
Fix missing space and closing <strong> tag in WooCommerce.com disconnect message

### DIFF
--- a/includes/admin/helper/views/html-oauth-start.php
+++ b/includes/admin/helper/views/html-oauth-start.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit();
 				<img src="<?php echo esc_url( WC()->plugin_url() . '/assets/images/woocommerce_logo.png' ); ?>" alt="WooCommerce" style="width:180px;">
 
 				<?php if ( ! empty( $_GET['wc-helper-status'] ) && 'helper-disconnected' === $_GET['wc-helper-status'] ) : ?>
-					<p><strong><?php esc_html_e( 'Sorry to see you go.', 'woocommerce' ) . '</strong>' . esc_html_e( 'Feel free to reconnect again using the button below.', 'woocommerce' ); ?></p>
+					<p><strong><?php esc_html_e( 'Sorry to see you go.', 'woocommerce' ); ?></strong> <?php esc_html_e( 'Feel free to reconnect again using the button below.', 'woocommerce' ); ?></p>
 				<?php endif; ?>
 
 				<h2><?php esc_html_e( 'Manage your subscriptions, get important product notifications, and updates, all from the convenience of your WooCommerce dashboard', 'woocommerce' ); ?></h2>


### PR DESCRIPTION
The closing strong tag was not being echoed and space was missing after full stop.

**Before:**
![Screenshot](https://cld.wthms.co/0rO7NN+)
Screenshot: https://cld.wthms.co/0rO7NN 

**After:**
![Screenshot](https://cld.wthms.co/LVH6rC+)
Screenshot: https://cld.wthms.co/LVH6rC 


### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Connect to WooCommerce to WooCommerce.com in the WP admin WooCommerce > Extensions WooCommerce.com Subscriptions.
2. Then disconnect