### PR TITLE
Do not minify FlexSlider library in every build

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -345,8 +345,7 @@ module.exports = function( grunt ) {
 	grunt.registerTask( 'js', [
 		'jshint',
 		'uglify:admin',
-		'uglify:frontend',
-		'uglify:flexslider'
+		'uglify:frontend'
 	]);
 
 	grunt.registerTask( 'css', [


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We are minifying FlexSlider library every time that we run `npm run build`, since is an library we don't need to build it every time.

Closes #24305.

### How to test the changes in this Pull Request:

1. Try run `npm run build` in `master` or `release/3.7`, and check `git status`.
2. Clean all `git checkout .`
3. Now apply this patch, and try step 1 again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

No need since is for a development tool.
