### PR TITLE
Changed wp_cache invalidation from using increment to using microtime.

### DIFF
--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -128,7 +128,7 @@ class WC_Settings_Tax extends WC_Settings_Page {
 		}
 
 		// Invalidate caches.
-		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
+		WC_Cache_Helper::invalidate_cache_group( 'taxes' );
 		WC_Cache_Helper::get_transient_version( 'shipping', true );
 		// phpcs:enable WordPress.Security.NonceVerification.NoNonceVerification
 	}

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2603,7 +2603,7 @@ class WC_AJAX {
 			}
 		}
 
-		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
+		WC_Cache_Helper::invalidate_cache_group( 'taxes' );
 		WC_Cache_Helper::get_transient_version( 'shipping', true );
 
 		wp_send_json_success(

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -94,7 +94,7 @@ class WC_Cache_Helper {
 		$prefix = wp_cache_get( 'wc_' . $group . '_cache_prefix', $group );
 
 		if ( false === $prefix ) {
-			$prefix = 1;
+			$prefix = microtime();
 			wp_cache_set( 'wc_' . $group . '_cache_prefix', $prefix, $group );
 		}
 
@@ -107,7 +107,7 @@ class WC_Cache_Helper {
 	 * @param string $group Group of cache to clear.
 	 */
 	public static function incr_cache_prefix( $group ) {
-		wp_cache_incr( 'wc_' . $group . '_cache_prefix', 1, $group );
+		wp_cache_set( 'wc_' . $group . '_cache_prefix', microtime(), $group );
 	}
 
 	/**

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -107,6 +107,17 @@ class WC_Cache_Helper {
 	 * @param string $group Group of cache to clear.
 	 */
 	public static function incr_cache_prefix( $group ) {
+		wc_deprecated_function( 'WC_Cache_Helper::incr_cache_prefix', '3.9.0', 'WC_Cache_Helper::invalidate_cache_group' );
+		self::invalidate_cache_group( $group );
+	}
+
+	/**
+	 * Invalidate cache group.
+	 *
+	 * @param string $group Group of cache to clear.
+	 * @since 3.9.0
+	 */
+	public static function invalidate_cache_group( $group ) {
 		wp_cache_set( 'wc_' . $group . '_cache_prefix', microtime(), $group );
 	}
 

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -462,7 +462,7 @@ class WC_Post_Data {
 	 * @param  string $meta_value Meta value.
 	 */
 	public static function flush_object_meta_cache( $meta_id, $object_id, $meta_key, $meta_value ) {
-		WC_Cache_Helper::incr_cache_prefix( 'object_' . $object_id );
+		WC_Cache_Helper::invalidate_cache_group( 'object_' . $object_id );
 	}
 
 	/**

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -302,7 +302,7 @@ class WC_Session_Handler extends WC_Session {
 		$wpdb->query( $wpdb->prepare( "DELETE FROM $this->_table WHERE session_expiry < %d", time() ) ); // @codingStandardsIgnoreLine.
 
 		if ( class_exists( 'WC_Cache_Helper' ) ) {
-			WC_Cache_Helper::incr_cache_prefix( WC_SESSION_CACHE_GROUP );
+			WC_Cache_Helper::invalidate_cache_group( WC_SESSION_CACHE_GROUP );
 		}
 	}
 

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -907,7 +907,7 @@ class WC_Tax {
 		}
 
 		wp_cache_delete( 'tax-rate-classes', 'taxes' );
-		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
+		WC_Cache_Helper::invalidate_cache_group( 'taxes' );
 
 		return (bool) $delete;
 	}
@@ -1025,7 +1025,7 @@ class WC_Tax {
 
 		$tax_rate_id = $wpdb->insert_id;
 
-		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
+		WC_Cache_Helper::invalidate_cache_group( 'taxes' );
 
 		do_action( 'woocommerce_tax_rate_added', $tax_rate_id, $tax_rate );
 
@@ -1082,7 +1082,7 @@ class WC_Tax {
 			)
 		);
 
-		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
+		WC_Cache_Helper::invalidate_cache_group( 'taxes' );
 
 		do_action( 'woocommerce_tax_rate_updated', $tax_rate_id, $tax_rate );
 	}
@@ -1101,7 +1101,7 @@ class WC_Tax {
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rate_locations WHERE tax_rate_id = %d;", $tax_rate_id ) );
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_tax_rates WHERE tax_rate_id = %d;", $tax_rate_id ) );
 
-		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
+		WC_Cache_Helper::invalidate_cache_group( 'taxes' );
 
 		do_action( 'woocommerce_tax_rate_deleted', $tax_rate_id );
 	}
@@ -1176,7 +1176,7 @@ class WC_Tax {
 			$wpdb->query( "INSERT INTO {$wpdb->prefix}woocommerce_tax_rate_locations ( location_code, tax_rate_id, location_type ) VALUES $sql;" ); // @codingStandardsIgnoreLine.
 		}
 
-		WC_Cache_Helper::incr_cache_prefix( 'taxes' );
+		WC_Cache_Helper::invalidate_cache_group( 'taxes' );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -842,10 +842,10 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		wc_delete_product_transients( $product->get_id() );
 		if ( $product->get_parent_id( 'edit' ) ) {
 			wc_delete_product_transients( $product->get_parent_id( 'edit' ) );
-			WC_Cache_Helper::incr_cache_prefix( 'product_' . $product->get_parent_id( 'edit' ) );
+			WC_Cache_Helper::invalidate_cache_group( 'product_' . $product->get_parent_id( 'edit' ) );
 		}
 		WC_Cache_Helper::invalidate_attribute_count( array_keys( $product->get_attributes() ) );
-		WC_Cache_Helper::incr_cache_prefix( 'product_' . $product->get_id() );
+		WC_Cache_Helper::invalidate_cache_group( 'product_' . $product->get_id() );
 	}
 
 	/*

--- a/includes/data-stores/class-wc-shipping-zone-data-store.php
+++ b/includes/data-stores/class-wc-shipping-zone-data-store.php
@@ -35,7 +35,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 		$zone->save_meta_data();
 		$this->save_locations( $zone );
 		$zone->apply_changes();
-		WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
+		WC_Cache_Helper::invalidate_cache_group( 'shipping_zones' );
 		WC_Cache_Helper::get_transient_version( 'shipping', true );
 	}
 
@@ -60,7 +60,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 		$zone->save_meta_data();
 		$this->save_locations( $zone );
 		$zone->apply_changes();
-		WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
+		WC_Cache_Helper::invalidate_cache_group( 'shipping_zones' );
 		WC_Cache_Helper::get_transient_version( 'shipping', true );
 	}
 
@@ -132,7 +132,7 @@ class WC_Shipping_Zone_Data_Store extends WC_Data_Store_WP implements WC_Shippin
 
 			$zone->set_id( null );
 
-			WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
+			WC_Cache_Helper::invalidate_cache_group( 'shipping_zones' );
 			WC_Cache_Helper::get_transient_version( 'shipping', true );
 
 			do_action( 'woocommerce_delete_shipping_zone', $zone_id );

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -60,7 +60,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 		$webhook->apply_changes();
 
 		$this->delete_transients( $webhook->get_status( 'edit' ) );
-		WC_Cache_Helper::incr_cache_prefix( 'webhooks' );
+		WC_Cache_Helper::invalidate_cache_group( 'webhooks' );
 		do_action( 'woocommerce_new_webhook', $webhook_id, $webhook );
 	}
 
@@ -157,7 +157,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 			$this->delete_transients( 'all' );
 		}
 		wp_cache_delete( $webhook->get_id(), 'webhooks' );
-		WC_Cache_Helper::incr_cache_prefix( 'webhooks' );
+		WC_Cache_Helper::invalidate_cache_group( 'webhooks' );
 
 		if ( 'active' === $webhook->get_status() && ( $trigger || $webhook->get_pending_delivery() ) ) {
 			$webhook->deliver_ping();
@@ -184,7 +184,7 @@ class WC_Webhook_Data_Store implements WC_Webhook_Data_Store_Interface {
 		); // WPCS: cache ok, DB call ok.
 
 		$this->delete_transients( 'all' );
-		WC_Cache_Helper::incr_cache_prefix( 'webhooks' );
+		WC_Cache_Helper::invalidate_cache_group( 'webhooks' );
 		do_action( 'woocommerce_webhook_deleted', $webhook->get_id(), $webhook );
 	}
 

--- a/includes/legacy/api/v2/class-wc-api-products.php
+++ b/includes/legacy/api/v2/class-wc-api-products.php
@@ -2023,7 +2023,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Clear transients
 			delete_transient( 'wc_attribute_taxonomies' );
-			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
+			WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 
 			$this->server->send_status( 201 );
 
@@ -2109,7 +2109,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Clear transients
 			delete_transient( 'wc_attribute_taxonomies' );
-			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
+			WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 
 			return $this->get_product_attribute( $id );
 		} catch ( WC_API_Exception $e ) {
@@ -2171,7 +2171,7 @@ class WC_API_Products extends WC_API_Resource {
 
 			// Clear transients
 			delete_transient( 'wc_attribute_taxonomies' );
-			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
+			WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 
 			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_attribute' ) );
 		} catch ( WC_API_Exception $e ) {

--- a/includes/legacy/api/v3/class-wc-api-products.php
+++ b/includes/legacy/api/v3/class-wc-api-products.php
@@ -2577,7 +2577,7 @@ class WC_API_Products extends WC_API_Resource {
 			// Clear transients.
 			wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 			delete_transient( 'wc_attribute_taxonomies' );
-			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
+			WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 
 			$this->server->send_status( 201 );
 
@@ -2664,7 +2664,7 @@ class WC_API_Products extends WC_API_Resource {
 			// Clear transients.
 			wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 			delete_transient( 'wc_attribute_taxonomies' );
-			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
+			WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 
 			return $this->get_product_attribute( $id );
 		} catch ( WC_API_Exception $e ) {
@@ -2727,7 +2727,7 @@ class WC_API_Products extends WC_API_Resource {
 			// Clear transients.
 			wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 			delete_transient( 'wc_attribute_taxonomies' );
-			WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
+			WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 
 			return array( 'message' => sprintf( __( 'Deleted %s', 'woocommerce' ), 'product_attribute' ) );
 		} catch ( WC_API_Exception $e ) {

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -611,7 +611,7 @@ function wc_create_attribute( $args ) {
 	// Clear cache and flush rewrite rules.
 	wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 	delete_transient( 'wc_attribute_taxonomies' );
-	WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
+	WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 
 	return $id;
 }
@@ -701,7 +701,7 @@ function wc_delete_attribute( $id ) {
 		do_action( 'woocommerce_attribute_deleted', $id, $name, $taxonomy );
 		wp_schedule_single_event( time(), 'woocommerce_flush_rewrite_rules' );
 		delete_transient( 'wc_attribute_taxonomies' );
-		WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
+		WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 
 		return true;
 	}

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -464,7 +464,7 @@ function wc_delete_shop_order_transients( $order = 0 ) {
 	WC_Cache_Helper::get_transient_version( 'orders', true );
 
 	// Do the same for regular cache.
-	WC_Cache_Helper::incr_cache_prefix( 'orders' );
+	WC_Cache_Helper::invalidate_cache_group( 'orders' );
 
 	do_action( 'woocommerce_delete_shop_order_transients', $order_id );
 }

--- a/includes/wc-order-item-functions.php
+++ b/includes/wc-order-item-functions.php
@@ -104,7 +104,7 @@ function wc_delete_order_item( $item_id ) {
 function wc_update_order_item_meta( $item_id, $meta_key, $meta_value, $prev_value = '' ) {
 	$data_store = WC_Data_Store::load( 'order-item' );
 	if ( $data_store->update_metadata( $item_id, $meta_key, $meta_value, $prev_value ) ) {
-		WC_Cache_Helper::incr_cache_prefix( 'object_' . $item_id ); // Invalidate cache.
+		WC_Cache_Helper::invalidate_cache_group( 'object_' . $item_id ); // Invalidate cache.
 		return true;
 	}
 	return false;
@@ -126,7 +126,7 @@ function wc_add_order_item_meta( $item_id, $meta_key, $meta_value, $unique = fal
 	$meta_id    = $data_store->add_metadata( $item_id, $meta_key, $meta_value, $unique );
 
 	if ( $meta_id ) {
-		WC_Cache_Helper::incr_cache_prefix( 'object_' . $item_id ); // Invalidate cache.
+		WC_Cache_Helper::invalidate_cache_group( 'object_' . $item_id ); // Invalidate cache.
 		return $meta_id;
 	}
 	return 0;
@@ -146,7 +146,7 @@ function wc_add_order_item_meta( $item_id, $meta_key, $meta_value, $unique = fal
 function wc_delete_order_item_meta( $item_id, $meta_key, $meta_value = '', $delete_all = false ) {
 	$data_store = WC_Data_Store::load( 'order-item' );
 	if ( $data_store->delete_metadata( $item_id, $meta_key, $meta_value, $delete_all ) ) {
-		WC_Cache_Helper::incr_cache_prefix( 'object_' . $item_id ); // Invalidate cache.
+		WC_Cache_Helper::invalidate_cache_group( 'object_' . $item_id ); // Invalidate cache.
 		return true;
 	}
 	return false;

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -674,7 +674,7 @@ function wc_update_220_attributes() {
 	}
 
 	delete_transient( 'wc_attribute_taxonomies' );
-	WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
+	WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 }
 
 /**

--- a/tests/framework/helpers/class-wc-helper-product.php
+++ b/tests/framework/helpers/class-wc-helper-product.php
@@ -224,7 +224,7 @@ class WC_Helper_Product {
 
 		// Make sure caches are clean.
 		delete_transient( 'wc_attribute_taxonomies' );
-		WC_Cache_Helper::incr_cache_prefix( 'woocommerce-attributes' );
+		WC_Cache_Helper::invalidate_cache_group( 'woocommerce-attributes' );
 
 		// These are exported as labels, so convert the label to a name if possible first.
 		$attribute_labels = wp_list_pluck( wc_get_attribute_taxonomies(), 'attribute_label', 'attribute_name' );

--- a/tests/framework/helpers/class-wc-helper-shipping-zones.php
+++ b/tests/framework/helpers/class-wc-helper-shipping-zones.php
@@ -51,6 +51,6 @@ class WC_Helper_Shipping_Zones {
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}woocommerce_shipping_zone_methods;" );
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}woocommerce_shipping_zone_locations;" );
 		$wpdb->query( "TRUNCATE TABLE {$wpdb->prefix}woocommerce_shipping_zones;" );
-		WC_Cache_Helper::incr_cache_prefix( 'shipping_zones' );
+		WC_Cache_Helper::invalidate_cache_group( 'shipping_zones' );
 	}
 }


### PR DESCRIPTION
This is a similar problem that WP core faced in https://core.trac.wordpress.org/ticket/23448.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Ref: p9F6qB-4fd-p2
TL;DR: Sometimes, product add-ons extension is showing previous version of the product after hitting update. Caching problems suspected. Solution similar to https://core.trac.wordpress.org/ticket/23448 was suggested.

### How to test the changes in this Pull Request:

1. The problem is quite elusive and difficult to reproduce locally. Memcached is probably evicting some keys sooner than others which causes invalid state for the application. Test on the original site might be necessary. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Changed wp_cache invalidation from using increment to using microtime.
