### PR TITLE
Prevent load order twice

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -147,8 +147,8 @@ class WC_Shortcode_My_Account {
 			'myaccount/view-order.php',
 			array(
 				'status'   => $status, // @deprecated 2.2.
-				'order'    => wc_get_order( $order_id ),
-				'order_id' => $order_id,
+				'order'    => $order,
+				'order_id' => $order->get_id(),
 			)
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I found it reviewing #24435, we load all data using `wc_get_order()` at the begin of the method, so no need to load again.

### How to test the changes in this Pull Request:

Just code clean up, but it's possible to test seeing any order in My Account > Orders.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Stop to load order data twice in "View order" screen on "My Account" page.
