### PR TITLE
Sort items for before applying discounts by the price property

### DIFF
--- a/plugins/woocommerce/changelog/fix-cart_discount_price_sort
+++ b/plugins/woocommerce/changelog/fix-cart_discount_price_sort
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Sort items for before applying discounts by the price property

--- a/plugins/woocommerce/includes/class-wc-discounts.php
+++ b/plugins/woocommerce/includes/class-wc-discounts.php
@@ -291,12 +291,10 @@ class WC_Discounts {
 	 * @return int
 	 */
 	protected function sort_by_price( $a, $b ) {
-		$price_1 = $a->price * $a->quantity;
-		$price_2 = $b->price * $b->quantity;
-		if ( $price_1 === $price_2 ) {
+		if ( $a->price === $b->price ) {
 			return 0;
 		}
-		return ( $price_1 < $price_2 ) ? 1 : -1;
+		return ( $a->price < $b->price ) ? 1 : -1;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Sort the items in the `WC_Discounts` object by the item's price property. The price prop accounts for the quantity already and so we don't need to multiply by the quantity again. 

### How to test the changes in this Pull Request:
1. Create 2 products for $10 and $100
2. Create a percentage coupon for 10% off https://d.pr/i/eWmCAR
3. Limit the coupon to 1 item https://d.pr/i/4QTWUT
4. Add both products to the cart.
5. Apply the coupon. 
6. You'll get a $10 discount (10% off the $100 product) https://d.pr/i/SzPRDL
7. Now increase the quantity of the $10 product to 4.
8. Now you only get a $1 discount (10% off the $10 product) https://d.pr/i/cMfWFY

What causes this?

1. The `WC_Totals` class sets the `WC_Discounts->items` [here](https://github.com/woocommerce/woocommerce/blob/3.8.1/includes/class-wc-cart-totals.php#L773).
2. The `WC_Totals` items array is generated [here](https://github.com/woocommerce/woocommerce/blob/3.8.1/includes/class-wc-cart-totals.php#L235). Note that the price property is the product price * qty.
3. When the `WC_Discounts` object sorts the items by price to apply discounts to higher-priced items first, it was [multiplying by the quantity again](https://github.com/woocommerce/woocommerce/blob/3.8.1/includes/class-wc-discounts.php#L290-L291).  

The result of this in this test scenario is: 

```
$10 * 4 = $40 * 4 = $160
$100 * 1 = $100 * 1 = $100
```
The $10 product is therefore higher and is first in line to be discounted.

### Other information:

There are 3 entry points for setting or generating the `WC_Discounts->items`. All of them set the price property to include the quantity.

1. Via [`WC_Totals` and `WC_Discounts->set_items()`](https://github.com/woocommerce/woocommerce/blob/3.8.1/includes/class-wc-cart-totals.php#L773), its item's prices [include the quantity](https://github.com/woocommerce/woocommerce/blob/3.8.1/includes/class-wc-cart-totals.php#L235).
2. Via `WC_Discounts::set_items_from_order()`, it sets the price from the [line item subtotal](https://github.com/woocommerce/woocommerce/blob/3.8.1/includes/class-wc-discounts.php#L114) which includes the quantity.
3. Via `WC_Discounts::set_items_from_cart()`, it sets the price from the [ cart item's price * qty](https://github.com/woocommerce/woocommerce/blob/3.8.1/includes/class-wc-discounts.php#L85).

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
