### PR TITLE
Check if wp_delete_user() exists before use

### DIFF
--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -344,7 +344,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 						'Subscriber',
 					)
 				),
-				'meta_query' => array(
+				'meta_query' => array( // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					'relation' => 'AND',
 					array(
 						'key'     => 'wc_last_active',
@@ -365,6 +365,10 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		$user_ids = $user_query->get_results();
 
 		if ( $user_ids ) {
+			if ( ! function_exists( 'wp_delete_user' ) ) {
+				require_once ABSPATH . 'wp-admin/includes/user.php';
+			}
+
 			foreach ( $user_ids as $user_id ) {
 				wp_delete_user( $user_id );
 				$count ++;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`wp_delete_user()` core functions is available only in the `wp-admin`, this function is included from `wp-admin/includes/user.php`, so any use in the front-end may cause "Undefined function" errors from PHP.

Closes #25338.

### How to test the changes in this Pull Request:

It's not easy to test it, and also we can't ensure that the error will occurs, since it may get triggered by the back-end where the function is included, anyway if you like to test it's possible with the follow steps:

1. Go to `wp-admin/admin.php?page=wc-settings&tab=account` and set some value to "Retain inactive accounts".
2. Create some user, and set some value for `wc_last_active`, e.g.: `update_user_meta( $user_id, 'wc_last_active', strtotime( '-2 years' ) );`
3. Wait for the next time that `woocommerce_cleanup_personal_data` will run, or if you can try force it with `wp_schedule_single_event( time() + 10, 'woocommerce_cleanup_personal_data' );`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Prevent undefined wp_delete_user() error while removing inactive accounts.
