### PR TITLE
Improve error codes for plugin installer API authentication

### DIFF
--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -15,6 +15,8 @@ defined( 'ABSPATH' ) || exit;
  */
 class WC_WCCOM_Site {
 
+	const AUTH_ERROR_FILTER_NAME = 'wccom_auth_error';
+
 	/**
 	 * Load the WCCOM site class.
 	 *
@@ -53,23 +55,78 @@ class WC_WCCOM_Site {
 
 		$auth_header = self::get_authorization_header();
 		if ( empty( $auth_header ) ) {
+			add_filter(
+				self::AUTH_ERROR_FILTER_NAME,
+				function() {
+					return new WP_Error(
+						WC_REST_WCCOM_Site_Installer_Errors::NO_AUTH_HEADER_CODE,
+						WC_REST_WCCOM_Site_Installer_Errors::NO_AUTH_HEADER_MESSAGE,
+						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::NO_AUTH_HEADER_HTTP_CODE )
+					);
+				}
+			);
 			return false;
 		}
 
 		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$request_auth = trim( $auth_header );
 		if ( stripos( $request_auth, 'Bearer ' ) !== 0 ) {
+			add_filter(
+				self::AUTH_ERROR_FILTER_NAME,
+				function() {
+					return new WP_Error(
+						WC_REST_WCCOM_Site_Installer_Errors::INVALID_AUTH_HEADER_CODE,
+						WC_REST_WCCOM_Site_Installer_Errors::INVALID_AUTH_HEADER_MESSAGE,
+						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::INVALID_AUTH_HEADER_HTTP_CODE )
+					);
+				}
+			);
 			return false;
 		}
 
 		if ( empty( $_SERVER['HTTP_X_WOO_SIGNATURE'] ) ) {
+			add_filter(
+				self::AUTH_ERROR_FILTER_NAME,
+				function() {
+					return new WP_Error(
+						WC_REST_WCCOM_Site_Installer_Errors::NO_SIGNATURE_HEADER_CODE,
+						WC_REST_WCCOM_Site_Installer_Errors::NO_SIGNATURE_HEADER_MESSAGE,
+						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::NO_SIGNATURE_HEADER_HTTP_CODE )
+					);
+				}
+			);
 			return false;
 		}
 
 		require_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php';
 		$access_token = trim( substr( $request_auth, 7 ) );
 		$site_auth    = WC_Helper_Options::get( 'auth' );
-		if ( empty( $site_auth['access_token'] ) || ! hash_equals( $access_token, $site_auth['access_token'] ) ) {
+
+		if ( empty( $site_auth['access_token'] ) ) {
+			add_filter(
+				self::AUTH_ERROR_FILTER_NAME,
+				function() {
+					return new WP_Error(
+						WC_REST_WCCOM_Site_Installer_Errors::SITE_NOT_CONNECTED_CODE,
+						WC_REST_WCCOM_Site_Installer_Errors::SITE_NOT_CONNECTED_MESSAGE,
+						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::SITE_NOT_CONNECTED_HTTP_CODE )
+					);
+				}
+			);
+			return false;
+		}
+
+		if ( ! hash_equals( $access_token, $site_auth['access_token'] ) ) {
+			add_filter(
+				self::AUTH_ERROR_FILTER_NAME,
+				function() {
+					return new WP_Error(
+						WC_REST_WCCOM_Site_Installer_Errors::INVALID_TOKEN_CODE,
+						WC_REST_WCCOM_Site_Installer_Errors::INVALID_TOKEN_MESSAGE,
+						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::INVALID_TOKEN_HTTP_CODE )
+					);
+				}
+			);
 			return false;
 		}
 
@@ -77,11 +134,31 @@ class WC_WCCOM_Site {
 		$signature = trim( $_SERVER['HTTP_X_WOO_SIGNATURE'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		if ( ! self::verify_wccom_request( $body, $signature, $site_auth['access_token_secret'] ) ) {
+			add_filter(
+				self::AUTH_ERROR_FILTER_NAME,
+				function() {
+					return new WP_Error(
+						WC_REST_WCCOM_Site_Installer_Errors::REQUEST_VERIFICATION_FAILED_CODE,
+						WC_REST_WCCOM_Site_Installer_Errors::REQUEST_VERIFICATION_FAILED_MESSAGE,
+						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::REQUEST_VERIFICATION_FAILED_HTTP_CODE )
+					);
+				}
+			);
 			return false;
 		}
 
 		$user = get_user_by( 'id', $site_auth['user_id'] );
 		if ( ! $user ) {
+			add_filter(
+				self::AUTH_ERROR_FILTER_NAME,
+				function() {
+					return new WP_Error(
+						WC_REST_WCCOM_Site_Installer_Errors::USER_NOT_FOUND_CODE,
+						WC_REST_WCCOM_Site_Installer_Errors::USER_NOT_FOUND_MESSAGE,
+						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::USER_NOT_FOUND_HTTP_CODE )
+					);
+				}
+			);
 			return false;
 		}
 

--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -166,6 +166,7 @@ class WC_WCCOM_Site {
 	 * @return array Registered namespaces.
 	 */
 	public static function register_rest_namespace( $namespaces ) {
+		require_once WC_ABSPATH . 'includes/wccom-site/rest-api/class-wc-rest-wccom-site-installer-errors.php';
 		require_once WC_ABSPATH . 'includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php';
 
 		$namespaces['wccom-site/v1'] = array(

--- a/includes/wccom-site/rest-api/class-wc-rest-wccom-site-installer-errors.php
+++ b/includes/wccom-site/rest-api/class-wc-rest-wccom-site-installer-errors.php
@@ -16,9 +16,65 @@ defined( 'ABSPATH' ) || exit;
 class WC_REST_WCCOM_Site_Installer_Errors {
 
 	/**
+	 * Not unauthenticated generic error
+	 */
+	const NOT_AUTHENTICATED_CODE      = 'not_authenticated';
+	const NOT_AUTHENTICATED_MESSAGE   = 'Authentication required';
+	const NOT_AUTHENTICATED_HTTP_CODE = 401;
+
+	/**
+	 * No Authorization header
+	 */
+	const NO_AUTH_HEADER_CODE      = 'no_auth_header';
+	const NO_AUTH_HEADER_MESSAGE   = 'No header "Authorization" present';
+	const NO_AUTH_HEADER_HTTP_CODE = 400;
+
+	/**
+	 * Authorization header invalid
+	 */
+	const INVALID_AUTH_HEADER_CODE      = 'no_auth_header';
+	const INVALID_AUTH_HEADER_MESSAGE   = 'Header "Authorization" is invalid';
+	const INVALID_AUTH_HEADER_HTTP_CODE = 400;
+
+	/**
+	 * No Signature header
+	 */
+	const NO_SIGNATURE_HEADER_CODE      = 'no_signature_header';
+	const NO_SIGNATURE_HEADER_MESSAGE   = 'No header "X-Woo-Signature" present';
+	const NO_SIGNATURE_HEADER_HTTP_CODE = 400;
+
+	/**
+	 * Site not connected to WooCommerce.com
+	 */
+	const SITE_NOT_CONNECTED_CODE      = 'site_not_connnected';
+	const SITE_NOT_CONNECTED_MESSAGE   = 'Site not connected to WooCommerce.com';
+	const SITE_NOT_CONNECTED_HTTP_CODE = 401;
+
+	/**
+	* Provided access token is not valid
+	*/
+	const INVALID_TOKEN_CODE      = 'invalid_token';
+	const INVALID_TOKEN_MESSAGE   = 'Invalid access token provided';
+	const INVALID_TOKEN_HTTP_CODE = 401;
+
+	/**
+	 * Request verification by provided signature failed
+	 */
+	const REQUEST_VERIFICATION_FAILED_CODE      = 'request_verification_failed';
+	const REQUEST_VERIFICATION_FAILED_MESSAGE   = 'Request verification by signature failed';
+	const REQUEST_VERIFICATION_FAILED_HTTP_CODE = 400;
+
+	/**
+	 * User doesn't exist
+	 */
+	const USER_NOT_FOUND_CODE      = 'user_not_found';
+	const USER_NOT_FOUND_MESSAGE   = 'Token owning user not found';
+	const USER_NOT_FOUND_HTTP_CODE = 401;
+
+	/**
 	 * No permissions error
 	 */
-	const NO_PERMISSION_CODE      = 'woocommerce_rest_cannot_install_product';
+	const NO_PERMISSION_CODE      = 'forbidden';
 	const NO_PERMISSION_MESSAGE   = 'You do not have permission to install plugin or theme';
-	const NO_PERMISSION_HTTP_CODE = 401;
+	const NO_PERMISSION_HTTP_CODE = 403;
 }

--- a/includes/wccom-site/rest-api/class-wc-rest-wccom-site-installer-errors.php
+++ b/includes/wccom-site/rest-api/class-wc-rest-wccom-site-installer-errors.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * WCCOM Site Installer Errors Class
+ *
+ * @package WooCommerce\WooCommerce_Site\Rest_Api
+ * @since   3.9.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WCCOM Site Installer Errors Class
+ *
+ * Stores data for errors, returned by installer API.
+ */
+class WC_REST_WCCOM_Site_Installer_Errors {
+
+	/**
+	 * No permissions error
+	 */
+	const NO_PERMISSION_CODE      = 'woocommerce_rest_cannot_install_product';
+	const NO_PERMISSION_MESSAGE   = 'You do not have permission to install plugin or theme';
+	const NO_PERMISSION_HTTP_CODE = 401;
+}

--- a/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
+++ b/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
@@ -70,7 +70,11 @@ class WC_REST_WCCOM_Site_Installer_Controller extends WC_REST_Controller {
 	 */
 	public function check_permission( $request ) {
 		if ( ! current_user_can( 'install_plugins' ) || ! current_user_can( 'install_themes' ) ) {
-			return new WP_Error( 'woocommerce_rest_cannot_install_product', __( 'You do not have permission to install plugin or theme', 'woocommerce' ), array( 'status' => 401 ) );
+			return new WP_Error(
+				\WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_CODE,
+				\WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_MESSAGE,
+				array( 'status' => \WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_HTTP_CODE )
+			);
 		}
 
 		return true;

--- a/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
+++ b/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
@@ -69,11 +69,24 @@ class WC_REST_WCCOM_Site_Installer_Controller extends WC_REST_Controller {
 	 * @return bool|WP_Error
 	 */
 	public function check_permission( $request ) {
-		if ( ! current_user_can( 'install_plugins' ) || ! current_user_can( 'install_themes' ) ) {
+		$current_user = wp_get_current_user();
+
+		if ( empty( $current_user ) || ( $current_user instanceof WP_User && ! $current_user->exists() ) ) {
+			return apply_filters(
+				WC_WCCOM_Site::AUTH_ERROR_FILTER_NAME,
+				new WP_Error(
+					WC_REST_WCCOM_Site_Installer_Errors::NOT_AUTHENTICATED_CODE,
+					WC_REST_WCCOM_Site_Installer_Errors::NOT_AUTHENTICATED_MESSAGE,
+					array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::NOT_AUTHENTICATED_HTTP_CODE )
+				)
+			);
+		}
+
+		if ( ! user_can( $current_user, 'install_plugins' ) || ! user_can( $current_user, 'install_themes' ) ) {
 			return new WP_Error(
-				\WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_CODE,
-				\WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_MESSAGE,
-				array( 'status' => \WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_HTTP_CODE )
+				WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_CODE,
+				WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_MESSAGE,
+				array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::NO_PERMISSION_HTTP_CODE )
 			);
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Current WooCommerce version 3.8 returns a generic API error "You do not have permission to install plugin or theme" for a bunch of various plugin auto-installation authentication failure reasons, such as missing Authorization header, invalid access token, insufficient user permissions, and several others. Thus, there is no possibility to identify a particular failure reason from the returned API response.

This PR introduces additional error codes, which will allow distinguishing different authentication errors.

### How to test the changes in this Pull Request:

1. Check out this branch on a local WooCommerce test site.
2. Make a request to plugin installation API endpoint without Authentication header `curl -v https://local-wp-site.test/wp-json/wccom-site/v1/installer` (replace `https://local-wp-site.test/` with your local Woo site URL).
3. Confirm a response with HTTP code 400 and the following body is returned:
```
{"code":"no_auth_header","message":"No header \"Authorization\" present","data":{"status":400}}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Not sure if we need a changelog for these changes.
