### PR TITLE
Return to Shop button filter

### DIFF
--- a/templates/cart/cart-empty.php
+++ b/templates/cart/cart-empty.php
@@ -25,7 +25,7 @@ do_action( 'woocommerce_cart_is_empty' );
 if ( wc_get_page_id( 'shop' ) > 0 ) : ?>
 	<p class="return-to-shop">
 		<a class="button wc-backward" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php esc_html_e( 'Return to shop', 'woocommerce' ); ?>
+			<?php echo apply_filters('woocommerce_return_to_shop_title', sprintf( '%s', __('Return To Shop', 'woocommerce' ) )); ?>
 		</a>
 	</p>
 <?php endif; ?>

--- a/templates/cart/cart-empty.php
+++ b/templates/cart/cart-empty.php
@@ -25,7 +25,7 @@ do_action( 'woocommerce_cart_is_empty' );
 if ( wc_get_page_id( 'shop' ) > 0 ) : ?>
 	<p class="return-to-shop">
 		<a class="button wc-backward" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php echo apply_filters('woocommerce_return_to_shop_title', sprintf( '%s', __('Return To Shop', 'woocommerce' ) )); ?>
+			<?php echo apply_filters('woocommerce_return_to_shop_title', __('Return To Shop', 'woocommerce' ) ); ?>
 		</a>
 	</p>
 <?php endif; ?>

--- a/templates/cart/cart-empty.php
+++ b/templates/cart/cart-empty.php
@@ -25,7 +25,15 @@ do_action( 'woocommerce_cart_is_empty' );
 if ( wc_get_page_id( 'shop' ) > 0 ) : ?>
 	<p class="return-to-shop">
 		<a class="button wc-backward" href="<?php echo esc_url( apply_filters( 'woocommerce_return_to_shop_redirect', wc_get_page_permalink( 'shop' ) ) ); ?>">
-			<?php echo apply_filters('woocommerce_return_to_shop_title', __('Return To Shop', 'woocommerce' ) ); ?>
+			<?php
+				/**
+				 * Filter "Return To Shop" text.
+				 *
+				 * @since 4.4.0
+				 * @param string $default_text Default text.
+				 */
+				echo esc_html( apply_filters( 'woocommerce_return_to_shop_text', __( 'Return To Shop', 'woocommerce' ) ) );
+			?>
 		</a>
 	</p>
 <?php endif; ?>


### PR DESCRIPTION
Added filter to change the "Return to Shop" button text. We can add a filter in our plugin or theme to rename the "Return to Shop" button texts with whatever button text we want like, Go Shop or Buy Some Tees, etc...

You can test this commit by adding a filter to a theme or a plugin and pass the button texts of your choice.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced `woocommerce_return_to_shop_text` filter.
