### PR TITLE
add filter for product import image separator

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -531,7 +531,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		}
 
 		$images    = array();
-		$separator = apply_filters( 'woocommerce_product_import_image_separator', ',' ); 
+		$separator = apply_filters( 'woocommerce_product_import_image_separator', ',' );
 
 		foreach ( $this->explode_values( $value, $separator ) as $image ) {
 			if ( stristr( $image, '://' ) ) {

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -530,9 +530,10 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			return array();
 		}
 
-		$images = array();
+		$images    = array();
+		$separator = apply_filters( 'woocommerce_product_import_image_separator', ',' ); 
 
-		foreach ( $this->explode_values( $value ) as $image ) {
+		foreach ( $this->explode_values( $value, $separator ) as $image ) {
 			if ( stristr( $image, '://' ) ) {
 				$images[] = esc_url_raw( $image );
 			} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the `woocommerce_product_import_image_separator` filter to allow the import image separator to be changed. This will allow importing images with a comma in the file name.

Closes #24110 .

### How to test the changes in this Pull Request:

1. Add the following filter
```
add_filter( 'woocommerce_product_import_image_separator', function() {
	return '|';
});
```
2. Edit a product import file to include multiple images separated by `|`.
3. Run the import
4. Check the imported product for images

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add filter for product import image separator
