### PR TITLE
Find the correct form element to update.

### DIFF
--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -168,7 +168,10 @@ jQuery( function( $ ) {
 
 	$( '.wc-wizard-services' ).on( 'change', '.wc-wizard-shipping-method-enable', function() {
 		var checked = $( this ).is( ':checked' );
-		var selectedMethod = $( '.wc-wizard-shipping-method-select .method' ).val();
+		var selectedMethod = $( this )
+			.closest( '.wc-wizard-service-item' )
+			.find( '.wc-wizard-shipping-method-select .method' )
+			.val();
 
 		$( this )
 			.closest( '.wc-wizard-service-item' )


### PR DESCRIPTION
Previously it just found the first one, which made the second checkbox buggy.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25358 .

### How to test the changes in this Pull Request:

1. Set up a new site or remove your shipping setup on existing site.
2. Start the setup wizard (e.g. via WooCommerce > Orders > Help > Setup Wizard)
3. At the shipping step, choose Free shipping for local shipping zone 
4. Then disable the checkbox next to 'Locations not covered...'
5. Try to go to the next step
6. See error
7. Apply branch and force reload to refresh JS
8. It should now allow you to continue with the setup wizard

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Setup wizard shipping setup verification logic correction.
