### PR TITLE
Remove %20 from fields in External Products form

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -699,7 +699,7 @@ function wc_product_class( $class = '', $product_id = null ) {
  */
 function wc_query_string_form_fields( $values = null, $exclude = array(), $current_key = '', $return = false ) {
 	if ( is_null( $values ) ) {
-		$values = $_GET; // WPCS: input var ok, CSRF ok.
+		$values = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	} elseif ( is_string( $values ) ) {
 		$url_parts = wp_parse_url( $values );
 		$values    = array();
@@ -707,8 +707,8 @@ function wc_query_string_form_fields( $values = null, $exclude = array(), $curre
 		if ( ! empty( $url_parts['query'] ) ) {
 			// This is to preserve full-stops, pluses and spaces in the query string when ran through parse_str.
 			$replace_chars = array(
-				'.'   => '{dot}',
-				'+'   => '{plus}',
+				'.' => '{dot}',
+				'+' => '{plus}',
 			);
 
 			$query_string = str_replace( array_keys( $replace_chars ), array_values( $replace_chars ), $url_parts['query'] );
@@ -744,7 +744,7 @@ function wc_query_string_form_fields( $values = null, $exclude = array(), $curre
 		return $html;
 	}
 
-	echo $html; // WPCS: XSS ok.
+	echo $html; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
 /**

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -709,7 +709,6 @@ function wc_query_string_form_fields( $values = null, $exclude = array(), $curre
 			$replace_chars = array(
 				'.'   => '{dot}',
 				'+'   => '{plus}',
-				'%20' => '{space}',
 			);
 
 			$query_string = str_replace( array_keys( $replace_chars ), array_values( $replace_chars ), $url_parts['query'] );

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -135,11 +135,11 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected_html, $actual_html );
 
 		$actual_html   = wc_query_string_form_fields( '?test+something=something+else', array(), '', true );
-		$expected_html = '<input type="hidden" name="test+something" value="something+else" />';
+		$expected_html = '<input type="hidden" name="test something" value="something else" />';
 		$this->assertEquals( $expected_html, $actual_html );
 
 		$actual_html   = wc_query_string_form_fields( '?test%20something=something%20else', array(), '', true );
-		$expected_html = '<input type="hidden" name="test%20something" value="something%20else" />';
+		$expected_html = '<input type="hidden" name="test something" value="something else" />';
 		$this->assertEquals( $expected_html, $actual_html );
 	}
 }

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -135,11 +135,11 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected_html, $actual_html );
 
 		$actual_html   = wc_query_string_form_fields( '?test+something=something+else', array(), '', true );
-		$expected_html = '<input type="hidden" name="test something" value="something else" />';
+		$expected_html = '<input type="hidden" name="test+something" value="something+else" />';
 		$this->assertEquals( $expected_html, $actual_html );
 
 		$actual_html   = wc_query_string_form_fields( '?test%20something=something%20else', array(), '', true );
-		$expected_html = '<input type="hidden" name="test something" value="something else" />';
+		$expected_html = '<input type="hidden" name="test_something" value="something else" />';
 		$this->assertEquals( $expected_html, $actual_html );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In query strings we should preserve `%20`, but in forms will generate incorrect data, since the request will be processed differently.

This will prevent this output:

```
<input type="hidden" name="title" value="Product%20Name">
```

Closes #24096.

### How to test the changes in this Pull Request:

See https://github.com/woocommerce/woocommerce/issues/24096

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed spaces in form fields of External Products.