### PR TITLE
[Importer] Fix "invalid product type message" for variations

### DIFF
--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -37,7 +37,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 	 *
 	 * @since 3.0.0
 	 * @param WC_Product_Variation $product Product object.
-	 * @throws WC_Data_Exception If WC_Product::set_tax_status() is called with an invalid tax status (via read_product_data).
+	 * @throws WC_Data_Exception If WC_Product::set_tax_status() is called with an invalid tax status (via read_product_data), or when passing an invalid ID.
 	 */
 	public function read( &$product ) {
 		$product->set_defaults();
@@ -53,7 +53,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 		}
 
 		if ( 'product_variation' !== $post_object->post_type ) {
-			throw new Exception( 'Invalid product type: passed ID does not correspond to a product variation.' );
+			throw new WC_Data_Exception( 'variation_invalid_id', __( 'Invalid product type: passed ID does not correspond to a product variation.', 'woocommerce' ) );
 		}
 
 		$product->set_props(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since #25178 it's no longer possible to import variations if they come before the variable product, this happens because we create "placeholder" products while importing a variation or any product that relies on a parent product, and after that the importer convert into the correct product type.

To fix it I'm converting into a `product_variation` before trying to read any product in case it's a variation.

Closes #25329.

### How to test the changes in this Pull Request:

1. Go to `/wp-admin/edit.php?post_type=product&page=product_importer`
2. Use the sample products csv that is [found in the Woo repo here](https://raw.githubusercontent.com/woocommerce/woocommerce/master/sample-data/sample_products.csv).
3. Accept the column mapping in step 2
4. Run the import, and note that some of the products fail to import with the "Invalid product type: passed ID does not correspond to a product variation." message.
5. Remove all imported products, apply this patch and try again, now should finish the importation without any error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->


