### PR TITLE
Request a new filter "woocommerce_can_restock_refunded_items"

### DIFF
--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -224,6 +224,9 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 * @since 3.0.0
 	 */
 	private function update_post_meta( &$coupon ) {
+		
+		$this->updated_props = array();
+		
 		$meta_key_to_props = array(
 			'discount_type'              => 'discount_type',
 			'coupon_amount'              => 'amount',

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -693,7 +693,7 @@ function wc_restock_refunded_items( $order, $refunded_line_items ) {
 		$item_stock_reduced = $item->get_meta( '_reduced_stock', true );
 		$qty_to_refund      = $refunded_line_items[ $item_id ]['qty'];
 
-		if ( ! $item_stock_reduced || ! $qty_to_refund || ! $product || ! $product->managing_stock() ) {
+		if ( ! $item_stock_reduced || ! $qty_to_refund || ! $product || ! $product->managing_stock() || ! apply_filters('woocommerce_can_restock_refunded_items', true, $order, $refunded_line_items ) ) {
 			continue;
 		}
 


### PR DESCRIPTION
I need this filter before process the restock for refund items.
It can be useful like woocommerce_can_reduce_order_stock or woocommerce_can_restore_order_stock

