### PR TITLE
Add WP version check before recommending WooCommerce Admin

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -49,6 +49,13 @@ class WC_Admin_Setup_Wizard {
 	);
 
 	/**
+	 * The version of WordPress required to run the WooCommerce Admin plugin
+	 *
+	 * @var string
+	 */
+	private $wc_admin_plugin_minimum_wordpress_version = '5.3';
+
+	/**
 	 * Hook in tabs.
 	 */
 	public function __construct() {
@@ -126,12 +133,15 @@ class WC_Admin_Setup_Wizard {
 	/**
 	 * Should we show the WooCommerce Admin install option?
 	 * True only if the user can install plugins,
-	 * and up until the end date of the recommendation.
+	 * and is running the correct version of WordPress.
+	 *
+	 * @see WC_Admin_Setup_Wizard::$wc_admin_plugin_minimum_wordpress_version
 	 *
 	 * @return boolean
 	 */
 	protected function should_show_wc_admin() {
-		return current_user_can( 'install_plugins' );
+		$wordpress_minimum_met = version_compare( get_bloginfo( 'version' ), $this->wc_admin_plugin_minimum_wordpress_version, '>=' );
+		return current_user_can( 'install_plugins' ) && $wordpress_minimum_met;
 	}
 
 	/**
@@ -140,7 +150,7 @@ class WC_Admin_Setup_Wizard {
 	 * @return boolean
 	 */
 	protected function should_show_wc_admin_onboarding() {
-		if ( ! current_user_can( 'install_plugins' ) ) {
+		if ( ! $this->should_show_wc_admin() ) {
 			return false;
 		}
 


### PR DESCRIPTION
WooCommerce Admin recently bumped its minimum WordPress requirement to 5.3.

This PR adds a WordPress version check before recommending WooCommerce Admin on the recommended tab and before recommending the new WooCommerce Admin Onboarding experience to a percentage of users.

@woocommerce/proton This would be great to include in the next 3.9 beta, so users on older version of WP can setup like normally. Relevant thread: p90Yrv-1rc-p2.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Run an older version of WordPress, like `5.2.5`.
2. Visit `/wp-admin/admin.php?page=wc-setup&step=recommended` and make sure the WooCommerce Admin extension is not recommended here.
3. Make sure you are in the onboarding test group. [This gist](https://gist.github.com/justinshreve/6e945dcb4714134156aba1b3c7f086cf) can be used to make sure you are.
4. Visit `/wp-admin/admin.php?page=wc-setup` and you should see the normal onboarding wizard.
5. Upgrade to `5.3`, and you should see the prompt for the new onboarding wizard (https://github.com/woocommerce/woocommerce/pull/24991).
### Changelog entry

Adds a WordPress version check before recommending the WooCommerce Admin plugin during setup
