### PR TITLE
Add support to allow connect and install for in-app purchase flow.

### DIFF
--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -487,9 +487,10 @@ class WC_Admin_Addons {
 		// so WCCOM "back" link returns user to where they were.
 		$back_admin_path = add_query_arg( array() );
 		return array(
-			'wccom-site'        => site_url(),
-			'wccom-back'        => esc_url( $back_admin_path ),
-			'wccom-woo-version' => WC_VERSION,
+			'wccom-site'         => site_url(),
+			'wccom-back'         => esc_url( $back_admin_path ),
+			'wccom-woo-version'  => WC_VERSION,
+			'wccom-helper-nonce' => wp_create_nonce( 'connect' ),
 		);
 	}
 

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -487,10 +487,10 @@ class WC_Admin_Addons {
 		// so WCCOM "back" link returns user to where they were.
 		$back_admin_path = add_query_arg( array() );
 		return array(
-			'wccom-site'         => site_url(),
-			'wccom-back'         => esc_url( $back_admin_path ),
-			'wccom-woo-version'  => WC_VERSION,
-			'wccom-helper-nonce' => wp_create_nonce( 'connect' ),
+			'wccom-site'          => site_url(),
+			'wccom-back'          => esc_url( $back_admin_path ),
+			'wccom-woo-version'   => WC_VERSION,
+			'wccom-connect-nonce' => wp_create_nonce( 'connect' ),
 		);
 	}
 

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -799,6 +799,13 @@ class WC_Helper {
 			WC_Tracker::send_tracking_data( true );
 		}
 
+		// If connecting through in-app purchase, redirects back to WooCommerce.com
+		// for product installation.
+		if ( ! empty( $_GET['wccom-install-url'] ) ) {
+			wp_redirect( wp_unslash( $_GET['wccom-install-url'] ) );
+			exit;
+		}
+
 		wp_safe_redirect(
 			add_query_arg(
 				array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Pass connect nonce to support authorization post-checkout for in-app purchase.
* Redirect to `wccom-install-url` (contains woocommerce.com order-received URL) if passed in query string once returned from Helper OAuth dance.

### How to test the changes in this Pull Request:

1. For connect nonce, go to `/wp-admin/admin.php?page=wc-addons` click any of the extension and verify that the URL contains nonce in `wccom-connect-nonce`.
2. For `wccom-install-url` redirection, it's a bit tricky to test as it's injected by WooCommerce.com once returned from OAuth authorization. Injecting it from the start won't work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add support to allow connect and install for in-app purchase flow.
