### PR TITLE
Fix closing product-data (on block editor)

### DIFF
--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -30,17 +30,13 @@ jQuery( function( $ ) {
 	$( '.type_box' ).appendTo( '#woocommerce-product-data .hndle span' );
 
 	$( function() {
-		// Prevent inputs in meta box headings opening/closing contents.
-		$( '#woocommerce-product-data' ).find( '.hndle' ).unbind( 'click.postboxes' );
-
-		$( '#woocommerce-product-data' ).on( 'click', '.hndle', function( event ) {
+		$( '#woocommerce-product-data' ).on( 'click.postboxes', '.hndle', function( event ) {
 
 			// If the user clicks on some form input inside the h3 the box should not be toggled.
 			if ( $( event.target ).filter( 'input, option, label, select' ).length ) {
-				return;
+				$( '#woocommerce-product-data' ).toggleClass( 'closed' );
 			}
 
-			$( '#woocommerce-product-data' ).toggleClass( 'closed' );
 		});
 	});
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

Closes #25354 .

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fixes a bug on product data click closing the box
