### PR TITLE
Add Group Descriptions for Privacy Exporters

### DIFF
--- a/includes/class-wc-privacy-exporters.php
+++ b/includes/class-wc-privacy-exporters.php
@@ -27,10 +27,11 @@ class WC_Privacy_Exporters {
 			$customer_personal_data = self::get_customer_personal_data( $user );
 			if ( ! empty( $customer_personal_data ) ) {
 				$data_to_export[] = array(
-					'group_id'    => 'woocommerce_customer',
-					'group_label' => __( 'Customer Data', 'woocommerce' ),
-					'item_id'     => 'user',
-					'data'        => $customer_personal_data,
+					'group_id'          => 'woocommerce_customer',
+					'group_label'       => __( 'Customer Data', 'woocommerce' ),
+					'group_description' => __( 'User&#8217;s WooCommerce customer data.', 'woocommerce' ),
+					'item_id'           => 'user',
+					'data'              => $customer_personal_data,
 				);
 			}
 		}
@@ -71,10 +72,11 @@ class WC_Privacy_Exporters {
 		if ( 0 < count( $orders ) ) {
 			foreach ( $orders as $order ) {
 				$data_to_export[] = array(
-					'group_id'    => 'woocommerce_orders',
-					'group_label' => __( 'Orders', 'woocommerce' ),
-					'item_id'     => 'order-' . $order->get_id(),
-					'data'        => self::get_order_personal_data( $order ),
+					'group_id'          => 'woocommerce_orders',
+					'group_label'       => __( 'Orders', 'woocommerce' ),
+					'group_description' => __( 'User&#8217;s WooCommerce orders data.', 'woocommerce' ),
+					'item_id'           => 'order-' . $order->get_id(),
+					'data'              => self::get_order_personal_data( $order ),
 				);
 			}
 			$done = 10 > count( $orders );
@@ -118,22 +120,24 @@ class WC_Privacy_Exporters {
 		if ( 0 < count( $downloads ) ) {
 			foreach ( $downloads as $download ) {
 				$data_to_export[] = array(
-					'group_id'    => 'woocommerce_downloads',
+					'group_id'          => 'woocommerce_downloads',
 					/* translators: This is the headline for a list of downloads purchased from the store for a given user. */
-					'group_label' => __( 'Purchased Downloads', 'woocommerce' ),
-					'item_id'     => 'download-' . $download->get_id(),
-					'data'        => self::get_download_personal_data( $download ),
+					'group_label'       => __( 'Purchased Downloads', 'woocommerce' ),
+					'group_description' => __( 'User&#8217;s WooCommerce purchased downloads data.', 'woocommerce' ),
+					'item_id'           => 'download-' . $download->get_id(),
+					'data'              => self::get_download_personal_data( $download ),
 				);
 
 				$download_logs = $customer_download_log_data_store->get_download_logs_for_permission( $download->get_id() );
 
 				foreach ( $download_logs as $download_log ) {
 					$data_to_export[] = array(
-						'group_id'    => 'woocommerce_download_logs',
+						'group_id'          => 'woocommerce_download_logs',
 						/* translators: This is the headline for a list of access logs for downloads purchased from the store for a given user. */
-						'group_label' => __( 'Access to Purchased Downloads', 'woocommerce' ),
-						'item_id'     => 'download-log-' . $download_log->get_id(),
-						'data'        => array(
+						'group_label'       => __( 'Access to Purchased Downloads', 'woocommerce' ),
+						'group_description' => __( 'User&#8217;s WooCommerce access to purchased downloads data.', 'woocommerce' ),
+						'item_id'           => 'download-log-' . $download_log->get_id(),
+						'data'              => array(
 							array(
 								'name'  => __( 'Download ID', 'woocommerce' ),
 								'value' => $download_log->get_permission_id(),
@@ -413,10 +417,11 @@ class WC_Privacy_Exporters {
 		if ( 0 < count( $tokens ) ) {
 			foreach ( $tokens as $token ) {
 				$data_to_export[] = array(
-					'group_id'    => 'woocommerce_tokens',
-					'group_label' => __( 'Payment Tokens', 'woocommerce' ),
-					'item_id'     => 'token-' . $token->get_id(),
-					'data'        => array(
+					'group_id'          => 'woocommerce_tokens',
+					'group_label'       => __( 'Payment Tokens', 'woocommerce' ),
+					'group_description' => __( 'User&#8217;s WooCommerce payment tokens data.', 'woocommerce' ),
+					'item_id'           => 'token-' . $token->get_id(),
+					'data'              => array(
 						array(
 							'name'  => __( 'Token', 'woocommerce' ),
 							'value' => $token->get_display_name(),

--- a/tests/unit-tests/privacy/export.php
+++ b/tests/unit-tests/privacy/export.php
@@ -71,10 +71,11 @@ class WC_Test_Privacy_Export extends WC_Unit_Test_Case {
 		$this->assertEquals(
 			array(
 				array(
-					'group_id'    => 'woocommerce_customer',
-					'group_label' => 'Customer Data',
-					'item_id'     => 'user',
-					'data'        => array(
+					'group_id'          => 'woocommerce_customer',
+					'group_label'       => 'Customer Data',
+					'group_description' => 'User&#8217;s WooCommerce customer data.',
+					'item_id'           => 'user',
+					'data'              => array(
 						array(
 							'name'  => 'Billing Address 1',
 							'value' => '123 South Street',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds support for group_description for privacy exporters which was added in WP5.3 through [WPCoreChangeset#45825](https://core.trac.wordpress.org/changeset/45825) and [WPCoreTracTicket#45491](https://core.trac.wordpress.org/ticket/45491)

### How to test the changes in this Pull Request:

1. Create customers will all exportable data types.
2. Run exporter.
3. Open export index.html to view new Group Description which are placed just after the Group Labels.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Adds support for the new group descriptions available on WordPress privacy exporters as of WP 5.3.