### PR TITLE
fix: show error message in myaccount if order does not exist.

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -133,7 +133,7 @@ class WC_Shortcode_My_Account {
 	public static function view_order( $order_id ) {
 		$order = wc_get_order( $order_id );
 
-		if ( ! current_user_can( 'view_order', $order_id ) ) {
+		if ( ! $order || ! current_user_can( 'view_order', $order_id ) ) {
 			echo '<div class="woocommerce-error">' . esc_html__( 'Invalid order.', 'woocommerce' ) . ' <a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '" class="wc-forward">' . esc_html__( 'My account', 'woocommerce' ) . '</a></div>';
 
 			return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Display `Invalid order` message in myaccount -> view order if the order id points to an order that does not exist. Currently this triggers a fatal error. See the issue this PR closes for further details.

Closes #24434 .

### How to test the changes in this Pull Request:

1. go to myaccount -> roders -> view order
2. type in random order number in the url (ensure no such order exists)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Show error message in "My Account - view order" if order does not exist.
