### PR TITLE
Make $subtext more darker to improve accessibility

### DIFF
--- a/assets/css/_variables.scss
+++ b/assets/css/_variables.scss
@@ -18,4 +18,4 @@ $highlight:         adjust-hue($primary, 150deg);               // Prices, In st
 $highlightext:      desaturate(lighten($highlight, 50%), 18%);  // Text on highlight color bg
 
 $contentbg:         #fff;                                       // Content BG - Tabs (active state)
-$subtext:           #777;                                       // small, breadcrumbs etc
+$subtext:           #767676;                                    // small, breadcrumbs etc


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Changed per suggestion on #24610

Closes #24610.

### How to test the changes in this Pull Request:

See #24610

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Accessibility - Make $subtext color darker.
