### PR TITLE
Textdomain update improvement

### DIFF
--- a/bin/package-update-textdomain.js
+++ b/bin/package-update-textdomain.js
@@ -5,4 +5,21 @@ wpTextdomain( 'packages/**/*.php', {
 	fix: true,
 	missingDomain: true,
 	variableDomain: true,
+	keywords: [
+		'__:1,2d',
+		'_e:1,2d',
+		'_x:1,2c,3d',
+		'esc_html__:1,2d',
+		'esc_html_e:1,2d',
+		'esc_html_x:1,2c,3d',
+		'esc_attr__:1,2d',
+		'esc_attr_e:1,2d',
+		'esc_attr_x:1,2c,3d',
+		'_ex:1,2c,3d',
+		'_n:1,2,4d',
+		'_nx:1,2,4c,5d',
+		'_n_noop:1,2,3d',
+		'_nx_noop:1,2,3c,4d',
+		'wp_set_script_translations:1,2d,3'
+	],
 } );

--- a/bin/package-update.sh
+++ b/bin/package-update.sh
@@ -26,8 +26,15 @@ composer dump-autoload
 output 2 "Done"
 
 # Convert textdomains
-output 3 "Updating package textdomains..."
+output 3 "Updating package PHP textdomains..."
 
 # Replace text domains within packages with woocommerce
 npm run packages:fix:textdomain
+output 2 "Done!"
+
+output 3 "Updating package JS textdomains..."
+find ./packages/woocommerce-blocks -iname '*.js' -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" -e "s/\"woo-gutenberg-products-block\"/'woocommerce'/g" {} \;
+
+# Cleanup backup files
+find ./packages -name "*.bak" -type f -delete
 output 2 "Done!"


### PR DESCRIPTION
- leave handling of PHP files to wp-textdomain, as it can parse PHP, it's a better solution than `sed`
- handle JS files using `sed`, as we don't seem to have an off the shelf solution
- included `wp_set_script_translations` in the list of functions for which the domain will get updated