### PR TITLE
E2E Tests: mount directory instead of copy.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,1 @@
 FROM wordpress:5.3
-
-COPY . /var/www/html/wp-content/plugins/woocommerce

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,7 +13,7 @@ services:
     volumes:
       - db:/var/lib/mysql
 
-  wordpress-woocomerce-dev:
+  wordpress-woocommerce-dev:
     depends_on:
       - db
     build:
@@ -35,7 +35,7 @@ services:
   wordpress-cli:
     depends_on:
       - db
-      - wordpress-woocomerce-dev
+      - wordpress-woocommerce-dev
     image: wordpress:cli
     restart: on-failure
     user: xfs

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -30,6 +30,7 @@ services:
       WORDPRESS_TABLE_PREFIX: "wp_"
       WORDPRESS_DEBUG: 1
     volumes:
+      - "./:/var/www/html/wp-content/plugins/woocommerce"
       - wordpress:/var/www/html
 
   wordpress-cli:
@@ -48,6 +49,7 @@ services:
       wp post create --post_type=page --post_status=publish --post_title='Ready' --post_content='E2E-tests.';
       '
     volumes:
+      - "./:/var/www/html/wp-content/plugins/woocommerce"
       - wordpress:/var/www/html
 
 volumes:

--- a/tests/e2e-tests/README.md
+++ b/tests/e2e-tests/README.md
@@ -105,7 +105,7 @@ woocommerce_wordpress-cli_1 exited with code 0
 
 - Run the following command to make sure the containers were built and running: `docker ps`. You should see the 2 following containers: 
 
-- `woocommerce_wordpress-woocomerce-dev`
+- `woocommerce_wordpress-woocommerce-dev`
 - `mariadb:10.4`
 
 - Navigate to `http://localhost:8084/`. If everything went well, you should be able to access the site.  


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25274.

This PR seeks to mount the local plugin directory into the docker containers rather than copy it. This allows for more rapid development as the container doesn't need to be rebuilt for all local file changes.

### How to test the changes in this Pull Request:

1. Follow the instructions here: https://github.com/woocommerce/woocommerce/tree/master/tests/e2e-tests#woocommerce-end-to-end-tests
2. Verify the E2E tests run and pass
