### PR TITLE
Only remove space for state if CA and US

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -996,9 +996,10 @@ class WC_Tax {
 	 * @return array
 	 */
 	private static function prepare_tax_rate( $tax_rate ) {
+		$is_us_or_ca = in_array( $tax_rate['tax_rate_country'], array( 'CA', 'US' ) );
 		foreach ( $tax_rate as $key => $value ) {
 			if ( method_exists( __CLASS__, 'format_' . $key ) ) {
-				if ( 'tax_rate_state' === $key ) {
+				if ( 'tax_rate_state' === $key && true === $is_us_or_ca ) {
 					$tax_rate[ $key ] = call_user_func( array( __CLASS__, 'format_' . $key ), sanitize_key( $value ) );
 				} else {
 					$tax_rate[ $key ] = call_user_func( array( __CLASS__, 'format_' . $key ), $value );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
It looks like we remove space in "state code" because state code doesn't have space. This rule seems to only apply to states in U.S. and provinces in Canada. I am using this https://developers.taxjar.com/api/reference/#post-calculate-sales-tax-for-an-order as a reference point. 

In this case, maybe we can apply `sanitize_key` only to known countries that need it, US/Canada.

This PR proposes adding that check so that the `wc-tax` class allows us to insert rates for country such as UK where the tax rate is found by providing the full county name (without stripping space).

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24354 .
Closes https://github.com/Automattic/woocommerce-services/issues/1600.

### How to test the changes in this Pull Request:
1. Go to tax standard rate and add a rate for UK, we should be able to add the rate for county without having it stripping off spaces
![image](https://user-images.githubusercontent.com/572862/70573228-c12c4080-1b5e-11ea-83d2-3e0e84e1f1d0.png)

### Test against WooCommerce Service "Enable Automated Taxes"
Taking steps from this https://github.com/Automattic/woocommerce-services/issues/1600
1. Install/Activate/Connect Jetpack
2. Install/Activate WooCommerce Services
3. Set your store address to have a UK address (e.g. 63 Elford Crescent, Plympton, Plymouth, UK, PL74BT)
4. Set your tax rate settings to "Enable Automated Taxes"
5. On the front end, add a product to the cart and proceed to checkout
6. On the billing address section, use any of the following address:
2 Chestnut Hall Avenue, Maghaberry, Moira, County Armagh, BT67 0GG
40 Whitehall Way, Rockingham, Rotherham, South yorkshire, S61 4HW
19 Carisbrooke Close, EASTBOURNE, East Sussex, BN23 8EQ
7. Notice on the checkout page that VAT is showing up as > `0.00`
8. Complete the order.
9. Notice that the postcode for that order has been added as a tax rate under WooCommerce > Settings > Tax > Standard Rates

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
