### PR TITLE
Add product data to itemReviewed markup

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -330,7 +330,7 @@ class WC_Structured_Data {
 		$markup = apply_filters( 'woocommerce_structured_data_product', $markup, $product );
 
 		// If this function was called from a product review, return the $markup now.
-		if ( $review_id ){
+		if ( $review_id ) {
 			return $markup;
 		}
 


### PR DESCRIPTION
Review data has a markup section called itemReviewed. Google Search Console is now expecting more complete product data in this markup section.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24950 .

### How to test the changes in this Pull Request:

1. Check Google Search Console after this is implemented and see no more errors relating to missing product data which they expect to be part of the review data.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
