### PR TITLE
Remove selectWoo as script dependency since allow to disable selectWoo

### DIFF
--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -247,7 +247,7 @@ class WC_Frontend_Scripts {
 			),
 			'wc-country-select'          => array(
 				'src'     => self::get_asset_url( 'assets/js/frontend/country-select' . $suffix . '.js' ),
-				'deps'    => array( 'jquery', 'selectWoo' ),
+				'deps'    => array( 'jquery' ),
 				'version' => WC_VERSION,
 			),
 			'wc-credit-card-form'        => array(

--- a/readme.txt
+++ b/readme.txt
@@ -278,7 +278,6 @@ INTERESTED IN DEVELOPMENT?
 * Fix - Use correct meta value for `downloadable` column in product lookup table regenerate function. #24681
 * Fix - Admin sub-menus becoming unaligned when scrolling down in the orders page when there are no orders. #24688
 * Fix - OWB country and sell in person alignment. #24700
-* Fix - Add selectWoo as dependency of country-select. #24347
 * Fix - Domain replacement script now replaces both double and single quoted `woo-gutenberg-products-block` with `woocommerce` in both PHP and JavaScript files. #24696
 * Fix - Convert `current_user_id` to string in some places to prevent unnecessary session database updates. #24016
 * Fix - Fixed description of failed order emails. #24737


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

SelectWoo should be a option dependency on WooCommerce, at least on the frontend.

Closes #24838.

### How to test the changes in this Pull Request:

See #24838.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Removed SelectWoo as dependency of `wc-country-select`.
