### PR TITLE
Allow process_payment results other than success and failure

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -490,8 +490,6 @@ jQuery( function( $ ) {
 								}
 							} else if ( 'failure' === result.result ) {
 								throw 'Result failure';
-							} else {
-								throw 'Invalid response';
 							}
 						} catch( err ) {
 							// Reload page
@@ -512,6 +510,7 @@ jQuery( function( $ ) {
 								wc_checkout_form.submit_error( '<div class="woocommerce-error">' + wc_checkout_params.i18n_checkout_error + '</div>' );
 							}
 						}
+						$( document.body ).trigger( 'checkout_result', result );
 					},
 					error:	function( jqXHR, textStatus, errorThrown ) {
 						wc_checkout_form.submit_error( '<div class="woocommerce-error">' + errorThrown + '</div>' );

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -924,10 +924,12 @@ class WC_Checkout {
 		$result = $available_gateways[ $payment_method ]->process_payment( $order_id );
 
 		// Redirect to success/confirmation/payment page.
-		if ( isset( $result['result'] ) && 'success' === $result['result'] ) {
-			$result = apply_filters( 'woocommerce_payment_successful_result', $result, $order_id );
+		if ( isset( $result['result'] ) && 'failure' !== $result['result'] ) {
+			if ( 'success' === $result['result'] ) {
+				$result = apply_filters( 'woocommerce_payment_successful_result', $result, $order_id );
+			}
 
-			if ( ! is_ajax() ) {
+			if ( ! is_ajax() && isset( $result['redirect'] ) ) {
 				wp_redirect( $result['redirect'] );
 				exit;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Proposing a change to allow for handling of custom payment results that are neither failures nor complete successes. Intended to support handling (by the gateway) of payment actions that do not involve a redirect away from the Checkout screen. The `woocommerce_payment_successful_result` filter is skipped if not a `success` result.

This could be reworked to simply trigger an event to enable custom checkout response handling, and allow `success` responses without a redirect.

Does not address Pay for Order screen yet.

### How to test the changes in this Pull Request:

It becomes possible to submit the form, then on `checkout_result` present an additional action to the customer, and then re-submit.

There should be no change to any existing behavior.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
