### PR TITLE
Allow select fields in credit card form to maintain value when the checkout form refreshes

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -357,8 +357,6 @@ jQuery( function( $ ) {
 						}
 					});
 					
-					// console.log(paymentDetails);
-
 					// Always update the fragments
 					if ( data && data.fragments ) {
 						$.each( data.fragments, function ( key, value ) {

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -356,6 +356,8 @@ jQuery( function( $ ) {
 							}
 						}
 					});
+					
+					// console.log(paymentDetails);
 
 					// Always update the fragments
 					if ( data && data.fragments ) {
@@ -374,10 +376,11 @@ jQuery( function( $ ) {
 					if ( ! $.isEmptyObject( paymentDetails ) ) {
 						$( '.payment_box :input' ).each( function() {
 							var ID = $( this ).attr( 'id' );
-
 							if ( ID ) {
 								if ( $.inArray( $( this ).attr( 'type' ), [ 'checkbox', 'radio' ] ) !== -1 ) {
 									$( this ).prop( 'checked', paymentDetails[ ID ] ).change();
+								} else if ( $.inArray( $( this ).attr( 'type' ), [ 'select' ] ) !== -1 ) {
+									$( this ).val( paymentDetails[ ID ] ).change();
 								} else if ( null !== $( this ).val() && 0 === $( this ).val().length ) {
 									$( this ).val( paymentDetails[ ID ] ).change();
 								}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently, if there is a select field in the checkout form then it's selected value is lost if the form refreshes (for example if the shipping of billing address is changed). This PR fixes that.

Select fields may be required in the checkout form, for example if the card holder has to choose their card type.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Maintain value of select fields in credit card form