### PR TITLE
Update class-wc-admin-duplicate-product.php

### DIFF
--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -59,12 +59,12 @@ class WC_Admin_Duplicate_Product {
 				get_delete_post_link( $the_product->get_id(), '', false ),
 				/* translators: %s: post title */
 				esc_attr( sprintf( __( 'Move &#8220;%s&#8221; to the Trash', 'woocommerce' ), $the_product->get_name() ) ),
-				__( 'Trash', 'woocommerce' )
+				esc_html__( 'Trash', 'woocommerce' )
 			);
 		}
 
 		$actions['duplicate'] = '<a href="' . wp_nonce_url( admin_url( 'edit.php?post_type=product&action=duplicate_product&amp;post=' . $post->ID ), 'woocommerce-duplicate-product_' . $post->ID ) . '" aria-label="' . esc_attr__( 'Make a duplicate from this product', 'woocommerce' )
-			. '" rel="permalink">' . __( 'Duplicate', 'woocommerce' ) . '</a>';
+			. '" rel="permalink">' . esc_html__( 'Duplicate', 'woocommerce' ) . '</a>';
 
 		return $actions;
 	}
@@ -90,7 +90,7 @@ class WC_Admin_Duplicate_Product {
 		if ( isset( $_GET['post'] ) ) {
 			$notify_url = wp_nonce_url( admin_url( 'edit.php?post_type=product&action=duplicate_product&post=' . absint( $_GET['post'] ) ), 'woocommerce-duplicate-product_' . $_GET['post'] );
 			?>
-			<div id="duplicate-action"><a class="submitduplicate duplication" href="<?php echo esc_url( $notify_url ); ?>"><?php _e( 'Copy to a new draft', 'woocommerce' ); ?></a></div>
+			<div id="duplicate-action"><a class="submitduplicate duplication" href="<?php echo esc_url( $notify_url ); ?>"><?php esc_html_e( 'Copy to a new draft', 'woocommerce' ); ?></a></div>
 			<?php
 		}
 	}
@@ -100,7 +100,7 @@ class WC_Admin_Duplicate_Product {
 	 */
 	public function duplicate_product_action() {
 		if ( empty( $_REQUEST['post'] ) ) {
-			wp_die( __( 'No product to duplicate has been supplied!', 'woocommerce' ) );
+			wp_die( esc_html__( 'No product to duplicate has been supplied!', 'woocommerce' ) );
 		}
 
 		$product_id = isset( $_REQUEST['post'] ) ? absint( $_REQUEST['post'] ) : '';
@@ -111,7 +111,7 @@ class WC_Admin_Duplicate_Product {
 
 		if ( false === $product ) {
 			/* translators: %s: product id */
-			wp_die( sprintf( __( 'Product creation failed, could not find original product: %s', 'woocommerce' ), $product_id ) );
+			wp_die( sprintf( esc_html__( 'Product creation failed, could not find original product: %s', 'woocommerce' ), $product_id ) );
 		}
 
 		$duplicate = $this->product_duplicate( $product );
@@ -137,7 +137,7 @@ class WC_Admin_Duplicate_Product {
 
 		$duplicate = clone $product;
 		$duplicate->set_id( 0 );
-		$duplicate->set_name( sprintf( __( '%s (Copy)', 'woocommerce' ), $duplicate->get_name() ) );
+		$duplicate->set_name( sprintf( esc_html__( '%s (Copy)', 'woocommerce' ), $duplicate->get_name() ) );
 		$duplicate->set_total_sales( 0 );
 		if ( '' !== $product->get_sku( 'edit' ) ) {
 			$duplicate->set_sku( wc_product_generate_unique_sku( 0, $product->get_sku( 'edit' ) ) );


### PR DESCRIPTION
Added escaping where required.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
1. Added escaping where required.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. If the value is "><script>alert();</script> and you tried to output it in an HTML attribute it would 
close the current HTML tag and open a script tag. This is unsafe. By escaping the value it won't be able to close the HTML attribute and tag and output unsafe HTML.
2. Now it will be fixed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added escaping where required.
