### PR TITLE
Fixed highlighted "Recommended items" on Setup Wizard 

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1394,6 +1394,7 @@ p.jetpack-terms {
 .wc-setup-content .recommended-item {
 	list-style: none;
 	margin-bottom: 1.5em;
+	padding-bottom: 0;
 
 	&:last-child {
 		margin-bottom: 0; // Avoid extra space at the end of the list.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There's extra padding in the recommended items on the Setup Wizard, this make the background invade any item below, reported by @timmyc in https://github.com/woocommerce/woocommerce/pull/24058#pullrequestreview-259026088

Example:
![60827215-8adc3680-a164-11e9-8df8-74518ba7b4d6](https://user-images.githubusercontent.com/1264099/60839118-c39b0080-a1a2-11e9-8fe1-21f263f69585.gif)

### How to test the changes in this Pull Request:

1. Go the `wp-admin/index.php?page=wc-setup&step=recommended` and hover any link at below "The following plugins will be installed and activated for you:", see that is background invade other items.
2. Apply this patch and run `grunt css`.
3. Check the links again, the background shows up just fine.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed highlighted "Recommended items" on Setup Wizard 
