### PR TITLE
Replace wc_get_page_permalink( 'cart' ) with wc_get_cart_url() so that the woocommerce_get_cart_url is usable

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -179,7 +179,7 @@ final class WC_Cart_Session {
 
 		// If this is a re-order, redirect to the cart page to get rid of the `order_again` query string.
 		if ( $order_again ) {
-			wp_safe_redirect( wc_get_page_permalink( 'cart' ) );
+			wp_safe_redirect( wc_get_cart_url() );
 			exit;
 		}
 	}

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -344,7 +344,7 @@ class WC_Form_Handler {
 			wc_nocache_headers();
 
 			if ( WC()->cart->is_empty() ) {
-				wp_safe_redirect( wc_get_page_permalink( 'cart' ) );
+				wp_safe_redirect( wc_get_cart_url() );
 				exit;
 			}
 

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1600,7 +1600,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string the cancel endpoint; either the cart page or the home page.
 	 */
 	public function get_cancel_endpoint() {
-		$cancel_endpoint = wc_get_page_permalink( 'cart' );
+		$cancel_endpoint = wc_get_cart_url();
 		if ( ! $cancel_endpoint ) {
 			$cancel_endpoint = home_url();
 		}

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -120,7 +120,7 @@ function wc_add_to_cart_message( $products, $show_qty = false, $return = false )
 		$return_to = apply_filters( 'woocommerce_continue_shopping_redirect', wc_get_raw_referer() ? wp_validate_redirect( wc_get_raw_referer(), false ) : wc_get_page_permalink( 'shop' ) );
 		$message   = sprintf( '<a href="%s" tabindex="1" class="button wc-forward">%s</a> %s', esc_url( $return_to ), esc_html__( 'Continue shopping', 'woocommerce' ), esc_html( $added_text ) );
 	} else {
-		$message = sprintf( '<a href="%s" tabindex="1" class="button wc-forward">%s</a> %s', esc_url( wc_get_page_permalink( 'cart' ) ), esc_html__( 'View cart', 'woocommerce' ), esc_html( $added_text ) );
+		$message = sprintf( '<a href="%s" tabindex="1" class="button wc-forward">%s</a> %s', esc_url( wc_get_cart_url() ), esc_html__( 'View cart', 'woocommerce' ), esc_html( $added_text ) );
 	}
 
 	if ( has_filter( 'wc_add_to_cart_message' ) ) {

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -25,7 +25,7 @@ function wc_template_redirect() {
 	// When on the checkout with an empty cart, redirect to cart page.
 	if ( is_page( wc_get_page_id( 'checkout' ) ) && wc_get_page_id( 'checkout' ) !== wc_get_page_id( 'cart' ) && WC()->cart->is_empty() && empty( $wp->query_vars['order-pay'] ) && ! isset( $wp->query_vars['order-received'] ) && ! is_customize_preview() && apply_filters( 'woocommerce_checkout_redirect_empty_cart', true ) ) {
 		wc_add_notice( __( 'Checkout is not available whilst your cart is empty.', 'woocommerce' ), 'notice' );
-		wp_safe_redirect( wc_get_page_permalink( 'cart' ) );
+		wp_safe_redirect( wc_get_cart_url() );
 		exit;
 
 	}
@@ -3602,7 +3602,7 @@ function wc_get_formatted_cart_item_data( $cart_item, $flat = false ) {
  * @return string url to page
  */
 function wc_get_cart_remove_url( $cart_item_key ) {
-	$cart_page_url = wc_get_page_permalink( 'cart' );
+	$cart_page_url = wc_get_cart_url();
 	return apply_filters( 'woocommerce_get_remove_url', $cart_page_url ? wp_nonce_url( add_query_arg( 'remove_item', $cart_item_key, $cart_page_url ), 'woocommerce-cart' ) : '' );
 }
 
@@ -3614,7 +3614,7 @@ function wc_get_cart_remove_url( $cart_item_key ) {
  * @return string url to page
  */
 function wc_get_cart_undo_url( $cart_item_key ) {
-	$cart_page_url = wc_get_page_permalink( 'cart' );
+	$cart_page_url = wc_get_cart_url();
 
 	$query_args = array(
 		'undo_item' => $cart_item_key,

--- a/templates/checkout/cart-errors.php
+++ b/templates/checkout/cart-errors.php
@@ -22,4 +22,4 @@ defined( 'ABSPATH' ) || exit;
 
 <?php do_action( 'woocommerce_cart_has_errors' ); ?>
 
-<p><a class="button wc-backward" href="<?php echo esc_url( wc_get_page_permalink( 'cart' ) ); ?>"><?php esc_html_e( 'Return to cart', 'woocommerce' ); ?></a></p>
+<p><a class="button wc-backward" href="<?php echo esc_url( wc_get_cart_url() ); ?>"><?php esc_html_e( 'Return to cart', 'woocommerce' ); ?></a></p>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

As discussed at #24508, the `woocommerce_get_cart_url` filter should be used if one wants to replace the cart page with something else, like merging the cart and checkout on the same page for example.

The problem is that this filter is called inside `wc_get_cart_url()` and there are still several files where `wc_get_page_permalink( 'cart' )` is being used.

The PR replaces `wc_get_page_permalink( 'cart' )` with `wc_get_cart_url()` everywhere (except on the wc_get_cart_url function, of course) so that the filter is indeed usable.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

Replace wc_get_page_permalink( 'cart' ) with wc_get_cart_url() so that the woocommerce_get_cart_url is usable.
