### PR TITLE
Update html-product-csv-import-form.php

### DIFF
--- a/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/includes/admin/importers/views/html-product-csv-import-form.php
@@ -49,7 +49,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							</small>
 							<?php
 						}
-					?>
+						?>
 					</td>
 				</tr>
 				<tr>

--- a/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/includes/admin/importers/views/html-product-csv-import-form.php
@@ -97,7 +97,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		});
 	</script>
 	<div class="wc-actions">
-		<a href="#" class="woocommerce-importer-toggle-advanced-options" data-hidetext="<?php esc_html_e( 'Hide advanced options', 'woocommerce' ); ?>" data-showtext="<?php esc_html_e( 'Show advanced options', 'woocommerce' ); ?>"><?php esc_html_e( 'Show advanced options', 'woocommerce' ); ?></a>
+		<a href="#" class="woocommerce-importer-toggle-advanced-options" data-hidetext="<?php esc_attr_e( 'Hide advanced options', 'woocommerce' ); ?>" data-showtext="<?php esc_html_e( 'Show advanced options', 'woocommerce' ); ?>"><?php esc_attr_e( 'Show advanced options', 'woocommerce' ); ?></a>
 		<button type="submit" class="button button-primary button-next" value="<?php esc_attr_e( 'Continue', 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></button>
 		<?php wp_nonce_field( 'woocommerce-csv-importer' ); ?>
 	</div>

--- a/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/includes/admin/importers/views/html-product-csv-import-form.php
@@ -97,7 +97,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		});
 	</script>
 	<div class="wc-actions">
-		<a href="#" class="woocommerce-importer-toggle-advanced-options" data-hidetext="<?php esc_attr_e( 'Hide advanced options', 'woocommerce' ); ?>" data-showtext="<?php esc_html_e( 'Show advanced options', 'woocommerce' ); ?>"><?php esc_attr_e( 'Show advanced options', 'woocommerce' ); ?></a>
+		<a href="#" class="woocommerce-importer-toggle-advanced-options" data-hidetext="<?php esc_attr_e( 'Hide advanced options', 'woocommerce' ); ?>" data-showtext="<?php esc_attr_e( 'Show advanced options', 'woocommerce' ); ?>"><?php esc_html_e( 'Show advanced options', 'woocommerce' ); ?></a>
 		<button type="submit" class="button button-primary button-next" value="<?php esc_attr_e( 'Continue', 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></button>
 		<?php wp_nonce_field( 'woocommerce-csv-importer' ); ?>
 	</div>

--- a/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/includes/admin/importers/views/html-product-csv-import-form.php
@@ -97,7 +97,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		});
 	</script>
 	<div class="wc-actions">
-		<a href="#" class="woocommerce-importer-toggle-advanced-options" data-hidetext="<?php esc_html_e( 'Hide advanced options', 'woocommerce' ); ?>" data-showtext="<?php esc_html_e( 'Hide advanced options', 'woocommerce' ); ?>"><?php esc_html_e( 'Show advanced options', 'woocommerce' ); ?></a>
+		<a href="#" class="woocommerce-importer-toggle-advanced-options" data-hidetext="<?php esc_html_e( 'Hide advanced options', 'woocommerce' ); ?>" data-showtext="<?php esc_html_e( 'Show advanced options', 'woocommerce' ); ?>"><?php esc_html_e( 'Show advanced options', 'woocommerce' ); ?></a>
 		<button type="submit" class="button button-primary button-next" value="<?php esc_attr_e( 'Continue', 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></button>
 		<?php wp_nonce_field( 'woocommerce-csv-importer' ); ?>
 	</div>


### PR DESCRIPTION
Fixed data-showtext value.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
1. Fixed data-showtext value.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Open Import Products page, then click on Show advanced options.
2. Then advanced options will get visible and that text becomes Hide advanced options but if we click again on it, advanced options get hide but the text remains as Hide advanced options.
3. It will be fixed now and changed to Show advanced options.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed data-showtext value.
