### PR TITLE
Fixed misleading message for Shipping options in cart

### DIFF
--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -59,7 +59,7 @@ $calculator_text          = '';
 			<?php
 		elseif ( ! $has_calculated_shipping || ! $formatted_destination ) :
 			if ( is_cart() && 'no' === get_option( 'woocommerce_enable_shipping_calc' ) ) {
-				echo wp_kses_post( apply_filters( 'woocommerce_shipping_may_be_available_cart_nocalc_html', __( 'Shipping costs are calculated during checkout.', 'woocommerce' ) ) );
+				echo wp_kses_post( apply_filters( 'woocommerce_shipping_not_enabled_on_cart_html', __( 'Shipping costs are calculated during checkout.', 'woocommerce' ) ) );
 			} else {
 				echo wp_kses_post( apply_filters( 'woocommerce_shipping_may_be_available_html', __( 'Enter your address to view shipping options.', 'woocommerce' ) ) );
 			}

--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -58,7 +58,11 @@ $calculator_text          = '';
 			<?php endif; ?>
 			<?php
 		elseif ( ! $has_calculated_shipping || ! $formatted_destination ) :
-			echo wp_kses_post( apply_filters( 'woocommerce_shipping_may_be_available_html', __( 'Enter your address to view shipping options.', 'woocommerce' ) ) );
+			if ( is_cart() && 'no' === get_option( 'woocommerce_enable_shipping_calc' ) ) {
+				echo wp_kses_post( apply_filters( 'woocommerce_shipping_may_be_available_cart_nocalc_html', __( 'Shipping costs are calculated during checkout.', 'woocommerce' ) ) );
+			} else {
+				echo wp_kses_post( apply_filters( 'woocommerce_shipping_may_be_available_html', __( 'Enter your address to view shipping options.', 'woocommerce' ) ) );
+			}
 		elseif ( ! is_cart() ) :
 			echo wp_kses_post( apply_filters( 'woocommerce_no_shipping_available_html', __( 'There are no shipping options available. Please ensure that your address has been entered correctly, or contact us if you need any help.', 'woocommerce' ) ) );
 		else :


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Changed as suggested in #24674

Closes #24674.

### How to test the changes in this Pull Request:

1. Go to `wp-admin/admin.php?page=wc-settings&tab=shipping&section=options` and disable "Enable the shipping calculator on the cart page" and "Hide shipping costs until an address is entered" options.
2. Go to `wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=0` and remove all your shipping methods from "Locations not covered by your other zones". 
3. Go to `wp-admin/admin.php?page=wc-settings&tab=general` and change "Default customer location" to "No location by default".
4. Open a private browsing window and add to the cart some simple product (need to make sure that is not virtual).
5. Check the message in the cart, will be "Enter your address to view shipping options.", and note that there's no form to fill the address, since we disabled it on step 1.
6. Apply this patch and check the new message "Shipping costs are calculated during checkout."

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed misleading message for Shipping options in cart.
> Dev - Introduced `woocommerce_shipping_not_enabled_on_cart_html` filter.
