### PR TITLE
Prevent PHP notices in WooCommerce widgets using Gutenberg's Legacy Widget Block

### DIFF
--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -78,6 +78,11 @@ abstract class WC_Widget extends WP_Widget {
 	 * @return bool true if the widget is cached otherwise false
 	 */
 	public function get_cached_widget( $args ) {
+		// Don't get cache if widget_id doesn't exists.
+		if ( empty( $args['widget_id'] ) ) {
+			return false;
+		}
+
 		$cache = wp_cache_get( $this->get_widget_id_for_cache( $this->widget_id ), 'widget' );
 
 		if ( ! is_array( $cache ) ) {
@@ -100,6 +105,11 @@ abstract class WC_Widget extends WP_Widget {
 	 * @return string the content that was cached
 	 */
 	public function cache_widget( $args, $content ) {
+		// Don't set any cache if widget_id doesn't exist.
+		if ( empty( $args['widget_id'] ) ) {
+			return $content;
+		}
+
 		$cache = wp_cache_get( $this->get_widget_id_for_cache( $this->widget_id ), 'widget' );
 
 		if ( ! is_array( $cache ) ) {

--- a/includes/widgets/class-wc-widget-products.php
+++ b/includes/widgets/class-wc-widget-products.php
@@ -193,7 +193,7 @@ class WC_Widget_Products extends WC_Widget {
 			echo wp_kses_post( apply_filters( 'woocommerce_before_widget_product_list', '<ul class="product_list_widget">' ) );
 
 			$template_args = array(
-				'widget_id'   => $args['widget_id'],
+				'widget_id'   => isset( $args['widget_id'] ) ? $args['widget_id'] : $this->widget_id,
 				'show_rating' => true,
 			);
 

--- a/includes/widgets/class-wc-widget-recently-viewed.php
+++ b/includes/widgets/class-wc-widget-recently-viewed.php
@@ -88,7 +88,7 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 			echo wp_kses_post( apply_filters( 'woocommerce_before_widget_product_list', '<ul class="product_list_widget">' ) );
 
 			$template_args = array(
-				'widget_id' => $args['widget_id'],
+				'widget_id' => isset( $args['widget_id'] ) ? $args['widget_id'] : $this->widget_id,
 			);
 
 			while ( $r->have_posts() ) {

--- a/includes/widgets/class-wc-widget-top-rated-products.php
+++ b/includes/widgets/class-wc-widget-top-rated-products.php
@@ -79,7 +79,7 @@ class WC_Widget_Top_Rated_Products extends WC_Widget {
 			echo wp_kses_post( apply_filters( 'woocommerce_before_widget_product_list', '<ul class="product_list_widget">' ) );
 
 			$template_args = array(
-				'widget_id'   => $args['widget_id'],
+				'widget_id'   => isset( $args['widget_id'] ) ? $args['widget_id'] : $this->widget_id,
 				'show_rating' => true,
 			);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WooCommerce expects an `widget_id` from arguments passed to `WP_Widget->widget()`, but `widget_id` is not always available, only in sidebars.
Also [docs for this methods](https://developer.wordpress.org/reference/classes/wp_widget/widget/#parameters) doesn't include any mention about `widget_id`: 

> $args
>    (array) (Required) Display arguments including 'before_title', 'after_title', 'before_widget', and 'after_widget'.

So it's better to check if exists before using, and this patches an issue with the Gutenberg's Legacy Widget Block that doesn't any `widget_id`.

See the output of `$args` from `WP_Widget->widget()` in for the Product's widget:

Gutenberg:

```
Array
(
    [before_widget] => <div class="widget woocommerce widget_products">
    [after_widget] => </div>
    [before_title] => <h2 class="widgettitle">
    [after_title] => </h2>
)
```

Sidebar:

```
Array
(
    [name] => Sidebar
    [id] => sidebar-1
    [description] => 
    [class] => 
    [before_widget] => <div id="woocommerce_products-2" class="widget woocommerce widget_products">
    [after_widget] => </div>
    [before_title] => <span class="gamma widget-title">
    [after_title] => </span>
    [widget_id] => woocommerce_products-2
    [widget_name] => Products
)
```

Both displays correct, but since there's no `widget_id` isn't possible to cache, not a big deal, since is on a page and not loaded in every single page like sidebars.

Note that this Pull Request only fixes the `widget_id` for caching, but doesn't fix the display on the content, also this feature is experimental and will have some updates in the future, so we need to check the docs in order to fix it if necessary, but suppose to work with any widget.

Closes #24116.

### How to test the changes in this Pull Request:

1. Install and activate the latest version of Gutenberg.
2. Go to Gutenberg settings in `wp-admin/admin.php?page=gutenberg-experiments` and enable "Enable Widgets Screen and Legacy Widget Block"
3. Add Gutenberg Legacy Block to a page, select any WooCommerce Widget (Products, Recently Viewed and Top Rated widgets throws more errors), and save.
4. Visit page and see the errors
5. Apply this patch and see that there's no more errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed support to Gutenberg's Legacy Widget block.
