### PR TITLE
Remove stale .order-actions css

### DIFF
--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -1135,14 +1135,6 @@ p.demo_store,
 		.button {
 			white-space: nowrap;
 		}
-
-		.order-actions {
-			text-align: right;
-
-			.button {
-				margin: 0.125em 0 0.125em 0.25em;
-			}
-		}
 	}
 
 	table.woocommerce-MyAccount-downloads {


### PR DESCRIPTION
Since commit https://github.com/woocommerce/woocommerce/commit/d5b86259c5bfd18ac9d5163b93a3302558feea54#diff-035896b9dcfca6957109ff14ed262109L33-R33 the `.order-actions` css class was refactored to `woocommerce-orders-table__header-order-actions. So the deleted CSS would not match anyway and can be deleted.

I guess this was just forgotten. Maybe running a tool to find unused CSS from time to time would make sense (https://developers.google.com/web/tools/chrome-devtools/coverage/, but maybe there is also an automatic CI tool for this)

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changelog entry

> Dev - Removed unused `.order-actions` CSS.