### PR TITLE
Use wp_mail() default args in WC_Email

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -441,17 +441,23 @@ class WC_Email extends WC_Settings_API {
 	/**
 	 * Get email content type.
 	 *
+	 * @param string $default_content_type Default wp_mail() content type.
 	 * @return string
 	 */
-	public function get_content_type() {
+	public function get_content_type( $default_content_type = '' ) {
 		switch ( $this->get_email_type() ) {
 			case 'html':
-				return 'text/html';
+				$content_type = 'text/html';
+				break;
 			case 'multipart':
-				return 'multipart/alternative';
+				$content_type = 'multipart/alternative';
+				break;
 			default:
-				return 'text/plain';
+				$content_type = 'text/plain';
+				break;
 		}
+
+		return apply_filters( 'woocommerce_email_content_type', $content_type, $this, $default_content_type );
 	}
 
 	/**
@@ -599,21 +605,23 @@ class WC_Email extends WC_Settings_API {
 	/**
 	 * Get the from name for outgoing emails.
 	 *
+	 * @param string $from_name Default wp_mail() name associated with the "from" email address.
 	 * @return string
 	 */
-	public function get_from_name() {
-		$from_name = apply_filters( 'woocommerce_email_from_name', get_option( 'woocommerce_email_from_name' ), $this );
+	public function get_from_name( $from_name = '' ) {
+		$from_name = apply_filters( 'woocommerce_email_from_name', get_option( 'woocommerce_email_from_name' ), $this, $from_name );
 		return wp_specialchars_decode( esc_html( $from_name ), ENT_QUOTES );
 	}
 
 	/**
 	 * Get the from address for outgoing emails.
 	 *
+	 * @param string $from_email Default wp_mail() email address to send from.
 	 * @return string
 	 */
-	public function get_from_address() {
-		$from_address = apply_filters( 'woocommerce_email_from_address', get_option( 'woocommerce_email_from_address' ), $this );
-		return sanitize_email( $from_address );
+	public function get_from_address( $from_email = '' ) {
+		$from_email = apply_filters( 'woocommerce_email_from_address', get_option( 'woocommerce_email_from_address' ), $this, $from_email );
+		return sanitize_email( $from_email );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

By default we override on the fly some filters form `wp_mail()` and we don't consider the default value from those filters, it can be a problem in some integrations like in #25385.

Closes #25385.

### How to test the changes in this Pull Request:

See https://github.com/woocommerce/woocommerce/issues/25385

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced `woocommerce_email_content_type` filter.
> Dev - Updated `woocommerce_email_from_name` filter arguments to include default `wp_email()` "from" name.
> Dev - Updated `woocommerce_email_from_address` filter arguments to include default `wp_email()` email address.
