### PR TITLE
Trim whitespaces and strip slashes from MaxMind License Key

### DIFF
--- a/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
+++ b/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
@@ -137,6 +137,9 @@ class WC_Integration_MaxMind_Geolocation extends WC_Integration {
 			return $value;
 		}
 
+		// Trim whitespaces and strip slashes.
+		$value = $this->validate_password_field( $key, $value );
+
 		// Check the license key by attempting to download the Geolocation database.
 		$tmp_database_path = $this->database_service->download_database( $value );
 		if ( is_wp_error( $tmp_database_path ) ) {

--- a/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
+++ b/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
@@ -132,13 +132,13 @@ class WC_Integration_MaxMind_Geolocation extends WC_Integration {
 	 * @throws Exception When the license key is invalid.
 	 */
 	public function validate_license_key_field( $key, $value ) {
-		// Empty license keys have no need to validate the data.
+		// Trim whitespaces and strip slashes.
+		$value = $this->validate_password_field( $key, $value );
+
+		// Empty license keys have no need test downloading a database.
 		if ( empty( $value ) ) {
 			return $value;
 		}
-
-		// Trim whitespaces and strip slashes.
-		$value = $this->validate_password_field( $key, $value );
 
 		// Check the license key by attempting to download the Geolocation database.
 		$tmp_database_path = $this->database_service->download_database( $value );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since it's a password field it's hard to check if there's any whitespaces on it, so we need to help a little.

Closes #25464.

### How to test the changes in this Pull Request:

1. Generate a license key, paste in the "MaxMind License Key" on the MaxMind Integration page, and include an extra whitespace after or before.
2. Try to save and check the error.
3. Apply this patch and try again, now should just save and validate without any trouble.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Trim whitespaces and strip slashes from MaxMind License Key
