### PR TITLE
Make trash status translatable

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -99,6 +99,7 @@ function wc_get_order_statuses() {
 		'wc-cancelled'  => _x( 'Cancelled', 'Order status', 'woocommerce' ),
 		'wc-refunded'   => _x( 'Refunded', 'Order status', 'woocommerce' ),
 		'wc-failed'     => _x( 'Failed', 'Order status', 'woocommerce' ),
+		'wc-trash'      => _x( 'Trash', 'Order status', 'woocommerce' ),
 	);
 	return apply_filters( 'wc_order_statuses', $order_statuses );
 }


### PR DESCRIPTION
When looking at admin screen on `/wp-admin/edit.php?post_status=trash&post_type=shop_order` orders with `trash` status have the status not localized. The status is not defined in the `wc_get_order_statuses()` function.
This commit adds the localized string.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds readable version of `trash` order status.

### How to test the changes in this Pull Request:

1. Go to `/wp-admin/edit.php?post_status=trash&post_type=shop_order` admin screen 
2. See the status being changed from `trash` to `Trash`
3. The string is now translatable

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?