### PR TITLE
Remove myclabs/deep-copy from the list of Composer dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,6 @@
     "woocommerce/woocommerce-rest-api": "1.0.3"
   },
   "require-dev": {
-    "myclabs/deep-copy": "1.7.0",
     "phpunit/phpunit": "7.5.15",
     "woocommerce/woocommerce-sniffs": "0.0.6"
   },


### PR DESCRIPTION
myclabs/deep-copy was added to composer.json directly as a workaround an issue in the Travis build when running PHP 5.6 (#24079). Considering that for this PR all Travis build jobs passed, it is not necessary anymore to include this package as a WooCommerce core dependency.

### How to test the changes in this Pull Request:

1. Check that all Travis build jobs passed, especially the PHP 5.6 build job.