### PR TITLE
Changed the shipping rates to not calculate until a full address is provided

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -293,8 +293,8 @@ class WC_Shipping {
 			return false;
 		}
 
-		$states = array_keys( WC()->countries->get_states( $country ) );
-		if ( is_array( $states ) && ! in_array( $package['destination']['state'], $states, true ) ) {
+		$states = WC()->countries->get_states( $country );
+		if ( is_array( $states ) && ! isset( $states[ $package['destination']['state'] ] ) ) {
 			return false;
 		}
 

--- a/tests/framework/helpers/class-wc-helper-order.php
+++ b/tests/framework/helpers/class-wc-helper-order.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Order helpers.
+ *
+ * @package WooCommerce/Tests
+ */
 
 /**
  * Class WC_Helper_Order.
@@ -33,8 +38,8 @@ class WC_Helper_Order {
 	 * @since   2.4
 	 * @version 3.0 New parameter $product.
 	 *
-	 * @param int        $customer_id
-	 * @param WC_Product $product
+	 * @param int        $customer_id The ID of the customer the order is for.
+	 * @param WC_Product $product The product to add to the order.
 	 *
 	 * @return WC_Order
 	 */
@@ -53,10 +58,10 @@ class WC_Helper_Order {
 			'total'         => '',
 		);
 
-		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // Required, else wc_create_order throws an exception
+		$_SERVER['REMOTE_ADDR'] = '127.0.0.1'; // Required, else wc_create_order throws an exception.
 		$order                  = wc_create_order( $order_data );
 
-		// Add order products
+		// Add order products.
 		$item = new WC_Order_Item_Product();
 		$item->set_props(
 			array(
@@ -69,7 +74,7 @@ class WC_Helper_Order {
 		$item->save();
 		$order->add_item( $item );
 
-		// Set billing address
+		// Set billing address.
 		$order->set_billing_first_name( 'Jeroen' );
 		$order->set_billing_last_name( 'Sormani' );
 		$order->set_billing_company( 'WooCompany' );
@@ -77,12 +82,12 @@ class WC_Helper_Order {
 		$order->set_billing_address_2( '' );
 		$order->set_billing_city( 'WooCity' );
 		$order->set_billing_state( 'NY' );
-		$order->set_billing_postcode( '123456' );
+		$order->set_billing_postcode( '12345' );
 		$order->set_billing_country( 'US' );
 		$order->set_billing_email( 'admin@example.org' );
 		$order->set_billing_phone( '555-32123' );
 
-		// Add shipping costs
+		// Add shipping costs.
 		$shipping_taxes = WC_Tax::calc_shipping_tax( '10', WC_Tax::get_shipping_tax_rates() );
 		$rate           = new WC_Shipping_Rate( 'flat_rate_shipping', 'Flat rate shipping', '10', $shipping_taxes, 'flat_rate' );
 		$item           = new WC_Order_Item_Shipping();
@@ -99,11 +104,11 @@ class WC_Helper_Order {
 		}
 		$order->add_item( $item );
 
-		// Set payment gateway
+		// Set payment gateway.
 		$payment_gateways = WC()->payment_gateways->payment_gateways();
 		$order->set_payment_method( $payment_gateways['bacs'] );
 
-		// Set totals
+		// Set totals.
 		$order->set_shipping_total( 10 );
 		$order->set_discount_total( 0 );
 		$order->set_discount_tax( 0 );

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -917,7 +917,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	/**
 	 * Helper that can be hooked to a filter to force the customer's shipping postal code to be ANN NAA.
 	 *
-	 * @since 3.9.0
+	 * @since 3.10.0
 	 * @param string $postcode Postal code..
 	 * @return string
 	 */
@@ -939,7 +939,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	/**
 	 * Helper that can be hooked to a filter to force the customer's shipping state to be NY.
 	 *
-	 * @since 3.9.0
+	 * @since 3.10.0
 	 * @param string $state State code.
 	 * @return string
 	 */
@@ -950,7 +950,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	/**
 	 * Helper that can be hooked to a filter to force the customer's shipping postal code to be 12345.
 	 *
-	 * @since 3.9.0
+	 * @since 3.10.0
 	 * @param string $postcode Postal code.
 	 * @return string
 	 */

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -172,6 +172,11 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_calc_taxes', 'yes' );
 		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
 
+		// Set an address so that shipping can be calculated.
+		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_us_country' ) );
+		add_filter( 'woocommerce_customer_get_shipping_state', array( $this, 'force_customer_us_state' ) );
+		add_filter( 'woocommerce_customer_get_shipping_postcode', array( $this, 'force_customer_us_postcode' ) );
+
 		$tax_rate    = array(
 			'tax_rate_country'  => '',
 			'tax_rate_state'    => '',
@@ -567,7 +572,8 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		$full_coupon->set_amount( 100 );
 		$full_coupon->save();
 
-		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_gb_shipping' ) );
+		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_gb_country' ) );
+		add_filter( 'woocommerce_customer_get_shipping_postcode', array( $this, 'force_customer_gb_postcode' ) );
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
 		// Test in store location with no coupon.
@@ -604,8 +610,11 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		WC()->cart->remove_coupons();
 
 		WC()->cart->empty_cart();
-		remove_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_gb_shipping' ) );
-		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_us_shipping' ) );
+		remove_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_gb_country' ) );
+		remove_filter( 'woocommerce_customer_get_shipping_postcode', array( $this, 'force_customer_gb_postcode' ) );
+		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_us_country' ) );
+		add_filter( 'woocommerce_customer_get_shipping_state', array( $this, 'force_customer_us_state' ) );
+		add_filter( 'woocommerce_customer_get_shipping_postcode', array( $this, 'force_customer_us_postcode' ) );
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
 		// Test out of store location with no coupon.
@@ -710,7 +719,8 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		$full_coupon->set_amount( 100 );
 		$full_coupon->save();
 
-		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_gb_shipping' ) );
+		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_gb_country' ) );
+		add_filter( 'woocommerce_customer_get_shipping_postcode', array( $this, 'force_customer_gb_postcode' ) );
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
 		// Test in store location with no coupon.
@@ -747,8 +757,11 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		WC()->cart->remove_coupons();
 
 		WC()->cart->empty_cart();
-		remove_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_gb_shipping' ) );
-		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_us_shipping' ) );
+		remove_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_gb_country' ) );
+		remove_filter( 'woocommerce_customer_get_shipping_postcode', array( $this, 'force_customer_gb_postcode' ) );
+		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_us_country' ) );
+		add_filter( 'woocommerce_customer_get_shipping_state', array( $this, 'force_customer_us_state' ) );
+		add_filter( 'woocommerce_customer_get_shipping_postcode', array( $this, 'force_customer_us_postcode' ) );
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
 		// Test out of store location with no coupon.
@@ -851,7 +864,9 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		$full_coupon->set_amount( 100 );
 		$full_coupon->save();
 
-		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_us_shipping' ) );
+		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_us_country' ) );
+		add_filter( 'woocommerce_customer_get_shipping_state', array( $this, 'force_customer_us_state' ) );
+		add_filter( 'woocommerce_customer_get_shipping_postcode', array( $this, 'force_customer_us_postcode' ) );
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
 		// Test out of store location with no coupon.
@@ -895,8 +910,19 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	 * @param string $country Country code.
 	 * @return string
 	 */
-	public function force_customer_gb_shipping( $country ) {
+	public function force_customer_gb_country( $country ) {
 		return 'GB';
+	}
+
+	/**
+	 * Helper that can be hooked to a filter to force the customer's shipping postal code to be ANN NAA.
+	 *
+	 * @since 3.9.0
+	 * @param string $postcode Postal code..
+	 * @return string
+	 */
+	public function force_customer_gb_postcode( $postcode ) {
+		return 'ANN NAA';
 	}
 
 	/**
@@ -906,8 +932,30 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	 * @param string $country Country code.
 	 * @return string
 	 */
-	public function force_customer_us_shipping( $country ) {
+	public function force_customer_us_country( $country ) {
 		return 'US';
+	}
+
+	/**
+	 * Helper that can be hooked to a filter to force the customer's shipping state to be NY.
+	 *
+	 * @since 3.9.0
+	 * @param string $state State code.
+	 * @return string
+	 */
+	public function force_customer_us_state( $state ) {
+		return 'NY';
+	}
+
+	/**
+	 * Helper that can be hooked to a filter to force the customer's shipping postal code to be 12345.
+	 *
+	 * @since 3.9.0
+	 * @param string $postcode Postal code.
+	 * @return string
+	 */
+	public function force_customer_us_postcode( $postcode ) {
+		return '12345';
 	}
 
 	/**
@@ -931,6 +979,11 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		// Store is set to enter product prices inclusive tax.
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		// Set an address so that shipping can be calculated.
+		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_us_country' ) );
+		add_filter( 'woocommerce_customer_get_shipping_state', array( $this, 'force_customer_us_state' ) );
+		add_filter( 'woocommerce_customer_get_shipping_postcode', array( $this, 'force_customer_us_postcode' ) );
 
 		// 19% tax.
 		$tax_rate = array(
@@ -1486,6 +1539,11 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 
 		// Add product to cart.
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		// Set an address so that shipping can be calculated.
+		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_us_country' ) );
+		add_filter( 'woocommerce_customer_get_shipping_state', array( $this, 'force_customer_us_state' ) );
+		add_filter( 'woocommerce_customer_get_shipping_postcode', array( $this, 'force_customer_us_postcode' ) );
 
 		// Set the flat_rate shipping method.
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -62,6 +62,10 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 			'cost'         => '9.59',
 		);
 		update_option( 'woocommerce_flat_rate_settings', $flat_rate_settings );
+		// Set an address so that shipping can be calculated.
+		add_filter( 'woocommerce_customer_get_shipping_country', array( $this, 'force_customer_us_country' ) );
+		add_filter( 'woocommerce_customer_get_shipping_state', array( $this, 'force_customer_us_state' ) );
+		add_filter( 'woocommerce_customer_get_shipping_postcode', array( $this, 'force_customer_us_postcode' ) );
 
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 		WC()->cart->add_discount( $coupon->get_code() );

--- a/tests/unit-tests/coupon/coupon.php
+++ b/tests/unit-tests/coupon/coupon.php
@@ -1,4 +1,9 @@
 <?php
+/**
+ * Coupon tests.
+ *
+ * @package WooCommerce\Tests\Coupon
+ */
 
 /**
  * Class Coupon.
@@ -7,6 +12,21 @@
  */
 class WC_Tests_Coupon extends WC_Unit_Test_Case {
 
+	/**
+	 * Sets up the test class.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Set a valid address for the customer so shipping rates will calculate.
+		WC()->customer->set_shipping_country( 'US' );
+		WC()->customer->set_shipping_state( 'NY' );
+		WC()->customer->set_shipping_postcode( '12345' );
+	}
+
+	/**
+	 * Cleans up after the test class.
+	 */
 	public function tearDown() {
 		WC()->cart->empty_cart();
 		WC()->cart->remove_coupons();
@@ -53,7 +73,7 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		$test_coupon = new WC_Coupon( (string) $coupon_2->get_id() );
 		$this->assertEquals( $coupon_2->get_id(), $test_coupon->get_id() );
 
-		// Test getting a coupon by coupon object
+		// Test getting a coupon by coupon object.
 		$test_coupon = new WC_Coupon( $coupon_1 );
 		$this->assertEquals( $test_coupon->get_id(), $coupon_1->get_id() );
 	}
@@ -65,13 +85,13 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	 */
 	public function test_add_discount() {
 
-		// Create coupon
+		// Create coupon.
 		$coupon = WC_Helper_Coupon::create_coupon();
 
-		// Add coupon, test return statement
+		// Add coupon, test return statement.
 		$this->assertTrue( WC()->cart->add_discount( $coupon->get_code() ) );
 
-		// Test if total amount of coupons is 1
+		// Test if total amount of coupons is 1.
 		$this->assertEquals( 1, count( WC()->cart->get_applied_coupons() ) );
 	}
 
@@ -82,16 +102,16 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	 */
 	public function test_add_discount_duplicate() {
 
-		// Create coupon
+		// Create coupon.
 		$coupon = WC_Helper_Coupon::create_coupon();
 
-		// Add coupon
+		// Add coupon.
 		$this->assertTrue( WC()->cart->add_discount( $coupon->get_code() ) );
 
-		// Add coupon again, test return statement
+		// Add coupon again, test return statement.
 		$this->assertFalse( WC()->cart->add_discount( $coupon->get_code() ) );
 
-		// Test if total amount of coupons is 1
+		// Test if total amount of coupons is 1.
 		$this->assertEquals( 1, count( WC()->cart->get_applied_coupons() ) );
 	}
 
@@ -102,30 +122,30 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	 */
 	public function test_fixed_cart_discount() {
 
-		// Create product
+		// Create product.
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_regular_price( 10 );
 		$product->save();
 
-		// Create coupon
+		// Create coupon.
 		$coupon = WC_Helper_Coupon::create_coupon();
 		update_post_meta( $coupon->get_id(), 'discount_type', 'fixed_cart' );
 		update_post_meta( $coupon->get_id(), 'coupon_amount', '5' );
 
-		// Create a flat rate method
+		// Create a flat rate method.
 		WC_Helper_Shipping::create_simple_flat_rate();
 
-		// Add product to cart
+		// Add product to cart.
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
-		// Add coupon
+		// Add coupon.
 		WC()->cart->add_discount( $coupon->get_code() );
 
-		// Set the flat_rate shipping method
+		// Set the flat_rate shipping method.
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
 		WC()->cart->calculate_totals();
 
-		// Test if the cart total amount is equal 15
+		// Test if the cart total amount is equal 15.
 		$this->assertEquals( 15, WC()->cart->total );
 	}
 
@@ -136,33 +156,33 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	 */
 	public function test_fixed_product_discount() {
 
-		// Create product
+		// Create product.
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_regular_price( 10 );
 		$product->save();
 
-		// Create coupon
+		// Create coupon.
 		$coupon = WC_Helper_Coupon::create_coupon();
 		update_post_meta( $coupon->get_id(), 'discount_type', 'fixed_product' );
 		update_post_meta( $coupon->get_id(), 'coupon_amount', '5' );
 
-		// Create a flat rate method - $10
+		// Create a flat rate method - $10.
 		WC_Helper_Shipping::create_simple_flat_rate();
 
-		// Add fee - $10
+		// Add fee - $10.
 		WC_Helper_Fee::add_cart_fee();
 
-		// Add product to cart
+		// Add product to cart.
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
-		// Add coupon
+		// Add coupon.
 		WC()->cart->add_discount( $coupon->get_code() );
 
-		// Set the flat_rate shipping method
+		// Set the flat_rate shipping method.
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
 		WC()->cart->calculate_totals();
 
-		// Test if the cart total amount is equal 25
+		// Test if the cart total amount is equal 25.
 		$this->assertEquals( 25, WC()->cart->total );
 	}
 
@@ -173,33 +193,33 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	 */
 	public function test_percent_discount() {
 
-		// Create product
+		// Create product.
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_regular_price( 10 );
 		$product->save();
 
-		// Create coupon
+		// Create coupon.
 		$coupon = WC_Helper_Coupon::create_coupon();
 		update_post_meta( $coupon->get_id(), 'discount_type', 'percent' );
 		update_post_meta( $coupon->get_id(), 'coupon_amount', '5' );
 
-		// Create a flat rate method
+		// Create a flat rate method.
 		WC_Helper_Shipping::create_simple_flat_rate();
 
-		// Add fee
+		// Add fee.
 		WC_Helper_Fee::add_cart_fee();
 
-		// Add product to cart
+		// Add product to cart.
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 
-		// Add coupon
+		// Add coupon.
 		WC()->cart->add_discount( $coupon->get_code() );
 
-		// Set the flat_rate shipping method
+		// Set the flat_rate shipping method.
 		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
 		WC()->cart->calculate_totals();
 
-		// Test if the cart total amount is equal 29.5
+		// Test if the cart total amount is equal 29.5.
 		$this->assertEquals( 29.5, WC()->cart->total );
 	}
 
@@ -229,12 +249,12 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	 * Test an item limit for percent discounts.
 	 */
 	public function test_percent_discount_item_limit() {
-		// Create product
+		// Create product.
 		$product = WC_Helper_Product::create_simple_product();
 		update_post_meta( $product->get_id(), '_price', '10' );
 		update_post_meta( $product->get_id(), '_regular_price', '10' );
 
-		// Create coupon
+		// Create coupon.
 		$coupon = WC_Helper_Coupon::create_coupon(
 			'dummycoupon',
 			array(
@@ -258,16 +278,19 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 		$this->assertEquals( 19.5, WC()->cart->total );
 	}
 
+	/**
+	 * Test the coupon's item limit.
+	 */
 	public function test_custom_discount_item_limit() {
 		// Register custom discount type.
 		WC_Helper_Coupon::register_custom_type( __FUNCTION__ );
 
-		// Create product
+		// Create product.
 		$product = WC_Helper_Product::create_simple_product();
 		update_post_meta( $product->get_id(), '_price', '10' );
 		update_post_meta( $product->get_id(), '_regular_price', '10' );
 
-		// Create coupon
+		// Create coupon.
 		$coupon = WC_Helper_Coupon::create_coupon(
 			'dummycoupon',
 			array(

--- a/tests/unit-tests/shipping/shipping-zone.php
+++ b/tests/unit-tests/shipping/shipping-zone.php
@@ -1,12 +1,13 @@
 <?php
 /**
- * Tests for the WC_Shopping_Zones class.
+ * Tests for the WC_Shopping_Zone class.
  *
- * @package WooCommerce\Tests\Shipping_Zone
+ * @package WooCommerce\Tests\Shipping
  */
 
 /**
  * Class Shipping_Zone.
+ * @package WooCommerce\Tests\Shipping
  */
 class WC_Tests_Shipping_Zone extends WC_Unit_Test_Case {
 

--- a/tests/unit-tests/shipping/shipping-zones.php
+++ b/tests/unit-tests/shipping/shipping-zones.php
@@ -1,11 +1,19 @@
 <?php
+/**
+ * Tests for the WC_Shopping_Zones class.
+ *
+ * @package WooCommerce\Tests\Shipping
+ */
 
 /**
  * Class Shipping_Zones.
- * @package WooCommerce\Tests\Shipping_Zones
+ * @package WooCommerce\Tests\Shipping
  */
 class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 
+	/**
+	 * Set up tests.
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -16,10 +24,10 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zones::get_zones
 	 */
 	public function test_get_zones() {
-		// Test
+		// Test.
 		$zones = WC_Shipping_Zones::get_zones();
 
-		// Assert
+		// Assert.
 		$this->assertTrue( is_array( $zones ) );
 		$this->assertTrue( 4 === count( $zones ) );
 	}
@@ -28,10 +36,10 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zones::get_zone
 	 */
 	public function test_get_zone() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone( 1 );
 
-		// Assert that the first zone is our local zone
+		// Assert that the first zone is our local zone.
 		$this->assertInstanceOf( 'WC_Shipping_Zone', $zone );
 		$this->assertEquals( $zone->get_zone_name(), 'Local' );
 	}
@@ -40,19 +48,19 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zones::get_zone_by
 	 */
 	public function test_get_zone_by() {
-		// Test
+		// Test.
 		$zone = WC_Shipping_Zones::get_zone_by( 'zone_id', 2 );
 
-		// Assert
+		// Assert.
 		$this->assertInstanceOf( 'WC_Shipping_Zone', $zone );
 		$this->assertEquals( $zone->get_zone_name(), 'Europe' );
 
-		// Test instance_id
+		// Test instance_id.
 		$instance_id = $zone->add_shipping_method( 'flat_rate' );
 
 		$zone = WC_Shipping_Zones::get_zone_by( 'instance_id', $instance_id );
 
-		// Assert
+		// Assert.
 		$this->assertInstanceOf( 'WC_Shipping_Zone', $zone );
 		$this->assertEquals( $zone->get_zone_name(), 'Europe' );
 	}
@@ -61,12 +69,12 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zones::get_shipping_method
 	 */
 	public function test_get_shipping_method() {
-		// Test
+		// Test.
 		$zone            = WC_Shipping_Zones::get_zone_by( 'zone_id', 1 );
 		$instance_id     = $zone->add_shipping_method( 'flat_rate' );
 		$shipping_method = WC_Shipping_Zones::get_shipping_method( $instance_id );
 
-		// Assert
+		// Assert.
 		$this->assertInstanceOf( 'WC_Shipping_Flat_Rate', $shipping_method );
 	}
 
@@ -74,11 +82,11 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zones::delete_zone
 	 */
 	public function test_delete_zone() {
-		// Test
+		// Test.
 		WC_Shipping_Zones::delete_zone( 1 );
 		$zones = WC_Shipping_Zones::get_zones();
 
-		// Assert
+		// Assert.
 		$this->assertTrue( 3 === count( $zones ) );
 	}
 
@@ -86,7 +94,7 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 	 * Test: WC_Shipping_Zones::get_zone_matching_package
 	 */
 	public function test_get_zone_matching_package() {
-		// Test
+		// Test.
 		$zone1 = WC_Shipping_Zones::get_zone_matching_package(
 			array(
 				'destination' => array(
@@ -124,7 +132,7 @@ class WC_Tests_Shipping_Zones extends WC_Unit_Test_Case {
 			)
 		);
 
-		// Assert
+		// Assert.
 		$this->assertEquals( 'Local', $zone1->get_zone_name() );
 		$this->assertEquals( 'Europe', $zone2->get_zone_name() );
 		$this->assertEquals( 'California', $zone3->get_zone_name() );

--- a/tests/unit-tests/shipping/shipping.php
+++ b/tests/unit-tests/shipping/shipping.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Unit tests for the shipping class.
+ *
+ * @package WooCommerce\Tests\Shipping
+ */
+
+/**
+ * WC_Tests_Shipping tests.
+ *
+ * @package WooCommerce\Tests\Shipping
+ * @since 3.9.0
+ */
+class WC_Tests_Shipping extends WC_Unit_Test_Case {
+
+	/**
+	 * Tests that whether or not a package is shippable is evaluated correctly.
+	 *
+	 * @since 3.9.0
+	 */
+	public function test_is_package_shippable() {
+		$shipping = new WC_Shipping();
+
+		// Failure for no country.
+		$result = $shipping->is_package_shippable(
+			array(
+				'destination' => array(
+					'country'  => '',
+					'state'    => 'CA',
+					'postcode' => '99999',
+					'address'  => '',
+				),
+			)
+		);
+		$this->assertFalse( $result );
+
+		// Failure for disallowed country.
+		$result = $shipping->is_package_shippable(
+			array(
+				'destination' => array(
+					'country'  => 'TEST',
+					'state'    => 'CA',
+					'postcode' => '99999',
+					'address'  => '',
+				),
+			)
+		);
+		$this->assertFalse( $result );
+
+		// Failure for no state when required.
+		$result = $shipping->is_package_shippable(
+			array(
+				'destination' => array(
+					'country'  => 'US',
+					'state'    => '',
+					'postcode' => '99999',
+					'address'  => '',
+				),
+			)
+		);
+		$this->assertFalse( $result );
+
+		// Failure for invalid postcode.
+		$result = $shipping->is_package_shippable(
+			array(
+				'destination' => array(
+					'country'  => 'US',
+					'state'    => 'CA',
+					'postcode' => 'test',
+					'address'  => '',
+				),
+			)
+		);
+		$this->assertFalse( $result );
+
+		// Success for correct address.
+		$result = $shipping->is_package_shippable(
+			array(
+				'destination' => array(
+					'country'  => 'US',
+					'state'    => 'CA',
+					'postcode' => '99999',
+					'address'  => '',
+				),
+			)
+		);
+		$this->assertTrue( $result );
+	}
+}

--- a/tests/unit-tests/shipping/shipping.php
+++ b/tests/unit-tests/shipping/shipping.php
@@ -9,14 +9,14 @@
  * WC_Tests_Shipping tests.
  *
  * @package WooCommerce\Tests\Shipping
- * @since 3.9.0
+ * @since 3.10.0
  */
 class WC_Tests_Shipping extends WC_Unit_Test_Case {
 
 	/**
 	 * Tests that whether or not a package is shippable is evaluated correctly.
 	 *
-	 * @since 3.9.0
+	 * @since 3.10.0
 	 */
 	public function test_is_package_shippable() {
 		$shipping = new WC_Shipping();

--- a/tests/unit-tests/totals/totals.php
+++ b/tests/unit-tests/totals/totals.php
@@ -30,6 +30,11 @@ class WC_Tests_Totals extends WC_Unit_Test_Case {
 	public function setUp() {
 		parent::setUp();
 
+		// Set a valid address for the customer so shipping rates will calculate.
+		WC()->customer->set_shipping_country( 'US' );
+		WC()->customer->set_shipping_state( 'NY' );
+		WC()->customer->set_shipping_postcode( '12345' );
+
 		$this->ids = array();
 
 		$tax_rate    = array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

By default, all packages are considered shippable unless proven otherwise. This has an interesting consequence in that all packages with an incomplete or invalid address match the fallback shipping zone. We don't actually allow the creation of orders with an incomplete address however, as the data is validated on submission and returns errors. I've added appropriate validation to whether or not a package is shippable, which prevents any rates from being shown until the address is filled out correctly. I think that this makes for a better user experience in the checkout process.

Closes #24549.

### How to test the changes in this Pull Request:

1. Add a shipping zone with a flat rate set, restricted to a specific state.
2. Add a flat rate to the fallback shipping zone.
3. In incognito mode, add a product to the cart and view.
4. Without the change, it will show the fallback shipping option. With the change, it will require you to enter an address.
5. Note that all of the errors given are reasonable, even the one when an invalid postcode is used but the rest of the address is filled out.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix: Adjusted package shipping rates to only be visible when a full address is entered.
