### PR TITLE
Prevent notice in PHP 7.4 when a variable product has no images

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -715,7 +715,7 @@ function wc_get_product_attachment_props( $attachment_id = null, $product = fals
 	);
 	$attachment = get_post( $attachment_id );
 
-	if ( $attachment ) {
+	if ( $attachment && 'attachment' === $attachment->post_type ) {
 		$props['title']   = wp_strip_all_tags( $attachment->post_title );
 		$props['caption'] = wp_strip_all_tags( $attachment->post_excerpt );
 		$props['url']     = wp_get_attachment_url( $attachment_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This fixes 12 PHP notices that appear when using PHP 7.4. The exact notice is:
Notice: Trying to access array offset on value of type bool in wordpress/wp-content/plugins/woocommerce/includes/wc-product-functions.php on line 736
These happen because. the `$src` variable is actually false because `$attachment` is not actually false. If you have a variable product without any images then it ends up passing `''` to `wc_get_product_attachment_props()` and then it ends up calling `get_post('')` which returns the global `$post` object.  

### How to test the changes in this Pull Request:

1. Create a variable product with several variations.
2. Visit the product page in PHP 7.4 with error logging turned on.
3. Observe no php notices are produced.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: prevent notice when a variable product has no images.
