### PR TITLE
Eliminate update order AJAX request on checkout page load

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -135,7 +135,10 @@ jQuery( function( $ ) {
 			}
 		},
 		init_checkout: function() {
-			$( document.body ).trigger( 'update_checkout' );
+			// Fire updated_checkout event after existing ready event handlers.
+			$( function() {
+				$( document.body ).trigger( 'updated_checkout' );
+			} );
 		},
 		maybe_input_changed: function( e ) {
 			if ( wc_checkout_form.dirtyInput ) {

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -189,10 +189,11 @@ jQuery( function( $ ) {
 			if ( ! $checkbox.prop( 'checked' ) ) {
 				var $billing = $( 'div.woocommerce-billing-fields' );
 
-				var $differentFields = jQuery( 'div.shipping_address' ).find( 'input, select' ).filter( function() {
-					jQuery( this ).attr( 'id' ).replace( 'shipping', 'billing' );
-					var id = jQuery( this ).attr( 'id' ).replace( 'shipping', 'billing' );
-					return jQuery( this ).val() !== $billing.find( '#' + id ).val();
+				// Find shipping field values that diverge from billing.
+				var $differentFields = $( 'div.shipping_address' ).find( 'input, select' ).filter( function() {
+					$( this ).attr( 'id' ).replace( 'shipping', 'billing' );
+					var id = $( this ).attr( 'id' ).replace( 'shipping', 'billing' );
+					return $( this ).val() !== $billing.find( '#' + id ).val();
 				} );
 
 				if ( $differentFields.length > 0 ) {

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -50,7 +50,7 @@ jQuery( function( $ ) {
 			this.$checkout_form.on( 'change', '#ship-to-different-address input', this.ship_to_different_address );
 
 			// Trigger events
-			this.ship_to_different_address();
+			this.init_ship_to_different_address();
 			this.init_payment_methods();
 
 			// Update on page load
@@ -183,11 +183,30 @@ jQuery( function( $ ) {
 				wc_checkout_form.trigger_update_checkout();
 			}
 		},
-		ship_to_different_address: function( e ) {
-			if ( $( '#ship-to-different-address input' ).is( ':checked' ) ) {
-				$( 'div.shipping_address' ).slideDown( e ? null : 0 );
+		init_ship_to_different_address: function() {
+			var $checkbox = $( '#ship-to-different-address input' );
+
+			if ( ! $checkbox.prop( 'checked' ) ) {
+				var $billing = $( 'div.woocommerce-billing-fields' );
+
+				var $differentFields = jQuery( 'div.shipping_address' ).find( 'input, select' ).filter( function() {
+					jQuery( this ).attr( 'id' ).replace( 'shipping', 'billing' );
+					var id = jQuery( this ).attr( 'id' ).replace( 'shipping', 'billing' );
+					return jQuery( this ).val() !== $billing.find( '#' + id ).val();
+				} );
+
+				if ( $differentFields.length > 0 ) {
+					$checkbox.prop( 'checked', true );
+				}
+			}
+
+			$( 'div.shipping_address' ).toggle( $checkbox.prop( 'checked' ) );
+		},
+		ship_to_different_address: function() {
+			if ( $( this ).is( ':checked' ) ) {
+				$( 'div.shipping_address' ).slideDown();
 			} else {
-				$( 'div.shipping_address' ).slideUp( e ? null : 0 );
+				$( 'div.shipping_address' ).slideUp();
 			}
 		},
 		reset_update_checkout_timer: function() {

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -50,7 +50,7 @@ jQuery( function( $ ) {
 			this.$checkout_form.on( 'change', '#ship-to-different-address input', this.ship_to_different_address );
 
 			// Trigger events
-			this.$checkout_form.find( '#ship-to-different-address input' ).change();
+			this.ship_to_different_address();
 			this.init_payment_methods();
 
 			// Update on page load
@@ -183,10 +183,11 @@ jQuery( function( $ ) {
 				wc_checkout_form.trigger_update_checkout();
 			}
 		},
-		ship_to_different_address: function() {
-			$( 'div.shipping_address' ).hide();
-			if ( $( this ).is( ':checked' ) ) {
-				$( 'div.shipping_address' ).slideDown();
+		ship_to_different_address: function( e ) {
+			if ( $( '#ship-to-different-address input' ).is( ':checked' ) ) {
+				$( 'div.shipping_address' ).slideDown( e ? null : 0 );
+			} else {
+				$( 'div.shipping_address' ).slideUp( e ? null : 0 );
 			}
 		},
 		reset_update_checkout_timer: function() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

With the understanding that the checkout page as initially loaded already contains the proper order review and payment markup, this change is to **significantly improve perceived load time of the checkout screen** by replacing the explicit `update_checkout` call on `init` with just the triggering of the `updated_checkout` event, and avoiding an incidental `update_checkout` call due to the way the visibility of the shipping address was being initialized.

I tested with various form values and settings and as far as I could tell, the state of the form was the same before and after the initial AJAX call, with the exception of the `ship_to_different_address` checkbox:
- The customer session on the backend stores the billing and shipping addresses, but not an explicit flag for whether they are the same, and the checkbox on the frontend was being initialized based on a setting and a filter only [[code](https://github.com/woocommerce/woocommerce/blob/d627a4bbb8ce5c7b49bcd8cbd6f4dd322d4faec5/templates/checkout/form-shipping.php#L26)].
- This can be verified in `master` by setting both addresses to yield one shipping/tax amount, then changing the shipping address to yield another shipping/tax amount, then refreshing to find that the initial page load contains the latter amount, while the AJAX response contains the former amount after finding the checkbox unchecked.
- To address this, I added initialization logic for the checkbox in https://github.com/woocommerce/woocommerce/commit/429161e1c66cb04e864529b47f03a92e57033196 that just determines whether or not the pre-filled billing and shipping addresses are in fact different.

It's possible that I've overlooked other reasons for this initial AJAX call, so this change **should be reviewed with the possibility of unintended consequences in mind**. In particular, I haven't tested whether `'request' => 'failure'` responses are rendered identically on page load.

Note: I would've preferred to have gone further and changed the _template_, rather than JS, to a) initialize the visibility of the shipping address, and b) initialize the state of the checkbox based on the billing vs shipping address diff, as described above. I stashed this approach after realizing that this change was probably not worth the burden on theme compatibility, but if that's not the case, I'd be glad to bring it back.

### How to test the changes in this Pull Request:

1. With items in cart, go to Checkout page
2. Verify no blocking and reloading of order review and payment sections
3. Verify consistent state of form despite lack of additional request
4. Repeat under any circumstances that could cause page load to diverge from AJAX update 😄 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Eliminate update order AJAX request on checkout page load