### PR TITLE
Set image CSS on emails to be max-width: 100%

### DIFF
--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -222,5 +222,7 @@ img {
 	text-transform: capitalize;
 	vertical-align: middle;
 	margin-<?php echo is_rtl() ? 'left' : 'right'; ?>: 10px;
+	max-width: 100%;
+	height: auto;
 }
 <?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24763 

### How to test the changes in this Pull Request:

1. Create an email with a large image on it and see that it doesn't break the email template after this PR

> Set image CSS on emails to be max-width: 100% so that they don't break the email template
