### PR TITLE
Fix missing translations for WooCommerce Blocks

### DIFF
--- a/bin/package-update.sh
+++ b/bin/package-update.sh
@@ -29,7 +29,7 @@ output 2 "Done"
 output 3 "Updating package textdomains..."
 
 # Replace text domains within packages with woocommerce
-find ./packages/woocommerce-blocks -iname '*.php' -exec sed -i.bak -e "s/, 'woo-gutenberg-products-block'/, 'woocommerce'/g" {} \;
+find ./packages/woocommerce-blocks \( -iname '*.php' -o -iname '*.js' \) -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" -e "s/\"woo-gutenberg-products-block\"/'woocommerce'/g" {} \;
 find ./packages/woocommerce-rest-api -iname '*.php' -exec sed -i.bak -e "s/, 'woocommerce-rest-api'/, 'woocommerce'/g" {} \;
 
 # Cleanup backup files


### PR DESCRIPTION
Fixes #24669

WooCommerce releases weren't showing translations for WooCommerce blocks because the domain replacement script was only replacing `woo-gutenberg-products-block` with `woocommerce` in php files.  In this pull the replacement script has been improved so that:

- `'woo-gutenberg-products-block'` **and** `"woo-gutenberg-products-block"` is replaced with `'woocommerce'` in php _and_ javascript files.  
- replacement is more greedy and I dropped the match on `, `. 

## To Test

* Set up development environment if you haven't already (`composer install` etc)
* Switch your WordPress site this is installed on to a different language (pick a language with good coverage in translations) and make sure the language packs for that language have been downloaded.
* run `./bin/package-update.sh` in the cli.
* you should now see all blocks with their translations in the editor.

## Next steps.

Might be good to do a point release for this?  Depends on how important it is to have translations showing - otherwise you can probably just include this with the next release.