### PR TITLE
Remove unneeded @throw tag | spotfix

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -943,7 +943,6 @@ class WC_Discounts {
 	 * - 114: Excluded categories.
 	 *
 	 * @since  3.2.0
-	 * @throws Exception Error message.
 	 * @param  WC_Coupon $coupon Coupon data.
 	 * @return bool|WP_Error
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removes an unneeded `@throw` tag.

Any exceptions thrown inside this method are also caught inside the method, so, other pieces of code making use of this method need not worry about exception handling (but the `@throw` tag implies that they should, and in fact makes various IDEs/analysis tools complain if there is no handling).

Removing the `@throw` tag is an easy way to solve this and improves the accuracy of the docblock.

### Changelog entry

> Remove unneeded `@throw` tag.
