### PR TITLE
Removed links to downloadable products from refund emails

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -428,7 +428,7 @@ class WC_Emails {
 	 * @param string   $email         Email address.
 	 */
 	public function order_downloads( $order, $sent_to_admin = false, $plain_text = false, $email = '' ) {
-		$show_downloads = $order->has_downloadable_item() && $order->is_download_permitted() && ! $sent_to_admin;
+		$show_downloads = $order->has_downloadable_item() && $order->is_download_permitted() && ! $sent_to_admin && ! is_a( $email, 'WC_Email_Customer_Refunded_Order' );
 
 		if ( ! $show_downloads ) {
 			return;

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1426,7 +1426,7 @@ class WC_Order extends WC_Abstract_Order {
 				continue;
 			}
 
-			// check item refunds
+			// Check item refunds.
 			$refunded_qty = abs( $this->get_qty_refunded_for_item( $item->get_id() ) );
 			if ( $refunded_qty && $item->get_quantity() === $refunded_qty ) {
 				continue;

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1427,8 +1427,8 @@ class WC_Order extends WC_Abstract_Order {
 			}
 
 			// check item refunds
-			$refunded_qty = $this->get_qty_refunded_for_item( $item->get_id() );
-			if ( $refunded_qty && $item->get_quantity() == $refunded_qty * -1 ) {
+			$refunded_qty = abs( $this->get_qty_refunded_for_item( $item->get_id() ) );
+			if ( $refunded_qty && $item->get_quantity() === $refunded_qty ) {
 				continue;
 			}
 

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1426,6 +1426,12 @@ class WC_Order extends WC_Abstract_Order {
 				continue;
 			}
 
+			// check item refunds
+			$refunded_qty = $this->get_qty_refunded_for_item( $item->get_id() );
+			if ( $refunded_qty && $item->get_quantity() == $refunded_qty * -1 ) {
+				continue;
+			}
+
 			if ( $item->is_type( 'line_item' ) ) {
 				$item_downloads = $item->get_item_downloads();
 				$product        = $item->get_product();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24430  .
As suggested in Slack, I removed the Downloads section altogether from the Refund email.

### How to test the changes in this Pull Request:

1. Create at least 2 different virtual downloadable products.
2. Buy them as a customer, with ability to see the emails being sent out to the customer.
3. Process the order as merchant, mark it as complete.
4. Verify that Order complete email contains the Downloads section and the links work.
5. Refund one of the products. 
6. Check that refund emails does **not** include Downloads section.
7. From order actions, Email Invoice/order details to customer, push the `>` button.
8. Verify the Downloads section only contains one (ideally, the non-refunded) product.
9. Test this all also with 1 product order.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Removed links to downloadable products from refund emails.
