### PR TITLE
Control categories export field based on export type

### DIFF
--- a/assets/js/admin/wc-product-export.js
+++ b/assets/js/admin/wc-product-export.js
@@ -15,6 +15,7 @@
 
 		// Events.
 		$form.on( 'submit', { productExportForm: this }, this.onSubmit );
+		$form.find( '.woocommerce-exporter-types' ).on( 'change', { productExportForm: this }, this.exportTypeFields );
 	};
 
 	/**
@@ -82,6 +83,20 @@
 		} ).fail( function( response ) {
 			window.console.log( response );
 		} );
+	};
+
+	/**
+	 * Handle fields per export type.
+	 */
+	productExportForm.prototype.exportTypeFields = function() {
+		var exportCategory = $( '.woocommerce-exporter-category' );
+
+		if ( -1 !== $.inArray( 'variation', $( this ).val() ) ) {
+			exportCategory.closest( 'tr' ).hide();
+			exportCategory.val( '' ).change(); // Reset WooSelect selected value.
+		} else {
+			exportCategory.closest( 'tr' ).show();
+		}
 	};
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Variations doesn't have any category assigned, since WooCommerce only assign categories to variable products, assigning categories for variations should increase performance problems.

This Pull Request prevent of showing the categories input while exporting products if selected "Product variations", since should result in a empty CSV file in case you only export variations.

Closes #24511.

### How to test the changes in this Pull Request:

1. Try export selection `Product variations` in "Which product types should be exported?", and then select any category.
2. Check the file contains only headers, since there's no assigned categories for variations.
3. Apply this patch and try again, now when selecting `Product variations` will hide the categories field prevent incorrect importation files.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Prevent filter per category while exporting product variations.
