### PR TITLE
Added selectWoo as dependency of country-select.

### DIFF
--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -247,7 +247,7 @@ class WC_Frontend_Scripts {
 			),
 			'wc-country-select'          => array(
 				'src'     => self::get_asset_url( 'assets/js/frontend/country-select' . $suffix . '.js' ),
-				'deps'    => array( 'jquery' ),
+				'deps'    => array( 'jquery', 'selectWoo' ),
 				'version' => WC_VERSION,
 			),
 			'wc-credit-card-form'        => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The frontend JS asset `country-select` is setting up the selectWoo for some fields but nowhere is ensuring that selectWoo is loaded.

This PR introduces the dependency from `country-select` to `selectWoo`. With it, in case some filters are changing how the scripts are loaded, makes the behavior more robust and prevent getting `selectWoo` fields broken.

Note that `country-select` is checking if `selectWoo` is loaded when is executed, but as long there is no JS dependency to it, selectWoo will be missed in case is loading after [this line is executed](https://github.com/woocommerce/woocommerce/blob/master/assets/js/frontend/country-select.js#L10) 

### How to test the changes in this Pull Request:

1. Add whatever filter to move the `<script>` tag for selectWoo into footer
2. Go to checkout page where the shipping country should be selected
3. The select input for country is not a selectWoo. When apply the patch then it is selectWoo

