### PR TITLE
Update the message on View Order use myaccount Title

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -134,7 +134,7 @@ class WC_Shortcode_My_Account {
 		$order = wc_get_order( $order_id );
 
 		if ( ! $order || ! current_user_can( 'view_order', $order_id ) ) {
-			echo '<div class="woocommerce-error">' . esc_html__( 'Invalid order.', 'woocommerce' ) . ' <a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '" class="wc-forward">' . esc_html__( 'My account', 'woocommerce' ) . '</a></div>';
+			echo '<div class="woocommerce-error">' . esc_html__( 'Invalid order.', 'woocommerce' ) . ' <a href="' . esc_url( wc_get_page_permalink( 'myaccount' ) ) . '" class="wc-forward">' . esc_html( get_the_title( wc_get_page_id( 'myaccount' ) ) ) . '</a></div>';
 
 			return;
 		}


### PR DESCRIPTION
Hello,

This little PR updates the message on the View Order screen when the order isn't viewable by allowing the 'My account' link to use the actual title of the page set for myaccount.

Cheers

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the error message when on View Order screen but viewing an invalid order or one you don't have permissions to. The existing implementation provides My Account link with the text translatable. This PR updates the title of the link to use the page title of the myaccount page.

### How to test the changes in this Pull Request:

1. Implement the PR.
2. Go to the View Order screen and enter an invalid ID.
3. Change you My Account page to use an alternate title, then go back to step #2 and confirm the link uses the new title.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### Changelog entry

Updates the Invalid Order message on the View Order screen to use the actual title of the myaccount page rather than the text string 'My Account'.