### PR TITLE
Adds shared code between Orders and Cart calculation logic.

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1510,7 +1510,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 		$cart_subtotal     = 0;
 		$cart_total        = 0;
-		$fees_total         = 0;
+		$fees_total        = 0;
 		$shipping_total    = 0;
 		$cart_subtotal_tax = 0;
 		$cart_total_tax    = 0;

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -780,7 +780,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	protected function get_values_for_total( $field ) {
 		$items = array_map(
 			function ( $item ) use ( $field ) {
-				return wc_add_number_precision( $item[ $field ] );
+				return wc_add_number_precision( $item[ $field ], false );
 			},
 			array_values( $this->get_items() )
 		);
@@ -1531,8 +1531,17 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		$cart_subtotal_tax = 0;
 		$cart_total_tax    = 0;
 
-		$cart_subtotal = wc_remove_number_precision( $this->get_rounded_items_total( 'subtotal' ) );
-		$cart_total = wc_remove_number_precision( $this->get_rounded_items_total() );
+		$cart_subtotal = wc_remove_number_precision(
+			$this->get_rounded_items_total(
+				$this->get_values_for_total( 'subtotal' )
+			)
+		);
+
+		$cart_total = wc_remove_number_precision(
+			$this->get_rounded_items_total(
+				$this->get_values_for_total( 'total' )
+			)
+		);
 
 		// Sum shipping costs.
 		foreach ( $this->get_shipping_methods() as $shipping ) {

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -871,18 +871,4 @@ final class WC_Cart_Totals {
 		// Allow plugins to filter the grand total, and sum the cart totals in case of modifications.
 		$this->cart->set_total( max( 0, apply_filters( 'woocommerce_calculated_total', $this->get_total( 'total' ), $this->cart ) ) );
 	}
-
-	/**
-	 * Apply rounding to an array of taxes before summing. Rounds to store DP setting, ignoring precision.
-	 *
-	 * @since  3.2.6
-	 * @param  float $value Tax value.
-	 * @return float
-	 */
-	protected function round_line_tax( $value ) {
-		if ( ! $this->round_at_subtotal() ) {
-			$value = wc_round_tax_total( $value, 0 );
-		}
-		return $value;
-	}
 }

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -860,7 +860,7 @@ final class WC_Cart_Totals {
 	 * @since 3.2.0
 	 */
 	protected function calculate_totals() {
-		$this->set_total( 'total', round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + array_sum( $this->get_merged_taxes( true ) ), 0 ) );
+		$this->set_total( 'total', round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + wc_round_tax_total( array_sum( $this->get_merged_taxes( true ) ), 0 ), 0 ) );
 		$this->cart->set_total_tax( array_sum( $this->get_merged_taxes( false ) ) );
 
 		// Allow plugins to hook and alter totals before final total is calculated.

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -684,7 +684,7 @@ final class WC_Cart_Totals {
 			$this->cart->cart_contents[ $item_key ]['line_tax']               = wc_remove_number_precision( $item->total_tax );
 		}
 
-		$items_total = $this->get_rounded_items_total();
+		$items_total = $this->get_rounded_items_total( $this->get_values_for_total( 'total' ) );
 
 		$this->set_total( 'items_total', round( $items_total ) );
 		$this->set_total( 'items_total_tax', array_sum( array_values( wp_list_pluck( $this->items, 'total_tax' ) ) ) );
@@ -747,7 +747,7 @@ final class WC_Cart_Totals {
 			$this->cart->cart_contents[ $item_key ]['line_subtotal_tax'] = wc_remove_number_precision( $item->subtotal_tax );
 		}
 
-		$items_subtotal = $this->get_rounded_items_total( 'subtotal' );
+		$items_subtotal = $this->get_rounded_items_total( $this->get_values_for_total( 'subtotal' ) );
 
 		$this->set_total( 'items_subtotal', round( $items_subtotal ) );
 		$this->set_total( 'items_subtotal_tax', wc_round_tax_total( array_sum( $merged_subtotal_taxes ), 0 ) );

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -554,6 +554,16 @@ final class WC_Cart_Totals {
 	}
 
 	/**
+	 * Returns array of values for totals calculation.
+	 *
+	 * @param string $field Field name. Will probably be `total` or `subtotal`.
+	 * @return array Items object
+	 */
+	protected function get_values_for_total( $field ) {
+		return array_values( wp_list_pluck( $this->items, $field ) );
+	}
+
+	/**
 	 * Get taxes merged by type.
 	 *
 	 * @since 3.2.0

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -338,6 +338,11 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/interfaces/class-wc-queue-interface.php';
 
 		/**
+		 * Core traits.
+		 */
+		include_once WC_ABSPATH . 'includes/traits/trait-wc-item-totals.php';
+
+		/**
 		 * Abstract classes.
 		 */
 		include_once WC_ABSPATH . 'includes/abstracts/abstract-wc-data.php';

--- a/includes/traits/trait-wc-item-totals.php
+++ b/includes/traits/trait-wc-item-totals.php
@@ -71,4 +71,19 @@ trait WC_Item_Totals {
 		return 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' );
 	}
 
+	/**
+	 * Apply rounding to an array of taxes before summing. Rounds to store DP setting, ignoring precision.
+	 *
+	 * @since  3.2.6
+	 * @param  float $value    Tax value.
+	 * @param  bool  $in_cents Whether precision of value is in cents.
+	 * @return float
+	 */
+	protected static function round_line_tax( $value, $in_cents = true ) {
+		if ( ! self::round_at_subtotal() ) {
+			$value = wc_round_tax_total( $value, $in_cents ? 0 : null );
+		}
+		return $value;
+	}
+
 }

--- a/includes/traits/trait-wc-item-totals.php
+++ b/includes/traits/trait-wc-item-totals.php
@@ -34,15 +34,15 @@ trait WC_Item_Totals {
 	 *
 	 * @since 3.9.0
 	 *
-	 * @param string $field Field to round and sum based on setting. Will likely be `total` or `subtotal`. Values must be without precision.
+	 * @param array $values Values to round. Should be with precision.
 	 *
 	 * @return float|int Appropriately rounded value.
 	 */
-	protected function get_rounded_items_total( $field = 'total' ) {
+	public static function get_rounded_items_total( $values ) {
 		return array_sum(
 			array_map(
-				array( $this, 'round_item_subtotal' ),
-				$this->get_values_for_total( $field )
+				array( self::class, 'round_item_subtotal' ),
+				$values
 			)
 		);
 	}
@@ -54,8 +54,8 @@ trait WC_Item_Totals {
 	 * @param float $value Item subtotal value.
 	 * @return float
 	 */
-	protected function round_item_subtotal( $value ) {
-		if ( ! $this->round_at_subtotal() ) {
+	public static function round_item_subtotal( $value ) {
+		if ( ! self::round_at_subtotal() ) {
 			$value = round( $value );
 		}
 		return $value;
@@ -67,7 +67,8 @@ trait WC_Item_Totals {
 	 * @since 3.9.0
 	 * @return bool
 	 */
-	protected function round_at_subtotal() {
+	protected static function round_at_subtotal() {
 		return 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' );
 	}
+
 }

--- a/includes/traits/trait-wc-item-totals.php
+++ b/includes/traits/trait-wc-item-totals.php
@@ -13,24 +13,28 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Trait WC_Item_Totals.
  *
+ * Right now this do not have much, but plan is to eventually move all shared calculation logic between Orders and Cart in this file.
+ *
  * @since 3.9.0
  */
 trait WC_Item_Totals {
 
 	/**
-	 * Line items to calculate. Overwrite in child class.
+	 * Line items to calculate. Define in child class.
 	 *
 	 * @since 3.9.0
-	 * @var WC_Order_Item[]
+	 * @param string $field Field name to calculate upon.
+	 *
+	 * @return array having `total`|`subtotal` property.
 	 */
-	protected $items = array();
+	abstract protected function get_values_for_total( $field );
 
 	/**
 	 * Return rounded total based on settings. Will be used by Cart and Orders.
 	 *
 	 * @since 3.9.0
 	 *
-	 * @param string $field Field to round and sum based on setting. Will likely be `total` or `subtotal`.
+	 * @param string $field Field to round and sum based on setting. Will likely be `total` or `subtotal`. Values must be without precision.
 	 *
 	 * @return float|int Appropriately rounded value.
 	 */
@@ -38,7 +42,7 @@ trait WC_Item_Totals {
 		return array_sum(
 			array_map(
 				array( $this, 'round_item_subtotal' ),
-				array_values( wp_list_pluck( $this->items, $field ) )
+				$this->get_values_for_total( $field )
 			)
 		);
 	}

--- a/includes/traits/trait-wc-item-totals.php
+++ b/includes/traits/trait-wc-item-totals.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This ongoing trait will have shared calculation logic between WC_Abstract_Order and WC_Cart_Totals classes.
+ *
+ * @package WooCommerce/Traits
+ * @version 3.9.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Trait WC_Item_Totals.
+ *
+ * @since 3.9.0
+ */
+trait WC_Item_Totals {
+
+	/**
+	 * Line items to calculate. Overwrite in child class.
+	 *
+	 * @since 3.9.0
+	 * @var WC_Order_Item[]
+	 */
+	protected $items = array();
+
+	/**
+	 * Return rounded total based on settings. Will be used by Cart and Orders.
+	 *
+	 * @since 3.9.0
+	 *
+	 * @param string $field Field to round and sum based on setting. Will likely be `total` or `subtotal`.
+	 *
+	 * @return float|int Appropriately rounded value.
+	 */
+	protected function get_rounded_items_total( $field = 'total' ) {
+		return array_sum(
+			array_map(
+				array( $this, 'round_item_subtotal' ),
+				array_values( wp_list_pluck( $this->items, $field ) )
+			)
+		);
+	}
+
+	/**
+	 * Apply rounding to item subtotal before summing.
+	 *
+	 * @since 3.9.0
+	 * @param float $value Item subtotal value.
+	 * @return float
+	 */
+	protected function round_item_subtotal( $value ) {
+		if ( ! $this->round_at_subtotal() ) {
+			$value = round( $value );
+		}
+		return $value;
+	}
+
+	/**
+	 * Should always round at subtotal?
+	 *
+	 * @since 3.9.0
+	 * @return bool
+	 */
+	protected function round_at_subtotal() {
+		return 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' );
+	}
+}

--- a/tests/unit-tests/order/class-wc-tests-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-orders.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Class WC_Tests_Order file.
+ *
+ * @package WooCommerce|Tests|Order
+ */
+
+/**
+ * Class WC_Tests_Order.
+ */
+class WC_Tests_Order extends WC_Unit_Test_Case {
+
+	/**
+	 * Test for total when round at subtotal is enabled.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/24695
+	 */
+	public function test_order_calculate_total_rounding_24695() {
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+
+		$tax_rate    = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '7.0000',
+			'tax_rate_name'     => 'CGST',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '0',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => 'tax_1',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate );
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 2 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 2.5 );
+		$product2->save();
+
+		$order = new WC_Order();
+		$order->add_product( $product1, 1 );
+		$order->add_product( $product2, 4 );
+		$order->save();
+
+		$order->calculate_totals( true );
+
+		$this->assertEquals( 12, $order->get_total() );
+		$this->assertEquals( 0.79, $order->get_total_tax() );
+	}
+
+}

--- a/tests/unit-tests/order/coupons.php
+++ b/tests/unit-tests/order/coupons.php
@@ -62,7 +62,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 				array(
 					'product'  => $product,
 					'quantity' => 1,
-					'subtotal' => 909.09, // Ex tax.
+					'subtotal' => 909.09, // Ex tax 10%.
 					'total'    => 726.36,
 				)
 			);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24695 #24633 #24540 . This adds a trait which contains shared logic in orders and carts in one place.

### How to test the changes in this Pull Request:

There are multiple things to test in this pull request: 

For issue #24695 

1. Set tax to 7%, price inclusive of taxes and round at subtotal.
2. Add 2 products for $2 and $2.5
3. Complete an order with 1 quantity of $2 product and 4 quantities of $2.5 product. In cart the total should be $12. 
4. Go to Edit order from admin view.  Click on recalculate. Without this patch, order total will change to $12.01. With this patch it will stay at $12.00.

For issue #24633

1. Set tax to 20%, enabled on shipping as well, price inclusive of taxes and round at subtotal.
2. Add a coupon for $5 flat cart discount.
3. Add a product for $8.99.
4. Add shipping for $7.99 flat rate.
5. Add the product (step 3), and apply the coupon (step 2) to the cart. Complete the order with Shipping selected (after-tax it should be 9.59). The total in the cart should be 13.58
6. Go to the admin view for the order. Set the status to payment-pending and click on recalculate. Without this patch, the discount for the coupon will change to $4.16, but with this patch, the discount will stay at $4.17.

For issue #24540 

1. Set tax to 20%, price inclusive of taxes, and round at subtotal.
2. Add products for $498, $99, $248, $44 and $69.
3. Add all these products in the cart and complete the order.
4. In order received page, without this patch subtotal will be 957.99, but with this patch, it will be correctly set to 958.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Dev - Refactor to use the same rounding logic in Order and Cart.
