### PR TITLE
Remove WC-Admin installation option from the old OBW

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,1 @@
-FROM wordpress:5.3
+FROM wordpress:5.3.2

--- a/tests/e2e-tests/specs/wp-admin/wp-admin-product-new.test.js
+++ b/tests/e2e-tests/specs/wp-admin/wp-admin-product-new.test.js
@@ -61,9 +61,6 @@ describe( 'Add New Simple Product Page', () => {
 } );
 
 describe( 'Add New Variable Product Page', () => {
-	beforeAll( async () => {
-		await StoreOwnerFlow.login();
-	} );
 	it( 'can create product with variations', async () => {
 		// Go to "add product" page
 		await StoreOwnerFlow.openNewProduct();

--- a/tests/e2e-tests/specs/wp-admin/wp-admin-settings-product.test.js
+++ b/tests/e2e-tests/specs/wp-admin/wp-admin-settings-product.test.js
@@ -21,7 +21,7 @@ describe( 'WooCommerce Products > Downloadable Products Settings', () => {
 		await expect( page ).toMatchElement( 'a.nav-tab-active', { text: 'Products' } );
 		await expect( page ).toMatchElement( 'ul.subsubsub > li > a.current', { text: 'Downloadable products' } );
 
-		await expect( page ).toSelect( '#woocommerce_file_download_method', 'Redirect only' );
+		await expect( page ).toSelect( '#woocommerce_file_download_method', 'Redirect only (Insecure)' );
 		await setCheckbox( '#woocommerce_downloads_require_login' );
 		await setCheckbox( '#woocommerce_downloads_grant_access_after_payment' );
 		await settingsPageSaveChanges();

--- a/tests/e2e-tests/specs/wp-admin/wp-admin-settings-product.test.js
+++ b/tests/e2e-tests/specs/wp-admin/wp-admin-settings-product.test.js
@@ -29,7 +29,7 @@ describe( 'WooCommerce Products > Downloadable Products Settings', () => {
 		// Verify that settings have been saved
 		await Promise.all( [
 			expect( page ).toMatchElement( '#message', { text: 'Your settings have been saved.' } ),
-			expect( page ).toMatchElement( '#woocommerce_file_download_method', { text: 'Redirect only' } ),
+			expect( page ).toMatchElement( '#woocommerce_file_download_method', { text: 'Redirect only (Insecure)' } ),
 			verifyCheckboxIsSet( '#woocommerce_downloads_require_login' ),
 			verifyCheckboxIsSet( '#woocommerce_downloads_grant_access_after_payment' ),
 		] );

--- a/tests/e2e-tests/utils/components.js
+++ b/tests/e2e-tests/utils/components.js
@@ -137,10 +137,6 @@ const completeOldSetupWizard = async () => {
 	await page.waitForSelector( '#wc_recommended_automated_taxes', { visible: true } );
 	await page.$eval( '#wc_recommended_automated_taxes', elem => elem.click() );
 
-	// Turn off WooCommerce Admin option
-	await page.waitForSelector( '#wc_recommended_wc_admin', { visible: true } );
-	await page.$eval( '#wc_recommended_wc_admin', elem => elem.click() );
-
 	// Turn off Mailchimp option
 	await page.waitForSelector( '#wc_recommended_mailchimp', { visible: true } );
 	await page.$eval( '#wc_recommended_mailchimp', elem => elem.click() );

--- a/tests/e2e-tests/utils/components.js
+++ b/tests/e2e-tests/utils/components.js
@@ -130,8 +130,8 @@ const completeOldSetupWizard = async () => {
 
 	// Fill out recommended section details
 	// Turn off Storefront Theme option
-	// await page.waitForSelector( '#wc_recommended_storefront_theme', { visible: true } );
-	// await page.$eval( '#wc_recommended_storefront_theme', elem => elem.click() );
+	await page.waitForSelector( '#wc_recommended_storefront_theme', { visible: true } );
+	await page.$eval( '#wc_recommended_storefront_theme', elem => elem.click() );
 
 	// Turn off Automated Taxes option
 	await page.waitForSelector( '#wc_recommended_automated_taxes', { visible: true } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

1. Remove WC-Admin installation option from the old OBW as we no longer offer it during Setup Wizard;
2. Enable Storefront option in the old OBW as it was disabled but actually needed to be enabled;
3. Update WP Docker Image from 5.3 to 5.3.2. 

### How to test the changes in this Pull Request:

1. Make sure all e2e tests are passing on both headless and `--dev` modes. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A
