### PR TITLE
[4.0] Increase Onboarding A/B Test to 50%

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -158,7 +158,7 @@ class WC_Admin_Setup_Wizard {
 
 		// If it doesn't exist yet, generate it for later use and save it, so we always show the same to this user.
 		if ( ! $ab_test ) {
-			$ab_test = 1 !== rand( 1, 10 ) ? 'a' : 'b'; // 10% of users. b gets the new experience.
+			$ab_test = 1 !== rand( 1, 2 ) ? 'a' : 'b'; // 50% of users. b gets the new experience.
 			update_option( 'woocommerce_setup_ab_wc_admin_onboarding', $ab_test );
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This branch increases the a/b test size of the new onboarding flow from 10% to 50%

Closes #25487 .

### How to test the changes in this Pull Request:

1. You can still force-test the new onboarding by manually setting the `woocommerce_setup_ab_wc_admin_onboarding` option to `b`. Otherwise not much to test here.
### Changelog entry

> Tweak - Increase onboarding A/B test to 50%.
