### PR TITLE
Fixed Netherlands postcode formatting

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -946,7 +946,7 @@ function wc_format_postcode( $postcode, $country ) {
 			$postcode = rtrim( substr_replace( $postcode, '-', 5, 0 ), '-' );
 			break;
 		case 'NL':
-			$postcode = substr_replace( $postcode, ' ', 4, 0 );
+			$postcode = trim( substr_replace( $postcode, ' ', 4, 0 ) );
 			break;
 	}
 

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -927,10 +927,10 @@ function wc_format_postcode( $postcode, $country ) {
 	switch ( $country ) {
 		case 'CA':
 		case 'GB':
-			$postcode = trim( substr_replace( $postcode, ' ', -3, 0 ) );
+			$postcode = substr_replace( $postcode, ' ', -3, 0 );
 			break;
 		case 'IE':
-			$postcode = trim( substr_replace( $postcode, ' ', 3, 0 ) );
+			$postcode = substr_replace( $postcode, ' ', 3, 0 );
 			break;
 		case 'BR':
 		case 'PL':
@@ -946,11 +946,11 @@ function wc_format_postcode( $postcode, $country ) {
 			$postcode = rtrim( substr_replace( $postcode, '-', 5, 0 ), '-' );
 			break;
 		case 'NL':
-			$postcode = trim( substr_replace( $postcode, ' ', 4, 0 ) );
+			$postcode = substr_replace( $postcode, ' ', 4, 0 );
 			break;
 	}
 
-	return apply_filters( 'woocommerce_format_postcode', $postcode, $country );
+	return apply_filters( 'woocommerce_format_postcode', trim( $postcode ), $country );
 }
 
 /**

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -774,6 +774,9 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
 		// JP postcode.
 		$this->assertEquals( '999-9999', wc_format_postcode( '9999999', 'JP' ) );
+
+		// Test empty NL postcode.
+		$this->assertEquals( '', wc_format_postcode( '', 'NL' ) );
 	}
 
 	/**


### PR DESCRIPTION
Trim all spaces, fixes issues when postcode is empty.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Using `substr_replace( '', ' ', 4, 0 )` will return an empty space, causing problems in the checkout validation, even when postcode is not required.

Closes #24225.

### How to test the changes in this Pull Request:

See #24225.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Ensure that postcode validation doesn't return any whitespace on beginning and end of a postcode.