### PR TITLE
Fix unit tests when running using WP nightly

### DIFF
--- a/tests/bin/install.sh
+++ b/tests/bin/install.sh
@@ -113,7 +113,7 @@ install_test_suite() {
 		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
 		# remove all forward slashes in the end
 		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
-		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption -E "s:(__DIR__ . '/src/'|dirname\( __FILE__ \) . '/src/'):'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
 		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The WooCommerce unit tests started failing when running using WP nightly with the following error:

```
Fatal error: require_once(): Failed opening required '/tmp/wordpress-tests-lib/src//wp-includes/class-phpmailer.php' (include_path='.:/home/travis/.phpenv/versions/7.4.2/share/pear') in /tmp/wordpress-tests-lib/includes/mock-mailer.php on line 2
```

https://travis-ci.org/woocommerce/woocommerce/jobs/646855363#L1955

This was happening because WP changed the syntax of the line where ABSPATH is defined in the context of the unit tests (https://core.trac.wordpress.org/changeset/47198/trunk/wp-tests-config-sample.php) and we rely on this syntax to change ABSPATH when running `tests/bin/install.sh`.

To fix this problem, this commit updates the sed command used to change ABSPATH to work when both the old and new syntaxes are used. In the future, we might want to consider a more robust solution to the problem of updating ABSPATH.

### How to test the changes in this Pull Request:

1. Check that the Travis build passed.