### PR TITLE
Prevent run wc_load_cart() before before_woocommerce_init

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2264,7 +2264,7 @@ function wc_get_server_database_version() {
  */
 function wc_load_cart() {
 	if ( ! did_action( 'before_woocommerce_init' ) || doing_action( 'before_woocommerce_init' ) ) {
-		/* translators: 1: wc_get_product 2: woocommerce_init */
+		/* translators: 1: wc_load_cart 2: woocommerce_init */
 		wc_doing_it_wrong( __FUNCTION__, sprintf( __( '%1$s should not be called before the %2$s action.', 'woocommerce' ), 'wc_load_cart', 'woocommerce_init' ), '3.7' );
 		return;
 	}

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2263,6 +2263,12 @@ function wc_get_server_database_version() {
  * @return void
  */
 function wc_load_cart() {
+	if ( ! did_action( 'woocommerce_loaded' ) ) {
+		/* translators: 1: wc_get_product 2: woocommerce_init */
+		wc_doing_it_wrong( __FUNCTION__, sprintf( __( '%1$s should not be called before the %2$s action.', 'woocommerce' ), 'wc_load_cart', 'woocommerce_init' ), '3.7' );
+		return;
+	}
+
 	WC()->initialize_session();
 	WC()->initialize_cart();
 }

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2263,7 +2263,7 @@ function wc_get_server_database_version() {
  * @return void
  */
 function wc_load_cart() {
-	if ( ! did_action( 'woocommerce_loaded' ) ) {
+	if ( ! did_action( 'before_woocommerce_init' ) || doing_action( 'before_woocommerce_init' ) ) {
 		/* translators: 1: wc_get_product 2: woocommerce_init */
 		wc_doing_it_wrong( __FUNCTION__, sprintf( __( '%1$s should not be called before the %2$s action.', 'woocommerce' ), 'wc_load_cart', 'woocommerce_init' ), '3.7' );
 		return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Prevent fatal error if trying to run `wc_load_cart()` before `before_woocommerce_init`.

Will output the follow notice:

```
PHP Notice:  wc_load_cart was called <strong>incorrectly</strong>. wc_load_cart should not be called before the woocommerce_init action. Backtrace: require('wp-blog-header.php'), require_once('wp-load.php'), require_once('wp-config.php'), require_once('wp-settings.php'), do_action('plugins_loaded'), WP_Hook->do_action, WP_Hook->apply_filters, WooCommerce->on_plugins_loaded, do_action('woocommerce_loaded'), WP_Hook->do_action, WP_Hook->apply_filters, {closure}, wc_load_cart, wc_doing_it_wrong Please see <a href="https://codex.wordpress.org/Debugging_in_WordPress">Debugging in WordPress</a> for more information. (This message was added in version 3.7.) in /var/www/woo/wp-includes/functions.php on line 4773
```

Closes #24190.

### How to test the changes in this Pull Request:

See #24190

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Prevent fatal error if trying to run `wc_load_cart()` before `before_woocommerce_init`.
