### PR TITLE
Make variables default to allow overriding

### DIFF
--- a/assets/css/_variables.scss
+++ b/assets/css/_variables.scss
@@ -2,20 +2,20 @@
  * WooCommerce CSS Variables
  */
 
-$woocommerce:   	#a46497;
-$green:         	#7ad03a;
-$red:           	#a00;
-$orange:        	#ffba00;
-$blue:          	#2ea2cc;
+$woocommerce:   	#a46497 !default;
+$green:         	#7ad03a !default;
+$red:           	#a00 !default;
+$orange:        	#ffba00 !default;
+$blue:          	#2ea2cc !default;
 
-$primary:           #a46497;                                    // Primary color for buttons (alt)
-$primarytext:       desaturate(lighten($primary, 50%), 18%);    // Text on primary color bg
+$primary:           #a46497 !default;                                    // Primary color for buttons (alt)
+$primarytext:       desaturate(lighten($primary, 50%), 18%) !default;    // Text on primary color bg
 
-$secondary:         desaturate(lighten($primary, 40%), 21%);    // Secondary buttons
-$secondarytext:     desaturate(darken($secondary, 60%), 21%);   // Text on secondary color bg
+$secondary:         desaturate(lighten($primary, 40%), 21%) !default;    // Secondary buttons
+$secondarytext:     desaturate(darken($secondary, 60%), 21%) !default;   // Text on secondary color bg
 
-$highlight:         adjust-hue($primary, 150deg);               // Prices, In stock labels, sales flash
-$highlightext:      desaturate(lighten($highlight, 50%), 18%);  // Text on highlight color bg
+$highlight:         adjust-hue($primary, 150deg) !default;               // Prices, In stock labels, sales flash
+$highlightext:      desaturate(lighten($highlight, 50%), 18%) !default;  // Text on highlight color bg
 
-$contentbg:         #fff;                                       // Content BG - Tabs (active state)
-$subtext:           #767676;                                    // small, breadcrumbs etc
+$contentbg:         #fff !default;                                       // Content BG - Tabs (active state)
+$subtext:           #767676 !default;                                    // small, breadcrumbs etc


### PR DESCRIPTION
### Description

This PR solves #24771, which makes it possible to use WooCommerce's styling and override its variables.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24771 .

### How to test the changes in this Pull Request:

1. Create your own Sass file
2. Create variables WooCommerce uses
3. Load `woocommerce/assets/css/woocommerce.scss`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [o] Have you written new tests for your changes, as applicable?
* [o] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

- Made variables in `_variables.scss` default.
