### PR TITLE
Fix - Flush plugins cache to make sure the custom WC plugin headers are always read

### DIFF
--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -24,6 +24,14 @@ class WC_Helper {
 	public static $log;
 
 	/**
+	 * The plugins cache needs to be cleared before calling get_plugins() to ensure the "Woo" header is read correctly.
+	 * This flag makes sure the cache is only cleared at most once per request, clearing it more times would be redundant.
+	 *
+	 * @var bool $is_plugin_cache_clean
+	 */
+	private static $is_plugin_cache_clean = false;
+
+	/**
 	 * Get an absolute path to the requested helper view.
 	 *
 	 * @param string $view The requested view file.
@@ -1147,6 +1155,10 @@ class WC_Helper {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
+		if ( ! self::$is_plugin_cache_clean ) {
+			wp_clean_plugins_cache( false );
+			self::$is_plugin_cache_clean = true;
+		}
 		$plugins     = get_plugins();
 		$woo_plugins = array();
 

--- a/includes/admin/plugin-updates/class-wc-plugin-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugin-updates.php
@@ -51,6 +51,13 @@ class WC_Plugin_Updates {
 	protected $minor_untested_plugins = array();
 
 	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		wp_clean_plugins_cache( false );
+	}
+
+	/**
 	 * Common JS for initializing and managing thickbox-based modals.
 	 */
 	protected function generic_modal_js() {

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2042,6 +2042,7 @@ function wc_enable_wc_plugin_headers( $headers ) {
 }
 add_filter( 'extra_theme_headers', 'wc_enable_wc_plugin_headers' );
 add_filter( 'extra_plugin_headers', 'wc_enable_wc_plugin_headers' );
+wp_cache_delete( 'plugins', 'plugins' );
 
 /**
  * Prevent auto-updating the WooCommerce plugin on major releases if there are untested extensions active.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2042,7 +2042,6 @@ function wc_enable_wc_plugin_headers( $headers ) {
 }
 add_filter( 'extra_theme_headers', 'wc_enable_wc_plugin_headers' );
 add_filter( 'extra_plugin_headers', 'wc_enable_wc_plugin_headers' );
-wp_cache_delete( 'plugins', 'plugins' );
 
 /**
  * Prevent auto-updating the WooCommerce plugin on major releases if there are untested extensions active.


### PR DESCRIPTION
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Description

See https://github.com/woocommerce/woocommerce/issues/25073#issuecomment-561489592 for more discussion.

A 3rd-party plugin can interfere with the normal plugin file parsing behaviour and essentially mark all the installed plugins as "Not tested with the active version of WooCommerce".

@thomas-zg sent me a plugin that triggered this wrong behaviour (thanks for that!).
That plugin, at startup, instantiates the class `morningtrain_updateChecker`. That class has this code:
```php
if(!function_exists('get_plugins')) {
	require_once(ABSPATH . 'wp-admin/includes/plugin.php');
}
$plugin_folder = get_plugins();
// Does some stuff with the $plugin_folder variable
```

That's problematic. WooCommerce sets up [these filters](https://github.com/woocommerce/woocommerce/blob/3dec01ce38bebc44df2f152f7c9ed240ba2cc5d2/includes/wc-core-functions.php#L2043-L2044) when the plugin is run. Without those filters in place, when the header of a plugin file is parsed (such as when calling `get_plugins()`), the `WC requires at least` and `WC tested up to` headers will simply be discarded. The result of `get_plugins()` is cached for the rest of the request ([see here](https://github.com/WordPress/WordPress/blob/6ddf02b1889daa274123e5a7a782c0e4daa1bfd7/wp-admin/includes/plugin.php#L346)).

The plugins are run on alphabetical order, and since the offending plugin (`woo-advanced-qty`) goes before `woocommerce`, it can interfere in that way.

### Changes proposed in this Pull Request:

The fix is to flush the plugins cache immediately after setting up the filters that add `WC requires at least` and `WC tested up to` to the list of accepted headers. It's very defensive, for sure. What do y'all think about it? Should we nudge the 3rd-party developer fix their plugin instead? It's impossible to account for all the ways a plugin can mess up the WordPress environment, and regardless of whose fault it is, it *looks* like a bug in WooCommerce.

### How to test the changes in this Pull Request:
The minimal way to reproduce this bug is to install a plugin called `aaa.php` with this:
```php
/*
Plugin Name: Aaaaaaaa
Plugin URI: http://wordpress.org/plugins/
Description: Endless scream
Author: XXXXX
Version: 1.0
Author URI: http://wordpress.org/plugins/
*/
if(!function_exists('get_plugins')) {
	require_once(ABSPATH . 'wp-admin/includes/plugin.php');
}
get_plugins();
```

After that, go to `WooCommerce -> Status` and scroll to the "Active plugins" section. You'll see that all the Woo-related plugins will say "Not tested with the active version of WooCommerce" even though some of them are (you can make sure of it by tweaking a plugin to say it's compatible with WC 3.9, since no plugin in the wild is yet).

If you apply this PR, you'll get the expected behaviour again.

