### PR TITLE
Fix second param of action hook woocommerce_coupon_object_updated_props

### DIFF
--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -224,7 +224,6 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 * @since 3.0.0
 	 */
 	private function update_post_meta( &$coupon ) {
-		$updated_props     = array();
 		$meta_key_to_props = array(
 			'discount_type'              => 'discount_type',
 			'coupon_amount'              => 'amount',

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -278,7 +278,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			}
 		}
 
-		do_action( 'woocommerce_coupon_object_updated_props', $coupon, $updated_props );
+		do_action( 'woocommerce_coupon_object_updated_props', $coupon, $this->updated_props );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR cherry-picks a commit from #25008 and leaves out another one that is not related to the changes that was proposed. I also include a commit to remove the unused variable.

### How to test the changes in this Pull Request:

1. Add the following code to your test site
```php
add_filter( 'woocommerce_coupon_object_updated_props', function ( $coupon, $changes ) {
    error_log( print_r( $changes, true ) );
}  );
```
2. Make a change to a coupon code in wp-admin and save
3. Check the error log en ensure the changes you made is reflected there.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Pass the correct `$this->updated_props` variable to the `woocommerce_coupon_object_updated_props` action's second paramater.