### PR TITLE
Made usage tracking link in setup more transparent

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -580,7 +580,7 @@ class WC_Admin_Setup_Wizard {
 								printf(
 									wp_kses(
 										/* translators: %1$s: usage tracking help link */
-										__( 'Learn more about how usage tracking works, and how you\'ll be helping <a href="%1$s" target="_blank">here</a>.', 'woocommerce' ),
+										__( 'Learn more about how usage tracking works, and how you\'ll be helping at <a href="%1$s" target="_blank">%1$s</a>.', 'woocommerce' ),
 										array(
 											'a'    => array(
 												'href'   => array(),

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -580,7 +580,7 @@ class WC_Admin_Setup_Wizard {
 								printf(
 									wp_kses(
 										/* translators: %1$s: usage tracking help link */
-										__( 'Learn more about how usage tracking works, and how you\'ll be helping at <a href="%1$s" target="_blank">%1$s</a>.', 'woocommerce' ),
+										__( 'Learn more about how usage tracking works, and how you\'ll be helping in our <a href="%1$s" target="_blank">usage tracking documentation</a>.', 'woocommerce' ),
 										array(
 											'a'    => array(
 												'href'   => array(),


### PR DESCRIPTION
# All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Replaces the anchor tag text "here" with the link so that users know where the link will lead just by looking at it.

Closes #25022.

### How to test the changes in this Pull Request:

1. Run the setup wizard and review the text in the tracking popup.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Made the usage tracking link on the setup wizard more transparent.
