### PR TITLE
Added unload event to prevent reload during checkout (#24429)

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -41,10 +41,10 @@ jQuery( function( $ ) {
 			this.$checkout_form.on( 'update', this.trigger_update_checkout );
 
 			// Inputs/selects which update totals
-			this.$checkout_form.on( 'change', 'select.shipping_method, input[name^="shipping_method"], #ship-to-different-address input, .update_totals_on_change select, .update_totals_on_change input[type="radio"], .update_totals_on_change input[type="checkbox"]', this.trigger_update_checkout );
+			this.$checkout_form.on( 'change', 'select.shipping_method, input[name^="shipping_method"], #ship-to-different-address input, .update_totals_on_change select, .update_totals_on_change input[type="radio"], .update_totals_on_change input[type="checkbox"]', this.trigger_update_checkout ); // eslint-disable-line max-len
 			this.$checkout_form.on( 'change', '.address-field select', this.input_changed );
-			this.$checkout_form.on( 'change', '.address-field input.input-text, .update_totals_on_change input.input-text', this.maybe_input_changed );
-			this.$checkout_form.on( 'keydown', '.address-field input.input-text, .update_totals_on_change input.input-text', this.queue_update_checkout );
+			this.$checkout_form.on( 'change', '.address-field input.input-text, .update_totals_on_change input.input-text', this.maybe_input_changed ); // eslint-disable-line max-len
+			this.$checkout_form.on( 'keydown', '.address-field input.input-text, .update_totals_on_change input.input-text', this.queue_update_checkout ); // eslint-disable-line max-len
 
 			// Address fields
 			this.$checkout_form.on( 'change', '#ship-to-different-address input', this.ship_to_different_address );
@@ -207,7 +207,7 @@ jQuery( function( $ ) {
 				event_type        = e.type;
 
 			if ( 'input' === event_type ) {
-				$parent.removeClass( 'woocommerce-invalid woocommerce-invalid-required-field woocommerce-invalid-email woocommerce-validated' );
+				$parent.removeClass( 'woocommerce-invalid woocommerce-invalid-required-field woocommerce-invalid-email woocommerce-validated' ); // eslint-disable-line max-len
 			}
 
 			if ( 'validate' === event_type || 'change' === event_type ) {
@@ -225,7 +225,7 @@ jQuery( function( $ ) {
 				if ( validate_email ) {
 					if ( $this.val() ) {
 						/* https://stackoverflow.com/questions/2855865/jquery-validate-e-mail-address-regex */
-						var pattern = new RegExp(/^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$/i);
+						var pattern = new RegExp(/^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$/i); // eslint-disable-line max-len
 
 						if ( ! pattern.test( $this.val()  ) ) {
 							$parent.removeClass( 'woocommerce-validated' ).addClass( 'woocommerce-invalid woocommerce-invalid-email' );
@@ -235,7 +235,7 @@ jQuery( function( $ ) {
 				}
 
 				if ( validated ) {
-					$parent.removeClass( 'woocommerce-invalid woocommerce-invalid-required-field woocommerce-invalid-email' ).addClass( 'woocommerce-validated' );
+					$parent.removeClass( 'woocommerce-invalid woocommerce-invalid-required-field woocommerce-invalid-email' ).addClass( 'woocommerce-validated' ); // eslint-disable-line max-len
 				}
 			}
 		},
@@ -311,6 +311,7 @@ jQuery( function( $ ) {
 			if ( false !== args.update_shipping_method ) {
 				var shipping_methods = {};
 
+        // eslint-disable-next-line max-len
 				$( 'select.shipping_method, input[name^="shipping_method"][type="radio"]:checked, input[name^="shipping_method"][type="hidden"]' ).each( function() {
 					shipping_methods[ $( this ).data( 'index' ) ] = $( this ).val();
 				} );
@@ -395,7 +396,7 @@ jQuery( function( $ ) {
 
 						// Add new errors returned by this event
 						if ( data.messages ) {
-							$form.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-updateOrderReview">' + data.messages + '</div>' );
+							$form.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-updateOrderReview">' + data.messages + '</div>' ); // eslint-disable-line max-len
 						} else {
 							$form.prepend( data );
 						}
@@ -414,7 +415,27 @@ jQuery( function( $ ) {
 				}
 
 			});
-		},
+    },
+    handleUnloadEvent: function( e ) {
+      // Modern browsers have their own standard generic messages that they will display.
+      // Confirm, alert, prompt or custom message are not allowed during the unload event
+      // Browsers will display their own standard messages
+
+      // Check if the browser is Internet Explorer
+      if((navigator.userAgent.indexOf('MSIE') !== -1 ) || (!!document.documentMode)) {
+        // IE handles unload events differently than modern browsers
+        e.preventDefault();
+        return undefined;
+      }
+
+      return true;
+    },
+    attachUnloadEventsOnSubmit: function() {
+      $( window ).on('beforeunload', this.handleUnloadEvent);
+    },
+    detachUnloadEventsOnSubmit: function() {
+      $( window ).unbind('beforeunload', this.handleUnloadEvent);
+    },
 		blockOnSubmit: function( $form ) {
 			var form_data = $form.data();
 
@@ -439,12 +460,16 @@ jQuery( function( $ ) {
 				return false;
 			}
 
-			// Trigger a handler to let gateways manipulate the checkout if needed
+      // Trigger a handler to let gateways manipulate the checkout if needed
+      // eslint-disable-next-line max-len
 			if ( $form.triggerHandler( 'checkout_place_order' ) !== false && $form.triggerHandler( 'checkout_place_order_' + wc_checkout_form.get_payment_method() ) !== false ) {
 
 				$form.addClass( 'processing' );
 
-				wc_checkout_form.blockOnSubmit( $form );
+        wc_checkout_form.blockOnSubmit( $form );
+
+        // Attach event to block reloading the page when the form has been submitted
+        wc_checkout_form.attachUnloadEventsOnSubmit();
 
 				// ajaxSetup is global, but we use it to ensure JSON is valid once returned.
 				$.ajaxSetup( {
@@ -481,6 +506,9 @@ jQuery( function( $ ) {
 					data:		$form.serialize(),
 					dataType:   'json',
 					success:	function( result ) {
+            // Detach the unload handler that prevents a reload / redirect
+            wc_checkout_form.detachUnloadEventsOnSubmit();
+
 						try {
 							if ( 'success' === result.result ) {
 								if ( -1 === result.redirect.indexOf( 'https://' ) || -1 === result.redirect.indexOf( 'http://' ) ) {
@@ -509,11 +537,14 @@ jQuery( function( $ ) {
 							if ( result.messages ) {
 								wc_checkout_form.submit_error( result.messages );
 							} else {
-								wc_checkout_form.submit_error( '<div class="woocommerce-error">' + wc_checkout_params.i18n_checkout_error + '</div>' );
+								wc_checkout_form.submit_error( '<div class="woocommerce-error">' + wc_checkout_params.i18n_checkout_error + '</div>' ); // eslint-disable-line max-len
 							}
 						}
 					},
 					error:	function( jqXHR, textStatus, errorThrown ) {
+            // Detach the unload handler that prevents a reload / redirect
+            wc_checkout_form.detachUnloadEventsOnSubmit();
+
 						wc_checkout_form.submit_error( '<div class="woocommerce-error">' + errorThrown + '</div>' );
 					}
 				});
@@ -523,7 +554,7 @@ jQuery( function( $ ) {
 		},
 		submit_error: function( error_message ) {
 			$( '.woocommerce-NoticeGroup-checkout, .woocommerce-error, .woocommerce-message' ).remove();
-			wc_checkout_form.$checkout_form.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' + error_message + '</div>' );
+			wc_checkout_form.$checkout_form.prepend( '<div class="woocommerce-NoticeGroup woocommerce-NoticeGroup-checkout">' + error_message + '</div>' ); // eslint-disable-line max-len
 			wc_checkout_form.$checkout_form.removeClass( 'processing' ).unblock();
 			wc_checkout_form.$checkout_form.find( '.input-text, select, input:checkbox' ).trigger( 'validate' ).blur();
 			wc_checkout_form.scroll_to_notices();

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -311,7 +311,7 @@ jQuery( function( $ ) {
 			if ( false !== args.update_shipping_method ) {
 				var shipping_methods = {};
 
-        // eslint-disable-next-line max-len
+				// eslint-disable-next-line max-len
 				$( 'select.shipping_method, input[name^="shipping_method"][type="radio"]:checked, input[name^="shipping_method"][type="hidden"]' ).each( function() {
 					shipping_methods[ $( this ).data( 'index' ) ] = $( this ).val();
 				} );
@@ -415,27 +415,27 @@ jQuery( function( $ ) {
 				}
 
 			});
-    },
-    handleUnloadEvent: function( e ) {
-      // Modern browsers have their own standard generic messages that they will display.
-      // Confirm, alert, prompt or custom message are not allowed during the unload event
-      // Browsers will display their own standard messages
+		},
+		handleUnloadEvent: function( e ) {
+			// Modern browsers have their own standard generic messages that they will display.
+			// Confirm, alert, prompt or custom message are not allowed during the unload event
+			// Browsers will display their own standard messages
 
-      // Check if the browser is Internet Explorer
-      if((navigator.userAgent.indexOf('MSIE') !== -1 ) || (!!document.documentMode)) {
-        // IE handles unload events differently than modern browsers
-        e.preventDefault();
-        return undefined;
-      }
+			// Check if the browser is Internet Explorer
+			if((navigator.userAgent.indexOf('MSIE') !== -1 ) || (!!document.documentMode)) {
+				// IE handles unload events differently than modern browsers
+				e.preventDefault();
+				return undefined;
+			}
 
-      return true;
-    },
-    attachUnloadEventsOnSubmit: function() {
-      $( window ).on('beforeunload', this.handleUnloadEvent);
-    },
-    detachUnloadEventsOnSubmit: function() {
-      $( window ).unbind('beforeunload', this.handleUnloadEvent);
-    },
+			return true;
+		},
+		attachUnloadEventsOnSubmit: function() {
+			$( window ).on('beforeunload', this.handleUnloadEvent);
+		},
+		detachUnloadEventsOnSubmit: function() {
+			$( window ).unbind('beforeunload', this.handleUnloadEvent);
+		},
 		blockOnSubmit: function( $form ) {
 			var form_data = $form.data();
 
@@ -460,16 +460,16 @@ jQuery( function( $ ) {
 				return false;
 			}
 
-      // Trigger a handler to let gateways manipulate the checkout if needed
-      // eslint-disable-next-line max-len
+			// Trigger a handler to let gateways manipulate the checkout if needed
+			// eslint-disable-next-line max-len
 			if ( $form.triggerHandler( 'checkout_place_order' ) !== false && $form.triggerHandler( 'checkout_place_order_' + wc_checkout_form.get_payment_method() ) !== false ) {
 
 				$form.addClass( 'processing' );
 
-        wc_checkout_form.blockOnSubmit( $form );
+				wc_checkout_form.blockOnSubmit( $form );
 
-        // Attach event to block reloading the page when the form has been submitted
-        wc_checkout_form.attachUnloadEventsOnSubmit();
+				// Attach event to block reloading the page when the form has been submitted
+				wc_checkout_form.attachUnloadEventsOnSubmit();
 
 				// ajaxSetup is global, but we use it to ensure JSON is valid once returned.
 				$.ajaxSetup( {
@@ -506,8 +506,8 @@ jQuery( function( $ ) {
 					data:		$form.serialize(),
 					dataType:   'json',
 					success:	function( result ) {
-            // Detach the unload handler that prevents a reload / redirect
-            wc_checkout_form.detachUnloadEventsOnSubmit();
+						// Detach the unload handler that prevents a reload / redirect
+						wc_checkout_form.detachUnloadEventsOnSubmit();
 
 						try {
 							if ( 'success' === result.result ) {
@@ -542,8 +542,8 @@ jQuery( function( $ ) {
 						}
 					},
 					error:	function( jqXHR, textStatus, errorThrown ) {
-            // Detach the unload handler that prevents a reload / redirect
-            wc_checkout_form.detachUnloadEventsOnSubmit();
+						// Detach the unload handler that prevents a reload / redirect
+						wc_checkout_form.detachUnloadEventsOnSubmit();
 
 						wc_checkout_form.submit_error( '<div class="woocommerce-error">' + errorThrown + '</div>' );
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

"After a user clicks the “Place Order” button on checkout page, the page is being blocked by an overlay and a loader GIF until the ajax finishes and the user is redirected to Thank You page.

But, if a user reloads the checkout page while the payment is processing, a new order is being created and both of the orders are being charged."

This pull request adds a "beforeunload" event when the order form is submitted. When the ajax finishes or fails, the event is unbound from the window to avoid issues with redirecting automatically to the thank you page.

I'd like to open a discussion about what should really happen. Modern browsers will not allow any modals or dialogs during the unload event, we have to display the default standard text which is displayed by the individual browsers. 

We could instead add a custom trigger event when the ajax is finished and have developers hook into that to remove their custom beforeunload event? This way the control is up to the user. (refer to the ticket created)

Closes #24429 

## Note:
I had to add eslint ignore to a bunch of max-len lines, I didn't think they could be broken down. Im happy to revisit this change if its not allowed to ignore eslint rules. 

### How to test the changes in this Pull Request:

1. Add an item to the cart and proceed to the checkout
2. Reload the page or navigate away immediately after submitting the order form
3. Ensure the page does not reload and you are prompted with a dialog box blocking your navigation attempt

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Dev - Add unload event to the checkout page to prevent reloading during checkout after placing an order.