### PR TITLE
Update wc-setup.scss

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1125,9 +1125,9 @@ h3.jetpack-reasons {
 	border-color: #ddd;
 	border-radius: 4px;
 	height: 30px;
-	width: calc(100% - 8px - 24px - 2px); // account for padding, border to align with other elements
+	width: calc(100% - 8px - 8px - 2px); // account for padding, border to align with other elements
 	padding-left: 8px;
-	padding-right: 24px;
+	padding-right: 8px;
 	font-size: 16px;
 	color: #444;
 	background-color: #fff;


### PR DESCRIPTION
Fixed CSS for .location-input

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
1. Fixed padding issue for the input field with class "location-input".

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. In WooCommerce setup wizard, you can see the padding in input field is not equal from left and right side.
2. Now, padding from both left and right side will be equal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed padding css for input tag with class location-input.
