### PR TITLE
Fixed post type count only when avaliable in REST API

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -12,7 +12,7 @@ global $wpdb;
 $report             = wc()->api->get_endpoint_data( '/wc/v3/system_status' );
 $environment        = $report['environment'];
 $database           = $report['database'];
-$post_type_counts   = $report['post_type_counts'];
+$post_type_counts   = isset( $report['post_type_counts'] ) ? $report['post_type_counts'] : array();
 $active_plugins     = $report['active_plugins'];
 $inactive_plugins   = $report['inactive_plugins'];
 $dropins_mu_plugins = $report['dropins_mu_plugins'];
@@ -518,26 +518,28 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 		<?php endif; ?>
 	</tbody>
 </table>
-<table class="wc_status_table widefat" cellspacing="0">
-	<thead>
-	<tr>
-		<th colspan="3" data-export-label="Post Type Counts"><h2><?php esc_html_e( 'Post Type Counts', 'woocommerce' ); ?></h2></th>
-	</tr>
-	</thead>
-	<tbody>
-		<?php
-		foreach ( $post_type_counts as $ptype ) {
-			?>
-			<tr>
-				<td><?php echo esc_html( $ptype['type'] ); ?></td>
-				<td class="help">&nbsp;</td>
-				<td><?php echo absint( $ptype['count'] ); ?></td>
-			</tr>
+<?php if ( $post_type_counts ) : ?>
+	<table class="wc_status_table widefat" cellspacing="0">
+		<thead>
+		<tr>
+			<th colspan="3" data-export-label="Post Type Counts"><h2><?php esc_html_e( 'Post Type Counts', 'woocommerce' ); ?></h2></th>
+		</tr>
+		</thead>
+		<tbody>
 			<?php
-		}
-		?>
-	</tbody>
-</table>
+			foreach ( $post_type_counts as $ptype ) {
+				?>
+				<tr>
+					<td><?php echo esc_html( $ptype['type'] ); ?></td>
+					<td class="help">&nbsp;</td>
+					<td><?php echo absint( $ptype['count'] ); ?></td>
+				</tr>
+				<?php
+			}
+			?>
+		</tbody>
+	</table>
+<?php endif; ?>
 <table class="wc_status_table widefat" cellspacing="0">
 	<thead>
 		<tr>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

It's required an updated in the REST API to make "Post Type Counts" available, for now just hide to support it when we update the REST API plugin/package.

### How to test the changes in this Pull Request:

1. Go to WooCommerce > System Status and check for PHP warnings.
2. Apply this patch and check again, should hide the table.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

No need to change log, this just improve support started with #24536
