### PR TITLE
Store get_cart() in a variable instead of evaluating it on every iteration of the cart.

### DIFF
--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -37,7 +37,8 @@ do_action( 'woocommerce_before_cart' ); ?>
 			<?php do_action( 'woocommerce_before_cart_contents' ); ?>
 
 			<?php
-			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+			$cart_items = WC()->cart->get_cart();
+			foreach ( $cart_items as $cart_item_key => $cart_item ) {
 				$_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 				$product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
 


### PR DESCRIPTION
Store `cart->get_cart()` in a variable instead of evaluating it on every iteration of the foreach.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moving the cart contents into a variable should improve performance by not re-evaluating the `get_cart()` method on each iteration of the loop.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Moving the cart contents into a variable should improve performance by not re-evaluating the `get_cart()` method on each iteration of the loop.