### PR TITLE
Replace {site_address} by {site_url} for consistency

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -128,7 +128,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				array(
 					'title'       => __( 'Footer text', 'woocommerce' ),
 					/* translators: %s: Available placeholders for use */
-					'desc'        => __( 'The text to appear in the footer of all WooCommerce emails.', 'woocommerce' ) . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title} {site_address}' ),
+					'desc'        => __( 'The text to appear in the footer of all WooCommerce emails.', 'woocommerce' ) . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title} {site_url}' ),
 					'id'          => 'woocommerce_email_footer_text',
 					'css'         => 'width:400px; height: 75px;',
 					'placeholder' => __( 'N/A', 'woocommerce' ),

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -289,7 +289,7 @@ class WC_Emails {
 		return str_replace(
 			array(
 				'{site_title}',
-				'{site_address}',
+				'{site_url}',
 				'{woocommerce}',
 				'{WooCommerce}',
 			),

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -289,12 +289,14 @@ class WC_Emails {
 		return str_replace(
 			array(
 				'{site_title}',
+				'{site_address}',
 				'{site_url}',
 				'{woocommerce}',
 				'{WooCommerce}',
 			),
 			array(
 				$this->get_blogname(),
+				$domain,
 				$domain,
 				'<a href="https://woocommerce.com">WooCommerce</a>',
 				'<a href="https://woocommerce.com">WooCommerce</a>',

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -112,7 +112,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 		 * @return string
 		 */
 		public function get_default_additional_content() {
-			return __( 'Thanks for using {site_address}!', 'woocommerce' );
+			return __( 'Thanks for using {site_url}!', 'woocommerce' );
 		}
 
 		/**

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -141,7 +141,7 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 		 * @return string
 		 */
 		public function get_default_additional_content() {
-			return __( 'Thanks for using {site_address}!', 'woocommerce' );
+			return __( 'Thanks for using {site_url}!', 'woocommerce' );
 		}
 	}
 

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -232,7 +232,7 @@ class WC_Email extends WC_Settings_API {
 		$this->placeholders = array_merge(
 			array(
 				'{site_title}'   => $this->get_blogname(),
-				'{site_address}' => wp_parse_url( home_url(), PHP_URL_HOST ),
+				'{site_url}' => wp_parse_url( home_url(), PHP_URL_HOST ),
 			),
 			$this->placeholders
 		);

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -232,6 +232,7 @@ class WC_Email extends WC_Settings_API {
 		$this->placeholders = array_merge(
 			array(
 				'{site_title}'   => $this->get_blogname(),
+				'{site_address}' => wp_parse_url( home_url(), PHP_URL_HOST ),
 				'{site_url}' => wp_parse_url( home_url(), PHP_URL_HOST ),
 			),
 			$this->placeholders

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -233,7 +233,7 @@ class WC_Email extends WC_Settings_API {
 			array(
 				'{site_title}'   => $this->get_blogname(),
 				'{site_address}' => wp_parse_url( home_url(), PHP_URL_HOST ),
-				'{site_url}' => wp_parse_url( home_url(), PHP_URL_HOST ),
+				'{site_url}'     => wp_parse_url( home_url(), PHP_URL_HOST ),
 			),
 			$this->placeholders
 		);


### PR DESCRIPTION
Replace {sitde_address} by {site_url} for consistency in WooCommerce emails, for better consistency.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25603 

### How to test the changes in this Pull Request:

1. Edit emails settings
2. Use {site_url} instead of {site_address}
3. Send yourself an email

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Replaced {site_address} by {site_url} in emails templates
