### PR TITLE
Add filter to the method WC_Countries::get_european_union_countries()

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -363,7 +363,7 @@ class WC_Countries {
 			$countries[] = 'IM';
 		}
 
-		return $countries;
+		return apply_filters( 'woocommerce_european_union_countries', $countries, $type );
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a filter called `woocommerce_european_union_countries` to the method WC_Countries::get_european_union_countries(). This is to let third party code to customize the list of countries returned by the method.

Related to #24666. This PR doesn't solve #24666, but it should help accommodate edge cases.

cc @claudiosanches who suggested the creation of this filter.

### How to test the changes in this Pull Request:

1. Test that the filter works and that the value returned by the method is still the same.

### Changelog entry

> Dev: Add filter `woocommerce_european_union_countries` to the method WC_Countries::get_european_union_countries()