### PR TITLE
Tweak: only consider orders created via checkout to hold stock

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -307,12 +307,15 @@ function wc_get_held_stock_quantity( $product, $exclude_order_id = 0 ) {
 			"
 			SELECT SUM( order_item_meta.meta_value ) AS held_qty
 			FROM {$wpdb->posts} AS posts
+			LEFT JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
 			LEFT JOIN {$wpdb->prefix}woocommerce_order_items as order_items ON posts.ID = order_items.order_id
 			LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
 			LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta2 ON order_items.order_item_id = order_item_meta2.order_item_id
 			WHERE 	order_item_meta.meta_key    = '_qty'
 			AND 	order_item_meta2.meta_key   = %s
 			AND 	order_item_meta2.meta_value = %d
+			AND		postmeta.meta_key			= '_created_via'
+			AND		postmeta.meta_value			= 'checkout'
 			AND 	posts.post_type             IN ( '" . implode( "','", wc_get_order_types() ) . "' )
 			AND 	posts.post_status           = 'wc-pending'
 			AND		posts.ID                    != %d;",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Plugins may create orders without the meta tag "_created_via"="checkout" for various purposes, e.g. a balance-due order for purchases via deposit, because only the deposit order should reduce stock on checkout. The SUMO Payment Plans plugin does exactly this, but core WC handles such orders inconsistently:
- wc_get_held_stock_quantity() counts their items against held stock, but
- wc_cancel_unpaid_orders() only cancels old orders with a meta tag of "_created_via"="checkout"

This PR fixes that inconsistency, which on my site was preventing a user from adding an in-stock product to her cart, just because a balance-due order for the same product was pending.

Workaround: clear the setting WC > Products > Inventory > Hold Time (default 60 minutes), which inhibits the use of wc_get_held_stock_quantity().

### How to test the changes in this Pull Request:

1. Create a pending order without the _created_via=checkout meta tag for an item with inventory=1.
2. Verify that this order does not inhibit adding the last inventory item to another user's cart.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Tweak: only consider orders created via checkout to hold stock