### PR TITLE
Fixed media element initialization for product variation descriptions

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -88,6 +88,18 @@
 			event.data.variationForm.$form.find( '.single_add_to_cart_button' ).removeClass( 'wc-variation-selection-needed' ).addClass( 'disabled wc-variation-is-unavailable' );
 			event.data.variationForm.$form.find( '.woocommerce-variation-add-to-cart' ).removeClass( 'woocommerce-variation-add-to-cart-enabled' ).addClass( 'woocommerce-variation-add-to-cart-disabled' );
 		}
+
+		// If present, the media element library needs initialized on the variation description.
+		if ( wp.mediaelement ) {
+			event.data.variationForm.$form.find( '.wp-audio-shortcode, .wp-video-shortcode' )
+				.not( '.mejs-container' )
+				.filter(
+					function () {
+						return ! $( this ).parent().hasClass( 'mejs-mediaelement' );
+					}
+				)
+				.mediaelementplayer( wp.mediaelement.settings );
+		}
 	};
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The media element player initialization currently only takes place after the page loads. This means that if an audio or video shortcode is present in a variation description, they will not be initialized. We can hook into the variation show event though and initialize the variation correctly without any concern.

Closes #24417. 

### How to test the changes in this Pull Request:

1. Create a product with a variation.
2. Add an audio shortcode to the variation description.
3. View the product page and select the variation.
4. Note that the play bar is styled correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix: Corrected the media element player initialization for product variation descriptions.