### PR TITLE
Fix typo - http must be https (#25224)

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -216,7 +216,7 @@ class WC_Structured_Data {
 
 		if ( '' !== $product->get_price() ) {
 			// Assume prices will be valid until the end of next year, unless on sale and there is an end date.
-			$price_valid_until = date( 'Y-12-31', time() + YEAR_IN_SECONDS );
+			$price_valid_until = gmdate( 'Y-12-31', time() + YEAR_IN_SECONDS );
 
 			if ( $product->is_type( 'variable' ) ) {
 				$lowest  = $product->get_variation_price( 'min', false );
@@ -243,7 +243,7 @@ class WC_Structured_Data {
 				}
 			} else {
 				if ( $product->is_on_sale() && $product->get_date_on_sale_to() ) {
-					$price_valid_until = date( 'Y-m-d', $product->get_date_on_sale_to()->getTimestamp() );
+					$price_valid_until = gmdate( 'Y-m-d', $product->get_date_on_sale_to()->getTimestamp() );
 				}
 				$markup_offer = array(
 					'@type'              => 'Offer',

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -259,7 +259,7 @@ class WC_Structured_Data {
 
 			$markup_offer += array(
 				'priceCurrency' => $currency,
-				'availability'  => 'http://schema.org/' . ( $product->is_in_stock() ? 'InStock' : 'OutOfStock' ),
+				'availability'  => 'https://schema.org/' . ( $product->is_in_stock() ? 'InStock' : 'OutOfStock' ),
 				'url'           => $permalink,
 				'seller'        => array(
 					'@type' => 'Organization',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix typo from `http` to `https`

Closes #25224 .