### PR TITLE
Fixed jshint problems

### DIFF
--- a/assets/js/frontend/add-to-cart.js
+++ b/assets/js/frontend/add-to-cart.js
@@ -29,12 +29,12 @@ jQuery( function( $ ) {
 		if ( 1 === this.requests.length ) {
 			this.run();
 		}
-	}
+	};
 
 	/**
 	 * Run add to cart events.
 	 */
-	AddToCartHandler.prototype.run = function( e ) {
+	AddToCartHandler.prototype.run = function() {
 		var requestManager = this,
 			originalCallback = requestManager.requests[0].complete;
 
@@ -51,7 +51,7 @@ jQuery( function( $ ) {
 		};
 
 		$.ajax( this.requests[0] );
-	}
+	};
 
 	/**
 	 * Handle the add to cart event.


### PR DESCRIPTION
We had a couple of jshint errors preventing the build of JS assets. This PR should fix that.

```
Running "jshint:all" (jshint) task

   assets/js/frontend/add-to-cart.js
     32 |    }
              ^ Missing semicolon.
     37 |    AddToCartHandler.prototype.run = function( e ) {
                                                        ^ 'e' is defined but never used.
     54 |    }
              ^ Missing semicolon.

>> 3 errors in 43 files
```