### PR TITLE
Handle 0 attribute value for variations correctly.

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1112,7 +1112,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 			// Loop over the variation meta keys and values i.e. what is saved to the products. Note: $attribute_value is empty when 'any' is in use.
 			foreach ( $variation as $attribute_key => $attribute_value ) {
-				$match_any_value = empty( $attribute_value );
+				$match_any_value = empty( $attribute_value ) && 0 != $attribute_value;
 
 				if ( ! $match_any_value && ! array_key_exists( $attribute_key, $match_attributes ) ) {
 					$match = false; // Requires a selection but no value was provide.

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1112,7 +1112,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 			// Loop over the variation meta keys and values i.e. what is saved to the products. Note: $attribute_value is empty when 'any' is in use.
 			foreach ( $variation as $attribute_key => $attribute_value ) {
-				$match_any_value = empty( $attribute_value ) && 0 != $attribute_value;
+				$match_any_value = empty( $attribute_value ) && 0.0 !== floatval( $attribute_value );
 
 				if ( ! $match_any_value && ! array_key_exists( $attribute_key, $match_attributes ) ) {
 					$match = false; // Requires a selection but no value was provide.

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1112,7 +1112,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 			// Loop over the variation meta keys and values i.e. what is saved to the products. Note: $attribute_value is empty when 'any' is in use.
 			foreach ( $variation as $attribute_key => $attribute_value ) {
-				$match_any_value = empty( $attribute_value ) && 0.0 !== floatval( $attribute_value );
+				$match_any_value = '' === $attribute_value;
 
 				if ( ! $match_any_value && ! array_key_exists( $attribute_key, $match_attributes ) ) {
 					$match = false; // Requires a selection but no value was provide.

--- a/tests/framework/helpers/class-wc-helper-product.php
+++ b/tests/framework/helpers/class-wc-helper-product.php
@@ -119,7 +119,7 @@ class WC_Helper_Product {
 		$attributes     = array();
 
 		$attribute      = new WC_Product_Attribute();
-		$attribute_data = self::create_attribute( 'size', array( 'small', 'large' ) );
+		$attribute_data = self::create_attribute( 'size', array( 'small', 'large', 'huge' ) );
 		$attribute->set_id( $attribute_data['attribute_id'] );
 		$attribute->set_name( $attribute_data['attribute_taxonomy'] );
 		$attribute->set_options( $attribute_data['term_ids'] );
@@ -130,6 +130,16 @@ class WC_Helper_Product {
 
 		$attribute      = new WC_Product_Attribute();
 		$attribute_data = self::create_attribute( 'colour', array( 'red', 'blue' ) );
+		$attribute->set_id( $attribute_data['attribute_id'] );
+		$attribute->set_name( $attribute_data['attribute_taxonomy'] );
+		$attribute->set_options( $attribute_data['term_ids'] );
+		$attribute->set_position( 1 );
+		$attribute->set_visible( true );
+		$attribute->set_variation( true );
+		$attributes[] = $attribute;
+
+		$attribute      = new WC_Product_Attribute();
+		$attribute_data = self::create_attribute( 'number', array( '0', '1', '2' ) );
 		$attribute->set_id( $attribute_data['attribute_id'] );
 		$attribute->set_name( $attribute_data['attribute_taxonomy'] );
 		$attribute->set_options( $attribute_data['term_ids'] );
@@ -162,6 +172,40 @@ class WC_Helper_Product {
 		);
 		$variation_2->set_attributes( array( 'pa_size' => 'large' ) );
 		$variation_2->save();
+
+		$variation_3 = new WC_Product_Variation();
+		$variation_3->set_props(
+			array(
+				'parent_id'     => $product->get_id(),
+				'sku'           => 'DUMMY SKU VARIABLE HUGE RED 0',
+				'regular_price' => 16,
+			)
+		);
+		$variation_3->set_attributes(
+			array(
+				'pa_size' => 'huge',
+				'pa_colour' => 'red',
+				'pa_number' => '0',
+			)
+		);
+		$variation_3->save();
+
+		$variation_4 = new WC_Product_Variation();
+		$variation_4->set_props(
+			array(
+				'parent_id'     => $product->get_id(),
+				'sku'           => 'DUMMY SKU VARIABLE HUGE RED 2',
+				'regular_price' => 17,
+			)
+		);
+		$variation_4->set_attributes(
+			array(
+				'pa_size' => 'huge',
+				'pa_colour' => 'red',
+				'pa_number' => '2',
+			)
+		);
+		$variation_4->save();
 
 		return wc_get_product( $product->get_id() );
 	}

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -1054,5 +1054,17 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 		);
 
 		$this->assertEquals( $children[3], $match );
+
+		// Test numeric attribute value 0.
+		$match = $data_store->find_matching_product_variation(
+			$product,
+			array(
+				'attribute_pa_size'   => 'huge',
+				'attribute_pa_colour' => 'red',
+				'attribute_pa_number' => '0',
+			)
+		);
+
+		$this->assertEquals( $children[2], $match );
 	}
 }

--- a/tests/unit-tests/product/data-store.php
+++ b/tests/unit-tests/product/data-store.php
@@ -216,22 +216,29 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 
 		$product = new WC_Product_Variable( $product->get_id() );
 
-		$this->assertEquals( 2, count( $product->get_children() ) );
+		$this->assertEquals( 4, count( $product->get_children() ) );
 
 		$expected_prices['price'][ $children[0] ] = 8.00;
 		$expected_prices['price'][ $children[1] ] = 15.00;
+		$expected_prices['price'][ $children[2] ] = 16.00;
+		$expected_prices['price'][ $children[3] ] = 17.00;
 
 		$expected_prices['regular_price'][ $children[0] ] = 10.00;
 		$expected_prices['regular_price'][ $children[1] ] = 15.00;
+		$expected_prices['regular_price'][ $children[2] ] = 16.00;
+		$expected_prices['regular_price'][ $children[3] ] = 17.00;
 
 		$expected_prices['sale_price'][ $children[0] ] = 8.00;
 		$expected_prices['sale_price'][ $children[1] ] = 15.00;
+		$expected_prices['sale_price'][ $children[2] ] = 16.00;
+		$expected_prices['sale_price'][ $children[3] ] = 17.00;
 
 		$this->assertEquals( $expected_prices, $product->get_variation_prices() );
 
 		$expected_attributes = array(
-			'pa_size'   => array( 'small', 'large' ),
-			'pa_colour' => array( 'blue', 'red' ),
+			'pa_size'   => array( 'small', 'large', 'huge' ),
+			'pa_colour' => array( 'red' ),
+			'pa_number' => array( '0', '2' ),
 		);
 		$this->assertEquals( $expected_attributes, $product->get_variation_attributes() );
 	}
@@ -1035,5 +1042,17 @@ class WC_Tests_Product_Data_Store extends WC_Unit_Test_Case {
 			array()
 		);
 		$this->assertEquals( 0, $match );
+
+		// Test numeric attribute values.
+		$match = $data_store->find_matching_product_variation(
+			$product,
+			array(
+				'attribute_pa_size'   => 'huge',
+				'attribute_pa_colour' => 'red',
+				'attribute_pa_number' => '2',
+			)
+		);
+
+		$this->assertEquals( $children[3], $match );
 	}
 }

--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -70,7 +70,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'type'   => 'variation',
 			)
 		);
-		$this->assertCount( 2, $products );
+		$this->assertCount( 4, $products );
 
 		// Test parent.
 		$products = wc_get_products(
@@ -80,7 +80,7 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 				'parent' => $variation->get_id(),
 			)
 		);
-		$this->assertCount( 2, $products );
+		$this->assertCount( 4, $products );
 
 		// Test parent_exclude.
 		$products = wc_get_products(

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -87,7 +87,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 	public function test_wc_dropdown_variation_attribute_options_should_return_attributes_list() {
 		$product = WC_Helper_Product::create_variation_product();
 
-		$this->expectOutputString( '<select id="pa_size" class="" name="attribute_pa_size" data-attribute_name="attribute_pa_size" data-show_option_none="yes"><option value="">Choose an option</option><option value="large" >large</option><option value="small" >small</option></select>' );
+		$this->expectOutputString( '<select id="pa_size" class="" name="attribute_pa_size" data-attribute_name="attribute_pa_size" data-show_option_none="yes"><option value="">Choose an option</option><option value="huge" >huge</option><option value="large" >large</option><option value="small" >small</option></select>' );
 
 		wc_dropdown_variation_attribute_options(
 			array(
@@ -104,7 +104,7 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$product                       = WC_Helper_Product::create_variation_product();
 		$_REQUEST['attribute_pa_size'] = 'large';
 
-		$this->expectOutputString( '<select id="pa_size" class="" name="attribute_pa_size" data-attribute_name="attribute_pa_size" data-show_option_none="yes"><option value="">Choose an option</option><option value="large"  selected=\'selected\'>large</option><option value="small" >small</option></select>' );
+		$this->expectOutputString( '<select id="pa_size" class="" name="attribute_pa_size" data-attribute_name="attribute_pa_size" data-show_option_none="yes"><option value="">Choose an option</option><option value="huge" >huge</option><option value="large"  selected=\'selected\'>large</option><option value="small" >small</option></select>' );
 
 		wc_dropdown_variation_attribute_options(
 			array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24667  .

### How to test the changes in this Pull Request:

1. Create a variable product with attribute having 0 and 1 values, set different prices for them.
2. Try to select variation with attribute value 1, observe the one with 0 gets selected (as the price is picked incorrectly).
3. Try to click on 'Add to cart', it fails.
4. After applying the change, both should work correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Handle 0 attribute value for variations correctly.
