### PR TITLE
Fixed sorting order in shortcode

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -115,7 +115,7 @@ class WC_Shortcode_Products {
 				'limit'          => '-1',      // Results limit.
 				'columns'        => '',        // Number of columns.
 				'rows'           => '',        // Number of rows. If defined, limit will be ignored.
-				'orderby'        => '',   	   // menu_order, title, date, rand, price, popularity, rating, or id.
+				'orderby'        => '',        // menu_order, title, date, rand, price, popularity, rating, or id.
 				'order'          => '',        // ASC or DESC.
 				'ids'            => '',        // Comma separated IDs.
 				'skus'           => '',        // Comma separated SKUs.
@@ -189,7 +189,7 @@ class WC_Shortcode_Products {
 		$query_args['order']   = $order;
 
 		if ( wc_string_to_bool( $this->attributes['paginate'] ) ) {
-			$this->attributes['page'] = absint( empty( $_GET['product-page'] ) ? 1 : $_GET['product-page'] ); // WPCS: input var ok, CSRF ok.
+			$this->attributes['page'] = absint( empty( $_GET['product-page'] ) ? 1 : $_GET['product-page'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		}
 
 		if ( ! empty( $this->attributes['rows'] ) ) {
@@ -643,7 +643,7 @@ class WC_Shortcode_Products {
 
 			if ( wc_get_loop_prop( 'total' ) ) {
 				foreach ( $products->ids as $product_id ) {
-					$GLOBALS['post'] = get_post( $product_id ); // WPCS: override ok.
+					$GLOBALS['post'] = get_post( $product_id ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 					setup_postdata( $GLOBALS['post'] );
 
 					// Set custom product visibility when quering hidden products.
@@ -657,7 +657,7 @@ class WC_Shortcode_Products {
 				}
 			}
 
-			$GLOBALS['post'] = $original_post; // WPCS: override ok.
+			$GLOBALS['post'] = $original_post; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 			woocommerce_product_loop_end();
 
 			// Fire standard shop loop hooks when paginating results so we can show result counts and so on.

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -115,8 +115,8 @@ class WC_Shortcode_Products {
 				'limit'          => '-1',      // Results limit.
 				'columns'        => '',        // Number of columns.
 				'rows'           => '',        // Number of rows. If defined, limit will be ignored.
-				'orderby'        => 'title',   // menu_order, title, date, rand, price, popularity, rating, or id.
-				'order'          => 'ASC',     // ASC or DESC.
+				'orderby'        => '',   	   // menu_order, title, date, rand, price, popularity, rating, or id.
+				'order'          => '',        // ASC or DESC.
 				'ids'            => '',        // Comma separated IDs.
 				'skus'           => '',        // Comma separated SKUs.
 				'category'       => '',        // Comma separated category slugs or ids.

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -125,9 +125,9 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => true,
-			'orderby'             => 'title',
+			'orderby'             => 'menu_order title',
 			'order'               => 'ASC',
-			'posts_per_page'      => '-1',
+			'posts_per_page'      => -1,
 			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'post__in'            => array( '1', '2', '3' ),
@@ -249,9 +249,9 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => true,
-			'orderby'             => 'title',
+			'orderby'             => 'menu_order title',
 			'order'               => 'ASC',
-			'posts_per_page'      => '1',
+			'posts_per_page'      => 1,
 			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'p'                   => '1',
@@ -465,7 +465,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => true,
-			'orderby'             => 'title',
+			'orderby'             => 'menu_order title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
 			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -493,7 +493,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => true,
-			'orderby'             => 'title',
+			'orderby'             => 'menu_order title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
 			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -528,7 +528,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => true,
-			'orderby'             => 'title',
+			'orderby'             => 'menu_order title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
 			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -565,7 +565,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => true,
-			'orderby'             => 'title',
+			'orderby'             => 'menu_order title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
 			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
@@ -598,7 +598,7 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => true,
-			'orderby'             => 'title',
+			'orderby'             => 'menu_order title',
 			'order'               => 'ASC',
 			'posts_per_page'      => -1,
 			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query

--- a/tests/unit-tests/shortcodes/products.php
+++ b/tests/unit-tests/shortcodes/products.php
@@ -18,8 +18,8 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 		$expected  = array(
 			'limit'          => '-1',
 			'columns'        => 4,
-			'orderby'        => 'title',
-			'order'          => 'ASC',
+			'orderby'        => '',
+			'order'          => '',
 			'ids'            => '',
 			'skus'           => '',
 			'category'       => '',
@@ -84,9 +84,9 @@ class WC_Test_Shortcode_Products extends WC_Unit_Test_Case {
 			'post_status'         => 'publish',
 			'ignore_sticky_posts' => true,
 			'no_found_rows'       => true,
-			'orderby'             => 'title',
+			'orderby'             => 'menu_order title',
 			'order'               => 'ASC',
-			'posts_per_page'      => '-1',
+			'posts_per_page'      => -1,
 			'meta_query'          => $meta_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			'tax_query'           => $tax_query, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 			'fields'              => 'ids',


### PR DESCRIPTION
## All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24575.

Thanks to @itzmekhokan for start working on it in #24586

### How to test the changes in this Pull Request:

1. Go to _Products > All products > Sorting_ and observe the current sorting of products
2. Create a test page with the `[products category="xxxx"]` shortcode, filling in a specific category.
3. View test page
4. Alter the sorting order over at _Products > All products > Sorting_ and reload test page
5. No changes happen on the test page, but if you look at the category archive you'll see that the order changes.
6. Apply this patch and check that the sorting order now is the same.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Use sorting settings as a default to product shortcodes.
