### PR TITLE
added woocommerce specific css selector to password visibility toggle to avoid conflicts

### DIFF
--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -80,7 +80,7 @@ jQuery( function( $ ) {
 	};
 
 	// Show password visiblity hover icon on woocommerce forms
-	$( '.woocommerce form input[type="password"]' ).wrap( '<span class="password-input"></span>' );
+	$( '.woocommerce form .woocommerce-Input[type="password"]' ).wrap( '<span class="password-input"></span>' );
 	$( '.password-input' ).append( '<span class="show-password-input"></span>' );
 
 	$( '.show-password-input' ).click(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Tweak to #24915 - added woocommerce specific css selector to woocommerce password visibility toggle to avoid conflict with other plugins

### How to test the changes in this Pull Request:

1.  Visit any woocommerce login form and hover over the new "eye" visibility icon on the password input
