### PR TITLE
Fix autoprefixer browsers option warning

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -306,7 +306,7 @@ module.exports = function( grunt ) {
 			options: {
 				processors: [
 					require( 'autoprefixer' )({
-						browsers: [
+						overrideBrowserslist: [
 							'> 0.1%',
 							'ie 8',
 							'ie 9'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -305,13 +305,7 @@ module.exports = function( grunt ) {
 		postcss: {
 			options: {
 				processors: [
-					require( 'autoprefixer' )({
-						overrideBrowserslist: [
-							'> 0.1%',
-							'ie 8',
-							'ie 9'
-						]
-					})
+					require( 'autoprefixer' )
 				]
 			},
 			dist: {

--- a/package.json
+++ b/package.json
@@ -85,5 +85,10 @@
       "eslint --fix",
       "git add"
     ]
-  }
+  },
+  "browserslist": [
+    "> 0.1%",
+    "ie 8",
+    "ie 9"
+  ]
 }


### PR DESCRIPTION
This PR fixes a warning when running the grunt css build where we are calling autoprefixer with the browsers option which was deprecated. In this PR the options are moved to the package.json file which is the recommended solution in the autoprefixer documentation.