### PR TITLE
Option for free shipping if should ignore discounts or not

### DIFF
--- a/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -62,9 +62,10 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 		$this->init_settings();
 
 		// Define user set variables.
-		$this->title      = $this->get_option( 'title' );
-		$this->min_amount = $this->get_option( 'min_amount', 0 );
-		$this->requires   = $this->get_option( 'requires' );
+		$this->title            = $this->get_option( 'title' );
+		$this->min_amount       = $this->get_option( 'min_amount', 0 );
+		$this->requires         = $this->get_option( 'requires' );
+		$this->ignore_discounts = $this->get_option( 'ignore_discounts' );
 
 		// Actions.
 		add_action( 'woocommerce_update_options_shipping_' . $this->id, array( $this, 'process_admin_options' ) );
@@ -102,6 +103,13 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 				'placeholder' => wc_format_localized_price( 0 ),
 				'description' => __( 'Users will need to spend this amount to get free shipping (if enabled above).', 'woocommerce' ),
 				'default'     => '0',
+				'desc_tip'    => true,
+			),
+			'ignore_discounts' => array(
+				'title'       => __( 'Ignore discounts', 'woocommerce' ),
+				'type'        => 'checkbox',
+				'description' => __( 'Discounts will not be applied to the minimum order amount.', 'woocommerce' ),
+				'default'     => 'no',
 				'desc_tip'    => true,
 			),
 		);
@@ -143,8 +151,10 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 			$total = WC()->cart->get_displayed_subtotal();
 
 			if ( WC()->cart->display_prices_including_tax() ) {
-				$total = round( $total - ( WC()->cart->get_discount_total() + WC()->cart->get_discount_tax() ), wc_get_price_decimals() );
-			} else {
+				$total = round( $total - WC()->cart->get_discount_tax(), wc_get_price_decimals() );
+			}
+
+			if ( 'no' === $this->ignore_discounts ) {
 				$total = round( $total - WC()->cart->get_discount_total(), wc_get_price_decimals() );
 			}
 
@@ -203,10 +213,13 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 				function wcFreeShippingShowHideMinAmountField( el ) {
 					var form = $( el ).closest( 'form' );
 					var minAmountField = $( '#woocommerce_free_shipping_min_amount', form ).closest( 'tr' );
+					var ignoreDiscountField = $( '#woocommerce_free_shipping_ignore_discounts', form ).closest( 'tr' );
 					if ( 'coupon' === $( el ).val() || '' === $( el ).val() ) {
 						minAmountField.hide();
+						ignoreDiscountField.hide();
 					} else {
 						minAmountField.show();
+						ignoreDiscountField.show();
 					}
 				}
 

--- a/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -106,7 +106,7 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 				'desc_tip'    => true,
 			),
 			'ignore_discounts' => array(
-				'title'       => __( 'Ignore discounts', 'woocommerce' ),
+				'title'       => __( 'Ignore coupons discounts', 'woocommerce' ),
 				'type'        => 'checkbox',
 				'description' => __( 'Discounts will not be applied to the minimum order amount.', 'woocommerce' ),
 				'default'     => 'no',
@@ -151,12 +151,14 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 			$total = WC()->cart->get_displayed_subtotal();
 
 			if ( WC()->cart->display_prices_including_tax() ) {
-				$total = round( $total - WC()->cart->get_discount_tax(), wc_get_price_decimals() );
+				$total = $total - WC()->cart->get_discount_tax();
 			}
 
 			if ( 'no' === $this->ignore_discounts ) {
-				$total = round( $total - WC()->cart->get_discount_total(), wc_get_price_decimals() );
+				$total = $total - WC()->cart->get_discount_total();
 			}
+
+			$total = round( $total, wc_get_price_decimals() );
 
 			if ( $total >= $this->min_amount ) {
 				$has_met_min_amount = true;


### PR DESCRIPTION
### All Submissions:

* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Hello guys, this is my first pull request, i hope i did everything right.
Let me know if i have to change something.

Closes #24754

### How to test the changes in this Pull Request:

1. Create a product
2. Create a discount coupon
3. Create a free shipping method:
 a. Select minimum order amount (insert the product price)
 b. Check the ignore discounts checkbox
4. Go to checkout and try the feature

### Changelog

> Enhancement - Added option to ignore discounts from cart's total amount to enable free shipping.