### PR TITLE
Add PHP 7.4 to the list of Travis build jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -46,9 +46,13 @@ matrix:
   - name: "WooCommerce unit tests using WordPress nightly"
     php: 7.3
     env: WP_VERSION=nightly WP_MULTISITE=0
+  - php: 7.4snapshot
+    env: WP_VERSION=nightly WP_MULTISITE=0
   allow_failures:
   - php: 7.3
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
+  - php: 7.4snapshot
+    env: WP_VERSION=nightly WP_MULTISITE=0
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the upcoming PHP 7.4 to the list of Travis build jobs so that we can start testing WooCommerce with this new version of PHP that is scheduled to be released in November.

For now, I'm including this build job in the list of jobs that can fail as it seems that even WordPress nightly is still throwing a few deprecated notices when running with PHP 7.4. Once that is fixed and we have made all the adjustments necessary in the WooCommerce codebase we can change that.

Kudos to @superdav42 to already started opening some PRs to address issues related to PHP 7.4.