### PR TITLE
[Tracker] Prevent PHP warning when order date is empty [part 2]

### DIFF
--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -77,7 +77,7 @@ class WC_Orders_Tracking {
 		}
 
 		$order        = wc_get_order( $id );
-		$date_created = $order->get_date_created()->date( 'Y-m-d H:i:s' );
+		$date_created = $order->get_date_created() ? $order->get_date_created()->date( 'Y-m-d H:i:s' ) : '';
 		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
 		$new_date = sprintf(
 			'%s %2d:%2d:%2d',

--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -27,9 +27,9 @@ class WC_Orders_Tracking {
 	 * Send a Tracks event when the Orders page is viewed.
 	 */
 	public function track_orders_view() {
-		if ( isset( $_GET['post_type'] ) && 'shop_order' === wp_unslash( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		if ( isset( $_GET['post_type'] ) && 'shop_order' === wp_unslash( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
-			// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput
+			// phpcs:disable WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput
 			$properties = array(
 				'status' => isset( $_GET['post_status'] ) ? sanitize_text_field( $_GET['post_status'] ) : 'all',
 			);
@@ -78,7 +78,7 @@ class WC_Orders_Tracking {
 
 		$order        = wc_get_order( $id );
 		$date_created = $order->get_date_created() ? $order->get_date_created()->date( 'Y-m-d H:i:s' ) : '';
-		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		// phpcs:disable WordPress.Security.NonceVerification
 		$new_date = sprintf(
 			'%s %2d:%2d:%2d',
 			isset( $_POST['order_date'] ) ? wc_clean( wp_unslash( $_POST['order_date'] ) ) : '',
@@ -104,7 +104,7 @@ class WC_Orders_Tracking {
 	 * @param int $order_id Order ID.
 	 */
 	public function track_order_action( $order_id ) {
-		// phpcs:disable WordPress.Security.NonceVerification.NoNonceVerification
+		// phpcs:disable WordPress.Security.NonceVerification
 		if ( ! empty( $_POST['wc_order_action'] ) ) {
 			$order      = wc_get_order( $order_id );
 			$action     = wc_clean( wp_unslash( $_POST['wc_order_action'] ) );
@@ -123,7 +123,7 @@ class WC_Orders_Tracking {
 	 * Track "add order" button on the Edit Order screen.
 	 */
 	public function track_add_order_from_edit() {
-		// phpcs:ignore WordPress.Security.NonceVerification.NoNonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		if ( isset( $_GET['post_type'] ) && 'shop_order' === wp_unslash( $_GET['post_type'] ) ) {
 			$referer = wp_get_referer();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is part of #24441, now this fixes all incorrect use case of `$order->get_date_created()->date()`.

### How to test the changes in this Pull Request:

See #24441

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
