### PR TITLE
Fix failing unit test due to change in WP nightly

### DIFF
--- a/tests/unit-tests/util/api-functions.php
+++ b/tests/unit-tests/util/api-functions.php
@@ -82,8 +82,12 @@ class WC_Tests_API_Functions extends WC_Unit_Test_Case {
 	 */
 	public function test_wc_rest_upload_image_from_url_should_return_error_when_invalid_image_is_passed() {
 		// empty file.
-		$expected_error_message = 'Invalid image: File is empty. Please upload something more substantial. This error could also be caused by uploads being disabled in your php.ini or by post_max_size being defined as smaller than upload_max_filesize in php.ini.';
-		$result                 = wc_rest_upload_image_from_url( 'http://somedomain.com/invalid-image-1.png' );
+		if ( version_compare( get_bloginfo( 'version' ), '5.4-alpha', '>=' ) ) {
+			$expected_error_message = 'Invalid image: File is empty. Please upload something more substantial. This error could also be caused by uploads being disabled in your php.ini file or by post_max_size being defined as smaller than upload_max_filesize in php.ini.';
+		} else {
+			$expected_error_message = 'Invalid image: File is empty. Please upload something more substantial. This error could also be caused by uploads being disabled in your php.ini or by post_max_size being defined as smaller than upload_max_filesize in php.ini.';
+		}
+		$result = wc_rest_upload_image_from_url( 'http://somedomain.com/invalid-image-1.png' );
 
 		$this->assertWPError( $result );
 		$this->assertEquals( $expected_error_message, $result->get_error_message() );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the unit test WC_Tests_API_Functions::test_wc_rest_upload_image_from_url_should_return_error_when_invalid_image_is_passed() which was  failing due to a change in a WordPress core message with the following error:

```
2) WC_Tests_API_Functions::test_wc_rest_upload_image_from_url_should_return_error_when_invalid_image_is_passed

Failed asserting that two strings are equal.

--- Expected

+++ Actual

@@ @@

-'Invalid image: File is empty. Please upload something more substantial. This error could also be caused by uploads being disabled in your php.ini or by post_max_size being defined as smaller than upload_max_filesize in php.ini.'

+'Invalid image: File is empty. Please upload something more substantial. This error could also be caused by uploads being disabled in your php.ini file or by post_max_size being defined as smaller than upload_max_filesize in php.ini.'

/home/travis/build/woocommerce/woocommerce/tests/unit-tests/util/api-functions.php:89
```

(https://travis-ci.org/woocommerce/woocommerce/jobs/637353161#L402)

This test only fails when using WordPress nightly build (the yet to be released WP 5.4).

To fix this problem, this PR adds an if statement to check for different error messages depending on the WordPress version that is being used to run the tests. In the future, we might want to refactor this test to remove its dependency to a WordPress error message to make it more robust and stable.

### How to test the changes in this Pull Request:

1. Check that the unit test mentioned above is passing in all Travis build jobs. There is currently a test failing (WC_Tests_Geolite_Integration::test_get_country_iso) that is not related to this PR and that is being addressed in #25378.