### PR TITLE
Onboarding - Show the new experience to 10% of new users

### DIFF
--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1070,6 +1070,19 @@ h3.jetpack-reasons {
 	}
 }
 
+.wc-setup-new-onboarding {
+
+	p {
+		text-align: center;
+	}
+
+	.onboarding-welcome,
+	.onboarding-plugin-info {
+		color: #7c7c7c;
+		font-size: 12px;
+	}
+}
+
 .step {
 	text-align: center;
 }

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -6,7 +6,7 @@ body {
 	padding: 0;
 }
 
-#wc-logo {
+.wc-logo {
 	border: 0;
 	margin: 0 0 24px;
 	padding: 0;
@@ -1070,16 +1070,28 @@ h3.jetpack-reasons {
 	}
 }
 
-.wc-setup-new-onboarding {
+.wc-setup-step__new_onboarding {
 
-	p {
-		text-align: center;
+	.wc-logo,
+	.wc-setup-steps {
+		display: none;
 	}
 
-	.onboarding-welcome,
-	.onboarding-plugin-info {
-		color: #7c7c7c;
-		font-size: 12px;
+	.wc-setup-step__new_onboarding-wrapper {
+
+		.wc-logo {
+			display: block;
+		}
+
+		p {
+			text-align: center;
+		}
+
+		.wc-setup-step__new_onboarding-welcome,
+		.wc-setup-step__new_onboarding-plugin-info {
+			color: #7c7c7c;
+			font-size: 12px;
+		}
 	}
 }
 
@@ -1517,7 +1529,7 @@ p.jetpack-terms {
 
 @media only screen and (max-width: 400px) {
 
-	#wc-logo img {
+	.wc-logo img {
 		max-width: 80%;
 	}
 

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -216,6 +216,11 @@ jQuery( function( $ ) {
 		waitForJetpackInstall();
 	} );
 
+	$( '.activate-new-onboarding' ).on( 'click', '.button-primary', function() {
+		// Show pending spinner while activate happens.
+		blockWizardUI();
+	} );
+
 	$( '.wc-wizard-services' ).on( 'change', 'input#stripe_create_account, input#ppec_paypal_reroute_requests', function() {
 		if ( $( this ).is( ':checked' ) ) {
 			$( this ).closest( '.wc-wizard-service-settings' )

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -390,13 +390,8 @@ class WC_Admin_Setup_Wizard {
 			<?php do_action( 'admin_print_styles' ); ?>
 			<?php do_action( 'admin_head' ); ?>
 		</head>
-		<body class="wc-setup wp-core-ui">
-		<?php
-		if ( 'new_onboarding' === $this->step ) {
-			return;
-		}
-		?>
-		<h1 id="wc-logo"><a href="https://woocommerce.com/"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/woocommerce_logo.png" alt="<?php esc_attr_e( 'WooCommerce', 'woocommerce' ); ?>" /></a></h1>
+		<body class="wc-setup wp-core-ui <?php echo esc_attr( 'wc-setup-step__' . $this->step ); ?>">
+		<h1 class="wc-logo"><a href="https://woocommerce.com/"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/woocommerce_logo.png" alt="<?php esc_attr_e( 'WooCommerce', 'woocommerce' ); ?>" /></a></h1>
 		<?php
 	}
 
@@ -432,11 +427,6 @@ class WC_Admin_Setup_Wizard {
 		}
 
 		unset( $output_steps['new_onboarding'] );
-
-		// Don't show the navigation on the onboarding prompt screen.
-		if ( 'new_onboarding' === $this->step ) {
-			return;
-		}
 
 		?>
 		<ol class="wc-setup-steps">
@@ -481,9 +471,9 @@ class WC_Admin_Setup_Wizard {
 	 */
 	public function wc_setup_new_onboarding() {
 		?>
-			<div class="wc-setup-new-onboarding">
-				<p class="onboarding-welcome"><?php esc_html_e( 'Welcome to', 'woocommerce' ); ?></p>
-				<h1 id="wc-logo"><a href="https://woocommerce.com/"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/woocommerce_logo.png" alt="<?php esc_attr_e( 'WooCommerce', 'woocommerce' ); ?>" /></a></h1>
+			<div class="wc-setup-step__new_onboarding-wrapper">
+				<p class="wc-setup-step__new_onboarding-welcome"><?php esc_html_e( 'Welcome to', 'woocommerce' ); ?></p>
+				<h1 class="wc-logo"><a href="https://woocommerce.com/"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/woocommerce_logo.png" alt="<?php esc_attr_e( 'WooCommerce', 'woocommerce' ); ?>" /></a></h1>
 				<p><?php esc_html_e( 'Get your store up and running more quickly with our new and improved setup experience', 'woocommerce' ); ?></p>
 
 				<form method="post" class="activate-new-onboarding">
@@ -494,7 +484,7 @@ class WC_Admin_Setup_Wizard {
 					</p>
 				</form>
 
-				<p class="onboarding-plugin-info"><?php esc_html_e( 'The "WooCommerce Admin" plugin will be installed and activated', 'woocommerce' ); ?></p>
+				<p class="wc-setup-step__new_onboarding-plugin-info"><?php esc_html_e( 'The "WooCommerce Admin" plugin will be installed and activated', 'woocommerce' ); ?></p>
 			</div>
 		<?php
 	}

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -505,7 +505,7 @@ class WC_Admin_Setup_Wizard {
 	public function wc_setup_new_onboarding_save() {
 		check_admin_referer( 'wc-setup' );
 
-		update_option( 'wc_onboarding_opt_in', true );
+		update_option( 'wc_onboarding_opt_in', 'yes' );
 
 		if ( function_exists( 'wc_admin_url' ) ) {
 			$this->wc_setup_redirect_to_wc_admin_onboarding();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Part of https://github.com/woocommerce/woocommerce-admin/issues/2759. Targeted for 3.9.

This PR adds an a/b test to the setup wizard, which for 10% of users will allow opt-in to the new WooCommerce Admin onboarding experience. This allows us to test our changes, prior to launching for all new users next year.

For users in the test group, the WooCommerce Admin installation step is done before anything else, and the user is redirected to the new onboarding experience after install.

<img width="1051" alt="Screen Shot 2019-11-06 at 1 42 06 PM" src="https://user-images.githubusercontent.com/689165/68332700-3f4f8000-00a5-11ea-83ea-96bec189fd06.png">

### How to test the changes in this Pull Request:

1. Uninstall WooCommerce Admin.
2. Go to `/wp-admin/admin.php?page=wc-setup` and try your luck with the a/b test logic. If you are part of the 90% that gets selected for the `a` (control) version, you should just see the normal setup wizard with no changes.
3. Update the `woocommerce_setup_ab_wc_admin_onboarding` option in your database to `b`.
4. Go back to `/wp-admin/admin.php?page=wc-setup` and you should now see the onboarding prompt screen.
5. Test the continue/skip link and make sure you can use the normal setup wizard.
6. Go back to `/wp-admin/admin.php?page=wc-setup` once again, and click `Yes Please`.
7. WooCommerce Admin should be ininstalled, and you should be redirected to the start of the new onboarding experience.

### Other information:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Changelog entry

Show the new WooCommerce Onboarding experience to 10% of new users.
