### PR TITLE
Add links to billing phone number

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -48,4 +48,12 @@
 		<exclude-pattern>i18n/</exclude-pattern>
 		<exclude-pattern>src/</exclude-pattern>
 	</rule>
+
+	<rule ref="WordPress.Security.EscapeOutput">
+		<properties>
+			<property name="customAutoEscapedFunctions" type="array">
+				<element value="wc_make_phone_clickable"/>
+			</property>
+		</properties>
+	</rule>
 </ruleset>

--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -31,7 +31,7 @@ $shipping   = $order->get_formatted_shipping_address();
 			<address class="address">
 				<?php echo wp_kses_post( $address ? $address : esc_html__( 'N/A', 'woocommerce' ) ); ?>
 				<?php if ( $order->get_billing_phone() ) : ?>
-					<br/><?php echo wc_make_phone_clickable( $order->get_billing_phone() ); ?>
+					<br/><?php echo wc_make_phone_clickable( $order->get_billing_phone() );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 				<?php endif; ?>
 				<?php if ( $order->get_billing_email() ) : ?>
 					<br/><?php echo esc_html( $order->get_billing_email() ); ?>

--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -31,7 +31,7 @@ $shipping   = $order->get_formatted_shipping_address();
 			<address class="address">
 				<?php echo wp_kses_post( $address ? $address : esc_html__( 'N/A', 'woocommerce' ) ); ?>
 				<?php if ( $order->get_billing_phone() ) : ?>
-					<br/><?php echo wc_make_phone_clickable( $order->get_billing_phone() );  // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					<br/><?php echo wc_make_phone_clickable( $order->get_billing_phone() ); ?>
 				<?php endif; ?>
 				<?php if ( $order->get_billing_email() ) : ?>
 					<br/><?php echo esc_html( $order->get_billing_email() ); ?>

--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -31,7 +31,7 @@ $shipping   = $order->get_formatted_shipping_address();
 			<address class="address">
 				<?php echo wp_kses_post( $address ? $address : esc_html__( 'N/A', 'woocommerce' ) ); ?>
 				<?php if ( $order->get_billing_phone() ) : ?>
-					<br/><?php echo esc_html( $order->get_billing_phone() ); ?>
+					<br/><?php echo wc_make_phone_clickable( $order->get_billing_phone() ); ?>
 				<?php endif; ?>
 				<?php if ( $order->get_billing_email() ) : ?>
 					<br/><?php echo esc_html( $order->get_billing_email() ); ?>


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Wrapped billing phone with `wc_make_phone_clickable`. I removed the call of `esc_html` because it's called inside of `wc_make_phone_clickable`  anyways.

Closes #24779

### How to test the changes in this Pull Request:

1. Add a product to your basket
2. Place an order and make sure you have a phone number added to your billing address
3. Check if the phone number is wrapped in a link containing `tel:` in the href

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Linked billing phone number in emails (customer order mail, owner order mail)