### PR TITLE
Added @version flag in updated notice functions

### DIFF
--- a/includes/wc-notice-functions.php
+++ b/includes/wc-notice-functions.php
@@ -66,6 +66,7 @@ function wc_has_notice( $message, $notice_type = 'success' ) {
  * Add and store a notice.
  *
  * @since 2.1
+ * @version 3.9.0
  * @param string $message     The text to display in the notice.
  * @param string $notice_type Optional. The name of the notice type - either error, success or notice.
  * @param array  $data        Optional notice data.
@@ -171,6 +172,7 @@ function wc_print_notices( $return = false ) {
  * Print a single notice immediately.
  *
  * @since 2.1
+ * @version 3.9.0
  * @param string $message The text to display in the notice.
  * @param string $notice_type Optional. The singular name of the notice type - either error, success or notice.
  * @param array  $data        Optional notice data. @since 3.9.0.
@@ -200,6 +202,7 @@ function wc_print_notice( $message, $notice_type = 'success', $data = array() ) 
  * Returns all queued notices, optionally filtered by a notice type.
  *
  * @since  2.1
+ * @version 3.9.0
  * @param  string $notice_type Optional. The singular name of the notice type - either error, success or notice.
  * @return array[]
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Just making clear that we made some changes on those functions.

Closes #25475.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

No need.
