### PR TITLE
Prevent creating products before registering related post types and taxonomies.

### DIFF
--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -53,9 +53,9 @@ function wc_get_products( $args ) {
  * @return WC_Product|null|false
  */
 function wc_get_product( $the_product = false, $deprecated = array() ) {
-	if ( ! did_action( 'woocommerce_init' ) ) {
-		/* translators: 1: wc_get_product 2: woocommerce_init */
-		wc_doing_it_wrong( __FUNCTION__, sprintf( __( '%1$s should not be called before the %2$s action.', 'woocommerce' ), 'wc_get_product', 'woocommerce_init' ), '2.5' );
+	if ( ! did_action( 'woocommerce_init' ) || ! did_action( 'woocommerce_after_register_taxonomy' ) || ! did_action( 'woocommerce_after_register_post_type' ) ) {
+		/* translators: 1: wc_get_product 2: woocommerce_init 3: woocommerce_after_register_taxonomy 4: woocommerce_after_register_post_type */
+		wc_doing_it_wrong( __FUNCTION__, sprintf( __( '%1$s should not be called before the %2$s, %3$s and %4$s actions have finished.', 'woocommerce' ), 'wc_get_product', 'woocommerce_init', 'woocommerce_after_register_taxonomy', 'woocommerce_after_register_post_type' ), '3.9' );
 		return false;
 	}
 	if ( ! empty( $deprecated ) ) {

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -46,6 +46,9 @@ function wc_get_products( $args ) {
 /**
  * Main function for returning products, uses the WC_Product_Factory class.
  *
+ * This function should only be called after 'init' action is finished, as there might be taxonomies that are getting
+ * registered during the init action.
+ *
  * @since 2.2.0
  *
  * @param mixed $the_product Post object or post ID of the product.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24953 .
Closes #24954.

I think if we're trying to safeguard people from incorrectly using a function, we should do it properly and ensure there is no in between state, where code is running after the `woocommerce_init`, but still not producing the correct product. 
I purposefully haven't tied it to WordPress `init` action, even though it could be better (?), as I feared some code might break unnecessarily. 

### How to test the changes in this Pull Request:

1. Create a variable product, with 1 global and 1 custom attribute.
2. Note the id of the product.
3. Add the snippet to one of the php files:
```
function product_test() {
	$product = wc_get_product( 48 ); //variable product id to see the mismatch
	$attrs = $product->get_attributes();
}
add_action('woocommerce_init', 'product_test', 999); // or anything before the init priority 5.
```
4. Examine the `$product`, it will be a `WC_Product_Simple` instance with one attribute, not a `WC_Product_Variable` instance with 2 attributes.
5. Apply the change, now the code should throw the updated notice that (hopefully better) explains the usage. 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Prevent creating products before registering related post types and taxonomies.
