### PR TITLE
Fixed warning notice when missing MaxMind database

### DIFF
--- a/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-database-service.php
+++ b/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-database-service.php
@@ -139,18 +139,23 @@ class WC_Integration_MaxMind_Database_Service {
 	 * Fetches the ISO country code associated with an IP address.
 	 *
 	 * @param string $ip_address The IP address to find the country code for.
-	 * @return string|null The country code for the IP address, or null if none was found.
+	 * @return string The country code for the IP address, or empty if not found.
 	 */
 	public function get_iso_country_code_for_ip( $ip_address ) {
-		$country_code = null;
+		$country_code = '';
 
 		if ( ! class_exists( 'MaxMind\Db\Reader' ) ) {
 			wc_get_logger()->notice( __( 'Missing MaxMind Reader library!', 'woocommerce' ), array( 'source' => 'maxmind-geolocation' ) );
 			return $country_code;
 		}
 
+		$database_path = $this->get_database_path();
+		if ( ! file_exists( $database_path ) ) {
+			return $country_code;
+		}
+
 		try {
-			$reader = new MaxMind\Db\Reader( $this->get_database_path() );
+			$reader = new MaxMind\Db\Reader( $database_path );
 			$data   = $reader->get( $ip_address );
 
 			if ( isset( $data['country']['iso_code'] ) ) {

--- a/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
+++ b/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
@@ -221,7 +221,7 @@ class WC_Integration_MaxMind_Geolocation extends WC_Integration {
 		$country_code = $this->database_service->get_iso_country_code_for_ip( $ip_address );
 
 		return array(
-			'country'  => $country_code ? $country_code : '',
+			'country'  => $country_code,
 			'state'    => '',
 			'city'     => '',
 			'postcode' => '',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If there's no file at the given path, it seems that the reader simply throws a warning. In order to make this a bit more functional, we won't perform the lookup if the database is missing.

Closes #25440

### How to test the changes in this Pull Request:

1. Remove the MaxMind database from `/uploads/woocommerce_uploaders/`
2. Visit an active cart to perform a lookup.
3. Notice before the fix that warnings will be added to a log file. After the fix, no warning will be given.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?