### PR TITLE
Format postcode from DB before checking

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1456,7 +1456,7 @@ function wc_postcode_location_matcher( $postcode, $objects, $object_id_key, $obj
 
 	foreach ( $objects as $object ) {
 		$object_id       = $object->$object_id_key;
-		$compare_against = $object->$object_compare_key;
+		$compare_against = wc_format_postcode( $object->$object_compare_key, $country );
 
 		// Handle postcodes containing ranges.
 		if ( strstr( $compare_against, '...' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When trying to match a single postcode with the appropriate Shipping Zone, the postcode data that comes out of the DB is never formatted -- only when a postcode range `...` is specified.

WC will try to match a formatted postcode with a raw DB postcode. (apples vs oranges). This PR will fix this problem by formatting the postcode before WC calls the `in_array` check.

Closes #24369

### How to test the changes in this Pull Request:

See #24369

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Ensure that postcode checking is properly formatted when matching a Shipping Zone.
