### PR TITLE
Remove PHP 7.2 Travis build job from allow_failures list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,8 +52,6 @@ matrix:
   allow_failures:
   - php: 7.3
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
-  - php: 7.2
-    env: WP_VERSION=latest WP_MULTISITE=0 
 
 before_script:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the PHP 7.2 Travis build job from the list of jobs that are allowed to fail. This job was added to this list probably by mistake in f9a9fbc2c73c1a55886a018eb589e6313fff9f8b.

### How to test the changes in this Pull Request:

1. Check that currently the PHP 7.2 job is in the list of jobs that are allowed to fail: https://travis-ci.org/woocommerce/woocommerce/builds/627689326
2. Check that the build for this PR removes PHP 7.2 job from this list.

cc @juliaamosova @vedanshujain 