### PR TITLE
Add testing instructions file for WC 3.7

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -110,3 +110,12 @@ If you created a style guide for your language, please let us know so we can add
 Another valuable way to help is by translating our growing library of WooCommerce video tutorials. Check out the [Translating  Our Videos](https://docs.woocommerce.com/document/translating-our-videos/) doc and join in!
 
 By translating video tutorials you'll be helping non-English speaking users and people affected by disabilities to get to grips with using WooCommerce for the first time, and to go on and create their businesses and make a living! That's something to be proud of and if you choose to dive into this area, we salute you.
+
+### Testing
+
+There can never be enough testing done which is why it is a great way to contribute to WooCommerce as well. 
+
+If you'd like to test WooCommerce, take a look at the guides below:
+
+- [General WooCommerce Core Testing Checklist](https://github.com/woocommerce/woocommerce/wiki/Core-Testing-Checklist)
+- [Testing instructions for the current WooCommerce release](https://github.com/woocommerce/woocommerce/blob/master/to-test.md)

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Another valuable way to help is by translating our growing library of WooCommerc
 
 By translating video tutorials you'll be helping non-English speaking users and people affected by disabilities to get to grips with using WooCommerce for the first time, and to go on and create their businesses and make a living! That's something to be proud of and if you choose to dive into this area, we salute you.
 
-### Testing
+## Testing 🔬
 
 There can never be enough testing done which is why it is a great way to contribute to WooCommerce as well. 
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -111,7 +111,7 @@ Another valuable way to help is by translating our growing library of WooCommerc
 
 By translating video tutorials you'll be helping non-English speaking users and people affected by disabilities to get to grips with using WooCommerce for the first time, and to go on and create their businesses and make a living! That's something to be proud of and if you choose to dive into this area, we salute you.
 
-## Testing 🔬
+## Testing WooCommerce 🔬
 
 There can never be enough testing done which is why it is a great way to contribute to WooCommerce as well. 
 

--- a/to-test.md
+++ b/to-test.md
@@ -1,0 +1,60 @@
+### 3.7
+
+### Product Blocks
+
+WooCommerce Product Blocks 2.3 is included in this release. WooCommerce Products Blocks is our eCommerce focused blocks for the Gutenberg editor that has been part of WordPress since 5.0.
+
+The first Product Blocks were included in WooCommerce 3.6 and with the inclusion of Product Blocks 2.3 in WooCommerce 3.7, there are several new features added:
+
+- A new Focal Point picker on the Featured Product block.
+- Searching for products in Featured Product & Hand-picked Product blocks is faster.
+- A new Product Categories List block.
+- Better block branding for easier discoverability.
+- A new Featured Category Block; feature a category and show a link to its archive.
+- A new Products by Tag(s) block.
+
+In order to have access to the new Product Blocks, you will need to have WordPress 5.1+ installed or have the latest version of the Gutenberg Editor plugin installed.
+
+To test, you'll want to add a new page or post and add each of the new blocks to that page. Some areas to focus on:
+
+- Blocks discoverability
+- Add, edit, publish, and delete block
+- Block customization
+
+### Additional enhancements
+
+In addition to the above, we have also included the following user-facing enhancements in WooCommerce 3.7.
+
+- The ability to change the “Thanks” wording in emails from the email settings.
+- Added new Coupon code generator functionality to the coupons page.
+
+To test, you'd want to make sure you can edit the text that appears below the main email content. To do that, navigate to `WooCommerce > Settings > Emails` and edit the `Additional content` field of the emails. The `Thanks` wording appears in the following emails by default:
+
+- Cancelled order
+- Processing order
+- Completed order
+- Customer invoice / Order details
+- Customer note
+- Reset password
+
+After the change in the text is made, you'd want to place an order and make sure the change appears in emails you receive. 
+
+When testing the new Coupon code generator functionality, focus on the following areas:
+
+- Add, edit, publish, and delete coupon
+- Apply coupon during checkout
+
+### Testing helpers
+
+- At any point during your testing, remember to [check your browser's JavaScript console](https://codex.wordpress.org/Using_Your_Browser_to_Diagnose_JavaScript_Errors#Step_3:_Diagnosis) and see if there are any errors reported by WooCommerce there.
+- Use [Debug Bar](https://wordpress.org/plugins/enable-wp-debug-from-admin-dashboard/) or [Query Monitor](https://en-gb.wordpress.org/plugins/query-monitor/) to help make PHP notices and warnings more noticeable and report anything you see.
+
+### Reporting bugs
+
+- Bugs related to Product Blocks should be reported in the [WooCommerce Gutenberg Products Block repository](https://github.com/woocommerce/woocommerce-gutenberg-products-block)
+- Bugs related to WooCommerce REST API should be reported in the [WooCommerce REST API](https://github.com/woocommerce/woocommerce-rest-api) repository
+- All other WooCommerce related issues should be reported here in the WooCommerce repository
+
+**Thank you for testing!**
+
+

--- a/to-test.md
+++ b/to-test.md
@@ -1,4 +1,4 @@
-### 3.7
+### WooCommerce 3.7
 
 ### Product Blocks
 
@@ -27,6 +27,9 @@ In addition to the above, we have also included the following user-facing enhanc
 
 - The ability to change the “Thanks” wording in emails from the email settings.
 - Added new Coupon code generator functionality to the coupons page.
+- If variations are missing prices, show a notice in the product data panel.
+- Show the quantity refunded on customer facing order screens.
+- CSV product import now allows true/false values for the published field, as well as the original 0 (private), -1 (draft), 1 (publish) values.
 
 To test, you'd want to make sure you can edit the text that appears below the main email content. To do that, navigate to `WooCommerce > Settings > Emails` and edit the `Additional content` field of the emails. The `Thanks` wording appears in the following emails by default:
 
@@ -43,6 +46,21 @@ When testing the new Coupon code generator functionality, focus on the following
 
 - Add, edit, publish, and delete coupon
 - Apply coupon during checkout
+
+To test the change around variations, create a variable product without setting the price for variations. Can you see a notice letting you know that some variations are missing the price?
+
+When testing to make sure the refunded amount of the order is visible on the customer facing pages as well, follow the steps below:
+
+- Place an order on the site
+- Refund the order partially
+- Make sure you can see the amount refunded when navigating to `My Account > Orders > Order refunded` page at the front end of the site
+
+Finally, to test the CSV Import, you'd want to follow the steps below:
+
+- Export products from one of your test sites
+- Edit the `Published` field of the CSV file to either `true` = `published` or `false` = `draft`
+- Import the file to your current testing site
+- Verify that the products that were marked as `true` are indeed published and those marked as `false` are saved as draft 
 
 ### Testing helpers
 

--- a/to-test.md
+++ b/to-test.md
@@ -46,7 +46,7 @@ When testing the new Coupon code generator functionality, focus on the following
 
 ### Testing helpers
 
-- At any point during your testing, remember to [check your browser's JavaScript console](https://codex.wordpress.org/Using_Your_Browser_to_Diagnose_JavaScript_Errors#Step_3:_Diagnosis) and see if there are any errors reported by WooCommerce there.
+- At any point during your testing, remember to [check your browser's JavaScript console](https://codex.wordpress.org/Using_Your_Browser_to_Diagnose_JavaScript_Errors#Step_3:_Diagnosis) and see if there are any errors reported by WooCommerce.
 - Use [Debug Bar](https://wordpress.org/plugins/enable-wp-debug-from-admin-dashboard/) or [Query Monitor](https://en-gb.wordpress.org/plugins/query-monitor/) to help make PHP notices and warnings more noticeable and report anything you see.
 
 ### Reporting bugs


### PR DESCRIPTION
### Changes proposed in this Pull Request:

- Add testing instructions for WooCommerce 3.7 RC;
- Create `Testing` chapter in the contributing file and reference testing instructions files there to tie resources across different parts of the repository.