### PR TITLE
FIX: Click event triggering if element doesn't exist

### DIFF
--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -32,9 +32,11 @@ jQuery( function( $ ) {
 	});
 
 	// Make form field descriptions toggle on focus.
-	$( document.body ).on( 'click', function() {
-		$( '.woocommerce-input-wrapper span.description:visible' ).prop( 'aria-hidden', true ).slideUp( 250 );
-	} );
+	if ( $( '.woocommerce-input-wrapper span.description' ).length ) {
+		$( document.body ).on( 'click', function() {
+			$( '.woocommerce-input-wrapper span.description:visible' ).prop( 'aria-hidden', true ).slideUp( 250 );
+		} );
+	}
 
 	$( '.woocommerce-input-wrapper' ).on( 'click', function( event ) {
 		event.stopPropagation();


### PR DESCRIPTION
### All Submissions:

- [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
- [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
- [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

 Fixing an issue with an on-body click triggering on pages that do no contain the referenced span.description element. Wrapped it in an if statement to make sure element exists beforehand.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added conditional IF statement around a body click function to make sure the element referenced '.woocommerce-input-wrapper span.description' exists.