### PR TITLE
Add woocommerce_order_payment_status_changed action

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -371,6 +371,21 @@ class WC_Order extends WC_Abstract_Order {
 
 					do_action( 'woocommerce_order_status_' . $status_transition['from'] . '_to_' . $status_transition['to'], $this->get_id(), $this );
 					do_action( 'woocommerce_order_status_changed', $this->get_id(), $status_transition['from'], $status_transition['to'], $this );
+
+					// Work out if this was for a payment, and trigger a payment_status hook instead.
+					if (
+						in_array( $status_transition['from'], apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ) ), true )
+						&& in_array( $status_transition['to'], wc_get_is_paid_statuses(), true )
+					) {
+						/**
+						 * Fires when the order progresses from a pending payment status to a paid one.
+						 *
+						 * @since 3.9.0
+						 * @param int Order ID
+						 * @param WC_Order Order object
+						 */
+						do_action( 'woocommerce_order_payment_status_changed', $this->get_id(), $this );
+					}
 				} else {
 					/* translators: %s: new order status */
 					$transition_note = sprintf( __( 'Order status set to %s.', 'woocommerce' ), wc_get_order_status_name( $status_transition['to'] ) );

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -113,7 +113,7 @@ class WC_Order extends WC_Abstract_Order {
 					$this->set_transaction_id( $transaction_id );
 				}
 				if ( ! $this->get_date_paid( 'edit' ) ) {
-					$this->set_date_paid( current_time( 'timestamp', true ) );
+					$this->set_date_paid( time() );
 				}
 				$this->set_status( apply_filters( 'woocommerce_payment_complete_order_status', $this->needs_processing() ? 'processing' : 'completed', $this->get_id(), $this ) );
 				$this->save();
@@ -292,11 +292,11 @@ class WC_Order extends WC_Abstract_Order {
 
 			if ( $this->has_status( $payment_completed_status ) ) {
 				// If payment complete status is reached, set paid now.
-				$this->set_date_paid( current_time( 'timestamp', true ) );
+				$this->set_date_paid( time() );
 
 			} elseif ( 'processing' === $payment_completed_status && $this->has_status( 'completed' ) ) {
 				// If payment complete status was processing, but we've passed that and still have no date, set it now.
-				$this->set_date_paid( current_time( 'timestamp', true ) );
+				$this->set_date_paid( time() );
 			}
 		}
 	}
@@ -310,7 +310,7 @@ class WC_Order extends WC_Abstract_Order {
 	 */
 	protected function maybe_set_date_completed() {
 		if ( $this->has_status( 'completed' ) ) {
-			$this->set_date_completed( current_time( 'timestamp', true ) );
+			$this->set_date_completed( time() );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR introduces a new `woocommerce_order_payment_status_changed` action that gets triggered when an order progresses from unpaid to paid. This should help address the usage of actions like `woocommerce_order_status_changed` and `woocommerce_order_status_x_to_y` for triggering when an order is paid since those actions might possibly be deprecated in a future release to support the new order status changes we have planned.

See the comments on p6q8Tx-1jX-p2 for context.

cc @danielbitzer 

### How to test the changes in this Pull Request:

1. Hook into the new woocommerce_order_payment_status_changed action to print some debugging message
2. Place a couple of orders transitioning the statuses
3. Check the debug logs to ensure the hook only fires when orders transition from pending or failed to processing or completed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - New `woocommerce_valid_order_statuses_for_payment` hook that triggers when an order is paid. Use this new hook instead of `woocommerce_order_status_changed` or `woocommerce_order_status_x_to_y` to trigger code for payment completion.
