### PR TITLE
Also consider refunded item quantity while increasing stock.

### DIFF
--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -222,6 +222,8 @@ function wc_maybe_adjust_line_item_product_stock( $item, $item_quantity = -1 ) {
 		$new_stock = wc_update_product_stock( $product, $diff * -1, 'increase' );
 	} elseif ( $diff > 0 ) {
 		$new_stock = wc_update_product_stock( $product, $diff, 'decrease' );
+	} else {
+		return false;
 	}
 
 	if ( is_wp_error( $new_stock ) ) {
@@ -230,10 +232,6 @@ function wc_maybe_adjust_line_item_product_stock( $item, $item_quantity = -1 ) {
 
 	$item->update_meta_data( '_reduced_stock', $item_quantity + $refunded_item_quantity );
 	$item->save();
-
-	if ( 0 === $diff ) {
-		return false;
-	}
 
 	return array(
 		'from' => $new_stock + $diff,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When updating an order, we call `wc_maybe_adjust_line_item_product_stock` to see if any item stock needs adjusting. We were not considering if an item has been refunded, which was causing incorrect stock adjustments.
This fix also takes in to account that an order has been refunded partially or fully.

Fixes #24489

### How to test the changes in this Pull Request:

See #24489

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Also consider refunded item when updating order and adjusting stocks.
