### PR TITLE
Add get_stripe_supported_countries method and update list

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1234,31 +1234,7 @@ class WC_Admin_Setup_Wizard {
 	 * @param string $country_code Country code.
 	 */
 	protected function is_stripe_supported_country( $country_code ) {
-		$stripe_supported_countries = array(
-			'AU',
-			'AT',
-			'BE',
-			'CA',
-			'DK',
-			'FI',
-			'FR',
-			'DE',
-			'HK',
-			'IE',
-			'JP',
-			'LU',
-			'NL',
-			'NZ',
-			'NO',
-			'SG',
-			'ES',
-			'SE',
-			'CH',
-			'GB',
-			'US',
-		);
-
-		return in_array( $country_code, $stripe_supported_countries, true );
+		return in_array( $country_code, WC()->countries->get_stripe_supported_countries(), true );
 	}
 
 	/**

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -348,6 +348,49 @@ class WC_Countries {
 	}
 
 	/**
+	 * Gets an array of countries that can use Stripe.
+	 *
+	 * @return string[]
+	 */
+	public function get_stripe_supported_countries() {
+		// https://stripe.com/global.
+		$countries = array(
+			'AU',
+			'AT',
+			'BE',
+			'CA',
+			'DK',
+			'EE',
+			'FI',
+			'FR',
+			'DE',
+			'GR',
+			'HK',
+			'IE',
+			'IT',
+			'JP',
+			'LV',
+			'LT',
+			'LU',
+			'MY',
+			'NL',
+			'NZ',
+			'NO',
+			'PL',
+			'PT',
+			'SG',
+			'SK',
+			'SI',
+			'ES',
+			'SE',
+			'CH',
+			'GB',
+			'US',
+		);
+		return $countries;
+	}
+
+	/**
 	 * Gets an array of countries in the EU.
 	 *
 	 * MC (monaco) and IM (isle of man, part of UK) also use VAT.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a new public `get_stripe_supported_countries()` method to `WC_Countries`, similar to the `get_european_union_countries` method.

This method will be used within the new WooCommerce Onboarding experience, to correctly show and enable the Stripe method without duplicating lists between core and WooComomerce Admin. See https://github.com/woocommerce/woocommerce-admin/pull/3099.

The list of supported countries has also been updated. Previously there were `21` supported countries. Now there are `31`. We should perhaps add a major release check-list item to look at the list of supported countries, because it looks like a few more are pending.

### How to test the changes in this Pull Request:

1. Go to `/wp-admin/admin.php?page=wc-setup` and set your country to a Stripe enabled country.
2. Continue to the payment step and make sure Stripe shows up.
3. Try again with a country not supported by Stripe, and make sure the payment method doesn't show up.

### Changelog entry

Dev: Adds a `get_stripe_supported_countries()` method to `WC_Countries`.
