### PR TITLE
Fix for Duplicate Webhook deliveries

### DIFF
--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -21,6 +21,14 @@ require_once 'legacy/class-wc-legacy-webhook.php';
 class WC_Webhook extends WC_Legacy_Webhook {
 
 	/**
+	 * Store which object IDs this webhook has processed (ie scheduled to be delivered)
+	 * within the current page request.
+	 *
+	 * @var array
+	 */
+	protected $processed = array();
+
+	/**
 	 * Stores webhook data.
 	 *
 	 * @var array
@@ -103,6 +111,9 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			return;
 		}
 
+		// Mark this $arg as processed to ensure it doesn't get processed again within the current request.
+		$this->processed[] = $arg;
+
 		/**
 		 * Process webhook delivery.
 		 *
@@ -123,7 +134,7 @@ class WC_Webhook extends WC_Legacy_Webhook {
 	 * @return bool       True if webhook should be delivered, false otherwise.
 	 */
 	private function should_deliver( $arg ) {
-		$should_deliver = $this->is_active() && $this->is_valid_topic() && $this->is_valid_action( $arg ) && $this->is_valid_resource( $arg );
+		$should_deliver = $this->is_active() && $this->is_valid_topic() && $this->is_valid_action( $arg ) && $this->is_valid_resource( $arg ) && ! $this->is_already_processed( $arg );
 
 		/**
 		 * Let other plugins intercept deliver for some messages queue like rabbit/zeromq.
@@ -278,6 +289,19 @@ class WC_Webhook extends WC_Legacy_Webhook {
 			}
 		}
 		return true;
+	}
+
+	/**
+	 * Checks if the specified resource has already been queued for delivery within the current request.
+	 *
+	 * Helps avoid duplication of data being sent for topics that have more than one hook defined.
+	 *
+	 * @param mixed $arg First hook argument.
+	 *
+	 * @return bool
+	 */
+	protected function is_already_processed( $arg ) {
+		return false !== array_search( $arg, $this->processed, true );
 	}
 
 	/**

--- a/tests/unit-tests/webhooks/functions.php
+++ b/tests/unit-tests/webhooks/functions.php
@@ -11,6 +11,10 @@
  */
 class WC_Tests_Webhook_Functions extends WC_Unit_Test_Case {
 
+	/**
+	 * Temporarily store webhook delivery counters.
+	 * @var array
+	 */
 	protected $delivery_counter = array();
 
 	/**
@@ -239,7 +243,7 @@ class WC_Tests_Webhook_Functions extends WC_Unit_Test_Case {
 	 * within the current request.
 	 *
 	 * @param WC_Webhook $webhook Webhook that is processing delivery.
-	 * @param mixed $arg Webhook arg (usually resource ID).
+	 * @param mixed      $arg Webhook arg (usually resource ID).
 	 */
 	public function woocommerce_webhook_process_delivery( $webhook, $arg ) {
 		if ( ! isset( $this->delivery_counter[ $webhook->get_id() . $arg ] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently, WooCommerce may trigger multiple webhook deliveries for a single webhook if the webhook topic has multiple hooks defined in [WC_Webhook::get_topic_hooks()](https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-webhook.php#L923), for example:

- Coupon Created (2)
- Coupon Updated (2)
- Customer Created (3)
- Customer Updated (2)
- Order Updated (2)
- Product Created (3)
- Product Updated (3)

If using the default Action Scheduler (async) delivery mechanism, this is less likely to be an issue due to the changes introduced in #22087, however, if someone is using a different mechanism such as synchronous (immediate) delivery then this is definitely a major issue.

Even if using the default Action Scheduler based delivery mechanism there is a chance that duplicate deliveries could occur if the first delivery is queued, then the scheduled action is processed, and then the duplicate delivery is queued.

This PR contains changes so that the `woocommerce_webhook_process_delivery` hook should only trigger once per webhook and webhook arg, which improves delivery reliability regardless of whether the user is using Action Scheduler, immediate (synchronous) delivery or their own Queueing/Delivery mechanism.

cc @thenbrent (who authored that previous change in #22087 in case he has feedback here).

Closes #24729 

### How to test the changes in this Pull Request:

The new unit test added verifies that the bug exists and that this change fixes it.

However in order to test things manually:

1.  add this line of code to instruct your WooCommerce installation to delivery webhooks synchronously:

```
add_filter( 'woocommerce_webhook_deliver_async', '__return_false' );
```


2. Create a new Webhook, choosing a webhook topic that has multiple hooks defined. For example, Customer Created (which has 3 defined).

3. Manually create a customer in your WooCommerce Store, and check the webhook delivery logs to verify that the customer was delivered once (not 3 times).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Duplicate webhook deliveries

### Next Steps

If this PR is merged,  I propose that the code introduced in #22087 is no longer necessary and could be reverted.
