### PR TITLE
Avoid duplicated process for IPN and PDT payment

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
@@ -63,11 +63,11 @@ abstract class WC_Gateway_Paypal_Response {
 	 * @param  string   $note Payment note.
 	 */
 	protected function payment_complete( $order, $txn_id = '', $note = '' ) {
-		if( ! $order->get_meta('_paypal_payment_completed',true) ) {
+		if( ! $order->get_meta( '_paypal_payment_completed', true ) ) {
 			$order->add_order_note( $note );
 			$order->payment_complete( $txn_id );
 			WC()->cart->empty_cart();
-			$order->update_meta_data('_paypal_payment_completed','yes');
+			$order->update_meta_data( '_paypal_payment_completed', 'yes' );
 		}
 	}
 

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
@@ -63,11 +63,11 @@ abstract class WC_Gateway_Paypal_Response {
 	 * @param  string   $note Payment note.
 	 */
 	protected function payment_complete( $order, $txn_id = '', $note = '' ) {
-		if( ! get_post_meta($order->get_id(),"_paypal_payment_completed",true) ) {
+		if( ! $order->get_meta('_paypal_payment_completed',true) ) {
 			$order->add_order_note( $note );
 			$order->payment_complete( $txn_id );
 			WC()->cart->empty_cart();
-			update_post_meta($order->get_id(),"_paypal_payment_completed","yes");
+			$order->update_meta_data('_paypal_payment_completed','yes');
 		}
 	}
 

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
@@ -63,9 +63,12 @@ abstract class WC_Gateway_Paypal_Response {
 	 * @param  string   $note Payment note.
 	 */
 	protected function payment_complete( $order, $txn_id = '', $note = '' ) {
-		$order->add_order_note( $note );
-		$order->payment_complete( $txn_id );
-		WC()->cart->empty_cart();
+		if( ! get_post_meta($order->get_id(),"_paypal_payment_completed",true) ) {
+			$order->add_order_note( $note );
+			$order->payment_complete( $txn_id );
+			WC()->cart->empty_cart();
+			update_post_meta($order->get_id(),"_paypal_payment_completed","yes");
+		}
 	}
 
 	/**

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
@@ -63,12 +63,10 @@ abstract class WC_Gateway_Paypal_Response {
 	 * @param  string   $note Payment note.
 	 */
 	protected function payment_complete( $order, $txn_id = '', $note = '' ) {
-		if ( ! $order->get_meta( '_paypal_payment_completed', true ) ) {
+		if ( ! $order->has_status( array( 'processing', 'completed' ) ) ) {
 			$order->add_order_note( $note );
 			$order->payment_complete( $txn_id );
 			WC()->cart->empty_cart();
-			$order->update_meta_data( '_paypal_payment_completed', 'yes' );
-			$order->save();
 		}
 	}
 

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
@@ -63,7 +63,7 @@ abstract class WC_Gateway_Paypal_Response {
 	 * @param  string   $note Payment note.
 	 */
 	protected function payment_complete( $order, $txn_id = '', $note = '' ) {
-		if( ! $order->get_meta( '_paypal_payment_completed', true ) ) {
+		if ( ! $order->get_meta( '_paypal_payment_completed', true ) ) {
 			$order->add_order_note( $note );
 			$order->payment_complete( $txn_id );
 			WC()->cart->empty_cart();

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
@@ -68,6 +68,7 @@ abstract class WC_Gateway_Paypal_Response {
 			$order->payment_complete( $txn_id );
 			WC()->cart->empty_cart();
 			$order->update_meta_data( '_paypal_payment_completed', 'yes' );
+			$order->save();
 		}
 	}
 


### PR DESCRIPTION
Currently, Woocommerce is processing twice the payment when IPN and PDT notifications are enable. This mean that stock is reduced twice.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
