### PR TITLE
Hide Germany's, Denmark's and Sweden's state field

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -908,6 +908,7 @@ class WC_Countries {
 						),
 						'state'    => array(
 							'required' => false,
+							'hidden' => true,
 						),
 					),
 					'DK' => array(
@@ -916,6 +917,7 @@ class WC_Countries {
 						),
 						'state'    => array(
 							'required' => false,
+							'hidden' => true,
 						),
 					),
 					'EE' => array(
@@ -1227,6 +1229,7 @@ class WC_Countries {
 						),
 						'state'    => array(
 							'required' => false,
+							'hidden' => true,
 						),
 					),
 					'TR' => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When you choose the country 'Germany'(or Denmark or Sweden) from a woocommerce website, the state field is hidden. So I added to be hidden in this class too.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:

1.  Make a custom endpoint that points to get_country_locale()
2. Test it with Postman

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> I added 'hidden' => true for the country Germany(DE), Denmark(DK) and Sweden(SE) in the get_country_locale() function