### PR TITLE
Avoid PHP notice when getting order item type

### DIFF
--- a/includes/data-stores/class-wc-order-item-data-store.php
+++ b/includes/data-stores/class-wc-order-item-data-store.php
@@ -145,11 +145,17 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 *
 	 * @since 3.0.0
 	 * @param int $item_id Item ID.
-	 * @return string
+	 * @return string|null Order item type or null if no order item entry found.
 	 */
 	public function get_order_item_type( $item_id ) {
 		global $wpdb;
-		$item_data = $wpdb->get_row( $wpdb->prepare( "SELECT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;", $item_id ) );
-		return $item_data->order_item_type;
+		$order_item_type = $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT order_item_type FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d LIMIT 1;",
+				$item_id
+			)
+		);
+
+		return $order_item_type;
 	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes WC_Order_Item_Data_Store::get_order_item_type() to avoid a PHP notice ("Notice: Trying to get property 'order_item_type' of non-object") when there is no entry in the database for the order item ID passed.

Closes #24334.

### How to test the changes in this Pull Request:

1. See #24334 for testing instructions.### Changelog entry

> Fix: prevent PHP notice in WC_Order_Item_Data_Store::get_order_item_type() when there is no entry in the database for the order item ID passed