### PR TITLE
Applied setup wizard CSS fixes to the respective WP versions

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -6818,50 +6818,47 @@ table.bar_chart {
 /**
   * Select2 colors for built-in admin color themes.
   */
-.branch-5-3 {
+.admin-color {
+	$wp_admin_colors: (
+		blue: #096484,
+		coffee: #c7a589,
+		ectoplasm: #a3b745,
+		midnight: #e14d43,
+		ocean: #9ebaa0,
+		sunrise: #dd823b,
+		light: #04a4cc
+	);
 
-	.admin-color {
-		$wp_admin_colors: (
-			blue: #096484,
-			coffee: #c7a589,
-			ectoplasm: #a3b745,
-			midnight: #e14d43,
-			ocean: #9ebaa0,
-			sunrise: #dd823b,
-			light: #04a4cc
-		);
+	@each $name, $color in $wp_admin_colors {
 
-		@each $name, $color in $wp_admin_colors {
+		&-#{$name}.branch-5-3 {
 
-			&-#{$name} {
+			.select2-dropdown {
+				border-color: $color;
+			}
 
-				.select2-dropdown {
-					border-color: $color;
-				}
+			.select2-dropdown--below {
+				box-shadow: 0 0 0 1px $color, 0 2px 1px rgba(0, 0, 0, 0.1);
+			}
 
-				.select2-dropdown--below {
-					box-shadow: 0 0 0 1px $color, 0 2px 1px rgba(0, 0, 0, 0.1);
-				}
+			.select2-dropdown--above {
+				box-shadow: 0 0 0 1px $color, 0 -2px 1px rgba(0, 0, 0, 0.1);
+			}
 
-				.select2-dropdown--above {
-					box-shadow: 0 0 0 1px $color, 0 -2px 1px rgba(0, 0, 0, 0.1);
-				}
+			.select2-selection--single .select2-selection__rendered:hover {
+				color: $color;
+			}
 
-				.select2-selection--single .select2-selection__rendered:hover {
-					color: $color;
-				}
+			.select2-container.select2-container--focus .select2-selection--single,
+			.select2-container.select2-container--open .select2-selection--single,
+			.select2-container.select2-container--open .select2-selection--multiple {
+				border-color: $color;
+				box-shadow: 0 0 0 1px $color;
+			}
 
-				.select2-container.select2-container--focus .select2-selection--single,
-				.select2-container.select2-container--open .select2-selection--single,
-				.select2-container.select2-container--open .select2-selection--multiple {
-					border-color: $color;
-					box-shadow: 0 0 0 1px $color;
-				}
-
-				.select2-container--default .select2-results__option--highlighted[aria-selected],
-				.select2-container--default .select2-results__option--highlighted[data-selected] {
-					background-color: $color;
-				}
+			.select2-container--default .select2-results__option--highlighted[aria-selected],
+			.select2-container--default .select2-results__option--highlighted[data-selected] {
+				background-color: $color;
 			}
 		}
 	}

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1171,7 +1171,7 @@ h3.jetpack-reasons {
 	border-color: #ddd;
 	border-radius: 4px;
 	height: 30px;
-	width: 100%;
+	width: calc(100% - 8px - 8px - 2px);
 	padding-left: 8px;
 	padding-right: 8px;
 	font-size: 16px;
@@ -1184,11 +1184,12 @@ h3.jetpack-reasons {
 	}
 }
 
+.branch-5-2,
 .branch-5-3 {
 
 	.location-input {
 		margin: 0;
-
+		width: 100%;
 	}
 }
 
@@ -1413,6 +1414,7 @@ p.jetpack-terms {
 	}
 }
 
+.branch-5-2,
 .branch-5-3 {
 
 	.wc-wizard-service-setting-stripe_create_account,

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -377,6 +377,9 @@ class WC_Admin_Setup_Wizard {
 	 * Setup Wizard Header.
 	 */
 	public function setup_wizard_header() {
+		// same as default WP from wp-admin/admin-header.php.
+		$version_class = 'branch-' . str_replace( array( '.', ',' ), '-', floatval( get_bloginfo( 'version' ) ) );
+
 		set_current_screen();
 		?>
 		<!DOCTYPE html>
@@ -390,7 +393,7 @@ class WC_Admin_Setup_Wizard {
 			<?php do_action( 'admin_print_styles' ); ?>
 			<?php do_action( 'admin_head' ); ?>
 		</head>
-		<body class="wc-setup wp-core-ui <?php echo esc_attr( 'wc-setup-step__' . $this->step ); ?>">
+		<body class="wc-setup wp-core-ui <?php echo esc_attr( 'wc-setup-step__' . $this->step ); ?> <?php echo esc_attr( $version_class ); ?>">
 		<h1 class="wc-logo"><a href="https://woocommerce.com/"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/woocommerce_logo.png" alt="<?php esc_attr_e( 'WooCommerce', 'woocommerce' ); ?>" /></a></h1>
 		<?php
 	}

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -378,7 +378,7 @@ class WC_Admin_Setup_Wizard {
 	 */
 	public function setup_wizard_header() {
 		// same as default WP from wp-admin/admin-header.php.
-		$version_class = 'branch-' . str_replace( array( '.', ',' ), '-', floatval( get_bloginfo( 'version' ) ) );
+		$wp_version_class = 'branch-' . str_replace( array( '.', ',' ), '-', floatval( get_bloginfo( 'version' ) ) );
 
 		set_current_screen();
 		?>
@@ -393,7 +393,7 @@ class WC_Admin_Setup_Wizard {
 			<?php do_action( 'admin_print_styles' ); ?>
 			<?php do_action( 'admin_head' ); ?>
 		</head>
-		<body class="wc-setup wp-core-ui <?php echo esc_attr( 'wc-setup-step__' . $this->step ); ?> <?php echo esc_attr( $version_class ); ?>">
+		<body class="wc-setup wp-core-ui <?php echo esc_attr( 'wc-setup-step__' . $this->step ); ?> <?php echo esc_attr( $wp_version_class ); ?>">
 		<h1 class="wc-logo"><a href="https://woocommerce.com/"><img src="<?php echo esc_url( WC()->plugin_url() ); ?>/assets/images/woocommerce_logo.png" alt="<?php esc_attr_e( 'WooCommerce', 'woocommerce' ); ?>" /></a></h1>
 		<?php
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24942 .
Supersedes #25034.
Thanks for your contribution, @passatgt.
As far as I know, both these can be closed after this one is merged. I haven't cherry-picked the last commit from #25034 as we've already merged #25125 and it would bring lots of conflicts.

Now the Setup Wizard should look nice(r) in WP 5.1:
WP 5.1 before the change:
![WP5 1_step1_before](https://user-images.githubusercontent.com/2207451/70532544-91c60580-1b57-11ea-9951-d7961d8cd4d8.png)

WP 5.1 after the change:
![WP5 1_step1_after](https://user-images.githubusercontent.com/2207451/70532570-9f7b8b00-1b57-11ea-9261-0db5893b331a.png)

WP 5.1 step 2:
![WP5 1_step2_after](https://user-images.githubusercontent.com/2207451/70532619-b6ba7880-1b57-11ea-8d4c-f25f2ac2e5de.png)


WP 5.2 still looks good:
![WP5 2_step1_after](https://user-images.githubusercontent.com/2207451/70532590-ab674d00-1b57-11ea-88f0-b7bdc7a00407.png)
![WP5 2_step2_after](https://user-images.githubusercontent.com/2207451/70532589-aaceb680-1b57-11ea-9453-a7e893988ac1.png)

WP 5.3 still looks nice:
![WP5 3_step1_after](https://user-images.githubusercontent.com/2207451/70532640-bfab4a00-1b57-11ea-970e-b2181de74399.png)
![WP5 3_step2_after](https://user-images.githubusercontent.com/2207451/70532641-bfab4a00-1b57-11ea-876f-d27105bbfb1a.png)

Accent in select2 should respect chosen color schema:
![select2 accent](https://user-images.githubusercontent.com/2207451/70532734-e9fd0780-1b57-11ea-8458-2552614334f5.png)


### How to test the changes in this Pull Request:

1. Apply changes, build assets
2. Check that the Setup Wizard looks fine in different WP versions. Can be rerun via Help submenu at the top of some screens, e.g. 
![Screenshot 2019-12-10 at 14 19 13](https://user-images.githubusercontent.com/2207451/70532842-1add3c80-1b58-11ea-9164-0080be0a84be.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Applied setup wizard CSS fixes to the respective WP versions.
