### PR TITLE
Use correct parameter order for implode.

### DIFF
--- a/includes/tracks/events/class-wc-settings-tracking.php
+++ b/includes/tracks/events/class-wc-settings-tracking.php
@@ -91,7 +91,7 @@ class WC_Settings_Tracking {
 		}
 
 		$properties = array(
-			'settings' => implode( $this->updated_options, ',' ),
+			'settings' => implode( ',', $this->updated_options ),
 		);
 
 		if ( isset( $current_tab ) ) {


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Use correct parameter order for implode. Solves deprecation notice in PHP 7.4
See https://www.php.net/manual/en/function.implode.php
and https://wiki.php.net/rfc/deprecations_php_7_4

### How to test the changes in this Pull Request:

1. Change general setting in WooCommerce such as address or currency. Needs to be running PHP 7.4 and have tracks enabled to see the deprecation warning.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix Deprecations notices with PHP 7.4
