### PR TITLE
Remove permalink reliance

### DIFF
--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -124,10 +124,17 @@ class WC_WCCOM_Site {
 	 * @return bool
 	 */
 	protected static function is_request_to_wccom_site_rest_api() {
-		global $wp;
-		$route = ltrim( $wp->query_vars['rest_route'], '/' );
+		$route = '/';
+		$rest_prefix = '';
 
-		return 0 !== strpos( $rest_route, 'wccom-site/' );
+		if ( isset( $_REQUEST['rest_route'] ) ) {
+			$route = esc_url_raw( wp_unslash( $_REQUEST['rest_route'] ) );
+		} else {
+			$route = esc_url_raw( wp_unslash( add_query_arg( array() ) ) );
+			$rest_prefix = trailingslashit( rest_get_url_prefix() );
+		}
+
+		return false !== strpos( $route, $rest_prefix . 'wccom-site/' );
 	}
 
 	/**

--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -124,13 +124,12 @@ class WC_WCCOM_Site {
 	 * @return bool
 	 */
 	protected static function is_request_to_wccom_site_rest_api() {
-		$route = '/';
 		$rest_prefix = '';
 
-		if ( isset( $_REQUEST['rest_route'] ) ) {
-			$route = esc_url_raw( wp_unslash( $_REQUEST['rest_route'] ) );
+		if ( isset( $_REQUEST['rest_route'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$route = wp_unslash( $_REQUEST['rest_route'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 		} else {
-			$route = esc_url_raw( wp_unslash( add_query_arg( array() ) ) );
+			$route       = wp_unslash( add_query_arg( array() ) );
 			$rest_prefix = trailingslashit( rest_get_url_prefix() );
 		}
 

--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -124,11 +124,10 @@ class WC_WCCOM_Site {
 	 * @return bool
 	 */
 	protected static function is_request_to_wccom_site_rest_api() {
-		$request_uri = add_query_arg( array() );
-		$rest_prefix = trailingslashit( rest_get_url_prefix() );
-		$request_uri = esc_url_raw( wp_unslash( $request_uri ) );
+		global $wp;
+		$route = ltrim( $wp->query_vars['rest_route'], '/' );
 
-		return false !== strpos( $request_uri, $rest_prefix . 'wccom-site/' );
+		return 0 !== strpos( $rest_route, 'wccom-site/' );
 	}
 
 	/**

--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -124,12 +124,13 @@ class WC_WCCOM_Site {
 	 * @return bool
 	 */
 	protected static function is_request_to_wccom_site_rest_api() {
+		$route = '/';
 		$rest_prefix = '';
 
-		if ( isset( $_REQUEST['rest_route'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
-			$route = esc_url_raw( get_rest_url( null, wp_unslash( $_REQUEST['rest_route'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+		if ( isset( $_REQUEST['rest_route'] ) ) {
+			$route = esc_url_raw( wp_unslash( $_REQUEST['rest_route'] ) );
 		} else {
-			$route       = esc_url_raw( wp_unslash( add_query_arg( array() ) ) );
+			$route = esc_url_raw( wp_unslash( add_query_arg( array() ) ) );
 			$rest_prefix = trailingslashit( rest_get_url_prefix() );
 		}
 

--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -124,13 +124,12 @@ class WC_WCCOM_Site {
 	 * @return bool
 	 */
 	protected static function is_request_to_wccom_site_rest_api() {
-		$route = '/';
 		$rest_prefix = '';
 
-		if ( isset( $_REQUEST['rest_route'] ) ) {
-			$route = esc_url_raw( wp_unslash( $_REQUEST['rest_route'] ) );
+		if ( isset( $_REQUEST['rest_route'] ) ) { // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+			$route = esc_url_raw( get_rest_url( null, wp_unslash( $_REQUEST['rest_route'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
 		} else {
-			$route = esc_url_raw( wp_unslash( add_query_arg( array() ) ) );
+			$route       = esc_url_raw( wp_unslash( add_query_arg( array() ) ) );
 			$rest_prefix = trailingslashit( rest_get_url_prefix() );
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Some sites don't have permalinks enabled (e.g. local dev environments) and can't use the WC site API functionality.

The `rest_get_url_prefix` elsewhere is only used in permalink context (e.g. `get_rest_url` uses it conditionally), while `$wp->query_vars` are always populated, even in rewrite condition, thus making them more accessible.

### How to test the changes in this Pull Request:

1. Check out this branch on a local WooCommerce test site.
2. Make a request to plugin installation API endpoint with a valid Authentication header `curl -H "Authorization: Bearer abcd" -v https://local-wp-site.test/?rest_route=wccom-site/v1/installer` .
3. Verify the request is processed and not aborted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enable WooCommerce Site API on installations not using permalink