### PR TITLE
Return folder_exists error as success

### DIFF
--- a/includes/wccom-site/class-wc-wccom-site-installer.php
+++ b/includes/wccom-site/class-wc-wccom-site-installer.php
@@ -247,6 +247,7 @@ class WC_WCCOM_Site_Installer {
 				case 'get_product_info':
 					$state_steps[ $product_id ]['download_url'] = $result['download_url'];
 					$state_steps[ $product_id ]['product_type'] = $result['product_type'];
+					$state_steps[ $product_id ]['product_name'] = $result['product_name'];
 					break;
 				case 'download_product':
 					$state_steps[ $product_id ]['download_path'] = $result;
@@ -257,7 +258,10 @@ class WC_WCCOM_Site_Installer {
 				case 'move_product':
 					$state_steps[ $product_id ]['installed_path'] = $result['destination'];
 					if ( $result[ self::$folder_exists ] ) {
-						$state_steps[ $product_id ]['warning'] = self::$folder_exists;
+						$state_steps[ $product_id ]['warning'] = array(
+							'message'     => self::$folder_exists,
+							'plugin_info' => self::get_plugin_info( $state_steps[ $product_id ]['installed_path'] ),
+						);
 					}
 					break;
 			}
@@ -297,6 +301,7 @@ class WC_WCCOM_Site_Installer {
 		$result = json_decode( wp_remote_retrieve_body( $request ), true );
 
 		$product_info['product_type'] = $result['_product_type'];
+		$product_info['product_name'] = $result['name'];
 
 		if ( ! empty( $result['_wporg_product'] ) && ! empty( $result['download_link'] ) ) {
 			// For wporg product, download is set already from info response.
@@ -530,6 +535,43 @@ class WC_WCCOM_Site_Installer {
 			}
 		}
 
+		return false;
+	}
+
+
+	/**
+	 * Get plugin info
+	 *
+	 * @since 3.9.0
+	 * @param string $dir Directory name of the plugin.
+	 * @return bool|array
+	 */
+	private static function get_plugin_info( $dir ) {
+		$plugin_folder = basename( $dir );
+
+		if ( ! function_exists( 'get_plugins' ) ) {
+			require_once ABSPATH . 'wp-admin/includes/plugin.php';
+		}
+
+		$plugins = get_plugins();
+
+		$related_plugins = array_filter(
+			$plugins,
+			function( $key ) use ( $plugin_folder ) {
+				return strpos( $key, $plugin_folder . '/' ) === 0;
+			},
+			ARRAY_FILTER_USE_KEY
+		);
+
+		if ( 1 === count( $related_plugins ) ) {
+			$plugin_key = array_keys( $related_plugins )[0];
+			$plugin_data = $plugins[ $plugin_key ];
+			return array(
+				'name'    => $plugin_data['Name'],
+				'version' => $plugin_data['Version'],
+				'active'  => is_plugin_active( $plugin_key ),
+			);
+		}
 		return false;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

If a user tries to install a plugin using the in-app install feature (WooCommerce->Extensions) and the plugin already exists on their site this will break the install and snow an error message to the user.  Because the plugin is actually installed this shouldn't be an error but a success.

To resolve this issue, this PR makes sure that if the plugin was already installed the `/wp-json/wccom-site/v1/installer` REST API endpoint will return success. 
To make a distinction between this case and a regular install the response will include a `warning` object. e.g. 
```
"warning": {
  "message":"folder_exists",
  "plugin_info": {
     "name": "WooCommerce Google Analytics Integration",
     "version": "1.4.15",
     "active": true
  }
}
```

To check f the installed plugin matches the existing plugin `product_name` was also added to the response.

![Screenshot 2019-12-02 at 16 08 26](https://user-images.githubusercontent.com/1199991/69971268-e8ac5900-151f-11ea-8524-dbf77920594e.png)

Closes woocommerce.com issue 6777

### How to test the changes in this Pull Request:

1. Pull this branch.
2. Connect your site to WooCommerce.com.
3. Buy a plugin using WooCommerce->Extensions.
4. After checkout, click Add to site.
6. During the install take a look at responses from this network call in your browser `/wp-json/wccom/in-app-purchase/v1/installer` and take note of the `status: finished` response message.
5. After a successful install, repeat the process.
6. Compare the two `status: finished` responses, the second one should also include `warning` and both should contain`product_name`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> /wp-json/wccom/in-app-purchase/v1/installer now returns success if the plugin was previously installed
