### PR TITLE
Check text domains in libraries

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -229,7 +229,6 @@ module.exports = function( grunt ) {
 			files: {
 				src:  [
 					'**/*.php',               // Include all files
-					'!includes/libraries/**', // Exclude libraries/
 					'!node_modules/**',       // Exclude node_modules/
 					'!tests/**',              // Exclude tests/
 					'!vendor/**',             // Exclude vendor/

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_Abstract_ListTable.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_Abstract_ListTable.php
@@ -107,7 +107,7 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	 * `_x` with some default (the package name)
 	 */
 	protected function translate( $text, $context = '' ) {
-		return _x( $text, $context, $this->package );
+		return $text;
 	}
 
 	/**
@@ -462,7 +462,7 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 			echo '</select>';
 		}
 
-		submit_button( $this->translate( 'Filter' ), '', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
+		submit_button( __( 'Filter', 'woocommerce' ), '', 'filter_action', false, array( 'id' => 'post-query-submit' ) );
 		echo '</div>';
 	}
 
@@ -561,7 +561,8 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	protected function display_header() {
 		echo '<h1 class="wp-heading-inline">' . esc_attr( $this->table_header ) . '</h1>';
 		if ( $this->get_request_search_query() ) {
-			echo '<span class="subtitle">' . esc_attr( $this->translate( sprintf( 'Search results for "%s"', $this->get_request_search_query() ) ) ) . '</span>';
+			/* translators: %s: search query */
+			echo '<span class="subtitle">' . esc_attr( sprintf( __( 'Search results for "%s"', 'woocommerce' ), $this->get_request_search_query() ) ) . '</span>';
 		}
 		echo '<hr class="wp-header-end">';
 	}
@@ -651,6 +652,6 @@ abstract class ActionScheduler_Abstract_ListTable extends WP_List_Table {
 	 * Get the text to display in the search box on the list table.
 	 */
 	protected function get_search_box_placeholder() {
-		return $this->translate( 'Search' );
+		return __( 'Search', 'woocommerce' );
 	}
 }

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_InvalidActionException.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_InvalidActionException.php
@@ -19,7 +19,7 @@ class ActionScheduler_InvalidActionException extends \InvalidArgumentException i
 	 */
 	public static function from_decoding_args( $action_id ) {
 		$message = sprintf(
-			__( 'Action [%s] has invalid arguments. It cannot be JSON decoded to an array.', 'action-scheduler' ),
+			__( 'Action [%s] has invalid arguments. It cannot be JSON decoded to an array.', 'woocommerce' ),
 			$action_id
 		);
 

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_ListTable.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_ListTable.php
@@ -86,20 +86,20 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		$this->logger = $logger;
 		$this->runner = $runner;
 
-		$this->table_header = __( 'Scheduled Actions', 'action-scheduler' );
+		$this->table_header = __( 'Scheduled Actions', 'woocommerce' );
 
 		$this->bulk_actions = array(
-			'delete' => __( 'Delete', 'action-scheduler' ),
+			'delete' => __( 'Delete', 'woocommerce' ),
 		);
 
 		$this->columns = array(
-			'hook'        => __( 'Hook', 'action-scheduler' ),
-			'status'      => __( 'Status', 'action-scheduler' ),
-			'args'        => __( 'Arguments', 'action-scheduler' ),
-			'group'       => __( 'Group', 'action-scheduler' ),
-			'recurrence'  => __( 'Recurrence', 'action-scheduler' ),
-			'schedule'    => __( 'Scheduled Date', 'action-scheduler' ),
-			'log_entries' => __( 'Log', 'action-scheduler' ),
+			'hook'        => __( 'Hook', 'woocommerce' ),
+			'status'      => __( 'Status', 'woocommerce' ),
+			'args'        => __( 'Arguments', 'woocommerce' ),
+			'group'       => __( 'Group', 'woocommerce' ),
+			'recurrence'  => __( 'Recurrence', 'woocommerce' ),
+			'schedule'    => __( 'Scheduled Date', 'woocommerce' ),
+			'log_entries' => __( 'Log', 'woocommerce' ),
 		);
 
 		$this->sort_by = array(
@@ -119,19 +119,19 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		if ( empty( $request_status ) ) {
 			$this->sort_by[] = 'status';
 		} elseif ( in_array( $request_status, array( 'in-progress', 'failed' ) ) ) {
-			$this->columns  += array( 'claim_id' => __( 'Claim ID', 'action-scheduler' ) );
+			$this->columns  += array( 'claim_id' => __( 'Claim ID', 'woocommerce' ) );
 			$this->sort_by[] = 'claim_id';
 		}
 
 		$this->row_actions = array(
 			'hook' => array(
 				'run' => array(
-					'name'  => __( 'Run', 'action-scheduler' ),
-					'desc'  => __( 'Process the action now as if it were run as part of a queue', 'action-scheduler' ),
+					'name'  => __( 'Run', 'woocommerce' ),
+					'desc'  => __( 'Process the action now as if it were run as part of a queue', 'woocommerce' ),
 				),
 				'cancel' => array(
-					'name'  => __( 'Cancel', 'action-scheduler' ),
-					'desc'  => __( 'Cancel the action now to avoid it being run in future', 'action-scheduler' ),
+					'name'  => __( 'Cancel', 'woocommerce' ),
+					'desc'  => __( 'Cancel the action now to avoid it being run in future', 'woocommerce' ),
 					'class' => 'cancel trash',
 				),
 			),
@@ -140,31 +140,31 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		self::$time_periods = array(
 			array(
 				'seconds' => YEAR_IN_SECONDS,
-				'names'   => _n_noop( '%s year', '%s years', 'action-scheduler' ),
+				'names'   => _n_noop( '%s year', '%s years', 'woocommerce' ),
 			),
 			array(
 				'seconds' => MONTH_IN_SECONDS,
-				'names'   => _n_noop( '%s month', '%s months', 'action-scheduler' ),
+				'names'   => _n_noop( '%s month', '%s months', 'woocommerce' ),
 			),
 			array(
 				'seconds' => WEEK_IN_SECONDS,
-				'names'   => _n_noop( '%s week', '%s weeks', 'action-scheduler' ),
+				'names'   => _n_noop( '%s week', '%s weeks', 'woocommerce' ),
 			),
 			array(
 				'seconds' => DAY_IN_SECONDS,
-				'names'   => _n_noop( '%s day', '%s days', 'action-scheduler' ),
+				'names'   => _n_noop( '%s day', '%s days', 'woocommerce' ),
 			),
 			array(
 				'seconds' => HOUR_IN_SECONDS,
-				'names'   => _n_noop( '%s hour', '%s hours', 'action-scheduler' ),
+				'names'   => _n_noop( '%s hour', '%s hours', 'woocommerce' ),
 			),
 			array(
 				'seconds' => MINUTE_IN_SECONDS,
-				'names'   => _n_noop( '%s minute', '%s minutes', 'action-scheduler' ),
+				'names'   => _n_noop( '%s minute', '%s minutes', 'woocommerce' ),
 			),
 			array(
 				'seconds' => 1,
-				'names'   => _n_noop( '%s second', '%s seconds', 'action-scheduler' ),
+				'names'   => _n_noop( '%s second', '%s seconds', 'woocommerce' ),
 			),
 		);
 
@@ -191,7 +191,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	private static function human_interval( $interval, $periods_to_include = 2 ) {
 
 		if ( $interval <= 0 ) {
-			return __( 'Now!', 'action-scheduler' );
+			return __( 'Now!', 'woocommerce' );
 		}
 
 		$output = '';
@@ -204,7 +204,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 				if ( ! empty( $output ) ) {
 					$output .= ' ';
 				}
-				$output .= sprintf( _n( self::$time_periods[ $time_period_index ]['names'][0], self::$time_periods[ $time_period_index ]['names'][1], $periods_in_interval, 'action-scheduler' ), $periods_in_interval );
+				$output .= sprintf( _n( self::$time_periods[ $time_period_index ]['names'][0], self::$time_periods[ $time_period_index ]['names'][1], $periods_in_interval, 'woocommerce' ), $periods_in_interval );
 				$seconds_remaining -= $periods_in_interval * self::$time_periods[ $time_period_index ]['seconds'];
 				$periods_included++;
 			}
@@ -224,15 +224,15 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		$recurrence = $action->get_schedule();
 		if ( $recurrence->is_recurring() ) {
 			if ( method_exists( $recurrence, 'interval_in_seconds' ) ) {
-				return sprintf( __( 'Every %s', 'action-scheduler' ), self::human_interval( $recurrence->interval_in_seconds() ) );
+				return sprintf( __( 'Every %s', 'woocommerce' ), self::human_interval( $recurrence->interval_in_seconds() ) );
 			}
 
 			if ( method_exists( $recurrence, 'get_recurrence' ) ) {
-				return sprintf( __( 'Cron %s', 'action-scheduler' ), $recurrence->get_recurrence() );
+				return sprintf( __( 'Cron %s', 'woocommerce' ), $recurrence->get_recurrence() );
 			}
 		}
 
-		return __( 'Non-repeating', 'action-scheduler' );
+		return __( 'Non-repeating', 'woocommerce' );
 	}
 
 	/**
@@ -318,7 +318,7 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		if ( $this->store->get_claim_count() >= $this->runner->get_allowed_concurrent_batches() ) {
 			$this->admin_notices[] = array(
 				'class'   => 'updated',
-				'message' => sprintf( __( 'Maximum simultaneous batches already in progress (%s queues). No actions will be processed until the current batches are complete.', 'action-scheduler' ), $this->store->get_claim_count() ),
+				'message' => sprintf( __( 'Maximum simultaneous batches already in progress (%s queues). No actions will be processed until the current batches are complete.', 'woocommerce' ), $this->store->get_claim_count() ),
 			);
 		}
 
@@ -333,18 +333,18 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 				$class = 'updated';
 				switch ( $notification['row_action_type'] ) {
 					case 'run' :
-						$action_message_html = sprintf( __( 'Successfully executed action: %s', 'action-scheduler' ), $action_hook_html );
+						$action_message_html = sprintf( __( 'Successfully executed action: %s', 'woocommerce' ), $action_hook_html );
 						break;
 					case 'cancel' :
-						$action_message_html = sprintf( __( 'Successfully canceled action: %s', 'action-scheduler' ), $action_hook_html );
+						$action_message_html = sprintf( __( 'Successfully canceled action: %s', 'woocommerce' ), $action_hook_html );
 						break;
 					default :
-						$action_message_html = sprintf( __( 'Successfully processed change for action: %s', 'action-scheduler' ), $action_hook_html );
+						$action_message_html = sprintf( __( 'Successfully processed change for action: %s', 'woocommerce' ), $action_hook_html );
 						break;
 				}
 			} else {
 				$class = 'error';
-				$action_message_html = sprintf( __( 'Could not process change for action: "%s" (ID: %d). Error: %s', 'action-scheduler' ), $action_hook_html, esc_html( $notification['action_id'] ), esc_html( $notification['error_message'] ) );
+				$action_message_html = sprintf( __( 'Could not process change for action: "%s" (ID: %d). Error: %s', 'woocommerce' ), $action_hook_html, esc_html( $notification['action_id'] ), esc_html( $notification['error_message'] ) );
 			}
 
 			$action_message_html = apply_filters( 'action_scheduler_admin_notice_html', $action_message_html, $action, $notification );
@@ -389,9 +389,9 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 		$schedule_display_string .= '<br/>';
 
 		if ( gmdate( 'U' ) > $next_timestamp ) {
-			$schedule_display_string .= sprintf( __( ' (%s ago)', 'action-scheduler' ), self::human_interval( gmdate( 'U' ) - $next_timestamp ) );
+			$schedule_display_string .= sprintf( __( ' (%s ago)', 'woocommerce' ), self::human_interval( gmdate( 'U' ) - $next_timestamp ) );
 		} else {
-			$schedule_display_string .= sprintf( __( ' (%s)', 'action-scheduler' ), self::human_interval( $next_timestamp - gmdate( 'U' ) ) );
+			$schedule_display_string .= sprintf( __( ' (%s)', 'woocommerce' ), self::human_interval( $next_timestamp - gmdate( 'U' ) ) );
 		}
 
 		return $schedule_display_string;
@@ -528,6 +528,6 @@ class ActionScheduler_ListTable extends ActionScheduler_Abstract_ListTable {
 	 * Get the text to display in the search box on the list table.
 	 */
 	protected function get_search_box_button_text() {
-		return __( 'Search hook, args and claim ID', 'action-scheduler' );
+		return __( 'Search hook, args and claim ID', 'woocommerce' );
 	}
 }

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_Logger.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_Logger.php
@@ -59,44 +59,44 @@ abstract class ActionScheduler_Logger {
 	}
 
 	public function log_stored_action( $action_id ) {
-		$this->log( $action_id, __( 'action created', 'action-scheduler' ) );
+		$this->log( $action_id, __( 'action created', 'woocommerce' ) );
 	}
 
 	public function log_canceled_action( $action_id ) {
-		$this->log( $action_id, __( 'action canceled', 'action-scheduler' ) );
+		$this->log( $action_id, __( 'action canceled', 'woocommerce' ) );
 	}
 
 	public function log_started_action( $action_id ) {
-		$this->log( $action_id, __( 'action started', 'action-scheduler' ) );
+		$this->log( $action_id, __( 'action started', 'woocommerce' ) );
 	}
 
 	public function log_completed_action( $action_id ) {
-		$this->log( $action_id, __( 'action complete', 'action-scheduler' ) );
+		$this->log( $action_id, __( 'action complete', 'woocommerce' ) );
 	}
 
 	public function log_failed_action( $action_id, Exception $exception ) {
-		$this->log( $action_id, sprintf( __( 'action failed: %s', 'action-scheduler' ), $exception->getMessage() ) );
+		$this->log( $action_id, sprintf( __( 'action failed: %s', 'woocommerce' ), $exception->getMessage() ) );
 	}
 
 	public function log_timed_out_action( $action_id, $timeout ) {
-		$this->log( $action_id, sprintf( __( 'action timed out after %s seconds', 'action-scheduler' ), $timeout ) );
+		$this->log( $action_id, sprintf( __( 'action timed out after %s seconds', 'woocommerce' ), $timeout ) );
 	}
 
 	public function log_unexpected_shutdown( $action_id, $error ) {
 		if ( ! empty( $error ) ) {
-			$this->log( $action_id, sprintf( __( 'unexpected shutdown: PHP Fatal error %s in %s on line %s', 'action-scheduler' ), $error['message'], $error['file'], $error['line'] ) );
+			$this->log( $action_id, sprintf( __( 'unexpected shutdown: PHP Fatal error %s in %s on line %s', 'woocommerce' ), $error['message'], $error['file'], $error['line'] ) );
 		}
 	}
 
 	public function log_reset_action( $action_id ) {
-		$this->log( $action_id, __( 'action reset', 'action_scheduler' ) );
+		$this->log( $action_id, __( 'action reset', 'woocommerce' ) );
 	}
 
 	public function log_ignored_action( $action_id ) {
-		$this->log( $action_id, __( 'action ignored', 'action-scheduler' ) );
+		$this->log( $action_id, __( 'action ignored', 'woocommerce' ) );
 	}
 
 	public function log_failed_fetch_action( $action_id ) {
-		$this->log( $action_id, __( 'There was a failure fetching this action', 'action-scheduler' ) );
+		$this->log( $action_id, __( 'There was a failure fetching this action', 'woocommerce' ) );
 	}
 }

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_QueueRunner.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_QueueRunner.php
@@ -107,7 +107,7 @@ class ActionScheduler_QueueRunner extends ActionScheduler_Abstract_QueueRunner {
 	public function add_wp_cron_schedule( $schedules ) {
 		$schedules['every_minute'] = array(
 			'interval' => 60, // in seconds
-			'display'  => __( 'Every minute' ),
+			'display'  => __( 'Every minute', 'woocommerce' ),
 		);
 
 		return $schedules;

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_Store.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_Store.php
@@ -149,7 +149,7 @@ abstract class ActionScheduler_Store {
 	protected function get_scheduled_date_string( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->next() : $scheduled_date;
 		if ( ! $next ) {
-			throw new InvalidArgumentException( __( 'Invalid schedule. Cannot save action.', 'action-scheduler' ) );
+			throw new InvalidArgumentException( __( 'Invalid schedule. Cannot save action.', 'woocommerce' ) );
 		}
 		$next->setTimezone( new DateTimeZone( 'UTC' ) );
 
@@ -166,7 +166,7 @@ abstract class ActionScheduler_Store {
 	protected function get_scheduled_date_string_local( ActionScheduler_Action $action, DateTime $scheduled_date = NULL ) {
 		$next = null === $scheduled_date ? $action->get_schedule()->next() : $scheduled_date;
 		if ( ! $next ) {
-			throw new InvalidArgumentException( __( 'Invalid schedule. Cannot save action.', 'action-scheduler' ) );
+			throw new InvalidArgumentException( __( 'Invalid schedule. Cannot save action.', 'woocommerce' ) );
 		}
 
 		ActionScheduler_TimezoneHelper::set_local_timezone( $next );
@@ -178,11 +178,11 @@ abstract class ActionScheduler_Store {
 	 */
 	public function get_status_labels() {
 		return array(
-			self::STATUS_COMPLETE => __( 'Complete', 'action-scheduler' ),
-			self::STATUS_PENDING  => __( 'Pending', 'action-scheduler' ),
-			self::STATUS_RUNNING  => __( 'In-progress', 'action-scheduler' ),
-			self::STATUS_FAILED   => __( 'Failed', 'action-scheduler' ),
-			self::STATUS_CANCELED => __( 'Canceled', 'action-scheduler' ),
+			self::STATUS_COMPLETE => __( 'Complete', 'woocommerce' ),
+			self::STATUS_PENDING  => __( 'Pending', 'woocommerce' ),
+			self::STATUS_RUNNING  => __( 'In-progress', 'woocommerce' ),
+			self::STATUS_FAILED   => __( 'Failed', 'woocommerce' ),
+			self::STATUS_CANCELED => __( 'Canceled', 'woocommerce' ),
 		);
 	}
 

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_WPCLI_QueueRunner.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_WPCLI_QueueRunner.php
@@ -28,7 +28,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	public function __construct( ActionScheduler_Store $store = null, ActionScheduler_FatalErrorMonitor $monitor = null, ActionScheduler_QueueCleaner $cleaner = null ) {
 		if ( ! ( defined( 'WP_CLI' ) && WP_CLI ) ) {
 			/* translators: %s php class name */
-			throw new Exception( sprintf( __( 'The %s class can only be run within WP CLI.', 'action-scheduler' ), __CLASS__ ) );
+			throw new Exception( sprintf( __( 'The %s class can only be run within WP CLI.', 'woocommerce' ), __CLASS__ ) );
 		}
 
 		parent::__construct( $store, $monitor, $cleaner );
@@ -56,9 +56,9 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		$too_many    = $claim_count >= $this->get_allowed_concurrent_batches();
 		if ( $too_many ) {
 			if ( $force ) {
-				WP_CLI::warning( __( 'There are too many concurrent batches, but the run is forced to continue.', 'action-scheduler' ) );
+				WP_CLI::warning( __( 'There are too many concurrent batches, but the run is forced to continue.', 'woocommerce' ) );
 			} else {
-				WP_CLI::error( __( 'There are too many concurrent batches.', 'action-scheduler' ) );
+				WP_CLI::error( __( 'There are too many concurrent batches.', 'woocommerce' ) );
 			}
 		}
 
@@ -89,7 +89,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	protected function setup_progress_bar() {
 		$count              = count( $this->actions );
 		$this->progress_bar = \WP_CLI\Utils\make_progress_bar(
-			sprintf( _n( 'Running %d action', 'Running %d actions', $count, 'action-scheduler' ), number_format_i18n( $count ) ),
+			sprintf( _n( 'Running %d action', 'Running %d actions', $count, 'woocommerce' ), number_format_i18n( $count ) ),
 			$count
 		);
 	}
@@ -106,7 +106,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 		foreach ( $this->actions as $action_id ) {
 			// Error if we lost the claim.
 			if ( ! in_array( $action_id, $this->store->find_actions_by_claim_id( $this->claim->get_id() ) ) ) {
-				WP_CLI::warning( __( 'The claim has been lost. Aborting current batch.', 'action-scheduler' ) );
+				WP_CLI::warning( __( 'The claim has been lost. Aborting current batch.', 'woocommerce' ) );
 				break;
 			}
 
@@ -132,7 +132,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 */
 	public function before_execute( $action_id ) {
 		/* translators: %s refers to the action ID */
-		WP_CLI::log( sprintf( __( 'Started processing action %s', 'action-scheduler' ), $action_id ) );
+		WP_CLI::log( sprintf( __( 'Started processing action %s', 'woocommerce' ), $action_id ) );
 	}
 
 	/**
@@ -149,7 +149,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 			$action = $this->store->fetch_action( $action_id );
 		}
 		/* translators: %s refers to the action ID */
-		WP_CLI::log( sprintf( __( 'Completed processing action %s with hook: %s', 'action-scheduler' ), $action_id, $action->get_hook() ) );
+		WP_CLI::log( sprintf( __( 'Completed processing action %s with hook: %s', 'woocommerce' ), $action_id, $action->get_hook() ) );
 	}
 
 	/**
@@ -164,7 +164,7 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	public function action_failed( $action_id, $exception ) {
 		WP_CLI::error(
 			/* translators: %1$s refers to the action ID, %2$s refers to the Exception message */
-			sprintf( __( 'Error processing action %1$s: %2$s', 'action-scheduler' ), $action_id, $exception->getMessage() ),
+			sprintf( __( 'Error processing action %1$s: %2$s', 'woocommerce' ), $action_id, $exception->getMessage() ),
 			false
 		);
 	}
@@ -176,11 +176,12 @@ class ActionScheduler_WPCLI_QueueRunner extends ActionScheduler_Abstract_QueueRu
 	 */
 	protected function stop_the_insanity( $sleep_time = 0 ) {
 		if ( 0 < $sleep_time ) {
-			WP_CLI::warning( sprintf( 'Stopped the insanity for %d %s', $sleep_time, _n( 'second', 'seconds', $sleep_time ) ) );
+			/* translators: 1: sleep time 2: time unit */
+			WP_CLI::warning( sprintf( __( 'Stopped the insanity for %$1d %$2s', 'woocommerce' ), $sleep_time, _n( 'second', 'seconds', $sleep_time, 'woocommerce' ) ) );
 			sleep( $sleep_time );
 		}
 
-		WP_CLI::warning( __( 'Attempting to reduce used memory...', 'action-scheduler' ) );
+		WP_CLI::warning( __( 'Attempting to reduce used memory...', 'woocommerce' ) );
 
 		/**
 		 * @var $wpdb            \wpdb

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_WPCLI_Scheduler_command.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_WPCLI_Scheduler_command.php
@@ -84,7 +84,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to how many scheduled taks were found to run */
-				_n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'action-scheduler' ),
+				_n( 'Found %d scheduled task', 'Found %d scheduled tasks', $total, 'woocommerce' ),
 				number_format_i18n( $total )
 			)
 		);
@@ -101,7 +101,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		WP_CLI::log(
 			sprintf(
 				/* translators: %d refers to the total number of batches executed */
-				_n( '%d batch executed.', '%d batches executed.', $batches_completed, 'action-scheduler' ),
+				_n( '%d batch executed.', '%d batches executed.', $batches_completed, 'woocommerce' ),
 				number_format_i18n( $batches_completed )
 			)
 		);
@@ -120,7 +120,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		WP_CLI::error(
 			sprintf(
 				/* translators: %s refers to the exception error message. */
-				__( 'There was an error running the action scheduler: %s', 'action-scheduler' ),
+				__( 'There was an error running the action scheduler: %s', 'woocommerce' ),
 				$e->getMessage()
 			)
 		);
@@ -137,7 +137,7 @@ class ActionScheduler_WPCLI_Scheduler_command extends WP_CLI_Command {
 		WP_CLI::success(
 			sprintf(
 				/* translators: %d refers to the total number of taskes completed */
-				_n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'action-scheduler' ),
+				_n( '%d scheduled task completed.', '%d scheduled tasks completed.', $actions_completed, 'woocommerce' ),
 				number_format_i18n( $actions_completed )
 			)
 		);

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_wcSystemStatus.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_wcSystemStatus.php
@@ -97,14 +97,14 @@ class ActionScheduler_wcSystemStatus {
 		<table class="wc_status_table widefat" cellspacing="0">
 			<thead>
 				<tr>
-					<th colspan="5" data-export-label="Action Scheduler"><h2><?php esc_html_e( 'Action Scheduler', 'action-scheduler' ); ?><?php echo wc_help_tip( esc_html__( 'This section shows scheduled action counts.', 'action-scheduler' ) ); ?></h2></th>
+					<th colspan="5" data-export-label="Action Scheduler"><h2><?php esc_html_e( 'Action Scheduler', 'woocommerce' ); ?><?php echo wc_help_tip( esc_html__( 'This section shows scheduled action counts.', 'woocommerce' ) ); ?></h2></th>
 				</tr>
 				<tr>
-					<td><strong><?php esc_html_e( 'Action Status', 'action-scheduler' ); ?></strong></td>
+					<td><strong><?php esc_html_e( 'Action Status', 'woocommerce' ); ?></strong></td>
 					<td class="help">&nbsp;</td>
-					<td><strong><?php esc_html_e( 'Count', 'action-scheduler' ); ?></strong></td>
-					<td><strong><?php esc_html_e( 'Oldest Scheduled Date', 'action-scheduler' ); ?></strong></td>
-					<td><strong><?php esc_html_e( 'Newest Scheduled Date', 'action-scheduler' ); ?></strong></td>
+					<td><strong><?php esc_html_e( 'Count', 'woocommerce' ); ?></strong></td>
+					<td><strong><?php esc_html_e( 'Oldest Scheduled Date', 'woocommerce' ); ?></strong></td>
+					<td><strong><?php esc_html_e( 'Newest Scheduled Date', 'woocommerce' ); ?></strong></td>
 				</tr>
 			</thead>
 			<tbody>

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore.php
@@ -30,7 +30,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 			do_action( 'action_scheduler_stored_action', $post_id );
 			return $post_id;
 		} catch ( Exception $e ) {
-			throw new RuntimeException( sprintf( __('Error saving action: %s', 'action-scheduler'), $e->getMessage() ), 0 );
+			throw new RuntimeException( sprintf( __('Error saving action: %s', 'woocommerce'), $e->getMessage() ), 0 );
 		}
 	}
 
@@ -54,7 +54,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		remove_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10 );
 
 		if ( is_wp_error($post_id) || empty($post_id) ) {
-			throw new RuntimeException(__('Unable to save action.', 'action-scheduler'));
+			throw new RuntimeException(__('Unable to save action.', 'woocommerce'));
 		}
 		return $post_id;
 	}
@@ -275,7 +275,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	protected function get_query_actions_sql( array $query, $select_or_count = 'select' ) {
 
 		if ( ! in_array( $select_or_count, array( 'select', 'count' ) ) ) {
-			throw new InvalidArgumentException(__('Invalid schedule. Cannot save action.', 'action-scheduler'));
+			throw new InvalidArgumentException(__('Invalid schedule. Cannot save action.', 'woocommerce'));
 		}
 
 		$query = wp_parse_args( $query, array(
@@ -448,7 +448,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	public function cancel_action( $action_id ) {
 		$post = get_post($action_id);
 		if ( empty($post) || ($post->post_type != self::POST_TYPE) ) {
-			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'action-scheduler'), $action_id));
+			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'woocommerce'), $action_id));
 		}
 		do_action( 'action_scheduler_canceled_action', $action_id );
 		add_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10, 5 );
@@ -459,7 +459,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	public function delete_action( $action_id ) {
 		$post = get_post($action_id);
 		if ( empty($post) || ($post->post_type != self::POST_TYPE) ) {
-			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'action-scheduler'), $action_id));
+			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'woocommerce'), $action_id));
 		}
 		do_action( 'action_scheduler_deleted_action', $action_id );
 		wp_delete_post($action_id, TRUE);
@@ -485,7 +485,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	public function get_date_gmt( $action_id ) {
 		$post = get_post($action_id);
 		if ( empty($post) || ($post->post_type != self::POST_TYPE) ) {
-			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'action-scheduler'), $action_id));
+			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'woocommerce'), $action_id));
 		}
 		if ( $post->post_status == 'publish' ) {
 			return as_get_datetime_object($post->post_modified_gmt);
@@ -597,7 +597,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		// Run the query and gather results.
 		$rows_affected = $wpdb->query( $wpdb->prepare( "{$update} {$where} {$order}", $params ) );
 		if ( $rows_affected === false ) {
-			throw new RuntimeException( __( 'Unable to claim actions. Database error.', 'action-scheduler' ) );
+			throw new RuntimeException( __( 'Unable to claim actions. Database error.', 'woocommerce' ) );
 		}
 
 		return (int) $rows_affected;
@@ -617,7 +617,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	protected function get_actions_by_group( $group, $limit, DateTime $date ) {
 		// Ensure the group exists before continuing.
 		if ( ! term_exists( $group, self::GROUP_TAXONOMY )) {
-			throw new InvalidArgumentException( sprintf( __( 'The group "%s" does not exist.', 'action-scheduler' ), $group ) );
+			throw new InvalidArgumentException( sprintf( __( 'The group "%s" does not exist.', 'woocommerce' ), $group ) );
 		}
 
 		// Set up a query for post IDs to use later.
@@ -678,7 +678,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$sql = $wpdb->prepare( $sql, array( $claim->get_id() ) );
 		$result = $wpdb->query($sql);
 		if ( $result === false ) {
-			throw new RuntimeException( sprintf( __('Unable to unlock claim %s. Database error.', 'action-scheduler'), $claim->get_id() ) );
+			throw new RuntimeException( sprintf( __('Unable to unlock claim %s. Database error.', 'woocommerce'), $claim->get_id() ) );
 		}
 	}
 
@@ -692,7 +692,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$sql = $wpdb->prepare( $sql, $action_id, self::POST_TYPE );
 		$result = $wpdb->query($sql);
 		if ( $result === false ) {
-			throw new RuntimeException( sprintf( __('Unable to unlock claim on action %s. Database error.', 'action-scheduler'), $action_id ) );
+			throw new RuntimeException( sprintf( __('Unable to unlock claim on action %s. Database error.', 'woocommerce'), $action_id ) );
 		}
 	}
 
@@ -703,7 +703,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$sql = $wpdb->prepare( $sql, self::STATUS_FAILED, $action_id, self::POST_TYPE );
 		$result = $wpdb->query($sql);
 		if ( $result === false ) {
-			throw new RuntimeException( sprintf( __('Unable to mark failure on action %s. Database error.', 'action-scheduler'), $action_id ) );
+			throw new RuntimeException( sprintf( __('Unable to mark failure on action %s. Database error.', 'woocommerce'), $action_id ) );
 		}
 	}
 
@@ -727,7 +727,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 		$status = $this->get_post_column( $action_id, 'post_status' );
 
 		if ( $status === null ) {
-			throw new InvalidArgumentException( __( 'Invalid action ID. No status found.', 'action-scheduler' ) );
+			throw new InvalidArgumentException( __( 'Invalid action ID. No status found.', 'woocommerce' ) );
 		}
 
 		return $this->get_action_status_by_post_status( $status );
@@ -755,7 +755,7 @@ class ActionScheduler_wpPostStore extends ActionScheduler_Store {
 	public function mark_complete( $action_id ) {
 		$post = get_post($action_id);
 		if ( empty($post) || ($post->post_type != self::POST_TYPE) ) {
-			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'action-scheduler'), $action_id));
+			throw new InvalidArgumentException(sprintf(__('Unidentified action %s', 'woocommerce'), $action_id));
 		}
 		add_filter( 'wp_insert_post_data', array( $this, 'filter_insert_post_data' ), 10, 1 );
 		add_filter( 'pre_wp_unique_post_slug', array( $this, 'set_unique_post_slug' ), 10, 5 );

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore_PostStatusRegistrar.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore_PostStatusRegistrar.php
@@ -33,8 +33,8 @@ class ActionScheduler_wpPostStore_PostStatusRegistrar {
 	 */
 	protected function post_status_failed_labels() {
 		$labels = array(
-			'label'       => _x( 'Failed', 'post' ),
-			'label_count' => _n_noop( 'Failed <span class="count">(%s)</span>', 'Failed <span class="count">(%s)</span>' ),
+			'label'       => _x( 'Failed', 'post', 'woocommerce' ),
+			'label_count' => _n_noop( 'Failed <span class="count">(%s)</span>', 'Failed <span class="count">(%s)</span>', 'woocommerce' ),
 		);
 
 		return apply_filters( 'action_scheduler_post_status_failed_labels', $labels );
@@ -47,11 +47,10 @@ class ActionScheduler_wpPostStore_PostStatusRegistrar {
 	 */
 	protected function post_status_running_labels() {
 		$labels = array(
-			'label'       => _x( 'In-Progress', 'post' ),
-			'label_count' => _n_noop( 'In-Progress <span class="count">(%s)</span>', 'In-Progress <span class="count">(%s)</span>' ),
+			'label'       => _x( 'In-Progress', 'post', 'woocommerce' ),
+			'label_count' => _n_noop( 'In-Progress <span class="count">(%s)</span>', 'In-Progress <span class="count">(%s)</span>', 'woocommerce' ),
 		);
 
 		return apply_filters( 'action_scheduler_post_status_running_labels', $labels );
 	}
 }
- 

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore_PostTypeRegistrar.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore_PostTypeRegistrar.php
@@ -30,9 +30,9 @@ class ActionScheduler_wpPostStore_PostTypeRegistrar {
 				'name' => __( 'Scheduled Actions', 'woocommerce' ),
 				'singular_name' => __( 'Scheduled Action', 'woocommerce' ),
 				'menu_name' => _x( 'Scheduled Actions', 'Admin menu name', 'woocommerce' ),
-				'add_new' => __( 'Add', 'action-scheduler' ),
+				'add_new' => __( 'Add', 'woocommerce' ),
 				'add_new_item' => __( 'Add New Scheduled Action', 'woocommerce' ),
-				'edit' => __( 'Edit', 'action-scheduler' ),
+				'edit' => __( 'Edit', 'woocommerce' ),
 				'edit_item' => __( 'Edit Scheduled Action', 'woocommerce' ),
 				'new_item' => __( 'New Scheduled Action', 'woocommerce' ),
 				'view' => __( 'View Action', 'woocommerce' ),
@@ -47,4 +47,4 @@ class ActionScheduler_wpPostStore_PostTypeRegistrar {
 		return $args;
 	}
 }
- 
+

--- a/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore_TaxonomyRegistrar.php
+++ b/includes/libraries/action-scheduler/classes/ActionScheduler_wpPostStore_TaxonomyRegistrar.php
@@ -11,7 +11,7 @@ class ActionScheduler_wpPostStore_TaxonomyRegistrar {
 
 	protected function taxonomy_args() {
 		$args = array(
-			'label' => __('Action Group', 'action-scheduler'),
+			'label' => __('Action Group', 'woocommerce'),
 			'public' => false,
 			'hierarchical' => false,
 			'show_admin_column' => true,
@@ -23,4 +23,3 @@ class ActionScheduler_wpPostStore_TaxonomyRegistrar {
 		return $args;
 	}
 }
- 

--- a/includes/libraries/wp-background-process.php
+++ b/includes/libraries/wp-background-process.php
@@ -420,7 +420,7 @@ abstract class WP_Background_Process extends WP_Async_Request {
 		// Adds every 5 minutes to the existing schedules.
 		$schedules[ $this->identifier . '_cron_interval' ] = array(
 			'interval' => MINUTE_IN_SECONDS * $interval,
-			'display'  => sprintf( __( 'Every %d Minutes' ), $interval ),
+			'display'  => sprintf( __( 'Every %d minutes', 'woocommerce' ), $interval ),
 		);
 
 		return $schedules;


### PR DESCRIPTION
We need to check for text domains in the libraries, there's several errors coming from `action-scheduler`, but Action Scheduler requires some updates in order to us proper fix it, also I think that we should start including the Action Scheduler as a package like we does for product blocks and REST API.