### PR TITLE
Update wording to redirect back to catalog when there's no orders or downloads in My Account

### DIFF
--- a/templates/myaccount/downloads.php
+++ b/templates/myaccount/downloads.php
@@ -12,7 +12,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	https://docs.woocommerce.com/document/template-structure/
+ * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
  * @version 3.2.0
  */
@@ -37,7 +37,7 @@ do_action( 'woocommerce_before_account_downloads', $has_downloads ); ?>
 <?php else : ?>
 	<div class="woocommerce-Message woocommerce-Message--info woocommerce-info">
 		<a class="woocommerce-Button button" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php esc_html_e( 'Go shop', 'woocommerce' ); ?>
+			<?php esc_html_e( 'Go to the shop', 'woocommerce' ); ?>
 		</a>
 		<?php esc_html_e( 'No downloads available yet.', 'woocommerce' ); ?>
 	</div>

--- a/templates/myaccount/downloads.php
+++ b/templates/myaccount/downloads.php
@@ -37,7 +37,7 @@ do_action( 'woocommerce_before_account_downloads', $has_downloads ); ?>
 <?php else : ?>
 	<div class="woocommerce-Message woocommerce-Message--info woocommerce-info">
 		<a class="woocommerce-Button button" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php esc_html_e( 'Go to the shop', 'woocommerce' ); ?>
+			<?php esc_html_e( 'Browse products', 'woocommerce' ); ?>
 		</a>
 		<?php esc_html_e( 'No downloads available yet.', 'woocommerce' ); ?>
 	</div>

--- a/templates/myaccount/orders.php
+++ b/templates/myaccount/orders.php
@@ -98,7 +98,7 @@ do_action( 'woocommerce_before_account_orders', $has_orders ); ?>
 <?php else : ?>
 	<div class="woocommerce-message woocommerce-message--info woocommerce-Message woocommerce-Message--info woocommerce-info">
 		<a class="woocommerce-Button button" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php esc_html_e( 'Go to the shop', 'woocommerce' ); ?>
+			<?php esc_html_e( 'Browse products', 'woocommerce' ); ?>
 		</a>
 		<?php esc_html_e( 'No order has been made yet.', 'woocommerce' ); ?>
 	</div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This make the strings more consistent, we already change one entry of "Go shop" in https://github.com/woocommerce/woocommerce/pull/23038, now changing here will reduce one entry to translate and help with consistency.

### How to test the changes in this Pull Request:

1. Go to My Account > Downloads, and check the message. (note that your user can't have any download)
2. Apply this patch and see the new message.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Better wording when no downloads are available on My Account > Downloads.
