### PR TITLE
Introduced "woocommerce_output_cart_shortcode_content" filter

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -67,6 +67,10 @@ class WC_Shortcode_Cart {
 	 * @param array $atts Shortcode attributes.
 	 */
 	public static function output( $atts ) {
+		if ( ! apply_filters( 'woocommerce_output_cart_shortcode_content', true ) ) {
+			return;
+		}
+
 		// Constants.
 		wc_maybe_define_constant( 'WOOCOMMERCE_CART', true );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This allow use cart and checkout shortcode in the same page, allowing hide the cart content in "Order received" and "Order pay", or any other endpoint of the checkout page.

Closes #24595.

### How to test the changes in this Pull Request:

See #24595

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced `woocommerce_output_cart_shortcode_content` filter.
