### PR TITLE
Apply rounding only if value is integer to display "-" when needed.

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -116,9 +116,11 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 			$tax_item_total    = isset( $tax_data['total'][ $tax_item_id ] ) ? $tax_data['total'][ $tax_item_id ] : '';
 			$tax_item_subtotal = isset( $tax_data['subtotal'][ $tax_item_id ] ) ? $tax_data['subtotal'][ $tax_item_id ] : '';
 
-			$round_at_subtotal = 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' );
-			$tax_item_total    = wc_round_tax_total( $tax_item_total, $round_at_subtotal ? wc_get_rounding_precision() : null );
-			$tax_item_subtotal = wc_round_tax_total( $tax_item_subtotal, $round_at_subtotal ? wc_get_rounding_precision() : null );
+			if ( '' !== $tax_item_subtotal ) {
+				$round_at_subtotal = 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' );
+				$tax_item_total    = wc_round_tax_total( $tax_item_total, $round_at_subtotal ? wc_get_rounding_precision() : null );
+				$tax_item_subtotal = wc_round_tax_total( $tax_item_subtotal, $round_at_subtotal ? wc_get_rounding_precision() : null );
+			}
 			?>
 			<td class="line_tax" width="1%">
 				<div class="view">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This addresses a regression where we were displaying `0` instead of `-` when there was no tax applied.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25463  .

### How to test the changes in this Pull Request:

1. Add two tax rates, 1 for standard and 1 for reduced tax rate.
2. Configure two different products with these different rates.
3. Manually create an order with these two products. The tax column for these products should display `-` instead of `0` for taxes that are not applicable.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>  Fix regression to show "-" instead of "0" when tax is not applicable to a product.
