### PR TITLE
Deprecate the `woocommerce_before_cart_item_quantity_zero` action

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1172,6 +1172,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function set_quantity( $cart_item_key, $quantity = 1, $refresh_totals = true ) {
 		if ( 0 === $quantity || $quantity < 0 ) {
+			wc_do_deprecated_action( 'woocommerce_before_cart_item_quantity_zero', array( $cart_item_key, $this ), '3.7.0', 'woocommerce_remove_cart_item' );
 			// If we're setting qty to 0 we're removing the item from the cart.
 			return $this->remove_cart_item( $cart_item_key );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR deprecates the `woocommerce_before_cart_item_quantity_zero` action. This action was removed in https://github.com/woocommerce/woocommerce/commit/921cc754b916deb5c3c077a9e2468005d6c74a4c.

It should be deprecated so third-parties using this action like Subscriptions are made aware of the new alternative.

### How to test the changes in this Pull Request:

1. Attach a callback to the `woocommerce_before_cart_item_quantity_zero` action.
2. Add any product to the cart
3. Set that product's qty to 0.
4. Click **Update cart**
   - On `2.6.x` your callback will run.
   - On `master` and `3.7.0-beta.1` your callback won't run.
   - On this branch it will still run with the following warning.

```
PHP Notice:  woocommerce_before_cart_item_quantity_zero is <strong>deprecated</strong> since version 2.7.0! Use woocommerce_remove_cart_item instead. in /app/public/wp-includes/functions.php on line 4711
```


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

No change log entry needed. This PR is in addition to the existing entry: 

```
* Dev - Removed the `woocommerce_before_cart_item_quantity_zero` action from `WC_Cart::restore_cart_item()` in favor of existing `woocommerce_cart_item_removed` action. #23112 ```