### PR TITLE
Parse attribute_id as int not string

### DIFF
--- a/includes/legacy/api/v3/class-wc-api-products.php
+++ b/includes/legacy/api/v3/class-wc-api-products.php
@@ -2752,6 +2752,7 @@ class WC_API_Products extends WC_API_Resource {
 				throw new WC_API_Exception( 'woocommerce_api_user_cannot_read_product_attribute_terms', __( 'You do not have permission to read product attribute terms', 'woocommerce' ), 401 );
 			}
 
+			$attribute_id = absint( $attribute_id );
 			$taxonomy = wc_attribute_taxonomy_name_by_id( $attribute_id );
 
 			if ( ! $taxonomy ) {
@@ -2792,6 +2793,7 @@ class WC_API_Products extends WC_API_Resource {
 
 		try {
 			$id = absint( $id );
+			$attribute_id = absint( $attribute_id );
 
 			// Validate ID
 			if ( empty( $id ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
In legacy API v3 for product attribute terms, the `$attribute_id` is received as string, but is required as int for proper handling.
Use `absint` to make sure it is a valid int id.

Closes #24160.

### How to test the changes in this Pull Request:

1. Make sure Legacy API checkbox is checked in WooCommerce Advanced settings section and generate API key and secret.
2. Add new one or find an existing product attribute having terms associated and note down its id.
3. Make a REST API request as follows, change host and attribute id according to your test environment.

```cURL
curl -X GET \
  'http://localhost/wc-api/v3/products/attributes/1/terms/?oauth_consumer_key=ck_47d3d18d8dff3f8070fe212179bcf8554d8dfff0&oauth_signature_method=HMAC-SHA1&oauth_timestamp=1563529409&oauth_nonce=bSiIMvsMfQA&oauth_version=1.0&oauth_signature=26vK7osALRP8XYgHk0GcrM+qGl4=' \
  -H 'cache-control: no-cache'
```

We've successfully loaded the attribute terms for products.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix product attribute terms endpoint in legacy REST API v3.
