### PR TITLE
Add filter for cancel unpaid orders cron duration

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -1117,7 +1117,8 @@ function wc_format_option_hold_stock_minutes( $value, $option, $raw_value ) {
 	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
 
 	if ( '' !== $value ) {
-		wp_schedule_single_event( time() + ( absint( $value ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
+		$duration = apply_filters( 'woocommerce_cancel_unpaid_orders_duration', $value );
+		wp_schedule_single_event( time() + ( absint( $duration ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
 	}
 
 	return $value;

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -909,6 +909,7 @@ function wc_cancel_unpaid_orders() {
 		}
 	}
 	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );
+	$held_duration = apply_filters( 'woocommerce_cancel_unpaid_orders_duration', $held_duration );
 	wp_schedule_single_event( time() + ( absint( $held_duration ) * 60 ), 'woocommerce_cancel_unpaid_orders' );
 }
 add_action( 'woocommerce_cancel_unpaid_orders', 'wc_cancel_unpaid_orders' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24581.

Add a filter called `woocommerce_cancel_unpaid_orders_duration` to override the cancel unpaid orders cron duration so that people can run cron more frequently if needed.

### How to test the changes in this Pull Request:

1. Hook a function to the `woocommerce_cancel_unpaid_orders_duration` filter.
2. Return duration that you want (in minutes) from that function.
3. The new duration will be used for the next cron schedule or after the `Hold stock (minutes)` setting is saved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduce `woocommerce_cancel_unpaid_orders_duration` filter.
