### PR TITLE
Update travis dist to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ php:
   - 7.2
   - 7.3
 
+# Since Xenial services are not started by default, we need to instruct it below to start.
+services:
+  - mysql
+
 env:
   - WP_VERSION=latest WP_MULTISITE=0
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: trusty
+dist: bionic
 
 sudo: false
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ matrix:
     php: 7.2
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_E2E=1
     addons:
-      chrome: stable
+      chrome: beta
       apt:
         packages:
           - nginx

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,6 +66,9 @@ before_script:
       bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION
       composer global require "phpunit/phpunit=5.7.*|7.5.*"
     fi
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
+  - sleep 3 # give xvfb some time to start
 
 script:
   - bash tests/bin/phpunit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ php:
 # Since Xenial services are not started by default, we need to instruct it below to start.
 services:
   - mysql
+  - xvfb
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 language: php
 dist: xenial
 
+# Since Xenial services are not started by default, we need to instruct it below to start.
+services:
+  - xvfb
+  - mysql
+
 sudo: false
 
 cache:
@@ -15,11 +20,6 @@ php:
   - 7.1
   - 7.2
   - 7.3
-
-# Since Xenial services are not started by default, we need to instruct it below to start.
-services:
-  - mysql
-  - xvfb
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
@@ -66,9 +66,7 @@ before_script:
       bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION
       composer global require "phpunit/phpunit=5.7.*|7.5.*"
     fi
-  - export DISPLAY=:99.0
-  - sh -e /etc/init.d/xvfb start
-  - sleep 3 # give xvfb some time to start
+  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 
 script:
   - bash tests/bin/phpunit.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: php
-dist: bionic
+dist: xenial
 
 sudo: false
 

--- a/tests/bin/run-e2e-CI.sh
+++ b/tests/bin/run-e2e-CI.sh
@@ -3,11 +3,8 @@ if [[ ${RUN_E2E} == 1 ]]; then
 
 	WP_SITE_URL="http://localhost:8080"
 
-	# Start xvfb to run the tests
+	# Set base url to that of e2e test suite.
 	export BASE_URL="$WP_SITE_URL"
-	export DISPLAY=:99.0
-	sh -e /etc/init.d/xvfb start
-	sleep 3
 
 	# Run the tests
 	npm test


### PR DESCRIPTION
This PR updates the Travis build environment to use xenial instead of trusty which is quite old. Since we now have PHP 5.6 as a minimum and xenial supports PHP 5.6+ this should be fine. It will also allow us to also skip issues with certain packages being outdated and not support anymore on trusty since it is end of standard support already.