### PR TITLE
Prefer wc_get_checkout_url() instead of wc_get_page_permalink( 'checkout' )

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -216,11 +216,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 		if ( $order ) {
 			$return_url = $order->get_checkout_order_received_url();
 		} else {
-			$return_url = wc_get_endpoint_url( 'order-received', '', wc_get_page_permalink( 'checkout' ) );
-		}
-
-		if ( is_ssl() || get_option( 'woocommerce_force_ssl_checkout' ) == 'yes' ) {
-			$return_url = str_replace( 'http:', 'https:', $return_url );
+			$return_url = wc_get_endpoint_url( 'order-received', '', wc_get_checkout_url() );
 		}
 
 		return apply_filters( 'woocommerce_get_return_url', $return_url, $order );
@@ -524,7 +520,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			esc_attr( $this->id ),
 			esc_html__( 'Save to account', 'woocommerce' )
 		);
-		
+
 		echo apply_filters( 'woocommerce_payment_gateway_save_new_payment_method_option_html', $html, $this );
 	}
 

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1510,11 +1510,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_checkout_payment_url( $on_checkout = false ) {
-		$pay_url = wc_get_endpoint_url( 'order-pay', $this->get_id(), wc_get_page_permalink( 'checkout' ) );
-
-		if ( 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) || is_ssl() ) {
-			$pay_url = str_replace( 'http:', 'https:', $pay_url );
-		}
+		$pay_url = wc_get_endpoint_url( 'order-pay', $this->get_id(), wc_get_checkout_url() );
 
 		if ( $on_checkout ) {
 			$pay_url = add_query_arg( 'key', $this->get_order_key(), $pay_url );
@@ -1537,12 +1533,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_checkout_order_received_url() {
-		$order_received_url = wc_get_endpoint_url( 'order-received', $this->get_id(), wc_get_page_permalink( 'checkout' ) );
-
-		if ( 'yes' === get_option( 'woocommerce_force_ssl_checkout' ) || is_ssl() ) {
-			$order_received_url = str_replace( 'http:', 'https:', $order_received_url );
-		}
-
+		$order_received_url = wc_get_endpoint_url( 'order-received', $this->get_id(), wc_get_checkout_url() );
 		$order_received_url = add_query_arg( 'key', $this->get_order_key(), $order_received_url );
 
 		return apply_filters( 'woocommerce_get_checkout_order_received_url', $order_received_url, $this );

--- a/templates/checkout/form-login.php
+++ b/templates/checkout/form-login.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 3.4.0
+ * @version 3.8.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -30,7 +30,7 @@ if ( is_user_logged_in() || 'no' === get_option( 'woocommerce_enable_checkout_lo
 woocommerce_login_form(
 	array(
 		'message'  => esc_html__( 'If you have shopped with us before, please enter your details below. If you are a new customer, please proceed to the Billing section.', 'woocommerce' ),
-		'redirect' => wc_get_page_permalink( 'checkout' ),
+		'redirect' => wc_get_checkout_url(),
 		'hidden'   => true,
 	)
 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Using `wc_get_checkout_url()` prevent us from check for HTTPS multiple times, and also applies a filter.

https://github.com/woocommerce/woocommerce/blob/b1c9243c1eb83101b66c810b60715a8547f0feb7/includes/wc-core-functions.php#L1317-L1334

I just left the follow files without any change:

- Customizer: This one should be already be on HTTPS anyway, but I can change if someone else thing that is necessary:
https://github.com/woocommerce/woocommerce/blob/d0491072e8a7d0a4535db0ec2bae4a6d43ff64fd/includes/customizer/class-wc-shop-customizer.php#L173-L179

- Legacy function: For this one I think that needs to check if the URL is already set as HTTPS, so we can't force HTTPS like in the other places in this PR.
https://github.com/woocommerce/woocommerce/blob/737f6af5e8af27ae768d087e84c0303d8059281a/includes/wc-conditional-functions.php#L400-L408

### How to test the changes in this Pull Request:

For testing it you probably should like to enable HTTPS for checkout.

1. First test is just placing an regular order as a guest, this tests also the `order-received` endpoint.
2. After try login in the checkout page and place an order, this will test the redirection after login.
3. Finally on the admin change the last order status for the logged in customer to "Pending Payment", then go to "My Account" > "Orders" in the front of the store and click in the "Pay" button for the changed order, after that just place a new payment.

Those steps should cover all changes in this PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Use `wc_get_checkout_url()` to get checkout URL.
