### PR TITLE
Add pay order product has enough stock filter

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -153,7 +153,7 @@ class WC_Shortcode_Checkout {
 							$held_stock     = ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product, $order->get_id() ) : 0;
 							$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
 
-							if ( $product->get_stock_quantity() < ( $held_stock + $required_stock ) ) {
+							if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() > ( $held_stock + $required_stock ) ), $product, $order ) ) {
 								/* translators: 1: product name 2: quantity in stock */
 								throw new Exception( sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woocommerce' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ) );
 							}

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -153,7 +153,7 @@ class WC_Shortcode_Checkout {
 							$held_stock     = ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product, $order->get_id() ) : 0;
 							$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
 
-							if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() > ( $held_stock + $required_stock ) ), $product, $order ) ) {
+							if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ! ( $product->get_stock_quantity() < ( $held_stock + $required_stock ) ), $product, $order ) ) {
 								/* translators: 1: product name 2: quantity in stock */
 								throw new Exception( sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woocommerce' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ) );
 							}

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -153,7 +153,7 @@ class WC_Shortcode_Checkout {
 							$held_stock     = ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product, $order->get_id() ) : 0;
 							$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
 
-							if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ! ( $product->get_stock_quantity() < ( $held_stock + $required_stock ) ), $product, $order ) ) {
+							if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {
 								/* translators: 1: product name 2: quantity in stock */
 								throw new Exception( sprintf( __( 'Sorry, we do not have enough "%1$s" in stock to fulfill your order (%2$s available). We apologize for any inconvenience caused.', 'woocommerce' ), $product->get_name(), wc_format_stock_quantity_for_display( $product->get_stock_quantity() - $held_stock, $product ) ) );
 							}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

To create this PR I cherry-picked the commits created by @unfulvio from #25036. This was necessary because, for some reason (likely a problem during a merge), the original PR includes a few dozen unrelated commits. The description that follows was copied from the original PR.

Adds a filter within the `WC_Shortcode_Checkout::order_pay()` method after the `woocommerce_pay_order_product_in_stock` filterable check, so that customer order statuses awaiting payment can still be paid as some products may have had already stock lowered in some circumstances and they don't need these checks anymore. (Applies to Order Status Manager).

Closes #25021 (see issue for more details)

### How to test the changes in this Pull Request:

1. Have a customer process a complete checkout with an item in stock
2. Customer should be able to process the checkout without errors

#### Scenario 2

1. Have an order awaiting payment: the order should contain an item with plenty of stock
2. Have customer pay for it from My Account > Orders > Pay
3. Result: order should be paid and no error should occur

#### Scenario 3

This scenario is the actual scenario the PR is going to address.

1. Install & Activate WooCommerce Order Status Manager
2. Create a custom order status with a "Payment required" flag
3. Create an inventory-managed product with stock of 1
4. Create an order using any payment method
5. Change the status of that order to any custom order status with "payment required"
6. With the customer user of that order, go to "My Account > Orders" and attempt to "Pay" that order

Currently, this would fail, because the stock has already dropped by 1 unit, and WooCommerce is attempting to drop it again; since it is at 1, it will fail and raise an user notice, preventing to complete payment. However, with this filter in place, one should be able to skip the checks in `WC_Shortcode_Checkout::order_pay()` and have the customer pay for the order awaiting payment.

### Changelog entry

I did not add the following in changelog.txt, just a suggestion:

> * Dev - Add filter to tweak whether a product has enough stock while attempting to pay for an order