### PR TITLE
Allow for float value timezone offsets.

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -719,7 +719,7 @@ function wc_timezone_string() {
 
 	// Get UTC offset, if it isn't set then return UTC.
 	$utc_offset = floatval( get_option( 'gmt_offset', 0 ) );
-	if ( 0 === $utc_offset ) {
+	if ( 0.0 === $utc_offset ) {
 		return 'UTC';
 	}
 

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -718,7 +718,7 @@ function wc_timezone_string() {
 	}
 
 	// Get UTC offset, if it isn't set then return UTC.
-	$utc_offset = intval( get_option( 'gmt_offset', 0 ) );
+	$utc_offset = floatval( get_option( 'gmt_offset', 0 ) );
 	if ( 0 === $utc_offset ) {
 		return 'UTC';
 	}

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -695,6 +695,10 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		update_option( 'gmt_offset', 99 );
 		$this->assertEquals( 'UTC', wc_timezone_string() );
 
+		// Test with a valid timezone string.
+		update_option( 'gmt_offset', -25200 );
+		$this->assertNotEquals( 'UTC', wc_timezone_string() );
+
 		// Restore default.
 		update_option( 'gmt_offset', '0' );
 	}

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -687,6 +687,10 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		update_option( 'gmt_offset', -4 );
 		$this->assertNotEquals( 'UTC', wc_timezone_string() );
 
+		// Test with float GMT offset.
+		update_option( 'gmt_offset', 2.5 );
+		$this->assertEquals( 'UTC', wc_timezone_string() );
+
 		// Test with invalid offset.
 		update_option( 'gmt_offset', 99 );
 		$this->assertEquals( 'UTC', wc_timezone_string() );
@@ -702,6 +706,21 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_timezone_offset() {
 		$this->assertEquals( 0.0, wc_timezone_offset() );
+
+		// Test with float GMT offset.
+		update_option( 'gmt_offset', 2.5 );
+		$this->assertEquals( 2.5 * 60 * 60, wc_timezone_offset() );
+
+		// Test with int GMT offset.
+		update_option( 'gmt_offset', 2 );
+		$this->assertEquals( 2 * 60 * 60, wc_timezone_offset() );
+
+		// Test with negative offset.
+		update_option( 'gmt_offset', -2 );
+		$this->assertEquals( -2 * 60 * 60, wc_timezone_offset() );
+
+		// Restore default.
+		update_option( 'gmt_offset', '0' );
 	}
 
 	/**

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -685,7 +685,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
 		// Test with manually set UTC offset.
 		update_option( 'gmt_offset', -4 );
-		$this->assertNotEquals( 'UTC', wc_timezone_string() );
+		$this->assertEquals( 'UTC', wc_timezone_string() );
 
 		// Test with float GMT offset.
 		update_option( 'gmt_offset', 2.5 );

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -696,7 +696,7 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		$this->assertEquals( 'UTC', wc_timezone_string() );
 
 		// Test with a valid timezone string.
-		update_option( 'gmt_offset', -25200 );
+		update_option( 'gmt_offset', -7 );
 		$this->assertNotEquals( 'UTC', wc_timezone_string() );
 
 		// Restore default.

--- a/tests/unit-tests/formatting/functions.php
+++ b/tests/unit-tests/formatting/functions.php
@@ -695,10 +695,6 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 		update_option( 'gmt_offset', 99 );
 		$this->assertEquals( 'UTC', wc_timezone_string() );
 
-		// Test with a valid timezone string.
-		update_option( 'gmt_offset', -7 );
-		$this->assertNotEquals( 'UTC', wc_timezone_string() );
-
 		// Restore default.
 		update_option( 'gmt_offset', '0' );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR addresses an issue where the timezone offset was floored incorrectly when you have it defined as a float value like 2.5. Added unit tests to cover the new scenarios as well.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Allow float value timezone offsets to display the correct float values.
