### PR TITLE
Fix position of ID section in mobile rows actions

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -2757,6 +2757,10 @@ table.wp-list-table {
 		color: #999;
 	}
 
+	.row-actions span.id {
+		padding-top: 8px;
+	}
+
 	td.column-thumb img {
 		margin: 0;
 		width: auto;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the position of the ID section in mobile rows actions when displaying the list of products in the admin. I just implemented the solution proposed by @jobthomas in the issue #24231. I don't know enough about CSS to tell if there is a better way to fix this.

Closes #24231.

### How to test the changes in this Pull Request:

1. See #24231 for a screenshot of the problem and testing instructions.

### Changelog entry

> Fix position of ID section in mobile rows actions when displaying the list of products in the admin