### PR TITLE
Remove PHP 7.4 job from the list of Travis jobs allowed to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,8 +51,6 @@ matrix:
   allow_failures:
   - php: 7.3
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
-  - php: 7.4snapshot
-    env: WP_VERSION=nightly WP_MULTISITE=0
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Now that WP fixed all the PHP 7.4 related notices and that the WC unit tests are passing when running against this PHP version, we can remove the PHP 7.4 from the list of Travis jobs that are allowed to fail.

### How to test the changes in this Pull Request:

1. Check Travis to confirm that the PHP 7.4 job passes and that it is not in the list of jobs that are allowed to fail.