### PR TITLE
[3.9] Fix shipping form always shown in checkout when custom fields are present

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -194,7 +194,7 @@ jQuery( function( $ ) {
 					$( this ).attr( 'id' ).replace( 'shipping', 'billing' );
 					var id = $( this ).attr( 'id' ).replace( 'shipping', 'billing' );
 					
-					if ($billing.find( '#' + id ).length) {
+					if ( $billing.find( '#' + id ).length ) {
 						return $( this ).val() !== $billing.find( '#' + id ).val();
 					}
 				} );

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -193,7 +193,10 @@ jQuery( function( $ ) {
 				var $differentFields = $( 'div.shipping_address' ).find( 'input, select' ).filter( function() {
 					$( this ).attr( 'id' ).replace( 'shipping', 'billing' );
 					var id = $( this ).attr( 'id' ).replace( 'shipping', 'billing' );
-					return $( this ).val() !== $billing.find( '#' + id ).val();
+					
+					if ($billing.find( '#' + id ).length) {
+						return $( this ).val() !== $billing.find( '#' + id ).val();
+					}
 				} );
 
 				if ( $differentFields.length > 0 ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I've added extra if statement that checks if field that is being compared actually exists. Thanks to this shipping form is not always shown on page load if custom fields are implemented and the function checks only fields that are present in both forms which is correct and expected behavior.

### Changelog entry

Fix - Shipping form in checkout always shown when custom fields are present