### PR TITLE
Update links to bug report and feature request issue templates

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -46,7 +46,7 @@ If you are contributing code to the REST API or editor blocks, these are develop
 
 ## Feature Requests 🚀
 
-Feature requests can be [submitted to our issue tracker](https://github.com/woocommerce/woocommerce/issues/new?template=Feature_request.md). Be sure to include a description of the expected behavior and use case, and before submitting a request, please search for similar ones in the closed issues.
+Feature requests can be [submitted to our issue tracker](https://github.com/woocommerce/woocommerce/issues/new?template=6-Feature-request.md). Be sure to include a description of the expected behavior and use case, and before submitting a request, please search for similar ones in the closed issues.
 
 Feature request issues will remain closed until we see sufficient interest via comments and [👍 reactions](https://help.github.com/articles/about-discussions-in-issues-and-pull-requests/) from the community.
 

--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -66,7 +66,7 @@ class WC_Admin_Help {
 					'<h2>' . __( 'Found a bug?', 'woocommerce' ) . '</h2>' .
 					/* translators: 1: GitHub issues URL 2: GitHub contribution guide URL 3: System status report URL */
 					'<p>' . sprintf( __( 'If you find a bug within WooCommerce core you can create a ticket via <a href="%1$s">Github issues</a>. Ensure you read the <a href="%2$s">contribution guide</a> prior to submitting your report. To help us solve your issue, please be as descriptive as possible and include your <a href="%3$s">system status report</a>.', 'woocommerce' ), 'https://github.com/woocommerce/woocommerce/issues?state=open', 'https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md', admin_url( 'admin.php?page=wc-status' ) ) . '</p>' .
-					'<p><a href="https://github.com/woocommerce/woocommerce/issues/new?template=Bug_report.md" class="button button-primary">' . __( 'Report a bug', 'woocommerce' ) . '</a> <a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button">' . __( 'System status', 'woocommerce' ) . '</a></p>',
+					'<p><a href="https://github.com/woocommerce/woocommerce/issues/new?template=4-Bug-report.md" class="button button-primary">' . __( 'Report a bug', 'woocommerce' ) . '</a> <a href="' . admin_url( 'admin.php?page=wc-status' ) . '" class="button">' . __( 'System status', 'woocommerce' ) . '</a></p>',
 
 			)
 		);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The names of the bug report and feature request issue templates were changed in #24844. This PR updates two places where links pointing to those templates were outdated.

@vedanshujain I'm adding this to the 3.8.0 milestone as #24844 was already merged and as this just changes two links. Let me know if you prefer to leave it for 3.8.1 and I can revert #24844.

### How to test the changes in this Pull Request:

1. Check that the links point to the correct issue template.
2. Check that there are not more links using the old issue templates names.
