### PR TITLE
Do not set tracking cookie on ajax requests

### DIFF
--- a/includes/tracks/class-wc-tracks-client.php
+++ b/includes/tracks/class-wc-tracks-client.php
@@ -43,6 +43,11 @@ class WC_Tracks_Client {
 	 * @return void
 	 */
 	public static function maybe_set_identity_cookie() {
+		// Do not set on AJAX requests.
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			return;
+		}
+
 		// Bail if cookie already set.
 		if ( isset( $_COOKIE['tk_ai'] ) ) {
 			return;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Tracking cookies should only be set in wp-admin, however, ajax requests fire the same admin_init hook used to set the cookie even when triggered from the frontend so this PR address that by excluding setting the cookies when doing an ajax request.

Closes #24792 

### How to test the changes in this Pull Request:

1. With ajax add to cart enabled visit the shop page in an incognito window
2. Click the add to cart button on a product
3. Inspect the requests in developer tools and observe that the cookie tk_ai is NOT set.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Do not set the tracking cookie when doing ajax requests.
