### PR TITLE
Declare support to Unicode CLDR recommendation

### DIFF
--- a/i18n/countries.php
+++ b/i18n/countries.php
@@ -3,9 +3,10 @@
  * Countries
  *
  * Returns an array of countries and codes.
+ * Country codes and names should follow the Unicode CLDR recommendation (http://cldr.unicode.org/translation/country-names).
  *
- * @package WooCommerce/i18n
- * @version 2.5.0
+ * @package WooCommerce\i18n
+ * @version 3.8.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/i18n/countries.php
+++ b/i18n/countries.php
@@ -140,7 +140,7 @@ return array(
 	'LI' => __( 'Liechtenstein', 'woocommerce' ),
 	'LT' => __( 'Lithuania', 'woocommerce' ),
 	'LU' => __( 'Luxembourg', 'woocommerce' ),
-	'MO' => __( 'Macao S.A.R., China', 'woocommerce' ),
+	'MO' => __( 'Macau', 'woocommerce' ),
 	'MK' => __( 'North Macedonia', 'woocommerce' ),
 	'MG' => __( 'Madagascar', 'woocommerce' ),
 	'MW' => __( 'Malawi', 'woocommerce' ),

--- a/i18n/countries.php
+++ b/i18n/countries.php
@@ -140,7 +140,7 @@ return array(
 	'LI' => __( 'Liechtenstein', 'woocommerce' ),
 	'LT' => __( 'Lithuania', 'woocommerce' ),
 	'LU' => __( 'Luxembourg', 'woocommerce' ),
-	'MO' => __( 'Macau', 'woocommerce' ),
+	'MO' => __( 'Macao', 'woocommerce' ),
 	'MK' => __( 'North Macedonia', 'woocommerce' ),
 	'MG' => __( 'Madagascar', 'woocommerce' ),
 	'MW' => __( 'Malawi', 'woocommerce' ),

--- a/i18n/states.php
+++ b/i18n/states.php
@@ -4,11 +4,11 @@
  *
  * Returns an array of country states. This deprecates and replaces the /states/ directory found in older versions.
  * States should be defined in English and translated native through localisation files.
- * Country codes and states (or province) names should follow the ISO_3166-2 standard (https://en.wikipedia.org/wiki/ISO_3166-2).
+ * Country codes and states (or province) names should follow the Unicode CLDR recommendation (http://cldr.unicode.org/translation/country-names).
  * Countries defined with empty arrays have no states.
  *
- * @package WooCommerce/i18n
- * @version 3.6.0
+ * @package WooCommerce\i18n
+ * @version 3.8.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -914,8 +914,6 @@ return array(
 
 	/**
 	 * Philippine Provinces.
-	 *
-	 * @todo DAC Needs to be updated when ISO code is assigned.
 	 */
 	'PH' => array(
 		'ABR' => __( 'Abra', 'woocommerce' ),

--- a/i18n/states.php
+++ b/i18n/states.php
@@ -285,7 +285,7 @@ return array(
 		'CN27' => __( 'Gansu / &#29976;&#32899;', 'woocommerce' ),
 		'CN28' => __( 'Qinghai / &#38738;&#28023;', 'woocommerce' ),
 		'CN29' => __( 'Ningxia Hui / &#23425;&#22799;', 'woocommerce' ),
-		'CN30' => __( 'Macau / &#28595;&#38376;', 'woocommerce' ),
+		'CN30' => __( 'Macao / &#28595;&#38376;', 'woocommerce' ),
 		'CN31' => __( 'Tibet / &#35199;&#34255;', 'woocommerce' ),
 		'CN32' => __( 'Xinjiang / &#26032;&#30086;', 'woocommerce' ),
 	),

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -320,6 +320,8 @@ function get_woocommerce_currency() {
 /**
  * Get full list of currency codes.
  *
+ * Currency Symbols and mames should follow the Unicode CLDR recommendation (http://cldr.unicode.org/translation/currency-names)
+ *
  * @return array
  */
 function get_woocommerce_currencies() {
@@ -504,6 +506,8 @@ function get_woocommerce_currencies() {
 
 /**
  * Get Currency symbol.
+ *
+ * Currency Symbols and mames should follow the Unicode CLDR recommendation (http://cldr.unicode.org/translation/currency-names)
  *
  * @param string $currency Currency. (default: '').
  * @return string


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR declares support for Unicode CLDR recommendation:

- http://cldr.unicode.org/translation/country-names
- http://cldr.unicode.org/translation/currency-names

The only change in the code is to "Macau", to follow the sort name, doing it because the "General Guidelines":

> 1. Use the most neutral grammatical form for the country/region that is natural for these two usages above. If there is no single form that can accomplish that, favor the usage within UI menus.
> 2. Use the capitalization that would be appropriate in the middle of a sentence; the  <contextTransforms> data can specify the capitalization for other contexts. For more information, see Capitalization. 
> 3. Each of the names must be unique (see below).
> 4. Don't use commas and don't invert the name (eg use "South Korea", not "Korea, South"). 

http://cldr.unicode.org/translation/country-names#TOC-General-Guidelines

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Improvement - Declared support to Unicode CLDR
