### PR TITLE
Fix randomly failing variations product test: add 1 second wait time between 2 UI blocks / AJAX calls

### DIFF
--- a/tests/e2e-tests/specs/wp-admin/wp-admin-product-new.test.js
+++ b/tests/e2e-tests/specs/wp-admin/wp-admin-product-new.test.js
@@ -94,6 +94,7 @@ describe( 'Add New Variable Product Page', () => {
 
 		// Wait for attribute form to save (triggers 2 UI blocks)
 		await uiUnblocked();
+		await page.waitFor( 1000 );
 		await uiUnblocked();
 
 		// Create variations from attributes

--- a/tests/e2e-tests/utils/components.js
+++ b/tests/e2e-tests/utils/components.js
@@ -78,6 +78,7 @@ const createVariableProduct = async () => {
 
 	// Wait for attribute form to save (triggers 2 UI blocks)
 	await uiUnblocked();
+	await page.waitFor( 1000 );
 	await uiUnblocked();
 
 	// Create variations from attributes


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix randomly failing variations product test by adding 1 second wait time between 2 UI blocks / AJAX calls. 

Sometimes the `front-end-single-product.test.js` and `wp-admin-product-new.test.js` randomly fail on the step where the variable product is being created. It usually fails with the following error message:

```
FAIL  tests/e2e-tests/specs/wp-admin/wp-admin-product-new.test.js (67.8s)
  Add New Simple Product Page
    ✓ can create simple virtual product titled "Simple Product" with regular price $9.99 (16002ms)
  Add New Variable Product Page
    ✕ can create product with variations (31511ms)

  ● Add New Variable Product Page › can create product with variations

    Node is either not visible or not an HTMLElement
```

In my debugging, I pinpointed it to the 2 UI blocks that happen consequently on the step when the user saves attributes:

![Screen Shot 2020-01-22 at 4 57 51 PM](https://user-images.githubusercontent.com/19143190/72915530-5f075380-3d38-11ea-9a56-08bb62a9c307.png)

The test runs too fast and skips the 2nd UI block resulting in an error. If we slow down the test a bit by adding 1 second between the 2 UI blocks, the issue is fixed. 

### How to test the changes in this Pull Request:

1. Run `npm run test:e2e` and make sure tests are passing;
2. Run `npm run test:e2e-dev` and make sure tests are passing. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A. 