### PR TITLE
Deprecate instead of remove

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -44,7 +44,18 @@ class WC_Tax {
 	 * @param  string $value New rates value.
 	 */
 	public static function maybe_remove_tax_class_rates( $old_value, $value ) {
-		wc_deprecated_function( 'WC_Tax::maybe_remove_tax_class_rates', '3.7' );
+		wc_deprecated_function( 'WC_Tax::maybe_remove_tax_class_rates', '3.7', 'WC_Tax::delete_tax_class_by' );
+
+		$tax_classes          = array_filter( array_map( 'trim', explode( "\n", $value ) ) );
+		$existing_tax_classes = self::get_tax_classes();
+		$removed              = array_diff( $existing_tax_classes, $tax_classes );
+		$added                = array_diff( $tax_classes, $existing_tax_classes );
+		foreach ( $removed as $name ) {
+			self::delete_tax_class_by( 'name', $name );
+		}
+		foreach ( $added as $name ) {
+			self::create_tax_class( $name );
+		}
 	}
 
 	/**

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -37,6 +37,17 @@ class WC_Tax {
 	}
 
 	/**
+	 * When the woocommerce_tax_classes option is changed, remove any orphan rates.
+	 *
+	 * @deprecated 3.7.0
+	 * @param  string $old_value Old rates value.
+	 * @param  string $value New rates value.
+	 */
+	public static function maybe_remove_tax_class_rates( $old_value, $value ) {
+		wc_deprecated_function( 'WC_Tax::maybe_remove_tax_class_rates', '3.7' );
+	}
+
+	/**
 	 * Calculate tax for a line.
 	 *
 	 * @param  float   $price              Price to calc tax on.

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -49,12 +49,8 @@ class WC_Tax {
 		$tax_classes          = array_filter( array_map( 'trim', explode( "\n", $value ) ) );
 		$existing_tax_classes = self::get_tax_classes();
 		$removed              = array_diff( $existing_tax_classes, $tax_classes );
-		$added                = array_diff( $tax_classes, $existing_tax_classes );
 		foreach ( $removed as $name ) {
 			self::delete_tax_class_by( 'name', $name );
-		}
-		foreach ( $added as $name ) {
-			self::create_tax_class( $name );
 		}
 	}
 

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -1993,6 +1993,7 @@ function wc_update_370_tax_rate_classes() {
 			WC_Tax::create_tax_class( $class );
 		}
 	}
+	delete_option( 'woocommerce_tax_classes' );
 }
 
 /**


### PR DESCRIPTION
This PR adds back the maybe_remove_tax_class_rates method which is public and available to be called by theme/plugin and instead deprecate it.

It also adds code to delete the old tax classes option after transferring it to the new tax table.