### PR TITLE
Add tag_operator to products shortcode

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -125,6 +125,7 @@ class WC_Shortcode_Products {
 				'terms'          => '',        // Comma separated term slugs or ids.
 				'terms_operator' => 'IN',      // Operator to compare terms. Possible values are 'IN', 'NOT IN', 'AND'.
 				'tag'            => '',        // Comma separated tag slugs.
+				'tag_operator'   => 'IN',      // Operator to compare tags. Possible values are 'IN', 'NOT IN', 'AND'.
 				'visibility'     => 'visible', // Product visibility setting. Possible values are 'visible', 'catalog', 'search', 'hidden'.
 				'class'          => '',        // HTML class.
 				'page'           => 1,         // Page for pagination.
@@ -369,7 +370,7 @@ class WC_Shortcode_Products {
 				'taxonomy' => 'product_tag',
 				'terms'    => array_map( 'sanitize_title', explode( ',', $this->attributes['tag'] ) ),
 				'field'    => 'slug',
-				'operator' => 'IN',
+				'operator' => $this->attributes['tag_operator'],
 			);
 		}
 	}


### PR DESCRIPTION
Allow user to decide how products are filtered by tag, instead of defaulting to IN

I've made these changes on my own woocommerce shop because I needed to display products with multiple tags, but must contain ALL tags. I was surprised to see ``terms_operator`` and ``cat_operator`` but no ``tag_operator``.

I can't seem to find any other PR or issue that describes this, or maybe there was some sort of reason for not implementing this. I figure this would help people in the future who share my issue.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Use shortcode ``[products tag='tag1,tag2' tag_operator='AND']``

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

- Added ``tag_operator`` to ``[products]`` shortcode attributes, mimics ``terms_operator`` and ``cat_operator``
- Changed the original operator to pull from the new ``tag_operator`` attribute
