### PR TITLE
Add tracking event to tracker for orders placed through frontend

### DIFF
--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -21,6 +21,7 @@ class WC_Orders_Tracking {
 		// WC_Meta_Box_Order_Actions::save() hooks in at priority 50.
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'track_order_action' ), 51 );
 		add_action( 'load-post-new.php', array( $this, 'track_add_order_from_edit' ), 10 );
+		add_action( 'woocommerce_thankyou', array( $this, 'track_order_placed' ), 10 );
 	}
 
 	/**
@@ -148,5 +149,28 @@ class WC_Orders_Tracking {
 				}
 			}
 		}
+	}
+
+	/**
+	 * Track orders placed by customers
+	 *
+	 * @param int $order_id Order ID.
+	 * @return void
+	 */
+	public function track_order_placed( $order_id ) {
+		$order = wc_get_order( $order_id );
+		if ( ! $order || ! is_a( $order, 'WC_Order' ) ) {
+			return;
+		}
+
+		$properties = array(
+			'order_id'       => $order->get_id(),
+			'total'          => $order->get_total(),
+			'currency'       => $order->get_currency(),
+			'status'         => $order->get_status(),
+			'payment_method' => $order->get_payment_method(),
+		);
+
+		WC_Tracks::record_event( 'order_placed', $properties );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds tracking on orders placed through the frontend, it will only track these orders when the store is opted into data tracking.


### How to test the changes in this Pull Request:

1. Make a test order
2. Check tracks for the new `order_placed` event.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> New - Track orders placed via the frontend when opted into data tracking.