### PR TITLE
Cache checkout fragments and update DOM on change only

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -360,9 +360,12 @@ jQuery( function( $ ) {
 					// Always update the fragments
 					if ( data && data.fragments ) {
 						$.each( data.fragments, function ( key, value ) {
-							$( key ).replaceWith( value );
+							if ( ! wc_checkout_form.fragments || wc_checkout_form.fragments[ key ] !== value ) {
+								$( key ).replaceWith( value );
+							}
 							$( key ).unblock();
 						} );
+						wc_checkout_form.fragments = data.fragments;
 					}
 
 					// Recheck the terms and conditions box, if needed


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This change is to cache AJAX checkout fragment strings, and only replace the DOM when the incoming fragment is different from the last.

The reason is to help avoid unnecessarily clearing payment form inputs. While https://github.com/woocommerce/woocommerce/pull/12821 restores the state of the form inputs, this doesn't work for remotely-hosted form elements (see https://github.com/woocommerce/woocommerce-gateway-stripe/issues/507).

Note:
- Depending on the number of shipping and payment methods enabled, the cached fragments could take up tens of kb in memory at a time – not sure if that's enough to have any concern about.
- To fulfill the purpose of this PR, changes to gateways may also be necessary to ensure that the form is only re-mounted when necessary (e.g. https://github.com/woocommerce/woocommerce-gateway-stripe/pull/927)
- This change would break a possible assumption that there is a newly mounted DOM fragment whenever `updated_checkout` is triggered (e.g. https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/pull/593)

### How to test the changes in this Pull Request:

- Check out https://github.com/woocommerce/woocommerce-gateway-stripe/pull/927 branch, and enable Stripe gateway
- On the Checkout screen, enter payment information (e.g. card number, expiration)
- Make a change to a checkout field such as the address, which should trigger an AJAX request (but make sure not to change the price, which is included in the Stripe payment method markup)
- Verify that the entered payment information is unchanged

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Cache checkout fragments and update DOM on change only