### PR TITLE
Use Macao instead of Macau to match short name in ISO-3166 (#24425)

### DIFF
--- a/i18n/states.php
+++ b/i18n/states.php
@@ -285,7 +285,7 @@ return array(
 		'CN27' => __( 'Gansu / &#29976;&#32899;', 'woocommerce' ),
 		'CN28' => __( 'Qinghai / &#38738;&#28023;', 'woocommerce' ),
 		'CN29' => __( 'Ningxia Hui / &#23425;&#22799;', 'woocommerce' ),
-		'CN30' => __( 'Macau / &#28595;&#38376;', 'woocommerce' ),
+		'CN30' => __( 'Macao / &#28595;&#38376;', 'woocommerce' ),
 		'CN31' => __( 'Tibet / &#35199;&#34255;', 'woocommerce' ),
 		'CN32' => __( 'Xinjiang / &#26032;&#30086;', 'woocommerce' ),
 	),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?  
  (I skimmed though it, apologies if there's anything non-compliant)
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?  
  (It is technically [part of PR #24425](https://github.com/woocommerce/woocommerce/pull/24425/commits/fe24c50b6656bd1b720954ec2f020927578c699f), however I believe this patch should in a separate PR like this one)

### Changes proposed in this Pull Request:

Although the name "Macau" is not wrong, the name "Macao" seems to be official now as it is specified in the ISO-3166 standard.  Also refer to <https://en.wikipedia.org/wiki/Talk:Macau#Spelling_(Macao_vs._Macau)>.

### How to test the changes in this Pull Request:

1. Run the steps specified in [How to set up WooCommerce development environment · woocommerce/woocommerce Wiki](https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment), instead of cloning the official repoitory, checkout Lin-Buo-Ren/woocommerce repo's fix/fix-macao-name branch.
2. Go to "WooCommerce > Settings > General" after login in <http://one.wordpress.test/wp-admin/>
3. Check out the drop down menu in "Country / State" field and search for Macao

![Screenshot_20190901_151400](https://user-images.githubusercontent.com/13408130/64073060-86974a00-cccb-11e9-9b9c-89db9bdf71b6.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry
Use Macao instead of Macau to match short name in ISO-3166 (#24425)
