### PR TITLE
Fix Tax Class table initialization

### DIFF
--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -140,7 +140,7 @@ class WC_Settings_Tax extends WC_Settings_Page {
 	 * @return null
 	 */
 	public function save_tax_classes( $raw_tax_classes ) {
-		$tax_classes          = array_map( 'trim', explode( "\n", $raw_tax_classes ) );
+		$tax_classes          = array_filter( array_map( 'trim', explode( "\n", $raw_tax_classes ) ) );
 		$existing_tax_classes = WC_Tax::get_tax_classes();
 		$removed              = array_diff( $existing_tax_classes, $tax_classes );
 		$added                = array_diff( $tax_classes, $existing_tax_classes );

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -918,6 +918,7 @@ CREATE TABLE {$wpdb->prefix}wc_tax_rate_classes (
 		$tables = array(
 			"{$wpdb->prefix}wc_download_log",
 			"{$wpdb->prefix}wc_product_meta_lookup",
+			"{$wpdb->prefix}wc_tax_rate_classes",
 			"{$wpdb->prefix}wc_webhooks",
 			"{$wpdb->prefix}woocommerce_api_keys",
 			"{$wpdb->prefix}woocommerce_attribute_taxonomies",

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -258,8 +258,8 @@ class WC_Install {
 
 		WC()->wpdb_table_fix();
 		self::remove_admin_notices();
-		self::create_options();
 		self::create_tables();
+		self::create_options();
 		self::create_roles();
 		self::setup_environment();
 		self::create_terms();

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -703,6 +703,13 @@ class WC_Install {
 			$collate = $wpdb->get_charset_collate();
 		}
 
+		/*
+		 * Indexes have a maximum size of 767 bytes. Historically, we haven't need to be concerned about that.
+		 * As of WP 4.2, however, they moved to utf8mb4, which uses 4 bytes per character. This means that an index which
+		 * used to have room for floor(767/3) = 255 characters, now only has room for floor(767/4) = 191 characters.
+		 */
+		$max_index_length = 191;
+
 		$tables = "
 CREATE TABLE {$wpdb->prefix}woocommerce_sessions (
   session_id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
@@ -903,7 +910,7 @@ CREATE TABLE {$wpdb->prefix}wc_tax_rate_classes (
   name varchar(200) NOT NULL DEFAULT '',
   slug varchar(200) NOT NULL DEFAULT '',
   PRIMARY KEY  (tax_rate_class_id),
-  UNIQUE KEY slug (slug)
+  UNIQUE KEY slug (slug($max_index_length))
 ) $collate;
 		";
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -525,6 +525,10 @@ class WC_Install {
 		add_option( 'woocommerce_thumbnail_image_width', '300', '', 'yes' );
 		add_option( 'woocommerce_checkout_highlight_required_fields', 'yes', '', 'yes' );
 		add_option( 'woocommerce_demo_store', 'no', '', 'no' );
+
+		// Define initial tax classes.
+		WC_Tax::create_tax_class( __( 'Reduced rate', 'woocommerce' ) );
+		WC_Tax::create_tax_class( __( 'Zero rate', 'woocommerce' ) );
 	}
 
 	/**

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -763,6 +763,10 @@ class WC_Tax {
 	public static function create_tax_class( $name, $slug = '' ) {
 		global $wpdb;
 
+		if ( empty( $name ) ) {
+			return new WP_Error( 'tax_class_invalid_name', __( 'Tax class requires a valid name', 'woocommerce' ) );
+		}
+
 		$existing       = self::get_tax_classes();
 		$existing_slugs = self::get_tax_class_slugs();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the initialization of the new Tax Class table:

1. Missing initial data, required initial "Reduced rate" and "Zero rate" entries.
2. Incorrect order of methods inside `WC_Install::install()`, tables need to be created before options, since we tax class table inside options.
3. Fixed missing entry in `WC_Install::get_tables()`.
4. Fixed unit tests (all of the above correct unit tests).
5. Prevent saving empty tax classes into the database, this generate a bug in the administrative interface, making impossible to edit tax classes options if some is saved as empty.
6. Also allows exclude all "custom" tax classes (also generated the problems described above).

### How to test the changes in this Pull Request:

1. Run unit tests.
2. Try install or update a current installation enabling taxes (may need to disable and enable again).
3. Try removing all tax classes, and then create new ones.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

No need for a changelog, since fixes bugs introduced in #23093
