### PR TITLE
Add action hook after products tab

### DIFF
--- a/templates/single-product/tabs/tabs.php
+++ b/templates/single-product/tabs/tabs.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
- * @version 2.4.0
+ * @version 3.8.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/single-product/tabs/tabs.php
+++ b/templates/single-product/tabs/tabs.php
@@ -50,7 +50,7 @@ if ( ! empty( $product_tabs ) ) : ?>
 			</div>
 		<?php endforeach; ?>
 
-		<?php do_action( 'woocommerce_after_tabs' ); ?>
+		<?php do_action( 'woocommerce_product_after_tabs' ); ?>
 	</div>
 
 <?php endif; ?>

--- a/templates/single-product/tabs/tabs.php
+++ b/templates/single-product/tabs/tabs.php
@@ -41,7 +41,8 @@ if ( ! empty( $tabs ) ) : ?>
 			<div class="woocommerce-Tabs-panel woocommerce-Tabs-panel--<?php echo esc_attr( $key ); ?> panel entry-content wc-tab" id="tab-<?php echo esc_attr( $key ); ?>" role="tabpanel" aria-labelledby="tab-title-<?php echo esc_attr( $key ); ?>">
 				<?php if ( isset( $tab['callback'] ) ) { call_user_func( $tab['callback'], $key, $tab ); } ?>
 			</div>
-		<?php endforeach; ?>
+		<?php endforeach;
+		do_action( 'woocommerce_after_tabs' ); ?>
 	</div>
 
 <?php endif; ?>

--- a/templates/single-product/tabs/tabs.php
+++ b/templates/single-product/tabs/tabs.php
@@ -10,7 +10,7 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	https://docs.woocommerce.com/document/template-structure/
+ * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce/Templates
  * @version 2.4.0
  */
@@ -23,26 +23,34 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Filter tabs and allow third parties to add their own.
  *
  * Each tab is an array containing title, callback and priority.
+ *
  * @see woocommerce_default_product_tabs()
  */
-$tabs = apply_filters( 'woocommerce_product_tabs', array() );
+$product_tabs = apply_filters( 'woocommerce_product_tabs', array() );
 
-if ( ! empty( $tabs ) ) : ?>
+if ( ! empty( $product_tabs ) ) : ?>
 
 	<div class="woocommerce-tabs wc-tabs-wrapper">
 		<ul class="tabs wc-tabs" role="tablist">
-			<?php foreach ( $tabs as $key => $tab ) : ?>
+			<?php foreach ( $product_tabs as $key => $product_tab ) : ?>
 				<li class="<?php echo esc_attr( $key ); ?>_tab" id="tab-title-<?php echo esc_attr( $key ); ?>" role="tab" aria-controls="tab-<?php echo esc_attr( $key ); ?>">
-					<a href="#tab-<?php echo esc_attr( $key ); ?>"><?php echo apply_filters( 'woocommerce_product_' . $key . '_tab_title', esc_html( $tab['title'] ), $key ); ?></a>
+					<a href="#tab-<?php echo esc_attr( $key ); ?>">
+						<?php echo wp_kses_post( apply_filters( 'woocommerce_product_' . $key . '_tab_title', $product_tab['title'], $key ) ); ?>
+					</a>
 				</li>
 			<?php endforeach; ?>
 		</ul>
-		<?php foreach ( $tabs as $key => $tab ) : ?>
+		<?php foreach ( $product_tabs as $key => $product_tab ) : ?>
 			<div class="woocommerce-Tabs-panel woocommerce-Tabs-panel--<?php echo esc_attr( $key ); ?> panel entry-content wc-tab" id="tab-<?php echo esc_attr( $key ); ?>" role="tabpanel" aria-labelledby="tab-title-<?php echo esc_attr( $key ); ?>">
-				<?php if ( isset( $tab['callback'] ) ) { call_user_func( $tab['callback'], $key, $tab ); } ?>
+				<?php
+				if ( isset( $product_tab['callback'] ) ) {
+					call_user_func( $product_tab['callback'], $key, $product_tab );
+				}
+				?>
 			</div>
-		<?php endforeach;
-		do_action( 'woocommerce_after_tabs' ); ?>
+		<?php endforeach; ?>
+
+		<?php do_action( 'woocommerce_after_tabs' ); ?>
 	</div>
 
 <?php endif; ?>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a new action hook that is executed after the product tabs are rendered in the products single page. This was requested by a user in #24687. This PR simply expands the original PR to include fixes to coding standard violations (both present in the file already and introduced in the original PR) and to change the name of the new action to a more specific name. See #24687 for details on why this action hook is needed.

Supersedes #24687

### How to test the changes in this Pull Request:

1. Use the new `woocommerce_product_after_tabs` hook to add HTML below the product tabs in a product single page.
2. Review code changes, specifically the commit that fixes PHPCS violations.

### Changelog entry

> Dev: new woocommerce_product_after_tabs action hook added.
