### PR TITLE
Add new hook for add-order-item

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -898,7 +898,7 @@ class WC_AJAX {
 				if ( ! $product ) {
 					throw new Exception( __( 'Invalid product ID', 'woocommerce' ) . ' ' . $product_id );
 				}
-				$check = apply_filters( 'woocommerce_add_item_check', $product, $order, $qty );
+				$check = apply_filters( 'woocommerce_ajax_add_order_item_validation', $product, $order, $qty );
 
 				if ( is_wp_error( $check ) ) {
 					throw new Exception( $check->get_error_message() );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -898,7 +898,11 @@ class WC_AJAX {
 				if ( ! $product ) {
 					throw new Exception( __( 'Invalid product ID', 'woocommerce' ) . ' ' . $product_id );
 				}
+				$check = apply_filters( 'woocommerce_add_item_check', $product, $order, $qty );
 
+				if ( is_wp_error( $check ) ) {
+					throw new Exception( $check->get_error_message() );
+				}
 				$item_id                 = $order->add_product( $product, $qty );
 				$item                    = apply_filters( 'woocommerce_ajax_order_item', $order->get_item( $item_id ), $item_id, $order, $product );
 				$added_items[ $item_id ] = $item;


### PR DESCRIPTION
Added a new hook for validations in the add_order_item() called in
WC->Orders->Add/Edit Orders.

Allow plugins to perform validations/changes to the order before a product is added to the order.