### PR TITLE
Account for non-EU countries that collect VAT and rename tax to VAT on the frontend for them

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -367,6 +367,17 @@ class WC_Countries {
 	}
 
 	/**
+	 * Gets an array of Non-EU countries that use VAT as the Local name for their taxes based on this list - https://en.wikipedia.org/wiki/Value-added_tax#Non-European_Union_countries
+	 *
+	 * @return string[]
+	 */
+	public function countries_using_vat() {
+		$countries = array( 'BS', 'BH', 'BB', 'EG', 'ET', 'FJ', 'GM', 'GH', 'IN', 'IR', 'KZ', 'MU', 'MN', 'NA', 'NP', 'NG', 'PS', 'RW', 'KN', 'SA', 'ZA', 'KR', 'LK', 'TH' );
+
+		return apply_filters( 'woocommerce_countries_using_vat', $countries );
+	}
+
+	/**
 	 * Gets the correct string for shipping - either 'to the' or 'to'.
 	 *
 	 * @param string $country_code Country code.
@@ -400,7 +411,7 @@ class WC_Countries {
 	 * @return string
 	 */
 	public function tax_or_vat() {
-		$return = in_array( $this->get_base_country(), array_merge( $this->get_european_union_countries( 'eu_vat' ), array( 'NO' ) ), true ) ? __( 'VAT', 'woocommerce' ) : __( 'Tax', 'woocommerce' );
+		$return = in_array( $this->get_base_country(), array_merge( $this->get_european_union_countries( 'eu_vat' ), array( 'NO' ), $this->countries_using_vat() ), true ) ? __( 'VAT', 'woocommerce' ) : __( 'Tax', 'woocommerce' );
 
 		return apply_filters( 'woocommerce_countries_tax_or_vat', $return );
 	}
@@ -411,7 +422,7 @@ class WC_Countries {
 	 * @return string
 	 */
 	public function inc_tax_or_vat() {
-		$return = in_array( $this->get_base_country(), array_merge( $this->get_european_union_countries( 'eu_vat' ), array( 'NO' ) ), true ) ? __( '(incl. VAT)', 'woocommerce' ) : __( '(incl. tax)', 'woocommerce' );
+		$return = in_array( $this->get_base_country(), array_merge( $this->get_european_union_countries( 'eu_vat' ), array( 'NO' ), $this->countries_using_vat() ), true ) ? __( '(incl. VAT)', 'woocommerce' ) : __( '(incl. tax)', 'woocommerce' );
 
 		return apply_filters( 'woocommerce_countries_inc_tax_or_vat', $return );
 	}
@@ -422,7 +433,7 @@ class WC_Countries {
 	 * @return string
 	 */
 	public function ex_tax_or_vat() {
-		$return = in_array( $this->get_base_country(), array_merge( $this->get_european_union_countries( 'eu_vat' ), array( 'NO' ) ), true ) ? __( '(ex. VAT)', 'woocommerce' ) : __( '(ex. tax)', 'woocommerce' );
+		$return = in_array( $this->get_base_country(), array_merge( $this->get_european_union_countries( 'eu_vat' ), array( 'NO' ), $this->countries_using_vat() ), true ) ? __( '(ex. VAT)', 'woocommerce' ) : __( '(ex. tax)', 'woocommerce' );
 
 		return apply_filters( 'woocommerce_countries_ex_tax_or_vat', $return );
 	}

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -372,7 +372,7 @@ class WC_Countries {
 	 * @return string[]
 	 */
 	public function countries_using_vat() {
-		$countries = array( 'AZ', 'BS', 'BH', 'BY', 'BB', 'EG', 'ET', 'FJ', 'GM', 'GH', 'IN', 'IR', 'IL', 'KZ', 'MU', 'MK', 'MX', 'MD', 'MN', 'ME', 'NA', 'NP', 'NG', 'PS', 'PY', 'RU', 'RW', 'KN', 'SA', 'RS', 'ZA', 'KR', 'LK', 'TH', 'TR', 'UA', 'UY', 'UZ', 'VE', 'VN', 'AE' );
+		$countries = array( 'AL', 'AR', 'AZ', 'BS', 'BH', 'BY', 'BB', 'BO', 'EG', 'ET', 'CL', 'CO', 'EC', 'SV', 'FJ', 'GM', 'GH', 'GT', 'IN', 'IR', 'IL', 'KZ', 'MU', 'MK', 'MX', 'MD', 'MN', 'ME', 'NA', 'NP', 'NG', 'PS', 'PY', 'RU', 'RW', 'KN', 'SA', 'RS', 'ZA', 'KR', 'LK', 'TH', 'TR', 'UA', 'UY', 'UZ', 'VE', 'VN', 'AE' );
 
 		return apply_filters( 'woocommerce_countries_using_vat', $countries );
 	}

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -372,7 +372,7 @@ class WC_Countries {
 	 * @return string[]
 	 */
 	public function countries_using_vat() {
-		$countries = array( 'BS', 'BH', 'BB', 'EG', 'ET', 'FJ', 'GM', 'GH', 'IN', 'IR', 'KZ', 'MU', 'MN', 'NA', 'NP', 'NG', 'PS', 'RW', 'KN', 'SA', 'ZA', 'KR', 'LK', 'TH' );
+		$countries = array( 'AZ', 'BS', 'BH', 'BY', 'BB', 'EG', 'ET', 'FJ', 'GM', 'GH', 'IN', 'IR', 'IL', 'KZ', 'MU', 'MK', 'MX', 'MD', 'MN', 'ME', 'NA', 'NP', 'NG', 'PS', 'PY', 'RU', 'RW', 'KN', 'SA', 'RS', 'ZA', 'KR', 'LK', 'TH', 'TR', 'UA', 'UY', 'UZ', 'VE', 'VN', 'AE' );
 
 		return apply_filters( 'woocommerce_countries_using_vat', $countries );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

* Collect an array of Non-EU countries that use VAT as the Local name for their taxes based on this list - https://en.wikipedia.org/wiki/Value-added_tax#Non-European_Union_countries. Countries accounted for are:

	- Albania
	- Argentina
	- Azerbaijan
	- Bahamas
	- Bahrain
	- Barbados
	- Belarus
	- Bolivia
	- Chile
	- Colombia
	- Ecuador
	- Egypt
	- El Salvador
	- Ethiopia
	- Fiji
	- Gambia
	- Ghana
	- Guatemala
	- India
	- Iran
	- Israel
	- Kazakhstan
	- Macedonia
	- Mauritius
	- Mexico
	- Moldova
	- Mongolia
	- Montenegro
	- Namibia
	- Nepal
	- Nigeria
	- Palestine
	- Paraguay
	- Russia
	- Rwanda
	- Saint Kitts and Nevis
	- Saudi Arabia
	- Serbia
	- South Africa
	- South Korea
	- Sri Lanka
	- Thailand
	- Turkey
	- UAE
	- Ukraine
	- Uruguay
	- Uzbekistan
	- Venezuela
	- Vietnam

* Rename Tax to VAT on the frontend for these countries.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24995 

### How to test the changes in this Pull Request:

1. Add a global tax rate to the store
![Tax Rate](https://user-images.githubusercontent.com/248077/68422682-93875c80-0198-11ea-9d3f-5def96dba172.jpg)

2. Change the base country of the shop to any of the countries listed above
![South Africa](https://user-images.githubusercontent.com/248077/68422845-dba67f00-0198-11ea-92de-95cd8b435bd0.jpg)

3. On the Cart & Checkout pages, the Tax line should read VAT rather than Tax as in the screenshot below
![VAT](https://user-images.githubusercontent.com/248077/68422958-11e3fe80-0199-11ea-85b2-4f25d3a3baab.jpg)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - Account for non-EU countries that collect VAT and rename tax to VAT on the frontend for them