### PR TITLE
Display schema for the latest 5 reviews inside product's schema

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -283,8 +283,6 @@ class WC_Structured_Data {
 					'post_status' => 'publish',
 					'post_type'   => 'product',
 					'parent'      => 0,
-					'meta_key'    => 'rating', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
-					'orderby'     => 'meta_value_num',
 					'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 						array(
 							'key'     => 'rating',

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -29,7 +29,6 @@ class WC_Structured_Data {
 		add_action( 'woocommerce_before_main_content', array( $this, 'generate_website_data' ), 30 );
 		add_action( 'woocommerce_breadcrumb', array( $this, 'generate_breadcrumblist_data' ), 10 );
 		add_action( 'woocommerce_single_product_summary', array( $this, 'generate_product_data' ), 60 );
-		add_action( 'woocommerce_review_meta', array( $this, 'generate_review_data' ), 20 );
 		add_action( 'woocommerce_email_order_details', array( $this, 'generate_order_data' ), 20, 3 );
 
 		// Output structured data.
@@ -275,38 +274,46 @@ class WC_Structured_Data {
 				'reviewCount' => $product->get_review_count(),
 			);
 
-			// Markup most recent rating/review.
+			// Markup 5 most recent rating/review.
 			$comments = get_comments(
 				array(
-					'number'      => 1,
+					'number'      => 5,
 					'post_id'     => $product->get_id(),
 					'status'      => 'approve',
 					'post_status' => 'publish',
 					'post_type'   => 'product',
 					'parent'      => 0,
-					'meta_key'    => 'rating',
+					'meta_key'    => 'rating', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 					'orderby'     => 'meta_value_num',
+					'meta_query'  => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
+						array(
+							'key'     => 'rating',
+							'type'    => 'NUMERIC',
+							'compare' => '>',
+							'value'   => 0,
+						),
+					),
 				)
 			);
 
 			if ( $comments ) {
+				$markup['review'] = array();
 				foreach ( $comments as $comment ) {
-					$rating = get_comment_meta( $comment->comment_ID, 'rating', true );
-
-					if ( ! $rating ) {
-						continue;
-					}
-
-					$markup['review'] = array(
-						'@type'        => 'Review',
-						'reviewRating' => array(
-							'@type'       => 'Rating',
-							'ratingValue' => $rating,
-						),
-						'author'       => array(
+					$markup['review'][] = array(
+						'@type'         => 'Review',
+						'author'        => array(
 							'@type' => 'Person',
 							'name'  => get_comment_author( $comment->comment_ID ),
 						),
+						'itemReviewed'  => array(
+							'@type' => 'Product',
+							'name'  => $product->get_name(),
+						),
+						'reviewRating'  => array(
+							'@type'       => 'Rating',
+							'ratingValue' => get_comment_meta( $comment->comment_ID, 'rating', true ),
+						),
+						'datePublished' => get_comment_date( 'c', $comment->comment_ID ),
 					);
 				}
 			}

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -299,15 +299,16 @@ class WC_Structured_Data {
 				foreach ( $comments as $comment ) {
 					$markup['review'][] = array(
 						'@type'         => 'Review',
-						'author'        => array(
-							'@type' => 'Person',
-							'name'  => get_comment_author( $comment->comment_ID ),
-						),
 						'reviewRating'  => array(
 							'@type'       => 'Rating',
 							'ratingValue' => get_comment_meta( $comment->comment_ID, 'rating', true ),
 						),
-						'datePublished' => get_comment_date( 'c', $comment->comment_ID ),
+						'author'        => array(
+							'@type' => 'Person',
+							'name'  => get_comment_author( $comment ),
+						),
+						'reviewBody'    => get_comment_text( $comment ),
+						'datePublished' => get_comment_date( 'c', $comment ),
 					);
 				}
 			}

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -303,10 +303,6 @@ class WC_Structured_Data {
 							'@type' => 'Person',
 							'name'  => get_comment_author( $comment->comment_ID ),
 						),
-						'itemReviewed'  => array(
-							'@type' => 'Product',
-							'name'  => $product->get_name(),
-						),
 						'reviewRating'  => array(
 							'@type'       => 'Rating',
 							'ratingValue' => get_comment_meta( $comment->comment_ID, 'rating', true ),

--- a/templates/single-product/review.php
+++ b/templates/single-product/review.php
@@ -48,7 +48,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 			 * The woocommerce_review_meta hook.
 			 *
 			 * @hooked woocommerce_review_display_meta - 10
-			 * @hooked WC_Structured_Data::generate_review_data() - 20
 			 */
 			do_action( 'woocommerce_review_meta', $comment );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Google recommend to include `review` inside products instead of a new schema just for reviews:

https://developers.google.com/search/docs/data-types/product

I removed the schema for reviews, I kept the method for now, we could deprecate later if necessary.
Note that only loads the latest 5 reviews to avoid performance issues.

By default this Pull Request also fixes the `Either “offers”, “review”, or “aggregateRating” should be specified` error, since it's only one schema for products.

Closes #23299.

### How to test the changes in this Pull Request:

> Create a product and include some reviews on it.
> Check your page (or source code) in https://search.google.com/structured-data/testing-tool/ and check for the errors.
> Now apply the code from this Pull Request and check again on https://search.google.com/structured-data/testing-tool/
> All errors should be fixed (of course should display warnings about brand and global identifier for now).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Include 5 latest reviews to Product's schema.