### PR TITLE
Restored Photoswipe custom styles

### DIFF
--- a/assets/css/photoswipe/photoswipe.css
+++ b/assets/css/photoswipe/photoswipe.css
@@ -1,3 +1,35 @@
+/**
+ * WooCommerce Photoswipe styles.
+ * 1. These styles are required to overwrite default theme button styles (Twenty Twelve adds gradients via background-image).
+ * 2. For zooming on mobile.
+ */
+.woocommerce img.pswp__img,
+.woocommerce-page img.pswp__img {
+	max-width: none; /* 2 */
+}
+button.pswp__button {
+	box-shadow: none !important;
+	background-image: url('default-skin/default-skin.png') !important;
+}
+button.pswp__button,
+button.pswp__button:hover,
+button.pswp__button--arrow--left::before,
+button.pswp__button--arrow--right::before {
+	background-color: transparent !important; /* 1 */
+}
+button.pswp__button--arrow--left,
+button.pswp__button--arrow--right,
+button.pswp__button--arrow--left:hover,
+button.pswp__button--arrow--right:hover {
+	background-image: none !important; /* 1 */
+}
+button.pswp__button--close:hover {
+	background-position: 0 -44px;
+}
+button.pswp__button--zoom:hover {
+	background-position: -88px 0;
+}
+
 /*! PhotoSwipe main CSS by Dmitry Semenov | photoswipe.com | MIT license */
 /*
 	Styles for basic PhotoSwipe functionality (sliding area, open/close transitions)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR restores our custom styles removed in https://github.com/woocommerce/woocommerce/commit/1caeb43baf3c465f3c3c4349875d9b409935f079#diff-b3aab570a7aec8b94c76c79a89fc89e6

Closes #23900.

Note that is not two separated files because of https://github.com/woocommerce/woocommerce/pull/19673

### How to test the changes in this Pull Request:

See #23900

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed Photoswipe styles.
