### PR TITLE
Make WC_Shipping::is package shippable less strict

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -294,12 +294,7 @@ class WC_Shipping {
 		}
 
 		$states = WC()->countries->get_states( $country );
-		if ( is_array( $states ) && ! isset( $states[ $package['destination']['state'] ] ) ) {
-			return false;
-		}
-
-		$postcode = wc_format_postcode( $package['destination']['postcode'], $country );
-		if ( ! WC_Validation::is_postcode( $postcode, $country ) ) {
+		if ( is_array( $states ) && ! empty( $states ) && ! isset( $states[ $package['destination']['state'] ] ) ) {
 			return false;
 		}
 

--- a/tests/unit-tests/shipping/shipping.php
+++ b/tests/unit-tests/shipping/shipping.php
@@ -60,19 +60,6 @@ class WC_Tests_Shipping extends WC_Unit_Test_Case {
 		);
 		$this->assertFalse( $result );
 
-		// Failure for invalid postcode.
-		$result = $shipping->is_package_shippable(
-			array(
-				'destination' => array(
-					'country'  => 'US',
-					'state'    => 'CA',
-					'postcode' => 'test',
-					'address'  => '',
-				),
-			)
-		);
-		$this->assertFalse( $result );
-
 		// Success for correct address.
 		$result = $shipping->is_package_shippable(
 			array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

After the changes from https://github.com/woocommerce/woocommerce/pull/25128 no shipping will display based on Geolocation or the store default address.

This makes the functionally less strict, allowing calculate for countries that doesn't list any state, and also without a postcode.
Note that after the customer enter with the complete address some shipping methods show up or get hide, or costs can get higher or not, since it's possible to register shipping zone for a range of postcodes.

### How to test the changes in this Pull Request:

1. Geolocation is broken on this branch, so just fill the store address, and set "Default customer location" as "Shop base address".
2. Create some shipping zones, and one for the shop base address.
3. Put some product that requires shipping in the cart and check the message, no shipping option should display, unless you inserted a postcode with the shop base address.
4. Clean all caches and apply this PR, try again putting some non-virtual product in the cart and check the shipping options available now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
