### PR TITLE
refs #24638 Fixed Stock status update on Bulk Edit

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -643,6 +643,12 @@ class WC_Admin_Post_Types {
 					break;
 			}
 		}
+		else
+		{
+			//Reset values if Manage Stock status is disabled
+			$product->set_stock_quantity('');
+			$product->set_manage_stock('no');
+		}
 
 		// Apply product type constraints to stock status.
 		if ( $product->is_type( 'external' ) ) {

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -642,12 +642,10 @@ class WC_Admin_Post_Types {
 					wc_update_product_stock( $product, $stock_amount, 'set', true );
 					break;
 			}
-		}
-		else
-		{
-			//Reset values if Manage Stock status is disabled
-			$product->set_stock_quantity('');
-			$product->set_manage_stock('no');
+		} else {
+			// Reset values if Manage Stock status is disabled.
+			$product->set_stock_quantity( '' );
+			$product->set_manage_stock( 'no' );
 		}
 
 		// Apply product type constraints to stock status.

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -643,7 +643,7 @@ class WC_Admin_Post_Types {
 					break;
 			}
 		} else {
-			// Reset values if Manage Stock status is disabled.
+			// Reset values if WooCommerce Setting - Manage Stock status is disabled.
 			$product->set_stock_quantity( '' );
 			$product->set_manage_stock( 'no' );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When "Enable stock management" checkbox is un-ticked in WooCommerce >> Settings >> Products >> Inventory - products, there is no reset of necessary data like manage stock & Stock quantity present. I have added it to take Stock status changes in effect. 

Closes #24638

### How to test the changes in this Pull Request:

1. "Enable stock management" checkbox is ticked in WooCommerce >> Settings >> Products >> Inventory
2. Create a couple of products with "Enable stock management at product level" checkbox ticked and a stock level of 0. It will show up as out of stock.
3. Un-tick "Enable stock management" checkbox in WooCommerce >> Settings >> Products >> Inventory
4. Head to "products", tick the checkboxes next to previously created products and select "edit" from "bulk actions" and apply.
5. The stock status of these products will be changed to the required setting.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### Changelog entry
Fixed Product Stock status changes on Bulk Edit save.