### PR TITLE
Update class-wc-shipping.php

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -160,8 +160,8 @@ class WC_Shipping {
 			$this->shipping_methods = $shipping_zone->get_shipping_methods( true );
 
 			// Debug output.
-			if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! defined( 'WC_DOING_AJAX' ) && ! wc_has_notice( 'Customer matched zone "' . $shipping_zone->get_zone_name() . '"' ) ) {
-				wc_add_notice( 'Customer matched zone "' . $shipping_zone->get_zone_name() . '"' );
+			if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! defined( 'WC_DOING_AJAX' ) && ! wc_has_notice( sprintf( esc_html__( 'Customer matched zone "%s"', 'woocommerce' ), $shipping_zone->get_zone_name() ) ) ) {
+				wc_add_notice( sprintf( esc_html__( 'Customer matched zone "%s"', 'woocommerce' ), $shipping_zone->get_zone_name() ) );
 			}
 		} else {
 			$this->shipping_methods = array();

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -155,20 +155,20 @@ class WC_Shipping {
 	 */
 	public function load_shipping_methods( $package = array() ) {
 		if ( ! empty( $package ) ) {
-			$debug_mode             = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
-			$shipping_zone          = WC_Shipping_Zones::get_zone_matching_package( $package );
-			$this->shipping_methods = $shipping_zone->get_shipping_methods( true );
-			
-			// translators: %s: shipping zone name
-			$matched_zone_notice = sprintf( __( 'Customer matched zone "%s"', 'woocommerce' ), $shipping_zone->get_zone_name() );
+            $debug_mode             = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
+            $shipping_zone          = WC_Shipping_Zones::get_zone_matching_package( $package );
+            $this->shipping_methods = $shipping_zone->get_shipping_methods( true );
+            
+            // translators: %s: shipping zone name.
+            $matched_zone_notice = sprintf( __( 'Customer matched zone "%s"', 'woocommerce' ), $shipping_zone->get_zone_name() );
 
-			// Debug output.
-			if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! defined( 'WC_DOING_AJAX' ) && ! wc_has_notice( $matched_zone_notice ) ) {
-				wc_add_notice( $matched_zone_notice );
-			}
-		} else {
-			$this->shipping_methods = array();
-		}
+            // Debug output.
+            if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! defined( 'WC_DOING_AJAX' ) && ! wc_has_notice( $matched_zone_notice ) ) {
+                wc_add_notice( $matched_zone_notice );
+            }
+        } else {
+            $this->shipping_methods = array();
+        }
 
 		// For the settings in the backend, and for non-shipping zone methods, we still need to load any registered classes here.
 		foreach ( $this->get_shipping_method_class_names() as $method_id => $method_class ) {

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -155,20 +155,20 @@ class WC_Shipping {
 	 */
 	public function load_shipping_methods( $package = array() ) {
 		if ( ! empty( $package ) ) {
-            $debug_mode             = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
-            $shipping_zone          = WC_Shipping_Zones::get_zone_matching_package( $package );
-            $this->shipping_methods = $shipping_zone->get_shipping_methods( true );
-            
-            // translators: %s: shipping zone name.
-            $matched_zone_notice = sprintf( __( 'Customer matched zone "%s"', 'woocommerce' ), $shipping_zone->get_zone_name() );
+			$debug_mode             = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
+			$shipping_zone          = WC_Shipping_Zones::get_zone_matching_package( $package );
+			$this->shipping_methods = $shipping_zone->get_shipping_methods( true );
 
-            // Debug output.
-            if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! defined( 'WC_DOING_AJAX' ) && ! wc_has_notice( $matched_zone_notice ) ) {
-                wc_add_notice( $matched_zone_notice );
-            }
-        } else {
-            $this->shipping_methods = array();
-        }
+			// translators: %s: shipping zone name.
+			$matched_zone_notice = sprintf( __( 'Customer matched zone "%s"', 'woocommerce' ), $shipping_zone->get_zone_name() );
+
+			// Debug output.
+			if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! defined( 'WC_DOING_AJAX' ) && ! wc_has_notice( $matched_zone_notice ) ) {
+				wc_add_notice( $matched_zone_notice );
+			}
+		} else {
+			$this->shipping_methods = array();
+		}
 
 		// For the settings in the backend, and for non-shipping zone methods, we still need to load any registered classes here.
 		foreach ( $this->get_shipping_method_class_names() as $method_id => $method_class ) {

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -158,10 +158,13 @@ class WC_Shipping {
 			$debug_mode             = 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' );
 			$shipping_zone          = WC_Shipping_Zones::get_zone_matching_package( $package );
 			$this->shipping_methods = $shipping_zone->get_shipping_methods( true );
+			
+			// translators: %s: shipping zone name
+			$matched_zone_notice = sprintf( __( 'Customer matched zone "%s"', 'woocommerce' ), $shipping_zone->get_zone_name() );
 
 			// Debug output.
-			if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! defined( 'WC_DOING_AJAX' ) && ! wc_has_notice( sprintf( esc_html__( 'Customer matched zone "%s"', 'woocommerce' ), $shipping_zone->get_zone_name() ) ) ) {
-				wc_add_notice( sprintf( esc_html__( 'Customer matched zone "%s"', 'woocommerce' ), $shipping_zone->get_zone_name() ) );
+			if ( $debug_mode && ! defined( 'WOOCOMMERCE_CHECKOUT' ) && ! defined( 'WC_DOING_AJAX' ) && ! wc_has_notice( $matched_zone_notice ) ) {
+				wc_add_notice( $matched_zone_notice );
 			}
 		} else {
 			$this->shipping_methods = array();


### PR DESCRIPTION
Added translation.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

# Added Translation.

### How to test the changes in this Pull Request:

1. Go to WooCommerce Settings menu, then enable debug mode for shipping from shipping options in Shipping tab.
2. Add shipping zone then add product in the cart. If shipping is added in the cart, customer is able to see the message that customer matched zone "name of the zone".
3. Now the message can be translated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added Translation in class-wc-shipping.php
