### PR TITLE
Before and after product list hooks

### DIFF
--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -33,6 +33,8 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 				'price',
 			), $product );
 
+			do_action( 'woocommerce_grouped_product_list_before' );
+
 			foreach ( $grouped_products as $grouped_product_child ) {
 				$post_object        = get_post( $grouped_product_child->get_id() );
 				$quantites_required = $quantites_required || ( $grouped_product_child->is_purchasable() && ! $grouped_product_child->has_options() );
@@ -90,6 +92,8 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 			}
 			$post = $previous_post; // WPCS: override ok.
 			setup_postdata( $post );
+
+			do_action( 'woocommerce_grouped_product_list_after' );
 			?>
 		</tbody>
 	</table>

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -33,7 +33,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 				'price',
 			), $product );
 
-			do_action( 'woocommerce_grouped_product_list_before' );
+			do_action( 'woocommerce_grouped_product_list_before', $grouped_product_columns, $quantites_required, $product );
 
 			foreach ( $grouped_products as $grouped_product_child ) {
 				$post_object        = get_post( $grouped_product_child->get_id() );
@@ -93,7 +93,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 			$post = $previous_post; // WPCS: override ok.
 			setup_postdata( $post );
 
-			do_action( 'woocommerce_grouped_product_list_after' );
+			do_action( 'woocommerce_grouped_product_list_after', $grouped_product_columns, $quantites_required, $product );
 			?>
 		</tbody>
 	</table>


### PR DESCRIPTION
Allows adding extra rows.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds two actions. One before and after the product list. This give users the ability to add rows to the product list. For example; header and footer rows.

### How to test the changes in this Pull Request:

Just hook into the action and add a table row.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] ~~Have you written new tests for your changes, as applicable?~~
* [x] ~~Have you successfully run tests with your changes locally?~~

No need for tests in this PR as it doesn't change functionality.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add actions before and after grouped product list to allow adding custom rows.
