### PR TITLE
Use a separate first parameter for the WP_Error

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -898,10 +898,11 @@ class WC_AJAX {
 				if ( ! $product ) {
 					throw new Exception( __( 'Invalid product ID', 'woocommerce' ) . ' ' . $product_id );
 				}
-				$check = apply_filters( 'woocommerce_ajax_add_order_item_validation', $product, $order, $qty );
+				$validation_error = new WP_Error();
+				$validation_error = apply_filters( 'woocommerce_ajax_add_order_item_validation', $validation_error, $product, $order, $qty );
 
-				if ( is_wp_error( $check ) ) {
-					throw new Exception( $check->get_error_message() );
+				if ( $validation_error->get_error_code() ) {
+					throw new Exception( '<strong>' . __( 'Error:', 'woocommerce' ) . '</strong> ' . $validation_error->get_error_message() );
 				}
 				$item_id                 = $order->add_product( $product, $qty );
 				$item                    = apply_filters( 'woocommerce_ajax_order_item', $order->get_item( $item_id ), $item_id, $order, $product );


### PR DESCRIPTION
This matches the pattern used elsewhere in WooCommerce and allows access to the original `WC_Product` object if an error is to be returned.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

See https://github.com/woocommerce/woocommerce/pull/24518#issuecomment-537631178

This matches the pattern used elsewhere in WooCommerce and allows access to the original `WC_Product` object if an error is to be returned.

For instance login errors.
```
$validation_error = new WP_Error();
$validation_error = apply_filters( 'woocommerce_process_login_errors', $validation_error, $creds['user_login'], $creds['user_password'] );

if ( $validation_error->get_error_code() ) {
	throw new Exception( '<strong>' . __( 'Error:', 'woocommerce' ) . '</strong> ' . $validation_error->get_error_message() );
}
```