### PR TITLE
Removed WC Admin from the Setup Wizard if it's already active.

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -136,7 +136,7 @@ class WC_Admin_Setup_Wizard {
 	 *
 	 * @return boolean
 	 */
-	protected function is_wc_admin_included_in_wc() {
+	protected function is_wc_admin_active() {
 		return function_exists( 'wc_admin_url' );
 	}
 
@@ -151,7 +151,7 @@ class WC_Admin_Setup_Wizard {
 	 */
 	protected function should_show_wc_admin() {
 		$wordpress_minimum_met = version_compare( get_bloginfo( 'version' ), $this->wc_admin_plugin_minimum_wordpress_version, '>=' );
-		return current_user_can( 'install_plugins' ) && $wordpress_minimum_met && ! $this->is_wc_admin_included_in_wc();
+		return current_user_can( 'install_plugins' ) && $wordpress_minimum_met && ! $this->is_wc_admin_active();
 	}
 
 	/**
@@ -160,7 +160,7 @@ class WC_Admin_Setup_Wizard {
 	 * @return boolean
 	 */
 	protected function should_show_wc_admin_onboarding() {
-		if ( ! $this->should_show_wc_admin() && ! $this->is_wc_admin_included_in_wc() ) {
+		if ( ! $this->should_show_wc_admin() && ! $this->is_wc_admin_active() ) {
 			return false;
 		}
 
@@ -485,7 +485,7 @@ class WC_Admin_Setup_Wizard {
 						<button class="button-primary button button-large" value="<?php esc_attr_e( 'Yes please', 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( 'Yes please', 'woocommerce' ); ?></button>
 					</p>
 				</form>
-				<?php if ( ! $this->is_wc_admin_included_in_wc() ) : ?>
+				<?php if ( ! $this->is_wc_admin_active() ) : ?>
 					<p class="wc-setup-step__new_onboarding-plugin-info"><?php esc_html_e( 'The "WooCommerce Admin" plugin will be installed and activated', 'woocommerce' ); ?></p>
 				<?php endif; ?>
 			</div>
@@ -498,7 +498,7 @@ class WC_Admin_Setup_Wizard {
 	public function wc_setup_new_onboarding_save() {
 		check_admin_referer( 'wc-setup' );
 
-		if ( $this->is_wc_admin_included_in_wc() ) {
+		if ( $this->is_wc_admin_active() ) {
 			$this->wc_setup_redirect_to_wc_admin_onboarding();
 		}
 
@@ -511,7 +511,7 @@ class WC_Admin_Setup_Wizard {
 		);
 
 		// The plugin was not successfully installed, so continue with normal setup.
-		if ( ! $this->is_wc_admin_included_in_wc() ) {
+		if ( ! $this->is_wc_admin_active() ) {
 			wp_safe_redirect( esc_url_raw( $this->get_next_step_link() ) );
 			exit;
 		}
@@ -523,7 +523,7 @@ class WC_Admin_Setup_Wizard {
 	 * Redirects to the onboarding wizard in WooCommerce Admin.
 	 */
 	private function wc_setup_redirect_to_wc_admin_onboarding() {
-		if ( ! $this->is_wc_admin_included_in_wc() ) {
+		if ( ! $this->is_wc_admin_active() ) {
 			return;
 		}
 

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -523,7 +523,7 @@ class WC_Admin_Setup_Wizard {
 	 * Redirects to the onboarding wizard in WooCommerce Admin.
 	 */
 	private function wc_setup_redirect_to_wc_admin_onboarding() {
-		if ( ! function_exists( 'wc_admin_url' ) ) {
+		if ( ! $this->is_wc_admin_included_in_wc() ) {
 			return;
 		}
 


### PR DESCRIPTION
Also, removed info about plugin installation if the plugin is active.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25560  .

### How to test the changes in this Pull Request:

1. Install WC
2. Install WC Admin
3. Activate WC, but return back from the wizard
4. Test the old OBW by updating option `woocommerce_setup_ab_wc_admin_onboarding` to value `a`:
5. Go to Setup Wizard (e.g. from WC > Orders > Help > Setup Wizard), go to Recommended step
6. WC Admin should not appear in the list of recommended plugins
6. Go back to WP admin
7. Deactivate/remove WC Admin
8. Go back to setup wizard, check the Recommended step, it should now show WC Admin
9. Test the new OBW by updating option `woocommerce_setup_ab_wc_admin_onboarding` to value `b`
10. Activate WC Admin again
11. Check the new OBW welcome screen, it should _not_ say it's going to install WC Admin anymore
12. Going to next step should launch the new OBW
13. If WC Admin is not present, user should be informed about the installation of the plugin when initiating the new OBW flow.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Removed WC Admin from the Setup Wizard if it's already active.
