### PR TITLE
Prevent browser cache when using back/forward buttons on non-cached pages

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -41,7 +41,7 @@ class WC_Cache_Helper {
 	 */
 	public static function additional_nocache_headers( $headers ) {
 		// Opt-out of Google weblight if page is dynamic e.g. cart/checkout. https://support.google.com/webmasters/answer/6211428?hl=en.
-		$headers['Cache-Control'] = 'no-transform, no-cache, must-revalidate, max-age=0';
+		$headers['Cache-Control'] = 'no-transform, no-cache, no-store, must-revalidate';
 		return $headers;
 	}
 

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -40,7 +40,7 @@ class WC_Cache_Helper {
 	 * @since 3.6.0
 	 */
 	public static function additional_nocache_headers( $headers ) {
-		// Opt-out of Google weblight if page is dynamic e.g. cart/checkout. https://support.google.com/webmasters/answer/6211428?hl=en.
+		// no-transform: Opt-out of Google weblight if page is dynamic e.g. cart/checkout. https://support.google.com/webmasters/answer/6211428?hl=en.
 		$headers['Cache-Control'] = 'no-transform, no-cache, no-store, must-revalidate';
 		return $headers;
 	}


### PR DESCRIPTION
Fixes #24653 

### Changes
Add `no-store` and remove `max-age` header (no longer needed)

### Tests
After adding the header, the "order received" page is no longer cached when using the browser buttons. 

Tested with Chrome and Firefox 
WP 5.2.3
Woo 3.6.5






