### PR TITLE
Update mini-cart.php

### DIFF
--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -73,7 +73,7 @@ do_action( 'woocommerce_before_mini_cart' ); ?>
 	<p class="woocommerce-mini-cart__total total">
 		<?php
 		/**
-		 * woocommerce_widget_shopping_cart_total hook.
+		 * Hook: woocommerce_widget_shopping_cart_total.
 		 *
 		 * @hooked woocommerce_widget_shopping_cart_subtotal - 10
 		 */

--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -73,7 +73,7 @@ do_action( 'woocommerce_before_mini_cart' ); ?>
 	<p class="woocommerce-mini-cart__total total">
 		<?php
 		/**
-		 * Woocommerce_widget_shopping_cart_total hook.
+		 * woocommerce_widget_shopping_cart_total hook.
 		 *
 		 * @hooked woocommerce_widget_shopping_cart_subtotal - 10
 		 */


### PR DESCRIPTION
Fixed spelling of woocommerce_widget_shopping_cart_total

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
1. Fixed spelling of woocommerce_widget_shopping_cart_total

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Just Fixed the spelling in commented code, will not create issue in functioning.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed spelling of woocommerce_widget_shopping_cart_total in mini-cart.php
