### PR TITLE
#24124 -- Partially Satisfied

### DIFF
--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -2195,6 +2195,11 @@ p.demo_store,
 					background-image: url("../images/icons/credit-cards/discover.svg");
 				}
 			}
+			
+			.wc-credit-card-form-card-number:valid {
+				font-weight: bold;
+				color: #57bf6d;
+			}
 
 			span.help {
 				font-size: 0.857em;

--- a/includes/gateways/class-wc-payment-gateway-cc.php
+++ b/includes/gateways/class-wc-payment-gateway-cc.php
@@ -64,8 +64,8 @@ class WC_Payment_Gateway_CC extends WC_Payment_Gateway {
 
 		$default_fields = array(
 			'card-number-field' => '<p class="form-row form-row-wide">
-				<label for="' . esc_attr( $this->id ) . '-card-number">' . esc_html__( 'Card number', 'woocommerce' ) . '&nbsp;<span class="required">*</span></label>
-				<input id="' . esc_attr( $this->id ) . '-card-number" class="input-text wc-credit-card-form-card-number" inputmode="numeric" autocomplete="cc-number" autocorrect="no" autocapitalize="no" spellcheck="no" type="tel" placeholder="&bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull;" ' . $this->field_name( 'card-number' ) . ' />
+				<label for="' . esc_attr( $this->id ) . '-card-number">' . esc_html__( 'Card number', 'woocommerce' ) . '&nbsp;(&bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull;)&nbsp;<span class="required">*</span></label>
+				<input id="' . esc_attr( $this->id ) . '-card-number" class="input-text wc-credit-card-form-card-number" inputmode="numeric" autocomplete="cc-number" autocorrect="no" autocapitalize="no" spellcheck="no" type="tel" placeholder="&bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull; &bull;&bull;&bull;&bull;" pattern="\d{4}( )?\d{4}( )?\d{4}( )?\d{4}(\d{1,3})?" maxlength="19" ' . $this->field_name( 'card-number' ) . ' />
 			</p>',
 			'card-expiry-field' => '<p class="form-row form-row-first">
 				<label for="' . esc_attr( $this->id ) . '-card-expiry">' . esc_html__( 'Expiry (MM/YY)', 'woocommerce' ) . '&nbsp;<span class="required">*</span></label>


### PR DESCRIPTION
### All Submissions:

* [X ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Make the checkout page's credit card number field easier to fill out by providing constantly visible example input (in the label), and validation using HTML and CSS for those who don't use JavaScript.

Satisfies most of the requirements of #24124.

### How to test the changes in this Pull Request:

1. Add any product to your cart
2. Visit the checkout page.
3. Select a payment method that will give you the credit card box
4. Start typing numbers into the credit card number field
5. Turn off JavaScript
6. Again start typing numbers into the credit card number field

### Other information:

* [X ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Added HTML and CSS validation to checkout page's credit card number field and made credit card number entry information clearer.
