### PR TITLE
Addressed issue #25615

### DIFF
--- a/assets/css/woocommerce-layout.scss
+++ b/assets/css/woocommerce-layout.scss
@@ -427,7 +427,7 @@
 		}
 
 		.show-password-input.display-password::after {
-			color: #e8e8e8;
+			color: #585858;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Addressed issue #25615 , Changed show password icon color to a darker grey hue, to improve accessibility. Conforms to WebAIM Contrast checker (https://webaim.org/resources/contrastchecker/?fcolor=585858&bcolor=FFFFFF).

### How to test the changes in this Pull Request:

1. Set theme to 2020 or 2019.
2. Go to "My Account" page.
3. Click on "Show Password" icon.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->