### PR TITLE
Filters: Short-circuit Variation calculations (2)

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -285,6 +285,12 @@ class WC_Product_Variable extends WC_Product {
 	 * @return array
 	 */
 	public function get_available_variations() {
+		// Allow 3rd parties to pre-load this data.
+		$available_variations = apply_filters( 'woocommerce_pre_get_available_variations', null, $this, $this->data_store );
+
+		if ( null !== $available_variations ) {
+			return $available_variations;
+		}
 
 		$variation_ids        = $this->get_children();
 		$available_variations = array();

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -286,84 +286,89 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 					'sale_price'    => array(),
 				);
 
-				$variation_ids = $product->get_visible_children();
+				// Allow 3rd parties to skip a full calculation of this data in favor of, for example, a background task.
+				$skip_price_data = apply_filters( 'woocommerce_variation_skip_price_data', false, $product );
 
-				if ( is_callable( '_prime_post_caches' ) ) {
-					_prime_post_caches( $variation_ids );
-				}
+				if ( ! $skip_price_data ) {
+					$variation_ids = $product->get_visible_children();
 
-				foreach ( $variation_ids as $variation_id ) {
-					$variation = wc_get_product( $variation_id );
+					if ( is_callable( '_prime_post_caches' ) ) {
+						_prime_post_caches( $variation_ids );
+					}
 
-					if ( $variation ) {
-						$price         = apply_filters( 'woocommerce_variation_prices_price', $variation->get_price( 'edit' ), $variation, $product );
-						$regular_price = apply_filters( 'woocommerce_variation_prices_regular_price', $variation->get_regular_price( 'edit' ), $variation, $product );
-						$sale_price    = apply_filters( 'woocommerce_variation_prices_sale_price', $variation->get_sale_price( 'edit' ), $variation, $product );
+					foreach ( $variation_ids as $variation_id ) {
+						$variation = wc_get_product( $variation_id );
 
-						// Skip empty prices.
-						if ( '' === $price ) {
-							continue;
-						}
+						if ( $variation ) {
+							$price         = apply_filters( 'woocommerce_variation_prices_price', $variation->get_price( 'edit' ), $variation, $product );
+							$regular_price = apply_filters( 'woocommerce_variation_prices_regular_price', $variation->get_regular_price( 'edit' ), $variation, $product );
+							$sale_price    = apply_filters( 'woocommerce_variation_prices_sale_price', $variation->get_sale_price( 'edit' ), $variation, $product );
 
-						// If sale price does not equal price, the product is not yet on sale.
-						if ( $sale_price === $regular_price || $sale_price !== $price ) {
-							$sale_price = $regular_price;
-						}
-
-						// If we are getting prices for display, we need to account for taxes.
-						if ( $for_display ) {
-							if ( 'incl' === get_option( 'woocommerce_tax_display_shop' ) ) {
-								$price         = '' === $price ? '' : wc_get_price_including_tax(
-									$variation,
-									array(
-										'qty'   => 1,
-										'price' => $price,
-									)
-								);
-								$regular_price = '' === $regular_price ? '' : wc_get_price_including_tax(
-									$variation,
-									array(
-										'qty'   => 1,
-										'price' => $regular_price,
-									)
-								);
-								$sale_price    = '' === $sale_price ? '' : wc_get_price_including_tax(
-									$variation,
-									array(
-										'qty'   => 1,
-										'price' => $sale_price,
-									)
-								);
-							} else {
-								$price         = '' === $price ? '' : wc_get_price_excluding_tax(
-									$variation,
-									array(
-										'qty'   => 1,
-										'price' => $price,
-									)
-								);
-								$regular_price = '' === $regular_price ? '' : wc_get_price_excluding_tax(
-									$variation,
-									array(
-										'qty'   => 1,
-										'price' => $regular_price,
-									)
-								);
-								$sale_price    = '' === $sale_price ? '' : wc_get_price_excluding_tax(
-									$variation,
-									array(
-										'qty'   => 1,
-										'price' => $sale_price,
-									)
-								);
+							// Skip empty prices.
+							if ( '' === $price ) {
+								continue;
 							}
+
+							// If sale price does not equal price, the product is not yet on sale.
+							if ( $sale_price === $regular_price || $sale_price !== $price ) {
+								$sale_price = $regular_price;
+							}
+
+							// If we are getting prices for display, we need to account for taxes.
+							if ( $for_display ) {
+								if ( 'incl' === get_option( 'woocommerce_tax_display_shop' ) ) {
+									$price         = '' === $price ? '' : wc_get_price_including_tax(
+										$variation,
+										array(
+											'qty'   => 1,
+											'price' => $price,
+										)
+									);
+									$regular_price = '' === $regular_price ? '' : wc_get_price_including_tax(
+										$variation,
+										array(
+											'qty'   => 1,
+											'price' => $regular_price,
+										)
+									);
+									$sale_price    = '' === $sale_price ? '' : wc_get_price_including_tax(
+										$variation,
+										array(
+											'qty'   => 1,
+											'price' => $sale_price,
+										)
+									);
+								} else {
+									$price         = '' === $price ? '' : wc_get_price_excluding_tax(
+										$variation,
+										array(
+											'qty'   => 1,
+											'price' => $price,
+										)
+									);
+									$regular_price = '' === $regular_price ? '' : wc_get_price_excluding_tax(
+										$variation,
+										array(
+											'qty'   => 1,
+											'price' => $regular_price,
+										)
+									);
+									$sale_price    = '' === $sale_price ? '' : wc_get_price_excluding_tax(
+										$variation,
+										array(
+											'qty'   => 1,
+											'price' => $sale_price,
+										)
+									);
+								}
+							}
+
+							$prices_array['price'][ $variation_id ]         = wc_format_decimal( $price, wc_get_price_decimals() );
+							$prices_array['regular_price'][ $variation_id ] = wc_format_decimal( $regular_price, wc_get_price_decimals() );
+							$prices_array['sale_price'][ $variation_id ]    = wc_format_decimal( $sale_price . '.00', wc_get_price_decimals() );
+
+							$prices_array = apply_filters( 'woocommerce_variation_prices_array', $prices_array, $variation, $for_display );
 						}
-
-						$prices_array['price'][ $variation_id ]         = wc_format_decimal( $price, wc_get_price_decimals() );
-						$prices_array['regular_price'][ $variation_id ] = wc_format_decimal( $regular_price, wc_get_price_decimals() );
-						$prices_array['sale_price'][ $variation_id ]    = wc_format_decimal( $sale_price . '.00', wc_get_price_decimals() );
-
-						$prices_array = apply_filters( 'woocommerce_variation_prices_array', $prices_array, $variation, $for_display );
 					}
 				}
 
@@ -372,7 +377,9 @@ class WC_Product_Variable_Data_Store_CPT extends WC_Product_Data_Store_CPT imple
 					$transient_cached_prices_array[ $price_hash ][ $key ] = $values;
 				}
 
-				set_transient( $transient_name, wp_json_encode( $transient_cached_prices_array ), DAY_IN_SECONDS * 30 );
+				if ( ! $skip_price_data ) {
+					set_transient( $transient_name, wp_json_encode( $transient_cached_prices_array ), DAY_IN_SECONDS * 30 );
+				}
 			}
 
 			/**


### PR DESCRIPTION
Accidentally pulled a non-master branch into previous PR. #24957

Relevant issue: #24659 (does not close)

Added short circuit filter for get_available_variations.
Added skip filter for Variation_Data_Store->read_price_data.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added filters allowing third parties to short-circuit some very expensive variation calculations. Background tasks can then be used to generate this data over time for eventual consistency.

### How to test the changes in this Pull Request:

1. Generate thousands of variations on a product
2. Try to use the store or admin regarding this variable product, the site will not be responsive.
3. Add a filter of each type short circuiting expensive calculations.
4. Try to use the store or admin, the site should be responsive now, though there won't be "good" data.
5. Run a background task or something to generate said data in the background.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

I'm not certain new tests will apply here, since they would just test `add_filters()`.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

```
Added short circuit filter for get_available_variations.
Added skip filter for Variation_Data_Store->read_price_data.
```