### PR TITLE
Coupon expiry date tooltip to help understand behaviour

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -116,7 +116,8 @@ class WC_Meta_Box_Coupon_Data {
 						'value'             => esc_attr( $expiry_date ),
 						'label'             => __( 'Coupon expiry date', 'woocommerce' ),
 						'placeholder'       => 'YYYY-MM-DD',
-						'description'       => '',
+						'description'       => __( 'The coupon will expire at 00:00:00 of this date.', 'woocommerce' ),
+						'desc_tip'    => true,
 						'class'             => 'date-picker',
 						'custom_attributes' => array(
 							'pattern' => apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ),

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -372,22 +372,21 @@ class WC_Meta_Box_Coupon_Data {
 				array(
 					'code'                        => $post->post_title,
 					'discount_type'               => isset( $_POST['discount_type'] ) ? wc_clean( wp_unslash( $_POST['discount_type'] ) ) : null,
-					'amount'                      => isset( $_POST['coupon_amount'] ) ? wc_format_decimal( wp_unslash( $_POST['coupon_amount'] ) ) : null, 
-					'date_expires'                => isset( $_POST['expiry_date'] ) ? wc_clean( wp_unslash( $_POST['expiry_date'] ) ) : null, 
+					'amount'                      => isset( $_POST['coupon_amount'] ) ? wc_format_decimal( wp_unslash( $_POST['coupon_amount'] ) ) : null,
+					'date_expires'                => isset( $_POST['expiry_date'] ) ? wc_clean( wp_unslash( $_POST['expiry_date'] ) ) : null,
 					'individual_use'              => isset( $_POST['individual_use'] ),
 					'product_ids'                 => isset( $_POST['product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['product_ids'] ) ) ) : array(), // WPCS: input var ok.
 					'excluded_product_ids'        => isset( $_POST['exclude_product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['exclude_product_ids'] ) ) ) : array(), // WPCS: input var ok.
-					'usage_limit'                 => isset( $_POST['usage_limit'] ) ? absint( wp_unslash( $_POST['usage_limit'] ) ) : null, 
-					'usage_limit_per_user'        => isset( $_POST['usage_limit_per_user'] ) ? absint( wp_unslash( $_POST['usage_limit_per_user'] ) ) : null, 
-					'limit_usage_to_x_items'      => isset( $_POST['limit_usage_to_x_items'] ) ? absint( wp_unslash( $_POST['limit_usage_to_x_items'] ) ) : null, 
+					'usage_limit'                 => isset( $_POST['usage_limit'] ) ? absint( wp_unslash( $_POST['usage_limit'] ) ) : null,
+					'usage_limit_per_user'        => isset( $_POST['usage_limit_per_user'] ) ? absint( wp_unslash( $_POST['usage_limit_per_user'] ) ) : null,
+					'limit_usage_to_x_items'      => isset( $_POST['limit_usage_to_x_items'] ) ? absint( wp_unslash( $_POST['limit_usage_to_x_items'] ) ) : null,
 					'free_shipping'               => isset( $_POST['free_shipping'] ),
 					'product_categories'          => array_filter( array_map( 'intval', $product_categories ) ),
 					'excluded_product_categories' => array_filter( array_map( 'intval', $exclude_product_categories ) ),
 					'exclude_sale_items'          => isset( $_POST['exclude_sale_items'] ),
-					'minimum_amount'              => isset( $_POST['minimum_amount'] ) ? wc_format_decimal( wp_unslash( $_POST['minimum_amount'] ) ) : null, 
-					'maximum_amount'              => isset( $_POST['maximum_amount'] ) ? wc_format_decimal( wp_unslash( $_POST['maximum_amount'] ) ) : null, 
-					'email_restrictions'          => array_filter( array_map( 'trim', explode( ',', wc_clean( wp_unslash( $_POST['customer_email'] ) ) ) )
-					),
+					'minimum_amount'              => isset( $_POST['minimum_amount'] ) ? wc_format_decimal( wp_unslash( $_POST['minimum_amount'] ) ) : null,
+					'maximum_amount'              => isset( $_POST['maximum_amount'] ) ? wc_format_decimal( wp_unslash( $_POST['maximum_amount'] ) ) : null,
+					'email_restrictions' => isset( $_POST['customer_email'] ) ? array_filter( array_map( 'trim', explode( ',', wc_clean( wp_unslash( $_POST['customer_email'] ) ) ) ) ) : array(),
 				)
 			);
 			$coupon->save();

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -371,21 +371,21 @@ class WC_Meta_Box_Coupon_Data {
 			$coupon->set_props(
 				array(
 					'code'                        => $post->post_title,
-					'discount_type'               => wc_clean( wp_unslash( $_POST['discount_type'] ) ),
-					'amount'                      => wc_format_decimal( wp_unslash( $_POST['coupon_amount'] ) ),
-					'date_expires'                => wc_clean( wp_unslash( $_POST['expiry_date'] ) ), // WPCS: input var ok.
+					'discount_type'               => wc_clean( wp_unslash( $_POST['discount_type'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
+					'amount'                      => wc_format_decimal( wp_unslash( $_POST['coupon_amount'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
+					'date_expires'                => wc_clean( wp_unslash( $_POST['expiry_date'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
 					'individual_use'              => isset( $_POST['individual_use'] ),
 					'product_ids'                 => isset( $_POST['product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['product_ids'] ) ) ) : array(), // WPCS: input var ok.
 					'excluded_product_ids'        => isset( $_POST['exclude_product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['exclude_product_ids'] ) ) ) : array(), // WPCS: input var ok.
-					'usage_limit'                 => absint( wp_unslash( $_POST['usage_limit'] ) ), // WPCS: input var ok.
-					'usage_limit_per_user'        => absint( wp_unslash( $_POST['usage_limit_per_user'] ) ), // WPCS: input var ok.
-					'limit_usage_to_x_items'      => absint( wp_unslash( $_POST['limit_usage_to_x_items'] ) ), // WPCS: input var ok.
+					'usage_limit'                 => absint( wp_unslash( $_POST['usage_limit'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
+					'usage_limit_per_user'        => absint( wp_unslash( $_POST['usage_limit_per_user'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
+					'limit_usage_to_x_items'      => absint( wp_unslash( $_POST['limit_usage_to_x_items'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
 					'free_shipping'               => isset( $_POST['free_shipping'] ),
 					'product_categories'          => array_filter( array_map( 'intval', $product_categories ) ),
 					'excluded_product_categories' => array_filter( array_map( 'intval', $exclude_product_categories ) ),
 					'exclude_sale_items'          => isset( $_POST['exclude_sale_items'] ),
-					'minimum_amount'              => wc_format_decimal( wp_unslash( $_POST['minimum_amount'] ) ), // WPCS: input var ok.
-					'maximum_amount'              => wc_format_decimal( wp_unslash( $_POST['maximum_amount'] ) ), // WPCS: input var ok.
+					'minimum_amount'              => wc_format_decimal( wp_unslash( $_POST['minimum_amount'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
+					'maximum_amount'              => wc_format_decimal( wp_unslash( $_POST['maximum_amount'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
 					'email_restrictions'          => array_filter( array_map( 'trim', explode( ',', wc_clean( wp_unslash( $_POST['customer_email'] ) ) ) )
 					),
 				)

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -371,21 +371,21 @@ class WC_Meta_Box_Coupon_Data {
 			$coupon->set_props(
 				array(
 					'code'                        => $post->post_title,
-					'discount_type'               => wc_clean( wp_unslash( $_POST['discount_type'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
-					'amount'                      => wc_format_decimal( wp_unslash( $_POST['coupon_amount'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
-					'date_expires'                => wc_clean( wp_unslash( $_POST['expiry_date'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
+					'discount_type'               => isset( $_POST['discount_type'] ) ? wc_clean( wp_unslash( $_POST['discount_type'] ) ) : null,
+					'amount'                      => isset( $_POST['coupon_amount'] ) ? wc_format_decimal( wp_unslash( $_POST['coupon_amount'] ) ) : null, 
+					'date_expires'                => isset( $_POST['expiry_date'] ) ? wc_clean( wp_unslash( $_POST['expiry_date'] ) ) : null, 
 					'individual_use'              => isset( $_POST['individual_use'] ),
 					'product_ids'                 => isset( $_POST['product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['product_ids'] ) ) ) : array(), // WPCS: input var ok.
 					'excluded_product_ids'        => isset( $_POST['exclude_product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['exclude_product_ids'] ) ) ) : array(), // WPCS: input var ok.
-					'usage_limit'                 => absint( wp_unslash( $_POST['usage_limit'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
-					'usage_limit_per_user'        => absint( wp_unslash( $_POST['usage_limit_per_user'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
-					'limit_usage_to_x_items'      => absint( wp_unslash( $_POST['limit_usage_to_x_items'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
+					'usage_limit'                 => isset( $_POST['usage_limit'] ) ? absint( wp_unslash( $_POST['usage_limit'] ) ) : null, 
+					'usage_limit_per_user'        => isset( $_POST['usage_limit_per_user'] ) ? absint( wp_unslash( $_POST['usage_limit_per_user'] ) ) : null, 
+					'limit_usage_to_x_items'      => isset( $_POST['limit_usage_to_x_items'] ) ? absint( wp_unslash( $_POST['limit_usage_to_x_items'] ) ) : null, 
 					'free_shipping'               => isset( $_POST['free_shipping'] ),
 					'product_categories'          => array_filter( array_map( 'intval', $product_categories ) ),
 					'excluded_product_categories' => array_filter( array_map( 'intval', $exclude_product_categories ) ),
 					'exclude_sale_items'          => isset( $_POST['exclude_sale_items'] ),
-					'minimum_amount'              => wc_format_decimal( wp_unslash( $_POST['minimum_amount'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
-					'maximum_amount'              => wc_format_decimal( wp_unslash( $_POST['maximum_amount'] ) ), // WPCS: sanitization ok, input var ok, CSRF ok.
+					'minimum_amount'              => isset( $_POST['minimum_amount'] ) ? wc_format_decimal( wp_unslash( $_POST['minimum_amount'] ) ) : null, 
+					'maximum_amount'              => isset( $_POST['maximum_amount'] ) ? wc_format_decimal( wp_unslash( $_POST['maximum_amount'] ) ) : null, 
 					'email_restrictions'          => array_filter( array_map( 'trim', explode( ',', wc_clean( wp_unslash( $_POST['customer_email'] ) ) ) )
 					),
 				)

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -117,7 +117,7 @@ class WC_Meta_Box_Coupon_Data {
 						'label'             => __( 'Coupon expiry date', 'woocommerce' ),
 						'placeholder'       => 'YYYY-MM-DD',
 						'description'       => __( 'The coupon will expire at 00:00:00 of this date.', 'woocommerce' ),
-						'desc_tip'    => true,
+						'desc_tip'    		=> true,
 						'class'             => 'date-picker',
 						'custom_attributes' => array(
 							'pattern' => apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ),

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -4,14 +4,13 @@
  *
  * Display the coupon data meta box.
  *
- * @author      WooThemes
- * @category    Admin
+ * @class    	WC_Meta_Box_Coupon_Data
  * @package     WooCommerce/Admin/Meta Boxes
  * @version     2.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**
@@ -64,7 +63,7 @@ class WC_Meta_Box_Coupon_Data {
 				foreach ( $coupon_data_tabs as $key => $tab ) :
 					?>
 					<li class="<?php echo $key; ?>_options <?php echo $key; ?>_tab <?php echo implode( ' ', (array) $tab['class'] ); ?>">
-						<a href="#<?php echo $tab['target']; ?>">
+						<a href="#<?php echo esc_html( $tab['target'] ); ?>">
 							<span><?php echo esc_html( $tab['label'] ); ?></span>
 						</a>
 					</li>
@@ -117,7 +116,7 @@ class WC_Meta_Box_Coupon_Data {
 						'label'             => __( 'Coupon expiry date', 'woocommerce' ),
 						'placeholder'       => 'YYYY-MM-DD',
 						'description'       => __( 'The coupon will expire at 00:00:00 of this date.', 'woocommerce' ),
-						'desc_tip'    		=> true,
+						'desc_tip'          => true,
 						'class'             => 'date-picker',
 						'custom_attributes' => array(
 							'pattern' => apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ),
@@ -279,7 +278,7 @@ class WC_Meta_Box_Coupon_Data {
 				?>
 			</div>
 			<?php do_action( 'woocommerce_coupon_options_usage_restriction', $coupon->get_id(), $coupon ); ?>
-			</div>
+		</div>
 			<div id="usage_limit_coupon_data" class="panel woocommerce_options_panel">
 				<div class="options_group">
 					<?php
@@ -342,7 +341,6 @@ class WC_Meta_Box_Coupon_Data {
 			</div>
 			<?php do_action( 'woocommerce_coupon_data_panels', $coupon->get_id(), $coupon ); ?>
 			<div class="clear"></div>
-		</div>
 		<?php
 	}
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -354,19 +354,18 @@ class WC_Meta_Box_Coupon_Data {
 	 */
 	public static function save( $post_id, $post ) {
 		// Not allowed, return regular value without updating meta.
-		if ( ! wp_verify_nonce( wp_unslash( $_POST['woocommerce_meta_nonce'] ), 'woocommerce_save_data' ) ) { // WPCS: input var ok, sanitization ok.
+		if ( wp_verify_nonce( wp_unslash( $_POST['woocommerce_meta_nonce'] ), 'woocommerce_save_data' ) ) { // WPCS: input var ok, sanitization ok.
 
 			// Check for dupe coupons.
 			$coupon_code  = wc_format_coupon_code( $post->post_title );
 			$id_from_code = wc_get_coupon_id_by_code( $coupon_code, $post_id );
 
 			if ( $id_from_code ) {
-				WC_Admin_Meta_Boxes::add_error( __( 'Coupon code already exists - customers will use the latest coupon with this code.',
-					'woocommerce' ) );
+				WC_Admin_Meta_Boxes::add_error( __( 'Coupon code already exists - customers will use the latest coupon with this code.', 'woocommerce' ) );
 			}
 
-			$product_categories         = isset( $_POST['product_categories'] ) ? (array) $_POST['product_categories'] : array();
-			$exclude_product_categories = isset( $_POST['exclude_product_categories'] ) ? (array) $_POST['exclude_product_categories'] : array();
+			$product_categories         = isset( $_POST['product_categories'] ) ? wp_unslash( (array) $_POST['product_categories'] ) : array();
+			$exclude_product_categories = isset( $_POST['exclude_product_categories'] ) ? wp_unslash( (array) $_POST['exclude_product_categories'] ) : array();
 
 			$coupon = new WC_Coupon( $post_id );
 			$coupon->set_props(
@@ -376,11 +375,8 @@ class WC_Meta_Box_Coupon_Data {
 					'amount'                      => wc_format_decimal( wp_unslash( $_POST['coupon_amount'] ) ),
 					'date_expires'                => wc_clean( wp_unslash( $_POST['expiry_date'] ) ),
 					'individual_use'              => isset( $_POST['individual_use'] ),
-					'product_ids'                 => isset( $_POST['product_ids'] ) ? array_filter( array_map( 'intval',
-						(array) $_POST['product_ids'] ) )
-						: array(),
-					'excluded_product_ids'        => isset( $_POST['exclude_product_ids'] ) ? array_filter( array_map( 'intval',
-						(array) $_POST['exclude_product_ids'] ) ) : array(),
+					'product_ids'                 => isset( $_POST['product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['product_ids'] ) ) ) : array(),
+					'excluded_product_ids'        => isset( $_POST['exclude_product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['exclude_product_ids'] ) ) ) : array(),
 					'usage_limit'                 => absint( wp_unslash( $_POST['usage_limit'] ) ),
 					'usage_limit_per_user'        => absint( wp_unslash( $_POST['usage_limit_per_user'] ) ),
 					'limit_usage_to_x_items'      => absint( wp_unslash( $_POST['limit_usage_to_x_items'] ) ),

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -63,7 +63,7 @@ class WC_Meta_Box_Coupon_Data {
 
 				foreach ( $coupon_data_tabs as $key => $tab ) :
 					?>
-					<li class="<?php echo esc_attr( $key ); ?>_options <?php echo esc_attr( $key ); ?>_tab <?php echo esc_attr( implode( ' ', (array) $tab['class'] )); ?>">
+					<li class="<?php echo esc_attr( $key ); ?>_options <?php echo esc_attr( $key ); ?>_tab <?php echo esc_attr( implode( ' ', (array) $tab['class'] ) ); ?>">
 						<a href="#<?php echo esc_html( $tab['target'] ); ?>">
 							<span><?php echo esc_html( $tab['label'] ); ?></span>
 						</a>
@@ -354,9 +354,7 @@ class WC_Meta_Box_Coupon_Data {
 	 */
 	public static function save( $post_id, $post ) {
 		// Not allowed, return regular value without updating meta.
-		if ( ! isset( $_POST['woocommerce_meta_nonce'], $_POST['rating'] )
-		     || ! wp_verify_nonce( wp_unslash( $_POST['woocommerce_meta_nonce'] ),
-				'woocommerce_save_data' ) ) { // WPCS: input var ok, sanitization ok.
+		if ( ! wp_verify_nonce( wp_unslash( $_POST['woocommerce_meta_nonce'] ), 'woocommerce_save_data' ) ) { // WPCS: input var ok, sanitization ok.
 
 			// Check for dupe coupons.
 			$coupon_code  = wc_format_coupon_code( $post->post_title );
@@ -374,25 +372,25 @@ class WC_Meta_Box_Coupon_Data {
 			$coupon->set_props(
 				array(
 					'code'                        => $post->post_title,
-					'discount_type'               => wc_clean( $_POST['discount_type'] ),
-					'amount'                      => wc_format_decimal( $_POST['coupon_amount'] ),
-					'date_expires'                => wc_clean( $_POST['expiry_date'] ),
+					'discount_type'               => wc_clean( wp_unslash( $_POST['discount_type'] ) ),
+					'amount'                      => wc_format_decimal( wp_unslash( $_POST['coupon_amount'] ) ),
+					'date_expires'                => wc_clean( wp_unslash( $_POST['expiry_date'] ) ),
 					'individual_use'              => isset( $_POST['individual_use'] ),
 					'product_ids'                 => isset( $_POST['product_ids'] ) ? array_filter( array_map( 'intval',
 						(array) $_POST['product_ids'] ) )
 						: array(),
 					'excluded_product_ids'        => isset( $_POST['exclude_product_ids'] ) ? array_filter( array_map( 'intval',
 						(array) $_POST['exclude_product_ids'] ) ) : array(),
-					'usage_limit'                 => absint( $_POST['usage_limit'] ),
-					'usage_limit_per_user'        => absint( $_POST['usage_limit_per_user'] ),
-					'limit_usage_to_x_items'      => absint( $_POST['limit_usage_to_x_items'] ),
+					'usage_limit'                 => absint( wp_unslash( $_POST['usage_limit'] ) ),
+					'usage_limit_per_user'        => absint( wp_unslash( $_POST['usage_limit_per_user'] ) ),
+					'limit_usage_to_x_items'      => absint( wp_unslash( $_POST['limit_usage_to_x_items'] ) ),
 					'free_shipping'               => isset( $_POST['free_shipping'] ),
 					'product_categories'          => array_filter( array_map( 'intval', $product_categories ) ),
 					'excluded_product_categories' => array_filter( array_map( 'intval', $exclude_product_categories ) ),
 					'exclude_sale_items'          => isset( $_POST['exclude_sale_items'] ),
-					'minimum_amount'              => wc_format_decimal( $_POST['minimum_amount'] ),
-					'maximum_amount'              => wc_format_decimal( $_POST['maximum_amount'] ),
-					'email_restrictions'          => array_filter( array_map( 'trim', explode( ',', wc_clean( $_POST['customer_email'] ) ) )
+					'minimum_amount'              => wc_format_decimal( wp_unslash( $_POST['minimum_amount'] ) ),
+					'maximum_amount'              => wc_format_decimal( wp_unslash( $_POST['maximum_amount'] ) ),
+					'email_restrictions'          => array_filter( array_map( 'trim', explode( ',', wc_clean( wp_unslash( $_POST['customer_email'] ) ) ) )
 					),
 				)
 			);

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -354,7 +354,7 @@ class WC_Meta_Box_Coupon_Data {
 	 */
 	public static function save( $post_id, $post ) {
 		// Not allowed, return regular value without updating meta.
-		if ( wp_verify_nonce( wp_unslash( $_POST['woocommerce_meta_nonce'] ), 'woocommerce_save_data' ) ) { // WPCS: input var ok, sanitization ok.
+		if ( wp_verify_nonce( wp_unslash( $_POST['woocommerce_meta_nonce'] ), 'woocommerce_save_data' ) ) { // @codingStandardsIgnoreLine.
 
 			// Check for dupe coupons.
 			$coupon_code  = wc_format_coupon_code( $post->post_title );
@@ -364,8 +364,8 @@ class WC_Meta_Box_Coupon_Data {
 				WC_Admin_Meta_Boxes::add_error( __( 'Coupon code already exists - customers will use the latest coupon with this code.', 'woocommerce' ) );
 			}
 
-			$product_categories         = isset( $_POST['product_categories'] ) ? wp_unslash( (array) $_POST['product_categories'] ) : array();
-			$exclude_product_categories = isset( $_POST['exclude_product_categories'] ) ? wp_unslash( (array) $_POST['exclude_product_categories'] ) : array();
+			$product_categories         = isset( $_POST['product_categories'] ) ? wp_unslash( (array) $_POST['product_categories'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			$exclude_product_categories = isset( $_POST['exclude_product_categories'] ) ? wp_unslash( (array) $_POST['exclude_product_categories'] ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 			$coupon = new WC_Coupon( $post_id );
 			$coupon->set_props(
@@ -373,19 +373,19 @@ class WC_Meta_Box_Coupon_Data {
 					'code'                        => $post->post_title,
 					'discount_type'               => wc_clean( wp_unslash( $_POST['discount_type'] ) ),
 					'amount'                      => wc_format_decimal( wp_unslash( $_POST['coupon_amount'] ) ),
-					'date_expires'                => wc_clean( wp_unslash( $_POST['expiry_date'] ) ),
+					'date_expires'                => wc_clean( wp_unslash( $_POST['expiry_date'] ) ), // WPCS: input var ok.
 					'individual_use'              => isset( $_POST['individual_use'] ),
-					'product_ids'                 => isset( $_POST['product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['product_ids'] ) ) ) : array(),
-					'excluded_product_ids'        => isset( $_POST['exclude_product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['exclude_product_ids'] ) ) ) : array(),
-					'usage_limit'                 => absint( wp_unslash( $_POST['usage_limit'] ) ),
-					'usage_limit_per_user'        => absint( wp_unslash( $_POST['usage_limit_per_user'] ) ),
-					'limit_usage_to_x_items'      => absint( wp_unslash( $_POST['limit_usage_to_x_items'] ) ),
+					'product_ids'                 => isset( $_POST['product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['product_ids'] ) ) ) : array(), // WPCS: input var ok.
+					'excluded_product_ids'        => isset( $_POST['exclude_product_ids'] ) ? array_filter( array_map( 'intval', wp_unslash( (array) $_POST['exclude_product_ids'] ) ) ) : array(), // WPCS: input var ok.
+					'usage_limit'                 => absint( wp_unslash( $_POST['usage_limit'] ) ), // WPCS: input var ok.
+					'usage_limit_per_user'        => absint( wp_unslash( $_POST['usage_limit_per_user'] ) ), // WPCS: input var ok.
+					'limit_usage_to_x_items'      => absint( wp_unslash( $_POST['limit_usage_to_x_items'] ) ), // WPCS: input var ok.
 					'free_shipping'               => isset( $_POST['free_shipping'] ),
 					'product_categories'          => array_filter( array_map( 'intval', $product_categories ) ),
 					'excluded_product_categories' => array_filter( array_map( 'intval', $exclude_product_categories ) ),
 					'exclude_sale_items'          => isset( $_POST['exclude_sale_items'] ),
-					'minimum_amount'              => wc_format_decimal( wp_unslash( $_POST['minimum_amount'] ) ),
-					'maximum_amount'              => wc_format_decimal( wp_unslash( $_POST['maximum_amount'] ) ),
+					'minimum_amount'              => wc_format_decimal( wp_unslash( $_POST['minimum_amount'] ) ), // WPCS: input var ok.
+					'maximum_amount'              => wc_format_decimal( wp_unslash( $_POST['maximum_amount'] ) ), // WPCS: input var ok.
 					'email_restrictions'          => array_filter( array_map( 'trim', explode( ',', wc_clean( wp_unslash( $_POST['customer_email'] ) ) ) )
 					),
 				)


### PR DESCRIPTION
Help understand if the date is included or excluded when addind a coupon expiry date.
In the current state, the coupon expires at 00:00:00 of the submitted date.

### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Added a tooltip in the "Coupon expity date" field, in backend coupon form.
