### PR TITLE
Handle multiple decimal points

### DIFF
--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -61,17 +61,15 @@
 			})
 
 			.on( 'change', '.wc_input_price[type=text], .wc_input_decimal[type=text], .wc-order-totals #refund_amount[type=text]', function() {
-				var regex, decimalRegex, decimailPoint;
+				var regex, decimalRegex,
+					decimailPoint = woocommerce_admin.decimal_point;
 
 				if ( $( this ).is( '.wc_input_price' ) || $( this ).is( '#refund_amount' ) ) {
 					decimailPoint = woocommerce_admin.mon_decimal_point;
-					regex = new RegExp( '[^\-0-9\%\\' + decimailPoint + ']+', 'gi' );
-					decimalRegex = new RegExp( '\\' + decimailPoint + '+', 'gi' );
-				} else {
-					decimailPoint = woocommerce_admin.decimal_point;
-					regex = new RegExp( '[^\-0-9\%\\' + decimailPoint + ']+', 'gi' );
-					decimalRegex = new RegExp( '\\' + decimailPoint + '+', 'gi' );
 				}
+
+				regex        = new RegExp( '[^\-0-9\%\\' + decimailPoint + ']+', 'gi' );
+				decimalRegex = new RegExp( '\\' + decimailPoint + '+', 'gi' );
 
 				var value    = $( this ).val();
 				var newvalue = value.replace( regex, '' ).replace( decimalRegex, decimailPoint );

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -61,16 +61,20 @@
 			})
 
 			.on( 'change', '.wc_input_price[type=text], .wc_input_decimal[type=text], .wc-order-totals #refund_amount[type=text]', function() {
-				var regex;
+				var regex, decimalRegex, decimailPoint;
 
 				if ( $( this ).is( '.wc_input_price' ) || $( this ).is( '#refund_amount' ) ) {
-					regex = new RegExp( '[^\-0-9\%\\' + woocommerce_admin.mon_decimal_point + ']+', 'gi' );
+					decimailPoint = woocommerce_admin.mon_decimal_point;
+					regex = new RegExp( '[^\-0-9\%\\' + decimailPoint + ']+', 'gi' );
+					decimalRegex = new RegExp( '\\' + decimailPoint + '+', 'gi' );
 				} else {
-					regex = new RegExp( '[^\-0-9\%\\' + woocommerce_admin.decimal_point + ']+', 'gi' );
+					decimailPoint = woocommerce_admin.decimal_point;
+					regex = new RegExp( '[^\-0-9\%\\' + decimailPoint + ']+', 'gi' );
+					decimalRegex = new RegExp( '\\' + decimailPoint + '+', 'gi' );
 				}
 
 				var value    = $( this ).val();
-				var newvalue = value.replace( regex, '' );
+				var newvalue = value.replace( regex, '' ).replace( decimalRegex, decimailPoint );
 
 				if ( value !== newvalue ) {
 					$( this ).val( newvalue );

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -78,21 +78,31 @@
 			})
 
 			.on( 'keyup', '.wc_input_price[type=text], .wc_input_decimal[type=text], .wc_input_country_iso[type=text], .wc-order-totals #refund_amount[type=text]', function() {
-				var regex, error;
+				var regex, error, decimalRegex;
+				var checkDecimalNumbers = false;
 
 				if ( $( this ).is( '.wc_input_price' ) || $( this ).is( '#refund_amount' ) ) {
+					checkDecimalNumbers = true;
 					regex = new RegExp( '[^\-0-9\%\\' + woocommerce_admin.mon_decimal_point + ']+', 'gi' );
+					decimalRegex = new RegExp( '[^\\' + woocommerce_admin.mon_decimal_point + ']', 'gi' );
 					error = 'i18n_mon_decimal_error';
 				} else if ( $( this ).is( '.wc_input_country_iso' ) ) {
 					regex = new RegExp( '([^A-Z])+|(.){3,}', 'im' );
 					error = 'i18n_country_iso_error';
 				} else {
+					checkDecimalNumbers = true;
 					regex = new RegExp( '[^\-0-9\%\\' + woocommerce_admin.decimal_point + ']+', 'gi' );
+					decimalRegex = new RegExp( '[^\\' + woocommerce_admin.decimal_point + ']', 'gi' );
 					error = 'i18n_decimal_error';
 				}
 
 				var value    = $( this ).val();
 				var newvalue = value.replace( regex, '' );
+
+				// Check if newvalue have more than one decimal point.
+				if ( checkDecimalNumbers && 1 < newvalue.replace( decimalRegex, '' ).length ) {
+					newvalue = newvalue.replace( decimalRegex, '' );
+				}
 
 				if ( value !== newvalue ) {
 					$( document.body ).triggerHandler( 'wc_add_error_tip', [ $( this ), error ] );

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -169,9 +169,9 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 
 				$params = array(
 					/* translators: %s: decimal */
-					'i18n_decimal_error'                => sprintf( __( 'Please enter in decimal (%s) format without thousand separators.', 'woocommerce' ), $decimal ),
+					'i18n_decimal_error'                => sprintf( __( 'Please enter with one decimal point (%s) without thousand separators.', 'woocommerce' ), $decimal ),
 					/* translators: %s: price decimal separator */
-					'i18n_mon_decimal_error'            => sprintf( __( 'Please enter in monetary decimal (%s) format without thousand separators and currency symbols.', 'woocommerce' ), wc_get_price_decimal_separator() ),
+					'i18n_mon_decimal_error'            => sprintf( __( 'Please enter with one monetary decimal point (%s) without thousand separators and currency symbols.', 'woocommerce' ), wc_get_price_decimal_separator() ),
 					'i18n_country_iso_error'            => __( 'Please enter in country code with two capital letters.', 'woocommerce' ),
 					'i18n_sale_less_than_regular_error' => __( 'Please enter in a value less than the regular price.', 'woocommerce' ),
 					'i18n_delete_product_notice'        => __( 'This product has produced sales and may be linked to existing orders. Are you sure you want to delete it?', 'woocommerce' ),

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -361,7 +361,7 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 
 						$prices_array['price'][ $variation_id ]         = wc_format_decimal( $price, wc_get_price_decimals() );
 						$prices_array['regular_price'][ $variation_id ] = wc_format_decimal( $regular_price, wc_get_price_decimals() );
-						$prices_array['sale_price'][ $variation_id ]    = wc_format_decimal( $sale_price . '.00', wc_get_price_decimals() );
+						$prices_array['sale_price'][ $variation_id ]    = wc_format_decimal( $sale_price, wc_get_price_decimals() );
 
 						$prices_array = apply_filters( 'woocommerce_variation_prices_array', $prices_array, $variation, $for_display );
 					}

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -293,6 +293,7 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 	if ( ! is_float( $number ) ) {
 		$number = str_replace( $decimals, '.', $number );
 		$number = preg_replace( '/[^0-9\.,-]/', '', wc_clean( $number ) );
+		$number = preg_replace( '/\.+/', '.', $number );
 	}
 
 	if ( false !== $dp ) {

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -293,6 +293,8 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 	if ( ! is_float( $number ) ) {
 		$number = str_replace( $decimals, '.', $number );
 		$number = preg_replace( '/[^0-9\.,-]/', '', wc_clean( $number ) );
+
+		// Convert multiple dots to just one.
 		$number = preg_replace( '/\.+/', '.', $number );
 	}
 

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -737,7 +737,8 @@ function wc_timezone_string() {
 	// Last try, guess timezone string manually.
 	foreach ( timezone_abbreviations_list() as $abbr ) {
 		foreach ( $abbr as $city ) {
-			if ( (bool) date( 'I' ) === (bool) $city['dst'] && $city['timezone_id'] && intval( $city['offset'] ) === $utc_offset ) {
+			// WordPress restrict the use of date(), since it's affected by timezone settings, but in this case is just what we need to guess the correct timezone.
+			if ( (bool) date( 'I' ) === (bool) $city['dst'] && $city['timezone_id'] && intval( $city['offset'] ) === $utc_offset ) { // phpcs:ignore WordPress.DateTime.RestrictedFunctions.date_date
 				return $city['timezone_id'];
 			}
 		}

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -292,10 +292,9 @@ function wc_format_decimal( $number, $dp = false, $trim_zeros = false ) {
 	// Remove locale from string.
 	if ( ! is_float( $number ) ) {
 		$number = str_replace( $decimals, '.', $number );
-		$number = preg_replace( '/[^0-9\.,-]/', '', wc_clean( $number ) );
 
 		// Convert multiple dots to just one.
-		$number = preg_replace( '/\.+/', '.', $number );
+		$number = preg_replace( '/\.(?![^.]+$)|[^0-9.-]/', '', wc_clean( $number ) );
 	}
 
 	if ( false !== $dp ) {

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -290,6 +290,9 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		// Given string.
 		$this->assertEquals( '9.99', wc_format_decimal( '9.99' ) );
 
+		// Given string with multiple decimals points.
+		$this->assertEquals( '9.99', wc_format_decimal( '9...99' ) );
+
 		// Float.
 		$this->assertEquals( '9.99', wc_format_decimal( 9.99 ) );
 
@@ -316,7 +319,10 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_price_thousand_sep', '.' );
 
 		// Given string.
-		$this->assertEquals( '9.99', wc_format_decimal( '9.99' ) );
+		$this->assertEquals( '9.99', wc_format_decimal( '9,99' ) );
+
+		// Given string with multiple decimals points.
+		$this->assertEquals( '9.99', wc_format_decimal( '9,,,99' ) );
 
 		// Float.
 		$this->assertEquals( '9.99', wc_format_decimal( 9.99 ) );

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -293,6 +293,12 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		// Given string with multiple decimals points.
 		$this->assertEquals( '9.99', wc_format_decimal( '9...99' ) );
 
+		// Given string with multiple decimals points.
+		$this->assertEquals( '99.9', wc_format_decimal( '9...9....9' ) );
+
+		// Negative string.
+		$this->assertEquals( '-9.99', wc_format_decimal( '-9.99' ) );
+
 		// Float.
 		$this->assertEquals( '9.99', wc_format_decimal( 9.99 ) );
 
@@ -323,6 +329,12 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
 		// Given string with multiple decimals points.
 		$this->assertEquals( '9.99', wc_format_decimal( '9,,,99' ) );
+
+		// Given string with multiple decimals points.
+		$this->assertEquals( '99.9', wc_format_decimal( '9,,,9,,,,9' ) );
+
+		// Negative string.
+		$this->assertEquals( '-9.99', wc_format_decimal( '-9,99' ) );
 
 		// Float.
 		$this->assertEquals( '9.99', wc_format_decimal( 9.99 ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`wc_format_decimal()` currently doesn't strip multiple decimal separators like for `12...99`, this PR fixes this behavior.
This fix prices in the front-end, REST API and more.

Also included validation and sanitization for inputs in the back-end.

Closes #24269.

### How to test the changes in this Pull Request:

1. Apply this patch, run `wp shell`
2. Try `wc_format_decimal( '12...99' )`, will output `12.99`. (maybe need to change to `,` depending on your settings, but the output uses period).
3. Go edit any product, and enter a price like `12...99`, see the notice about, after press tab, and see that the number is converted to `12.99`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Correct number of decimal points in prices.