### PR TITLE
Add action to after tabs

### DIFF
--- a/templates/single-product/tabs/tabs.php
+++ b/templates/single-product/tabs/tabs.php
@@ -41,7 +41,8 @@ if ( ! empty( $tabs ) ) : ?>
 			<div class="woocommerce-Tabs-panel woocommerce-Tabs-panel--<?php echo esc_attr( $key ); ?> panel entry-content wc-tab" id="tab-<?php echo esc_attr( $key ); ?>" role="tabpanel" aria-labelledby="tab-title-<?php echo esc_attr( $key ); ?>">
 				<?php if ( isset( $tab['callback'] ) ) { call_user_func( $tab['callback'], $key, $tab ); } ?>
 			</div>
-		<?php endforeach; ?>
+		<?php endforeach;
+		do_action( 'woocommerce_after_tabs' ); ?>
 	</div>
 
 <?php endif; ?>


### PR DESCRIPTION
If you have a long product description the space under the tabs is empty and is space that can be used to include banners, images, whatever. Therefore it seems appropriate to have an action to hook into after the tabs. A lot of sites we build we end up having to override the tabs.php file in the theme to achieve this as there is no hook.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
