### PR TITLE
Don't escape subscription count as it contains safe HTML string.

### DIFF
--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -21,7 +21,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			// translators: Count of updates for WooCommerce.com subscriptions.
 			$menu_title = sprintf( __( 'WooCommerce.com Subscriptions %s', 'woocommerce' ), $count_html );
 		?>
-		<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>" class="nav-tab"><?php echo esc_html( $menu_title ); ?></a>
+		<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) ); ?>" class="nav-tab"><?php echo $menu_title; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></a>
 	</nav>
 
 	<h1 class="screen-reader-text"><?php esc_html_e( 'WooCommerce Extensions', 'woocommerce' ); ?></h1>


### PR DESCRIPTION
The `$menu_title` contains safe HTML string as it's sprintf'ed with numeric
placeholders.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Remove the `esc_html`. See similar partial in:
 https://github.com/woocommerce/woocommerce/blob/ca77f939981e2750907005704a09e86558a0483c/includes/admin/helper/views/html-section-nav.php#L10

Closes #24392.

### How to test the changes in this Pull Request:

1. Go to `/wp-admin/admin.php?page=wc-addons`
2. Make sure there's an update on your WooCommerce.com subscriptions.
3. You should see update count rendered as expected in the tab.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Don't escape WooCommerce.com subscription updates count as it contains safe HTML string.