### PR TITLE
add $this param to woocommerce_email_additional_content_

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -368,7 +368,7 @@ class WC_Email extends WC_Settings_API {
 	public function get_additional_content() {
 		$content = $this->get_option( 'additional_content', '' );
 
-		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $content ), $this->object );
+		return apply_filters( 'woocommerce_email_additional_content_' . $this->id, $this->format_string( $content ), $this->object, $this );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

add $this param to woocommerce_email_additional_content_ filter to be consistent with 'woocommerce_email_subject_' .  and 'woocommerce_email_heading_' .  filters.

$this was added to the other filters in April on:
https://github.com/woocommerce/woocommerce/pull/23250

but then not included in the new woocommerce_email_additional_content_ filter


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

add $this param to email filter for additional_content added in 3.7