### PR TITLE
Small refactor in WC_Order methods to get formatted address

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -882,7 +882,7 @@ class WC_Order extends WC_Abstract_Order {
 		/**
 		 * Filter orders formatterd billing address.
 		 *
-		 * @since 3.7.1
+		 * @since 3.8.0
 		 * @param string $address     Formatted billing address string.
 		 * @param array  $raw_address Raw billing address.
 		 */
@@ -907,7 +907,7 @@ class WC_Order extends WC_Abstract_Order {
 		/**
 		 * Filter orders formatterd shipping address.
 		 *
-		 * @since 3.7.1
+		 * @since 3.8.0
 		 * @param string $address     Formatted shipping address string.
 		 * @param array  $raw_address Raw shipping address.
 		 */

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -876,10 +876,17 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_formatted_billing_address( $empty_content = '' ) {
-		$address = apply_filters( 'woocommerce_order_formatted_billing_address', $this->get_address( 'billing' ), $this );
-		$address = WC()->countries->get_formatted_address( $address );
+		$raw_address = apply_filters( 'woocommerce_order_formatted_billing_address', $this->get_address( 'billing' ), $this );
+		$address     = WC()->countries->get_formatted_address( $raw_address );
 
-		return $address ? $address : $empty_content;
+		/**
+		 * Filter orders formatterd billing address.
+		 *
+		 * @since 3.7.1
+		 * @param string $address     Formatted billing address string.
+		 * @param array  $raw_address Raw billing address.
+		 */
+		return apply_filters( 'woocommerce_order_get_formatted_billing_address', $address ? $address : $empty_content, $raw_address );
 	}
 
 	/**
@@ -889,17 +896,22 @@ class WC_Order extends WC_Abstract_Order {
 	 * @return string
 	 */
 	public function get_formatted_shipping_address( $empty_content = '' ) {
-		$address = '';
-		if ( $this->has_shipping_address() ) {
-			$address = $this->get_address( 'shipping' );
-		}
-		$address = apply_filters( 'woocommerce_order_formatted_shipping_address', $address, $this );
+		$address     = '';
+		$raw_address = $this->get_address( 'shipping' );
 
 		if ( $this->has_shipping_address() ) {
-			$address = WC()->countries->get_formatted_address( $address );
+			$raw_address = apply_filters( 'woocommerce_order_formatted_shipping_address', $raw_address, $this );
+			$address     = WC()->countries->get_formatted_address( $raw_address );
 		}
 
-		return $address ? $address : $empty_content;
+		/**
+		 * Filter orders formatterd shipping address.
+		 *
+		 * @since 3.7.1
+		 * @param string $address     Formatted shipping address string.
+		 * @param array  $raw_address Raw shipping address.
+		 */
+		return apply_filters( 'woocommerce_order_get_formatted_shipping_address', $address ? $address : $empty_content, $raw_address );
 	}
 
 	/**


### PR DESCRIPTION
Introduces new filters to better handle order's formatted addresses

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

#23859 proposed changes to allow always filter shipping address, but this caused problems fixed by #24146, this last PR also introduced a new bug, since `$address` is an empty string, but 
the filter expects an array, so it's a backwards compatibility issue now.

This PR introduces new filters to proper filter formatted address as string, avoiding any trouble or creating backwards compatibility issues.

Also note that in future releases e should be able to deprecated `woocommerce_order_formatted_billing_address` and `woocommerce_order_formatted_shipping_address`, even more because there's already `woocommerce_get_order_address` filter in `WC_Order::get_address()`.

### How to test the changes in this Pull Request:

1. Ensure unit tests pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced `woocommerce_order_get_formatted_billing_address` and `woocommerce_order_get_formatted_shipping_address` filters.
- Dev - Fixed backwards compatibility of `WC_Order::get_formatted_shipping_address()` method.
