### PR TITLE
Try to fix the setup wizard trouble on JN

### DIFF
--- a/bin/package-update.sh
+++ b/bin/package-update.sh
@@ -39,3 +39,10 @@ find ./packages/woocommerce-admin -iname '*.js' -exec sed -i.bak -e "s/, 'woocom
 # Cleanup backup files
 find ./packages -name "*.bak" -type f -delete
 output 2 "Done!"
+
+# Apply patches
+output 2 "Applying patch #450 to Action Schduler"
+cd packages/action-scheduler
+curl -O https://patch-diff.githubusercontent.com/raw/woocommerce/action-scheduler/pull/450.patch
+patch -p1 < 450.patch
+output 2 "Done!"

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -49,7 +49,7 @@ class WC_Admin_Notices {
 		add_action( 'switch_theme', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'hide_notices' ) );
-		if ( ! wc_is_running_from_async_action_scheduler() ) {
+		if ( ! WC_Install::is_new_install() || ! wc_is_running_from_async_action_scheduler() ) {
 			add_action( 'shutdown', array( __CLASS__, 'store_notices' ) );
 		}
 

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -49,7 +49,9 @@ class WC_Admin_Notices {
 		add_action( 'switch_theme', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'hide_notices' ) );
-		add_action( 'shutdown', array( __CLASS__, 'store_notices' ) );
+		if ( ! wc_is_running_from_async_action_scheduler() ) {
+			add_action( 'shutdown', array( __CLASS__, 'store_notices' ) );
+		}
 
 		if ( current_user_can( 'manage_woocommerce' ) ) {
 			add_action( 'admin_print_styles', array( __CLASS__, 'add_notices' ) );

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -49,6 +49,9 @@ class WC_Admin_Notices {
 		add_action( 'switch_theme', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'woocommerce_installed', array( __CLASS__, 'reset_admin_notices' ) );
 		add_action( 'wp_loaded', array( __CLASS__, 'hide_notices' ) );
+		// @TODO: This prevents Action Scheduler async jobs from storing empty list of notices during WC installation.
+		// That could lead to OBW not starting and 'Run setup wizard' notice not appearing in WP admin, which we want
+		// to avoid.
 		if ( ! WC_Install::is_new_install() || ! wc_is_running_from_async_action_scheduler() ) {
 			add_action( 'shutdown', array( __CLASS__, 'store_notices' ) );
 		}

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -127,6 +127,8 @@ class WC_Admin {
 	 * For setup wizard, transient must be present, the user must have access rights, and we must ignore the network/bulk plugin updaters.
 	 */
 	public function admin_redirects() {
+		// Don't run this fn from Action Scheduler requests, as it would clear _wc_activation_redirect transient.
+		// That means OBW would never be shown.
 		if ( wc_is_running_from_async_action_scheduler() ) {
 			return;
 		}

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -127,6 +127,10 @@ class WC_Admin {
 	 * For setup wizard, transient must be present, the user must have access rights, and we must ignore the network/bulk plugin updaters.
 	 */
 	public function admin_redirects() {
+		if ( wc_is_running_from_async_action_scheduler() ) {
+			return;
+		}
+
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		// Nonced plugin install redirects (whitelisted).
 		if ( ! empty( $_GET['wc-install-plugin-redirect'] ) ) {

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -319,7 +319,7 @@ class WC_Install {
 	 * @since  3.2.0
 	 * @return boolean
 	 */
-	private static function is_new_install() {
+	public static function is_new_install() {
 		$product_count = array_sum( (array) wp_count_posts( 'product' ) );
 
 		return is_null( get_option( 'woocommerce_version', null ) ) || ( 0 === $product_count && -1 === wc_get_page_id( 'shop' ) );

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2273,3 +2273,13 @@ function wc_load_cart() {
 	WC()->initialize_session();
 	WC()->initialize_cart();
 }
+
+/**
+ * Test whether the context of execution comes from async action scheduler.
+ *
+ * @since 4.0.0
+ * @return bool
+ */
+function wc_is_running_from_async_action_scheduler() {
+	return isset( $_REQUEST['action'] ) && 'as_async_request_queue_runner' === $_REQUEST['action'];
+}


### PR DESCRIPTION
# Background
OBW was skipped on JN, even though it was working fine on local machine. The problem, as I discovered, was caused by actions being trigerred too quickly/often on JN, which cleared up the transient instantly and (sometimes) saved incorrect values of notices, i.e. changed values of variables affecting whether merchants is redirected to OBW or not. 

## Scenario 1

1. Click `Activate plugin`, which runs /wp-admin/plugins.php?action=activate&plugin=woocommerce%2Fwoocommerce.php&_wpnonce=57c117faca
2. during the run (here https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-install.php#L350)
4. run WC_Admin_Notices::add_notice('install') (this however, only saves to memory)
3. set transient _wc_activation_redirect: 1 (this saves to db), 
3. in the bg, AS is trigerred: /wp-admin/admin-ajax.php?action=as_async_request_queue_runner&nonce=7388fe17ef
4. This would trigger `\WC_Admin::admin_redirects` which would read `WC_Admin_Notices` from the database, but as nothing have been saved yet, transient `_wc_activation_redirect` is deleted here: https://github.com/woocommerce/woocommerce/blob/master/includes/admin/class-wc-admin.php#L158
5. By the time regular request [gets to test whether the merchant should be redirected](https://github.com/woocommerce/woocommerce/blob/master/includes/admin/class-wc-admin.php#L147) to OBW, the transient is gone, so no OBW for the merchant.

**Solution**: don't run `admin_redirects` during AS requests. It's not needed.

## Scenario 2 
Even if the transient clearing is removed (which causes the OBW to be displayed, yay), the notice to display the notification to continue with OBW if merchant quits it initially can be lost as well:

1. Click `Activate plugin`, which runs /wp-admin/plugins.php?action=activate&plugin=woocommerce%2Fwoocommerce.php&_wpnonce=57c117faca
2. during the run (here https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-install.php#L350)
4. run WC_Admin_Notices::add_notice('install') (this however, only saves to memory)
3. set transient _wc_activation_redirect: 1 (this saves to db), 
4. in the context of AS, read notices from db (aka nothing)
5. in the context of normal request, save notices to db on shutdown
6. get redirected, another regular request, read the notices from the db
7. redirect to OBW, yay!, but I don't want it now, going back to dashboard
8. AS request from 5 is finishing, saves 0 notices to db
9. No more notices to finish OBW in the dashboard.

**Solution**: don't save notices, if we're in installation phase & running in context of AS.

# Generalization
Basically, any time we load something on init and save it on shutdown, we need to expect AS to run any time in between… so e.g.
1. AS init: read_x; sees x = null;
2. regular request init: do stuff that results in set_x = 3;
3. regular request shutdown: store_x = 3 to db;
4. AS shutdown: store_x = null;

or 1, 2, 4, 3 (between 4 and 3 weird stuff might happen)
or any combo of these…

I’m not sure what’s the best way to prevent this from happening… I’m adding some conditionals to the code (i.e. if you’re running from AS context, don’t save the values), but that is probably not always viable

@rrennick advised there's a $context parameter when action is being run for async processing. 

However, I'm afraid it does not matter if it’s an async request or if it runs via cron, in either of those cases, we need to avoid the side effects from AS. 

## How to test this PR

1. Check out the branch 
2. Build a package, but you need to apply the fix from https://github.com/woocommerce/action-scheduler/pull/450
3. Install on JN and atomic, ideally multiple times, it should always show OBW, 
4. if OBW is cancelled, it should show a notification to run it.
