### PR TITLE
added single product meta filters for categories and tags

### DIFF
--- a/templates/single-product/meta.php
+++ b/templates/single-product/meta.php
@@ -31,13 +31,17 @@ global $product;
 
 	<?php endif; ?>
 
-	<?php if ( apply_filters( 'wc_product_categories_enabled', true ) ) : 
-		echo wc_get_product_category_list( $product->get_id(), ', ', '<span class="posted_in">' . _n( 'Category:', 'Categories:', count( $product->get_category_ids() ), 'woocommerce' ) . ' ', '</span>' ); 
-	endif; ?>
+	<?php if ( apply_filters( 'wc_product_categories_enabled', true ) ) : ?>
 	
-	<?php if ( apply_filters( 'wc_product_tags_enabled', true ) ) :
-		echo wc_get_product_tag_list( $product->get_id(), ', ', '<span class="tagged_as">' . _n( 'Tag:', 'Tags:', count( $product->get_tag_ids() ), 'woocommerce' ) . ' ', '</span>' ); 
-	endif;?>
+	<?php echo wc_get_product_category_list( $product->get_id(), ', ', '<span class="posted_in">' . _n( 'Category:', 'Categories:', count( $product->get_category_ids() ), 'woocommerce' ) . ' ', '</span>' ); ?>
+
+	<?php endif; ?>
+	
+	<?php if ( apply_filters( 'wc_product_tags_enabled', true ) ) : ?>
+
+	<?php echo wc_get_product_tag_list( $product->get_id(), ', ', '<span class="tagged_as">' . _n( 'Tag:', 'Tags:', count( $product->get_tag_ids() ), 'woocommerce' ) . ' ', '</span>' ); ?>
+
+	<?php endif;?>
 
 	<?php do_action( 'woocommerce_product_meta_end' ); ?>
 

--- a/templates/single-product/meta.php
+++ b/templates/single-product/meta.php
@@ -12,7 +12,7 @@
  *
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @package 	WooCommerce/Templates
- * @version     3.0.0
+ * @version 	3.8.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -31,9 +31,13 @@ global $product;
 
 	<?php endif; ?>
 
-	<?php echo wc_get_product_category_list( $product->get_id(), ', ', '<span class="posted_in">' . _n( 'Category:', 'Categories:', count( $product->get_category_ids() ), 'woocommerce' ) . ' ', '</span>' ); ?>
-
-	<?php echo wc_get_product_tag_list( $product->get_id(), ', ', '<span class="tagged_as">' . _n( 'Tag:', 'Tags:', count( $product->get_tag_ids() ), 'woocommerce' ) . ' ', '</span>' ); ?>
+	<?php if ( apply_filters( 'wc_product_categories_enabled', true ) ) : 
+		echo wc_get_product_category_list( $product->get_id(), ', ', '<span class="posted_in">' . _n( 'Category:', 'Categories:', count( $product->get_category_ids() ), 'woocommerce' ) . ' ', '</span>' ); 
+	endif; ?>
+	
+	<?php if ( apply_filters( 'wc_product_tags_enabled', true ) ) :
+		echo wc_get_product_tag_list( $product->get_id(), ', ', '<span class="tagged_as">' . _n( 'Tag:', 'Tags:', count( $product->get_tag_ids() ), 'woocommerce' ) . ' ', '</span>' ); 
+	endif;?>
 
 	<?php do_action( 'woocommerce_product_meta_end' ); ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline]
yes
* [x] Does your code follow the [WordPress' coding standards]
yes
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
I dont know where can I check but I think there are not

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Now anyone can disable showing product categories just with filter and not to rewrite full file. The same I added for product tags.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. By default there should be shown categories and tags
2. When you add filter kind of add_filter( 'wc_product_categories_enabled', function() { return false; } ) - categories should not be shown in that case 
3. When you add filter kind of add_filter( 'wc_product_tags_enabled', function() { return false; } ) - tags should not be shown in that case 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
* [x] Have you written new tests for your changes, as applicable?

<!-- Mark completed items with an [x] -->

### Changelog entry
Added: wc_product_categories_enabled and wc_product_tags_enabled filter for categories and tags
