### PR TITLE
add password confirmation do_actions

### DIFF
--- a/templates/myaccount/lost-password-confirmation.php
+++ b/templates/myaccount/lost-password-confirmation.php
@@ -20,4 +20,8 @@ defined( 'ABSPATH' ) || exit;
 wc_print_notice( esc_html__( 'Password reset email has been sent.', 'woocommerce' ) );
 ?>
 
+<?php do_action( 'woocommerce_before_lost_password_confirmation_message' ); ?>
+
 <p><?php echo esc_html( apply_filters( 'woocommerce_lost_password_confirmation_message', esc_html__( 'A password reset email has been sent to the email address on file for your account, but may take several minutes to show up in your inbox. Please wait at least 10 minutes before attempting another reset.', 'woocommerce' ) ) ); ?></p>
+
+<?php do_action( 'woocommerce_after_lost_password_confirmation_message' ); ?>


### PR DESCRIPTION
add two action hooks on lost-passsword-confirmation.php so developers can output html before/after the confirmation page.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added hooks to lost password confirmation page

Closes #25095 

### How to test the changes in this Pull Request:

1. return some message for the action hooks `woocommerce_before_lost_password_confirmation_message` and `woocommerce_after_lost_password_confirmation_message`
2. navigate to `/my-account/lost-password/` and fill out the form

### Changelog entry

> Add action hooks before and after confirmation message on user password reset confirmation page