### PR TITLE
Fix typo in test installation instructions.

### DIFF
--- a/tests/e2e-tests/README.md
+++ b/tests/e2e-tests/README.md
@@ -84,7 +84,7 @@ Setup Wizard e2e test (located in `activate-and-setup` directory) will run befor
 
 - Checkout the branch to test and stay on this branch. 
 
-- Run `nmp install`
+- Run `npm install`
 
 - Run `composer install --no-dev`
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes a typo in the testing installation instructions. "nmp" -> "npm".
