### PR TITLE
phpcs: Allow short array syntax declaration

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -47,5 +47,11 @@
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
 		<exclude-pattern>i18n/</exclude-pattern>
 		<exclude-pattern>src/</exclude-pattern>
+		<exclude-pattern>packages/*</exclude-pattern>
+	</rule>
+
+	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
+		<exclude-pattern>src/*</exclude-pattern>
+		<exclude-pattern>packages/*</exclude-pattern>
 	</rule>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -47,11 +47,9 @@
 	<rule ref="WordPress.Files.FileName.NotHyphenatedLowercase">
 		<exclude-pattern>i18n/</exclude-pattern>
 		<exclude-pattern>src/</exclude-pattern>
-		<exclude-pattern>packages/*</exclude-pattern>
 	</rule>
 
 	<rule ref="Generic.Arrays.DisallowShortArraySyntax.Found">
 		<exclude-pattern>src/*</exclude-pattern>
-		<exclude-pattern>packages/*</exclude-pattern>
 	</rule>
 </ruleset>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Add a PHP Code Sniffer rule to allow Short Array syntax.

>As of PHP 5.4 you can also use the short array syntax, which replaces array() with [].

~ https://www.php.net/manual/en/language.types.array.php

Since WC has a requirement for PHP 5.6, the syntax is valid and should be allowed.

### How to test the changes in this Pull Request:

1. Declare an array somewhere in the code using the new syntax: `$thing = [];`
2. See the linter pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Allow short array syntax declaration

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
