### PR TITLE
Fixed incorrect page setting id

### DIFF
--- a/includes/admin/settings/class-wc-settings-advanced.php
+++ b/includes/admin/settings/class-wc-settings-advanced.php
@@ -183,7 +183,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 						'title' => __( 'Checkout endpoints', 'woocommerce' ),
 						'type'  => 'title',
 						'desc'  => __( 'Endpoints are appended to your page URLs to handle specific actions during the checkout process. They should be unique.', 'woocommerce' ),
-						'id'    => 'account_endpoint_options',
+						'id'    => 'checkout_endpoint_options',
 					),
 
 					array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changed the Checkout endpoints title page setting id to 'checkout_endpoint_options' to match the sectionend.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Changelog entry

> Fixed duplicate id in pages settings
