### PR TITLE
Only update the customer IP address when order gets created from admin

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -2044,4 +2044,15 @@ class WC_Order extends WC_Abstract_Order {
 
 		return apply_filters( 'woocommerce_get_order_item_totals', $total_rows, $this, $tax_display );
 	}
+
+	/**
+	 * Check if order has been created via admin, checkout, or in another way.
+	 *
+	 * @since 3.9.0
+	 * @param string $modus Way of creating the order to test for.
+	 * @return bool
+	 */
+	public function is_created_via( $modus ) {
+		return apply_filters( 'woocommerce_order_is_created_via', $modus === $this->get_created_via(), $this, $modus );
+	}
 }

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -2048,7 +2048,7 @@ class WC_Order extends WC_Abstract_Order {
 	/**
 	 * Check if order has been created via admin, checkout, or in another way.
 	 *
-	 * @since 3.9.0
+	 * @since 3.10.0
 	 * @param string $modus Way of creating the order to test for.
 	 * @return bool
 	 */

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -2048,7 +2048,7 @@ class WC_Order extends WC_Abstract_Order {
 	/**
 	 * Check if order has been created via admin, checkout, or in another way.
 	 *
-	 * @since 3.10.0
+	 * @since 4.0.0
 	 * @param string $modus Way of creating the order to test for.
 	 * @return bool
 	 */

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -238,7 +238,7 @@ class WC_Shortcode_Checkout {
 
 		// In case order is created from admin, but paid by the actual customer, store the ip address of the payer
 		// when they visit the payment confirmation page.
-		if ( $order && 'admin' === $order->get_created_via() ) {
+		if ( $order && $order->is_created_via( 'admin' ) ) {
 			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );
 			$order->save();
 		}

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -236,8 +236,9 @@ class WC_Shortcode_Checkout {
 		// Empty awaiting payment session.
 		unset( WC()->session->order_awaiting_payment );
 
-		// In case order is created from admin, but paid by the actual customer, store the ip address of the payer.
-		if ( $order ) {
+		// In case order is created from admin, but paid by the actual customer, store the ip address of the payer
+		// when they visit the payment confirmation page.
+		if ( $order && 'admin' === $order->get_created_via() ) {
 			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );
 			$order->save();
 		}


### PR DESCRIPTION
This should prevent potential conflicts/race conditions with callbacks from payment gateways updating the order in parallel.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24936  .

### How to test the changes in this Pull Request:

1. Try to through checkout via IP address 1, check that it's correctly captured on the order.
2. Create order via admin, then use the payment link to pay the order via IP address 2, check that it's correctly captured in the order info.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Only update the customer IP address when order gets created from admin.
