### PR TITLE
Add space before parentheses of if condition for JS consistency

### DIFF
--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -104,7 +104,7 @@
 			.on( 'change', '#_sale_price.wc_input_price[type=text], .wc_input_price[name^=variable_sale_price]', function() {
 				var sale_price_field = $( this ), regular_price_field;
 
-				if( sale_price_field.attr( 'name' ).indexOf( 'variable' ) !== -1 ) {
+				if ( sale_price_field.attr( 'name' ).indexOf( 'variable' ) !== -1 ) {
 					regular_price_field = sale_price_field.parents( '.variable_pricing' ).find( '.wc_input_price[name^=variable_regular_price]' );
 				} else {
 					regular_price_field = $( '#_regular_price' );
@@ -121,7 +121,7 @@
 			.on( 'keyup', '#_sale_price.wc_input_price[type=text], .wc_input_price[name^=variable_sale_price]', function() {
 				var sale_price_field = $( this ), regular_price_field;
 
-				if( sale_price_field.attr( 'name' ).indexOf( 'variable' ) !== -1 ) {
+				if ( sale_price_field.attr( 'name' ).indexOf( 'variable' ) !== -1 ) {
 					regular_price_field = sale_price_field.parents( '.variable_pricing' ).find( '.wc_input_price[name^=variable_regular_price]' );
 				} else {
 					regular_price_field = $( '#_regular_price' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline]
* [x] Does your code follow the [WordPress' coding standards]
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Added space before parentheses of if condition for JS consistency on `/assets/js/admin/woocommerce_admin.js`