### PR TITLE
Only add the image node to structured data if product has image

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -194,15 +194,19 @@ class WC_Structured_Data {
 		$shop_url  = home_url();
 		$currency  = get_woocommerce_currency();
 		$permalink = get_permalink( $product->get_id() );
+		$image     = wp_get_attachment_url( $product->get_image_id() );
 
 		$markup = array(
 			'@type'       => 'Product',
 			'@id'         => $permalink . '#product', // Append '#product' to differentiate between this @id and the @id generated for the Breadcrumblist.
 			'name'        => $product->get_name(),
 			'url'         => $permalink,
-			'image'       => wp_get_attachment_url( $product->get_image_id() ),
 			'description' => wp_strip_all_tags( do_shortcode( $product->get_short_description() ? $product->get_short_description() : $product->get_description() ) ),
 		);
+
+		if ( $image ) {
+			$markup['image'] = $image;
+		}
 
 		// Declare SKU or fallback to ID.
 		if ( $product->get_sku() ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a check to verify if a given product has an image before adding the image node to the structured data output. If there is no image, the image node should be omitted instead of displayed with `false` as its value.

Closes #24188

### How to test the changes in this Pull Request:

1. See #24188 for test instructions

### Changelog entry

> Fix: Only add the image node to structured data if product has image