### PR TITLE
Fix wrong context help for translators

### DIFF
--- a/includes/payment-tokens/class-wc-payment-token-echeck.php
+++ b/includes/payment-tokens/class-wc-payment-token-echeck.php
@@ -46,7 +46,7 @@ class WC_Payment_Token_ECheck extends WC_Payment_Token {
 	 */
 	public function get_display_name( $deprecated = '' ) {
 		$display = sprintf(
-			/* translators: 1: credit card type 2: last 4 digits 3: expiry month 4: expiry year */
+			/* translators: 1: last 4 digits */
 			__( 'eCheck ending in %1$s', 'woocommerce' ),
 			$this->get_last4()
 		);


### PR DESCRIPTION
I found this very confusing at https://translate.wordpress.org/projects/wp-plugins/woocommerce/stable/de/default/?filters%5Bterm%5D=ending+in&filters%5Buser_login%5D=&filters%5Bstatus%5D=current_or_waiting_or_fuzzy_or_untranslated&filter=Filter&sort%5Bby%5D=priority&sort%5Bhow%5D=desc that the comment is wrong for translator.

I mean the "Comment" here is confusing, cause it talks about several arguments when there is only one:
![image](https://user-images.githubusercontent.com/12525563/73138629-35666900-4065-11ea-828b-7afbc17f4567.png)

Here's a fix.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
