### PR TITLE
Use isset for data['payment_method']

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -376,7 +376,11 @@ class WC_Checkout {
 			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );
 			$order->set_customer_user_agent( wc_get_user_agent() );
 			$order->set_customer_note( isset( $data['order_comments'] ) ? $data['order_comments'] : '' );
-			$order->set_payment_method( isset( $available_gateways[ $data['payment_method'] ] ) ? $available_gateways[ $data['payment_method'] ] : $data['payment_method'] );
+			if ( isset( $data['payment_method'] ) ) {
+				$order->set_payment_method( isset( $available_gateways[ $data['payment_method'] ] ) ? $available_gateways[ $data['payment_method'] ] : $data['payment_method'] );
+			} else {
+				$order->set_payment_method( '' );
+			}
 			$order->set_shipping_total( WC()->cart->get_shipping_total() );
 			$order->set_discount_total( WC()->cart->get_discount_total() );
 			$order->set_discount_tax( WC()->cart->get_discount_tax() );


### PR DESCRIPTION
Some create_order calls in the backend, for example using WooCommerce Deposits, may not have a value for payment_method. For example, an order may not require payment. This triggers a PHP Notice. 

I see that isset is used for other times that $data['payment_method'] is used, even in this file in the function get_posted_data() : 646.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Check that data is set before trying to use it to access another object.

### How to test the changes in this Pull Request:

1. Create_order without setting $data['payment_method']
2. No PHP notice will be emitted
3. All other orders should proceed

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
