### PR TITLE
Move E2E tests to allowed_failures section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,6 +51,8 @@ matrix:
   allow_failures:
   - php: 7.3
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
+  - php: 7.2
+    env: WP_VERSION=latest WP_MULTISITE=0 RUN_E2E=1
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"


### PR DESCRIPTION
Since our new e2e tests are still being worked out and all the final issues ironed out, this PR moves the existing failing e2e tests to the allowed_failures section of the travis config file so we can easily check whether PR's pass coding standards and unit tests without the need to go into the travis build to verify.

Once the new e2e tests are done and merged we can move it back out of the allowed_failure section.