### PR TITLE
Add query params as fallback for passing authentication data to WC Helper API

### DIFF
--- a/includes/admin/helper/class-wc-helper-api.php
+++ b/includes/admin/helper/class-wc-helper-api.php
@@ -56,7 +56,7 @@ class WC_Helper_API {
 	 * @param array  $args By-ref, the args that will be passed to wp_remote_request().
 	 * @return bool Were the headers added?
 	 */
-	private static function _authenticate( $url, &$args ) {
+	private static function _authenticate( &$url, &$args ) {
 		$auth = WC_Helper_Options::get( 'auth' );
 
 		if ( empty( $auth['access_token'] ) || empty( $auth['access_token_secret'] ) ) {
@@ -88,6 +88,14 @@ class WC_Helper_API {
 		$args['headers'] = array(
 			'Authorization'   => 'Bearer ' . $auth['access_token'],
 			'X-Woo-Signature' => $signature,
+		);
+
+		$url = add_query_arg(
+			array(
+				'token'     => $auth['access_token'],
+				'signature' => $signature,
+			),
+			$url
 		);
 
 		return true;

--- a/includes/admin/helper/class-wc-helper-api.php
+++ b/includes/admin/helper/class-wc-helper-api.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * WooCommerce Admin
+ *
+ * @class    WC_Helper_API
+ * @package  WooCommerce/Admin
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -9,6 +16,11 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Provides a communication interface with the WooCommerce.com Helper API.
  */
 class WC_Helper_API {
+	/**
+	 * Base path for API routes.
+	 *
+	 * @var $api_base
+	 */
 	public static $api_base;
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Many requests to WC Helper API miss authentication data (access token and signature), passed in the request headers. The headers get removed on the way from Woo store to WooCommerce.com by intermediate parties.

Pass access token and signature in query params for extra reliability to ensure the auth data gets delivered.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Add the following code to file [/includes/admin/helper/class-wc-helper-api.php line 59](https://github.com/woocommerce/woocommerce/blob/e496d6ea3fa9e6b84a896a24fedae4432ae1171d/includes/admin/helper/class-wc-helper-api.php#L59) to log URLs of the outgoing requests to WC Helper API.
  ```php
  error_log($url);
  ```
3. Ensure you have debug mode and saving logs to file enabled in `wp-config.php`:
  ```php
  define( 'WP_DEBUG', true);
  define( 'WP_DEBUG_LOG', true );
  ```
4. Go to [WooCommerce.com Subscriptions](https://wp.test:444/wp-admin/admin.php?page=wc-addons&section=helper) section and connect your store to WooCommerce.com. If it is already connected, click **Update** subscriptions.
5. View your `debug.log` file and confirm the logged request URLs contain `token` and `signature` query params, like this:
  ```
  [03-Feb-2020 20:24:43 UTC] https://woocommerce.test/wp-json/helper/1.0/update-check?token=a8a12369e1be606e85ac24e73acd0dcdef0007cx&signature=e1bb6225fc4b18f275a810b9791043e8658800dda3c48708e898fc1a70b3897c
  ```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - WooCommerce.com plugins auto-install and update improvement.

