### PR TITLE
Revert "Fix #23784 Shipping zonde UI issue"

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3271,10 +3271,6 @@ table.wc_shipping {
 	margin-top: 0;
 }
 
-.wc-shipping-zone-settings tbody {
-	display: inherit;
-}
-
 table {
 
 	tr,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This reverts commit f42b5a5f37c21114bbaa73238d4214ae9377f9a8. Reverting to fix UI issue that was causing content to shift left.

Looks like this was added to counter a change by Grammerly plugin, but unfortunately this breaks UI when Grammerly is not installed.

Before:

<img width="1064" alt="Screenshot 2019-07-17 at 12 57 07 AM" src="https://user-images.githubusercontent.com/7571618/61323684-3e60bd00-a82e-11e9-818b-74059c40c41d.png">

After

<img width="1070" alt="Screenshot 2019-07-17 at 12 56 50 AM" src="https://user-images.githubusercontent.com/7571618/61323691-43257100-a82e-11e9-9f52-fd14496fd40c.png">

### How to test the changes in this Pull Request:

1. Visit shipping zone page for `Locations not covered by your other zones` at `admin.php?page=wc-settings&tab=shipping&zone_id=0`
2. You would see that UI will be as expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
