### PR TITLE
Add postcode validation for Slovenia

### DIFF
--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -97,7 +97,7 @@ class WC_Validation {
 				$valid = (bool) preg_match( '/^([1-9][0-9]{3})(\s?)(?!SA|SD|SS)[A-Z]{2}$/i', $postcode );
 				break;
 			case 'SI':
-				$valid = (bool) preg_match( '/^([1-9][0-9]{3})$/i', $postcode );
+				$valid = (bool) preg_match( '/^([1-9][0-9]{3})$/', $postcode );
 				break;
 			default:
 				$valid = true;

--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -96,7 +96,9 @@ class WC_Validation {
 			case 'NL':
 				$valid = (bool) preg_match( '/^([1-9][0-9]{3})(\s?)(?!SA|SD|SS)[A-Z]{2}$/i', $postcode );
 				break;
-
+			case 'SI':
+				$valid = (bool) preg_match( '/^([1-9][0-9]{3})$/i', $postcode );
+				break;
 			default:
 				$valid = true;
 				break;

--- a/tests/unit-tests/util/validation.php
+++ b/tests/unit-tests/util/validation.php
@@ -106,7 +106,7 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 			array( false, WC_Validation::is_postcode( '3852 SA', 'NL' ) ),
 			array( false, WC_Validation::is_postcode( '3852 sa', 'NL' ) ),
 		);
-		
+
 		$si = array(
 			array( true, WC_Validation::is_postcode( '1234', 'SI' ) ),
 			array( true, WC_Validation::is_postcode( '1000', 'SI' ) ),

--- a/tests/unit-tests/util/validation.php
+++ b/tests/unit-tests/util/validation.php
@@ -106,8 +106,16 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 			array( false, WC_Validation::is_postcode( '3852 SA', 'NL' ) ),
 			array( false, WC_Validation::is_postcode( '3852 sa', 'NL' ) ),
 		);
+		
+		$si = array(
+			array( true, WC_Validation::is_postcode( '1234', 'SI' ) ),
+			array( true, WC_Validation::is_postcode( '1000', 'SI' ) ),
+			array( true, WC_Validation::is_postcode( '9876', 'SI' ) ),
+			array( false, WC_Validation::is_postcode( '12345', 'SI' ) ),
+			array( false, WC_Validation::is_postcode( '0123', 'SI' ) ),
+		);
 
-		return array_merge( $it, $gb, $us, $ch, $br, $ca, $nl );
+		return array_merge( $it, $gb, $us, $ch, $br, $ca, $nl, $si );
 	}
 
 	/**


### PR DESCRIPTION
Postcode in Slovenia consists of 4 numbers. First number can be in range 1-9 and the rest can also include 0.

https://en.wikipedia.org/wiki/Postal_codes_in_Slovenia

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

Add postcode validation for Slovenia
