### PR TITLE
Remove duplicate tooltip text in emails additional content

### DIFF
--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -184,7 +184,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 				),
 				'additional_content' => array(
 					'title'       => __( 'Additional content', 'woocommerce' ),
-					'description' => __( 'Text to appear to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
+					'description' => __( 'Text to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
 					'css'         => 'width:400px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),
 					'type'        => 'textarea',

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -221,7 +221,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 				),
 				'additional_content' => array(
 					'title'       => __( 'Additional content', 'woocommerce' ),
-					'description' => __( 'Text to appear to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
+					'description' => __( 'Text to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
 					'css'         => 'width:400px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),
 					'type'        => 'textarea',

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -277,7 +277,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 				),
 				'additional_content' => array(
 					'title'       => __( 'Additional content', 'woocommerce' ),
-					'description' => __( 'Text to appear to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
+					'description' => __( 'Text to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
 					'css'         => 'width:400px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),
 					'type'        => 'textarea',

--- a/includes/emails/class-wc-email-failed-order.php
+++ b/includes/emails/class-wc-email-failed-order.php
@@ -182,7 +182,7 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 				),
 				'additional_content' => array(
 					'title'       => __( 'Additional content', 'woocommerce' ),
-					'description' => __( 'Text to appear to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
+					'description' => __( 'Text to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
 					'css'         => 'width:400px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),
 					'type'        => 'textarea',

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -189,7 +189,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 				),
 				'additional_content' => array(
 					'title'       => __( 'Additional content', 'woocommerce' ),
-					'description' => __( 'Text to appear to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
+					'description' => __( 'Text to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
 					'css'         => 'width:400px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),
 					'type'        => 'textarea',

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -674,7 +674,7 @@ class WC_Email extends WC_Settings_API {
 			),
 			'additional_content' => array(
 				'title'       => __( 'Additional content', 'woocommerce' ),
-				'description' => __( 'Text to appear to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
+				'description' => __( 'Text to appear below the main email content.', 'woocommerce' ) . ' ' . $placeholder_text,
 				'css'         => 'width:400px; height: 75px;',
 				'placeholder' => __( 'N/A', 'woocommerce' ),
 				'type'        => 'textarea',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes the duplicate text in the emails additional content tooltips.

![](https://user-images.githubusercontent.com/271630/62637624-26b3ba80-b93c-11e9-8850-970cc670303b.png)


### How to test the changes in this Pull Request:

1. Go to `WooCommerce -> Settings -> Emails`
2. Visit each email type and verify the `Additional content` tooltip does not have duplicate text.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

