### PR TITLE
Fix product import CSV path styling

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -6738,6 +6738,7 @@ table.bar_chart {
 				outline: 0;
 				line-height: 1;
 				display: block;
+				padding: 7px;
 
 				code {
 					background: none;
@@ -6745,7 +6746,7 @@ table.bar_chart {
 					padding: 0;
 					margin: 0;
 					color: #999;
-					padding: 7px 0 0 7px;
+					max-width: 100%;
 					display: inline-block;
 				}
 
@@ -6756,6 +6757,8 @@ table.bar_chart {
 					outline: 0;
 					box-shadow: none;
 					display: inline-block;
+					max-width: 100%;
+					padding: 7px 0 0 0;
 				}
 			}
 		}

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -6756,7 +6756,6 @@ table.bar_chart {
 					outline: 0;
 					box-shadow: none;
 					display: inline-block;
-					min-width: 100%;
 				}
 			}
 		}


### PR DESCRIPTION
Fixed css for woocommerce-importer-file-url-field-wrapper input.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
1. Fixed css for woocommerce-importer-file-url-field-wrapper input.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Open Import Products page, then click on Show advanced options and check the "Alternatively, enter the path to a CSV file on your server:" input tag border.
2. Now, it will be look good.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed css for woocommerce-importer-file-url-field-wrapper input.