### PR TITLE
Bump PHP and WP recommended versions

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -229,8 +229,8 @@ final class WooCommerce {
 		$this->define( 'WC_LOG_DIR', $upload_dir['basedir'] . '/wc-logs/' );
 		$this->define( 'WC_SESSION_CACHE_GROUP', 'wc_session_id' );
 		$this->define( 'WC_TEMPLATE_DEBUG_MODE', false );
-		$this->define( 'WC_NOTICE_MIN_PHP_VERSION', '5.6.20' );
-		$this->define( 'WC_NOTICE_MIN_WP_VERSION', '4.9' );
+		$this->define( 'WC_NOTICE_MIN_PHP_VERSION', '7.0' );
+		$this->define( 'WC_NOTICE_MIN_WP_VERSION', '5.0' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the minimum recommended WP and PHP versions. New recommended PHP is 7.0 and new recommended WP is 5.0.

### Changelog entry

> Update the recommended PHP version to 7.0 and the recommended WP version to 5.0