### PR TITLE
Add in-app-purchase params to extensions screen & suggestions

### DIFF
--- a/assets/js/admin/marketplace-suggestions.js
+++ b/assets/js/admin/marketplace-suggestions.js
@@ -114,7 +114,14 @@
 
 			var utmUrl = addURLParameters( context, url );
 			linkoutButton.setAttribute( 'href', utmUrl );
-			linkoutButton.setAttribute( 'target', 'blank' );
+
+			// By default, CTA links should open in same tab (and feel integrated with Woo).
+			// Exception: when editing products, use new tab. User may have product edits
+			// that need to be saved.
+			if ( 'editproduct' === context ) {
+				linkoutButton.setAttribute( 'target', 'blank' );
+			}
+
 			linkoutButton.textContent = text;
 
 			linkoutButton.onclick = function() {

--- a/assets/js/admin/marketplace-suggestions.js
+++ b/assets/js/admin/marketplace-suggestions.js
@@ -72,12 +72,12 @@
 			return dismissButton;
 		}
 
-		function addUTMParameters( context, url ) {
-			var utmParams = {
-				utm_source: 'unknown',
-				utm_campaign: 'marketplacesuggestions',
-				utm_medium: 'product'
-			};
+		function addURLParameters( context, url ) {
+			var urlParams = marketplace_suggestions.in_app_purchase_params;
+			urlParams.utm_source = 'unknown';
+			urlParams.utm_campaign = 'marketplacesuggestions';
+			urlParams.utm_medium = 'product';
+
 			var sourceContextMap = {
 				'productstable': [
 					'products-list-inline'
@@ -102,17 +102,17 @@
 				return _.contains( sourceInfo, context );
 			} );
 			if ( utmSource ) {
-				utmParams.utm_source = utmSource;
+				urlParams.utm_source = utmSource;
 			}
 
-			return url + '?' + jQuery.param( utmParams );
+			return url + '?' + jQuery.param( urlParams );
 		}
 
 		// Render DOM element for suggestion linkout, optionally with button style.
 		function renderLinkout( context, product, promoted, slug, url, text, isButton ) {
 			var linkoutButton = document.createElement( 'a' );
 
-			var utmUrl = addUTMParameters( context, url );
+			var utmUrl = addURLParameters( context, url );
 			linkoutButton.setAttribute( 'href', utmUrl );
 			linkoutButton.setAttribute( 'target', 'blank' );
 			linkoutButton.textContent = text;

--- a/assets/js/admin/marketplace-suggestions.js
+++ b/assets/js/admin/marketplace-suggestions.js
@@ -118,7 +118,12 @@
 			// By default, CTA links should open in same tab (and feel integrated with Woo).
 			// Exception: when editing products, use new tab. User may have product edits
 			// that need to be saved.
-			if ( 'editproduct' === context ) {
+			var newTabContexts = [
+				'product-edit-meta-tab-header',
+				'product-edit-meta-tab-footer',
+				'product-edit-meta-tab-body'
+			];
+			if ( _.includes( newTabContexts, context ) ) {
 				linkoutButton.setAttribute( 'target', 'blank' );
 			}
 

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -2,8 +2,6 @@
 /**
  * Addons Page
  *
- * @author   WooThemes
- * @category Admin
  * @package  WooCommerce/Admin
  * @version  2.5.0
  */
@@ -23,7 +21,8 @@ class WC_Admin_Addons {
 	 * @return array of objects
 	 */
 	public static function get_featured() {
-		if ( false === ( $featured = get_transient( 'wc_addons_featured' ) ) ) {
+		$featured = get_transient( 'wc_addons_featured' );
+		if ( false === $featured ) {
 			$raw_featured = wp_safe_remote_get( 'https://d3t0oesq8995hv.cloudfront.net/add-ons/featured-v2.json', array( 'user-agent' => 'WooCommerce Addons Page' ) );
 			if ( ! is_wp_error( $raw_featured ) ) {
 				$featured = json_decode( wp_remote_retrieve_body( $raw_featured ) );
@@ -42,9 +41,9 @@ class WC_Admin_Addons {
 	/**
 	 * Build url parameter string
 	 *
-	 * @param  string $category
-	 * @param  string $term
-	 * @param  string $country
+	 * @param  string $category Addon (sub) category.
+	 * @param  string $term     Search terms.
+	 * @param  string $country  Store country.
 	 *
 	 * @return string url parameter string
 	 */
@@ -62,9 +61,9 @@ class WC_Admin_Addons {
 	/**
 	 * Call API to get extensions
 	 *
-	 * @param  string $category
-	 * @param  string $term
-	 * @param  string $country
+	 * @param  string $category Addon (sub) category.
+	 * @param  string $term     Search terms.
+	 * @param  string $country  Store country.
 	 *
 	 * @return array of extensions
 	 */
@@ -103,7 +102,7 @@ class WC_Admin_Addons {
 	/**
 	 * Get section for the addons screen.
 	 *
-	 * @param  string $section_id
+	 * @param  string $section_id Required section ID.
 	 *
 	 * @return object|bool
 	 */
@@ -118,7 +117,7 @@ class WC_Admin_Addons {
 	/**
 	 * Get section content for the addons screen.
 	 *
-	 * @param  string $section_id
+	 * @param  string $section_id Required section ID.
 	 *
 	 * @return array
 	 */
@@ -127,7 +126,8 @@ class WC_Admin_Addons {
 		$section_data = '';
 
 		if ( ! empty( $section->endpoint ) ) {
-			if ( false === ( $section_data = get_transient( 'wc_addons_section_' . $section_id ) ) ) {
+			$section_data = get_transient( 'wc_addons_section_' . $section_id );
+			if ( false === $section_data ) {
 				$raw_section = wp_safe_remote_get( esc_url_raw( $section->endpoint ), array( 'user-agent' => 'WooCommerce Addons Page' ) );
 
 				if ( ! is_wp_error( $raw_section ) ) {
@@ -172,7 +172,8 @@ class WC_Admin_Addons {
 				'utm_medium'   => 'product',
 				'utm_campaign' => 'woocommerceplugin',
 				'utm_content'  => $utm_content,
-			), $url
+			),
+			$url
 		);
 
 		echo '<a href="' . esc_url( $url ) . '" class="add-new-h2">' . esc_html( $text ) . '</a>' . "\n";
@@ -181,7 +182,7 @@ class WC_Admin_Addons {
 	/**
 	 * Handles the outputting of a banner block.
 	 *
-	 * @param object $block
+	 * @param object $block Banner data.
 	 */
 	public static function output_banner_block( $block ) {
 		?>
@@ -218,7 +219,7 @@ class WC_Admin_Addons {
 	/**
 	 * Handles the outputting of a column.
 	 *
-	 * @param object $block
+	 * @param object $block Column data.
 	 */
 	public static function output_column( $block ) {
 		if ( isset( $block->container ) && 'column_container_start' === $block->container ) {
@@ -245,7 +246,7 @@ class WC_Admin_Addons {
 	/**
 	 * Handles the outputting of a column block.
 	 *
-	 * @param object $block
+	 * @param object $block Column block data.
 	 */
 	public static function output_column_block( $block ) {
 		?>
@@ -281,7 +282,7 @@ class WC_Admin_Addons {
 	/**
 	 * Handles the outputting of a small light block.
 	 *
-	 * @param object $block
+	 * @param object $block Block data.
 	 */
 	public static function output_small_light_block( $block ) {
 		?>
@@ -309,7 +310,7 @@ class WC_Admin_Addons {
 	/**
 	 * Handles the outputting of a small dark block.
 	 *
-	 * @param object $block
+	 * @param object $block Block data.
 	 */
 	public static function output_small_dark_block( $block ) {
 		?>
@@ -341,7 +342,7 @@ class WC_Admin_Addons {
 	/**
 	 * Handles the outputting of the WooCommerce Services banner block.
 	 *
-	 * @param object $block
+	 * @param object $block Block data.
 	 */
 	public static function output_wcs_banner_block( $block = array() ) {
 		$is_active = is_plugin_active( 'woocommerce-services/woocommerce-services.php' );
@@ -382,7 +383,8 @@ class WC_Admin_Addons {
 					'title'       => __( 'Show Canada Post shipping rates', 'woocommerce' ),
 					'description' => __( 'Display live rates from Canada Post at checkout to make shipping a breeze. Powered by WooCommerce Services.', 'woocommerce' ),
 					'logos'       => array_merge(
-						$defaults['logos'], array(
+						$defaults['logos'],
+						array(
 							array(
 								'link' => WC()->plugin_url() . '/assets/images/wcs-canada-post-logo.jpg',
 								'alt'  => 'Canada Post logo',
@@ -394,7 +396,8 @@ class WC_Admin_Addons {
 			case 'US':
 				$local_defaults = array(
 					'logos' => array_merge(
-						$defaults['logos'], array(
+						$defaults['logos'],
+						array(
 							array(
 								'link' => WC()->plugin_url() . '/assets/images/wcs-usps-logo.png',
 								'alt'  => 'USPS logo',
@@ -440,13 +443,13 @@ class WC_Admin_Addons {
 				?>
 			</div>
 		</div>
-	<?php
+		<?php
 	}
 
 	/**
 	 * Handles the outputting of featured sections
 	 *
-	 * @param array $sections
+	 * @param array $sections Section data.
 	 */
 	public static function output_featured_sections( $sections ) {
 		foreach ( $sections as $section ) {
@@ -479,10 +482,10 @@ class WC_Admin_Addons {
 	/**
 	 * Outputs a button.
 	 *
-	 * @param string $url
-	 * @param string $text
-	 * @param string $theme
-	 * @param string $plugin
+	 * @param string $url    Destination URL.
+	 * @param string $text   Button label text.
+	 * @param string $theme  Button style class (not to be confused with WP theme!).
+	 * @param string $plugin The plugin the button is promoting.
 	 */
 	public static function output_button( $url, $text, $theme, $plugin = '' ) {
 		$theme = __( 'Free', 'woocommerce' ) === $text ? 'addons-button-outline-green' : $theme;
@@ -502,6 +505,9 @@ class WC_Admin_Addons {
 	 * Handles output of the addons page in admin.
 	 */
 	public static function output() {
+		$section = isset( $_GET['section'] ) ? sanitize_text_field( wp_unslash( $_GET['section'] ) ) : '_featured';
+		$search = isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '';
+
 		if ( isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
 			do_action( 'woocommerce_helper_output' );
 			return;
@@ -513,12 +519,12 @@ class WC_Admin_Addons {
 
 		$sections        = self::get_sections();
 		$theme           = wp_get_theme();
-		$current_section = isset( $_GET['section'] ) ? sanitize_text_field( $_GET['section'] ) : '_featured';
+		$current_section = isset( $_GET['section'] ) ? $section : '_featured';
 		$addons          = array();
 
 		if ( '_featured' !== $current_section ) {
-			$category = isset( $_GET['section'] ) ? $_GET['section'] : null;
-			$term     = isset( $_GET['search'] ) ? $_GET['search'] : null;
+			$category = $section ? $section : null;
+			$term     = $search ? $search : null;
 			$country  = WC()->countries->get_base_country();
 			$addons   = self::get_extension_data( $category, $term, $country );
 		}
@@ -555,7 +561,7 @@ class WC_Admin_Addons {
 	/**
 	 * Should an extension be shown on the featured page.
 	 *
-	 * @param object $item
+	 * @param object $item Item data.
 	 * @return boolean
 	 */
 	public static function show_extension( $item ) {

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -480,6 +480,24 @@ class WC_Admin_Addons {
 	}
 
 	/**
+	 * Add in-app-purchase URL params to link.
+	 *
+	 * Adds various url parameters to a url to support a streamlined
+	 * flow for obtaining and setting up WooCommerce extensons.
+	 *
+	 * @param string $url    Destination URL.
+	 */
+	public static function add_in_app_purchase_url_params( $url ) {
+		return add_query_arg(
+			array(
+				'in-app-purchase-site'        => site_url(),
+				'in-app-purchase-woo-version' => WC_VERSION,
+			),
+			$url
+		);
+	}
+
+	/**
 	 * Outputs a button.
 	 *
 	 * @param string $url    Destination URL.
@@ -491,13 +509,7 @@ class WC_Admin_Addons {
 		$theme = __( 'Free', 'woocommerce' ) === $text ? 'addons-button-outline-green' : $theme;
 		$theme = is_plugin_active( $plugin ) ? 'addons-button-installed' : $theme;
 		$text  = is_plugin_active( $plugin ) ? __( 'Installed', 'woocommerce' ) : $text;
-		$url   = add_query_arg(
-			array(
-				'in-app-purchase-site'        => site_url(),
-				'in-app-purchase-woo-version' => WC_VERSION,
-			),
-			$url
-		);
+		$url   = self::add_in_app_purchase_url_params( $url );
 		?>
 		<a
 			class="addons-button <?php echo esc_attr( $theme ); ?>"

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -480,6 +480,16 @@ class WC_Admin_Addons {
 	}
 
 	/**
+	 * Returns in-app-purchase URL params.
+	 */
+	public static function get_in_app_purchase_url_params() {
+		return array(
+			'in-app-purchase-site'        => site_url(),
+			'in-app-purchase-woo-version' => WC_VERSION,
+		);
+	}
+
+	/**
 	 * Add in-app-purchase URL params to link.
 	 *
 	 * Adds various url parameters to a url to support a streamlined
@@ -489,10 +499,7 @@ class WC_Admin_Addons {
 	 */
 	public static function add_in_app_purchase_url_params( $url ) {
 		return add_query_arg(
-			array(
-				'in-app-purchase-site'        => site_url(),
-				'in-app-purchase-woo-version' => WC_VERSION,
-			),
+			self::get_in_app_purchase_url_params(),
 			$url
 		);
 	}

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -483,10 +483,12 @@ class WC_Admin_Addons {
 	 * Returns in-app-purchase URL params.
 	 */
 	public static function get_in_app_purchase_url_params() {
-		$back_admin_path = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+		// Get url (from path onward) for the current page,
+		// so WCCOM "back" link returns user to where they were.
+		$back_admin_path = add_query_arg( array() );
 		return array(
 			'in-app-purchase-site'        => site_url(),
-			'in-app-purchase-back'        => $back_admin_path,
+			'in-app-purchase-back'        => esc_url( $back_admin_path ),
 			'in-app-purchase-woo-version' => WC_VERSION,
 		);
 	}

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -511,17 +511,17 @@ class WC_Admin_Addons {
 	 *
 	 * @param string $url    Destination URL.
 	 * @param string $text   Button label text.
-	 * @param string $theme  Button style class (not to be confused with WP theme!).
+	 * @param string $style  Button style class.
 	 * @param string $plugin The plugin the button is promoting.
 	 */
-	public static function output_button( $url, $text, $theme, $plugin = '' ) {
-		$theme = __( 'Free', 'woocommerce' ) === $text ? 'addons-button-outline-green' : $theme;
-		$theme = is_plugin_active( $plugin ) ? 'addons-button-installed' : $theme;
+	public static function output_button( $url, $text, $style, $plugin = '' ) {
+		$style = __( 'Free', 'woocommerce' ) === $text ? 'addons-button-outline-green' : $style;
+		$style = is_plugin_active( $plugin ) ? 'addons-button-installed' : $style;
 		$text  = is_plugin_active( $plugin ) ? __( 'Installed', 'woocommerce' ) : $text;
 		$url   = self::add_in_app_purchase_url_params( $url );
 		?>
 		<a
-			class="addons-button <?php echo esc_attr( $theme ); ?>"
+			class="addons-button <?php echo esc_attr( $style ); ?>"
 			href="<?php echo esc_url( $url ); ?>">
 			<?php echo esc_html( $text ); ?>
 		</a>

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -491,6 +491,13 @@ class WC_Admin_Addons {
 		$theme = __( 'Free', 'woocommerce' ) === $text ? 'addons-button-outline-green' : $theme;
 		$theme = is_plugin_active( $plugin ) ? 'addons-button-installed' : $theme;
 		$text  = is_plugin_active( $plugin ) ? __( 'Installed', 'woocommerce' ) : $text;
+		$url   = add_query_arg(
+			array(
+				'in-app-purchase-site'        => site_url(),
+				'in-app-purchase-woo-version' => WC_VERSION,
+			),
+			$url
+		);
 		?>
 		<a
 			class="addons-button <?php echo esc_attr( $theme ); ?>"

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -483,8 +483,10 @@ class WC_Admin_Addons {
 	 * Returns in-app-purchase URL params.
 	 */
 	public static function get_in_app_purchase_url_params() {
+		$back_admin_path = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 		return array(
 			'in-app-purchase-site'        => site_url(),
+			'in-app-purchase-back'        => $back_admin_path,
 			'in-app-purchase-woo-version' => WC_VERSION,
 		);
 	}

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -454,6 +454,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 						'dismissed_suggestions'    => WC_Marketplace_Suggestions::get_dismissed_suggestions(),
 						'suggestions_data'         => WC_Marketplace_Suggestions::get_suggestions_api_data(),
 						'manage_suggestions_url'   => admin_url( 'admin.php?page=wc-settings&tab=advanced&section=woocommerce_com' ),
+						'in_app_purchase_params'   => WC_Admin_Addons::get_in_app_purchase_url_params(),
 						'i18n_marketplace_suggestions_default_cta'
 							=> esc_html__( 'Learn More', 'woocommerce' ),
 						'i18n_marketplace_suggestions_dismiss_tooltip'

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -96,7 +96,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				}
 				?>
 				<li class="product">
-					<a href="<?php echo esc_attr( $addon->link ); ?>">
+					<a href="<?php echo esc_attr( WC_Admin_Addons::add_in_app_purchase_url_params( $addon->link ) ); ?>">
 						<?php if ( ! empty( $addon->image ) ) : ?>
 							<span class="product-img-wrap"><img src="<?php echo esc_url( $addon->image ); ?>"/></span>
 						<?php else : ?>

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -2,9 +2,11 @@
 /**
  * Admin View: Page - Addons
  *
+ * @package WooCommerce/Admin
  * @var string $view
  * @var object $addons
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -12,16 +14,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div class="wrap woocommerce wc_addons_wrap">
 	<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
-		<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons' ) ); ?>" class="nav-tab nav-tab-active"><?php _e( 'Browse Extensions', 'woocommerce' ); ?></a>
+		<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons' ) ); ?>" class="nav-tab nav-tab-active"><?php esc_html_e( 'Browse Extensions', 'woocommerce' ); ?></a>
 
 		<?php
 			$count_html = WC_Helper_Updater::get_updates_count_html();
+			// translators: Count of updates for WooCommerce.com subscriptions.
 			$menu_title = sprintf( __( 'WooCommerce.com Subscriptions %s', 'woocommerce' ), $count_html );
 		?>
-		<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>" class="nav-tab"><?php echo $menu_title; ?></a>
+		<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>" class="nav-tab"><?php echo esc_html( $menu_title ); ?></a>
 	</nav>
 
-	<h1 class="screen-reader-text"><?php _e( 'WooCommerce Extensions', 'woocommerce' ); ?></h1>
+	<h1 class="screen-reader-text"><?php esc_html_e( 'WooCommerce Extensions', 'woocommerce' ); ?></h1>
 
 	<?php if ( $sections ) : ?>
 		<ul class="subsubsub">
@@ -29,7 +32,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				<li>
 					<a
 						class="<?php echo $current_section === $section->slug ? 'current' : ''; ?>"
-						href="<?php echo admin_url( 'admin.php?page=wc-addons&section=' . esc_attr( $section->slug ) ); ?>">
+						href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=' . esc_attr( $section->slug ) ) ); ?>">
 						<?php echo esc_html( $section->label ); ?>
 					</a>
 				</li>
@@ -38,7 +41,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 		<?php if ( isset( $_GET['search'] ) ) : ?>
 			<h1 class="search-form-title" >
-				<?php printf( __( 'Showing search results for: %s', 'woocommerce' ), '<strong>' . esc_html( $_GET['search'] ) . '</strong>' ); ?>
+				<?php printf( esc_html( 'Showing search results for: %s', 'woocommerce' ), '<strong>' . esc_html( sanitize_text_field( wp_unslash( $_GET['search'] ) ) ) . '</strong>' ); ?>
 			</h1>
 		<?php endif; ?>
 
@@ -49,10 +52,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<input
 				type="text"
 				name="search"
-				value="<?php echo esc_attr( isset( $_GET['search'] ) ? $_GET['search'] : '' ); ?>"
-				placeholder="<?php _e( 'Enter a search term and press enter', 'woocommerce' ); ?>">
+				value="<?php echo esc_attr( isset( $_GET['search'] ) ? sanitize_text_field( wp_unslash( $_GET['search'] ) ) : '' ); ?>"
+				placeholder="<?php esc_html_e( 'Enter a search term and press enter', 'woocommerce' ); ?>">
 			<input type="hidden" name="page" value="wc-addons">
-			<?php $page_section = ( isset( $_GET['section'] ) && '_featured' !== $_GET['section'] ) ? $_GET['section'] : '_all'; ?>
+			<?php $page_section = ( isset( $_GET['section'] ) && '_featured' !== $_GET['section'] ) ? sanitize_text_field( wp_unslash( $_GET['section'] ) ) : '_all'; ?>
 			<input type="hidden" name="section" value="<?php echo esc_attr( $page_section ); ?>">
 		</form>
 		<?php if ( '_featured' === $current_section ) : ?>
@@ -76,14 +79,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 					$country = WC()->countries->get_base_country();
 					if ( 'US' === $country
 						&& false !== strpos(
-							$addon->link, 'woocommerce.com/products/usps-shipping-method'
+							$addon->link,
+							'woocommerce.com/products/usps-shipping-method'
 						)
 					) {
 						continue;
 					}
 					if ( 'CA' === $country
 						&& false !== strpos(
-							$addon->link, 'woocommerce.com/products/canada-post-shipping-method'
+							$addon->link,
+							'woocommerce.com/products/canada-post-shipping-method'
 						)
 					) {
 						continue;
@@ -105,18 +110,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</ul>
 		<?php endif; ?>
 	<?php else : ?>
-		<p><?php printf( __( 'Our catalog of WooCommerce Extensions can be found on WooCommerce.com here: <a href="%s">WooCommerce Extensions Catalog</a>', 'woocommerce' ), 'https://woocommerce.com/product-category/woocommerce-extensions/' ); ?></p>
+		<?php /* translators: a url */ ?>
+		<p><?php printf( esc_html__( 'Our catalog of WooCommerce Extensions can be found on WooCommerce.com here: <a href="%s">WooCommerce Extensions Catalog</a>', 'woocommerce' ), 'https://woocommerce.com/product-category/woocommerce-extensions/' ); ?></p>
 	<?php endif; ?>
 
 	<?php if ( 'Storefront' !== $theme['Name'] && '_featured' !== $current_section ) : ?>
 		<div class="storefront">
-			<a href="<?php echo esc_url( 'https://woocommerce.com/storefront/' ); ?>" target="_blank"><img src="<?php echo WC()->plugin_url(); ?>/assets/images/storefront.png" alt="Storefront" /></a>
-			<h2><?php _e( 'Looking for a WooCommerce theme?', 'woocommerce' ); ?></h2>
-			<p><?php _e( 'We recommend Storefront, the <em>official</em> WooCommerce theme.', 'woocommerce' ); ?></p>
-			<p><?php _e( 'Storefront is an intuitive, flexible and <strong>free</strong> WordPress theme offering deep integration with WooCommerce and many of the most popular customer-facing extensions.', 'woocommerce' ); ?></p>
+			<a href="<?php echo esc_url( 'https://woocommerce.com/storefront/' ); ?>" target="_blank"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/storefront.png" alt="Storefront" /></a>
+			<h2><?php esc_html_e( 'Looking for a WooCommerce theme?', 'woocommerce' ); ?></h2>
+			<p><?php esc_html_e( 'We recommend Storefront, the <em>official</em> WooCommerce theme.', 'woocommerce' ); ?></p>
+			<p><?php esc_html_e( 'Storefront is an intuitive, flexible and <strong>free</strong> WordPress theme offering deep integration with WooCommerce and many of the most popular customer-facing extensions.', 'woocommerce' ); ?></p>
 			<p>
-				<a href="https://woocommerce.com/storefront/" target="_blank" class="button"><?php _e( 'Read all about it', 'woocommerce' ); ?></a>
-				<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'update.php?action=install-theme&theme=storefront' ), 'install-theme_storefront' ) ); ?>" class="button button-primary"><?php _e( 'Download &amp; install', 'woocommerce' ); ?></a>
+				<a href="https://woocommerce.com/storefront/" target="_blank" class="button"><?php esc_html_e( 'Read all about it', 'woocommerce' ); ?></a>
+				<a href="<?php echo esc_url( wp_nonce_url( self_admin_url( 'update.php?action=install-theme&theme=storefront' ), 'install-theme_storefront' ) ); ?>" class="button button-primary"><?php esc_html_e( 'Download &amp; install', 'woocommerce' ); ?></a>
 			</p>
 		</div>
 	<?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Adds new url parameters to buttons/links to marketplace (from extensions page or suggestions). These will be used to trigger a more streamlined purchase experience (still in development).

The new params are:

```php
// Site base url – protocol, host & path
'in-app-purchase-site'        => site_url(),
// Url fragment (path onward) for current page, for smart "back" behaviour
'in-app-purchase-back'        => $_SERVER['REQUEST_URI'],
// The version of Woo core running on the site
'in-app-purchase-woo-version' => WC_VERSION,
```

The site URL is used as a trigger for the new experience, and to ensure "back to my site" links work nicely (along with back fragment).

The version is passed so that WooCommerce.com knows site version for the request and we can ensure compatibility of interfaces between WooCommerce sites and WooCommerce.com.

Marketplace Suggestions CTA links now open in the same tab by default (except for in product edit page). 

Note that this PR also includes quite a few linter fixes for two PHP files to bring them up to standards. Because of this, we'll need to carefully test related functionality (particularly the Woo Extensions screen).

### How to test the changes in this Pull Request:
1. Clone this branch on a local WooCommerce test site.
2. View extensions page; should see new url params on all linkout buttons (on all tabs/categories).
3. View products empty state, orders empty state, or product edit suggestions; url params should be on all CTA buttons.

Also general testing of Woo Extensions / Addons screen, as there are extensive linter fixes on related files.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Support for an improved browse and purchase experience on WooCommerce.com Marketplace (in progress).