### PR TITLE
Add WCCOM requirements check to /installer REST API endpoint

### DIFF
--- a/includes/wccom-site/class-wc-wccom-site-installer-requirements-check.php
+++ b/includes/wccom-site/class-wc-wccom-site-installer-requirements-check.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ * WooCommerce.com Product Installation Requirements Check.
+ *
+ * @package WooCommerce\WooCommerce_Site
+ * @since   3.8.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_WCCOM_Site_Installer_Requirements_Check Class
+ * Contains functionality to check the necessary requirements for the installer.
+ */
+class WC_WCCOM_Site_Installer_Requirements_Check {
+	/**
+	 * Check if the site met the requirements
+	 *
+	 * @version 3.8.0
+	 * @return bool|WP_Error Does the site met the requirements?
+	 */
+	public static function met_requirements() {
+		$errs = [];
+
+		if ( ! self::met_wp_cron_requirement() ) {
+			$errs[] = 'wp-cron';
+		}
+
+		if ( ! self::met_filesystem_requirement() ) {
+			$errs[] = 'filesystem';
+		}
+
+		if ( ! empty( $errs ) ) {
+			// translators: %s: Requirements unmet.
+			return new WP_Error( 'requirements_not_met', sprintf( __( 'Server requirements not met, missing requirement(s): %s.', 'woocommerce' ), implode( ', ', $errs ) ), array( 'status' => 503 ) );
+		}
+
+		return true;
+	}
+
+	/**
+	 * Validates if WP CRON is enabled.
+	 *
+	 * @since 3.8.0
+	 * @return bool
+	 */
+	private static function met_wp_cron_requirement() {
+		return ! ( defined( 'DISABLE_WP_CRON' ) && DISABLE_WP_CRON );
+	}
+
+	/**
+	 * Validates if `WP_CONTENT_DIR` is writable.
+	 *
+	 * @since 3.8.0
+	 * @return bool
+	 */
+	private static function met_filesystem_requirement() {
+		return is_writable( WP_CONTENT_DIR );
+	}
+}

--- a/includes/wccom-site/class-wc-wccom-site-installer-requirements-check.php
+++ b/includes/wccom-site/class-wc-wccom-site-installer-requirements-check.php
@@ -32,7 +32,7 @@ class WC_WCCOM_Site_Installer_Requirements_Check {
 
 		if ( ! empty( $errs ) ) {
 			// translators: %s: Requirements unmet.
-			return new WP_Error( 'requirements_not_met', sprintf( __( 'Server requirements not met, missing requirement(s): %s.', 'woocommerce' ), implode( ', ', $errs ) ), array( 'status' => 503 ) );
+			return new WP_Error( 'requirements_not_met', sprintf( __( 'Server requirements not met, missing requirement(s): %s.', 'woocommerce' ), implode( ', ', $errs ) ), array( 'status' => 400 ) );
 		}
 
 		return true;

--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -36,6 +36,7 @@ class WC_WCCOM_Site {
 	protected static function includes() {
 		require_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php';
 		require_once WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site-installer.php';
+		require_once WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site-installer-requirements-check.php';
 	}
 
 	/**

--- a/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
+++ b/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
@@ -95,6 +95,11 @@ class WC_REST_WCCOM_Site_Installer_Controller extends WC_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function install( $request ) {
+		$requirements_met = WC_WCCOM_Site_Installer_Requirements_Check::met_requirements();
+		if ( is_wp_error( $requirements_met ) ) {
+			return $requirements_met;
+		}
+
 		if ( empty( $request['products'] ) ) {
 			return new WP_Error( 'missing_products', __( 'Missing products in request body.', 'woocommerce' ), array( 'status' => 400 ) );
 		}

--- a/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
+++ b/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
@@ -84,6 +84,11 @@ class WC_REST_WCCOM_Site_Installer_Controller extends WC_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function get_install_state( $request ) {
+		$requirements_met = WC_WCCOM_Site_Installer_Requirements_Check::met_requirements();
+		if ( is_wp_error( $requirements_met ) ) {
+			return $requirements_met;
+		}
+
 		return rest_ensure_response( WC_WCCOM_Site_Installer::get_state() );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adds internal REST API endpoint to allow WC.COM to validate user's site has met all the requirements to install purchased products.

- Adds API endpoint
    - `GET /wccom-site/v1/installer/requirements_check` te retreive if requirements are met.
- Request is authenticated using `access_token` and `access_token_secret` that are stored in site option after connecting to WooCommerce.com (via __WooCommerce > Extensions > WooCommerce.com Subscriptions__).

### How to test the changes in this Pull Request:
To test this, your WooCommerce site needs to be connected to WooCommerce.com (via __WooCommerce > Extensions > WooCommerce.com Subscriptions__). Once connected, you will need to generate a signature for the request. For example, if your WooCommerce site is https://woo-site.test, signature for `GET /wccom-site/v1/installer/requirements_check` can be generated with:

```php
require_once( WC_ABSPATH . 'includes/admin/helper/class-wc-helper.php' );

$auth                = WC_Helper_Options::get( 'auth' );
$access_token_secret = $auth['access_token_secret'];
$signature           = hash_hmac(
	'sha256',
	json_encode( [
		'host'        => 'woo-site.test:6320',
		'request_uri' => '/wp-json/wccom-site/v1/installer/requirements_check',
		'method'      => 'GET',
	] ),
	$access_token_secret
);
```
Where:

- `$signature` => `X-Woo-Signature: `
- `$auth['access_token']` => `Authorization: Bearer <TOKEN>`

#### Example Request and Response
```
curl -X GET \
  http://woo-site.test:6320/wp-json/wccom-site/v1/installer/requirements_check \
  -H 'Authorization: Bearer bcdc6118bf1bdaa328960b5e5b12cab3cbcad01c' \
  -H 'X-Woo-Signature: e4b39d23cdcf9b549c588151f3dab7bd2c92d0d0f49442e0346d3af7cc35de96'

{"passed":true,"errors":[]}
```
My local instance has met all the necessary requirements, so `passed` is `true` in this case.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add WCCOM Site Installer REST API endpoint to validate server requirements
