### PR TITLE
Updated since tags for the upcoming version.

### DIFF
--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -921,7 +921,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	/**
 	 * Helper that can be hooked to a filter to force the customer's shipping postal code to be ANN NAA.
 	 *
-	 * @since 3.10.0
+	 * @since 4.0.0
 	 * @param string $postcode Postal code..
 	 * @return string
 	 */
@@ -943,7 +943,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	/**
 	 * Helper that can be hooked to a filter to force the customer's shipping state to be NY.
 	 *
-	 * @since 3.10.0
+	 * @since 4.0.0
 	 * @param string $state State code.
 	 * @return string
 	 */
@@ -954,7 +954,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	/**
 	 * Helper that can be hooked to a filter to force the customer's shipping postal code to be 12345.
 	 *
-	 * @since 3.10.0
+	 * @since 4.0.0
 	 * @param string $postcode Postal code.
 	 * @return string
 	 */

--- a/tests/unit-tests/shipping/shipping.php
+++ b/tests/unit-tests/shipping/shipping.php
@@ -9,14 +9,14 @@
  * WC_Tests_Shipping tests.
  *
  * @package WooCommerce\Tests\Shipping
- * @since 3.10.0
+ * @since 4.0.0
  */
 class WC_Tests_Shipping extends WC_Unit_Test_Case {
 
 	/**
 	 * Tests that whether or not a package is shippable is evaluated correctly.
 	 *
-	 * @since 3.10.0
+	 * @since 4.0.0
 	 */
 	public function test_is_package_shippable() {
 		$shipping = new WC_Shipping();


### PR DESCRIPTION
Replaced tag `@since 3.10` -> `@since 4.0` in master.