### PR TITLE
Add missing additional content output to new account email

### DIFF
--- a/templates/emails/admin-cancelled-order.php
+++ b/templates/emails/admin-cancelled-order.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates/Emails
- * @version 3.6.0
+ * @version 3.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/emails/customer-new-account.php
+++ b/templates/emails/customer-new-account.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates/Emails
- * @version 3.5.2
+ * @version 3.7.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -28,7 +28,12 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 	<p><?php printf( esc_html__( 'Your password has been automatically generated: %s', 'woocommerce' ), '<strong>' . esc_html( $user_pass ) . '</strong>' ); ?></p>
 <?php endif; ?>
 
-<p><?php esc_html_e( 'We look forward to seeing you soon.', 'woocommerce' ); ?></p>
-
 <?php
+/**
+ * Show user-defined additonal content - this is set in each email's settings.
+ */
+if ( $additional_content ) {
+	echo wp_kses_post( wpautop( wptexturize( $additional_content ) ) );
+}
+
 do_action( 'woocommerce_email_footer', $email );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds the additional content output to the new account email that was mistakenly never added in the original PR.

Closes #24316 

### How to test the changes in this Pull Request:

1. Set additional content for New Account email under WooCommerce -> Settings -> Emails
2. Create a new account and check the email contains the entered additional content text.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
