### PR TITLE
Use "Country / Region" for country selection drop-down label to (try to) avoid political complaints (#24425)

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -650,7 +650,7 @@ class WC_Countries {
 			),
 			'country'    => array(
 				'type'         => 'country',
-				'label'        => __( 'Country', 'woocommerce' ),
+				'label'        => __( 'Country / Region', 'woocommerce' ),
 				'required'     => true,
 				'class'        => array( 'form-row-wide', 'address-field', 'update_totals_on_change' ),
 				'autocomplete' => 'country',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Due to the One China Policy, vendors will be blamed on if a certain region is labeled as either "Country" or "Province of Country", avoid this problem in advance by generalizing the label of the drop-down selection menu.  Refer PR#24425 for more details.

### How to test the changes in this Pull Request:

1. Run the steps specified in [How to set up WooCommerce development environment · woocommerce/woocommerce Wiki](https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment), instead of cloning the official repoitory, checkout Lin-Buo-Ren : fix/fix-country-selection-field-label-being-named-as-country branch.
2. Add a product in the admin pages
3. Buy a product in the user pages and proceed to the Checkout phase
4. Verify the "Country / Region" selection field label is "Country / Region"

![Verification screenshot](https://user-images.githubusercontent.com/13408130/64074342-64f28e80-ccdc-11e9-8f89-009eadf01528.png "Verification screenshot")

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Use "Country / Region" for country selection drop-down label to (try to) avoid political complaints regarding with the One China Policy