### PR TITLE
Use PHP 7.4 instead of PHP 7.4snapshot in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
@@ -45,8 +46,6 @@ matrix:
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   - name: "WooCommerce unit tests using WordPress nightly"
     php: 7.3
-    env: WP_VERSION=nightly WP_MULTISITE=0
-  - php: 7.4snapshot
     env: WP_VERSION=nightly WP_MULTISITE=0
   allow_failures:
   - php: 7.3


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR simply updates the PHP 7.4 version that is used in Travis now that PHP 7.4 has been officially released. Previously we were using 7.4 development versions to test the upcoming release.

### How to test the changes in this Pull Request:

1. Check the Travis configuration changes
2. Make sure that the Travis build is passing