### PR TITLE
Initial support for "pay button"

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -132,6 +132,13 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 	public $new_method_label = '';
 
 	/**
+	 * Pay button ID if supported.
+	 *
+	 * @var string
+	 */
+	public $pay_button_id = '';
+
+	/**
 	 * Contains a users saved tokens for this gateway.
 	 *
 	 * @var array
@@ -315,6 +322,16 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 		$icon = $this->icon ? '<img src="' . WC_HTTPS::force_https_url( $this->icon ) . '" alt="' . esc_attr( $this->get_title() ) . '" />' : '';
 
 		return apply_filters( 'woocommerce_gateway_icon', $icon, $this->id );
+	}
+
+	/**
+	 * Return the gateway's pay button ID.
+	 *
+	 * @since 3.9.0
+	 * @return string
+	 */
+	public function get_pay_button_id() {
+		return sanitize_html_class( $this->pay_button_id );
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -456,7 +456,9 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 		);
 
 		wp_localize_script(
-			'woocommerce-tokenization-form', 'wc_tokenization_form_params', array(
+			'woocommerce-tokenization-form',
+			'wc_tokenization_form_params',
+			array(
 				'is_registration_required' => WC()->checkout()->is_registration_required(),
 				'is_logged_in'             => is_user_logged_in(),
 			)
@@ -538,7 +540,7 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 			esc_html__( 'Save to account', 'woocommerce' )
 		);
 
-		echo apply_filters( 'woocommerce_payment_gateway_save_new_payment_method_option_html', $html, $this );
+		echo apply_filters( 'woocommerce_payment_gateway_save_new_payment_method_option_html', $html, $this ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 	}
 
 	/**

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3664,3 +3664,29 @@ if ( ! function_exists( 'woocommerce_product_reviews_tab' ) ) {
 		wc_deprecated_function( 'woocommerce_product_reviews_tab', '2.4' );
 	}
 }
+
+/**
+ * Display pay buttons HTML.
+ *
+ * @since 3.9.0
+ */
+function wc_get_pay_buttons() {
+	$supported_gateways = array();
+	$available_gateways = WC()->payment_gateways()->get_available_payment_gateways();
+
+	foreach ( $available_gateways as $gateway ) {
+		if ( $gateway->supports( 'pay_button' ) ) {
+			$supported_gateways[] = $gateway->get_pay_button_id();
+		}
+	}
+
+	if ( ! $supported_gateways ) {
+		return;
+	}
+
+	echo '<div class="woocommerce-pay-buttons">';
+	foreach ( $supported_gateways as $pay_button_id ) {
+		echo sprintf( '<div class="woocommerce-pay-button__%1$s %1$s" id="%1$s"></div>', esc_attr( $pay_button_id ) );
+	}
+	echo '</div>';
+}

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -207,6 +207,9 @@ add_action( 'woocommerce_product_additional_information', 'wc_display_product_at
  * @see woocommerce_checkout_coupon_form()
  * @see woocommerce_order_review()
  * @see woocommerce_checkout_payment()
+ * @see wc_checkout_privacy_policy_text()
+ * @see wc_terms_and_conditions_page_content()
+ * @see wc_get_pay_buttons()
  */
 add_action( 'woocommerce_before_checkout_form', 'woocommerce_checkout_login_form', 10 );
 add_action( 'woocommerce_before_checkout_form', 'woocommerce_checkout_coupon_form', 10 );
@@ -214,6 +217,7 @@ add_action( 'woocommerce_checkout_order_review', 'woocommerce_order_review', 10 
 add_action( 'woocommerce_checkout_order_review', 'woocommerce_checkout_payment', 20 );
 add_action( 'woocommerce_checkout_terms_and_conditions', 'wc_checkout_privacy_policy_text', 20 );
 add_action( 'woocommerce_checkout_terms_and_conditions', 'wc_terms_and_conditions_page_content', 30 );
+add_action( 'woocommerce_checkout_before_customer_details', 'wc_get_pay_buttons', 30 );
 
 /**
  * Cart widget
@@ -227,10 +231,13 @@ add_action( 'woocommerce_widget_shopping_cart_total', 'woocommerce_widget_shoppi
  *
  * @see woocommerce_cross_sell_display()
  * @see woocommerce_cart_totals()
+ * @see wc_get_pay_buttons()
  * @see woocommerce_button_proceed_to_checkout()
+ * @see wc_empty_cart_message()
  */
 add_action( 'woocommerce_cart_collaterals', 'woocommerce_cross_sell_display' );
 add_action( 'woocommerce_cart_collaterals', 'woocommerce_cart_totals', 10 );
+add_action( 'woocommerce_proceed_to_checkout', 'wc_get_pay_buttons', 10 );
 add_action( 'woocommerce_proceed_to_checkout', 'woocommerce_button_proceed_to_checkout', 20 );
 add_action( 'woocommerce_cart_is_empty', 'wc_empty_cart_message', 10 );
 

--- a/tests/framework/class-wc-mock-payment-gateway.php
+++ b/tests/framework/class-wc-mock-payment-gateway.php
@@ -4,18 +4,35 @@ class WC_Mock_Payment_Gateway extends WC_Payment_Gateway {
 	 * Constructor for the gateway.
 	 */
 	public function __construct() {
+		$this->enabled            = 'yes';
 		$this->id                 = 'mock';
 		$this->has_fields         = false;
 		$this->order_button_text  = __( 'Proceed to PayPal', 'woocommerce' );
 		$this->method_title       = 'Mock Gateway';
 		$this->method_description = 'Mock Gateway for unit tests';
+		$this->pay_button_id      = 'mock-pay-button';
 		$this->supports           = array(
 			'products',
+			'pay_button',
 		);
 
 		// Load the settings.
 		$this->init_form_fields();
 		$this->init_settings();
+	}
+
+	/**
+	 * Initialise Gateway Settings Form Fields.
+	 */
+	public function init_form_fields() {
+		$this->form_fields = array(
+			'enabled' => array(
+				'title'   => '',
+				'type'    => 'checkbox',
+				'label'   => '',
+				'default' => 'yes',
+			),
+		);
 	}
 }
 

--- a/tests/framework/class-wc-mock-payment-gateway.php
+++ b/tests/framework/class-wc-mock-payment-gateway.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Class WC_Mock_Payment_Gateway
+ *
+ * @package WooCommerce\Tests\Framework
+ */
+
+/**
+ * Class WC_Mock_Payment_Gateway
+ */
 class WC_Mock_Payment_Gateway extends WC_Payment_Gateway {
 	/**
 	 * Constructor for the gateway.

--- a/tests/unit-tests/gateways/gateways.php
+++ b/tests/unit-tests/gateways/gateways.php
@@ -64,5 +64,20 @@ class WC_Tests_Gateways extends WC_Unit_Test_Case {
 		$order->save();
 		$this->assertFalse( $gateway->can_refund_order( $order ) );
 	}
+
+	/**
+	 * Test WC_Payment_Gateway::get_pay_button_id();
+	 *
+	 * @return void
+	 */
+	public function test_get_pay_button_id() {
+		$gateway = new WC_Mock_Payment_Gateway();
+
+		$this->assertEquals( $gateway->pay_button_id, $gateway->get_pay_button_id() );
+
+		$gateway->pay_button_id = 'new-pay-button';
+
+		$this->assertEquals( $gateway->pay_button_id, $gateway->get_pay_button_id() );
+	}
 }
 

--- a/tests/unit-tests/gateways/gateways.php
+++ b/tests/unit-tests/gateways/gateways.php
@@ -4,6 +4,10 @@
  *
  * @package WooCommerce\Tests\Gateways
  */
+
+/**
+ * Unit tests for gateways.
+ */
 class WC_Tests_Gateways extends WC_Unit_Test_Case {
 
 	/**

--- a/tests/unit-tests/templates/functions.php
+++ b/tests/unit-tests/templates/functions.php
@@ -142,4 +142,40 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$expected_html = '<input type="hidden" name="test_something" value="something else" />';
 		$this->assertEquals( $expected_html, $actual_html );
 	}
+
+	/**
+	 * Test test_wc_get_pay_buttons().
+	 */
+	public function test_wc_get_pay_buttons() {
+		// Test default.
+		ob_start();
+		wc_get_pay_buttons();
+		$actual_html = ob_get_clean();
+
+		$this->assertEquals( '', $actual_html );
+
+		// Include a payment gateway that supports "pay button".
+		add_filter(
+			'woocommerce_payment_gateways',
+			function( $gateways ) {
+				$gateways[] = 'WC_Mock_Payment_Gateway';
+
+				return $gateways;
+			}
+		);
+		WC()->payment_gateways()->init();
+
+		// Test pay buttons HTML.
+		ob_start();
+		wc_get_pay_buttons();
+		$actual_html = ob_get_clean();
+
+		$gateway       = new WC_Mock_Payment_Gateway();
+		$expected_html = sprintf(
+			'<div class="woocommerce-pay-buttons"><div class="woocommerce-pay-button__%1$s %1$s" id="%1$s"></div></div>',
+			$gateway->get_pay_button_id()
+		);
+
+		$this->assertEquals( $expected_html, $actual_html );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This includes initial support to a "pay button" functionality on WooCommerce, creating a standard for where to display and how.
Since in most of the cases a "pay button" is generated by JS, so we can now provide a proper place to insert those buttons, instead of creating custom hooks and HTML in each payment gateway/plugin.

Note: For now we are not including any styling for this feature, so themes should decide of how to customize.

### How to test the changes in this Pull Request:

1. Create and enable a payment gateway that support pay button, you can get one sample in https://gist.github.com/claudiosanches/27918ec8a28fd1650b6a2fbc6dfed767
2. After installing the sample plugin, you can go to the cart and checkout page.
3. Check if the cart and checkout page contains the test button.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced Payment Gateway API to support "pay button".