### PR TITLE
Show password hover on wc forms

### DIFF
--- a/assets/css/woocommerce-layout.scss
+++ b/assets/css/woocommerce-layout.scss
@@ -352,6 +352,27 @@
 		.form-row-wide {
 			clear: both;
 		}
+
+		.password-input {
+			display: flex;
+			flex-direction: column;
+			justify-content: center;
+			position: relative;
+		}
+
+		.show-password-input {
+			position: absolute;
+			right: 0.7em;
+			top: 0.7em;
+		}
+
+		.show-password-input::after {
+			@include iconafter( "\e010" ); 	// Icon styles and glyph
+		}
+
+		.show-password-input:hover::after {
+			color: #e8e8e8;
+		}
 	}
 
 	#payment {

--- a/assets/css/woocommerce-layout.scss
+++ b/assets/css/woocommerce-layout.scss
@@ -364,13 +364,14 @@
 			position: absolute;
 			right: 0.7em;
 			top: 0.7em;
+			cursor: pointer;
 		}
 
 		.show-password-input::after {
 			@include iconafter( "\e010" ); 	// Icon styles and glyph
 		}
 
-		.show-password-input:hover::after {
+		.show-password-input.display-password:after {
 			color: #e8e8e8;
 		}
 	}

--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -78,4 +78,17 @@ jQuery( function( $ ) {
 			}, 1000 );
 		}
 	};
+
+	// Show password visiblity hover icon on woocommerce forms
+	$( '.woocommerce form input[type="password"]' ).wrap( '<span class="password-input"></span>' );
+	$( '.password-input' ).append( '<span class="show-password-input"></span>' );
+
+	$( '.show-password-input' ).hover(
+		function() {
+			$( this ).siblings( array( 'input[name="password"]', 'input[type="password"]' ) ).prop( 'type', 'text' );
+		},
+		function() {
+			$( this ).siblings( array( 'input[name="password"]', 'input[type="password"]' ) ).prop( 'type', 'password' );
+		}
+	);
 });

--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -83,12 +83,14 @@ jQuery( function( $ ) {
 	$( '.woocommerce form input[type="password"]' ).wrap( '<span class="password-input"></span>' );
 	$( '.password-input' ).append( '<span class="show-password-input"></span>' );
 
-	$( '.show-password-input' ).hover(
+	$( '.show-password-input' ).click(
 		function() {
-			$( this ).siblings( ['input[name="password"]', 'input[type="password"]'] ).prop( 'type', 'text' );
-		},
-		function() {
-			$( this ).siblings( ['input[name="password"]', 'input[type="password"]'] ).prop( 'type', 'password' );
+			$( this ).toggleClass( 'display-password' );
+			if ( $( this ).hasClass('display-password') ) {
+				$( this ).siblings( ['input[name="password"]', 'input[type="password"]'] ).prop('type', 'text');
+			} else {
+				$( this ).siblings( 'input[name="password"]' ).prop('type', 'password');
+			}
 		}
 	);
 });

--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -85,10 +85,10 @@ jQuery( function( $ ) {
 
 	$( '.show-password-input' ).hover(
 		function() {
-			$( this ).siblings( array( 'input[name="password"]', 'input[type="password"]' ) ).prop( 'type', 'text' );
+			$( this ).siblings( ['input[name="password"]', 'input[type="password"]'] ).prop( 'type', 'text' );
 		},
 		function() {
-			$( this ).siblings( array( 'input[name="password"]', 'input[type="password"]' ) ).prop( 'type', 'password' );
+			$( this ).siblings( ['input[name="password"]', 'input[type="password"]'] ).prop( 'type', 'password' );
 		}
 	);
 });


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added a javascript only solution to display a password visibilty icon on all woocommerce login form password inputs, as I found a related open issue (#24823 ) and i thought it was a good idea for my first pull request!

### How to test the changes in this Pull Request:

1. Visit any woocommerce login form and hover over the new "eye" visibility icon on the password input

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added hover icon on password input fields to briefly toggle input text visibility for browsers with javascript enabled
