### PR TITLE
Ignore bin/ directory when generating WooCommerce zip file for GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 /.* export-ignore
+bin export-ignore
 CODE_OF_CONDUCT.md export-ignore
 CHANGELOG.txt export-ignore
 composer.* export-ignore


### PR DESCRIPTION
Files and directories that are used for development should not be part of the final package.

I noticed this while reviewing #25130.