### PR TITLE
Check for max discount to be -ve to prevent overwriting fee.

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1534,7 +1534,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			if ( 0 > $fee_total ) {
 				$max_discount = round( $cart_total + $fees_total + $shipping_total, wc_get_price_decimals() ) * -1;
 
-				if ( $fee_total < $max_discount ) {
+				if ( $fee_total < $max_discount && 0 > $max_discount ) {
 					$item->set_total( $max_discount );
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When we refund fee and some other line item whose value is more than fee in a single requst, value of line item will overwrite refund fee.

This is because where we check to make sure that we do not discount more than total possible value (to prevent negative total), we do not account for the fact that sometimes the cart could contain refund items. In those cases max_discount * -1 will always be larges then fees total.

This commit adds a check to make sure that max discount * -1 is indeed negative before overwriting fee total.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24238 

### How to test the changes in this Pull Request:

1. Create an order with a fee more than total of all line items.
2. Refund the order along with full or partial fee and some of the line item.
3. You would see that displayed refunded fee is correct. (see #24238)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Dev -    Check for max discount to be -ve to prevent overwriting refunded fee amount.
