### PR TITLE
Allow override payment token classes

### DIFF
--- a/includes/class-wc-payment-tokens.php
+++ b/includes/class-wc-payment-tokens.php
@@ -212,4 +212,22 @@ class WC_Payment_Tokens {
 		$data_store = WC_Data_Store::load( 'payment-token' );
 		return $data_store->get_token_type_by_id( $token_id );
 	}
+
+	/**
+	 * Get class based on token type.
+	 *
+	 * @since 3.8.0
+	 * @param string $type Token type.
+	 * @return WC_Payment_Token
+	 */
+	protected static function get_token_class( $type ) {
+		/**
+		 * Filter paymenter token class per type.
+		 *
+		 * @since 3.8.0
+		 * @param WC_Payment_Token $class Payment token class.
+		 * @param string $type Token type.
+		 */
+		return apply_filters( 'woocommerce_payment_token_get_class', 'WC_Payment_Token_' . $type, $type );
+	}
 }

--- a/includes/class-wc-payment-tokens.php
+++ b/includes/class-wc-payment-tokens.php
@@ -215,18 +215,18 @@ class WC_Payment_Tokens {
 	}
 
 	/**
-	 * Get class based on token type.
+	 * Get classname based on token type.
 	 *
 	 * @since 3.8.0
 	 * @param string $type Token type.
-	 * @return WC_Payment_Token
+	 * @return string
 	 */
-	protected static function get_token_class( $type ) {
+	protected static function get_token_classname( $type ) {
 		/**
-		 * Filter paymenter token class per type.
+		 * Filter payment token class per type.
 		 *
 		 * @since 3.8.0
-		 * @param WC_Payment_Token $class Payment token class.
+		 * @param string $class Payment token class.
 		 * @param string $type Token type.
 		 */
 		return apply_filters( 'woocommerce_payment_token_class', 'WC_Payment_Token_' . $type, $type );

--- a/includes/class-wc-payment-tokens.php
+++ b/includes/class-wc-payment-tokens.php
@@ -32,7 +32,8 @@ class WC_Payment_Tokens {
 	 */
 	public static function get_tokens( $args ) {
 		$args = wp_parse_args(
-			$args, array(
+			$args,
+			array(
 				'token_id'   => '',
 				'user_id'    => '',
 				'gateway_id' => '',

--- a/includes/class-wc-payment-tokens.php
+++ b/includes/class-wc-payment-tokens.php
@@ -151,7 +151,7 @@ class WC_Payment_Tokens {
 			}
 		}
 
-		$token_class = 'WC_Payment_Token_' . $token_result->type;
+		$token_class = self::get_token_class( $token_result->type );
 
 		if ( class_exists( $token_class ) ) {
 			$meta        = $data_store->get_metadata( $token_id );
@@ -176,7 +176,7 @@ class WC_Payment_Tokens {
 	public static function delete( $token_id ) {
 		$type = self::get_token_type_by_id( $token_id );
 		if ( ! empty( $type ) ) {
-			$class = 'WC_Payment_Token_' . $type;
+			$class = self::get_token_class( $type );
 			$token = new $class( $token_id );
 			$token->delete();
 		}
@@ -229,6 +229,6 @@ class WC_Payment_Tokens {
 		 * @param WC_Payment_Token $class Payment token class.
 		 * @param string $type Token type.
 		 */
-		return apply_filters( 'woocommerce_payment_token_get_class', 'WC_Payment_Token_' . $type, $type );
+		return apply_filters( 'woocommerce_payment_token_class', 'WC_Payment_Token_' . $type, $type );
 	}
 }

--- a/includes/class-wc-payment-tokens.php
+++ b/includes/class-wc-payment-tokens.php
@@ -151,7 +151,7 @@ class WC_Payment_Tokens {
 			}
 		}
 
-		$token_class = self::get_token_class( $token_result->type );
+		$token_class = self::get_token_classname( $token_result->type );
 
 		if ( class_exists( $token_class ) ) {
 			$meta        = $data_store->get_metadata( $token_id );
@@ -176,7 +176,7 @@ class WC_Payment_Tokens {
 	public static function delete( $token_id ) {
 		$type = self::get_token_type_by_id( $token_id );
 		if ( ! empty( $type ) ) {
-			$class = self::get_token_class( $type );
+			$class = self::get_token_classname( $type );
 			$token = new $class( $token_id );
 			$token->delete();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This allow override the token class if necessary, mostly should help when using namespaces.
I took products and orders as inspiration:

https://github.com/woocommerce/woocommerce/blob/e7296aec03cdc77a8fa9963d4a2550d227229b7c/includes/class-wc-product-factory.php#L52-L68

https://github.com/woocommerce/woocommerce/blob/d0491072e8a7d0a4535db0ec2bae4a6d43ff64fd/includes/class-wc-order-factory.php#L39-L40

Closes #24541.

### How to test the changes in this Pull Request:

See #24541

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced `woocommerce_payment_token_class` filter.