### PR TITLE
Prevent update variation name and attribute summary if no parent is set

### DIFF
--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -76,7 +76,13 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		$this->read_extra_data( $product );
 		$product->set_attributes( wc_get_product_variation_attributes( $product->get_id() ) );
 
+		if ( ! $product->get_parent_id() ) {
+			$product->set_object_read( true );
+			return;
+		}
+
 		$updates = array();
+
 		/**
 		 * If a variation title is not in sync with the parent e.g. saved prior to 3.0, or if the parent title has changed, detect here and update.
 		 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This Pull Request try to help with incorrect instantiation of `WC_Product_Variation`, when setting some regular product ID instead a proper variation ID.

Not a big fan of this change, since no one should directly create an instance of `WC_Product_Variation` or any other product type class, since all of this should be handled by the `WC_Product_Factory` class, where allows by filters to customize any product type class, see:

https://github.com/woocommerce/woocommerce/blob/b433219f71a76fc84b382b20f9efc5a13b047f2c/includes/class-wc-product-factory.php#L52-L68

Closes #24956.

### How to test the changes in this Pull Request:

1. Run the follow code with `wp shell`:
```php
global $post;
$post->post_title = 'foo';
new WC_Product_Variation(14); // ID of any variable product
wc_get_product(14)->get_name(); // will display "foo"
```

After running this code you can check that `WC_Product_Variation` is setting the new product name with [code for backwards compatibility](https://github.com/woocommerce/woocommerce/blob/master/includes/data-stores/class-wc-product-variation-data-store-cpt.php#L79-L105).

2. Apply this patch and try again

Now should stop saving the name or except.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
