### PR TITLE
Capitalize `T` in `Move to trash` phrase on order page in wp-admin

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -62,7 +62,7 @@ class WC_Meta_Box_Order_Actions {
 						if ( ! EMPTY_TRASH_DAYS ) {
 							$delete_text = __( 'Delete permanently', 'woocommerce' );
 						} else {
-							$delete_text = __( 'Move to trash', 'woocommerce' );
+							$delete_text = __( 'Move to Trash', 'woocommerce' );
 						}
 						?>
 						<a class="submitdelete deletion" href="<?php echo esc_url( get_delete_post_link( $post->ID ) ); ?>"><?php echo esc_html( $delete_text ); ?></a>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Capitalize `T` in `Move to trash` phrase on order page in `wp-admin` to be in line with product and coupon pages, where `T` is capitalized in the word `Trash`. 

On product and coupon pages, `T` is capitalized in the word `Trash`:

![product](https://user-images.githubusercontent.com/19143190/63958011-6ecc8580-ca81-11e9-9e52-81bdc6d8d1ed.jpg)

![coupon](https://user-images.githubusercontent.com/19143190/63958025-73913980-ca81-11e9-88ce-6c3808f3795f.jpg)

However, on the order page, `T` is not capitalized:

![order](https://user-images.githubusercontent.com/19143190/63958088-91f73500-ca81-11e9-92fe-814f2e95c785.jpg)

The existing condition requires special functionality for e2e testing on that page (see https://github.com/woocommerce/woocommerce/pull/24532). Capitalizing `T` will allow avoiding creating that special functionality and will also make the interface consistent across pages. 

### How to test the changes in this Pull Request:

1. Note the `t` not capitalized on the order page in `Move to trash` phrase in wp-admin;

![not_capitalized](https://user-images.githubusercontent.com/19143190/67100761-2e070800-f1b8-11e9-9e8f-cb8a4bed1d01.jpg)

2. Checkout the branch;

3. `T` should now be capitalized in `Move to Trash` phrase: 

![capitalized](https://user-images.githubusercontent.com/19143190/67100899-758d9400-f1b8-11e9-9d52-ab833cf10bff.jpg)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Capitalize `T` in `Move to trash` phrase on order page in wp-admin to be consistent with product and coupon pages. 
