### PR TITLE
Remove methods assertIsWPError() and assertNotWPError() from WC_Unit_Test_Case

### DIFF
--- a/tests/framework/class-wc-unit-test-case.php
+++ b/tests/framework/class-wc-unit-test-case.php
@@ -86,30 +86,6 @@ class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 	}
 
 	/**
-	 * Asserts thing is not WP_Error.
-	 *
-	 * @since 2.2
-	 * @param mixed  $actual  The object to assert is not an instance of WP_Error.
-	 * @param string $message A message to display if the assertion fails.
-	 */
-	public function assertNotWPError( $actual, $message = '' ) {
-		if ( ! $message && is_wp_error( $actual ) ) {
-			$message = $actual->get_error_message();
-		}
-		$this->assertNotInstanceOf( 'WP_Error', $actual, $message );
-	}
-
-	/**
-	 * Asserts thing is WP_Error.
-	 *
-	 * @param mixed  $actual  The object to assert is an instance of WP_Error.
-	 * @param string $message A message to display if the assertion fails.
-	 */
-	public function assertIsWPError( $actual, $message = '' ) {
-		$this->assertInstanceOf( 'WP_Error', $actual, $message );
-	}
-
-	/**
 	 * Throws an exception with an optional message and code.
 	 *
 	 * Note: can't use `throwException` as that's reserved.

--- a/tests/unit-tests/util/api-functions.php
+++ b/tests/unit-tests/util/api-functions.php
@@ -71,7 +71,7 @@ class WC_Tests_API_Functions extends WC_Unit_Test_Case {
 		$expected_error_message = 'Error getting remote image http://somedomain.com/nonexistent-image.png. Error: Not found.';
 		$result                 = wc_rest_upload_image_from_url( 'http://somedomain.com/nonexistent-image.png' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 		$this->assertEquals( $expected_error_message, $result->get_error_message() );
 	}
 
@@ -85,14 +85,14 @@ class WC_Tests_API_Functions extends WC_Unit_Test_Case {
 		$expected_error_message = 'Invalid image: File is empty. Please upload something more substantial. This error could also be caused by uploads being disabled in your php.ini or by post_max_size being defined as smaller than upload_max_filesize in php.ini.';
 		$result                 = wc_rest_upload_image_from_url( 'http://somedomain.com/invalid-image-1.png' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 		$this->assertEquals( $expected_error_message, $result->get_error_message() );
 
 		// unsupported mime type.
 		$expected_error_message = 'Invalid image: Sorry, this file type is not permitted for security reasons.';
 		$result                 = wc_rest_upload_image_from_url( 'http://somedomain.com/invalid-image-2.png' );
 
-		$this->assertIsWPError( $result );
+		$this->assertWPError( $result );
 		$this->assertEquals( $expected_error_message, $result->get_error_message() );
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Those two methods are already declared in the class WP_UnitTestCase, so there is no need to declare them again in the class WC_Unit_Test_Case. The only caveat is that assertIsWPError() is called assertWPError() in WP_UnitTestCase so it was necessary to update all of its usages.

### How to test the changes in this Pull Request:

1. Check that the tests are still passing.