### PR TITLE
Added empty categories to the product exporter admin view

### DIFF
--- a/includes/admin/views/html-admin-page-product-export.php
+++ b/includes/admin/views/html-admin-page-product-export.php
@@ -64,7 +64,13 @@ $exporter = new WC_Product_CSV_Exporter();
 							<td>
 								<select id="woocommerce-exporter-category" class="woocommerce-exporter-category wc-enhanced-select" style="width:100%;" multiple data-placeholder="<?php esc_attr_e( 'Export all categories', 'woocommerce' ); ?>">
 								<?php
-								foreach ( get_categories( array( 'taxonomy' => 'product_cat' ) ) as $category ) {
+								$categories = get_categories(
+									array(
+										'taxonomy'   => 'product_cat',
+										'hide_empty' => false,
+									)
+								);
+								foreach ( $categories as $category ) {
 									echo '<option value="' . esc_attr( $category->slug ) . '">' . esc_html( $category->name ) . '</option>';
 								}
 								?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Any category that is empty will be hidden from the exporter's selection. This is problematic because categories with only private products are "empty" even though we will be able to export the product.

Closes #24812.

### How to test the changes in this Pull Request:

1. Create a new product category.
2. Add a product marked private to the category.
3. Visit the product exporter on the Products > Export page.
4. Without the change, the category you created will not be present. With the change, it will be.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix: Ensure that categories containing only private products are selectable in the product exporter.
