### PR TITLE
Add support for '_held_for_checkout` records to prevent race conditions.

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -323,7 +323,6 @@ class WC_Checkout {
 			return $order_id;
 		}
 
-		$error = null;
 		try {
 			$order_id           = absint( WC()->session->get( 'order_awaiting_payment' ) );
 			$cart_hash          = WC()->cart->get_cart_hash();

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -323,6 +323,7 @@ class WC_Checkout {
 			return $order_id;
 		}
 
+		$error = null;
 		try {
 			$order_id           = absint( WC()->session->get( 'order_awaiting_payment' ) );
 			$cart_hash          = WC()->cart->get_cart_hash();
@@ -366,6 +367,7 @@ class WC_Checkout {
 				}
 			}
 
+			$order->hold_stock_for_checkout( WC()->cart );
 			$order->set_created_via( 'checkout' );
 			$order->set_cart_hash( $cart_hash );
 			$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) );
@@ -403,6 +405,9 @@ class WC_Checkout {
 
 			return $order_id;
 		} catch ( Exception $e ) {
+			if ( $order && $order instanceof WC_Order ) {
+				$order->release_held_stock();
+			}
 			return new WP_Error( 'checkout-error', $e->getMessage() );
 		}
 	}

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -2070,9 +2070,12 @@ class WC_Order extends WC_Abstract_Order {
 		$error = null;
 
 		try {
-			// TODO: Move to correct place.
 			foreach ( $cart->get_cart() as $cart_item_key => $values ) {
 				$product    = wc_get_product( $values['data'] );
+				if ( ! $product ) {
+					// Unsupported product!
+					continue;
+				}
 				$product_id = $product->get_stock_managed_by_id();
 				$result     = $this->hold_product_for_checkout( $product, $product_qty_in_cart[ $product_id ] );
 				if ( false === $result ) {

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -2072,9 +2072,9 @@ class WC_Order extends WC_Abstract_Order {
 		try {
 			// TODO: Move to correct place.
 			foreach ( $cart->get_cart() as $cart_item_key => $values ) {
-				$product                        = wc_get_product( $values['data'] );
-				$product_id                     = $product->get_stock_managed_by_id();
-				$result = $this->hold_product_for_checkout( $product, $product_qty_in_cart[ $product_id ] );
+				$product    = wc_get_product( $values['data'] );
+				$product_id = $product->get_stock_managed_by_id();
+				$result     = $this->hold_product_for_checkout( $product, $product_qty_in_cart[ $product_id ] );
 				if ( false === $result ) {
 					// translators: Name of the product.
 					throw new Exception( sprintf( __( 'Something changed during checkout. %s is no longer available.', 'woocommerce' ), $product->get_name() ) );

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -2066,7 +2066,7 @@ class WC_Order extends WC_Abstract_Order {
 		}
 
 		$product_qty_in_cart = $cart->get_cart_item_quantities();
-		$stock_held_keys     = [];
+		$stock_held_keys     = array();
 		$error = null;
 
 		try {

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -879,8 +879,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$outofstock_where = ' AND exclude_join.object_id IS NULL';
 		}
 
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		return $wpdb->get_results(
-			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
 			"
 			SELECT posts.ID as id, posts.post_parent as parent_id
 			FROM {$wpdb->posts} AS posts
@@ -898,7 +898,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			)
 			GROUP BY posts.ID
 			"
-		); // WPCS: unprepared SQL ok.
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**
@@ -1594,7 +1595,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 			foreach ( $search_terms as $search_term ) {
 				$like              = '%' . $wpdb->esc_like( $search_term ) . '%';
-				$term_group_query .= $wpdb->prepare( " {$searchand} ( ( posts.post_title LIKE %s) OR ( posts.post_excerpt LIKE %s) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s ) )", $like, $like, $like, $like ); // WPCS: unprepared SQL ok.
+				$term_group_query .= $wpdb->prepare( " {$searchand} ( ( posts.post_title LIKE %s) OR ( posts.post_excerpt LIKE %s) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s ) )", $like, $like, $like, $like ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$searchand         = ' AND ';
 			}
 
@@ -2055,8 +2056,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	/**
 	 * Returns query statement for getting current `_stock` of a product.
 	 *
+	 * @since 3.9.0
 	 * @param int $product_id Product ID.
-	 *
 	 * @return string|void Query statement.
 	 */
 	public function get_query_for_stock( $product_id ) {
@@ -2076,8 +2077,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 	/**
 	 * Returns query statement for getting quantity of stock held by orders in checkout.
 	 *
+	 * @since 3.9.0
 	 * @param int $product_id Product ID.
-	 *
 	 * @return string|void Query statement.
 	 */
 	public function get_query_for_held_stock( $product_id ) {

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -898,8 +898,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			)
 			GROUP BY posts.ID
 			"
-			// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-		);
+		); // WPCS: unprepared SQL ok.
 	}
 
 	/**
@@ -1595,7 +1594,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 			foreach ( $search_terms as $search_term ) {
 				$like              = '%' . $wpdb->esc_like( $search_term ) . '%';
-				$term_group_query .= $wpdb->prepare( " {$searchand} ( ( posts.post_title LIKE %s) OR ( posts.post_excerpt LIKE %s) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s ) )", $like, $like, $like, $like ); // @codingStandardsIgnoreLine.
+				$term_group_query .= $wpdb->prepare( " {$searchand} ( ( posts.post_title LIKE %s) OR ( posts.post_excerpt LIKE %s) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s ) )", $like, $like, $like, $like ); // WPCS: unprepared SQL ok.
 				$searchand         = ' AND ';
 			}
 
@@ -2051,5 +2050,49 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			return 'product_id';
 		}
 		return '';
+	}
+
+	/**
+	 * Returns query statement for getting current `_stock` of a product.
+	 *
+	 * @param int $product_id Product ID.
+	 *
+	 * @return string|void Query statement.
+	 */
+	public function get_query_for_stock( $product_id ) {
+		global $wpdb;
+		return $wpdb->prepare(
+			// MAX function below is used to make sure result is a scalar.
+			"
+			SELECT COALESCE ( MAX( meta_value ), 0 ) FROM $wpdb->postmeta
+			WHERE {$wpdb->postmeta}.meta_key = '_stock'
+			AND {$wpdb->postmeta}.post_id = %d
+			FOR UPDATE
+			",
+			$product_id
+		);
+	}
+
+	/**
+	 * Returns query statement for getting quantity of stock held by orders in checkout.
+	 *
+	 * @param int $product_id Product ID.
+	 *
+	 * @return string|void Query statement.
+	 */
+	public function get_query_for_held_stock( $product_id ) {
+		global $wpdb;
+		return $wpdb->prepare(
+			"
+			SELECT COALESCE ( SUM( meta_value ), 0 ) FROM $wpdb->postmeta
+			WHERE {$wpdb->postmeta}.meta_key like %s
+			AND {$wpdb->postmeta}.meta_key > CONCAT( %s, UNIX_TIMESTAMP() )
+			AND {$wpdb->postmeta}.post_id = %d
+			FOR UPDATE
+			",
+			'_held_for_checkout_%',
+			'_held_for_checkout_',
+			$product_id
+		);
 	}
 }

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -150,7 +150,7 @@ class WC_Shortcode_Checkout {
 							}
 
 							// Check stock based on all items in the cart and consider any held stock within pending orders.
-							$held_stock     = ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product, $order->get_id() ) : 0;
+							$held_stock     = ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product ) : 0;
 							$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
 
 							if ( $product->get_stock_quantity() < ( $held_stock + $required_stock ) ) {

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -886,6 +886,7 @@ function wc_update_coupon_usage_counts( $order_id ) {
 /**
  * Release held stock if any for an order.
  *
+ * @since 3.9.0
  * @param int $order_id Order ID.
  */
 function wc_release_held_stock( $order_id ) {

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -803,6 +803,8 @@ function wc_order_search( $term ) {
 function wc_update_total_sales_counts( $order_id ) {
 	$order = wc_get_order( $order_id );
 
+	$order->release_held_stock();
+
 	if ( ! $order || $order->get_data_store()->get_recorded_sales( $order ) ) {
 		return;
 	}
@@ -906,6 +908,7 @@ function wc_cancel_unpaid_orders() {
 			if ( apply_filters( 'woocommerce_cancel_unpaid_order', 'checkout' === $order->get_created_via(), $order ) ) {
 				$order->update_status( 'cancelled', __( 'Unpaid order cancelled - time limit reached.', 'woocommerce' ) );
 			}
+			$order->release_held_stock();
 		}
 	}
 	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -890,7 +890,7 @@ function wc_update_coupon_usage_counts( $order_id ) {
  * @param int $order_id Order ID.
  */
 function wc_release_held_stock( $order_id ) {
-	$order = new WC_Order( $order_id );
+	$order = wc_get_order( $order_id );
 	if ( ! $order ) {
 		return;
 	}

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -882,6 +882,22 @@ function wc_update_coupon_usage_counts( $order_id ) {
 		}
 	}
 }
+
+/**
+ * Release held stock if any for an order.
+ *
+ * @param int $order_id Order ID.
+ */
+function wc_release_held_stock( $order_id ) {
+	$order = new WC_Order( $order_id );
+	if ( ! $order ) {
+		return;
+	}
+
+	$order->release_held_stock();
+}
+add_action( 'woocommerce_order_status_cancelled', 'wc_release_held_stock' );
+
 add_action( 'woocommerce_order_status_pending', 'wc_update_coupon_usage_counts' );
 add_action( 'woocommerce_order_status_completed', 'wc_update_coupon_usage_counts' );
 add_action( 'woocommerce_order_status_processing', 'wc_update_coupon_usage_counts' );
@@ -908,7 +924,6 @@ function wc_cancel_unpaid_orders() {
 			if ( apply_filters( 'woocommerce_cancel_unpaid_order', 'checkout' === $order->get_created_via(), $order ) ) {
 				$order->update_status( 'cancelled', __( 'Unpaid order cancelled - time limit reached.', 'woocommerce' ) );
 			}
-			$order->release_held_stock();
 		}
 	}
 	wp_clear_scheduled_hook( 'woocommerce_cancel_unpaid_orders' );

--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -302,23 +302,38 @@ function wc_increase_stock_levels( $order_id ) {
 function wc_get_held_stock_quantity( $product, $exclude_order_id = 0 ) {
 	global $wpdb;
 
+	if ( apply_filters( 'enable_hold_stock_3_9', true ) ) {
+		/**
+		 * DOES NOT SUPPORT `exclude_order_id` param, which was primarily being used to exclude the current order!
+		 * While creating an order during checkout flow, this logic relies on the fact that order is not yet saved and therefore will be excluded.
+		 *
+		 * Query for calculating held stock which uses '_held_for_checkout' records instead of actually querying all orders with wc-pending status.
+		 * This is introduced to handle race conditions.
+		 *
+		 * @since 3.9.0
+		 */
+		$product_data_store = WC_Data_Store::load( 'product' );
+		$product_id = $product->get_stock_managed_by_id();
+		return $wpdb->get_var( $product_data_store->get_query_for_held_stock( $product_id ) ); // WPCS: unprepared SQL ok.
+	}
+
 	return $wpdb->get_var(
 		$wpdb->prepare(
 			"
-			SELECT SUM( order_item_meta.meta_value ) AS held_qty
-			FROM {$wpdb->posts} AS posts
-			LEFT JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
-			LEFT JOIN {$wpdb->prefix}woocommerce_order_items as order_items ON posts.ID = order_items.order_id
-			LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
-			LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta2 ON order_items.order_item_id = order_item_meta2.order_item_id
-			WHERE 	order_item_meta.meta_key    = '_qty'
-			AND 	order_item_meta2.meta_key   = %s
-			AND 	order_item_meta2.meta_value = %d
-			AND		postmeta.meta_key			= '_created_via'
-			AND		postmeta.meta_value			= 'checkout'
-			AND 	posts.post_type             IN ( '" . implode( "','", wc_get_order_types() ) . "' )
-			AND 	posts.post_status           = 'wc-pending'
-			AND		posts.ID                    != %d;",
+		SELECT SUM( order_item_meta.meta_value ) AS held_qty
+		FROM {$wpdb->posts} AS posts
+		LEFT JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
+		LEFT JOIN {$wpdb->prefix}woocommerce_order_items as order_items ON posts.ID = order_items.order_id
+		LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
+		LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta2 ON order_items.order_item_id = order_item_meta2.order_item_id
+		WHERE 	order_item_meta.meta_key    = '_qty'
+		AND 	order_item_meta2.meta_key   = %s
+		AND 	order_item_meta2.meta_value = %d
+		AND		postmeta.meta_key			= '_created_via'
+		AND		postmeta.meta_value			= 'checkout'
+		AND 	posts.post_type             IN ( '" . implode( "','", wc_get_order_types() ) . "' )
+		AND 	posts.post_status           = 'wc-pending'
+		AND		posts.ID                    != %d;",
 			'product_variation' === get_post_type( $product->get_stock_managed_by_id() ) ? '_variation_id' : '_product_id',
 			$product->get_stock_managed_by_id(),
 			$exclude_order_id

--- a/tests/unit-tests/checkout/checkout.php
+++ b/tests/unit-tests/checkout/checkout.php
@@ -77,7 +77,7 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 	 * @throws Exception When unable to create order.
 	 */
 	public function test_create_order_when_out_of_stock_legacy() {
-		add_filter( 'enable_hold_stock_3_9', '__return_false' );
+		add_filter( 'woocommerce_hold_stock_for_checkout', '__return_false' );
 		$this->test_create_order_when_out_of_stock();
 	}
 

--- a/tests/unit-tests/checkout/checkout.php
+++ b/tests/unit-tests/checkout/checkout.php
@@ -1,0 +1,143 @@
+<?php
+/**
+ * Checkout tests.
+ *
+ * @package WooCommerce|Tests|Checkout
+ */
+
+/**
+ * Class WC_Checkout
+ */
+class WC_Tests_Checkout extends WC_Unit_Test_Case {
+	/**
+	 * TearDown.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		WC()->cart->empty_cart();
+	}
+
+	/**
+	 * Helper method to create a managed product and a order for that product.
+	 *
+	 * @return array( WC_Product, WC_Order ) array
+	 * @throws Exception When unable to create an order.
+	 */
+	protected function create_order_for_managed_inventory_product() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_props( array( 'manage_stock' => true ) );
+		$product->set_stock_quantity( 10 );
+		$product->save();
+
+		WC()->cart->add_to_cart( $product->get_id(), 9 );
+		$this->assertEquals( true, WC()->cart->check_cart_items() );
+
+		$checkout = WC_Checkout::instance();
+		$order_id = $checkout->create_order(
+			array(
+				'payment_method' => 'cod',
+				'billing_email' => 'a@b.com',
+			)
+		);
+
+		// Assertions whether the order was created successfully.
+		$this->assertNotWPError( $order_id );
+		$order = new WC_Order( $order_id );
+
+		return array( $product, $order );
+	}
+
+	/**
+	 * Test when order is out stock because it is held by an order in pending status.
+	 * @throws Exception When unable to create order.
+	 */
+	public function test_create_order_when_out_of_stock() {
+		list( $product, $order ) = $this->create_order_for_managed_inventory_product();
+
+		$this->assertEquals( 9, $order->get_item_count() );
+		$this->assertEquals( 'pending', $order->get_status() );
+		$this->assertEquals( 9, wc_get_held_stock_quantity( $product ) );
+
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $product->get_stock_managed_by_id(), 2 );
+
+		$this->assertEquals( false, WC()->cart->check_cart_items() );
+	}
+
+	/**
+	 * Legacy version for test `test_create_order_when_out_of_stock` above.
+	 * @throws Exception When unable to create order.
+	 */
+	public function test_create_order_when_out_of_stock_legacy() {
+		add_filter( 'enable_hold_stock_3_9', '__return_false' );
+		$this->test_create_order_when_out_of_stock();
+	}
+
+	/**
+	 * Test if pending stock is cleared when order is cancelled.
+	 *
+	 * @throws Exception When unable to create order.
+	 */
+	public function test_pending_is_cleared_when_order_is_cancelled() {
+		list( $product, $order ) = $this->create_order_for_managed_inventory_product();
+
+		$this->assertEquals( 9, wc_get_held_stock_quantity( $product ) );
+		$order->set_status( 'cancelled' );
+		$order->save();
+
+		$this->assertEquals( 0, wc_get_held_stock_quantity( $product ) );
+		$this->assertEquals( 10, $product->get_stock_quantity() );
+
+	}
+
+	/**
+	 * Test if pending stock is cleared when order is processing.
+	 *
+	 * @throws Exception When unable to create order.
+	 */
+	public function test_pending_is_cleared_when_order_processed() {
+		list( $product, $order ) = $this->create_order_for_managed_inventory_product();
+
+		$this->assertEquals( 9, wc_get_held_stock_quantity( $product ) );
+		$order->set_status( 'processing' );
+		$order->save();
+
+		$this->assertEquals( 0, wc_get_held_stock_quantity( $product ) );
+	}
+
+	/**
+	 * Test creating order from managed stock for variable product.
+	 * @throws Exception When unable to create an order.
+	 */
+	public function test_create_order_for_variation_product() {
+		$parent_product = WC_Helper_Product::create_variation_product();
+		$variation = $parent_product->get_available_variations()[0];
+		$variation = wc_get_product( $variation['variation_id'] );
+		$variation->set_manage_stock( true );
+		$variation->set_stock_quantity( 10 );
+		$variation->save();
+		WC()->cart->add_to_cart( $variation->get_id(), 9 );
+		$this->assertEquals( true, WC()->cart->check_cart_items() );
+
+		$checkout = WC_Checkout::instance();
+		$order_id = $checkout->create_order(
+			array(
+				'payment_method' => 'cod',
+				'billing_email' => 'a@b.com',
+			)
+		);
+
+		// Assertions whether the first order was created successfully.
+		$this->assertNotWPError( $order_id );
+		$order = new WC_Order( $order_id );
+
+		$this->assertEquals( 9, $order->get_item_count() );
+		$this->assertEquals( 'pending', $order->get_status() );
+		$this->assertEquals( 9, wc_get_held_stock_quantity( $variation ) );
+
+		WC()->cart->empty_cart();
+		WC()->cart->add_to_cart( $variation->get_stock_managed_by_id(), 2 );
+
+		$this->assertEquals( false, WC()->cart->check_cart_items() );
+	}
+}

--- a/tests/unit-tests/checkout/checkout.php
+++ b/tests/unit-tests/checkout/checkout.php
@@ -44,13 +44,13 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 		$order_id = $checkout->create_order(
 			array(
 				'payment_method' => 'cod',
-				'billing_email' => 'a@b.com',
+				'billing_email'  => 'a@b.com',
 			)
 		);
 
 		// Assertions whether the order was created successfully.
 		$this->assertNotWPError( $order_id );
-		$order = new WC_Order( $order_id );
+		$order = wc_get_order( $order_id );
 
 		return array( $product, $order );
 	}
@@ -119,8 +119,8 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 	 */
 	public function test_create_order_for_variation_product() {
 		$parent_product = WC_Helper_Product::create_variation_product();
-		$variation = $parent_product->get_available_variations()[0];
-		$variation = wc_get_product( $variation['variation_id'] );
+		$variation      = $parent_product->get_available_variations()[0];
+		$variation      = wc_get_product( $variation['variation_id'] );
 		$variation->set_manage_stock( true );
 		$variation->set_stock_quantity( 10 );
 		$variation->save();
@@ -131,13 +131,13 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 		$order_id = $checkout->create_order(
 			array(
 				'payment_method' => 'cod',
-				'billing_email' => 'a@b.com',
+				'billing_email'  => 'a@b.com',
 			)
 		);
 
 		// Assertions whether the first order was created successfully.
 		$this->assertNotWPError( $order_id );
-		$order = new WC_Order( $order_id );
+		$order = wc_get_order( $order_id );
 
 		$this->assertEquals( 9, $order->get_item_count() );
 		$this->assertEquals( 'pending', $order->get_status() );

--- a/tests/unit-tests/checkout/checkout.php
+++ b/tests/unit-tests/checkout/checkout.php
@@ -18,6 +18,14 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Setup.
+	 */
+	public function setUp() {
+		parent::setUp();
+		WC()->cart->empty_cart();
+	}
+
+	/**
 	 * Helper method to create a managed product and a order for that product.
 	 *
 	 * @return array( WC_Product, WC_Order ) array

--- a/tests/unit-tests/order/class-wc-tests-order.php
+++ b/tests/unit-tests/order/class-wc-tests-order.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ * Class WC_Tests_Order file.
+ *
+ * @package WooCommerce/Tests
+ */
+
+/**
+ * Class Functions.
+ *
+ * @package WooCommerce/Tests/Order
+ * @since 3.9.0
+ */
+class WC_Tests_Order extends WC_Unit_Test_Case {
+	/**
+	 * TearDown.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+		WC()->cart->empty_cart();
+	}
+
+	/**
+	 * Test pending stock and `release_held_stock` and `record_held_stock` methods as well.
+	 * @throws Exception When unable to create an order.
+	 */
+	public function test_pending_stock_for_order_with_multiple_product() {
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_props( array( 'manage_stock' => true ) );
+		$product1->set_stock_quantity( 10 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_props( array( 'manage_stock' => true ) );
+		$product2->set_stock_quantity( 10 );
+		$product2->save();
+
+		WC()->cart->add_to_cart( $product1->get_id(), 9 );
+		WC()->cart->add_to_cart( $product2->get_id(), 5 );
+		$this->assertEquals( true, WC()->cart->check_cart_items() );
+
+		$checkout = WC_Checkout::instance();
+		$order_id = $checkout->create_order(
+			array(
+				'payment_method' => 'cod',
+				'billing_email' => 'a@b.com',
+			)
+		);
+
+		$this->assertNotWPError( $order_id );
+		$order_held_stock_keys = get_post_meta( $order_id, '_stock_held_keys', true );
+
+		$product1_id = $product1->get_stock_managed_by_id();
+		$product2_id = $product2->get_stock_managed_by_id();
+
+		$this->assertEquals( true, in_array( $product1_id, array_keys( $order_held_stock_keys ) ) );
+		$this->assertEquals( true, in_array( $product2_id, array_keys( $order_held_stock_keys ) ) );
+
+		$this->assertEquals( 9, wc_get_held_stock_quantity( $product1 ) );
+		$this->assertEquals( 5, wc_get_held_stock_quantity( $product2 ) );
+
+		$order = wc_get_order( $order_id );
+		$order->release_held_stock();
+
+		$this->assertEquals( 0, wc_get_held_stock_quantity( $product1 ) );
+		$this->assertEquals( 0, wc_get_held_stock_quantity( $product2 ) );
+	}
+
+	/**
+	 * Test `release_held_stock` function of unmanaged product.
+	 * @throws Exception When unable to create an order.
+	 */
+	public function test_release_held_of_unmanaged_product() {
+		$product = WC_Helper_Product::create_simple_product();
+
+		WC()->cart->add_to_cart( $product->get_id(), 9 );
+		$this->assertEquals( true, WC()->cart->check_cart_items() );
+		$checkout = WC_Checkout::instance();
+		$order_id = $checkout->create_order(
+			array(
+				'payment_method' => 'cod',
+				'billing_email' => 'a@b.com',
+			)
+		);
+
+		$this->assertNotWPError( $order_id );
+		$order = wc_get_order( $order_id );
+		$this->assertEquals( 0, wc_get_held_stock_quantity( $product ) );
+
+		$order->release_held_stock();
+		$this->assertEquals( 0, wc_get_held_stock_quantity( $product ) );
+	}
+}


### PR DESCRIPTION
Currently, when stock is susceptible to race condition as reported in #24009. This is because where we check if we have the required number of stocks (in `check_cart_item_stock` method inside `class-wc-cart.php`) is quite far away from where we actually create the order (`create_order` method inside `class-wc-checkout.php`) and therefore these operations are not atomic.

This PR attempts to fix this behavior by adding a `_held_for_checkout` record with an expiry timestamp embedded when creating the order. This is added in an atomic manner along with making a check whether we have current stock or not.

This record is removed when order status goes to either `processing` or `completed`.

This PR uses the following query pattern to achieve atomicity:

```sql
INSERT INTO {order_table} VALUES (order_id, meta_key, quantity)
SELECT {order_id}, {meta_key}, {quantity} FROM DUAL 
WHERE {query_for_stock} - {query_for_held_stock} >= {required_stock}
```

This record indicates a held record, and `query_for_held_stock` queries these records.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes #24009 

### How to test the changes in this Pull Request:

Unfortunately, this requires simulating race conditions so this is not trivial to test. I'd recommend using this plugin https://github.com/Automattic/wc-load-testing/ to simulate race conditions on a _test site_ and using a config where stock quantity is less than the number of request like so:

1. Install the plugin by following the instructions on the README page of the plugin. Activate the plugin.
2. Go to `Tools > WooCommerce Load Testing` in the wp-admin page on your site.
3. Scroll down to the `Process Checkout` test section.
4. Use a config so that number of stocks are less then number of requests like so:
<img width="997" alt="Screenshot 2019-11-22 at 12 50 54 PM" src="https://user-images.githubusercontent.com/7571618/69406090-3a3a3400-0d27-11ea-9d67-07578df4685c.png">

5. Run the test, then go the Products page. The most recent product will have negative stock without this patch. Apply this patch and run test again, now the most recent product should have `0` stock.

(Make sure that cart is empty before running the test)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add `held_for_checkout` records to prevent race conditions in Stocks.
