### PR TITLE
Remove hash_equals() polyfill as it is no longer needed

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1157,36 +1157,6 @@ function wc_get_user_agent() {
 	return isset( $_SERVER['HTTP_USER_AGENT'] ) ? wc_clean( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : ''; // @codingStandardsIgnoreLine
 }
 
-// This function can be removed when WP 3.9.2 or greater is required.
-if ( ! function_exists( 'hash_equals' ) ) :
-	/**
-	 * Compare two strings in constant time.
-	 *
-	 * This function was added in PHP 5.6.
-	 * It can leak the length of a string.
-	 *
-	 * @since 3.9.2
-	 *
-	 * @param string $a Expected string.
-	 * @param string $b Actual string.
-	 * @return bool Whether strings are equal.
-	 */
-	function hash_equals( $a, $b ) {
-		$a_length = strlen( $a );
-		if ( strlen( $b ) !== $a_length ) {
-			return false;
-		}
-		$result = 0;
-
-		// Do not attempt to "optimize" this.
-		for ( $i = 0; $i < $a_length; $i++ ) {
-			$result |= ord( $a[ $i ] ) ^ ord( $b[ $i ] );
-		}
-
-		return 0 === $result;
-	}
-endif;
-
 /**
  * Generate a rand hash.
  *


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The hash_equals() polyfill was added back in 2015 (https://github.com/woocommerce/woocommerce/pull/7147/commits/1f62a53e0e88920fc7c7f009c6467a9228fb47e3). WP includes the same polyfill
since version 3.9.2 and WC requires WP >= 5.0 (https://github.com/WordPress/WordPress/commit/7d672c38a4d5834711c3e278fbd0a71257bb8604). So we don't need to maintain our own version of this function anymore.

### Changelog entry

> Dev - Removed `hash_equals()` polyfill as it was no longer needed.
