### PR TITLE
Improved performance when saving variations

### DIFF
--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -447,8 +447,13 @@ jQuery( function( $ ) {
 		 * @return {Object}
 		 */
 		get_variations_fields: function( fields ) {
-			var data = $( ':input', fields ).serializeJSON();
-
+			
+			var data = {};
+			
+			$( ':input', fields ).each( function(index, elem) {
+				data[elem.name] = elem.value;
+			});
+			
 			$( '.variations-defaults select' ).each( function( index, element ) {
 				var select = $( element );
 				data[ select.attr( 'name' ) ] = select.val();

--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -454,6 +454,11 @@ jQuery( function( $ ) {
 				
 				var $input = $(elem);
 				
+				// Bypass inputs without name att
+				if (!elem.name) {
+					return;
+				}
+				
 				// Bypass non-checked checkboxes and radio buttons.
 				if (($input.is(':radio') || $input.is(':checkbox')) && !$input.is(':checked')) {
 					return;

--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -451,7 +451,21 @@ jQuery( function( $ ) {
 			var data = {};
 			
 			$( ':input', fields ).each( function(index, elem) {
+				
+				var $input = $(elem);
+				
+				// Bypass non-checked checkboxes and radio buttons.
+				if (($input.is(':radio') || $input.is(':checkbox')) && !$input.is(':checked')) {
+					return;
+				}
+				
+				// Bypass disabled fields.
+				if (true === $input.prop('disabled')) {
+					return;
+				}
+				
 				data[elem.name] = elem.value;
+				
 			});
 			
 			$( '.variations-defaults select' ).each( function( index, element ) {

--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -447,32 +447,32 @@ jQuery( function( $ ) {
 		 * @return {Object}
 		 */
 		get_variations_fields: function( fields ) {
-			
+
 			var data = {};
-			
-			$( ':input', fields ).each( function(index, elem) {
-				
-				var $input = $(elem);
-				
+
+			$( ':input', fields ).each( function( index, elem ) {
+
+				var $input = $( elem );
+
 				// Bypass inputs without name att
-				if (!elem.name) {
+				if ( ! elem.name ) {
 					return;
 				}
-				
+
 				// Bypass non-checked checkboxes and radio buttons.
-				if (($input.is(':radio') || $input.is(':checkbox')) && !$input.is(':checked')) {
+				if ( ( $input.is( ':radio' ) || $input.is( ':checkbox' ) ) && ! $input.is( ':checked' ) ) {
 					return;
 				}
-				
+
 				// Bypass disabled fields.
-				if (true === $input.prop('disabled')) {
+				if ( true === $input.prop( 'disabled' ) ) {
 					return;
 				}
-				
-				data[elem.name] = elem.value;
-				
+
+				data[ elem.name ] = elem.value;
+
 			});
-			
+
 			$( '.variations-defaults select' ).each( function( index, element ) {
 				var select = $( element );
 				data[ select.attr( 'name' ) ] = select.val();


### PR DESCRIPTION
#24840 

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The serializeJSON function was causing a long delay when preparing the JSON if there are many input fields within the variations (even worse if 3rd party plugins add their own extra fields there too).

### How to test the changes in this Pull Request:

1. Open a variable product.
2. Open the variations tab.
3. Edit the variations and Save.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Performance - Improved the client-side preparation for variation saving.
