### PR TITLE
Fix/20921 - Throw error for invalid character in flat rate cost.

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -1279,13 +1279,19 @@ class WC_Admin_Setup_Wizard {
 
 			// Save chosen shipping method settings (using REST controller for convenience).
 			if ( ! empty( $_POST['shipping_zones']['domestic'][ $domestic_method ] ) ) { // WPCS: input var ok.
+
+				// Sanitize the cost field.
+				$domestic_cost = wc_clean( wp_unslash( $_POST['shipping_zones']['domestic'][ $domestic_method ] ) );
+				$domestic_cost = str_replace( array( get_woocommerce_currency_symbol(), html_entity_decode( get_woocommerce_currency_symbol() ) ), '', $domestic_cost );
+
+				// Build and make a REST request to save the shipping zone and method set.
 				$request = new WP_REST_Request( 'POST', "/wc/v3/shipping/zones/{$zone_id}/methods" );
 				$request->add_header( 'Content-Type', 'application/json' );
 				$request->set_body(
 					wp_json_encode(
 						array(
 							'method_id' => $domestic_method,
-							'settings'  => wc_clean( wp_unslash( $_POST['shipping_zones']['domestic'][ $domestic_method ] ) ),
+							'settings'  => $domestic_cost,
 						)
 					)
 				);
@@ -1297,13 +1303,19 @@ class WC_Admin_Setup_Wizard {
 		if ( $setup_intl ) {
 			// Save chosen shipping method settings (using REST controller for convenience).
 			if ( ! empty( $_POST['shipping_zones']['intl'][ $intl_method ] ) ) { // WPCS: input var ok.
+
+				// Sanitize the cost field.
+				$intl_cost = wc_clean( wp_unslash( $_POST['shipping_zones']['intl'][ $intl_method ] ) );
+				$intl_cost = str_replace( array( get_woocommerce_currency_symbol(), html_entity_decode( get_woocommerce_currency_symbol() ) ), '', $intl_cost );
+
+				// Build and make a REST request to save the shipping zone and method set.
 				$request = new WP_REST_Request( 'POST', '/wc/v3/shipping/zones/0/methods' );
 				$request->add_header( 'Content-Type', 'application/json' );
 				$request->set_body(
 					wp_json_encode(
 						array(
 							'method_id' => $intl_method,
-							'settings'  => wc_clean( wp_unslash( $_POST['shipping_zones']['intl'][ $intl_method ] ) ),
+							'settings'  => $intl_cost,
 						)
 					)
 				);

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -937,6 +937,7 @@ class WC_Admin_Setup_Wizard {
 						'default_value' => __( 'Cost', 'woocommerce' ),
 						'description'   => __( 'What would you like to charge for flat rate shipping?', 'woocommerce' ),
 						'required'      => true,
+						'pattern'       => '^[+-]?[0-9]{1,3}(?:[0-9]*(?:[.,][0-9]{2})?|(?:,[0-9]{3})*(?:\.[0-9]{2})?|(?:\.[0-9]{3})*(?:,[0-9]{2})?)$',
 					),
 				),
 			),
@@ -999,6 +1000,7 @@ class WC_Admin_Setup_Wizard {
 					name="<?php echo esc_attr( $method_setting_id ); ?>"
 					class="<?php echo esc_attr( $setting['required'] ? 'shipping-method-required-field' : '' ); ?>"
 					<?php echo ( $method_id === $selected && $setting['required'] ) ? 'required' : ''; ?>
+					pattern=<?php echo esc_attr( $method_id === $selected && $setting['pattern'] ? $setting['pattern'] : '' ); ?>
 				/>
 				<p class="description">
 					<?php echo esc_html( $setting['description'] ); ?>

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -937,7 +937,6 @@ class WC_Admin_Setup_Wizard {
 						'default_value' => __( 'Cost', 'woocommerce' ),
 						'description'   => __( 'What would you like to charge for flat rate shipping?', 'woocommerce' ),
 						'required'      => true,
-						'pattern'       => '^[+-]?[0-9]{1,3}(?:[0-9]*(?:[.,][0-9]{2})?|(?:,[0-9]{3})*(?:\.[0-9]{2})?|(?:\.[0-9]{3})*(?:,[0-9]{2})?)$',
 					),
 				),
 			),
@@ -1000,7 +999,6 @@ class WC_Admin_Setup_Wizard {
 					name="<?php echo esc_attr( $method_setting_id ); ?>"
 					class="<?php echo esc_attr( $setting['required'] ? 'shipping-method-required-field' : '' ); ?>"
 					<?php echo ( $method_id === $selected && $setting['required'] ) ? 'required' : ''; ?>
-					pattern=<?php echo esc_attr( $method_id === $selected && $setting['pattern'] ? $setting['pattern'] : '' ); ?>
 				/>
 				<p class="description">
 					<?php echo esc_html( $setting['description'] ); ?>

--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -264,7 +264,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 		$value = wp_kses_post( trim( wp_unslash( $value ) ) );
 		$value = str_replace( array( get_woocommerce_currency_symbol(), html_entity_decode( get_woocommerce_currency_symbol() ) ), '', $value );
 		// Thrown an error on the front end if the evaluate_cost will fail.
-		if ( ! $this->evaluate_cost( $value ) ) {
+		if ( false === $this->evaluate_cost( $value ) ) {
 			throw new Exception( WC_Eval_Math::$last_error );
 		}
 		return $value;

--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -256,12 +256,17 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 	 *
 	 * @since 3.4.0
 	 * @param string $value Unsanitized value.
+	 * @throws Exception Last error triggered.
 	 * @return string
 	 */
 	public function sanitize_cost( $value ) {
 		$value = is_null( $value ) ? '' : $value;
 		$value = wp_kses_post( trim( wp_unslash( $value ) ) );
 		$value = str_replace( array( get_woocommerce_currency_symbol(), html_entity_decode( get_woocommerce_currency_symbol() ) ), '', $value );
+		// Thrown an error on the front end if the evaluate_cost will fail.
+		if ( ! $this->evaluate_cost( $value ) ) {
+			throw new Exception( WC_Eval_Math::$last_error );
+		}
 		return $value;
 	}
 }


### PR DESCRIPTION
Added a call to the evaluate_cost function in the flat rate shipping cost input's sanitize_cost function to throw an exception if there is an illegal character in the input in the back end to avoid the error going unnoticed until a user/customer hits it in the front-end

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This change would run the the evaluate_cost function on the flat rate shipping's input sanitize_cost function throwing any error in the back-end before they happen on the front end.
Closes #20921

### How to test the changes in this Pull Request:

1. In WooCommerce General Settings set the site currency to EUR €.
2. Set up a shipping zone with a flat rate shipping method.
3. Enter a USD $ currency symbol or some other invalid character like an under score _ into the cost field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix: Added validation to the cost field for flat rate shipping.

