### PR TITLE
[Beta fix] Return early if post status is `auto-draft` to prevent fatal.

### DIFF
--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -73,6 +73,10 @@ class WC_Orders_Tracking {
 			return;
 		}
 
+		if ( 'auto-draft' === get_post_status( $id ) ) {
+			return;
+		}
+
 		$order        = wc_get_order( $id );
 		$date_created = $order->get_date_created()->date( 'Y-m-d H:i:s' );
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

While creating an order, if we remove an item after adding, `pre_post_update` hook gets called. Since the order is not created yet, `$order->get_date_created()` will be null, and this will cause a fatal in the event tracker which checks for and tracks edit in order created date.

We now return early when order status is `auto-draft` to prevent these kind of errors.


### How to test the changes in this Pull Request:

1. Start creating a new order from `wp-admin/post-new.php?post_type=shop_order`
2. Add any product, and then remove it. You would see that removing of product will be successful. This will cause a fatal without this patch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
