### PR TITLE
Make wc_get_endpoint_url() follow WordPress permalink settings

### DIFF
--- a/includes/wc-page-functions.php
+++ b/includes/wc-page-functions.php
@@ -101,10 +101,12 @@ function wc_get_endpoint_url( $endpoint, $value = '', $permalink = '' ) {
 		} else {
 			$query_string = '';
 		}
-		$url = trailingslashit( $permalink ) . trailingslashit( $endpoint );
+		$url = trailingslashit( $permalink );
 
 		if ( $value ) {
-			$url .= trailingslashit( $value );
+			$url .= trailingslashit( $endpoint ) . user_trailingslashit( $value );
+		} else {
+			$url .= user_trailingslashit( $endpoint );
 		}
 
 		$url .= $query_string;

--- a/tests/unit-tests/page-functions/class-wc-tests-page-functions.php
+++ b/tests/unit-tests/page-functions/class-wc-tests-page-functions.php
@@ -1,0 +1,46 @@
+<?php
+/**
+ * Tests for the functions in includes/wc-page-functions.php.
+ *
+ * @package WooCommerce\Tests\PageFunctions
+ */
+
+/**
+ * Page functions tests.
+ */
+class WC_Tests_Page_Functions extends WC_Unit_Test_Case {
+
+	/**
+	 * Test wc_get_endpoint_url() when the option permalink_structure is not set.
+	 */
+	public function test_wc_get_endpoint_url_should_add_endpoint_to_query_string() {
+		$url = wc_get_endpoint_url( 'customer-logout', 'yes', 'https://example.org/' );
+		$this->assertEquals( 'https://example.org/?customer-logout=yes', $url );
+	}
+
+	/**
+	 * Test wc_get_endpoint_url() when the option permalink_structure is set.
+	 */
+	public function test_wc_get_endpoint_url_should_add_endpoint_to_query_path() {
+		global $wp_rewrite;
+
+		update_option( 'permalink_structure', '/%postname%/' );
+		$wp_rewrite->use_trailing_slashes = true;
+
+		$url = wc_get_endpoint_url( 'customer-logout', '', 'https://example.org/' );
+		$this->assertEquals( 'https://example.org/customer-logout/', $url );
+
+		$url = wc_get_endpoint_url( 'customer-logout', 'yes', 'https://example.org/' );
+		$this->assertEquals( 'https://example.org/customer-logout/yes/', $url );
+
+		$url = wc_get_endpoint_url( 'customer-logout', 'yes', 'https://example.org/?foo=bar' );
+		$this->assertEquals( 'https://example.org/customer-logout/yes/?foo=bar', $url );
+
+		// test added after issue https://github.com/woocommerce/woocommerce/issues/24240.
+		update_option( 'permalink_structure', '/%postname%' );
+		$wp_rewrite->use_trailing_slashes = false;
+
+		$url = wc_get_endpoint_url( 'customer-logout', '', 'https://example.org/' );
+		$this->assertEquals( 'https://example.org/customer-logout', $url );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Currently if using a permalink settings like `/%postname%` endpoints will still include a `/` by the end of the URL causing a 301 to the correct URL.

Closes #24240.

### How to test the changes in this Pull Request:

1. Set WordPress permalink in `/wp-admin/options-permalink.php` to: `/%postname%`
2. Go to `my-account` page and click on any link in the tabs (just not the Dashboard that doesn't use `wc_get_endpoint_url()`)
3. Check network tab in devtools, and see the redirect
4. Apply this patch and try again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed endpoints URLs to follow slashes preferences from WordPress permalinks.
