### PR TITLE
Update usage tracking UI, default to opted-out.

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -20,6 +20,10 @@ body {
 .wc-setup {
 	text-align: center;
 
+	#wc_tracker_checkbox {
+		display: none;
+	}
+
 	.select2-container {
 		text-align: left;
 		width: auto;
@@ -409,27 +413,6 @@ body {
 		}
 	}
 
-	.woocommerce-tracker {
-		margin: 24px 0;
-		border: 1px solid #eee;
-		padding: 20px;
-		border-radius: 4px;
-		overflow: hidden;
-
-		p {
-			font-size: 14px;
-			line-height: 1.5;
-		}
-
-		.checkbox {
-			line-height: 24px;
-			font-weight: 500;
-			font-size: 1em;
-			margin-top: 0;
-			margin-bottom: 20px;
-		}
-	}
-
 	.checkbox {
 
 		input[type="checkbox"] {
@@ -488,6 +471,43 @@ body {
 			background: #935687;
 			border-color: #935687;
 		}
+	}
+}
+
+.woocommerce-tracker {
+	margin: 24px 0;
+	border: 1px solid #eee;
+	padding: 20px;
+	border-radius: 4px;
+	overflow: hidden;
+	text-align: left;
+
+	h1 {
+		border-bottom: 0;
+		padding-bottom: 0;
+	}
+
+	.wc-backbone-modal-header {
+		border-bottom: 0;
+	}
+
+	.wc-backbone-modal-main article {
+		padding-top: 0;
+	}
+
+	.wc-backbone-modal-main footer {
+		border-top: 0;
+		box-shadow: none;
+	}
+
+	p {
+		font-size: 14px;
+		line-height: 1.5;
+	}
+
+	.woocommerce-tracker-checkbox label {
+		margin-top: -4px;
+		display: inline-block;
 	}
 }
 
@@ -565,22 +585,23 @@ body {
 	overflow: hidden;
 	margin: 20px 0 0;
 	position: relative;
+}
 
-	.button-primary {
-		background-color: #bb77ae;
+.wc-setup .wc-setup-actions .button-primary,
+.woocommerce-tracker .button-primary {
+	background-color: #bb77ae;
+	border-color: #a36597;
+	box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
+	text-shadow: 0 -1px 1px #a36597, 1px 0 1px #a36597, 0 1px 1px #a36597, -1px 0 1px #a36597;
+	margin: 0;
+	opacity: 1;
+
+	&:hover,
+	&:focus,
+	&:active {
+		background: #a36597;
 		border-color: #a36597;
 		box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
-		text-shadow: 0 -1px 1px #a36597, 1px 0 1px #a36597, 0 1px 1px #a36597, -1px 0 1px #a36597;
-		margin: 0;
-		opacity: 1;
-
-		&:hover,
-		&:focus,
-		&:active {
-			background: #a36597;
-			border-color: #a36597;
-			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.25), 0 1px 0 #a36597;
-		}
 	}
 }
 

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -22,6 +22,35 @@ jQuery( function( $ ) {
 		return true;
 	} );
 
+	$( 'form.address-step' ).on( 'submit', function( e ) {
+		var form = $( this );
+		if ( ( 'function' !== typeof form.checkValidity ) || form.checkValidity() ) {
+			blockWizardUI();
+		}
+
+		e.preventDefault();
+		$('.wc-setup-content').unblock();
+
+		$( this ).WCBackboneModal( {
+			template: 'wc-modal-tracking-setup'
+		} );
+
+		$( document.body ).on( 'wc_backbone_modal_response', function() {
+			form.unbind( 'submit' ).submit();
+		} );
+
+		$( '#wc_tracker_checkbox_dialog' ).on( 'change', function( e ) {
+			var eventTarget = $( e.target );
+			$( '#wc_tracker_checkbox' ).prop( 'checked', eventTarget.prop( 'checked' ) );
+		} );
+
+		$( '#wc_tracker_submit' ).on( 'click', function () {
+			form.unbind( 'submit' ).submit();
+		} );
+
+		return true;
+	} );
+
 	$( '#store_country' ).on( 'change', function() {
 		// Prevent if we don't have the metabox data
 		if ( wc_setup_params.states === null ){

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -204,7 +204,7 @@ class WC_Admin_Setup_Wizard {
 		wp_enqueue_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), WC_VERSION );
 		wp_enqueue_style( 'wc-setup', WC()->plugin_url() . '/assets/css/wc-setup.css', array( 'dashicons', 'install' ), WC_VERSION );
 
-		wp_register_script( 'wc-setup', WC()->plugin_url() . '/assets/js/admin/wc-setup' . $suffix . '.js', array( 'jquery', 'wc-enhanced-select', 'jquery-blockui', 'wp-util', 'jquery-tiptip' ), WC_VERSION );
+		wp_register_script( 'wc-setup', WC()->plugin_url() . '/assets/js/admin/wc-setup' . $suffix . '.js', array( 'jquery', 'wc-enhanced-select', 'jquery-blockui', 'wp-util', 'jquery-tiptip', 'backbone', 'wc-backbone-modal' ), WC_VERSION );
 		wp_localize_script(
 			'wc-setup',
 			'wc_setup_params',
@@ -456,6 +456,7 @@ class WC_Admin_Setup_Wizard {
 		$currency_by_country = wp_list_pluck( $locale_info, 'currency_code' );
 		?>
 		<form method="post" class="address-step">
+			<input type="hidden" name="save_step" value="store_setup" />
 			<?php wp_nonce_field( 'wc-setup' ); ?>
 			<p class="store-setup"><?php esc_html_e( 'The following wizard will help you configure your store and get you started quickly.', 'woocommerce' ); ?></p>
 
@@ -548,22 +549,62 @@ class WC_Admin_Setup_Wizard {
 				<?php esc_html_e( 'I will also be selling products or services in person.', 'woocommerce' ); ?>
 			</label>
 
-			<div class="woocommerce-tracker">
-				<p class="checkbox">
-					<input type="checkbox" id="wc_tracker_checkbox" name="wc_tracker_checkbox" value="yes" checked />
-					<label for="wc_tracker_checkbox"><?php esc_html_e( 'Help WooCommerce improve with usage tracking.', 'woocommerce' ); ?></label>
-				</p>
-				<p>
-				<?php
-				esc_html_e( 'Gathering usage data allows us to make WooCommerce better &mdash; your store will be considered as we evaluate new features, judge the quality of an update, or determine if an improvement makes sense. If you would rather opt-out, and do not check this box, we will not know this store exists and we will not collect any usage data.', 'woocommerce' );
-				echo ' <a target="_blank" href="https://woocommerce.com/usage-tracking/">' . esc_html__( 'Read more about what we collect.', 'woocommerce' ) . '</a>';
-				?>
-				</p>
-			</div>
+			<input type="checkbox" id="wc_tracker_checkbox" name="wc_tracker_checkbox" value="yes" />
+
+			<?php $this->tracking_modal(); ?>
+
 			<p class="wc-setup-actions step">
-				<button type="submit" class="button-primary button button-large button-next" value="<?php esc_attr_e( "Let's go!", 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( "Let's go!", 'woocommerce' ); ?></button>
+				<button class="button-primary button button-large" value="<?php esc_attr_e( "Let's go!", 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( "Let's go!", 'woocommerce' ); ?></button>
 			</p>
 		</form>
+		<?php
+	}
+
+	/**
+	 * Template for the usage tracking modal.
+	 */
+	public function tracking_modal() {
+		?>
+		<script type="text/template" id="tmpl-wc-modal-tracking-setup">
+			<div class="wc-backbone-modal woocommerce-tracker">
+				<div class="wc-backbone-modal-content">
+					<section class="wc-backbone-modal-main" role="main">
+						<header class="wc-backbone-modal-header">
+							<h1><?php esc_html_e( 'Help improve WooCommerce with usage tracking', 'woocommerce' ); ?></h1>
+						</header>
+						<article>
+							<p>
+							<?php
+								printf(
+									wp_kses(
+										/* translators: %1$s: usage tracking help link */
+										__( 'Learn more about how usage tracking works, and how you\'ll be helping <a href="%1$s" target="_blank">here</a>.', 'woocommerce' ),
+										array(
+											'a'    => array(
+												'href'   => array(),
+												'target' => array(),
+											),
+										)
+									),
+									'https://woocommerce.com/usage-tracking/'
+								);
+							?>
+							</p>
+							<p class="woocommerce-tracker-checkbox">
+								<input type="checkbox" id="wc_tracker_checkbox_dialog" name="wc_tracker_checkbox_dialog" value="yes" />
+								<label for="wc_tracker_checkbox_dialog"><?php esc_html_e( 'Enable usage tracking and help improve WooCommerce', 'woocommerce' ); ?></label>
+							</p>
+						</article>
+						<footer>
+							<div class="inner">
+								<button class="button button-primary button-large" id="wc_tracker_submit" aria-label="<?php esc_attr_e( 'Continue', 'woocommerce' ); ?>"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></a>
+							</div>
+						</footer>
+					</section>
+				</div>
+			</div>
+			<div class="wc-backbone-modal-backdrop modal-close"></div>
+		</script>
 		<?php
 	}
 
@@ -1078,7 +1119,7 @@ class WC_Admin_Setup_Wizard {
 
 			<p class="wc-setup-actions step">
 				<?php $this->plugin_install_info(); ?>
-				<button type="submit" class="button-primary button button-large button-next" value="<?php esc_attr_e( 'Continue', 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></button>
+				<button class="button-primary button button-large button-next" value="<?php esc_attr_e( 'Continue', 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( 'Continue', 'woocommerce' ); ?></button>
 				<?php wp_nonce_field( 'wc-setup' ); ?>
 			</p>
 		</form>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -549,7 +549,7 @@ class WC_Admin_Setup_Wizard {
 				<?php esc_html_e( 'I will also be selling products or services in person.', 'woocommerce' ); ?>
 			</label>
 
-			<input type="checkbox" id="wc_tracker_checkbox" name="wc_tracker_checkbox" value="yes" />
+			<input type="checkbox" id="wc_tracker_checkbox" name="wc_tracker_checkbox" value="yes" <?php checked( 'yes', get_option( 'woocommerce_allow_tracking', 'no' ) ); ?> />
 
 			<?php $this->tracking_modal(); ?>
 
@@ -591,7 +591,7 @@ class WC_Admin_Setup_Wizard {
 							?>
 							</p>
 							<p class="woocommerce-tracker-checkbox">
-								<input type="checkbox" id="wc_tracker_checkbox_dialog" name="wc_tracker_checkbox_dialog" value="yes" />
+								<input type="checkbox" id="wc_tracker_checkbox_dialog" name="wc_tracker_checkbox_dialog" value="yes" <?php checked( 'yes', get_option( 'woocommerce_allow_tracking', 'no' ) ); ?> />
 								<label for="wc_tracker_checkbox_dialog"><?php esc_html_e( 'Enable usage tracking and help improve WooCommerce', 'woocommerce' ); ?></label>
 							</p>
 						</article>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

We would like to get these changes into WooCommerce 3.8.

This PR updates the tracking opt-in checkbox in the current onboarding experience. The checkbox is now unchecked by default (no tracking). The message and checkbox are now also moved to a dialog prior to submitting the form.

See https://github.com/woocommerce/woocommerce-admin/issues/2934.

<img width="891" alt="Screen Shot 2019-09-24 at 2 06 46 PM" src="https://user-images.githubusercontent.com/689165/65539974-7ba19500-ded8-11e9-85c3-72c883f33301.png">

### How to test the changes in this Pull Request:

1. Go to `/wp-admin/admin.php?page=wc-setup` and verify the tracking checkbox is not shown.
2. Test form validation by trying to submit with a blank address, state, or other field.
3. Submit a valid form. You should see the tracking dialog.
4. Test submitting with the checkbox unselected. Look at your `woocommerce_allow_tracking` option. The value should be `no`.
5. Test again, with the checkbox selected. Look at your `woocommerce_allow_tracking` option and the value should be `yes`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Update usage tracking checkbox to be opted-out by default.