### PR TITLE
Add woocommerce_admin_process_variation_object before $variation->save()

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -527,6 +527,15 @@ class WC_Meta_Box_Product_Data {
 					WC_Admin_Meta_Boxes::add_error( $errors->get_error_message() );
 				}
 
+				/**
+				 * Set variation props before save.
+				 *
+				 * @param object $variation WC_Product_Variation object.
+	 			 * @param int $i
+				 * @since 3.8.0
+				 */
+				do_action( 'woocommerce_admin_process_variation_object', $variation, $i );
+
 				$variation->save();
 
 				do_action( 'woocommerce_save_product_variation', $variation_id, $i );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add `woocommerce_admin_process_variation_object` hook before `$variation->save()`
Pass `WC_Product_Variation` to hooks in the variation metabox

These reduce the need to re-instantiate a `$variation` object and run `save()` multiple times in order to save additional variation data. This brings the save process more in line with regular simple products which have a comparable `woocommerce_admin_process_product_object`

### How to test the changes in this Pull Request:

Use the following snippet to add and save extra fields in the variations metabox:
```

/**
 * Add custom fields to product variation settings
 *
 * @param int $i
 * @param array $variation_data
 * @param WP_Post $variation
 * @param WC_Product_Variation
 */
function add_variation_options_other_dimensions( $i, $variation_data, $variation, $variation_obj ){

    woocommerce_wp_text_input( array(
        'id' => 'test[' . $i . ']',
        'class' => 'short',
        'label'       => __( 'Test Data', 'woocommerce' ),
        'desc_tip'    => 'true',
        'description' => __( 'Dummy test data.', 'woocommerce' ),
        'value'       => $variation_obj->get_meta( '_test', true ),
    ) );

}
add_action( 'woocommerce_product_after_variable_attributes','add_variation_options_other_dimensions', 10, 4 );


/**
 * Save product variation custom fields values
 *
 * @param obj $variation_id
 * @param int $i
 */
function save_variation_options_other_dimensions( $variation, $i ) {

    if ( isset( $_POST["test"][$i] ) ) {
        $variation->update_meta_data( '_test', wc_clean( $_POST["test"][$i] ) );
    }

}
add_action( 'woocommerce_admin_process_variation_object','save_variation_options_other_dimensions', 10, 2 );
```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Add `woocommerce_admin_process_variation_object ` hook before `$variation->save()`
>Pass `WC_Product_Variation` object to hooks in the variation metabox
