### PR TITLE
Add order note before do_action() to maintain order of notes

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -367,7 +367,7 @@ class WC_Order extends WC_Abstract_Order {
 					$transition_note = sprintf( __( 'Order status changed from %1$s to %2$s.', 'woocommerce' ), wc_get_order_status_name( $status_transition['from'] ), wc_get_order_status_name( $status_transition['to'] ) );
 
 					// Note the transition occurred.
-					$this->add_order_note( trim( $status_transition['note'] . ' ' . $transition_note ), 0, $status_transition['manual'] );
+					$this->add_status_transition_note( $transition_note, $status_transition );
 
 					do_action( 'woocommerce_order_status_' . $status_transition['from'] . '_to_' . $status_transition['to'], $this->get_id(), $this );
 					do_action( 'woocommerce_order_status_changed', $this->get_id(), $status_transition['from'], $status_transition['to'], $this );
@@ -376,7 +376,7 @@ class WC_Order extends WC_Abstract_Order {
 					$transition_note = sprintf( __( 'Order status set to %s.', 'woocommerce' ), wc_get_order_status_name( $status_transition['to'] ) );
 
 					// Note the transition occurred.
-					$this->add_order_note( trim( $status_transition['note'] . ' ' . $transition_note ), 0, $status_transition['manual'] );
+					$this->add_status_transition_note( $transition_note, $status_transition );
 				}
 			} catch ( Exception $e ) {
 				$logger = wc_get_logger();
@@ -1706,6 +1706,19 @@ class WC_Order extends WC_Abstract_Order {
 		}
 
 		return $comment_id;
+	}
+
+	/**
+	 * Add an order note for status transition
+	 *
+	 * @since 3.9.0
+	 * @uses WC_Order::add_order_note()
+	 * @param string $note          Note to be added giving status transition from and to details.
+	 * @param bool   $transition    Details of the status transition.
+	 * @return int                  Comment ID.
+	 */
+	private function add_status_transition_note( $note, $transition ) {
+		return $this->add_order_note( trim( $transition['note'] . ' ' . $note ), 0, $transition['manual'] );
 	}
 
 	/**

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -366,15 +366,18 @@ class WC_Order extends WC_Abstract_Order {
 					/* translators: 1: old order status 2: new order status */
 					$transition_note = sprintf( __( 'Order status changed from %1$s to %2$s.', 'woocommerce' ), wc_get_order_status_name( $status_transition['from'] ), wc_get_order_status_name( $status_transition['to'] ) );
 
+					// Note the transition occurred.
+					$this->add_order_note( trim( $status_transition['note'] . ' ' . $transition_note ), 0, $status_transition['manual'] );
+
 					do_action( 'woocommerce_order_status_' . $status_transition['from'] . '_to_' . $status_transition['to'], $this->get_id(), $this );
 					do_action( 'woocommerce_order_status_changed', $this->get_id(), $status_transition['from'], $status_transition['to'], $this );
 				} else {
 					/* translators: %s: new order status */
 					$transition_note = sprintf( __( 'Order status set to %s.', 'woocommerce' ), wc_get_order_status_name( $status_transition['to'] ) );
-				}
 
-				// Note the transition occurred.
-				$this->add_order_note( trim( $status_transition['note'] . ' ' . $transition_note ), 0, $status_transition['manual'] );
+					// Note the transition occurred.
+					$this->add_order_note( trim( $status_transition['note'] . ' ' . $transition_note ), 0, $status_transition['manual'] );
+				}
 			} catch ( Exception $e ) {
 				$logger = wc_get_logger();
 				$logger->error(


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
While doing a status transition of an order in the [status_transition() function](https://github.com/woocommerce/woocommerce/blob/43f6e67bdf3de4590a57a465eaa1b1baf26458fe/includes/class-wc-order.php#L355), an order note is added [here](https://github.com/woocommerce/woocommerce/blob/43f6e67bdf3de4590a57a465eaa1b1baf26458fe/includes/class-wc-order.php#L377) after the `woocommerce_order_status_changed` action. When we hook into this action, and do another status transition(as in Subscriptions), this causes a lot of confusion because the order note for the second status transition is added before the first one.

This order note should be added before the `do_action()` calls [here](https://github.com/woocommerce/woocommerce/blob/43f6e67bdf3de4590a57a465eaa1b1baf26458fe/includes/class-wc-order.php#L369-L370) so that any note added by functions that hook into these actions do not get added before the status transition order note. 



### How to test the changes in this Pull Request:

1. Add a function that hooks into `woocommerce_order_status_changed`. Let this function add an order note. Something like this:
```
        add_action( 'woocommerce_order_status_changed', 'my_func_adds_order_note', 10, 4 );
        function my_func_adds_order_note( $order_id, $from_status, $to_status, $order ) {
	     $order->add_order_note( 'Can I change status to something else?', 'woocommerce');
	     return;
         }
```

2. Create an order and change its status.
3. On master it can be noted that the order of notes is such that the status change note appears after the note in the `my_func_adds_order_note` like [this](https://cld.wthms.co/LEzqCB). On this branch, the status change note appears first and then the note in the function.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add order note immediately after status change before the 'woocommerce_order_status_changed' action.
