### PR TITLE
Allow heading filter for up sells component

### DIFF
--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -37,7 +37,7 @@ if ( $upsells ) : ?>
 				<?php
 				$post_object = get_post( $upsell->get_id() );
 
-				setup_postdata( $GLOBALS['post'] =& $post_object );
+				setup_postdata( $GLOBALS['post'] =& $post_object ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited, Squiz.PHP.DisallowMultipleAssignments.Found
 
 				wc_get_template_part( 'content', 'product' );
 				?>

--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -22,8 +22,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 if ( $upsells ) : ?>
 
 	<section class="up-sells upsells products">
+		<?php
+		$heading = apply_filters( 'woocommerce_product_upsells_products_heading', __( 'You may also like&hellip;', 'woocommerce' ) );
 
-		<h2><?php esc_html_e( 'You may also like&hellip;', 'woocommerce' ); ?></h2>
+		if ( $heading ) :
+			?>
+			<h2><?php echo esc_html( $heading ); ?></h2>
+		<?php endif; ?>
 
 		<?php woocommerce_product_loop_start(); ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR allows for modification of the header for the up sells component. It prevents a user from having to copy and overwrite the entire template. This is an extension of and early PR for the related products component. See https://github.com/woocommerce/woocommerce/pull/25059

### How to test the changes in this Pull Request:

1. Run the new `woocommerce_product_upsells_products_heading` filter to overwrite the heading title
2. Load a single product template

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
Template: single-product/up-sells.php - Add new filter `woocommerce_product_upsells_products_heading` to allow heading modification without having to override the template file
