### PR TITLE
Refactor to remove PHP 7 Error

### DIFF
--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -22,6 +22,7 @@ class WC_Order_Factory {
 	 * @return WC_Order|bool
 	 */
 	public static function get_order( $order_id = false ) {
+		$passed_args = $order_id;
 		$order_id = self::get_order_id( $order_id );
 
 		if ( ! $order_id ) {
@@ -46,7 +47,7 @@ class WC_Order_Factory {
 		try {
 			return new $classname( $order_id );
 		} catch ( Exception $e ) {
-			wc_caught_exception( $e, __FUNCTION__, func_get_args() );
+			wc_caught_exception( $e, __FUNCTION__, $passed_args );
 			return false;
 		}
 	}

--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -22,7 +22,6 @@ class WC_Order_Factory {
 	 * @return WC_Order|bool
 	 */
 	public static function get_order( $order_id = false ) {
-		$passed_args = $order_id;
 		$order_id = self::get_order_id( $order_id );
 
 		if ( ! $order_id ) {
@@ -47,7 +46,7 @@ class WC_Order_Factory {
 		try {
 			return new $classname( $order_id );
 		} catch ( Exception $e ) {
-			wc_caught_exception( $e, __FUNCTION__, $passed_args );
+			wc_caught_exception( $e, __FUNCTION__, array( $order_id ) );
 			return false;
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Replaced call to func_get_args() in WC_Order_Factory::get_order() with a variable to store the original passed arguments. This removes the PHP 7.0 error described in issue #24841 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24841 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Refactored WC_Order_Factory::get_order() to remove function deprecated in PHP 7.0
