### PR TITLE
Use query params as fallback for obtaining authentication data in plugin installer API

### DIFF
--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -192,10 +192,10 @@ class WC_WCCOM_Site {
 	 * @return bool
 	 */
 	protected static function is_request_to_wccom_site_rest_api() {
-		$rest_prefix = '';
 
 		if ( isset( $_REQUEST['rest_route'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$route = wp_unslash( $_REQUEST['rest_route'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+			$route       = wp_unslash( $_REQUEST['rest_route'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification.Recommended
+			$rest_prefix = '';
 		} else {
 			$route       = wp_unslash( add_query_arg( array() ) );
 			$rest_prefix = trailingslashit( rest_get_url_prefix() );

--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -217,7 +217,7 @@ class WC_WCCOM_Site {
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$data = array(
 			'host'        => $_SERVER['HTTP_HOST'],
-			'request_uri' => urldecode( remove_query_arg( array( 'token', 'signature' ) ) ),
+			'request_uri' => urldecode( remove_query_arg( array( 'token', 'signature' ), $_SERVER['REQUEST_URI'] ) ),
 			'method'      => strtoupper( $_SERVER['REQUEST_METHOD'] ),
 		);
 		// phpcs:enable

--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -53,45 +53,38 @@ class WC_WCCOM_Site {
 			return $user_id;
 		}
 
-		$auth_header = self::get_authorization_header();
-		if ( empty( $auth_header ) ) {
+		$auth_header = trim( self::get_authorization_header() );
+
+		if ( stripos( $auth_header, 'Bearer ' ) === 0 ) {
+			$access_token = trim( substr( $auth_header, 7 ) );
+		} elseif ( ! empty( $_GET['token'] ) && is_string( $_GET['token'] ) ) {  // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$access_token = trim( $_GET['token'] );  // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		} else {
 			add_filter(
 				self::AUTH_ERROR_FILTER_NAME,
 				function() {
 					return new WP_Error(
-						WC_REST_WCCOM_Site_Installer_Errors::NO_AUTH_HEADER_CODE,
-						WC_REST_WCCOM_Site_Installer_Errors::NO_AUTH_HEADER_MESSAGE,
-						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::NO_AUTH_HEADER_HTTP_CODE )
+						WC_REST_WCCOM_Site_Installer_Errors::NO_ACCESS_TOKEN_CODE,
+						WC_REST_WCCOM_Site_Installer_Errors::NO_ACCESS_TOKEN_MESSAGE,
+						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::NO_ACCESS_TOKEN_HTTP_CODE )
 					);
 				}
 			);
 			return false;
 		}
 
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-		$request_auth = trim( $auth_header );
-		if ( stripos( $request_auth, 'Bearer ' ) !== 0 ) {
+		if ( ! empty( $_SERVER['HTTP_X_WOO_SIGNATURE'] ) ) {
+			$signature = trim( $_SERVER['HTTP_X_WOO_SIGNATURE'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		} elseif ( ! empty( $_GET['signature'] ) && is_string( $_GET['signature'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$signature = trim( $_GET['signature'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		} else {
 			add_filter(
 				self::AUTH_ERROR_FILTER_NAME,
 				function() {
 					return new WP_Error(
-						WC_REST_WCCOM_Site_Installer_Errors::INVALID_AUTH_HEADER_CODE,
-						WC_REST_WCCOM_Site_Installer_Errors::INVALID_AUTH_HEADER_MESSAGE,
-						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::INVALID_AUTH_HEADER_HTTP_CODE )
-					);
-				}
-			);
-			return false;
-		}
-
-		if ( empty( $_SERVER['HTTP_X_WOO_SIGNATURE'] ) ) {
-			add_filter(
-				self::AUTH_ERROR_FILTER_NAME,
-				function() {
-					return new WP_Error(
-						WC_REST_WCCOM_Site_Installer_Errors::NO_SIGNATURE_HEADER_CODE,
-						WC_REST_WCCOM_Site_Installer_Errors::NO_SIGNATURE_HEADER_MESSAGE,
-						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::NO_SIGNATURE_HEADER_HTTP_CODE )
+						WC_REST_WCCOM_Site_Installer_Errors::NO_SIGNATURE_CODE,
+						WC_REST_WCCOM_Site_Installer_Errors::NO_SIGNATURE_MESSAGE,
+						array( 'status' => WC_REST_WCCOM_Site_Installer_Errors::NO_SIGNATURE_HTTP_CODE )
 					);
 				}
 			);
@@ -99,8 +92,7 @@ class WC_WCCOM_Site {
 		}
 
 		require_once WC_ABSPATH . 'includes/admin/helper/class-wc-helper-options.php';
-		$access_token = trim( substr( $request_auth, 7 ) );
-		$site_auth    = WC_Helper_Options::get( 'auth' );
+		$site_auth = WC_Helper_Options::get( 'auth' );
 
 		if ( empty( $site_auth['access_token'] ) ) {
 			add_filter(
@@ -130,8 +122,7 @@ class WC_WCCOM_Site {
 			return false;
 		}
 
-		$body      = WP_REST_Server::get_raw_data();
-		$signature = trim( $_SERVER['HTTP_X_WOO_SIGNATURE'] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$body = WP_REST_Server::get_raw_data();
 
 		if ( ! self::verify_wccom_request( $body, $signature, $site_auth['access_token_secret'] ) ) {
 			add_filter(
@@ -226,7 +217,7 @@ class WC_WCCOM_Site {
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotValidated, WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		$data = array(
 			'host'        => $_SERVER['HTTP_HOST'],
-			'request_uri' => $_SERVER['REQUEST_URI'],
+			'request_uri' => urldecode( remove_query_arg( array( 'token', 'signature' ) ) ),
 			'method'      => strtoupper( $_SERVER['REQUEST_METHOD'] ),
 		);
 		// phpcs:enable

--- a/includes/wccom-site/rest-api/class-wc-rest-wccom-site-installer-errors.php
+++ b/includes/wccom-site/rest-api/class-wc-rest-wccom-site-installer-errors.php
@@ -23,25 +23,18 @@ class WC_REST_WCCOM_Site_Installer_Errors {
 	const NOT_AUTHENTICATED_HTTP_CODE = 401;
 
 	/**
-	 * No Authorization header
+	 * No access token provided
 	 */
-	const NO_AUTH_HEADER_CODE      = 'no_auth_header';
-	const NO_AUTH_HEADER_MESSAGE   = 'No header "Authorization" present';
-	const NO_AUTH_HEADER_HTTP_CODE = 400;
+	const NO_ACCESS_TOKEN_CODE      = 'no_access_token';
+	const NO_ACCESS_TOKEN_MESSAGE   = 'No access token provided';
+	const NO_ACCESS_TOKEN_HTTP_CODE = 400;
 
 	/**
-	 * Authorization header invalid
+	 * No signature provided
 	 */
-	const INVALID_AUTH_HEADER_CODE      = 'no_auth_header';
-	const INVALID_AUTH_HEADER_MESSAGE   = 'Header "Authorization" is invalid';
-	const INVALID_AUTH_HEADER_HTTP_CODE = 400;
-
-	/**
-	 * No Signature header
-	 */
-	const NO_SIGNATURE_HEADER_CODE      = 'no_signature_header';
-	const NO_SIGNATURE_HEADER_MESSAGE   = 'No header "X-Woo-Signature" present';
-	const NO_SIGNATURE_HEADER_HTTP_CODE = 400;
+	const NO_SIGNATURE_CODE      = 'no_signature';
+	const NO_SIGNATURE_MESSAGE   = 'No signature provided';
+	const NO_SIGNATURE_HTTP_CODE = 400;
 
 	/**
 	 * Site not connected to WooCommerce.com

--- a/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
+++ b/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
@@ -51,6 +51,12 @@ class WC_REST_WCCOM_Site_Installer_Controller extends WC_REST_Controller {
 					'methods'             => WP_REST_Server::CREATABLE,
 					'callback'            => array( $this, 'install' ),
 					'permission_callback' => array( $this, 'check_permission' ),
+					'args'                => array(
+						'products' => array(
+							'required' => true,
+							'type'     => 'array',
+						),
+					),
 				),
 				array(
 					'methods'             => WP_REST_Server::DELETABLE,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

A big amount of plugin installation attempts are failing due to a missing access token in the request to plugin installer API. The access token is sent in the “Authorization” header, which gets removed on the way from WooCommerce.com to the Woo store.

This PR introduces an alternative way to obtain an access token and additionally a request signature through query parameters in case corresponding request headers are not present.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Connect your Woo store to WooCommerce.com from [this page](https://wp.test:444/wp-admin/admin.php?page=wc-addons&section=helper) if it is not connected. Note that you'll need a WooCommerce.com account in order to do that.
3. Get access token and access token secret of the established connection from options by running the 
following query to the DB:
  ```sql
  SELECT option_value FROM `wp_options` WHERE `option_name` = 'woocommerce_helper_data';
  ```
4. Run this PHP code to generate a valid request signature, which will be used further in the request to installer API. (You may run PHP code from the shell `php -a`)
  ```php
  php -r "echo hash_hmac( 'sha256', json_encode( array('host' => 'local-wp-site.test', 'request_uri' => '/?rest_route=/wccom-site/v1/installer/', 'method' => 'GET')), 'access_token_secret' );"
  ```
  Replace `local-wp-site.test` with your local Woo store host and `access_token_secret` with the access token secret you got from the DB.

5. Make the following requests to installer API endpoint and confirm they return the same 200 response with json encoded object.
  Passing auth data in headers (the old way):
  ```bash
  curl -k 'https://local-wp-site.test/?rest_route=/wccom-site/v1/installer/' \
--header 'Authorization: Bearer ACCESS_TOKEN' \
--header 'X-Woo-Signature: SIGNATURE'
  ```
  Passing auth data in query params (the new way):
  ```bash
  curl -k 'https://local-wp-site.test/?rest_route=/wccom-site/v1/installer/&token=ACCESS_TOKEN&signature=SIGNATURE'
  ```
  Replace `local-wp-site.test'` with your local Woo store host, `ACCESS_TOKEN` with the access token secret you got from the DB, `SIGNATURE` with the signature you obtained on previous step.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

WooCommerce.com plugins auto-install improvement.