### PR TITLE
Raise exception when WC_Product_Variation is instantiated with the wrong ID

### DIFF
--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -116,7 +116,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 */
 	public function create( &$product ) {
 		if ( ! $product->get_date_created() ) {
-			$product->set_date_created( current_time( 'timestamp', true ) );
+			$product->set_date_created( time() );
 		}
 
 		$new_title = $this->generate_product_title( $product );
@@ -186,7 +186,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		$product->save_meta_data();
 
 		if ( ! $product->get_date_created() ) {
-			$product->set_date_created( current_time( 'timestamp', true ) );
+			$product->set_date_created( time() );
 		}
 
 		$new_title = $this->generate_product_title( $product );

--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -48,8 +48,12 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 
 		$post_object = get_post( $product->get_id() );
 
-		if ( ! $post_object || ! in_array( $post_object->post_type, array( 'product', 'product_variation' ), true ) ) {
+		if ( ! $post_object ) {
 			return;
+		}
+
+		if ( 'product_variation' !== $post_object->post_type ) {
+			throw new Exception( 'Invalid product type: passed ID does not correspond to a product variation.' );
 		}
 
 		$product->set_props(

--- a/tests/unit-tests/product/product-variation.php
+++ b/tests/unit-tests/product/product-variation.php
@@ -77,4 +77,18 @@ class WC_Tests_Product_Variation extends WC_Unit_Test_Case {
 		$this->assertEquals( 'parent', $variation->get_tax_class( 'edit' ) );
 		$this->assertEquals( 'zero-rate', $variation->get_tax_class( 'view' ) );
 	}
+
+	/**
+	 * Test that WC_Product_Variation throws an exception
+	 * when called with a product ID that belongs to a product
+	 * of a different type.
+	 *
+	 * Ticket: https://github.com/woocommerce/woocommerce/issues/24956
+	 */
+	public function test_product_variation_should_throw_exception_when_instantiated_with_invalid_id() {
+		$this->expectExceptionMessage( 'Invalid product type: passed ID does not correspond to a product variation.' );
+
+		$variable_product = WC_Helper_Product::create_variation_product();
+		new WC_Product_Variation( $variable_product->get_id() );
+	}
 }


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR changes WC_Product_Variation to raise an exception when the class is instantiated with an ID that belongs to a post object that is not a product variation.

This is necessary to avoid problems like the one described in #24956, where passing a variable product ID to WC_Product_Variation would result in transparently modifying the variable product title and excerpt. There is another PR already (#25032) to fix the same issue, but I'm creating this one to suggest we consider a different approach. IMO, the code should bail early with an error if an ID that belongs to a different product type (or post type) is passed to WC_Product_Variation instead of returning a WC_Product_Variation instance without running the part of the code that causes the bug as proposed in #25032. My concern is that we could run into similar bugs in the future if we continue returning an instance when the wrong ID is passed. We might want to consider similar approaches in the other product classes.

The bug described in #24956 is being triggered by code in WC_Product_Variation::read() that [handles legacy variations](https://github.com/woocommerce/woocommerce/blob/master/includes/data-stores/class-wc-product-variation-data-store-cpt.php#L79-L105).

This PR also includes fixes for PHPCS violations in the modified files.

Closes #24956.

### How to test the changes in this Pull Request:

1. On master, run the follow code with `wp shell` and notice that the title of the variable product is unexpectedly changed:
```php
global $post;
$post->post_title = 'foo';
new WC_Product_Variation(14); // ID of a variable product
wc_get_product(14)->get_name(); // will display "foo"
```
2. Apply this patch and try again. The code will raise an exception and the title of the variable product won't be modified.

### Changelog entry

> Raise exception when WC_Product_Variation is instantiated with an ID that belongs to an object that is not a variation
