### PR TITLE
Bump template versions for 3.7

### DIFF
--- a/templates/checkout/thankyou.php
+++ b/templates/checkout/thankyou.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.2.0
+ * @version 3.7.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 
 <div class="woocommerce-order">
 
-	<?php if ( $order ) : 
+	<?php if ( $order ) :
 
 		do_action( 'woocommerce_before_thankyou', $order->get_id() ); ?>
 

--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -12,9 +12,9 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @package 	WooCommerce/Templates
- * @version     3.3.0
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @package     WooCommerce/Templates
+ * @version     3.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
This PR adjusts the template versions for templates that changes but never had their versions updated. I did not fix PHPCS errors so that will likely fail in the travis build.