### PR TITLE
Use full year and 24h format in order note tooltip

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-notes.php
+++ b/includes/admin/meta-boxes/views/html-order-notes.php
@@ -22,7 +22,7 @@ defined( 'ABSPATH' ) || exit;
 					<?php echo wpautop( wptexturize( wp_kses_post( $note->content ) ) ); // @codingStandardsIgnoreLine ?>
 				</div>
 				<p class="meta">
-					<abbr class="exact-date" title="<?php echo esc_attr( $note->date_created->date( 'y-m-d h:i:s' ) ); ?>">
+					<abbr class="exact-date" title="<?php echo esc_attr( $note->date_created->date( 'Y-m-d H:i:s' ) ); ?>">
 						<?php
 						/* translators: %1$s: note date %2$s: note time */
 						echo esc_html( sprintf( __( '%1$s at %2$s', 'woocommerce' ), $note->date_created->date_i18n( wc_date_format() ), $note->date_created->date_i18n( wc_time_format() ) ) );


### PR DESCRIPTION
The order notes tooltip uses 12h hour format, but without specifying `am` or `pm`. This PR changes it to use 24h format and a full year.