### PR TITLE
Use enable onboarding path instead of manually setting onboarding option

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -512,6 +512,10 @@ class WC_Admin_Setup_Wizard {
 	 * Redirects to the onboarding wizard in WooCommerce Admin.
 	 */
 	private function wc_setup_redirect_to_wc_admin_onboarding() {
+		if ( ! function_exists( 'wc_admin_url' ) ) {
+			return;
+		}
+
 		// Renables the wizard.
 		$profile_updates = array( 'completed' => false );
 		$onboarding_data = get_option( 'woocommerce_onboarding_profile', array() );

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -487,8 +487,6 @@ class WC_Admin_Setup_Wizard {
 	public function wc_setup_new_onboarding_save() {
 		check_admin_referer( 'wc-setup' );
 
-		update_option( 'wc_onboarding_opt_in', 'yes' );
-
 		if ( function_exists( 'wc_admin_url' ) ) {
 			$this->wc_setup_redirect_to_wc_admin_onboarding();
 			exit;
@@ -521,7 +519,7 @@ class WC_Admin_Setup_Wizard {
 		$onboarding_data = get_option( 'wc_onboarding_profile', array() );
 		update_option( 'wc_onboarding_profile', array_merge( $onboarding_data, $profile_updates ) );
 
-		wp_safe_redirect( esc_url_raw( admin_url( 'admin.php?page=wc-admin' ) ) );
+		wp_safe_redirect( wc_admin_url( '&enable_onboarding=1' ) );
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -489,7 +489,6 @@ class WC_Admin_Setup_Wizard {
 
 		if ( function_exists( 'wc_admin_url' ) ) {
 			$this->wc_setup_redirect_to_wc_admin_onboarding();
-			exit;
 		}
 
 		WC_Install::background_installer(
@@ -507,7 +506,6 @@ class WC_Admin_Setup_Wizard {
 		}
 
 		$this->wc_setup_redirect_to_wc_admin_onboarding();
-		exit;
 	}
 
 	/**
@@ -516,10 +514,11 @@ class WC_Admin_Setup_Wizard {
 	private function wc_setup_redirect_to_wc_admin_onboarding() {
 		// Renables the wizard.
 		$profile_updates = array( 'completed' => false );
-		$onboarding_data = get_option( 'wc_onboarding_profile', array() );
-		update_option( 'wc_onboarding_profile', array_merge( $onboarding_data, $profile_updates ) );
+		$onboarding_data = get_option( 'woocommerce_onboarding_profile', array() );
+		update_option( 'woocommerce_onboarding_profile', array_merge( $onboarding_data, $profile_updates ) );
 
 		wp_safe_redirect( wc_admin_url( '&enable_onboarding=1' ) );
+		exit;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Use wc admin built-in methods to enable onboarding

Closes #25526 

### How to test the changes in this Pull Request:

1. Create a new site.
1. Check out this branch
1. Force the new onboarding via `update_option( 'woocommerce_setup_ab_wc_admin_onboarding', 'b' )`
1. Upload and activate https://github.com/woocommerce/woocommerce-admin/releases/tag/v0.25.0-plugin
1. Go to `/wp-admin?page=wc-setup`
1. Click the button to use the new experience.
1. Check that the new onboarding experience is enabled and you end up in the profiler.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?