### PR TITLE
Add product lookup table tax columns

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -140,9 +140,9 @@ class WC_Install {
 			'wc_update_390_change_geolocation_database_update_cron',
 			'wc_update_390_db_version',
 		),
-		'3.10.0' => array(
+		'4.0.0' => array(
 			'wc_update_product_lookup_tables',
-			'wc_update_3100_db_version',
+			'wc_update_400_db_version',
 		),
 	);
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -140,6 +140,10 @@ class WC_Install {
 			'wc_update_390_change_geolocation_database_update_cron',
 			'wc_update_390_db_version',
 		),
+		'3.10.0' => array(
+			'wc_update_product_lookup_tables',
+			'wc_update_3100_db_version',
+		),
 	);
 
 	/**
@@ -422,7 +426,7 @@ class WC_Install {
 	 * @return array
 	 */
 	public static function cron_schedules( $schedules ) {
-		$schedules['monthly'] = array(
+		$schedules['monthly']     = array(
 			'interval' => 2635200,
 			'display'  => __( 'Monthly', 'woocommerce' ),
 		);
@@ -903,6 +907,8 @@ CREATE TABLE {$wpdb->prefix}wc_product_meta_lookup (
   `rating_count` bigint(20) NULL default 0,
   `average_rating` decimal(3,2) NULL default 0.00,
   `total_sales` bigint(20) NULL default 0,
+  `tax_status` varchar(100) NULL default 'taxable',
+  `tax_class` varchar(100) NULL default '',
   PRIMARY KEY  (`product_id`),
   KEY `virtual` (`virtual`),
   KEY `downloadable` (`downloadable`),

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -644,7 +644,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			}
 		}
 
-		if ( array_intersect( $this->updated_props, array( 'sku', 'regular_price', 'sale_price', 'date_on_sale_from', 'date_on_sale_to', 'total_sales', 'average_rating', 'stock_quantity', 'stock_status', 'manage_stock', 'downloadable', 'virtual' ) ) ) {
+		if ( array_intersect( $this->updated_props, array( 'sku', 'regular_price', 'sale_price', 'date_on_sale_from', 'date_on_sale_to', 'total_sales', 'average_rating', 'stock_quantity', 'stock_status', 'manage_stock', 'downloadable', 'virtual', 'tax_status', 'tax_class' ) ) ) {
 			$this->update_lookup_table( $product->get_id(), 'wc_product_meta_lookup' );
 		}
 
@@ -2033,6 +2033,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				'rating_count'   => array_sum( (array) get_post_meta( $id, '_wc_rating_count', true ) ),
 				'average_rating' => get_post_meta( $id, '_wc_average_rating', true ),
 				'total_sales'    => get_post_meta( $id, 'total_sales', true ),
+				'tax_status'     => get_post_meta( $id, '_tax_status', true ),
+				'tax_class'      => get_post_meta( $id, '_tax_class', true ),
 			);
 		}
 		return array();

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -1365,7 +1365,9 @@ function wc_update_product_lookup_tables() {
 		'total_sales',
 		'downloadable',
 		'virtual',
-		'onsale', // When last column is updated, woocommerce_product_lookup_table_is_generating is updated.
+		'onsale',
+		'tax_class',
+		'tax_status', // When last column is updated, woocommerce_product_lookup_table_is_generating is updated.
 	);
 
 	foreach ( $columns as $index => $column ) {
@@ -1457,6 +1459,8 @@ function wc_update_product_lookup_tables_column( $column ) {
 		case 'stock_status':
 		case 'average_rating':
 		case 'total_sales':
+		case 'tax_class':
+		case 'tax_status':
 			if ( 'total_sales' === $column ) {
 				$meta_key = 'total_sales';
 			} elseif ( 'average_rating' === $column ) {
@@ -1523,9 +1527,12 @@ function wc_update_product_lookup_tables_column( $column ) {
 				)
 			);
 			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-
-			delete_option( 'woocommerce_product_lookup_table_is_generating' ); // Complete.
 			break;
+	}
+
+	// Final column - mark complete.
+	if ( 'tax_status' === $column ) {
+		delete_option( 'woocommerce_product_lookup_table_is_generating' );
 	}
 }
 add_action( 'wc_update_product_lookup_tables_column', 'wc_update_product_lookup_tables_column' );

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2081,3 +2081,10 @@ function wc_update_390_change_geolocation_database_update_cron() {
 function wc_update_390_db_version() {
 	WC_Install::update_db_version( '3.9.0' );
 }
+
+/**
+ * Update DB version.
+ */
+function wc_update_3100_db_version() {
+	WC_Install::update_db_version( '3.10.0' );
+}

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2085,6 +2085,6 @@ function wc_update_390_db_version() {
 /**
  * Update DB version.
  */
-function wc_update_3100_db_version() {
-	WC_Install::update_db_version( '3.10.0' );
+function wc_update_400_db_version() {
+	WC_Install::update_db_version( '4.0.0' );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR introduces 2 extra columns to the product lookup table to cover tax class, and tax status. 

As well as making these additions to the schema, I've added it to the update routines so product data is regenerated. The defaults for these columns match the product defaults also (taxable, and standard tax class).

This will be used to fix and improve price filtering queries in blocks (https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/1492) since prices can be displayed different to how they are stored in the DB. Without this we'd need to resort to post meta table joins.

On the blocks side, we'll do a version check for `3.10` (or `4.0 depending on what is next) before making use of the new data.

### How to test the changes in this Pull Request:

1. Check out pull and de/re-activate WC to get the update routine going and installer updating table schema.
2. Check the `wp_wc_product_meta_lookup` table for 2 new columns; `tax_status` and `tax_class`.
3. Wait for update routine to finish and check this table has values. You should also edit a product and change the tax class to something like 'reduced rate' and ensure the table matches this after saving.

### Changelog entry

> Added tax_status and tax_class columns to the product meta data lookup table.
