### PR TITLE
Disable Codecov in PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,7 +8,7 @@ coverage:
   range: "50...100"
 
   status:
-    project: yes
+    project: off
     patch: off
     changes: off
 

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -20,7 +20,4 @@ parsers:
       method: no
       macro: no
 
-comment:
-  layout: "files"
-  behavior: default
-  require_changes: yes
+comment: false


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR disables the Codecov integration with GitHub PRs. After this is merged Codecov will stop reporting if each PR passed its test for code coverage and will stop adding comments in each PR. It will still be possible to check code coverage for the WooCommerce project by checking the badge that we display on the home page of the repository or by visiting the WooCommerce page on the Codecov site. We decided to do this because we feel that often times Codecov failures are a false positive and that the comments add a lot of noise to the PR.

### How to test the changes in this Pull Request:

1. Check that the PR doesn't contain a comment added by Codecov reporting code coverage changes
2. Check that there is only one check (Travis) performed in this PR instead of two. See section "All checks have passed".
3. See that the "Unit tests code coverage" Travis build job successfully send code coverage information to Codecov: https://travis-ci.org/woocommerce/woocommerce/jobs/640592746#L549