### PR TITLE
Honor tax rounding preference in edit item and refund flows

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -383,10 +383,12 @@ jQuery( function ( $ ) {
 				var unit_total_tax     = accounting.unformat( $line_total_tax.attr( 'data-total_tax' ), woocommerce_admin.mon_decimal_point ) / o_qty;
 				var $line_subtotal_tax = $( 'input.line_subtotal_tax[data-tax_id="' + tax_id + '"]', $row );
 				var unit_subtotal_tax  = accounting.unformat( $line_subtotal_tax.attr( 'data-subtotal_tax' ), woocommerce_admin.mon_decimal_point ) / o_qty;
+				var round_at_subtotal  = 'yes' === woocommerce_admin_meta_boxes.round_at_subtotal;
+				var precision          = woocommerce_admin_meta_boxes[ round_at_subtotal ? 'rounding_precision' : 'currency_format_num_decimals' ];
 
 				if ( 0 < unit_total_tax ) {
 					$line_total_tax.val(
-						parseFloat( accounting.formatNumber( unit_total_tax * qty, woocommerce_admin_meta_boxes.rounding_precision, '' ) )
+						parseFloat( accounting.formatNumber( unit_total_tax * qty, precision, '' ) )
 							.toString()
 							.replace( '.', woocommerce_admin.mon_decimal_point )
 					);
@@ -394,7 +396,7 @@ jQuery( function ( $ ) {
 
 				if ( 0 < unit_subtotal_tax ) {
 					$line_subtotal_tax.val(
-						parseFloat( accounting.formatNumber( unit_subtotal_tax * qty, woocommerce_admin_meta_boxes.rounding_precision, '' ) )
+						parseFloat( accounting.formatNumber( unit_subtotal_tax * qty, precision, '' ) )
 							.toString()
 							.replace( '.', woocommerce_admin.mon_decimal_point )
 					);
@@ -1019,8 +1021,11 @@ jQuery( function ( $ ) {
 					var unit_total_tax         = accounting.unformat( line_total_tax.data( 'total_tax' ), woocommerce_admin.mon_decimal_point ) / qty;
 
 					if ( 0 < unit_total_tax ) {
+						var round_at_subtotal = 'yes' === woocommerce_admin_meta_boxes.round_at_subtotal;
+						var precision         = woocommerce_admin_meta_boxes[ round_at_subtotal ? 'rounding_precision' : 'currency_format_num_decimals' ];
+
 						$refund_line_total_tax.val(
-							parseFloat( accounting.formatNumber( unit_total_tax * refund_qty, woocommerce_admin_meta_boxes.rounding_precision, '' ) )
+							parseFloat( accounting.formatNumber( unit_total_tax * refund_qty, precision, '' ) )
 								.toString()
 								.replace( '.', woocommerce_admin.mon_decimal_point )
 						).change();

--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -115,6 +115,10 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 			$tax_item_id       = $tax_item->get_rate_id();
 			$tax_item_total    = isset( $tax_data['total'][ $tax_item_id ] ) ? $tax_data['total'][ $tax_item_id ] : '';
 			$tax_item_subtotal = isset( $tax_data['subtotal'][ $tax_item_id ] ) ? $tax_data['subtotal'][ $tax_item_id ] : '';
+
+			$round_at_subtotal = 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' );
+			$tax_item_total    = wc_round_tax_total( $tax_item_total, $round_at_subtotal ? wc_get_rounding_precision() : null );
+			$tax_item_subtotal = wc_round_tax_total( $tax_item_subtotal, $round_at_subtotal ? wc_get_rounding_precision() : null );
 			?>
 			<td class="line_tax" width="1%">
 				<div class="view">


### PR DESCRIPTION
# All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The setting to round taxes at subtotal level has a default value (`'no'`) that was not being honored on the Edit Order screen – the values were never rounded at the line item level – which resulted in off-by-one discrepancies between the checkout item total and the edited or refunded item total.

This change is to round to the proper precision (w.r.t. the `woocommerce_tax_round_at_subtotal` setting) for the default value of the edit item form, as well as when the values are dynamically recomputed in the edit item and refund forms.

Edit item | Refund
-- | --
<img width="537" src="https://user-images.githubusercontent.com/1867547/61541376-87bb3300-aa0d-11e9-8dbb-b83290d746ab.png"> | <img width="450" src="https://user-images.githubusercontent.com/1867547/61541394-8ee24100-aa0d-11e9-8c2b-30ef50c53693.png">

Tested by creating the order at checkout with a $2.30 item and a $3.00 item, with an 8.5% tax rate. In `master`, just clicking edit on the items and immediately saving reduces the amount by $0.01. Also, refunding each item results in a partial refund of the total minus $0.01. (In this branch, this would occur only if toggling the setting to `'yes'` between checking out and editing the order.)

### How to test the changes in this Pull Request:

1. Set up a tax rate (e.g. 8.5%) for the checkout location, and have "round at subtotal level" toggled off
2. Check out with two items with the total tax rate rounded at line item level diverging from that rounded at subtotal level (e.g. $3.00 at 8.5% = $0.255; $0.255 * 2 = $0.51; round( $0.255 ) * 2 = $0.52).
3. Verify that editing or refunding both items yields the same checkout total, both initially and on quantity change.
4. Can also regression test consistency when "round at subtotal level" is toggled on.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Honor tax rounding preference in edit item and refund flows