### PR TITLE
Bump WP minimum version.

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, kloon, rodrigosprimo, peterfabian1000, vedjain
 Tags: ecommerce, e-commerce, store, sales, sell, shop, cart, checkout, downloadable, downloads, payments, paypal, storefront, stripe, woo commerce, woo
-Requires at least: 4.7
+Requires at least: 4.9
 Tested up to: 5.2
 Requires PHP: 5.6
 Stable tag: 3.6.0


### PR DESCRIPTION
This PR updates the new minimum WP version required to run WooCommerce 3.7 to WordPress 4.9.

Changelog entry is done in #23267 