### PR TITLE
WC_Order::get_formatted_shipping_address refactor

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -889,7 +889,11 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_formatted_shipping_address( $empty_content = '' ) {
-		$address = apply_filters( 'woocommerce_order_formatted_shipping_address', $this->get_address( 'shipping' ), $this );
+		$address = '';
+		if ( $this->has_shipping_address() ) {
+			$address = $this->get_address( 'shipping' );
+		}
+		$address = apply_filters( 'woocommerce_order_formatted_shipping_address', $address, $this );
 
 		if ( $this->has_shipping_address() ) {
 			$address = WC()->countries->get_formatted_address( $address );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
In #23859 a logic bug was introduced which cause the $empty_content param to not be used anymore and a few unit tests to fail. This PR adjusts the logic keeping the functionality in place introduced in #23859
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Ensure unit tests pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
