### PR TITLE
Added new filter for modification of order processing count in menu

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -184,7 +184,7 @@ class WC_Admin_Menus {
 
 			// Add count if user has access.
 			if ( apply_filters( 'woocommerce_include_processing_order_count_in_menu', true ) && current_user_can( 'manage_woocommerce' ) ) {
-				$order_count = apply_filters('woocommerce_modify_processing_order_count_in_menu', wc_processing_order_count());
+				$order_count = apply_filters( 'woocommerce_modify_processing_order_count_in_menu', wc_processing_order_count() );
 				
 				if ( $order_count ) {
 					foreach ( $submenu['woocommerce'] as $key => $menu_item ) {

--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -184,8 +184,8 @@ class WC_Admin_Menus {
 
 			// Add count if user has access.
 			if ( apply_filters( 'woocommerce_include_processing_order_count_in_menu', true ) && current_user_can( 'manage_woocommerce' ) ) {
-				$order_count = wc_processing_order_count();
-
+				$order_count = apply_filters('woocommerce_modify_processing_order_count_in_menu', wc_processing_order_count());
+				
 				if ( $order_count ) {
 					foreach ( $submenu['woocommerce'] as $key => $menu_item ) {
 						if ( 0 === strpos( $menu_item[0], _x( 'Orders', 'Admin menu name', 'woocommerce' ) ) ) {

--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -184,8 +184,8 @@ class WC_Admin_Menus {
 
 			// Add count if user has access.
 			if ( apply_filters( 'woocommerce_include_processing_order_count_in_menu', true ) && current_user_can( 'manage_woocommerce' ) ) {
-				$order_count = apply_filters( 'woocommerce_modify_processing_order_count_in_menu', wc_processing_order_count() );
-				
+				$order_count = wc_processing_order_count();
+
 				if ( $order_count ) {
 					foreach ( $submenu['woocommerce'] as $key => $menu_item ) {
 						if ( 0 === strpos( $menu_item[0], _x( 'Orders', 'Admin menu name', 'woocommerce' ) ) ) {

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -317,7 +317,7 @@ function wc_register_order_type( $type, $args = array() ) {
  * @return int
  */
 function wc_processing_order_count() {
-	return wc_orders_count( 'processing' );
+	return apply_filters( 'woocommerce_modify_processing_order_count_in_menu', wc_orders_count( 'processing' ) );
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Enables modification of order counter "bubble"/notification in menu.
I require this change for including the order count of another status then "processing".
I do not see any sideeffects of this change.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:

add filter, that modifies the value.
my example for the newly defined status "new":

```
add_filter( 'woocommerce_modify_processing_order_count_in_menu', 'fb_custom_status_update_order_count');

function fb_custom_status_update_order_count( $order_count ){
      return $order_count + wc_orders_count( 'new' );
   }
```


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

- added new filter for modification of order processing count in menu