### PR TITLE
Add order meta `is_vat_exempt` with unique meta key.

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -371,7 +371,7 @@ class WC_Checkout {
 			$order->set_cart_hash( $cart_hash );
 			$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) );
 			$order_vat_exempt = WC()->cart->get_customer()->get_is_vat_exempt() ? 'yes' : 'no';
-			$order->add_meta_data( 'is_vat_exempt', $order_vat_exempt );
+			$order->add_meta_data( 'is_vat_exempt', $order_vat_exempt, true );
 			$order->set_currency( get_woocommerce_currency() );
 			$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
 			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In `WC_Checkout::create_order()` the `is_vat_exempt` meta data gets added to the order using the `add_meta_data()` method (from `WC_Data` abstract). However, the call does not set the 3rd parameter `$unique`, which can result in the meta unnecessary being added multiple times. For example, if a customer is redirected to payment gateway and then abandons the payment and returns back to the checkout page to start a new payment again. This PR adds sets the `$unique` parameter to `true`, so there will only be a single `is_vat_exempt` meta for an order in the described case.

### How to test the changes in this Pull Request:

1. Place an order with a payment gateway that uses a redirect to a payment screen
2. Abandon the payment using the back button of the browser
3. From the checkout page, start a new payment again

Without the proposed changes, you'll end up with multiple `is_vat_exempt` meta for the order. With the changes, there will only be a single meta for this key.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix possible multiple `is_vat_exempt` order meta in order creation.
