### PR TITLE
Update address setting for Japanese

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -996,7 +996,7 @@ class WC_Countries {
 							'class'    => array( 'form-row-first' ),
 							'priority' => 10,
 						),
-						'first_name'=> array(
+						'first_name' => array(
 							'class'    => array( 'form-row-last' ),
 							'priority' => 20,
 						),

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -992,11 +992,21 @@ class WC_Countries {
 						),
 					),
 					'JP' => array(
+						'last_name' => array(
+							'class'    => array( 'form-row-first' ),
+							'priority' => 10,
+						),
+						'first_name'=> array(
+							'class'    => array( 'form-row-last' ),
+							'priority' => 20,
+						),
 						'postcode'  => array(
+							'class'    => array( 'form-row-first' ),
 							'priority' => 65,
 						),
 						'state'     => array(
 							'label'    => __( 'Prefecture', 'woocommerce' ),
+							'class'    => array( 'form-row-last' ),
 							'priority' => 66,
 						),
 						'city'      => array(


### PR DESCRIPTION
Update setting for Japanese Name and postcode and Prefecture.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Correspondence of the order of address and first and last name in Japan.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1.latest WooCommerce demo site.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed Adaptation of the order of last name and first name and addresses in Japan.
