### PR TITLE
Exclude package vendor folders from checktextdomain call

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -233,7 +233,8 @@ module.exports = function( grunt ) {
 					'!node_modules/**',       // Exclude node_modules/
 					'!tests/**',              // Exclude tests/
 					'!vendor/**',             // Exclude vendor/
-					'!tmp/**'                 // Exclude tmp/
+					'!tmp/**',                // Exclude tmp/
+					'!packages/*/vendor/**'   // Exclude packages/*/vendor
 				],
 				expand: true
 			}


### PR DESCRIPTION
This PR fixes an issue with the release build where it was checking the individual packages' vendor folder when doing checktextdomain. This excludes those folders from the check.