### PR TITLE
Hide Edge native "reveal password" feature

### DIFF
--- a/assets/css/woocommerce-layout.scss
+++ b/assets/css/woocommerce-layout.scss
@@ -407,6 +407,11 @@
 			input[type="password"] {
 				padding-right: 2.5rem;
 			}
+
+			/* Hide the Edge "reveal password" native button */
+			input::-ms-reveal {
+				display: none;
+			}
 		}
 
 		.show-password-input {


### PR DESCRIPTION
Just a small tweak for #24915 

This solution it's the same used by WordPress core: https://core.trac.wordpress.org/ticket/42888#comment:67