### PR TITLE
Remove constants and autoloader from the uninstall script

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -25,7 +25,7 @@ wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
  * wp-config.php. This is to prevent data loss when deleting the plugin from the backend
  * and to ensure only the site owner can perform this action.
  */
-if ( defined( 'WC_REMOVE_ALL_DATA' ) ) {
+if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	// Drop WC Admin tables.
 	include_once dirname( __FILE__ ) . '/packages/woocommerce-admin/src/Install.php';
 	\Automattic\WooCommerce\Admin\Install::drop_tables();

--- a/uninstall.php
+++ b/uninstall.php
@@ -26,19 +26,9 @@ wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
  * and to ensure only the site owner can perform this action.
  */
 if ( defined( 'WC_REMOVE_ALL_DATA' ) ) {
-	/**
-	 * Load core packages autoloader.
-	 */
-	if ( ! class_exists( 'Automattic\WooCommerce\Admin\Install' ) ) {
-		require __DIR__ . '/src/Autoloader.php';
-
-		if ( \Automattic\WooCommerce\Autoloader::init() ) {
-			// Hook in WooCommerce Admin installation code.
-			// @todo an alternate way to do this is allow FeaturePlugin::has_satisfied_dependencies()
-			// to work during uninstall - (no WooCommerce instance).
-			\Automattic\WooCommerce\Admin\Install::drop_tables();
-		}
-	}
+	// Drop WC Admin tables.
+	include_once dirname( __FILE__ ) . '/packages/woocommerce-admin/src/Install.php';
+	\Automattic\WooCommerce\Admin\Install::drop_tables();
 
 	include_once dirname( __FILE__ ) . '/includes/class-wc-install.php';
 

--- a/uninstall.php
+++ b/uninstall.php
@@ -8,8 +8,6 @@
  * @version 2.3.0
  */
 
-use Automattic\Jetpack\Constants;
-
 defined( 'WP_UNINSTALL_PLUGIN' ) || exit;
 
 global $wpdb, $wp_version;
@@ -27,7 +25,7 @@ wp_clear_scheduled_hook( 'woocommerce_tracker_send_event' );
  * wp-config.php. This is to prevent data loss when deleting the plugin from the backend
  * and to ensure only the site owner can perform this action.
  */
-if ( Constants::is_true( 'WC_REMOVE_ALL_DATA' ) ) {
+if ( defined( 'WC_REMOVE_ALL_DATA' ) ) {
 	/**
 	 * Load core packages autoloader.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR should solve two problems:
1. Constants are not loaded in uninstall.php script, so the check for WC_REMOVE_ALL_DATA would produce fatal error, resulting in an inability to remove WC
2. Cleanup for WC Admin has been simplified to use a basic include and direct call as we do with `WC_Install` class.

### How to test the changes in this Pull Request:

1. Try to uninstall WC, it should fail in master.
2. Try to uninstall with the patch applied, it should work.
3. Backup your db
4. Define `WC_REMOVE_ALL_DATA` in your `wp-config.php`
5. Remove WC, check that data is gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Removed constants and autoloader from the uninstall script.
