### PR TITLE
Fix PHP Notice:  Undefined index: folder_exists

### DIFF
--- a/includes/wccom-site/class-wc-wccom-site-installer.php
+++ b/includes/wccom-site/class-wc-wccom-site-installer.php
@@ -257,7 +257,7 @@ class WC_WCCOM_Site_Installer {
 					break;
 				case 'move_product':
 					$state_steps[ $product_id ]['installed_path'] = $result['destination'];
-					if ( $result[ self::$folder_exists ] ) {
+					if ( isset( $result[ self::$folder_exists ] ) ) {
 						$state_steps[ $product_id ]['warning'] = array(
 							'message'     => self::$folder_exists,
 							'plugin_info' => self::get_plugin_info( $state_steps[ $product_id ]['installed_path'] ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added check to move_product case to make sure result array contains folder_exists item and doesn't return a warning introduced in #25140.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:


1. Pull this branch.
2. Connect your site to WooCommerce.com.
3. Buy a plugin using WooCommerce->Extensions.
4. After checkout, click Add to site.
6. During the install take a look at responses from this network call in your browser `/wp-json/wccom/in-app-purchase/v1/installer` and take note of the `status: finished` response message.
5. After a successful install, repeat the process.
6. Check debug.log, there shouldn't be any warnings related to wccom-site files.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added check to move_product case to make sure result array contains folder_exists item and doesn't return a warning. 
