### PR TITLE
Refine static homepage check to exclude blog archive queries. Fixes #…

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -234,7 +234,7 @@ class WC_Query {
 	 * @return bool
 	 */
 	private function is_showing_page_on_front( $q ) {
-		return $q->is_home() && 'page' === get_option( 'show_on_front' );
+		return ( $q->is_home() && ! $q->is_posts_page ) && 'page' === get_option( 'show_on_front' );
 	}
 
 	/**


### PR DESCRIPTION
…24582

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prevent overriding of the query when using orderby on a blog archive with a static homepage. Make a distinction between the orderby query used on the homepage (which sets is_home() to true behind the scenes) and when used as part of a blog archive query.

Closes #24582 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix overriding of query when using orderby on archives with a static homepage.