### PR TITLE
Ignore renovate.json while generating packages

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@ phpcs.xml export-ignore
 phpunit.* export-ignore
 README.md export-ignore
 tests export-ignore
+renovate.json export-ignore


### PR DESCRIPTION
We should ignore it from our packages.