### PR TITLE
Default order is ASC not dependant on order of some orderby attribute

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -179,14 +179,15 @@ class WC_Shortcode_Products {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => false === wc_string_to_bool( $this->attributes['paginate'] ),
-			'orderby'             => empty( $_GET['orderby'] ) ? $this->attributes['orderby'] : wc_clean( wp_unslash( $_GET['orderby'] ) ), // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+			'orderby'             => $this->attributes['orderby'],
+			'order'               => strtoupper( $this->attributes['order'] ),
 		);
 
-		$orderby_value         = explode( '-', $query_args['orderby'] );
-		$orderby               = esc_attr( $orderby_value[0] );
-		$order                 = ! empty( $orderby_value[1] ) ? $orderby_value[1] : ( empty( $_GET['orderby'] ) ? strtoupper( $this->attributes['order'] ) : 'ASC' ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
-		$query_args['orderby'] = $orderby;
-		$query_args['order']   = $order;
+		if ( ! empty( $_GET['orderby'] ) ) {
+			$orderby_value         = explode( '-', wc_clean( wp_unslash( $_GET['orderby'] ) ) ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
+			$query_args['orderby'] = esc_attr( $orderby_value[0] );
+			$query_args['order']   = ! empty( $orderby_value[1] ) ? strtoupper( esc_attr( $orderby_value[1] ) ) : 'ASC';
+		}
 
 		if ( wc_string_to_bool( $this->attributes['paginate'] ) ) {
 			$this->attributes['page'] = absint( empty( $_GET['product-page'] ) ? 1 : $_GET['product-page'] ); // WPCS: input var ok, CSRF ok.

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -184,7 +184,7 @@ class WC_Shortcode_Products {
 
 		$orderby_value         = explode( '-', $query_args['orderby'] );
 		$orderby               = esc_attr( $orderby_value[0] );
-		$order                 = ! empty( $orderby_value[1] ) ? $orderby_value[1] : strtoupper( $this->attributes['order'] );
+		$order                 = ! empty( $orderby_value[1] ) ? $orderby_value[1] : ( empty( $_GET['orderby'] ) ? strtoupper( $this->attributes['order'] ) : 'ASC' ); // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification
 		$query_args['orderby'] = $orderby;
 		$query_args['order']   = $order;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

For products shortcodes with order attribute set as DESC and some orderby attribute then default sorting of price with query param (?orderby=price) also uses DESC order instead of default ASC.
Resolve #24219 by fixing above behavior using ASC order for query param if no order found instead of using unrelated order attribute value of shortcode which can be DESC.
The language is bit confusing but steps below to test the changes should make sense.

### How to test the changes in this Pull Request:

1. Use following shortcode in a page and change sorting order to `price:low to high`.
```
[products limit="48" orderby="date" order="DESC" columns="3" paginate="true"]
```
2. Without the changes products are sorted in DESC price order because of DESC attribute value of shortcode instead of expected ASC for price.  With the changes from this PR the products are sorted correctly for price.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix products shortcodes sorting order for price when order attribute is provided in shortcode.
