### PR TITLE
Fix typo in DocBlock of `woocommerce_template_loop_product_link_close()`

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1162,7 +1162,7 @@ if ( ! function_exists( 'woocommerce_template_loop_product_link_open' ) ) {
 
 if ( ! function_exists( 'woocommerce_template_loop_product_link_close' ) ) {
 	/**
-	 * Insert the opening anchor tag for products in the loop.
+	 * Insert the closing anchor tag for products in the loop.
 	 */
 	function woocommerce_template_loop_product_link_close() {
 		echo '</a>';


### PR DESCRIPTION
This PR fixes a small typo in the DocBlock of `woocommerce_template_loop_product_link_close()`.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/commit/b1bef237d1097a487565b68aa4ff326ab70bed58#diff-65760bf45f136dba5d546afa2c8b7ee9R668 introduced a typo in `woocommerce_template_loop_product_link_close()`'s DocBlock:

> Insert the opening anchor tag for products in the loop.

But instead, it should read

> Insert the _closing_ anchor tag for products in the loop.

because that's what the function does.

This PR fixes this.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix typo in DocBlock of `woocommerce_template_loop_product_link_close()` function