### PR TITLE
Fix order action button centering for WP 5.3

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -2158,6 +2158,22 @@ ul.wc_coupon_list_block {
 	}
 }
 
+.branch-5-3 {
+
+	.widefat {
+
+		.column-wc_actions {
+
+			a.button {
+
+				&::after {
+					margin-top: 2px;
+				}
+			}
+		}
+	}
+}
+
 .post-type-shop_order {
 
 	.tablenav .one-page .displaying-num {
@@ -4183,7 +4199,7 @@ img.help_tip {
 				right: -8px;
 				padding: 2px;
 				display: none;
-				
+
 				@media (max-width: 768px) {
 					display: block;
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24731 .

### How to test the changes in this Pull Request:

1. Start with WP 5.2, check that
- action buttons have their symbols centered within the box
2. Upgrade to WP 5.3, check the same


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix order action button centering for WP 5.3.
