### PR TITLE
Prevent fatal error in set_current_gateway with no WC session

### DIFF
--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -183,10 +183,13 @@ class WC_Payment_Gateways {
 		}
 
 		$current_gateway = false;
-		$current         = WC()->session->get( 'chosen_payment_method' );
 
-		if ( $current && isset( $gateways[ $current ] ) ) {
-			$current_gateway = $gateways[ $current ];
+		if ( WC()->session ) {
+			$current = WC()->session->get( 'chosen_payment_method' );
+
+			if ( $current && isset( $gateways[ $current ] ) ) {
+				$current_gateway = $gateways[ $current ];
+			}
 		}
 
 		if ( ! $current_gateway ) {


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As far as I can tell, the session section is not critical to the functionality of this function. Because of that, I moved the session code inside a block that is only run if there is a WC session object.

Closes #25241 .

### How to test the changes in this Pull Request:

1. Call `WC()->payment_gateways()->set_current_gateway( $gateways )` from a plugin code when `WC()->session` is null.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fix fatal error that would occur when calling the WC_Payment_Gateways::set_current_gateway() function and there is no WC session.
