### PR TITLE
update composer.lock to use the correct blocks version hash

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -170,12 +170,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "a65d34c9368283fb27a5f1eefefef15c8acc57ac"
+                "reference": "24b6552d38204fbbdd87ec5ba76f3ec391b042d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/a65d34c9368283fb27a5f1eefefef15c8acc57ac",
-                "reference": "a65d34c9368283fb27a5f1eefefef15c8acc57ac",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/24b6552d38204fbbdd87ec5ba76f3ec391b042d0",
+                "reference": "24b6552d38204fbbdd87ec5ba76f3ec391b042d0",
                 "shasum": ""
             },
             "require": {


### PR DESCRIPTION
fixes #25325 

This PR updates composer.lock to use the correct version of wc-blocks, the current hash is for a faulty version of wc-blocks that was deleted, the new version is the correct one.


### How to test
1- Disable wc-blocks plugin if you have it
2- Run `composer install`
3- Test blocks

Deeper discussion can be found at p1577452895145600-slack-C0E1AV8T0