### PR TITLE
Introduced woocommerce_kses_notice_allowed_tags filter

### DIFF
--- a/includes/wc-notice-functions.php
+++ b/includes/wc-notice-functions.php
@@ -136,9 +136,12 @@ function wc_print_notices( $return = false ) {
 
 	foreach ( $notice_types as $notice_type ) {
 		if ( wc_notice_count( $notice_type ) > 0 ) {
-			wc_get_template( "notices/{$notice_type}.php", array(
-				'messages' => array_filter( $all_notices[ $notice_type ] ),
-			) );
+			wc_get_template(
+				"notices/{$notice_type}.php",
+				array(
+					'messages' => array_filter( $all_notices[ $notice_type ] ),
+				)
+			);
 		}
 	}
 
@@ -165,9 +168,12 @@ function wc_print_notice( $message, $notice_type = 'success' ) {
 		$message = apply_filters( 'woocommerce_add_message', $message );
 	}
 
-	wc_get_template( "notices/{$notice_type}.php", array(
-		'messages' => array( apply_filters( 'woocommerce_add_' . $notice_type, $message ) ),
-	) );
+	wc_get_template(
+		"notices/{$notice_type}.php",
+		array(
+			'messages' => array( apply_filters( 'woocommerce_add_' . $notice_type, $message ) ),
+		)
+	);
 }
 
 /**

--- a/includes/wc-notice-functions.php
+++ b/includes/wc-notice-functions.php
@@ -217,14 +217,20 @@ function wc_add_wp_error_notices( $errors ) {
  * @return string
  */
 function wc_kses_notice( $message ) {
-	return wp_kses( $message,
-		array_replace_recursive( // phpcs:ignore PHPCompatibility.PHP.NewFunctions.array_replace_recursiveFound
-			wp_kses_allowed_html( 'post' ),
-			array(
-				'a' => array(
-					'tabindex' => true,
-				),
-			)
+	$allowed_tags = array_replace_recursive(
+		wp_kses_allowed_html( 'post' ),
+		array(
+			'a' => array(
+				'tabindex' => true,
+			),
 		)
 	);
+
+	/**
+	 * Kses notice allowed tags.
+	 *
+	 * @since 3.9.0
+	 * @param array[]|string $allowed_tags An array of allowed HTML elements and attributes, or a context name such as 'post'.
+	 */
+	return wp_kses( $message, apply_filters( 'woocommerce_kses_notice_allowed_tags', $allowed_tags ) );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Allows set custom allowed tags for `wp_kses()` on `wc_kses_notices()`.

Closes #24839.

### How to test the changes in this Pull Request:

See #24839.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced `woocommerce_kses_notice_allowed_tags` filter.
