### PR TITLE
Fix namespaced Jetpack tracks_get_identity

### DIFF
--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -139,7 +139,7 @@ class WC_Tracks_Client {
 	public static function get_identity( $user_id ) {
 		$jetpack_lib = '/tracks/client.php';
 
-		if ( class_exists( 'Jetpack' ) && defined( JETPACK__VERSION ) ) {
+		if ( class_exists( 'Jetpack' ) && defined( 'JETPACK__VERSION' ) ) {
 			if ( version_compare( JETPACK__VERSION, '7.5', '<' ) ) {
 				if ( file_exists( jetpack_require_lib_dir() . $jetpack_lib ) ) {
 					include_once jetpack_require_lib_dir() . $jetpack_lib;
@@ -148,7 +148,8 @@ class WC_Tracks_Client {
 					}
 				}
 			} else {
-				return Automattic\Jetpack\Tracking::tracks_get_identity( $user_id );
+				$tracking = new Automattic\Jetpack\Tracking();
+				return $tracking->tracks_get_identity( $user_id );
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While investigating https://github.com/Automattic/woocommerce-services/issues/1633 I found a similar fix in Woo core in #24050

Unfortunately, it has a few problems:
* `defined( JETPACK__VERSION )` will always return false so the identity will never be retrieved
* `tracks_get_identity` is not a static function, so calling it as such would cause an error

### How to test the changes in this Pull Request:

1. Install Jetpack 7.4 installed and test that no notices are given on tracking requests
2. Install Jetpack 7.5 and test that no notices are given on tracking requests.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
