### PR TITLE
Remove a few calls to func_get_args() and call_user_func_array()

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -700,7 +700,7 @@ class WC_Admin_Setup_Wizard {
 	public function run_deferred_actions() {
 		$this->close_http_connection();
 		foreach ( $this->deferred_actions as $action ) {
-			call_user_func_array( $action['func'], $action['args'] );
+			$action['func']( ...$action['args'] );
 
 			// Clear the background installation flag if this is a plugin.
 			if (

--- a/includes/class-wc-data-store.php
+++ b/includes/class-wc-data-store.php
@@ -202,8 +202,9 @@ class WC_Data_Store {
 	 */
 	public function __call( $method, $parameters ) {
 		if ( is_callable( array( $this->instance, $method ) ) ) {
-			$object = array_shift( $parameters );
-			return call_user_func_array( array( $this->instance, $method ), array_merge( array( &$object ), $parameters ) );
+			$object     = array_shift( $parameters );
+			$parameters = array_merge( array( &$object ), $parameters );
+			return $this->instance->$method( ...$parameters );
 		}
 	}
 }

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -118,8 +118,10 @@ class WC_Emails {
 	/**
 	 * Queues transactional email so it's not sent in current request if enabled,
 	 * otherwise falls back to send now.
+	 *
+	 * @param mixed ...$args Optional arguments.
 	 */
-	public static function queue_transactional_email() {
+	public static function queue_transactional_email( ...$args ) {
 		if ( is_a( self::$background_emailer, 'WC_Background_Emailer' ) ) {
 			self::$background_emailer->push_to_queue(
 				array(
@@ -128,7 +130,7 @@ class WC_Emails {
 				)
 			);
 		} else {
-			call_user_func_array( array( __CLASS__, 'send_transactional_email' ), func_get_args() ); // phpcs:ignore PHPCompatibility.FunctionUse.ArgumentFunctionsUsage.InParameterList
+			self::send_transactional_email( ...$args );
 		}
 	}
 

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -261,7 +261,7 @@ class WC_Email extends WC_Settings_API {
 	 */
 	public function handle_multipart( $mailer ) {
 		if ( $this->sending && 'multipart' === $this->get_email_type() ) {
-			$mailer->AltBody = wordwrap( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.NotSnakeCaseMemberVar
+			$mailer->AltBody = wordwrap( // phpcs:ignore WordPress.NamingConventions.ValidVariableName.UsedPropertyNotSnakeCase
 				preg_replace( $this->plain_search, $this->plain_replace, wp_strip_all_tags( $this->get_content_plain() ) )
 			);
 			$this->sending   = false;

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -634,7 +634,7 @@ class WC_Email extends WC_Settings_API {
 		$message              = apply_filters( 'woocommerce_mail_content', $this->style_inline( $message ) );
 		$mail_callback        = apply_filters( 'woocommerce_mail_callback', 'wp_mail', $this );
 		$mail_callback_params = apply_filters( 'woocommerce_mail_callback_params', array( $to, $subject, $message, $headers, $attachments ), $this );
-		$return               = call_user_func_array( $mail_callback, $mail_callback_params );
+		$return               = $mail_callback( ...$mail_callback_params );
 
 		remove_filter( 'wp_mail_from', array( $this, 'get_from_address' ) );
 		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1826,7 +1826,7 @@ function wc_print_r( $expression, $return = false ) {
 
 	foreach ( $alternatives as $alternative ) {
 		if ( function_exists( $alternative['func'] ) ) {
-			$res = call_user_func_array( $alternative['func'], $alternative['args'] );
+			$res = $alternative['func']( ...$alternative['args'] );
 			if ( $return ) {
 				return $res;
 			}

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -253,11 +253,10 @@ function wc_product_dropdown_categories( $args = array() ) {
  *
  * Previously used by wc_product_dropdown_categories, but wp_dropdown_categories has been fixed in core.
  *
+ * @param mixed ...$args Variable number of parameters to be passed to the walker.
  * @return mixed
  */
-function wc_walk_category_dropdown_tree() {
-	$args = func_get_args();
-
+function wc_walk_category_dropdown_tree( ...$args ) {
 	if ( ! class_exists( 'WC_Product_Cat_Dropdown_Walker', false ) ) {
 		include_once WC()->plugin_path() . '/includes/walkers/class-wc-product-cat-dropdown-walker.php';
 	}
@@ -269,7 +268,7 @@ function wc_walk_category_dropdown_tree() {
 		$walker = $args[2]['walker'];
 	}
 
-	return call_user_func_array( array( &$walker, 'walk' ), $args );
+	return $walker->walk( ...$args );
 }
 
 /**

--- a/tests/framework/class-wc-dummy-data-store.php
+++ b/tests/framework/class-wc-dummy-data-store.php
@@ -1,7 +1,15 @@
 <?php
+/**
+ * Dummy WC data stores used to test data store functionality.
+ *
+ * @package WooCommerce\Tests\Framework
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
+
+// phpcs:disable Squiz.Commenting
 
 /**
  * WC Dummy Data Store: CPT.
@@ -9,8 +17,6 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Used to test swapping out data stores.
  *
  * @version  3.0.0
- * @category Class
- * @author   WooThemes
  */
 class WC_Dummy_Data_Store_CPT implements WC_Object_Data_Store_Interface {
 	public function create( &$data ) { }
@@ -29,8 +35,6 @@ class WC_Dummy_Data_Store_CPT implements WC_Object_Data_Store_Interface {
  * Used to test swapping out data stores.
  *
  * @version  3.0.0
- * @category Class
- * @author   WooThemes
  */
 class WC_Dummy_Data_Store_Custom_Table implements WC_Object_Data_Store_Interface {
 	public function create( &$data ) { }
@@ -42,3 +46,5 @@ class WC_Dummy_Data_Store_Custom_Table implements WC_Object_Data_Store_Interface
 	public function add_meta( &$data, $meta ) { }
 	public function update_meta( &$data, $meta ) { }
 }
+
+// phpcs:enable

--- a/tests/framework/class-wc-dummy-data-store.php
+++ b/tests/framework/class-wc-dummy-data-store.php
@@ -27,6 +27,15 @@ class WC_Dummy_Data_Store_CPT implements WC_Object_Data_Store_Interface {
 	public function delete_meta( &$data, $meta ) { }
 	public function add_meta( &$data, $meta ) { }
 	public function update_meta( &$data, $meta ) { }
+
+	/**
+	 * Method used to test WC_Data_Store::__call().
+	 *
+	 * @return array
+	 */
+	public function custom_method( $first_param, $second_param, $third_param ) {
+		return array( $first_param, $second_param, $third_param );
+	}
 }
 
 /**

--- a/tests/unit-tests/crud/data-store.php
+++ b/tests/unit-tests/crud/data-store.php
@@ -69,8 +69,21 @@ class WC_Tests_Data_Store extends WC_Unit_Test_Case {
 	 */
 	public function test_store_sub_type() {
 		$this->load_dummy_store();
+
 		$store = WC_Data_Store::load( 'dummy-sub' );
 		$this->assertEquals( 'WC_Dummy_Data_Store_CPT', $store->get_current_class_name() );
+	}
+
+	/**
+	 * Test WC_Data_Store::__call().
+	 */
+	public function test_data_store_method_overloading() {
+		$this->load_dummy_store();
+		$store = WC_Data_Store::load( 'dummy-sub' );
+		$this->assertEquals(
+			array( 'first param', 'second param', 'third param' ),
+			$store->custom_method( 'first param', 'second param', 'third param', 'asdfsdf' )
+		);
 	}
 
 	/* Helper Functions. */

--- a/tests/unit-tests/crud/data-store.php
+++ b/tests/unit-tests/crud/data-store.php
@@ -1,7 +1,13 @@
 <?php
 /**
- * Data Store Tests
+ * Data Store tests
+ *
  * @package WooCommerce\Tests\Product
+ */
+
+/**
+ * Class for Data Store tests
+ *
  * @since 3.0.0
  */
 class WC_Tests_Data_Store extends WC_Unit_Test_Case {
@@ -12,9 +18,9 @@ class WC_Tests_Data_Store extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0.0
 	 */
-	function test_invalid_store_throws_exception() {
+	public function test_invalid_store_throws_exception() {
 		try {
-			$product_store = new WC_Data_Store( 'bogus' );
+			new WC_Data_Store( 'bogus' );
 		} catch ( Exception $e ) {
 			$this->assertEquals( $e->getMessage(), 'Invalid data store.' );
 			return;
@@ -27,9 +33,9 @@ class WC_Tests_Data_Store extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0.0
 	 */
-	function test_invalid_store_load_throws_exception() {
+	public function test_invalid_store_load_throws_exception() {
 		try {
-			$product_store = WC_Data_Store::load( 'does-not-exist' );
+			WC_Data_Store::load( 'does-not-exist' );
 		} catch ( Exception $e ) {
 			$this->assertEquals( $e->getMessage(), 'Invalid data store.' );
 			return;
@@ -42,7 +48,7 @@ class WC_Tests_Data_Store extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0.0
 	 */
-	function test_store_swap() {
+	public function test_store_swap() {
 		$this->load_dummy_store();
 
 		$store = new WC_Data_Store( 'dummy' );
@@ -61,7 +67,7 @@ class WC_Tests_Data_Store extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0.0
 	 */
-	function test_store_sub_type() {
+	public function test_store_sub_type() {
 		$this->load_dummy_store();
 		$store = WC_Data_Store::load( 'dummy-sub' );
 		$this->assertEquals( 'WC_Dummy_Data_Store_CPT', $store->get_current_class_name() );
@@ -74,7 +80,7 @@ class WC_Tests_Data_Store extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0.0
 	 */
-	function load_dummy_store() {
+	private function load_dummy_store() {
 		include_once dirname( dirname( dirname( __FILE__ ) ) ) . '/framework/class-wc-dummy-data-store.php';
 		add_filter( 'woocommerce_data_stores', array( $this, 'add_dummy_data_store' ) );
 	}
@@ -82,9 +88,11 @@ class WC_Tests_Data_Store extends WC_Unit_Test_Case {
 	/**
 	 * Adds a default class for the 'dummy' data store.
 	 *
+	 * @param array $stores Loaded data stores.
+	 * @return array Modified list of data stores.
 	 * @since 3.0.0
 	 */
-	function add_dummy_data_store( $stores ) {
+	public function add_dummy_data_store( $stores ) {
 		$stores['dummy'] = 'WC_Dummy_Data_Store_CPT';
 		return $stores;
 	}
@@ -92,9 +100,11 @@ class WC_Tests_Data_Store extends WC_Unit_Test_Case {
 	/**
 	 * Helper function/filter to swap out the default dummy store for a different one.
 	 *
+	 * @param string $store Data store class name.
+	 * @return string New data store class name.
 	 * @since 3.0.0
 	 */
-	function set_dummy_store( $store ) {
+	public function set_dummy_store( $store ) {
 		return 'WC_Dummy_Data_Store_Custom_Table';
 	}
 }

--- a/tests/unit-tests/crud/data-store.php
+++ b/tests/unit-tests/crud/data-store.php
@@ -97,13 +97,4 @@ class WC_Tests_Data_Store extends WC_Unit_Test_Case {
 	function set_dummy_store( $store ) {
 		return 'WC_Dummy_Data_Store_Custom_Table';
 	}
-
-	/**
-	 * Helper function/filter to swap out the 'dummy' store for the default one.
-	 *
-	 * @since 3.0.0
-	 */
-	function set_default_product_store( $store ) {
-		return 'WC_Dummy_Data_Store_CPT';
-	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes a few calls to func_get_args() and call_user_func_array() in the WooCommerce codebase and replace it with more modern alternatives now that we dropped support for PHP < 5.6.

func_get_args() can be replaced with variadic functions using the spread operator. This makes it more explicit that a given function accepts a variable number of parameters as this information is added to the function signature.

call_user_func_array() can be replaced with argument unpacking using the spread operator in some cases, and this makes it possible to call functions or methods directly. [Calling a function using call_user_func_array() is about three times slower than calling it directly](https://core.trac.wordpress.org/ticket/47678#comment:31). The performance gain is not substantial, but it is a nice little improvement. 

This PR was inspired by the following WP core ticket that shipped with version 5.3. Kudos to @jrfnl for their work on the original ticket. I highly recommend reading the ticket description and skimming through the discussion and there is some valuable information about PHP there.

https://core.trac.wordpress.org/ticket/47678

This PR also includes a few commits fixing PHPCS violations in the modified files and a unit test to cover a changed WC_Data_Store method.

### How to test the changes in this Pull Request:

1. Before starting to test this PR, it is important to have an understanding of the instances where func_get_args() and call_user_func_array() can be replaced with the spread operator and where that is not possible. For that see: https://core.trac.wordpress.org/ticket/47678#comment:31
2. Probably the best way to review this PR is a careful review of the code changes. Besides that, manually testing some of the changed parts is a good idea, but some of the modifications, unfortunately, are not that easy to test and are not covered by tests.

### Changelog entry

> Dev: Remove a few calls to func_get_args() and call_user_func_array() with the spread operator for better code legibility and performance gains.
