### PR TITLE
Allow related title changes

### DIFF
--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -38,7 +38,7 @@ if ( $related_products ) : ?>
 					<?php
 					$post_object = get_post( $related_product->get_id() );
 
-					setup_postdata( $GLOBALS['post'] =& $post_object ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited, Squiz.PHP.DisallowMultipleAssignments.Found
+					setup_postdata( $GLOBALS['post'] =& $post_object ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, Squiz.PHP.DisallowMultipleAssignments.Found
 
 					wc_get_template_part( 'content', 'product' );
 					?>

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -23,7 +23,7 @@ if ( $related_products ) : ?>
 
 	<section class="related products">
         <?php
-        $heading = apply_filters( 'woocommerce_product_related_heading', __( 'Related products', 'woocommerce' ) );
+        $heading = apply_filters( 'woocommerce_product_related_products_heading', __( 'Related products', 'woocommerce' ) );
         if ( $heading ) : ?>
             <h2><?php echo esc_html( $heading ); ?></h2>
         <?php endif; ?>

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -38,7 +38,7 @@ if ( $related_products ) : ?>
 					<?php
 					$post_object = get_post( $related_product->get_id() );
 
-					setup_postdata( $GLOBALS['post'] =& $post_object );
+					setup_postdata( $GLOBALS['post'] =& $post_object ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.OverrideProhibited, Squiz.PHP.DisallowMultipleAssignments.Found
 
 					wc_get_template_part( 'content', 'product' );
 					?>
@@ -48,8 +48,7 @@ if ( $related_products ) : ?>
 		<?php woocommerce_product_loop_end(); ?>
 
 	</section>
-
-<?php
+	<?php
 endif;
 
 wp_reset_postdata();

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -25,8 +25,9 @@ if ( $related_products ) : ?>
 
 		<?php
 		$heading = apply_filters( 'woocommerce_product_related_products_heading', __( 'Related products', 'woocommerce' ) );
-		
-		if ( $heading ) : ?>
+
+		if ( $heading ) : 
+		?>
 			<h2><?php echo esc_html( $heading ); ?></h2>
 		<?php endif; ?>
 		
@@ -34,12 +35,13 @@ if ( $related_products ) : ?>
 
 			<?php foreach ( $related_products as $related_product ) : ?>
 
-				<?php
-				 	$post_object = get_post( $related_product->get_id() );
+					<?php
+					$post_object = get_post( $related_product->get_id() );
 
 					setup_postdata( $GLOBALS['post'] =& $post_object );
 
-					wc_get_template_part( 'content', 'product' ); ?>
+					wc_get_template_part( 'content', 'product' );
+			?>
 
 			<?php endforeach; ?>
 
@@ -47,6 +49,7 @@ if ( $related_products ) : ?>
 
 	</section>
 
-<?php endif;
+<?php 
+endif;
 
 wp_reset_postdata();

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -10,8 +10,8 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see 	    https://docs.woocommerce.com/document/template-structure/
- * @package 	WooCommerce/Templates
+ * @see         https://docs.woocommerce.com/document/template-structure/
+ * @package     WooCommerce/Templates
  * @version     3.9.0
  */
 
@@ -22,11 +22,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( $related_products ) : ?>
 
 	<section class="related products">
-        <?php
-        $heading = apply_filters( 'woocommerce_product_related_products_heading', __( 'Related products', 'woocommerce' ) );
-        if ( $heading ) : ?>
-            <h2><?php echo esc_html( $heading ); ?></h2>
-        <?php endif; ?>
+
+		<?php
+		$heading = apply_filters( 'woocommerce_product_related_products_heading', __( 'Related products', 'woocommerce' ) );
+		
+		if ( $heading ) : ?>
+			<h2><?php echo esc_html( $heading ); ?></h2>
+		<?php endif; ?>
 		
 		<?php woocommerce_product_loop_start(); ?>
 

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -22,9 +22,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( $related_products ) : ?>
 
 	<section class="related products">
-
-		<h2><?php esc_html_e( 'Related products', 'woocommerce' ); ?></h2>
-
+        <?php
+        $heading = apply_filters( 'woocommerce_product_related_heading', __( 'Related products', 'woocommerce' ) );
+        if ( $heading ) : ?>
+            <h2><?php echo esc_html( $heading ); ?></h2>
+        <?php endif; ?>
+		
 		<?php woocommerce_product_loop_start(); ?>
 
 			<?php foreach ( $related_products as $related_product ) : ?>

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -12,7 +12,7 @@
  *
  * @see 	    https://docs.woocommerce.com/document/template-structure/
  * @package 	WooCommerce/Templates
- * @version     3.0.0
+ * @version     3.9.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -26,8 +26,8 @@ if ( $related_products ) : ?>
 		<?php
 		$heading = apply_filters( 'woocommerce_product_related_products_heading', __( 'Related products', 'woocommerce' ) );
 
-		if ( $heading ) : 
-		?>
+		if ( $heading ) :
+			?>
 			<h2><?php echo esc_html( $heading ); ?></h2>
 		<?php endif; ?>
 		
@@ -41,7 +41,7 @@ if ( $related_products ) : ?>
 					setup_postdata( $GLOBALS['post'] =& $post_object );
 
 					wc_get_template_part( 'content', 'product' );
-			?>
+					?>
 
 			<?php endforeach; ?>
 
@@ -49,7 +49,7 @@ if ( $related_products ) : ?>
 
 	</section>
 
-<?php 
+<?php
 endif;
 
 wp_reset_postdata();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This modification enables the change of the related products title via a filter. This was not possible before and related.php had to be edited.

### Changelog entry

Template: single-product/related.php - Add new filter `woocommerce_product_related_products_heading` for changing the Related Products heading without the need to override the template.
