### PR TITLE
added functions for product categories and product tags filter

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -125,8 +125,12 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 		}
 
 		$show_columns['price']        = __( 'Price', 'woocommerce' );
-		$show_columns['product_cat']  = __( 'Categories', 'woocommerce' );
-		$show_columns['product_tag']  = __( 'Tags', 'woocommerce' );
+		if ( wc_product_categories_enabled() ) {
+			$show_columns['product_cat']  = __( 'Categories', 'woocommerce' );
+		}
+		if ( wc_product_tags_enabled() ) {
+			$show_columns['product_tag']  = __( 'Tags', 'woocommerce' );
+		}
 		$show_columns['featured']     = '<span class="wc-featured parent-tips" data-tip="' . esc_attr__( 'Featured', 'woocommerce' ) . '">' . __( 'Featured', 'woocommerce' ) . '</span>';
 		$show_columns['date']         = __( 'Date', 'woocommerce' );
 

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -74,6 +74,24 @@ function wc_product_sku_enabled() {
 }
 
 /**
+ * Returns whether or not product categories are enabled.
+ *
+ * @return bool
+ */
+function wc_product_categories_enabled() {
+	return apply_filters( 'wc_product_categories_enabled', true );
+}
+
+/**
+ * Returns whether or not product tags are enabled.
+ *
+ * @return bool
+ */
+function wc_product_tags_enabled() {
+	return apply_filters( 'wc_product_tags_enabled', true );
+}
+
+/**
  * Returns whether or not product weights are enabled.
  *
  * @return bool

--- a/templates/single-product/meta.php
+++ b/templates/single-product/meta.php
@@ -12,7 +12,7 @@
  *
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @package 	WooCommerce/Templates
- * @version     3.0.0
+ * @version     3.8.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -31,9 +31,17 @@ global $product;
 
 	<?php endif; ?>
 
+	<?php if ( wc_product_categories_enabled() ) : ?>
+
 	<?php echo wc_get_product_category_list( $product->get_id(), ', ', '<span class="posted_in">' . _n( 'Category:', 'Categories:', count( $product->get_category_ids() ), 'woocommerce' ) . ' ', '</span>' ); ?>
 
+	<?php endif; ?>
+
+	<?php if ( wc_product_tags_enabled() ) : ?>
+
 	<?php echo wc_get_product_tag_list( $product->get_id(), ', ', '<span class="tagged_as">' . _n( 'Tag:', 'Tags:', count( $product->get_tag_ids() ), 'woocommerce' ) . ' ', '</span>' ); ?>
+
+	<?php endif; ?>
 
 	<?php do_action( 'woocommerce_product_meta_end' ); ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Any user now can disable only product categories or tags inside product meta via filter

Closes # .

### How to test the changes in this Pull Request:

1. All elements in product meta should be shown by default
2. When you add filter in your theme or child-theme add_filter( 'wc_product_categories_enabled', function(){return false} ); your product categories will not be shown in product meta content
3. When you add filter in your theme or child-theme add_filter( 'wc_product_tags_enabled', function(){return false} ); your product tags will not be shown in product meta content

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
5