### PR TITLE
Fix #24365: Prevent billing address from being updated on shipping update.

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -40,6 +40,9 @@ class WC_Shortcode_Cart {
 			}
 
 			if ( $address['country'] ) {
+				if ( ! WC()->customer->get_billing_first_name() ){
+				WC()->customer->set_billing_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
+				}
 				WC()->customer->set_shipping_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
 			} else {
 				WC()->customer->set_billing_address_to_base();

--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -41,7 +41,7 @@ class WC_Shortcode_Cart {
 
 			if ( $address['country'] ) {
 				if ( ! WC()->customer->get_billing_first_name() ) {
-				WC()->customer->set_billing_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
+					WC()->customer->set_billing_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
 				}
 				WC()->customer->set_shipping_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
 			} else {

--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -40,7 +40,6 @@ class WC_Shortcode_Cart {
 			}
 
 			if ( $address['country'] ) {
-				WC()->customer->set_billing_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
 				WC()->customer->set_shipping_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
 			} else {
 				WC()->customer->set_billing_address_to_base();

--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -40,7 +40,7 @@ class WC_Shortcode_Cart {
 			}
 
 			if ( $address['country'] ) {
-				if ( ! WC()->customer->get_billing_first_name() ){
+				if ( ! WC()->customer->get_billing_first_name() ) {
 				WC()->customer->set_billing_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );
 				}
 				WC()->customer->set_shipping_location( $address['country'], $address['state'], $address['postcode'], $address['city'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:
When you press the update button in the modify shipping section of your cart page, a function called 'calculate_shipping()' gets executed (class-wc-shortcode-cart.php). 

Inside this function, there's a particular method "WC()->customer->set_billing_location( [params])" which causes the undesired behavior presented in this bug. By simply deleting it, the problem gets solved. 

Now, when updating your shipping information in the cart page, only the shipping address will change; billing information will remain the same.

Closes #24365  .

### How to test the changes in this Pull Request:

(Same as the steps described in the issue description)
1. Create User with full Billing and Shipping Address in account details
2. Enable Shipping calculator in cart
3. Add items to cart and see that shipping calculator is pre-loaded with users address
4. Change shipping address in shipping calculator
5. Go to checkout page
6. Billing address should be the same (when running this PR code); only shipping address should have changed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Changelog entry
Prevent billing address from being updated on shipping update.
