### PR TITLE
Update class-wc-deprecated-action-hooks.php

### DIFF
--- a/includes/class-wc-deprecated-action-hooks.php
+++ b/includes/class-wc-deprecated-action-hooks.php
@@ -156,7 +156,7 @@ class WC_Deprecated_Action_Hooks extends WC_Deprecated_Hooks {
 				$item     = $new_callback_args[1];
 				$order_id = $new_callback_args[2];
 				if ( is_a( $item, 'WC_Order_Item_Product' ) ) {
-					do_action( $old_hook, $item_id, $item->legacy_values, $item->legacy_cart_item_key );
+					do_action( $old_hook, $item_id, isset( $item->legacy_values ) ? $item->legacy_values : array(), isset( $item->legacy_cart_item_key ) ? $item->legacy_cart_item_key : '' );
 				}
 				break;
 			case 'woocommerce_add_order_fee_meta':


### PR DESCRIPTION
Fix a bug where $item->legacy_cart_item_key and $item->legacy_values are not present

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Fixed a bug where $item->legacy_cart_item_key and $item->legacy_values are not present which can cause a php error
Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Fixed a bug where $item->legacy_cart_item_key and $item->legacy_values are not present. I have NOT checked the other cases in the switch due to not using them within the project. Those might also have the same issue.