### PR TITLE
Prevent empty notices to get added

### DIFF
--- a/includes/wc-notice-functions.php
+++ b/includes/wc-notice-functions.php
@@ -84,10 +84,14 @@ function wc_add_notice( $message, $notice_type = 'success', $data = array() ) {
 		$message = apply_filters( 'woocommerce_add_message', $message );
 	}
 
-	$notices[ $notice_type ][] = array(
-		'notice' => apply_filters( 'woocommerce_add_' . $notice_type, $message ),
-		'data'   => $data,
-	);
+	$message = apply_filters( 'woocommerce_add_' . $notice_type, $message );
+
+	if ( ! empty( $message ) ) {
+		$notices[ $notice_type ][] = array(
+			'notice' => apply_filters( 'woocommerce_add_' . $notice_type, $message ),
+			'data'   => $data,
+		);
+	}
 
 	WC()->session->set( 'wc_notices', $notices );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Seems like that some 3rd party developers are hiding some of our messages, but we still output the empty HTML.

Closes #25478.

### How to test the changes in this Pull Request:

See #25478.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Prevent empty notices to get displayed on frontend.
