### PR TITLE
Improved styling for select2 and checkboxes in WP 5.3

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -6563,6 +6563,12 @@ table.bar_chart {
 		border-radius: 0;
 		line-height: 1.5;
 
+		&:focus-within {
+			border-color: #5b9dd9;
+			box-shadow: 0 0 2px rgba(30,140,190,.8);
+			outline: 2px solid transparent;
+		}
+
 		li {
 			margin: 0;
 		}
@@ -6586,6 +6592,21 @@ table.bar_chart {
 		font-size: inherit;
 		font-weight: inherit;
 		padding: 3px 0;
+	}
+}
+
+.branch-5-3 {
+
+	.select2-container {
+		.select2-selection--multiple {
+			border-radius: 4px;
+
+			&:focus-within {
+				border-color: #007cba;
+				box-shadow: 0 0 0 1px #007cba;
+				outline: 2px solid transparent;
+			}
+		}
 	}
 }
 

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -579,6 +579,7 @@
 }
 
 #variable_product_options {
+
 	.form-row select {
 		max-width: 100%;
 	}
@@ -4183,7 +4184,7 @@ img.help_tip {
 				right: -8px;
 				padding: 2px;
 				display: none;
-				
+
 				@media (max-width: 768px) {
 					display: block;
 				}
@@ -4545,7 +4546,6 @@ img.help_tip {
 
 .woocommerce_options_panel .checkbox,
 .woocommerce_variable_attributes .checkbox {
-	width: auto;
 	margin: 4px 0 !important;
 	vertical-align: middle;
 	float: left;

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -6598,7 +6598,9 @@ table.bar_chart {
 .branch-5-3 {
 
 	.select2-container {
+
 		.select2-selection--multiple {
+			border-color: #7e8993;
 			border-radius: 4px;
 
 			&:focus-within {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24942  .

Screenshots:

WP 5.2
<img width="1500" alt="Screenshot 2019-11-26 at 22 19 39" src="https://user-images.githubusercontent.com/2207451/69673762-5f1e0680-109b-11ea-99f5-96153dcfc6bf.png">


WP 5.3
<img width="1500" alt="Screenshot 2019-11-26 at 22 21 37" src="https://user-images.githubusercontent.com/2207451/69673775-6513e780-109b-11ea-84c4-b0f6782500a2.png">


### How to test the changes in this Pull Request:

1. Start with WP 5.2, check that 
- the [checkboxes don't change their width](https://share.getcloudapp.com/z8uwLW2q) and 
- select2 styling corresponds to WP 5.2 inputs
2. Upgrade to WP 5.3, check the same


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Improved styling for select2 and checkboxes in WP 5.3.
