### PR TITLE
Fix-24115, Downloads report not getting 503 any more, If previously d…

### DIFF
--- a/includes/admin/reports/class-wc-report-downloads.php
+++ b/includes/admin/reports/class-wc-report-downloads.php
@@ -164,8 +164,8 @@ class WC_Report_Downloads extends WP_List_Table {
 					// File information.
 					$file = $product->get_file( $permission->get_download_id() );
 
-					if( false === $file ){
-						echo esc_html__( 'File not exists', 'woocommerce' );
+					if ( false === $file ) {
+						echo esc_html__( 'File does not exist', 'woocommerce' );
 					} else {
 						echo esc_html( $file->get_name() . ' - ' . basename( $file->get_file() ) );
 

--- a/includes/admin/reports/class-wc-report-downloads.php
+++ b/includes/admin/reports/class-wc-report-downloads.php
@@ -164,11 +164,15 @@ class WC_Report_Downloads extends WP_List_Table {
 					// File information.
 					$file = $product->get_file( $permission->get_download_id() );
 
-					echo esc_html( $file->get_name() . ' - ' . basename( $file->get_file() ) );
+					if( false === $file ){
+						echo esc_html__( 'File not exists', 'woocommerce' );
+					} else {
+						echo esc_html( $file->get_name() . ' - ' . basename( $file->get_file() ) );
 
-					echo '<div class="row-actions">';
-					echo '<a href="' . esc_url( add_query_arg( 'download_id', $permission->get_download_id() ) ) . '">' . esc_html__( 'Filter by file', 'woocommerce' ) . '</a>';
-					echo '</div>';
+						echo '<div class="row-actions">';
+						echo '<a href="' . esc_url( add_query_arg( 'download_id', $permission->get_download_id() ) ) . '">' . esc_html__( 'Filter by file', 'woocommerce' ) . '</a>';
+						echo '</div>';
+					}
 				}
 				break;
 			case 'order':


### PR DESCRIPTION
#24115 I have tested this one and found as a bug, Which I resolved by this PR. Kindly review and let me know if there are any changes required.

Downloads report not getting 503 any more, If previously downloaded files are removed from the product then I have added a simple message like File not exists instead of the file name.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Closes #24115 