### PR TITLE
Fix recursive init_session_cookie() with cast.

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -93,7 +93,7 @@ class WC_Session_Handler extends WC_Session {
 			$this->_data               = $this->get_session_data();
 
 			// If the user logs in, update session.
-			if ( is_user_logged_in() && get_current_user_id() !== $this->_customer_id ) {
+			if ( is_user_logged_in() && get_current_user_id() !== (int) $this->_customer_id ) {
 				$guest_session_id = $this->_customer_id;
 				$this->_customer_id = get_current_user_id();
 				$this->_dirty       = true;


### PR DESCRIPTION
The customer_id retrieved from the cookie will always 
be of type "String" while the id retrieved from 
`get_current_user_id()` is of type "Integer". 
Because of the strict conditional, this will always result
in false and recursive this method on every request.

This commit uses a simple cast to resolve the recursion.

### How to test the changes in this Pull Request:

1. Add a breakpoint to `\WC_Session_Handler::init_session_cookie` method.
2. View any page which loads this and see each time it is marked "_dirty" and re-saved.
3. Add this commit and retry.

