### PR TITLE
Update downloadable/virtual case in wc_update_product_lookup_tables_column( $column )

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1452,15 +1452,18 @@ function wc_update_product_lookup_tables_column( $column ) {
 		case 'downloadable':
 		case 'virtual':
 			$column = esc_sql( $column );
-
+			$meta_key = '_' . $column;
 			$wpdb->query(
-				"
-				UPDATE
-					{$wpdb->wc_product_meta_lookup} lookup_table
-					LEFT JOIN {$wpdb->postmeta} meta1 ON lookup_table.product_id = meta1.post_id AND meta1.meta_key = '_virtual'
-				SET
-					lookup_table.`{$column}` = IF ( meta1.meta_value = 'yes', 1, 0 )
-				"
+				$wpdb->prepare(
+					"
+					UPDATE
+						{$wpdb->wc_product_meta_lookup} lookup_table
+						LEFT JOIN {$wpdb->postmeta} meta1 ON lookup_table.product_id = meta1.post_id AND meta1.meta_key = %s
+					SET
+						lookup_table.`{$column}` = IF ( meta1.meta_value = 'yes', 1, 0 )
+					",
+					$meta_key
+				)
 			);
 			break;
 		case 'onsale':


### PR DESCRIPTION
Adds prepared statement to the 'downloadable' and 'virtual' cases (similar to the 'total_sales' case of wc_update_product_lookup_tables_column(). Suggested fix for issue #24681.

Closes #24681.

### How to test the changes in this Pull Request:

1. In WP Admin, go to WooCommerce --> Status --> Tools
2. Click on Regenerate button in the Product Lookup tables row.
3. Verify that the downloadable column in the wp_wc_product_meta_lookup table correctly reflects the _downloadable postmeta value for each product.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update wc_update_product_lookup_tables_column( $column )
