### PR TITLE
Updates message shown when no shipping options have been selected

### DIFF
--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -58,7 +58,7 @@ $calculator_text          = '';
 			<?php endif; ?>
 			<?php
 		elseif ( ! $has_calculated_shipping || ! $formatted_destination ) :
-			echo wp_kses_post( apply_filters( 'woocommerce_shipping_may_be_available_html', __( 'Enter your address to view shipping options.', 'woocommerce' ) ) );
+			echo wp_kses_post( apply_filters( 'woocommerce_shipping_may_be_available_html', __( 'Shipping options will be updated during checkout.', 'woocommerce' ) ) );
 		elseif ( ! is_cart() ) :
 			echo wp_kses_post( apply_filters( 'woocommerce_no_shipping_available_html', __( 'There are no shipping options available. Please ensure that your address has been entered correctly, or contact us if you need any help.', 'woocommerce' ) ) );
 		else :


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Changes confusing message shown in basket relating to shipping totals.

Closes #24674.

### How to test the changes in this Pull Request:

1. In Woocommerce admin, go to 'Shipping Options'
2. Ensure that the two checkboxes under 'Calculations' are unchecked
3. On the frontend, add an item to the basket
4. View basket, under 'Cart Totals', the message next to 'Shipping' should read: 'Shipping options will be updated during checkout.'

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

Update message shown when no shipping options have been selected
