### PR TITLE
Update Renovate bot configuration to update dev dependencies monthly

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     },
     {
       "depTypeList": ["devDependencies"],
-      "schedule": "every month"
+      "extends": ["schedule:monthly"]
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,10 @@
     {
       "packageNames": ["automattic/jetpack-autoloader"],
       "rangeStrategy": "bump"
+    },
+    {
+      "depTypeList": ["devDependencies"],
+      "schedule": "every month"
     }
   ]
 }


### PR DESCRIPTION
Attempt number 2 for #25259.

### Changes proposed in this Pull Request:

This PR changes Renovate bot configuration to update dev dependencies only once per month to reduce the noise caused by this bot creating several PRs in a short window of time for packages that are updated frequently.

### How to test the changes in this Pull Request:

1. I'm not aware of way to test Renovate bot configuration changes other than merging the PR and checking if the bot starts behaving as expected. If there is a way, please let me know (cc @belcherj in case you know something about this).