### PR TITLE
Adds a `woocommerce_shortcode_products_query_results` hook

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -593,7 +593,7 @@ class WC_Shortcode_Products {
 		// Remove ordering query arguments which may have been added by get_catalog_ordering_args.
 		WC()->query->remove_ordering_args();
 
-		return $results;
+		return apply_filters( 'woocommerce_shortcode_products_query_results', $results );
 	}
 
 	/**

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -593,7 +593,14 @@ class WC_Shortcode_Products {
 		// Remove ordering query arguments which may have been added by get_catalog_ordering_args.
 		WC()->query->remove_ordering_args();
 
-		return apply_filters( 'woocommerce_shortcode_products_query_results', $results );
+		/**
+		 * Filter shortcode products query results.
+		 *
+		 * @since 4.0.0
+		 * @param stdClass $results Query results.
+		 * @param WC_Shortcode_Products $this WC_Shortcode_Products instance.
+		 */
+		return apply_filters( 'woocommerce_shortcode_products_query_results', $results, $this );
 	}
 
 	/**


### PR DESCRIPTION
This hook makes it easier to grab a [products] shortcode's result data (product IDs, pager data).

### Problem

I discovered that Elementor Pro was actually calling `WC_Shortcode_Products->get_query_results()` **twice** because there isn't a better way to grab shortcode result counts.

<img src="https://cdn-std.droplr.net/files/acc_173670/iZwNLy" />

### Solution

This new hook will allow users (and developers, like the Elementor team) to grab query result data much more efficiently.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:

Since this is a simple hook, this should not impact existing functionality.

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced `woocommerce_shortcode_products_query_results` filter.