### PR TITLE
Fix/24461

### DIFF
--- a/includes/libraries/action-scheduler/classes/ActionScheduler_AdminView.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_AdminView.php
@@ -50,7 +50,7 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 	 * @return array $tabs An associative array of tab key => label, including Action Scheduler's tabs
 	 */
 	public function register_system_status_tab( array $tabs ) {
-		$tabs['action-scheduler'] = __( 'Scheduled Actions', 'action-scheduler' );
+		$tabs['action-scheduler'] = __( 'Scheduled Actions', 'woocommerce' );
 
 		return $tabs;
 	}
@@ -65,8 +65,8 @@ class ActionScheduler_AdminView extends ActionScheduler_AdminView_Deprecated {
 	public function register_menu() {
 		add_submenu_page(
 			'tools.php',
-			__( 'Scheduled Actions', 'action-scheduler' ),
-			__( 'Scheduled Actions', 'action-scheduler' ),
+			__( 'Scheduled Actions', 'woocommerce' ),
+			__( 'Scheduled Actions', 'woocommerce' ),
 			'manage_options',
 			'action-scheduler',
 			array( $this, 'render_admin_ui' )

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore_PostTypeRegistrar.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore_PostTypeRegistrar.php
@@ -16,8 +16,8 @@ class ActionScheduler_wpPostStore_PostTypeRegistrar {
 	 */
 	protected function post_type_args() {
 		$args = array(
-			'label' => __( 'Scheduled Actions', 'action-scheduler' ),
-			'description' => __( 'Scheduled actions are hooks triggered on a cetain date and time.', 'action-scheduler' ),
+			'label' => __( 'Scheduled Actions', 'woocommerce' ),
+			'description' => __( 'Scheduled actions are hooks triggered on a cetain date and time.', 'woocommerce' ),
 			'public' => false,
 			'map_meta_cap' => true,
 			'hierarchical' => false,
@@ -27,19 +27,19 @@ class ActionScheduler_wpPostStore_PostTypeRegistrar {
 			'can_export' => true,
 			'ep_mask' => EP_NONE,
 			'labels' => array(
-				'name' => __( 'Scheduled Actions', 'action-scheduler' ),
-				'singular_name' => __( 'Scheduled Action', 'action-scheduler' ),
-				'menu_name' => _x( 'Scheduled Actions', 'Admin menu name', 'action-scheduler' ),
+				'name' => __( 'Scheduled Actions', 'woocommerce' ),
+				'singular_name' => __( 'Scheduled Action', 'woocommerce' ),
+				'menu_name' => _x( 'Scheduled Actions', 'Admin menu name', 'woocommerce' ),
 				'add_new' => __( 'Add', 'action-scheduler' ),
-				'add_new_item' => __( 'Add New Scheduled Action', 'action-scheduler' ),
+				'add_new_item' => __( 'Add New Scheduled Action', 'woocommerce' ),
 				'edit' => __( 'Edit', 'action-scheduler' ),
-				'edit_item' => __( 'Edit Scheduled Action', 'action-scheduler' ),
-				'new_item' => __( 'New Scheduled Action', 'action-scheduler' ),
-				'view' => __( 'View Action', 'action-scheduler' ),
-				'view_item' => __( 'View Action', 'action-scheduler' ),
-				'search_items' => __( 'Search Scheduled Actions', 'action-scheduler' ),
-				'not_found' => __( 'No actions found', 'action-scheduler' ),
-				'not_found_in_trash' => __( 'No actions found in trash', 'action-scheduler' ),
+				'edit_item' => __( 'Edit Scheduled Action', 'woocommerce' ),
+				'new_item' => __( 'New Scheduled Action', 'woocommerce' ),
+				'view' => __( 'View Action', 'woocommerce' ),
+				'view_item' => __( 'View Action', 'woocommerce' ),
+				'search_items' => __( 'Search Scheduled Actions', 'woocommerce' ),
+				'not_found' => __( 'No actions found', 'woocommerce' ),
+				'not_found_in_trash' => __( 'No actions found in trash', 'woocommerce' ),
 			),
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changed 'action-scheduler' text domain to 'woocommerce'

Closes #24461 

### How to test the changes in this Pull Request:

1. Change language to other than English
2. Backend "Scheduled Actions" tab should translate

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Changed 'action-scheduler' text domain to 'woocommerce'