### PR TITLE
Added arguments to filter `woocommerce_ajax_order_item`

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -900,7 +900,7 @@ class WC_AJAX {
 				}
 
 				$item_id                 = $order->add_product( $product, $qty );
-				$item                    = apply_filters( 'woocommerce_ajax_order_item', $order->get_item( $item_id ), $item_id );
+				$item                    = apply_filters( 'woocommerce_ajax_order_item', $order->get_item( $item_id ), $item_id, $order, $product );
 				$added_items[ $item_id ] = $item;
 				$order_notes[ $item_id ] = $product->get_formatted_name();
 


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request
Added arguments `$order` and `$product` to filter `woocommerce_ajax_order_item`. That will allow 3rd parties to get that information without having to initalise new instances by calling `$item->get_order()` and `$item->get_product()`.

Ref. https://github.com/woocommerce/woocommerce/issues/24107

### How to test the changes in this Pull Request:
1. Add a filter for hook `woocommerce_ajax_order_item`, accepting 4 arguments:
  * Order item
  * Item ID
  * Order
  * Product
2. Create or edit an order in the backend.
3. Add product to the order.
4. Filter `woocommerce_ajax_order_item` should now receive four arguments, including order and product.

### Other information:
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry
Added $order and $product as parameters to filter "woocommerce_ajax_order_item".

