### PR TITLE
Use the $username variable

### DIFF
--- a/tests/unit-tests/customer/crud.php
+++ b/tests/unit-tests/customer/crud.php
@@ -13,7 +13,7 @@ class WC_Tests_CustomerCRUD extends WC_Unit_Test_Case {
 	public function test_create_customer() {
 		$username = 'testusername-' . time();
 		$customer = new WC_Customer();
-		$customer->set_username( 'testusername-' . time() );
+		$customer->set_username( $username );
 		$customer->set_password( 'test123' );
 		$customer->set_email( 'test@woo.local' );
 		$customer->save();


### PR DESCRIPTION
This test could fail if time() does not return the same value twice.

### All Submissions:

* [ X ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ X ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


I have stripped other sections as this fix is self-explanatory.
