### PR TITLE
Update grunt contributors command to take a branch input

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -260,7 +260,7 @@ module.exports = function( grunt ) {
 					'echo "Generating contributor list since <%= fromDate %>"',
 					'./node_modules/.bin/githubcontrib --owner woocommerce --repo woocommerce --fromDate <%= fromDate %>' +
 					' --authToken <%= authToken %> --cols 6 --sortBy contributions --format md --sortOrder desc' +
-					' --showlogin true > contributors.md'
+					' --showlogin true --sha <%= sha %> > contributors.md'
 				].join( '&&' )
 			}
 		},
@@ -273,6 +273,11 @@ module.exports = function( grunt ) {
 							config: 'fromDate',
 							type: 'input',
 							message: 'What date (YYYY-MM-DD) should we get contributions since?'
+						},
+						{
+							config: 'sha',
+							type: 'input',
+							message: 'What branch should we get contributors from?'
 						},
 						{
 							config: 'authToken',

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -260,7 +260,7 @@ module.exports = function( grunt ) {
 					'echo "Generating contributor list since <%= fromDate %>"',
 					'./node_modules/.bin/githubcontrib --owner woocommerce --repo woocommerce --fromDate <%= fromDate %>' +
 					' --authToken <%= authToken %> --cols 6 --sortBy contributions --format md --sortOrder desc' +
-					' --showlogin true --sha <%= sha %> > contributors.md'
+					' --showlogin true --sha <%= sha %> --filter renovate-bot > contributors.md'
 				].join( '&&' )
 			}
 		},


### PR DESCRIPTION
This PR updates the grunt contributors shell command to take a new input for the branch name and then runs the command against that branch instead. Provides a more accurate date based contribution list when run on release branches.