### PR TITLE
Fix failing WC_Shortcode_Product unit tests

### DIFF
--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -207,7 +207,7 @@ PHP
 		php wp-cli.phar search-replace "http://local.wordpress.test" "$WP_SITE_URL"
 		php wp-cli.phar theme install twentytwelve --activate
 		php wp-cli.phar plugin install https://github.com/$REPO/archive/$BRANCH.zip --activate
-
+		php wp-cli.phar wc update
 		cd "$WORKING_DIR"
 
 	fi

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -17,7 +17,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$shortcode = new WC_Shortcode_Products();
 		$expected  = array(
 			'limit'          => '-1',
-			'columns'        => '4',
+			'columns'        => 4,
 			'orderby'        => 'title',
 			'order'          => 'ASC',
 			'ids'            => '',
@@ -27,6 +27,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'attribute'      => '',
 			'terms'          => '',
 			'terms_operator' => 'IN',
+			'tag'            => '',
+			'tag_operator'   => 'IN',
 			'visibility'     => 'visible',
 			'class'          => '',
 			'rows'           => '',
@@ -55,6 +57,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'attribute'      => '',
 			'terms'          => '',
 			'terms_operator' => 'IN',
+			'tag'            => '',
+			'tag_operator'   => 'IN',
 			'visibility'     => 'visible',
 			'class'          => '',
 			'rows'           => '',


### PR DESCRIPTION
This PR fixes the failing unit tests caused by changes to the default attributes of the WC_Shortcode_Product class in #24111 