### PR TITLE
wc_mail returning the same as $mailer->send

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -695,6 +695,7 @@ function get_woocommerce_currency_symbol( $currency = '' ) {
  * @param mixed  $message     Message.
  * @param string $headers     Headers. (default: "Content-Type: text/html\r\n").
  * @param string $attachments Attachments. (default: "").
+ * @return bool
  */
 function wc_mail( $to, $subject, $message, $headers = "Content-Type: text/html\r\n", $attachments = '' ) {
 	$mailer = WC()->mailer();

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -699,7 +699,7 @@ function get_woocommerce_currency_symbol( $currency = '' ) {
 function wc_mail( $to, $subject, $message, $headers = "Content-Type: text/html\r\n", $attachments = '' ) {
 	$mailer = WC()->mailer();
 
-	$mailer->send( $to, $subject, $message, $headers, $attachments );
+	return $mailer->send( $to, $subject, $message, $headers, $attachments );
 }
 
 /**


### PR DESCRIPTION
When using wc_mail, third-party developers should be able to get the value from $mailer->send so that can take measures if it returns false.

Closes #24504

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #24504 

### How to test the changes in this Pull Request:

1. Send a mail using wc_mail and check the returned value (true or false)

### Changelog entry

> wc_mail returning the same as $mailer->send