### PR TITLE
Removed duplicated include of WC_Admin_Importers

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -80,11 +80,6 @@ class WC_Admin {
 			}
 		}
 
-		// Importers.
-		if ( defined( 'WP_LOAD_IMPORTERS' ) ) {
-			include_once dirname( __FILE__ ) . '/class-wc-admin-importers.php';
-		}
-
 		// Helper.
 		include_once dirname( __FILE__ ) . '/helper/class-wc-helper.php';
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We are including the same class twice, also inside `WC_Admin_Importers` there's already checks if `WP_LOAD_IMPORTERS` is defined.

Closes #24748.

### How to test the changes in this Pull Request:

See #24748.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Removed duplicated include of `WC_Admin_Importers`.