### PR TITLE
Centralize check for default themes

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -73,34 +73,13 @@ class WC_Admin_Setup_Wizard {
 	 * @return boolean
 	 */
 	protected function should_show_theme() {
-		$support_woocommerce = current_theme_supports( 'woocommerce' ) && ! $this->is_default_theme();
+		$support_woocommerce = current_theme_supports( 'woocommerce' ) && ! wc_is_wp_default_theme_active();
 
 		return (
 			current_user_can( 'install_themes' ) &&
 			current_user_can( 'switch_themes' ) &&
 			! is_multisite() &&
 			! $support_woocommerce
-		);
-	}
-
-	/**
-	 * Is the user using a default WP theme?
-	 *
-	 * @return boolean
-	 */
-	protected function is_default_theme() {
-		return wc_is_active_theme(
-			array(
-				'twentynineteen',
-				'twentyseventeen',
-				'twentysixteen',
-				'twentyfifteen',
-				'twentyfourteen',
-				'twentythirteen',
-				'twentyeleven',
-				'twentytwelve',
-				'twentyten',
-			)
 		);
 	}
 

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -478,7 +478,7 @@ final class WooCommerce {
 	 * @since 3.3.0
 	 */
 	private function theme_support_includes() {
-		if ( wc_is_active_theme( array( 'twentytwenty', 'twentynineteen', 'twentyseventeen', 'twentysixteen', 'twentyfifteen', 'twentyfourteen', 'twentythirteen', 'twentyeleven', 'twentytwelve', 'twentyten' ) ) ) {
+		if ( wc_is_wp_default_theme_active() ) {
 			switch ( get_template() ) {
 				case 'twentyten':
 					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-ten.php';

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2144,6 +2144,28 @@ function wc_is_active_theme( $theme ) {
 }
 
 /**
+ * Is the user using a default WP theme?
+ *
+ * @return boolean
+ */
+function wc_is_wp_default_theme_active() {
+	return wc_is_active_theme(
+		array(
+			'twentytwenty',
+			'twentynineteen',
+			'twentyseventeen',
+			'twentysixteen',
+			'twentyfifteen',
+			'twentyfourteen',
+			'twentythirteen',
+			'twentyeleven',
+			'twentytwelve',
+			'twentyten',
+		)
+	);
+}
+
+/**
  * Cleans up session data - cron callback.
  *
  * @since 3.3.0

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2144,7 +2144,7 @@ function wc_is_active_theme( $theme ) {
 }
 
 /**
- * Is the user using a default WP theme?
+ * Is the site using a default WP theme?
  *
  * @return boolean
  */


### PR DESCRIPTION
This should make Storefront appear in the Setup Wizard again.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25215  .

### How to test the changes in this Pull Request:

1. Activate Twenty twenty
2. Go through the setup wizard and observe Storefront is *not* listed among the Recommended extensions
3. Apply the branch
4. Go through the setup wizard and observe Storefront is listed among the Recommended extensions
5. Check that the styling for 2020 is still applied correctly (e.g. wp-content/plugins/woocommerce/assets/css/twenty-twenty.css?ver=3.9.0 is loaded)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Centralize check for default themes to fix Storefront appearance in the Setup Wizard.
