### PR TITLE
Remove call to get_magic_quotes_runtime() as it is deprecated as of PHP 7.4

### DIFF
--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -474,9 +474,6 @@ class WC_Download_Handler {
 	 */
 	private static function check_server_config() {
 		wc_set_time_limit( 0 );
-		if ( function_exists( 'get_magic_quotes_runtime' ) && get_magic_quotes_runtime() && version_compare( phpversion(), '5.4', '<' ) ) {
-			set_magic_quotes_runtime( 0 ); // @codingStandardsIgnoreLine
-		}
 		if ( function_exists( 'apache_setenv' ) ) {
 			@apache_setenv( 'no-gzip', 1 ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged, WordPress.PHP.DiscouragedPHPFunctions.runtime_configuration_apache_setenv
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Remove call to get_magic_quotes_runtime() as this function is deprecated as of PHP 7.4 (see https://wiki.php.net/rfc/deprecations_php_7_4). This part of the code was only needed for PHP <= 5.3 and this version is not supported anymore by WooCommerce.

### How to test the changes in this Pull Request:

1. Check that the code changes make sense. This is a bit trick to test.

### Changelog entry

> Remove call to get_magic_quotes_runtime() as it is deprecated as of PHP 7.4
