### PR TITLE
Revert PR 24526.

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1426,12 +1426,6 @@ class WC_Order extends WC_Abstract_Order {
 				continue;
 			}
 
-			// Check item refunds.
-			$refunded_qty = abs( $this->get_qty_refunded_for_item( $item->get_id() ) );
-			if ( $refunded_qty && $item->get_quantity() === $refunded_qty ) {
-				continue;
-			}
-
 			if ( $item->is_type( 'line_item' ) ) {
 				$item_downloads = $item->get_item_downloads();
 				$product        = $item->get_product();

--- a/readme.txt
+++ b/readme.txt
@@ -264,7 +264,6 @@ INTERESTED IN DEVELOPMENT?
 * Fix - Use `esc_attr_e` instead of `esc_html_e` for escaping an attribute in multiple places. #24481, #24520, #24521, #24522, #24523, #24524
 * Fix - Use `esc_attr__` instead of `esc_html__` in escaping attributes string. #24525, #24529
 * Fix - Typo fix in payment captured error message. #24501
-* Fix - Remove broken download link for downloadable product in refund emails. #24526
 * Fix - Documentation URL in failed order email content. #24535
 * Fix - "Add to cart" links in feed. #24545
 * Fix - Escaping in Storefront banner. #24546


### PR DESCRIPTION


### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This reverts PR #24526 because in the refund mail this completely removes the downloadable product. We should instead only remove the downloadable link and keep the details of the product.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

