### PR TITLE
Revert "Prevent negative prices on products"

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -828,7 +828,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param string $price Price.
 	 */
 	public function set_price( $price ) {
-		$this->set_prop( 'price', wc_format_decimal( $price, false, false, true ) );
+		$this->set_prop( 'price', wc_format_decimal( $price ) );
 	}
 
 	/**
@@ -838,7 +838,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param string $price Regular price.
 	 */
 	public function set_regular_price( $price ) {
-		$this->set_prop( 'regular_price', wc_format_decimal( $price, false, false, true ) );
+		$this->set_prop( 'regular_price', wc_format_decimal( $price ) );
 	}
 
 	/**
@@ -848,7 +848,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @param string $price sale price.
 	 */
 	public function set_sale_price( $price ) {
-		$this->set_prop( 'sale_price', wc_format_decimal( $price, false, false, true ) );
+		$this->set_prop( 'sale_price', wc_format_decimal( $price ) );
 	}
 
 	/**

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -281,12 +281,11 @@ function wc_format_refund_total( $amount ) {
  * This function does not remove thousands - this should be done before passing a value to the function.
  *
  * @param  float|string $number     Expects either a float or a string with a decimal separator only (no thousands).
- * @param  bool|integer $dp         Number of decimal points to use, blank to use woocommerce_price_num_decimals, or false to avoid all rounding.
+ * @param  mixed        $dp number  Number of decimal points to use, blank to use woocommerce_price_num_decimals, or false to avoid all rounding.
  * @param  bool         $trim_zeros From end of string.
- * @param  bool         $abs        Converts to absolute value of a number. See PHP abs().
  * @return string
  */
-function wc_format_decimal( $number, $dp = false, $trim_zeros = false, $abs = false ) {
+function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 	$locale   = localeconv();
 	$decimals = array( wc_get_price_decimal_separator(), $locale['decimal_point'], $locale['mon_decimal_point'] );
 
@@ -294,11 +293,6 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false, $abs = fa
 	if ( ! is_float( $number ) ) {
 		$number = str_replace( $decimals, '.', $number );
 		$number = preg_replace( '/[^0-9\.,-]/', '', wc_clean( $number ) );
-	}
-
-	// Convert to absolute number. Avoid empty values to not convert to 0.
-	if ( '' !== $number && $abs ) {
-		$number = abs( $number );
 	}
 
 	if ( false !== $dp ) {

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -311,15 +311,6 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		// Trim zeros and round.
 		$this->assertEquals( '10', wc_format_decimal( 9.9999, '', true ) );
 
-		// Negative values.
-		$this->assertEquals( '-9.9999', wc_format_decimal( -9.9999 ) );
-		$this->assertEquals( '-10.00', wc_format_decimal( -9.9999, '' ) );
-		$this->assertEquals( '-9.991', wc_format_decimal( -9.9912, 3 ) );
-		$this->assertEquals( '-9', wc_format_decimal( -9.00, false, true ) );
-
-		// Convert nevative to absolute value.
-		$this->assertEquals( '9.9999', wc_format_decimal( -9.9999, false, false, true ) );
-
 		// Given string with thousands in german format.
 		update_option( 'woocommerce_price_decimal_sep', ',' );
 		update_option( 'woocommerce_price_thousand_sep', '.' );


### PR DESCRIPTION
This PR reverts #23705 as it is causing unit tests to fail for WC_Product_Query. Lets revisit #23705 again and ensure it does not break any functionality before merging again.

cc @claudiosanches 