### PR TITLE
Fixed "Add payment method" menu highlight in My Account page

### DIFF
--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -151,6 +151,8 @@ function wc_get_account_menu_item_classes( $endpoint ) {
 		$current = true; // Dashboard is not an endpoint, so needs a custom check.
 	} elseif ( 'orders' === $endpoint && isset( $wp->query_vars['view-order'] ) ) {
 		$current = true; // When looking at individual order, highlight Orders list item (to signify where in the menu the user currently is).
+	} elseif ( 'payment-methods' === $endpoint && isset( $wp->query_vars['add-payment-method'] ) ) {
+		$current = true;
 	}
 
 	if ( $current ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This fix the menu highlight of the "Add payment method" in My Account page.

Closes #25039.

### How to test the changes in this Pull Request:
1. Go to my account area
2. Go to payment methods tab
3. Try to enter new payment method
4. On your right, you will see "Payment methods" tab not highlighted

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Fixed menu highlight of My Account page when browsing "Add payment method" page.
