### PR TITLE
[Tracker] Prevent PHP warning when order date is empty 

### DIFF
--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -79,7 +79,7 @@ class WC_Orders_Tracking {
 		$order        = wc_get_order( $id );
 		$date_created = $order->get_date_created()->date( 'Y-m-d H:i:s' );
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
-		$new_date     = sprintf(
+		$new_date = sprintf(
 			'%s %2d:%2d:%2d',
 			isset( $_POST['order_date'] ) ? wc_clean( wp_unslash( $_POST['order_date'] ) ) : '',
 			isset( $_POST['order_date_hour'] ) ? wc_clean( wp_unslash( $_POST['order_date_hour'] ) ) : '',
@@ -90,8 +90,8 @@ class WC_Orders_Tracking {
 
 		if ( $new_date !== $date_created ) {
 			$properties = array(
-				'order_id'   => $id,
-				'status'     => $order->get_status(),
+				'order_id' => $id,
+				'status'   => $order->get_status(),
 			);
 
 			WC_Tracks::record_event( 'order_edit_date_created', $properties );
@@ -128,9 +128,9 @@ class WC_Orders_Tracking {
 			$referer = wp_get_referer();
 
 			if ( $referer ) {
-				$referring_page = parse_url( $referer );
+				$referring_page = wp_parse_url( $referer );
 				$referring_args = array();
-				$post_edit_page = parse_url( admin_url( 'post.php' ) );
+				$post_edit_page = wp_parse_url( admin_url( 'post.php' ) );
 
 				if ( ! empty( $referring_page['query'] ) ) {
 					parse_str( $referring_page['query'], $referring_args );

--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -48,13 +48,12 @@ class WC_Orders_Tracking {
 	 */
 	public function track_order_status_change( $id, $previous_status, $next_status ) {
 		$order = wc_get_order( $id );
-		$date  = $order->get_date_created();
 
 		$properties = array(
 			'order_id'        => $id,
 			'next_status'     => $next_status,
 			'previous_status' => $previous_status,
-			'date_created'    => $date->date( 'Y-m-d' ),
+			'date_created'    => $order->get_date_created() ? $order->get_date_created()->date( 'Y-m-d' ) : '',
 			'payment_method'  => $order->get_payment_method(),
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We use the same check in other places in our code base, if for some reason an order have no date will return `null`, so need to check before trying to access any method.

Closes #24416.

Also I fixed some coding standards issues, like use of `wp_parse_url()` and spacing.

### How to test the changes in this Pull Request:

See #24416.
No luck trying to reproduce it, still it need to be patched anyway.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Prevent PHP warnings in tracker if order doesn't have a created date yet.
