### PR TITLE
Fix failing cart e2e test: fix setup wizard logic if new onboarding is presented

### DIFF
--- a/tests/e2e-tests/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e-tests/specs/activate-and-setup/setup-wizard.test.js
@@ -64,7 +64,6 @@ describe( 'Store owner can go through store Setup Wizard', () => {
 					// Wait for the store setup section to load
 					page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 				] );
-				await completeOldSetupWizard();
 			}
 			await completeOldSetupWizard();
 		}

--- a/tests/e2e-tests/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e-tests/specs/activate-and-setup/setup-wizard.test.js
@@ -65,9 +65,8 @@ describe( 'Store owner can go through store Setup Wizard', () => {
 					page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 				] );
 				await completeOldSetupWizard();
-			} else {
-				await completeOldSetupWizard();
 			}
+			await completeOldSetupWizard();
 		}
 	} );
 } );

--- a/tests/e2e-tests/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e-tests/specs/activate-and-setup/setup-wizard.test.js
@@ -6,6 +6,7 @@
  * Internal dependencies
  */
 import { StoreOwnerFlow } from '../../utils/flows';
+import { completeOldSetupWizard } from '../../utils/components';
 import {
 	permalinkSettingsPageSaveChanges,
 	setCheckbox,
@@ -60,148 +61,12 @@ describe( 'Store owner can go through store Setup Wizard', () => {
 					// Click on "Continue with the old setup wizard" footer link to start the old setup wizard
 					page.$eval( '.wc-setup-footer-links', elem => elem.click() ),
 
-					// Wait for the Payment section to load
+					// Wait for the store setup section to load
 					page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 				] );
+				await completeOldSetupWizard();
 			} else {
-
-				// Fill out store setup section details
-				// Select country where the store is located
-				await expect( page ).toSelect( 'select[name="store_country"]', config.get( 'addresses.admin.store.country' ) );
-				// Fill store's address - first line
-				await expect( page ).toFill( '#store_address', config.get( 'addresses.admin.store.addressfirstline' ) );
-
-				// Fill store's address - second line
-				await expect( page ).toFill( '#store_address_2', config.get( 'addresses.admin.store.addresssecondline' ) );
-
-				// Fill the city where the store is located
-				await expect( page ).toFill( '#store_city', config.get( 'addresses.admin.store.city' ) );
-
-				// Select the state where the store is located
-				await expect( page ).toSelect( 'select[name="store_state"]', config.get( 'addresses.admin.store.state') );
-
-				// Fill postcode of the store
-				await expect( page ).toFill( '#store_postcode', config.get( 'addresses.admin.store.postcode' ) );
-
-				// Select currency and type of products to sell details
-				await expect( page ).toSelect( 'select[name="currency_code"]', '\n' +
-					'\t\t\t\t\t\tUnited States (US) dollar ($ USD)\t\t\t\t\t' );
-				await expect( page ).toSelect( 'select[name="product_type"]', 'I plan to sell both physical and digital products' );
-
-				// Verify that checkbox next to "I will also be selling products or services in person." is not selected
-				await verifyCheckboxIsUnset( '#woocommerce_sell_in_person' );
-
-				// Click on "Let's go!" button to move to the next step
-				await page.$eval( 'button[name=save_step]', elem => elem.click() );
-
-				// Wait for usage tracking pop-up window to appear
-				await page.waitForSelector( '#wc-backbone-modal-dialog' );
-				await expect( page ).toMatchElement(
-					'.wc-backbone-modal-header', { text: 'Help improve WooCommerce with usage tracking' }
-					);
-
-				await page.waitForSelector( '#wc_tracker_checkbox_dialog' );
-
-				// Verify that checkbox next to "Enable usage tracking and help improve WooCommerce" is not selected
-				await verifyCheckboxIsUnset( '#wc_tracker_checkbox_dialog' );
-
-				await Promise.all( [
-					// Click on "Continue" button to move to the next step
-					page.$eval( '#wc_tracker_submit', elem => elem.click() ),
-
-					// Wait for the Payment section to load
-					page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-				] );
-
-				// Fill out payment section details
-				// Turn off Stripe account toggle
-				await page.click( '.wc-wizard-service-toggle' );
-
-				await Promise.all( [
-					// Click on "Continue" button to move to the next step
-					page.click( 'button[name=save_step]', { text: 'Continue' } ),
-
-					// Wait for the Shipping section to load
-					page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-				] );
-
-				// Fill out shipping section details
-				// Turn off WooCommerce Shipping option
-				await page.$eval( '#wc_recommended_woocommerce_services', elem => elem.click() );
-
-				await page.waitForSelector( 'select[name="shipping_zones[domestic][method]"]' );
-				await page.waitForSelector( 'select[name="shipping_zones[intl][method]"]' );
-
-				// Select Flat Rate shipping method for domestic shipping zone
-				await page.evaluate( () => {
-					document.querySelector( 'select[name="shipping_zones[domestic][method]"] > option:nth-child(1)' ).selected = true;
-					let element = document.querySelector( 'select[name="shipping_zones[domestic][method]"]' );
-					let event = new Event( 'change', { bubbles: true } );
-					event.simulated = true;
-					element.dispatchEvent( event );
-				} );
-
-				await page.$eval( 'input[name="shipping_zones[domestic][flat_rate][cost]"]', e => e.setAttribute( 'value', '10.00' ) );
-
-				// Select Flat Rate shipping method for the rest of the world shipping zone
-				await page.evaluate( () => {
-					document.querySelector( 'select[name="shipping_zones[intl][method]"] > option:nth-child(1)' ).selected = true;
-					let element = document.querySelector( 'select[name="shipping_zones[intl][method]"]' );
-					let event = new Event( 'change', { bubbles: true } );
-					event.simulated = true;
-					element.dispatchEvent( event );
-				} );
-
-				await page.$eval( 'input[name="shipping_zones[intl][flat_rate][cost]"]', e => e.setAttribute( 'value', '20.00' ) );
-
-				// Select product weight and product dimensions options
-				await expect( page ).toSelect( 'select[name="weight_unit"]', 'Pounds' );
-				await expect( page ).toSelect( 'select[name="dimension_unit"]', 'Inches' );
-
-				await Promise.all( [
-					// Click on "Continue" button to move to the next step
-					page.click( 'button[name=save_step]', { text: 'Continue' } ),
-
-					// Wait for the Recommended section to load
-					page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-				] );
-
-				// Fill out recommended section details
-				// Turn off Storefront Theme option
-				// await page.waitForSelector( '#wc_recommended_storefront_theme', { visible: true } );
-				// await page.$eval( '#wc_recommended_storefront_theme', elem => elem.click() );
-
-				// Turn off Automated Taxes option
-				await page.waitForSelector( '#wc_recommended_automated_taxes', { visible: true } );
-				await page.$eval( '#wc_recommended_automated_taxes', elem => elem.click() );
-
-				// Turn off WooCommerce Admin option
-				await page.waitForSelector( '#wc_recommended_wc_admin', { visible: true } );
-				await page.$eval( '#wc_recommended_wc_admin', elem => elem.click() );
-
-				// Turn off Mailchimp option
-				await page.waitForSelector( '#wc_recommended_mailchimp', { visible: true } );
-				await page.$eval( '#wc_recommended_mailchimp', elem => elem.click() );
-
-				// Turn off Facebook option
-				await page.waitForSelector( '#wc_recommended_facebook', { visible: true } );
-				await page.$eval( '#wc_recommended_facebook', elem => elem.click() );
-
-				await Promise.all( [
-					// Click on "Continue" button to move to the next step
-					page.click( 'button[name=save_step]', { text: 'Continue' } ),
-
-					// Wait for the Jetpack section to load
-					page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-				] );
-
-				// Skip activate Jetpack section
-				// Click on "Skip this step" in order to skip Jetpack installation
-				await page.click( '.wc-setup-footer-links' );
-
-				// Finish Setup Wizard - Ready! section
-				// Visit Dashboard
-				await StoreOwnerFlow.openDashboard();
+				await completeOldSetupWizard();
 			}
 		}
 	} );

--- a/tests/e2e-tests/utils/components.js
+++ b/tests/e2e-tests/utils/components.js
@@ -5,8 +5,8 @@
 /**
  * Internal dependencies
  */
-import { StoreOwnerFlow } from "./flows";
-import { clickTab, uiUnblocked } from "./index";
+import { StoreOwnerFlow } from './flows';
+import { clickTab, uiUnblocked, verifyCheckboxIsUnset } from './index';
 
 const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );
@@ -22,6 +22,149 @@ const verifyAndPublish = async () => {
 	// Verify
 	await expect( page ).toMatchElement( '.updated.notice', { text: 'Product published.' } );
 };
+
+/**
+ * Complete old setup wizard.
+ */
+const completeOldSetupWizard = async () => {
+	// Fill out store setup section details
+	// Select country where the store is located
+	await expect( page ).toSelect( 'select[name="store_country"]', config.get( 'addresses.admin.store.country' ) );
+	// Fill store's address - first line
+	await expect( page ).toFill( '#store_address', config.get( 'addresses.admin.store.addressfirstline' ) );
+
+	// Fill store's address - second line
+	await expect( page ).toFill( '#store_address_2', config.get( 'addresses.admin.store.addresssecondline' ) );
+
+	// Fill the city where the store is located
+	await expect( page ).toFill( '#store_city', config.get( 'addresses.admin.store.city' ) );
+
+	// Select the state where the store is located
+	await expect( page ).toSelect( 'select[name="store_state"]', config.get( 'addresses.admin.store.state') );
+
+	// Fill postcode of the store
+	await expect( page ).toFill( '#store_postcode', config.get( 'addresses.admin.store.postcode' ) );
+
+	// Select currency and type of products to sell details
+	await expect( page ).toSelect( 'select[name="currency_code"]', '\n' +
+		'\t\t\t\t\t\tUnited States (US) dollar ($ USD)\t\t\t\t\t' );
+	await expect( page ).toSelect( 'select[name="product_type"]', 'I plan to sell both physical and digital products' );
+
+	// Verify that checkbox next to "I will also be selling products or services in person." is not selected
+	await verifyCheckboxIsUnset( '#woocommerce_sell_in_person' );
+
+	// Click on "Let's go!" button to move to the next step
+	await page.$eval( 'button[name=save_step]', elem => elem.click() );
+
+	// Wait for usage tracking pop-up window to appear
+	await page.waitForSelector( '#wc-backbone-modal-dialog' );
+	await expect( page ).toMatchElement(
+		'.wc-backbone-modal-header', { text: 'Help improve WooCommerce with usage tracking' }
+	);
+
+	await page.waitForSelector( '#wc_tracker_checkbox_dialog' );
+
+	// Verify that checkbox next to "Enable usage tracking and help improve WooCommerce" is not selected
+	await verifyCheckboxIsUnset( '#wc_tracker_checkbox_dialog' );
+
+	await Promise.all( [
+		// Click on "Continue" button to move to the next step
+		page.$eval( '#wc_tracker_submit', elem => elem.click() ),
+
+		// Wait for the Payment section to load
+		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+	] );
+
+	// Fill out payment section details
+	// Turn off Stripe account toggle
+	await page.click( '.wc-wizard-service-toggle' );
+
+	await Promise.all( [
+		// Click on "Continue" button to move to the next step
+		page.click( 'button[name=save_step]', { text: 'Continue' } ),
+
+		// Wait for the Shipping section to load
+		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+	] );
+
+	// Fill out shipping section details
+	// Turn off WooCommerce Shipping option
+	await page.$eval( '#wc_recommended_woocommerce_services', elem => elem.click() );
+
+	await page.waitForSelector( 'select[name="shipping_zones[domestic][method]"]' );
+	await page.waitForSelector( 'select[name="shipping_zones[intl][method]"]' );
+
+	// Select Flat Rate shipping method for domestic shipping zone
+	await page.evaluate( () => {
+		document.querySelector( 'select[name="shipping_zones[domestic][method]"] > option:nth-child(1)' ).selected = true;
+		let element = document.querySelector( 'select[name="shipping_zones[domestic][method]"]' );
+		let event = new Event( 'change', { bubbles: true } );
+		event.simulated = true;
+		element.dispatchEvent( event );
+	} );
+
+	await page.$eval( 'input[name="shipping_zones[domestic][flat_rate][cost]"]', e => e.setAttribute( 'value', '10.00' ) );
+
+	// Select Flat Rate shipping method for the rest of the world shipping zone
+	await page.evaluate( () => {
+		document.querySelector( 'select[name="shipping_zones[intl][method]"] > option:nth-child(1)' ).selected = true;
+		let element = document.querySelector( 'select[name="shipping_zones[intl][method]"]' );
+		let event = new Event( 'change', { bubbles: true } );
+		event.simulated = true;
+		element.dispatchEvent( event );
+	} );
+
+	await page.$eval( 'input[name="shipping_zones[intl][flat_rate][cost]"]', e => e.setAttribute( 'value', '20.00' ) );
+
+	// Select product weight and product dimensions options
+	await expect( page ).toSelect( 'select[name="weight_unit"]', 'Pounds' );
+	await expect( page ).toSelect( 'select[name="dimension_unit"]', 'Inches' );
+
+	await Promise.all( [
+		// Click on "Continue" button to move to the next step
+		page.click( 'button[name=save_step]', { text: 'Continue' } ),
+
+		// Wait for the Recommended section to load
+		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+	] );
+
+	// Fill out recommended section details
+	// Turn off Storefront Theme option
+	// await page.waitForSelector( '#wc_recommended_storefront_theme', { visible: true } );
+	// await page.$eval( '#wc_recommended_storefront_theme', elem => elem.click() );
+
+	// Turn off Automated Taxes option
+	await page.waitForSelector( '#wc_recommended_automated_taxes', { visible: true } );
+	await page.$eval( '#wc_recommended_automated_taxes', elem => elem.click() );
+
+	// Turn off WooCommerce Admin option
+	await page.waitForSelector( '#wc_recommended_wc_admin', { visible: true } );
+	await page.$eval( '#wc_recommended_wc_admin', elem => elem.click() );
+
+	// Turn off Mailchimp option
+	await page.waitForSelector( '#wc_recommended_mailchimp', { visible: true } );
+	await page.$eval( '#wc_recommended_mailchimp', elem => elem.click() );
+
+	// Turn off Facebook option
+	await page.waitForSelector( '#wc_recommended_facebook', { visible: true } );
+	await page.$eval( '#wc_recommended_facebook', elem => elem.click() );
+
+	await Promise.all( [
+		// Click on "Continue" button to move to the next step
+		page.click( 'button[name=save_step]', { text: 'Continue' } ),
+
+		// Wait for the Jetpack section to load
+		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+	] );
+
+	// Skip activate Jetpack section
+	// Click on "Skip this step" in order to skip Jetpack installation
+	await page.click( '.wc-setup-footer-links' );
+
+	// Finish Setup Wizard - Ready! section
+	// Visit Dashboard
+	await StoreOwnerFlow.openDashboard();
+} ;
 
 /**
  * Create simple product.
@@ -176,4 +319,4 @@ const createVariableProduct = async () => {
 	return variablePostIdValue;
 };
 
-export { createSimpleProduct, createVariableProduct };
+export { completeOldSetupWizard, createSimpleProduct, createVariableProduct };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Cart e2e test (`tests/e2e-tests/specs/front-end/front-end-cart.test.js`) fails randomly right now with the following message:

```
FAIL  tests/e2e-tests/specs/front-end/front-end-cart.test.js (31.921s)
  Cart page
    ✕ should display no item in the cart (2350ms)
    ✕ should add the product to the cart when "Add to cart" is clicked (2867ms)
    ✕ should increase item qty when "Add to cart" of the same product is clicked (2332ms)
    ✕ should update qty when updated via qty input (1069ms)
    ✕ should remove the item from the cart when remove is clicked (1319ms)
    ✕ should update subtotal in cart totals when adding product to the cart (2320ms)
    ✕ should go to the checkout page when "Proceed to Checkout" is clicked (1864ms)

  ● Cart page › should display no item in the cart

    TimeoutError: Element .cart-empty (text: "Your cart is currently empty.") not found

      waiting for function failed: timeout 500ms exceeded

  ● Cart page › should add the product to the cart when "Add to cart" is clicked

    expect(received).resolves.toHaveLength(expected)

    Expected length: 1
    Received length: 0
    Received array:  []

      173 | 		const cartItemXPath = getCartItemExpression( productTitle, cartItemArgs );
      174 |
    > 175 | 		await expect( page.$x( cartItemXPath ) ).resolves.toHaveLength( 1 );
          | 		                                                  ^
      176 | 	},
      177 |
      178 | 	fillBillingDetails: async (	customerBillingDetails ) => {
```

In my troubleshooting, I discovered that the issue is actually not with the `cart` test but with the `setup wizard` test. When the new onboarding is present, we previously selected to go through the old onboarding in the test but there was no further step to actually complete the old onboarding when it was selected over the new one. As a result, the onboarding would not be completed and the cart page not created. The `cart` test that goes after the `setup wizard` test would fail because there is no cart page created. I noticed other tests were failing as well (not just the `cart` test) because of the exact same reason. 

This also explains why it was failing randomly - the new onboarding is not always present (currently only for 10% of the users randomly). 

### How to test the changes in this Pull Request:

To properly test it, you'd need to test with both new onboarding present and not. Once you built the test site but before you run the tests:

1. Activate new onboarding by using the following [snippet](https://gist.github.com/justinshreve/6e945dcb4714134156aba1b3c7f086cf); 
2. Run `npm run test:e2e` and make sure all tests pass;
3. Run `npm run test:e2e-dev` and make sure all tests pass.

Next, rebuild the test site by running the following commands:

1. Press `Ctrl+C` in the terminal window where the containers are running;
2. Stop the container(s) and delete all volumes using the following command: `docker-compose down -v`;
3. Restart the containers using the following command: `docker-compose up --build`.

Once the new site is built, test with the new onboarding off:

1. Deactivate new onboarding by using the following [snippet](https://gist.github.com/justinshreve/6e945dcb4714134156aba1b3c7f086cf) but change `b` to `a` instead (on line 10 of the snippet);
2. Run `npm run test:e2e` and make sure all tests pass;
3. Run `npm run test:e2e-dev` and make sure all tests pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A
