### PR TITLE
Allow wc_string_to_bool to not be case sensitive

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -18,7 +18,7 @@ defined( 'ABSPATH' ) || exit;
  * @return bool
  */
 function wc_string_to_bool( $string ) {
-	return is_bool( $string ) ? $string : ( 'yes' === $string || 1 === $string || 'true' === $string || '1' === $string );
+	return is_bool( $string ) ? $string : ( 'yes' === strtolower( $string ) || 1 === $string || 'true' === strtolower( $string ) || '1' === $string );
 }
 
 /**

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -30,10 +30,18 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	public function test_wc_string_to_bool() {
 		$this->assertTrue( wc_string_to_bool( 1 ) );
 		$this->assertTrue( wc_string_to_bool( 'yes' ) );
+		$this->assertTrue( wc_string_to_bool( 'Yes' ) );
+		$this->assertTrue( wc_string_to_bool( 'YES' ) );
 		$this->assertTrue( wc_string_to_bool( 'true' ) );
+		$this->assertTrue( wc_string_to_bool( 'True' ) );
+		$this->assertTrue( wc_string_to_bool( 'TRUE' ) );
 		$this->assertFalse( wc_string_to_bool( 0 ) );
 		$this->assertFalse( wc_string_to_bool( 'no' ) );
+		$this->assertFalse( wc_string_to_bool( 'No' ) );
+		$this->assertFalse( wc_string_to_bool( 'NO' ) );
 		$this->assertFalse( wc_string_to_bool( 'false' ) );
+		$this->assertFalse( wc_string_to_bool( 'False' ) );
+		$this->assertFalse( wc_string_to_bool( 'FALSE' ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue in the CSV importer and more specifically wc_string_to_bool where if you passed uppercase or camelcase values such as True or YES it returned the incorrect boolean value.

### How to test the changes in this Pull Request:

1. Create a product import file with the product published value set to `TRUE` or `YES`
2. Import product and check the product is set to published

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Make wc_string_to_bool so it is not case sensitive.
