### PR TITLE
fixed the security check error while previewing the email template

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -204,7 +204,7 @@ class WC_Admin {
 	public function preview_emails() {
 
 		if ( isset( $_GET['preview_woocommerce_mail'] ) ) {
-			if ( ! ( isset( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'], 'preview-mail' ) ) ) ) ) {
+			if ( ! ( isset( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_REQUEST['_wpnonce'] ) ), 'preview-mail' ) ) ) {
 				die( 'Security check' );
 			}
 


### PR DESCRIPTION
### All Submissions:
#24378 
I have fixed that issue
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
