### PR TITLE
Add a 'html' field type to woocommerce_admin_fields() to allow for arbitrary HTML to be printed on the settings page.

### DIFF
--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -672,6 +672,10 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 						<?php
 						break;
 
+					case 'html':
+						echo $value['html']; // WPCS: XSS ok.
+						break;
+
 					// Default: run an action.
 					default:
 						do_action( 'woocommerce_admin_field_' . $value['type'], $value );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`WC_Admin_Settings` has a function called `woocommerce_admin_fields` that builds up the fields shown on a settings page. The core supports a lot of different field types, and also allows you to create your own by using the `woocommerce_admin_field_$type` action. Sometimes you may only want to print some arbitary HTML, like `<br>`, `<hr>` or a link or image, so creating an action for these seems overkill.

This PR simply adds a new type, named 'html' to the settings array that prints out some HTML.

### How to test the changes in this Pull Request:

1. Create a new settings tab
2. Add an item to an array that gets passed to `woocommerce_admin_fields()` such as:
```
    'message' => ['type' => 'html', 'html' => '<hr>'],
```
3. See your HTML printed when `woocommerce_admin_fields()` is called.

### Changelog entry

> Add a 'html' field type to woocommerce_admin_fields() to allow for arbitrary HTML to be printed on the settings page.