### PR TITLE
Add Zambia's Provinces to the list of states.

### DIFF
--- a/i18n/states.php
+++ b/i18n/states.php
@@ -1346,4 +1346,16 @@ return array(
 		'NW'  => __( 'North West', 'woocommerce' ),
 		'WC'  => __( 'Western Cape', 'woocommerce' ),
 	),
+	'ZM' => array( // Zambia's Provinces. Ref: https://en.wikipedia.org/wiki/ISO_3166-2:ZM
+		'ZM-01' => __( 'Western', 'woocommerce' ),
+		'ZM-02' => __( 'Central', 'woocommerce' ),
+		'ZM-03' => __( 'Eastern', 'woocommerce' ),
+		'ZM-04' => __( 'Luapula', 'woocommerce' ),
+		'ZM-05' => __( 'Northern', 'woocommerce' ),
+		'ZM-06' => __( 'North-Western', 'woocommerce' ),
+		'ZM-07' => __( 'Southern', 'woocommerce' ),
+		'ZM-08' => __( 'Copperbelt', 'woocommerce' ),
+		'ZM-09' => __( 'Lusaka', 'woocommerce' ),
+		'ZM-10' => __( 'Muchinga', 'woocommerce' ),
+	),
 );


### PR DESCRIPTION
This Pull Request uses the ISO_3166-2 standard to add Zambia's Provinces to WooCommerce. Ref: https://en.wikipedia.org/wiki/ISO_3166-2:ZM.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This pull request adds the Provinces of Zambia so that they can be selected in WooCommerce.

### How to test the changes in this Pull Request:

One way to test the changes is to add a shipping zone. Before this pull request it was not possible to add Zambia's Provinces from the `Zone regions` list:
1. Visit WooCommerce > Settings > Shipping
2. Click `Add shipping zone`
3. Under `Zone regions` type in a Zambian Province, e.g. `Muchinga`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

This Pull Request adds the Provinces of Zambia.
