### PR TITLE
Fix output escaping for menu titles on WooCommerce > Extensions page [3.7 RC]

### DIFF
--- a/includes/admin/helper/views/html-section-nav.php
+++ b/includes/admin/helper/views/html-section-nav.php
@@ -7,5 +7,5 @@
 		$count_html = WC_Helper_Updater::get_updates_count_html();
 		$menu_title = sprintf( __( 'WooCommerce.com Subscriptions %s', 'woocommerce' ), $count_html );
 	?>
-	<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>" class="nav-tab nav-tab-active"><?php echo $menu_title; ?></a>
+	<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>" class="nav-tab nav-tab-active"><?php echo wp_kses_post( $menu_title ); ?></a>
 </nav>

--- a/includes/admin/helper/views/html-section-nav.php
+++ b/includes/admin/helper/views/html-section-nav.php
@@ -1,10 +1,18 @@
-<?php defined( 'ABSPATH' ) or exit(); ?>
+<?php
+/**
+ * Helper admin navigation.
+ *
+ * @package WooCommerce/Helper
+ */
+
+defined( 'ABSPATH' ) || exit(); ?>
 
 <nav class="nav-tab-wrapper woo-nav-tab-wrapper">
-	<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons' ) ); ?>" class="nav-tab"><?php _e( 'Browse Extensions', 'woocommerce' ); ?></a>
+	<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons' ) ); ?>" class="nav-tab"><?php esc_html_e( 'Browse Extensions', 'woocommerce' ); ?></a>
 
 	<?php
 		$count_html = WC_Helper_Updater::get_updates_count_html();
+		/* translators: %s: WooCommerce.com Subscriptions tab count HTML. */
 		$menu_title = sprintf( __( 'WooCommerce.com Subscriptions %s', 'woocommerce' ), $count_html );
 	?>
 	<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>" class="nav-tab nav-tab-active"><?php echo wp_kses_post( $menu_title ); ?></a>

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			// translators: Count of updates for WooCommerce.com subscriptions.
 			$menu_title = sprintf( __( 'WooCommerce.com Subscriptions %s', 'woocommerce' ), $count_html );
 		?>
-		<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>" class="nav-tab"><?php echo esc_html( $menu_title ); ?></a>
+		<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>" class="nav-tab"><?php echo wp_kses_post( $menu_title ); ?></a>
 	</nav>
 
 	<h1 class="screen-reader-text"><?php esc_html_e( 'WooCommerce Extensions', 'woocommerce' ); ?></h1>


### PR DESCRIPTION
Found this HTML escaping issue while testing 3.7 RC2. Please see screenshot.

![Screenshot](https://cld.wthms.co/X67Yte+)
Screenshot: https://cld.wthms.co/X67Yte 