### PR TITLE
Remove Emoji from default additional email content

### DIFF
--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -146,7 +146,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		 * @return string
 		 */
 		public function get_default_additional_content() {
-			return __( 'Congratulations on the sale 🙌', 'woocommerce' );
+			return __( 'Congratulations on the sale.', 'woocommerce' );
 		}
 
 		/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This doesn't affect all installations, since this issue depends on the database structure, not all WordPress installations properly support emojis, this will stop email settings to get saved, so it's easy to just remove this emoji for now.

Closes #24405.

### How to test the changes in this Pull Request:

1. Since this not affect all installations may become hard to test, but you can try change the database to something else that is not `utf8mb4`.
2. Try save the settings with an emoji like `🙌`, this may stop the page get saved, you can try reload or access the URL again: `wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_new_order`
3. And now the only way to save is to remove all emojis from the content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Removed Emoji from default additional email content due problem on some database that doesn't allow Emojis.