### PR TITLE
Fix a typo in WC Payment Gateway abstract '3rd party gateway size'

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -227,7 +227,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	}
 
 	/**
-	 * Get a link to the transaction on the 3rd party gateway size (if applicable).
+	 * Get a link to the transaction on the 3rd party gateway site (if applicable).
 	 *
 	 * @param  WC_Order $order the order object.
 	 * @return string transaction URL, or empty string.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

There is a typo in `WC_Payment_Gateway::get_transaction_url` docblock where it says `... 3rd party gateway size`, but I believe it meant to say `... 3rd party gateway site`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fixed a typo in `WC_Payment_Gateway::get_transaction_url` docblock.
