### PR TITLE
Correct comments in stock increase methods

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -121,16 +121,16 @@ function wc_maybe_increase_stock_levels( $order_id ) {
 	}
 
 	$stock_reduced  = $order->get_data_store()->get_stock_reduced( $order_id );
-	$trigger_reduce = (bool) $stock_reduced;
+	$trigger_increase = (bool) $stock_reduced;
 
-	// Only continue if we're reducing stock.
-	if ( ! $trigger_reduce ) {
+	// Only continue if we're increasing stock.
+	if ( ! $trigger_increase ) {
 		return;
 	}
 
 	wc_increase_stock_levels( $order );
 
-	// Ensure stock is marked as "reduced" in case payment complete or other stock actions are called.
+	// Ensure stock is not marked as "reduced" anymore.
 	$order->get_data_store()->set_stock_reduced( $order_id, false );
 }
 add_action( 'woocommerce_order_status_cancelled', 'wc_maybe_increase_stock_levels' );
@@ -261,7 +261,7 @@ function wc_increase_stock_levels( $order_id ) {
 			continue;
 		}
 
-		// Only reduce stock once for each item.
+		// Only increase stock once for each item.
 		$product            = $item->get_product();
 		$item_stock_reduced = $item->get_meta( '_reduced_stock', true );
 


### PR DESCRIPTION
Fixes some semantic comments and a variable name in the stock increase methods. The comments were obviously copy-pasted from the decrease-stock methods and not adapted.

There is however a logic problem remaining, I think, where the value taken for the per-item `_reduced_stock` meta value falls back to `true` when the meta key does not exist (line 266), however the key is deleted at the end of the loop (line 281), thus allowing the `wc_increase_stock_levels` methods to increase the stock again when re-run directly.