### PR TITLE
Sort shipping classes under products alphabetically

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-shipping.php
+++ b/includes/admin/meta-boxes/views/html-product-data-shipping.php
@@ -50,6 +50,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			'id'               => 'product_shipping_class',
 			'selected'         => $product_object->get_shipping_class_id( 'edit' ),
 			'class'            => 'select short',
+			'orderby'          => 'name',
 		);
 		?>
 		<p class="form-field shipping_class_field">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Alphabetically sorts the Shipping Classes under a product's _Shipping_ tab. 
Requested here: https://wordpress.org/support/topic/alphabetically-sort-shipping-classes/

### How to test the changes in this Pull Request:

1. Products > Add New
2. Click on Shipping tab
3. View Shipping Classes in drop down

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Sort shipping classes under products alphabetically
