### PR TITLE
Fixed add to cart link for simple products on feed

### DIFF
--- a/includes/class-wc-product-simple.php
+++ b/includes/class-wc-product-simple.php
@@ -39,8 +39,15 @@ class WC_Product_Simple extends WC_Product {
 	 * @return string
 	 */
 	public function add_to_cart_url() {
-		$url = $this->is_purchasable() && $this->is_in_stock() ? remove_query_arg( 'added-to-cart', add_query_arg( 'add-to-cart', $this->id ) ) : get_permalink( $this->id );
-
+		$url = $this->is_purchasable() && $this->is_in_stock() ? remove_query_arg(
+			'added-to-cart',
+			add_query_arg(
+				array(
+					'add-to-cart' => $this->get_id(),
+				),
+				function_exists( 'is_feed' ) && is_feed() ? $this->get_permalink() : ''
+			)
+		) : $this->get_permalink();
 		return apply_filters( 'woocommerce_product_add_to_cart_url', $url, $this );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Links in feed can't be relative, so this forces for the product's page.

Closes #24537.

### How to test the changes in this Pull Request:

See #24537

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed "add to cart" links in feed.