### PR TITLE
Fix admin sub-menus becoming unaligned when scrolling #24671

### DIFF
--- a/includes/admin/list-tables/abstract-class-wc-admin-list-table.php
+++ b/includes/admin/list-tables/abstract-class-wc-admin-list-table.php
@@ -72,7 +72,7 @@ abstract class WC_Admin_List_Table {
 
 			$this->render_blank_state();
 
-			echo '<style type="text/css">#posts-filter .wp-list-table, #posts-filter .tablenav.top, .tablenav.bottom .actions, .wrap .subsubsub  { display: none; } </style>';
+			echo '<style type="text/css">#posts-filter .wp-list-table, #posts-filter .tablenav.top, .tablenav.bottom .actions, .wrap .subsubsub  { display: none; } #posts-filter .tablenav.bottom { height: auto; } </style>';
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Added a CSS style to override the default behaviour of WordPress' `tablenav` class. By default the div is limited to a height of **30px** which causes the `render_blank_state` markup to overflow and is not counted towards the `#wpbody` divs final height. This causes WordPress to think we are scrolling the whole body and offsets the submenus.

Closes #24671 .

### Changelog entry

> Fix admin sub-menus becoming unaligned when scrolling down in the orders page when there are no orders.
