### PR TITLE
Refactor to use constant so that we have easy way to reset admin noti…

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -9,6 +9,14 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
+ * Name for notice for showing minimum version requirements. Change value to invalidate previous dismissals when requirement changes in future.
+ * Last changed in 3.8.
+ *
+ * @since 3.8.0.
+ */
+define( 'WC_PHP_MIN_REQUIREMENTS_NOTICE', 'wp_php_min_requirements_3_8' );
+
+/**
  * WC_Admin_Notices Class.
  */
 class WC_Admin_Notices {
@@ -26,16 +34,16 @@ class WC_Admin_Notices {
 	 * @var array
 	 */
 	private static $core_notices = array(
-		'install'                   => 'install_notice',
-		'update'                    => 'update_notice',
-		'template_files'            => 'template_file_check_notice',
-		'legacy_shipping'           => 'legacy_shipping_notice',
-		'no_shipping_methods'       => 'no_shipping_methods_notice',
-		'regenerating_thumbnails'   => 'regenerating_thumbnails_notice',
-		'regenerating_lookup_table' => 'regenerating_lookup_table_notice',
-		'no_secure_connection'      => 'secure_connection_notice',
-		'wc_admin'                  => 'wc_admin_feature_plugin_notice',
-		'wp_php_min_requirements'   => 'wp_php_min_requirements_notice',
+		'install'                      => 'install_notice',
+		'update'                       => 'update_notice',
+		'template_files'               => 'template_file_check_notice',
+		'legacy_shipping'              => 'legacy_shipping_notice',
+		'no_shipping_methods'          => 'no_shipping_methods_notice',
+		'regenerating_thumbnails'      => 'regenerating_thumbnails_notice',
+		'regenerating_lookup_table'    => 'regenerating_lookup_table_notice',
+		'no_secure_connection'         => 'secure_connection_notice',
+		'wc_admin'                     => 'wc_admin_feature_plugin_notice',
+		WC_PHP_MIN_REQUIREMENTS_NOTICE => 'wp_php_min_requirements_notice',
 	);
 
 	/**
@@ -380,7 +388,7 @@ class WC_Admin_Notices {
 	 */
 	public static function add_min_version_notice() {
 		if ( version_compare( phpversion(), WC_NOTICE_MIN_PHP_VERSION, '<' ) || version_compare( get_bloginfo( 'version' ), WC_NOTICE_MIN_WP_VERSION, '<' ) ) {
-			self::add_notice( 'wp_php_min_requirements' );
+			self::add_notice( WC_PHP_MIN_REQUIREMENTS_NOTICE );
 		}
 	}
 
@@ -391,8 +399,8 @@ class WC_Admin_Notices {
 	 * @return void
 	 */
 	public static function wp_php_min_requirements_notice() {
-		if ( apply_filters( 'woocommerce_hide_php_wp_nag', get_user_meta( get_current_user_id(), 'dismissed_wp_php_min_requirements_notice', true ) ) ) {
-			self::remove_notice( 'wp_php_min_requirements' );
+		if ( apply_filters( 'woocommerce_hide_php_wp_nag', get_user_meta( get_current_user_id(), 'dismissed_' . WC_PHP_MIN_REQUIREMENTS_NOTICE . '_notice', true ) ) ) {
+			self::remove_notice( WC_PHP_MIN_REQUIREMENTS_NOTICE );
 			return;
 		}
 

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -9,14 +9,6 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Name for notice for showing minimum version requirements. Change value to invalidate previous dismissals when requirement changes in future.
- * Last changed in 3.8.
- *
- * @since 3.8.0.
- */
-define( 'WC_PHP_MIN_REQUIREMENTS_NOTICE', 'wp_php_min_requirements_3_8' );
-
-/**
  * WC_Admin_Notices Class.
  */
 class WC_Admin_Notices {

--- a/includes/admin/views/html-notice-wp-php-minimum-requirements.php
+++ b/includes/admin/views/html-notice-wp-php-minimum-requirements.php
@@ -8,7 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 ?>
 <div id="message" class="updated woocommerce-message">
-	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'wp_php_min_requirements' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', WC_PHP_MIN_REQUIREMENTS_NOTICE ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>"><?php esc_html_e( 'Dismiss', 'woocommerce' ); ?></a>
 
 	<p>
 		<?php

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -231,6 +231,7 @@ final class WooCommerce {
 		$this->define( 'WC_TEMPLATE_DEBUG_MODE', false );
 		$this->define( 'WC_NOTICE_MIN_PHP_VERSION', '7.0' );
 		$this->define( 'WC_NOTICE_MIN_WP_VERSION', '5.0' );
+		$this->define( 'WC_PHP_MIN_REQUIREMENTS_NOTICE', 'wp_php_min_requirements_' . WC_NOTICE_MIN_PHP_VERSION . '_' . WC_NOTICE_MIN_WP_VERSION );
 	}
 
 	/**


### PR DESCRIPTION
…ce version

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Refactor minimum requirement notice to use a constant so that it will easier to update in future when we need it.

### How to test the changes in this Pull Request:

1. Switch to < PHP7 or <WP5 (like PHP 5.6 or WP 4.9)
2. Change the theme or change WooCommer version
3. You should see a minimum requirement notice. Dismissing it once should hide and you won;t see it again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Refactor minimum requirement notice to use constant for easier changes in the future.
