### PR TITLE
Add support for custom attributes to wc_placeholder_img().

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1859,7 +1859,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		}
 
 		if ( ! $image && $placeholder ) {
-			$image = wc_placeholder_img( $size );
+			$image = wc_placeholder_img( $size, $attr );
 		}
 
 		return apply_filters( 'woocommerce_product_get_image', $image, $this, $size, $attr, $placeholder, $image );

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -288,26 +288,37 @@ function wc_placeholder_img_src( $size = 'woocommerce_thumbnail' ) {
  *
  * Uses wp_get_attachment_image if using an attachment ID @since 3.6.0 to handle responsiveness.
  *
- * @param string $size Image size.
+ * @param string       $size Image size.
+ * @param string|array $attr Optional. Attributes for the image markup. Default empty.
  * @return string
  */
-function wc_placeholder_img( $size = 'woocommerce_thumbnail' ) {
+function wc_placeholder_img( $size = 'woocommerce_thumbnail', $attr = '' ) {
 	$dimensions        = wc_get_image_size( $size );
 	$placeholder_image = get_option( 'woocommerce_placeholder_image', 0 );
+
+	$default_attr = array(
+		'class' => 'woocommerce-placeholder wp-post-image',
+		'alt'   => __( 'Placeholder', 'woocommerce' ),
+	);
+
+	$attr = wp_parse_args( $attr, $default_attr );
 
 	if ( wp_attachment_is_image( $placeholder_image ) ) {
 		$image_html = wp_get_attachment_image(
 			$placeholder_image,
 			$size,
 			false,
-			array(
-				'alt'   => __( 'Placeholder', 'woocommerce' ),
-				'class' => 'woocommerce-placeholder wp-post-image',
-			)
+			$attr
 		);
 	} else {
 		$image      = wc_placeholder_img_src( $size );
-		$image_html = '<img src="' . esc_attr( $image ) . '" alt="' . esc_attr__( 'Placeholder', 'woocommerce' ) . '" width="' . esc_attr( $dimensions['width'] ) . '" class="woocommerce-placeholder wp-post-image" height="' . esc_attr( $dimensions['height'] ) . '" />';
+		$hwstring   = image_hwstring( $dimensions['width'], $dimensions['height'] );
+		$attr = array_map( 'esc_attr', $attr );
+		$image_html = rtrim( '<img src="' . esc_attr( $image ) . '" ' . $hwstring );
+		foreach ( $attr as $name => $value ) {
+			$image_html .= " $name=" . '"' . $value . '"';
+		}
+		$image_html .= ' />';
 	}
 
 	return apply_filters( 'woocommerce_placeholder_img', $image_html, $size, $dimensions );

--- a/tests/unit-tests/product/data.php
+++ b/tests/unit-tests/product/data.php
@@ -324,6 +324,10 @@ class WC_Tests_Product_Data extends WC_Unit_Test_Case {
 		$product = new WC_Product();
 
 		$this->assertContains( wc_placeholder_img_src(), $product->get_image() );
+
+		// Test custom class attribute is honoured.
+		$image = $product->get_image( 'woocommerce_thumbnail', array( 'class' => 'custom-class' ) );
+		$this->assertContains( 'class="custom-class"', $image );
 	}
 
 	/**

--- a/tests/unit-tests/product/functions.php
+++ b/tests/unit-tests/product/functions.php
@@ -885,6 +885,10 @@ class WC_Tests_Product_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_placeholder_img() {
 		$this->assertTrue( (bool) strstr( wc_placeholder_img(), wc_placeholder_img_src() ) );
+
+		// Test custom class attribute is honoured.
+		$attr = array( 'class' => 'custom-class' );
+		$this->assertContains( 'class="custom-class"', wc_placeholder_img( 'woocommerce_thumbnail', $attr ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When displaying a list of images you often want a specific class to be
attached to each image, therefore you pass through a custom class using
the attr parameter. Unfortunately this doesn't get passed through to a
placeholder image should one be needed. This means that, for example, if
you're custom class center an image or something, it won't be honoured
for placeholders, which can lead to some wonky image listings.

You can work around this currently by leverging the
`woocommerce_product_get_image` filter, but it's a bit gnarly as you
need to do some regexing or string splitting or something and checking
class names and what not. This provides a much easier way, by
supporting custom attrs on placeholder images as is the case for non
placehodler images.

### How to test the changes in this Pull Request:

1. Set up a product listing page which contains a mix of valid product images and placeholder images.
2. On the product listing page, find where `$product->get_image()` is being called.
3. Add a custom class to it, e.g. `$product->get_image( 'woocommerce_thumbnail', [ 'class' => 'custom-class' ] )`
4. Observe custom class is present not just on valid product images but on placeholder images also.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

I added assertions to existing tests as I think that was the preference as per your guidelines, but happy to split out into separate tests if you'd prefer.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added support for custom attributes on placeholder images.
