### PR TITLE
Fix select2 style and admin screen button alignments in WP 5.3

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3926,6 +3926,10 @@ img.help_tip {
 			margin: 0;
 			box-sizing: border-box;
 			vertical-align: top;
+
+			@media only screen and (max-width: 782px) {
+				width: 100%;
+			}
 		}
 
 		input[type="datetime-local"],
@@ -3942,6 +3946,10 @@ img.help_tip {
 			box-sizing: border-box;
 			line-height: 32px;
 			vertical-align: top;
+
+			@media only screen and (max-width: 782px) {
+				width: 100%;
+			}
 		}
 
 		input[size] {
@@ -3994,6 +4002,11 @@ img.help_tip {
 				position: absolute;
 				right: 0;
 				top: 50%;
+
+				@media only screen and (max-width: 782px) {
+					right: auto;
+					margin-left: 5px;
+				}
 			}
 		}
 
@@ -4069,14 +4082,21 @@ img.help_tip {
 		}
 
 		.colorpickpreview {
-			padding: 7px 0;
+			padding: 0;
 			line-height: 1em;
 			display: inline-block;
 			width: 30px;
+			height: 30px;
 			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
 			font-size: 16px;
 			border-radius: 4px;
 			margin-right: 3px;
+
+			@media only screen and (max-width: 782px) {
+				float: left;
+				width: 40px;
+				height: 40px;
+			}
 		}
 
 		.image_width_settings {
@@ -6568,6 +6588,10 @@ table.bar_chart {
 
 .select2-container {
 
+	@media only screen and (max-width: 782px) {
+		font-size: 16px;
+	}
+
 	&:focus {
 		outline: none;
 	}
@@ -6588,6 +6612,10 @@ table.bar_chart {
 		height: 30px;
 		border-color: #7e8993;
 
+		@media only screen and (max-width: 782px) {
+			height: 40px;
+		}
+
 		&:focus {
 			outline: none;
 		}
@@ -6595,6 +6623,10 @@ table.bar_chart {
 		.select2-selection__rendered {
 			line-height: 28px;
 			padding-right: 24px;
+
+			@media only screen and (max-width: 782px) {
+				line-height: 38px;
+			}
 
 			&:hover {
 				color: #007cba;
@@ -6607,6 +6639,10 @@ table.bar_chart {
 			width: 28px;
 			background: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E") no-repeat right 5px top 55%;
 			background-size: 16px 16px;
+
+			@media only screen and (max-width: 782px) {
+				height: 38px;
+			}
 
 			b {
 				display: none;
@@ -6657,6 +6693,10 @@ table.bar_chart {
 
 .woocommerce table.form-table .select2-container {
 	min-width: 400px !important;
+
+	@media only screen and (max-width: 782px) {
+		min-width: 100% !important;
+	}
 }
 
 .post-type-product .tablenav,

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -6699,6 +6699,56 @@ table.bar_chart {
 	}
 }
 
+/**
+  * Select2 colors for built-in admin color themes.
+  */
+.admin-color {
+	$wp_admin_colors: (
+		blue: #096484,
+		coffee: #c7a589,
+		ectoplasm: #a3b745,
+		midnight: #e14d43,
+		ocean: #9ebaa0,
+		sunrise: #dd823b,
+		light: #04a4cc
+	);
+
+	@each $name, $color in $wp_admin_colors {
+
+		&-#{$name} {
+
+			.select2-dropdown {
+				border-color: $color;
+			}
+
+			.select2-dropdown--below {
+				box-shadow: 0 0 0 1px $color, 0 2px 1px rgba(0, 0, 0, 0.1);
+			}
+
+			.select2-dropdown--above {
+				box-shadow: 0 0 0 1px $color, 0 -2px 1px rgba(0, 0, 0, 0.1);
+			}
+
+			.select2-selection--single .select2-selection__rendered:hover {
+				color: $color;
+			}
+
+			.select2-container.select2-container--focus .select2-selection--single,
+			.select2-container.select2-container--open .select2-selection--single,
+			.select2-container.select2-container--open .select2-selection--multiple {
+				border-color: $color;
+				box-shadow: 0 0 0 1px $color;
+			}
+
+			.select2-container--default .select2-results__option--highlighted[aria-selected],
+			.select2-container--default .select2-results__option--highlighted[data-selected] {
+				background-color: $color;
+			}
+		}
+	}
+}
+
+
 .post-type-product .tablenav,
 .post-type-shop_order .tablenav {
 

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -622,18 +622,25 @@ mark.amount {
 .woocommerce-help-tip {
 	color: #666;
 	display: inline-block;
-	font-size: 1.2em;
+	font-size: 1.1em;
 	font-style: normal;
 	height: 16px;
 	line-height: 16px;
 	position: relative;
 	vertical-align: middle;
 	width: 16px;
-	cursor: help;
 
 	&::after {
 
 		@include icon_dashicons( "\f223" );
+		cursor: help;
+	}
+}
+
+.branch-5-3 {
+
+	.woocommerce-help-tip {
+		font-size: 1.2em;
 		cursor: help;
 	}
 }
@@ -3849,14 +3856,6 @@ img.help_tip {
 		margin: -8px 0 0;
 	}
 
-	h2.wc-table-list-header {
-		margin: 1em 0 0.35em 0;
-	}
-
-	input + .subsubsub {
-		margin: 8px 0 0;
-	}
-
 	.wc-admin-breadcrumb {
 		margin-left: 0.5em;
 
@@ -3926,10 +3925,6 @@ img.help_tip {
 			margin: 0;
 			box-sizing: border-box;
 			vertical-align: top;
-
-			@media only screen and (max-width: 782px) {
-				width: 100%;
-			}
 		}
 
 		input[type="datetime-local"],
@@ -3946,10 +3941,6 @@ img.help_tip {
 			box-sizing: border-box;
 			line-height: 32px;
 			vertical-align: top;
-
-			@media only screen and (max-width: 782px) {
-				width: 100%;
-			}
 		}
 
 		input[size] {
@@ -3998,15 +3989,10 @@ img.help_tip {
 
 			img.help_tip,
 			.woocommerce-help-tip {
-				margin: -7px -24px 0 0;
+				margin: -8px -24px 0 0;
 				position: absolute;
 				right: 0;
 				top: 50%;
-
-				@media only screen and (max-width: 782px) {
-					right: auto;
-					margin-left: 5px;
-				}
 			}
 		}
 
@@ -4077,26 +4063,13 @@ img.help_tip {
 			background-color: #ffafaf;
 		}
 
-		.forminp-color {
-			font-size: 0;
-		}
-
 		.colorpickpreview {
-			padding: 0;
+			padding: 7px 0;
 			line-height: 1em;
 			display: inline-block;
-			width: 30px;
-			height: 30px;
-			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
-			font-size: 16px;
-			border-radius: 4px;
-			margin-right: 3px;
-
-			@media only screen and (max-width: 782px) {
-				float: left;
-				width: 40px;
-				height: 40px;
-			}
+			width: 26px;
+			border: 1px solid #ddd;
+			font-size: 14px;
 		}
 
 		.image_width_settings {
@@ -4129,6 +4102,83 @@ img.help_tip {
 
 			.select2-search input {
 				padding: 6px;
+			}
+		}
+	}
+}
+
+.branch-5-3 {
+
+	.woocommerce {
+
+		h2.wc-table-list-header {
+			margin: 1em 0 0.35em 0;
+		}
+
+		input + .subsubsub {
+			margin: 8px 0 0;
+		}
+
+		table.form-table {
+
+			// Give regular settings inputs a standard width and padding.
+			textarea,
+			input[type="text"],
+			input[type="email"],
+			input[type="number"],
+			input[type="password"],
+			input[type="datetime"],
+			input[type="datetime-local"],
+			input[type="date"],
+			input[type="time"],
+			input[type="week"],
+			input[type="url"],
+			input[type="tel"],
+			input.regular-input {
+
+				@media only screen and (max-width: 782px) {
+					width: 100%;
+				}
+			}
+
+			select {
+
+				@media only screen and (max-width: 782px) {
+					width: 100%;
+				}
+			}
+
+			th label {
+
+				img.help_tip,
+				.woocommerce-help-tip {
+					margin: -7px -24px 0 0;
+
+					@media only screen and (max-width: 782px) {
+						right: auto;
+						margin-left: 5px;
+					}
+				}
+			}
+
+			.forminp-color {
+				font-size: 0;
+			}
+
+			.colorpickpreview {
+				padding: 0;
+				width: 30px;
+				height: 30px;
+				box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+				font-size: 16px;
+				border-radius: 4px;
+				margin-right: 3px;
+
+				@media only screen and (max-width: 782px) {
+					float: left;
+					width: 40px;
+					height: 40px;
+				}
 			}
 		}
 	}
@@ -4218,7 +4268,7 @@ img.help_tip {
 				right: -8px;
 				padding: 2px;
 				display: none;
-				
+
 				@media (max-width: 768px) {
 					display: block;
 				}
@@ -6544,10 +6594,6 @@ table.bar_chart {
 	.select2-results__group {
 		margin: 0;
 		padding: 8px;
-
-		&:focus {
-			outline: none;
-		}
 	}
 
 	.description {
@@ -6558,43 +6604,18 @@ table.bar_chart {
 }
 
 .select2-dropdown {
-	border-color: #007cba;
-
-	&::after {
-		position: absolute;
-		left: 0;
-		right: 0;
-		height: 1px;
-		background: #fff;
-		content: "";
-	}
+	border-color: #ddd;
 }
 
 .select2-dropdown--below {
-	box-shadow: 0 0 0 1px #007cba, 0 2px 1px rgba(0, 0, 0, 0.1);
-
-	&::after {
-		top: -1px;
-	}
+	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
 }
 
 .select2-dropdown--above {
-	box-shadow: 0 0 0 1px #007cba, 0 -2px 1px rgba(0, 0, 0, 0.1);
-
-	&::after {
-		bottom: -1px;
-	}
+	box-shadow: 0 -1px 1px rgba(0, 0, 0, 0.1);
 }
 
 .select2-container {
-
-	@media only screen and (max-width: 782px) {
-		font-size: 16px;
-	}
-
-	&:focus {
-		outline: none;
-	}
 
 	.select2-selection__rendered.ui-sortable li {
 		cursor: move;
@@ -6609,60 +6630,23 @@ table.bar_chart {
 	}
 
 	.select2-selection--single {
-		height: 30px;
-		border-color: #7e8993;
-
-		@media only screen and (max-width: 782px) {
-			height: 40px;
-		}
-
-		&:focus {
-			outline: none;
-		}
+		height: 40px;
 
 		.select2-selection__rendered {
-			line-height: 28px;
+			line-height: 40px;
 			padding-right: 24px;
-
-			@media only screen and (max-width: 782px) {
-				line-height: 38px;
-			}
-
-			&:hover {
-				color: #007cba;
-			}
 		}
 
 		.select2-selection__arrow {
-			right: 1px;
-			height: 28px;
-			width: 28px;
-			background: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E") no-repeat right 5px top 55%;
-			background-size: 16px 16px;
-
-			@media only screen and (max-width: 782px) {
-				height: 38px;
-			}
-
-			b {
-				display: none;
-			}
+			right: 3px;
+			height: 36px;
 		}
 	}
 
-	&.select2-container--focus .select2-selection--single,
-	&.select2-container--open .select2-selection--single,
-	&.select2-container--open .select2-selection--multiple {
-		border-color: #007cba;
-		box-shadow: 0 0 0 1px #007cba;
-	}
-
 	.select2-selection--multiple {
-		min-height: 30px;
+		min-height: 28px;
 		border-radius: 0;
 		line-height: 1.5;
-		border-color: #7e8993;
-		border-radius: 4px;
 
 		li {
 			margin: 0;
@@ -6686,63 +6670,182 @@ table.bar_chart {
 		font-family: inherit;
 		font-size: inherit;
 		font-weight: inherit;
-		padding: 0 0 0 3px;
-		min-height: 28px;
+		padding: 3px 0;
 	}
 }
 
 .woocommerce table.form-table .select2-container {
 	min-width: 400px !important;
+}
 
-	@media only screen and (max-width: 782px) {
-		min-width: 100% !important;
+.branch-5-3 {
+
+	.select2-results {
+
+		.select2-results__option,
+		.select2-results__group {
+
+			&:focus {
+				outline: none;
+			}
+		}
+	}
+
+	.select2-dropdown {
+		border-color: #007cba;
+
+		&::after {
+			position: absolute;
+			left: 0;
+			right: 0;
+			height: 1px;
+			background: #fff;
+			content: "";
+		}
+	}
+
+	.select2-dropdown--below {
+		box-shadow: 0 0 0 1px #007cba, 0 2px 1px rgba(0, 0, 0, 0.1);
+
+		&::after {
+			top: -1px;
+		}
+	}
+
+	.select2-dropdown--above {
+		box-shadow: 0 0 0 1px #007cba, 0 -2px 1px rgba(0, 0, 0, 0.1);
+
+		&::after {
+			bottom: -1px;
+		}
+	}
+
+	.select2-container {
+
+		@media only screen and (max-width: 782px) {
+			font-size: 16px;
+		}
+
+		&:focus {
+			outline: none;
+		}
+
+		.select2-selection--single {
+			height: 30px;
+			border-color: #7e8993;
+
+			@media only screen and (max-width: 782px) {
+				height: 40px;
+			}
+
+			&:focus {
+				outline: none;
+			}
+
+			.select2-selection__rendered {
+				line-height: 28px;
+
+				@media only screen and (max-width: 782px) {
+					line-height: 38px;
+				}
+
+				&:hover {
+					color: #007cba;
+				}
+			}
+
+			.select2-selection__arrow {
+				right: 1px;
+				height: 28px;
+				width: 28px;
+				background: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E") no-repeat right 5px top 55%;
+				background-size: 16px 16px;
+
+				@media only screen and (max-width: 782px) {
+					height: 38px;
+				}
+
+				b {
+					display: none;
+				}
+			}
+		}
+
+		&.select2-container--focus .select2-selection--single,
+		&.select2-container--open .select2-selection--single,
+		&.select2-container--open .select2-selection--multiple {
+			border-color: #007cba;
+			box-shadow: 0 0 0 1px #007cba;
+		}
+
+		.select2-selection--multiple {
+			min-height: 30px;
+			border-color: #7e8993;
+			border-radius: 4px;
+		}
+
+		.select2-search--inline .select2-search__field {
+			padding: 0 0 0 3px;
+			min-height: 28px;
+		}
+
+	}
+
+	.woocommerce table.form-table .select2-container {
+
+		@media only screen and (max-width: 782px) {
+			min-width: 100% !important;
+		}
 	}
 }
 
 /**
   * Select2 colors for built-in admin color themes.
   */
-.admin-color {
-	$wp_admin_colors: (
-		blue: #096484,
-		coffee: #c7a589,
-		ectoplasm: #a3b745,
-		midnight: #e14d43,
-		ocean: #9ebaa0,
-		sunrise: #dd823b,
-		light: #04a4cc
-	);
+.branch-5-3 {
 
-	@each $name, $color in $wp_admin_colors {
+	.admin-color {
+		$wp_admin_colors: (
+			blue: #096484,
+			coffee: #c7a589,
+			ectoplasm: #a3b745,
+			midnight: #e14d43,
+			ocean: #9ebaa0,
+			sunrise: #dd823b,
+			light: #04a4cc
+		);
 
-		&-#{$name} {
+		@each $name, $color in $wp_admin_colors {
 
-			.select2-dropdown {
-				border-color: $color;
-			}
+			&-#{$name} {
 
-			.select2-dropdown--below {
-				box-shadow: 0 0 0 1px $color, 0 2px 1px rgba(0, 0, 0, 0.1);
-			}
+				.select2-dropdown {
+					border-color: $color;
+				}
 
-			.select2-dropdown--above {
-				box-shadow: 0 0 0 1px $color, 0 -2px 1px rgba(0, 0, 0, 0.1);
-			}
+				.select2-dropdown--below {
+					box-shadow: 0 0 0 1px $color, 0 2px 1px rgba(0, 0, 0, 0.1);
+				}
 
-			.select2-selection--single .select2-selection__rendered:hover {
-				color: $color;
-			}
+				.select2-dropdown--above {
+					box-shadow: 0 0 0 1px $color, 0 -2px 1px rgba(0, 0, 0, 0.1);
+				}
 
-			.select2-container.select2-container--focus .select2-selection--single,
-			.select2-container.select2-container--open .select2-selection--single,
-			.select2-container.select2-container--open .select2-selection--multiple {
-				border-color: $color;
-				box-shadow: 0 0 0 1px $color;
-			}
+				.select2-selection--single .select2-selection__rendered:hover {
+					color: $color;
+				}
 
-			.select2-container--default .select2-results__option--highlighted[aria-selected],
-			.select2-container--default .select2-results__option--highlighted[data-selected] {
-				background-color: $color;
+				.select2-container.select2-container--focus .select2-selection--single,
+				.select2-container.select2-container--open .select2-selection--single,
+				.select2-container.select2-container--open .select2-selection--multiple {
+					border-color: $color;
+					box-shadow: 0 0 0 1px $color;
+				}
+
+				.select2-container--default .select2-results__option--highlighted[aria-selected],
+				.select2-container--default .select2-results__option--highlighted[data-selected] {
+					background-color: $color;
+				}
 			}
 		}
 	}

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -4136,6 +4136,7 @@ img.help_tip {
 			input[type="url"],
 			input[type="tel"],
 			input.regular-input {
+				padding: 0 8px;
 
 				@media only screen and (max-width: 782px) {
 					width: 100%;

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3044,7 +3044,6 @@ table.wc_input_table {
 			vertical-align: middle;
 
 			input {
-				width: auto;
 				padding: 0;
 			}
 		}
@@ -4632,7 +4631,6 @@ img.help_tip {
 
 .woocommerce_options_panel .checkbox,
 .woocommerce_variable_attributes .checkbox {
-	width: auto;
 	margin: 4px 0 !important;
 	vertical-align: middle;
 	float: left;

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3923,6 +3923,7 @@ img.help_tip {
 		input.regular-input {
 			width: 400px;
 			margin: 0;
+			padding: 6px;
 			box-sizing: border-box;
 			vertical-align: top;
 		}

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -579,6 +579,7 @@
 }
 
 #variable_product_options {
+
 	.form-row select {
 		max-width: 100%;
 	}
@@ -621,13 +622,14 @@ mark.amount {
 .woocommerce-help-tip {
 	color: #666;
 	display: inline-block;
-	font-size: 1.1em;
+	font-size: 1.2em;
 	font-style: normal;
 	height: 16px;
 	line-height: 16px;
 	position: relative;
 	vertical-align: middle;
 	width: 16px;
+	cursor: help;
 
 	&::after {
 
@@ -3847,6 +3849,14 @@ img.help_tip {
 		margin: -8px 0 0;
 	}
 
+	h2.wc-table-list-header {
+		margin: 1em 0 0.35em 0;
+	}
+
+	input + .subsubsub {
+		margin: 8px 0 0;
+	}
+
 	.wc-admin-breadcrumb {
 		margin-left: 0.5em;
 
@@ -3914,7 +3924,6 @@ img.help_tip {
 		input.regular-input {
 			width: 400px;
 			margin: 0;
-			padding: 6px;
 			box-sizing: border-box;
 			vertical-align: top;
 		}
@@ -3981,7 +3990,7 @@ img.help_tip {
 
 			img.help_tip,
 			.woocommerce-help-tip {
-				margin: -8px -24px 0 0;
+				margin: -7px -24px 0 0;
 				position: absolute;
 				right: 0;
 				top: 50%;
@@ -4055,13 +4064,19 @@ img.help_tip {
 			background-color: #ffafaf;
 		}
 
+		.forminp-color {
+			font-size: 0;
+		}
+
 		.colorpickpreview {
 			padding: 7px 0;
 			line-height: 1em;
 			display: inline-block;
-			width: 26px;
-			border: 1px solid #ddd;
-			font-size: 14px;
+			width: 30px;
+			box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.2);
+			font-size: 16px;
+			border-radius: 4px;
+			margin-right: 3px;
 		}
 
 		.image_width_settings {
@@ -6509,6 +6524,10 @@ table.bar_chart {
 	.select2-results__group {
 		margin: 0;
 		padding: 8px;
+
+		&:focus {
+			outline: none;
+		}
 	}
 
 	.description {
@@ -6519,18 +6538,39 @@ table.bar_chart {
 }
 
 .select2-dropdown {
-	border-color: #ddd;
+	border-color: #007cba;
+
+	&::after {
+		position: absolute;
+		left: 0;
+		right: 0;
+		height: 1px;
+		background: #fff;
+		content: "";
+	}
 }
 
 .select2-dropdown--below {
-	box-shadow: 0 1px 1px rgba(0, 0, 0, 0.1);
+	box-shadow: 0 0 0 1px #007cba, 0 2px 1px rgba(0, 0, 0, 0.1);
+
+	&::after {
+		top: -1px;
+	}
 }
 
 .select2-dropdown--above {
-	box-shadow: 0 -1px 1px rgba(0, 0, 0, 0.1);
+	box-shadow: 0 0 0 1px #007cba, 0 -2px 1px rgba(0, 0, 0, 0.1);
+
+	&::after {
+		bottom: -1px;
+	}
 }
 
 .select2-container {
+
+	&:focus {
+		outline: none;
+	}
 
 	.select2-selection__rendered.ui-sortable li {
 		cursor: move;
@@ -6545,23 +6585,48 @@ table.bar_chart {
 	}
 
 	.select2-selection--single {
-		height: 40px;
+		height: 30px;
+		border-color: #7e8993;
+
+		&:focus {
+			outline: none;
+		}
 
 		.select2-selection__rendered {
-			line-height: 40px;
+			line-height: 28px;
 			padding-right: 24px;
+
+			&:hover {
+				color: #007cba;
+			}
 		}
 
 		.select2-selection__arrow {
-			right: 3px;
-			height: 36px;
+			right: 1px;
+			height: 28px;
+			width: 28px;
+			background: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E") no-repeat right 5px top 55%;
+			background-size: 16px 16px;
+
+			b {
+				display: none;
+			}
 		}
 	}
 
+	&.select2-container--focus .select2-selection--single,
+	&.select2-container--open .select2-selection--single,
+	&.select2-container--open .select2-selection--multiple {
+		border-color: #007cba;
+		box-shadow: 0 0 0 1px #007cba;
+	}
+
 	.select2-selection--multiple {
-		min-height: 28px;
+		min-height: 30px;
 		border-radius: 0;
 		line-height: 1.5;
+		border-color: #7e8993;
+		border-radius: 4px;
 
 		li {
 			margin: 0;
@@ -6585,7 +6650,8 @@ table.bar_chart {
 		font-family: inherit;
 		font-size: inherit;
 		font-weight: inherit;
-		padding: 3px 0;
+		padding: 0 0 0 3px;
+		min-height: 28px;
 	}
 }
 

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1153,10 +1153,17 @@ h3.jetpack-reasons {
 	color: #444;
 	background-color: #fff;
 	display: block;
-	margin: 0;
 
 	&.dropdown {
 		width: 100%;
+	}
+}
+
+.branch-5-3 {
+
+	.location-input {
+		margin: 0;
+
 	}
 }
 
@@ -1369,7 +1376,7 @@ p.jetpack-terms {
 
 	.payment-checkbox-input {
 		order: 1;
-		margin-top: 3px;
+		margin-top: 5px;
 		margin-left: 0;
 		margin-right: 0;
 	}
@@ -1378,6 +1385,17 @@ p.jetpack-terms {
 	.ppec_paypal_reroute_requests {
 		order: 2;
 		margin-left: 0.3em;
+	}
+}
+
+.branch-5-3 {
+
+	.wc-wizard-service-setting-stripe_create_account,
+	.wc-wizard-service-setting-ppec_paypal_reroute_requests {
+
+		.payment-checkbox-input {
+			margin-top: 3px;
+		}
 	}
 }
 

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1153,6 +1153,7 @@ h3.jetpack-reasons {
 	color: #444;
 	background-color: #fff;
 	display: block;
+	margin: 0;
 
 	&.dropdown {
 		width: 100%;
@@ -1368,7 +1369,7 @@ p.jetpack-terms {
 
 	.payment-checkbox-input {
 		order: 1;
-		margin-top: 5px;
+		margin-top: 3px;
 		margin-left: 0;
 		margin-right: 0;
 	}

--- a/includes/admin/class-wc-admin-api-keys.php
+++ b/includes/admin/class-wc-admin-api-keys.php
@@ -95,7 +95,7 @@ class WC_Admin_API_Keys {
 	private static function table_list_output() {
 		global $wpdb, $keys_table_list;
 
-		echo '<h2>' . esc_html__( 'REST API', 'woocommerce' ) . ' <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=advanced&section=keys&create-key=1' ) ) . '" class="add-new-h2">' . esc_html__( 'Add key', 'woocommerce' ) . '</a></h2>';
+		echo '<h2 class="wc-table-list-header">' . esc_html__( 'REST API', 'woocommerce' ) . ' <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=advanced&section=keys&create-key=1' ) ) . '" class="add-new-h2">' . esc_html__( 'Add key', 'woocommerce' ) . '</a></h2>';
 
 		// Get the API keys count.
 		$count = $wpdb->get_var( "SELECT COUNT(key_id) FROM {$wpdb->prefix}woocommerce_api_keys WHERE 1 = 1;" );

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -706,7 +706,7 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 			} elseif ( $description && in_array( $value['type'], array( 'checkbox' ), true ) ) {
 				$description = wp_kses_post( $description );
 			} elseif ( $description ) {
-				$description = '<span class="description">' . wp_kses_post( $description ) . '</span>';
+				$description = '<p class="description">' . wp_kses_post( $description ) . '</p>';
 			}
 
 			if ( $tooltip_html && in_array( $value['type'], array( 'checkbox' ), true ) ) {

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -267,7 +267,7 @@ class WC_Admin_Webhooks {
 	private static function table_list_output() {
 		global $webhooks_table_list;
 
-		echo '<h2>' . esc_html__( 'Webhooks', 'woocommerce' ) . ' <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=advanced&section=webhooks&edit-webhook=0' ) ) . '" class="add-new-h2">' . esc_html__( 'Add webhook', 'woocommerce' ) . '</a></h2>';
+		echo '<h2 class="wc-table-list-header">' . esc_html__( 'Webhooks', 'woocommerce' ) . ' <a href="' . esc_url( admin_url( 'admin.php?page=wc-settings&tab=advanced&section=webhooks&edit-webhook=0' ) ) . '" class="add-new-h2">' . esc_html__( 'Add webhook', 'woocommerce' ) . '</a></h2>';
 
 		// Get the webhooks count.
 		$data_store   = WC_Data_Store::load( 'webhook' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This is an adaptation to the #25034 to only apply those CSS updates in WP 5.3

### How to test the changes in this Pull Request:

1. Check select2 elements and aligning of buttons in WP 5.2 and 5.3

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix select2 style and admin screen button alignments in WP 5.3.
