### PR TITLE
silence wpTextdomain warnings in e2e tests

### DIFF
--- a/tests/bin/run-e2e-CI.sh
+++ b/tests/bin/run-e2e-CI.sh
@@ -25,4 +25,4 @@ done
 
 echo "$(date) - Docker container had been built successfully"
 
-npm run test:e2e
+npm run test:e2e  --no-warnings


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR silences the wpTextDomain warnings when the e2e tests are running in Travis CI. Ref #25536

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
