### PR TITLE
Fix alignment issues in the OBW

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1117,7 +1117,7 @@ h3.jetpack-reasons {
 	font-weight: 500;
 	margin-bottom: 0.5em;
 	margin-top: 0.85em;
-	display: block;
+	display: inline-block;
 }
 
 .location-input {
@@ -1167,13 +1167,15 @@ h3.jetpack-reasons {
 	}
 }
 
-.product-type-container {
+.product-type-container,
+.sell-in-person-container {
 	margin-top: 14px;
 	margin-bottom: 1px;
 }
 
 #woocommerce_sell_in_person {
 	margin-left: 0;
+	margin-top: calc(0.85em / 2);
 }
 
 .wc-wizard-service-settings {

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1117,7 +1117,7 @@ h3.jetpack-reasons {
 	font-weight: 500;
 	margin-bottom: 0.5em;
 	margin-top: 0.85em;
-	display: inline-block;
+	display: block;
 }
 
 .location-input {
@@ -1131,7 +1131,7 @@ h3.jetpack-reasons {
 	font-size: 16px;
 	color: #444;
 	background-color: #fff;
-	display: inline-block;
+	display: block;
 
 	&.dropdown {
 		width: 100%;

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -537,6 +537,7 @@ class WC_Admin_Setup_Wizard {
 			</select>
 			</div>
 
+			<div class="sell-in-person-container">
 			<input
 				type="checkbox"
 				id="woocommerce_sell_in_person"
@@ -547,6 +548,7 @@ class WC_Admin_Setup_Wizard {
 			<label class="location-prompt" for="woocommerce_sell_in_person">
 				<?php esc_html_e( 'I will also be selling products or services in person.', 'woocommerce' ); ?>
 			</label>
+			</div>
 
 			<div class="woocommerce-tracker">
 				<p class="checkbox">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR addresses some alignment issues with the city and sell in person options in the OBW.

### How to test the changes in this Pull Request:

1. Run `grunt css`
2. Load admin.php?page=wc-setup and ensure the city and sell in person options are aligned correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - OWB country and sell in person allignment.
