### PR TITLE
Add back post type count to system status report

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -12,6 +12,7 @@ global $wpdb;
 $report             = wc()->api->get_endpoint_data( '/wc/v3/system_status' );
 $environment        = $report['environment'];
 $database           = $report['database'];
+$post_type_counts   = $report['post_type_counts'];
 $active_plugins     = $report['active_plugins'];
 $inactive_plugins   = $report['inactive_plugins'];
 $dropins_mu_plugins = $report['dropins_mu_plugins'];
@@ -515,6 +516,26 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 				</td>
 			</tr>
 		<?php endif; ?>
+	</tbody>
+</table>
+<table class="wc_status_table widefat" cellspacing="0">
+	<thead>
+	<tr>
+		<th colspan="3" data-export-label="Post Type Counts"><h2><?php esc_html_e( 'Post Type Counts', 'woocommerce' ); ?></h2></th>
+	</tr>
+	</thead>
+	<tbody>
+		<?php
+		foreach ( $post_type_counts as $ptype ) {
+			?>
+			<tr>
+				<td><?php echo esc_html( $ptype['type'] ); ?></td>
+				<td class="help">&nbsp;</td>
+				<td><?php echo absint( $ptype['count'] ); ?></td>
+			</tr>
+			<?php
+		}
+		?>
 	</tbody>
 </table>
 <table class="wc_status_table widefat" cellspacing="0">


### PR DESCRIPTION
Added the missing post type count section.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
1. The data for this section is needed to come from the rest API for which the changes are made in the pull request link: https://github.com/woocommerce/woocommerce-rest-api/pull/29

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Closes #24401 

### How to test the changes in this Pull Request:

1. For checking this the pull request generated for the WooCommerce Rest API ( https://github.com/woocommerce/woocommerce-rest-api/pull/29 ) need to be merge so that the data needed for the section is added in it.
2. After that the Post Count Type section will be visible as shown in below screenshot:
 
![Screenshot](https://user-images.githubusercontent.com/54429476/63997850-56aa4400-cb1d-11e9-92dd-27b3be4dd7a9.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
