### PR TITLE
Fix CI unit tests on PHP 5.6 and PHP 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,9 +60,6 @@ before_script:
       bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION
       composer global require "phpunit/phpunit=4.8.*|6.5.*"
     fi
-  - |
-    # Install wpcs globally:
-    composer require woocommerce/woocommerce-sniffs
 
 script:
   - bash tests/bin/phpunit.sh

--- a/composer.lock
+++ b/composer.lock
@@ -1040,7 +1040,7 @@
                 "ext-libxml": "*",
                 "ext-mbstring": "*",
                 "ext-xml": "*",
-                "myclabs/deep-copy": "^1.6.1",
+                "myclabs/deep-copy": "1.7.0",
                 "phar-io/manifest": "^1.0.1",
                 "phar-io/version": "^1.0",
                 "php": "^7.0",

--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -5,6 +5,9 @@ if [[ ${RUN_PHPCS} == 1 ]]; then
 	IGNORE="tests/cli/,includes/libraries/,includes/api/legacy/"
 
 	if [ "$CHANGED_FILES" != "" ]; then
+		# Install wpcs globally:
+    	composer require woocommerce/woocommerce-sniffs
+
 		echo "Running Code Sniffer."
 		./vendor/bin/phpcs --ignore=$IGNORE --encoding=utf-8 -s -n -p $CHANGED_FILES
 	fi


### PR DESCRIPTION
Changes:
- New myclabs-deep-copy does not run on PHP < 7.1, so pinned version 1.7.0
- woocommerce-sniffs require php >=7.0, so install it only when running PHP CS.