### PR TITLE
Fix/23870

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -43,11 +43,11 @@ jQuery( function ( $ ) {
 			var $this = $( this ),
 				country = $this.val(),
 				$state = $this.parents( 'div.edit_address' ).find( ':input.js_field-state' ),
-				$stateValue = $state.val(),
 				$parent = $state.parent(),
+				stateValue = $state.val(),
 				input_name = $state.attr( 'name' ),
 				input_id = $state.attr( 'id' ),
-				value = $this.data( 'woocommerce.stickState-' + country ) ? $this.data( 'woocommerce.stickState-' + country ) : $stateValue,
+				value = $this.data( 'woocommerce.stickState-' + country ) ? $this.data( 'woocommerce.stickState-' + country ) : stateValue,
 				placeholder = $state.attr( 'placeholder' ),
 				$newstate;
 
@@ -74,6 +74,9 @@ jQuery( function ( $ ) {
 						var $option = $( '<option></option>' )
 							.prop( 'value', index )
 							.text( state[ index ] );
+						if ( index == stateValue ) {
+							$option.prop( 'selected' );
+						}
 						$newstate.append( $option );
 					} );
 
@@ -88,7 +91,7 @@ jQuery( function ( $ ) {
 					.prop( 'name', input_name )
 					.prop( 'placeholder', placeholder )
 					.addClass( 'js_field-state' )
-					.val( $stateValue );
+					.val( stateValue );
 				$state.replaceWith( $newstate );
 			}
 

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -74,7 +74,7 @@ jQuery( function ( $ ) {
 						var $option = $( '<option></option>' )
 							.prop( 'value', index )
 							.text( state[ index ] );
-						if ( index == stateValue ) {
+						if ( index === stateValue ) {
 							$option.prop( 'selected' );
 						}
 						$newstate.append( $option );

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -43,10 +43,11 @@ jQuery( function ( $ ) {
 			var $this = $( this ),
 				country = $this.val(),
 				$state = $this.parents( 'div.edit_address' ).find( ':input.js_field-state' ),
+				$stateValue = $state.val(),
 				$parent = $state.parent(),
 				input_name = $state.attr( 'name' ),
 				input_id = $state.attr( 'id' ),
-				value = $this.data( 'woocommerce.stickState-' + country ) ? $this.data( 'woocommerce.stickState-' + country ) : $state.val(),
+				value = $this.data( 'woocommerce.stickState-' + country ) ? $this.data( 'woocommerce.stickState-' + country ) : $stateValue,
 				placeholder = $state.attr( 'placeholder' ),
 				$newstate;
 
@@ -87,7 +88,7 @@ jQuery( function ( $ ) {
 					.prop( 'name', input_name )
 					.prop( 'placeholder', placeholder )
 					.addClass( 'js_field-state' )
-					.val( '' );
+					.val( $stateValue );
 				$state.replaceWith( $newstate );
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is an alternative to #24019 and introduce changes as per https://github.com/dtwist/woocommerce/commit/2320244065782e18456f0df279d6dc336fc0ac54

Closes #23870

### How to test the changes in this Pull Request:

1. Go to your shop page, add product to the cart and check out using any shipping / payment method
2. Once the order has been placed, go to WooCommerce > Orders > YOUR ORDER
For the shipping address, notice the presense of the County/State field
3. Click on the "edit" button
4. Earlier the State/County field was empty. After these changes, the State/County will be filled with the correct value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Changed assets/js/admin/meta-boxes-order.js to fill the state/county field value using jquery and fix issue with empty states when editing an order in wp-admin.
