### PR TITLE
Add a triggerHandler called "checkout_place_order_success" so plugin developers can hook into AJAX order success event.

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -381,7 +381,7 @@ jQuery( function( $ ) {
 							}
 						}
 					});
-					
+
 					// Always update the fragments
 					if ( data && data.fragments ) {
 						$.each( data.fragments, function ( key, value ) {
@@ -538,7 +538,7 @@ jQuery( function( $ ) {
 						wc_checkout_form.detachUnloadEventsOnSubmit();
 
 						try {
-							if ( 'success' === result.result ) {
+							if ( 'success' === result.result && $form.triggerHandler( 'checkout_place_order_success' ) !== false ) {
 								if ( -1 === result.redirect.indexOf( 'https://' ) || -1 === result.redirect.indexOf( 'http://' ) ) {
 									window.location = result.redirect;
 								} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Adds a `triggerHandler` called `checkout_place_order_success` on a successful order during the checkout process. This allows plugin develops to hook into the JavaScript process that gets triggered on the client side on order checkout.

This already happens for payment gateways [here](https://github.com/woocommerce/woocommerce/blob/master/assets/js/frontend/checkout.js#L493) via the `checkout_place_order` or the `'checkout_place_order_' + wc_checkout_form.get_payment_method()` triggerHandlers.

While it is possible to use various hooks in the back-end like `woocommerce_checkout_process` or `woocommerce_checkout_order_processed`, the fact that this is happening client side means that plugin developers can trigger various client side logic like manipulating the form or making additional async AJAX requests to update external sources of inventory after an order is successfully completed.

### How to test the changes in this Pull Request:
1. Create a WP test plugin and load a JS file with your plugin. I would use [`wp_enqueue_script()`](https://developer.wordpress.org/reference/functions/wp_enqueue_script/) somewhere in your main plugin file.

2. In your JS script, add the following snippet:
```
( function( $ ) {
    $( 'form.woocommerce-checkout' ).on(
	    'checkout_place_order_success',
	    function() { alert('hello world') }
    );
)( jQuery );
```
3. Add a product to your WooCommerce store, add it to your card and checkout.
4. When you've submitted your order, you'll notice the `checkout_place_order_success` event will have triggered and the  `hello world` alert will show up, allow you to now run various client side logic once a successful order has been submitted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?

**I don't think there are applicable tests!**

* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Adds a `triggerHandler` called `checkout_place_order_success` on a successful order during the checkout process. This allows plugin develops to hook into the JavaScript process that gets triggered on the client side on order checkout.
