### PR TITLE
Fix undefined function error when accessing COD gateway class outside admin

### DIFF
--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -175,12 +175,20 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 	 * @return bool
 	 */
 	private function is_accessing_settings() {
-		if ( function_exists( 'get_current_screen' ) ) {
-			$screen = get_current_screen();
-			// phpcs:ignore WordPress.Security.NonceVerification
-			if ( $screen && $screen->in_admin() && 'woocommerce_page_wc-settings' === $screen->id && isset( $_REQUEST['tab'] ) && 'checkout' === $_REQUEST['tab'] ) {
-				return true;
+		if ( is_admin() ) {
+			// phpcs:disable WordPress.Security.NonceVerification
+			if ( ! isset( $_REQUEST['page'] ) || 'wc-settings' !== $_REQUEST['page'] ) {
+				return false;
 			}
+			if ( ! isset( $_REQUEST['tab'] ) || 'checkout' !== $_REQUEST['tab'] ) {
+				return false;
+			}
+			if ( ! isset( $_REQUEST['section'] ) || 'cod' !== $_REQUEST['section'] ) {
+				return false;
+			}
+			// phpcs:enable WordPress.Security.NonceVerification
+
+			return true;
 		}
 
 		if ( Constants::is_true( 'REST_REQUEST' ) ) {

--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -175,10 +175,12 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 	 * @return bool
 	 */
 	private function is_accessing_settings() {
-		$screen = get_current_screen();
-		// phpcs:ignore WordPress.Security.NonceVerification
-		if ( $screen && $screen->in_admin() && 'woocommerce_page_wc-settings' === $screen->id && isset( $_REQUEST['tab'] ) && 'checkout' === $_REQUEST['tab'] ) {
-			return true;
+		if ( function_exists( 'get_current_screen' ) ) {
+			$screen = get_current_screen();
+			// phpcs:ignore WordPress.Security.NonceVerification
+			if ( $screen && $screen->in_admin() && 'woocommerce_page_wc-settings' === $screen->id && isset( $_REQUEST['tab'] ) && 'checkout' === $_REQUEST['tab'] ) {
+				return true;
+			}
 		}
 
 		if ( Constants::is_true( 'REST_REQUEST' ) ) {

--- a/tests/unit-tests/payment-gateways/cod.php
+++ b/tests/unit-tests/payment-gateways/cod.php
@@ -37,14 +37,19 @@ class WC_Tests_Payment_Gateway_COD extends WC_Unit_Test_Case {
 	 */
 	public function test_method_options_loaded_for_admin_page() {
 		set_current_screen( 'woocommerce_page_wc-settings' );
-		$_REQUEST['tab'] = 'checkout';
+		$_REQUEST['page']    = 'wc-settings';
+		$_REQUEST['tab']     = 'checkout';
+		$_REQUEST['section'] = 'cod';
 
 		$gateway = new WC_Gateway_COD();
 
 		$form_fields = $gateway->get_form_fields();
 
-		// Clear the screen!
+		// Clean up!
 		$GLOBALS['current_screen'] = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		unset( $_REQUEST['page'] );
+		unset( $_REQUEST['tab'] );
+		unset( $_REQUEST['section'] );
 
 		$this->assertArrayHasKey( 'enable_for_methods', $form_fields );
 		$this->assertNotEmpty( $form_fields['enable_for_methods']['options'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In #25512 we introduced an exception caused by `get_current_screen` being used outside of the admin area. This fixes that.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
