### PR TITLE
Fire related actions when deleting all product variations

### DIFF
--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -659,9 +659,12 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 		if ( ! empty( $variation_ids ) ) {
 			foreach ( $variation_ids as $variation_id ) {
 				if ( $force_delete ) {
+					do_action( 'woocommerce_before_delete_product_variation' , $variation_id );
 					wp_delete_post( $variation_id, true );
+					do_action( 'woocommerce_delete_product_variation' , $variation_id );
 				} else {
 					wp_trash_post( $variation_id );
+					do_action( 'woocommerce_trash_product_variation' , $variation_id );
 				}
 			}
 		}

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -659,12 +659,12 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 		if ( ! empty( $variation_ids ) ) {
 			foreach ( $variation_ids as $variation_id ) {
 				if ( $force_delete ) {
-					do_action( 'woocommerce_before_delete_product_variation' , $variation_id );
+					do_action( 'woocommerce_before_delete_product_variation', $variation_id );
 					wp_delete_post( $variation_id, true );
-					do_action( 'woocommerce_delete_product_variation' , $variation_id );
+					do_action( 'woocommerce_delete_product_variation', $variation_id );
 				} else {
 					wp_trash_post( $variation_id );
-					do_action( 'woocommerce_trash_product_variation' , $variation_id );
+					do_action( 'woocommerce_trash_product_variation', $variation_id );
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
When a product variation is deleted (or trashed), the actions `woocommerce_before_delete_product_variation` and `woocommerce_delete_product_variation` or `woocommerce_trash_product_variation` are fired. See: https://github.com/woocommerce/woocommerce/blob/3.7.0-beta.1/includes/data-stores/class-wc-product-data-store-cpt.php#L291-L300

These actions are currently not fired when all variations are deleted at once. See https://github.com/woocommerce/woocommerce/blob/3.7.0-beta.1/includes/data-stores/class-wc-product-variable-data-store-cpt.php#L661-L665

This PR fires the actions for all variations when the thy are deleted all at once.

### How to test the changes in this Pull Request:

I noticed this issue because I am using `woocommerce_before_delete_product_variation` to take actions when a variation is deleted and, following https://github.com/woocommerce/woocommerce/pull/23478, these actions are not executed when when deleting the variations after changing the product type of a variable product.  

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fire related actions when deleting all product variations.
