### PR TITLE
Make WC_Product_Variation_Data_Store_CPT::read check only for product_variation

### DIFF
--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -48,7 +48,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		$post_object = get_post( $product->get_id() );
 
-		if ( ! $post_object || ! in_array( $post_object->post_type, array( 'product', 'product_variation' ), true ) ) {
+		if ( ! $post_object || 'product_variation' !== $post_object->post_type ) {
 			return;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Currently `WC_Product_Variation_Data_Store_CPT::read` is checking for `product` and `product_variation` at the same time, what isn't correct, since it should be look only for `product_variation`.

Closes #24956.

### How to test the changes in this Pull Request:

1. Run the follow code with `wp shell`:
```php
global $post;
$post->post_title = 'foo';
new WC_Product_Variation(14); // ID of any variable product
wc_get_product(14)->get_name(); // will display "foo"
```

After running this code you can check that `WC_Product_Variation` is setting the new product name with [code for backwards compatibility](https://github.com/woocommerce/woocommerce/blob/master/includes/data-stores/class-wc-product-variation-data-store-cpt.php#L79-L105).

2. Apply this patch and try again

Now should stop saving the title or except if is not a `product_variation`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Fixed `WC_Product_Variation_Data_Store_CPT::read` to allow only `product_variation`.
