### PR TITLE
Fix failing variable e2e tests: Refactor simple & variable products tests by splitting them

### DIFF
--- a/tests/e2e-tests/README.md
+++ b/tests/e2e-tests/README.md
@@ -133,7 +133,7 @@ The dev mode also enables SlowMo mode. SlowMo slows down Puppeteer’s operation
 To run an individual test, use the direct path to the spec. For example:
 
 ```bash
-npm run test:e2e ./tests/e2e-tests/specs/wp-admin/wp-admin-product-new.test.js
+npm run test:e2e ./tests/e2e-tests/specs/wp-admin/wp-admin-product-simple-new.test.js
 ``` 
 
 ### How to skip tests

--- a/tests/e2e-tests/config/jest.setup.js
+++ b/tests/e2e-tests/config/jest.setup.js
@@ -1,7 +1,7 @@
 /** format */
 
-//Set the default test timeout to 30s
-let jestTimeoutInMilliSeconds = 30000;
+//Set the default test timeout to 60s
+let jestTimeoutInMilliSeconds = 60000;
 
 // When running test in the Development mode, the test timeout is increased to 2 minutes which allows for errors to be inspected.
 // Use `await jestPuppeteer.debug()` in test code to pause execution.

--- a/tests/e2e-tests/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e-tests/specs/activate-and-setup/setup-wizard.test.js
@@ -17,7 +17,7 @@ import {
 
 const config = require( 'config' );
 
-describe( 'Store owner can login and make sure WooCommerce is activated', () => {
+describe( 'Login', () => {
 
 	it( 'can login', async () => {
 		await StoreOwnerFlow.login();
@@ -36,7 +36,7 @@ describe( 'Store owner can login and make sure WooCommerce is activated', () => 
 
 } );
 
-describe( 'Store owner can go through store Setup Wizard', () => {
+describe( 'Setup Wizard', () => {
 
 	it( 'can start Setup Wizard when visiting the site for the first time. Skip all other times.', async () => {
 		// Check if Setup Wizard Notice is visible on the screen.
@@ -70,7 +70,7 @@ describe( 'Store owner can go through store Setup Wizard', () => {
 	} );
 } );
 
-describe( 'Store owner can finish initial store setup', () => {
+describe( 'Initial Store Setup', () => {
 
 	it( 'can enable tax rates and calculations', async () => {
 		// Go to general settings page

--- a/tests/e2e-tests/specs/front-end/front-end-cart.test.js
+++ b/tests/e2e-tests/specs/front-end/front-end-cart.test.js
@@ -9,7 +9,7 @@ import { createSimpleProduct } from '../../utils/components';
 import { CustomerFlow, StoreOwnerFlow } from '../../utils/flows';
 import { uiUnblocked } from '../../utils';
 
-describe( 'Cart page', () => {
+describe( 'Cart Page', () => {
 	beforeAll( async () => {
 		await StoreOwnerFlow.login();
 		await createSimpleProduct();

--- a/tests/e2e-tests/specs/front-end/front-end-checkout.test.js
+++ b/tests/e2e-tests/specs/front-end/front-end-checkout.test.js
@@ -13,11 +13,13 @@ const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );
 let orderId;
 
-describe( 'Checkout page', () => {
-	beforeAll( async () => {
+describe( 'Checkout Page', () => {
+	it( 'should login and create simple product', async () => {
 		await StoreOwnerFlow.login();
 		await createSimpleProduct();
+	} );
 
+	it( 'should configure general settings', async () => {
 		// Go to general settings page
 		await StoreOwnerFlow.openSettings( 'general' );
 
@@ -38,7 +40,9 @@ describe( 'Checkout page', () => {
 			expect( page ).toMatchElement( '#woocommerce_allowed_countries', { text: 'Sell to all countries' } ),
 			expect( page ).toMatchElement( '#woocommerce_currency', { text: 'United States (US) dollar ($)' } ),
 		] );
+	} );
 
+	it( 'should configure payments settings', async () => {
 		// Enable BACS payment method
 		await StoreOwnerFlow.openSettings( 'checkout', 'bacs' );
 		await setCheckbox( '#woocommerce_bacs_enabled' );

--- a/tests/e2e-tests/specs/front-end/front-end-my-account.test.js
+++ b/tests/e2e-tests/specs/front-end/front-end-my-account.test.js
@@ -7,7 +7,7 @@
  */
 import { CustomerFlow, StoreOwnerFlow } from '../../utils/flows';
 
-describe( 'My account page', () => {
+describe( 'My Account Page', () => {
 	it( 'allows customer to login', async () => {
 		await StoreOwnerFlow.logout();
 		await CustomerFlow.login();

--- a/tests/e2e-tests/specs/front-end/front-end-simple-product.test.js
+++ b/tests/e2e-tests/specs/front-end/front-end-simple-product.test.js
@@ -13,7 +13,7 @@ let simplePostIdValue;
 const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );
 
-describe( 'Single Product Page', () => {
+describe( 'Simple Product Page', () => {
 	it( 'should be able to create simple product', async () => {
 		await StoreOwnerFlow.login();
 		simplePostIdValue = await createSimpleProduct();

--- a/tests/e2e-tests/specs/front-end/front-end-simple-product.test.js
+++ b/tests/e2e-tests/specs/front-end/front-end-simple-product.test.js
@@ -1,0 +1,39 @@
+/**
+ * @format
+ */
+
+/**
+ * Internal dependencies
+ */
+import { createSimpleProduct } from '../../utils/components';
+import { CustomerFlow, StoreOwnerFlow } from '../../utils/flows';
+import { uiUnblocked } from '../../utils';
+
+let simplePostIdValue;
+const config = require( 'config' );
+const simpleProductName = config.get( 'products.simple.name' );
+
+describe( 'Single Product Page', () => {
+	it( 'should be able to create simple product', async () => {
+		await StoreOwnerFlow.login();
+		simplePostIdValue = await createSimpleProduct();
+		await StoreOwnerFlow.logout();
+	} );
+
+	it( 'should be able to add simple product to the cart', async () => {
+		// Add 5 simple products to cart
+		await CustomerFlow.goToProduct( simplePostIdValue );
+		await expect( page ).toFill( 'div.quantity input.qty', '5' );
+		await CustomerFlow.addToCart();
+		await expect( page ).toMatchElement( '.woocommerce-message', { text: 'have been added to your cart.' } );
+
+		// Verify cart contents
+		await CustomerFlow.goToCart();
+		await CustomerFlow.productIsInCart( simpleProductName, 5 );
+
+		// Remove items from cart
+		await CustomerFlow.removeFromCart( simpleProductName );
+		await uiUnblocked();
+		await expect( page ).toMatchElement( '.cart-empty', { text: 'Your cart is currently empty.' } );
+	} );
+} );

--- a/tests/e2e-tests/specs/front-end/front-end-variable-product.test.js
+++ b/tests/e2e-tests/specs/front-end/front-end-variable-product.test.js
@@ -1,0 +1,41 @@
+/**
+ * @format
+ */
+
+/**
+ * Internal dependencies
+ */
+import { createVariableProduct } from '../../utils/components';
+import { CustomerFlow, StoreOwnerFlow } from '../../utils/flows';
+import { uiUnblocked } from '../../utils';
+
+let variablePostIdValue;
+const config = require( 'config' );
+const variableProductName = config.get( 'products.variable.name' );
+
+describe( 'Variable Product Page', () => {
+	it( 'should be able to create variable product', async () => {
+		await StoreOwnerFlow.login();
+		variablePostIdValue = await createVariableProduct();
+		await StoreOwnerFlow.logout();
+	} );
+
+	it( 'should be able to add variation product to the cart', async () => {
+		// Add a product with one set of variations to cart
+		await CustomerFlow.goToProduct( variablePostIdValue );
+		await expect( page ).toSelect( '#attr-1', 'val1' );
+		await expect( page ).toSelect( '#attr-2', 'val1' );
+		await expect( page ).toSelect( '#attr-3', 'val1' );
+		await CustomerFlow.addToCart();
+		await expect( page ).toMatchElement( '.woocommerce-message', { text: 'has been added to your cart.' } );
+
+		// Verify cart contents
+		await CustomerFlow.goToCart();
+		await CustomerFlow.productIsInCart( variableProductName );
+
+		// Remove items from cart
+		await CustomerFlow.removeFromCart( variableProductName );
+		await uiUnblocked();
+		await expect( page ).toMatchElement( '.cart-empty', { text: 'Your cart is currently empty.' } );
+	} );
+} );

--- a/tests/e2e-tests/specs/wp-admin/wp-admin-product-simple-new.test.js
+++ b/tests/e2e-tests/specs/wp-admin/wp-admin-product-simple-new.test.js
@@ -1,0 +1,19 @@
+/**
+ * @format
+ */
+
+/**
+ * Internal dependencies
+ */
+import { StoreOwnerFlow } from '../../utils/flows';
+import { deleteProduct } from '../../utils';
+import { createSimpleProduct } from '../../utils/components';
+
+describe( 'Add New Simple Product Page', () => {
+	it( 'can create simple product and delete it after', async () => {
+		await StoreOwnerFlow.login();
+		await createSimpleProduct();
+		await deleteProduct();
+	} );
+} );
+

--- a/tests/e2e-tests/specs/wp-admin/wp-admin-product-variable-new.test.js
+++ b/tests/e2e-tests/specs/wp-admin/wp-admin-product-variable-new.test.js
@@ -1,0 +1,19 @@
+/**
+ * @format
+ */
+
+/**
+ * Internal dependencies
+ */
+import { StoreOwnerFlow } from '../../utils/flows';
+import { deleteProduct } from '../../utils';
+import { createVariableProduct } from '../../utils/components';
+
+describe( 'Add New Variable Product Page', () => {
+	it( 'can create variable product and delete it after', async () => {
+		await StoreOwnerFlow.login();
+		await createVariableProduct();
+		await deleteProduct();
+	} );
+} );
+

--- a/tests/e2e-tests/specs/wp-admin/wp-admin-product-variable-new.test.js
+++ b/tests/e2e-tests/specs/wp-admin/wp-admin-product-variable-new.test.js
@@ -6,13 +6,146 @@
  * Internal dependencies
  */
 import { StoreOwnerFlow } from '../../utils/flows';
-import { deleteProduct } from '../../utils';
-import { createVariableProduct } from '../../utils/components';
+import { clickTab, deleteProduct, uiUnblocked } from '../../utils';
+import { verifyAndPublish } from '../../utils/components';
 
 describe( 'Add New Variable Product Page', () => {
-	it( 'can create variable product and delete it after', async () => {
+	it( 'should login', async () => {
 		await StoreOwnerFlow.login();
-		await createVariableProduct();
+	} );
+
+	it( 'should open "add new product" page and set initial product data', async () => {
+		// Go to "add product" page
+		await StoreOwnerFlow.openNewProduct();
+
+		// Make sure we're on the add product page
+		await expect( page ).toMatchElement( '.wp-heading-inline', { text: 'Add new product' } );
+
+		// Set product data
+		await expect( page ).toFill( '#title', 'Variable Product with Three Variations' );
+		await expect( page ).toSelect( '#product-type', 'Variable product' );
+	} );
+
+	it( 'should create attributes', async () => {
+		// Create attributes for variations
+		await clickTab( 'Attributes' );
+		await expect( page ).toSelect( 'select[name="attribute_taxonomy"]', 'Custom product attribute' );
+
+		for ( let i = 0; i < 3; i++ ) {
+			await expect( page ).toClick( 'button.add_attribute', { text: 'Add' } );
+			// Wait for attribute form to load
+			await uiUnblocked();
+
+			await page.focus( `input[name="attribute_names[${ i }]"]` );
+			await expect( page ).toFill( `input[name="attribute_names[${ i }]"]`, 'attr #' + ( i + 1 ) );
+			await expect( page ).toFill( `textarea[name="attribute_values[${ i }]"]`, 'val1 | val2' );
+			await expect( page ).toClick( `input[name="attribute_variation[${ i }]"]` );
+		}
+
+		await expect( page ).toClick( 'button', { text: 'Save attributes' } );
+
+		// Wait for attribute form to save (triggers 2 UI blocks)
+		await uiUnblocked();
+		await uiUnblocked();
+	} );
+
+	it( 'should create variations', async () => {
+		// Create variations from attributes
+		await clickTab( 'Variations' );
+		await page.waitForSelector( 'select.variation_actions:not([disabled])' );
+		await page.focus( 'select.variation_actions' );
+		await expect( page ).toSelect( 'select.variation_actions', 'Create variations from all attributes' );
+
+		// Close all dialogues that pop up
+		page.on( 'dialog', async dialog => {
+			await dialog.accept();
+		} );
+
+		// Normally clicking a link would be like this:
+		// 		await page.waitForSelector('a.do_variation_action');
+		// 		await page.click('a.do_variation_action');
+		// However this doesn't work. Using another technique:
+		// See: https://github.com/GoogleChrome/puppeteer/issues/1805#issuecomment-464802876
+		await page.$eval( 'a.do_variation_action', elem => elem.click() );
+
+		// Set variation data (2 UI blocks)
+		await uiUnblocked();
+		await uiUnblocked();
+	} );
+
+	it( 'should make sure that variations were created', async () => {
+		// 'Variations price is not set...' notice should be displayed
+		await page.waitForSelector( '.woocommerce-notice-invalid-variation' );
+
+		// Verify that variations were created
+		await Promise.all( [
+			expect( page ).toMatchElement( 'select[name="attribute_attr-1[0]"]', { text: 'val1' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-2[0]"]', { text: 'val1' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-3[0]"]', { text: 'val1' } ),
+
+			expect( page ).toMatchElement( 'select[name="attribute_attr-1[1]"]', { text: 'val1' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-2[1]"]', { text: 'val1' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-3[1]"]', { text: 'val2' } ),
+
+			expect( page ).toMatchElement( 'select[name="attribute_attr-1[2]"]', { text: 'val1' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-2[2]"]', { text: 'val2' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-3[2]"]', { text: 'val1' } ),
+
+			expect( page ).toMatchElement( 'select[name="attribute_attr-1[3]"]', { text: 'val1' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-2[3]"]', { text: 'val2' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-3[3]"]', { text: 'val2' } ),
+
+			expect( page ).toMatchElement( 'select[name="attribute_attr-1[4]"]', { text: 'val2' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-2[4]"]', { text: 'val1' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-3[4]"]', { text: 'val1' } ),
+
+			expect( page ).toMatchElement( 'select[name="attribute_attr-1[5]"]', { text: 'val2' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-2[5]"]', { text: 'val1' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-3[5]"]', { text: 'val2' } ),
+
+			expect( page ).toMatchElement( 'select[name="attribute_attr-1[6]"]', { text: 'val2' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-2[6]"]', { text: 'val2' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-3[6]"]', { text: 'val1' } ),
+
+			expect( page ).toMatchElement( 'select[name="attribute_attr-1[7]"]', { text: 'val2' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-2[7]"]', { text: 'val2' } ),
+			expect( page ).toMatchElement( 'select[name="attribute_attr-3[7]"]', { text: 'val2' } ),
+		] );
+	} );
+
+	it( 'should fill out details of the 3 variations and publish product', async () => {
+		await page.waitFor( 2000 ); // waitForSelector fails here...To-Do
+		await expect( page ).toClick( '.woocommerce_variation:nth-of-type(2) .handlediv' );
+
+		await page.waitFor( 2000 ); // wait for dropdown details to load...To-Do
+		await expect( page ).toClick( 'input[name="variable_is_virtual[0]"]' );
+		await expect( page ).toFill( 'input[name="variable_regular_price[0]"]', '9.99' );
+
+		await expect( page ).toClick( '.woocommerce_variation:nth-of-type(3) .handlediv' );
+
+		await page.waitFor( 2000 ); // wait for dropdown details to load...To-Do
+		await expect( page ).toClick( 'input[name="variable_is_virtual[1]"]' );
+		await expect( page ).toFill( 'input[name="variable_regular_price[1]"]', '11.99' );
+
+		await expect( page ).toClick( '.woocommerce_variation:nth-of-type(4) .handlediv' );
+
+		await page.waitFor( 2000 ); // wait for dropdown details to load...To-Do
+		await expect( page ).toClick( 'input[name="variable_manage_stock[2]"]' );
+		await expect( page ).toFill( 'input[name="variable_regular_price[2]"]', '20' );
+		await expect( page ).toFill( 'input[name="variable_weight[2]"]', '200' );
+		await expect( page ).toFill( 'input[name="variable_length[2]"]', '10' );
+		await expect( page ).toFill( 'input[name="variable_width[2]"]', '20' );
+		await expect( page ).toFill( 'input[name="variable_height[2]"]', '15' );
+
+		await page.focus( 'button.save-variation-changes' );
+		await expect( page ).toClick( 'button.save-variation-changes', { text: 'Save changes' } );
+	} );
+
+	it( 'should publish variable product', async () => {
+		await verifyAndPublish();
+	} );
+
+	it( 'should delete variable product', async () => {
 		await deleteProduct();
 	} );
 } );

--- a/tests/e2e-tests/specs/wp-admin/wp-admin-product-variable-new.test.js
+++ b/tests/e2e-tests/specs/wp-admin/wp-admin-product-variable-new.test.js
@@ -74,6 +74,7 @@ describe( 'Add New Variable Product Page', () => {
 	} );
 
 	it( 'should make sure that variations were created', async () => {
+		await page.waitFor( 2000 ); // waitForSelector fails here...To-Do
 		// 'Variations price is not set...' notice should be displayed
 		await page.waitForSelector( '.woocommerce-notice-invalid-variation' );
 

--- a/tests/e2e-tests/utils/components.js
+++ b/tests/e2e-tests/utils/components.js
@@ -171,8 +171,8 @@ const createSimpleProduct = async () => {
 	// Go to "add product" page
 	await StoreOwnerFlow.openNewProduct();
 
-	// Make sure we're on the add order page
-	await expect( page.title() ).resolves.toMatch( 'Add new product' );
+	// Make sure we're on the add product page
+	await expect( page ).toMatchElement( '.wp-heading-inline', { text: 'Add new product' } );
 
 	// Set product data
 	await expect( page ).toFill( '#title', simpleProductName );
@@ -193,8 +193,8 @@ const createVariableProduct = async () => {
 	// Go to "add product" page
 	await StoreOwnerFlow.openNewProduct();
 
-	// Make sure we're on the add order page
-	await expect( page.title() ).resolves.toMatch( 'Add new product' );
+	// Make sure we're on the add product page
+	await expect( page ).toMatchElement( '.wp-heading-inline', { text: 'Add new product' } );
 
 	// Set product data
 	await expect( page ).toFill( '#title', 'Variable Product with Three Variations' );

--- a/tests/e2e-tests/utils/components.js
+++ b/tests/e2e-tests/utils/components.js
@@ -279,7 +279,9 @@ const createVariableProduct = async () => {
 		expect( page ).toMatchElement( 'select[name="attribute_attr-1[7]"]', { text: 'val2' } ),
 		expect( page ).toMatchElement( 'select[name="attribute_attr-2[7]"]', { text: 'val2' } ),
 		expect( page ).toMatchElement( 'select[name="attribute_attr-3[7]"]', { text: 'val2' } ),
-	] );
+	] )
+		.catch( e => console.error( e ) )
+		.finally( () => console.log( 'Promise executed: variations were created' ) );
 
 	await page.waitFor( 2000 ); // waitForSelector fails here...To-Do
 	await expect( page ).toClick( '.woocommerce_variation:nth-of-type(2) .handlediv' );

--- a/tests/e2e-tests/utils/components.js
+++ b/tests/e2e-tests/utils/components.js
@@ -13,13 +13,13 @@ const simpleProductName = config.get( 'products.simple.name' );
 
 const verifyAndPublish = async () => {
 	// Wait for auto save
-	await page.waitFor( 2000 );
+	await page.waitFor( 3000 );
 
 	// Publish product
 	await expect( page ).toClick( '#publish' );
 	await page.waitForSelector( '.updated.notice' );
 	// waitForSelector is not enough here...To-Do: think of a better solution
-	await page.waitFor( 2000 );
+	await page.waitFor( 3000 );
 
 	// Verify
 	await expect( page ).toMatchElement( '.updated.notice', { text: 'Product published.' } );

--- a/tests/e2e-tests/utils/index.js
+++ b/tests/e2e-tests/utils/index.js
@@ -30,6 +30,18 @@ const clickTab = async ( tabName ) => {
 };
 
 /**
+ * Delete product from wp-admin product page.
+ */
+const deleteProduct = async () => {
+	await page.waitForSelector( 'a', { text: 'Move to Trash' } );
+	// Trash product
+	await expect( page ).toClick( 'a', { text: 'Move to Trash' } );
+	await page.waitForSelector( '.updated.notice', { text: '1 product moved to the Trash.' } );
+	// Verify
+	await expect( page ).toMatchElement( '.updated.notice', { text: '1 product moved to the Trash.' } );
+};
+
+/**
  * Save changes on a WooCommerce settings page.
  */
 const settingsPageSaveChanges = async () => {
@@ -83,7 +95,7 @@ const unsetCheckbox = async( selector ) => {
  * Wait for UI blocking to end.
  */
 const uiUnblocked = async () => {
-	await page.waitForFunction( () => ! Boolean( document.querySelector( '.blockUI' ) ) );
+	await page.waitForFunction( () => ! Boolean( document.querySelector( '.blockUI' ) ), { polling: 100 } );
 };
 
 /**
@@ -163,6 +175,7 @@ module.exports = {
 	...flows,
 	clearAndFillInput,
 	clickTab,
+	deleteProduct,
 	settingsPageSaveChanges,
 	permalinkSettingsPageSaveChanges,
 	setCheckbox,

--- a/tests/e2e-tests/utils/index.js
+++ b/tests/e2e-tests/utils/index.js
@@ -129,6 +129,7 @@ const verifyPublishAndTrash = async ( button, publishNotice, publishVerification
 	// Trash
 	await expect( page ).toClick( 'a', { text: "Move to Trash" } );
 	await page.waitForSelector( '#message' );
+	await page.waitFor( 2000 );
 
 	// Verify
 	await expect( page ).toMatchElement( publishNotice, { text: trashVerification } );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

1. Increase default test timeout from 30 seconds to 60 seconds - some tests run longer than 30 seconds and therefore fail due to timeout. Increasing timeout helps to avoid it. 
2. Small changes related to the formatting of test titles in order to standardize them. 
3. Split front end product test to 2 tests: simple and variable - this was needed in order to simplify a previously complex test.
4. Split wp-admin new product test to 2 tests: simple and variable - this was needed in order to simplify a previously complex test. 
5. Add waiting for 2 seconds when publishing a product - not ideal but we will be able to address it in a much better way when we merge this PR https://github.com/woocommerce/woocommerce/pull/25417 that adds [shared puppeteer utils package](https://github.com/Automattic/puppeteer-utils) - it adds a [custom function](https://github.com/Automattic/puppeteer-utils/blob/master/src/page-utils.js#L104) to deal with cases where `waitForSelector()` is not enough. We should be able to replace all the `waitFor()` that we currently use with that new custom function. 
6. Refactor how we deal with 2 pop-up dialogs that come up when creating variations. Previously, there was a concurrency and callbacks hell which was causing tests to fail. Now, it is handled much better by using the [Dialog class](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#class-dialog).
7.  Add new `deleteProduct()` helper function that is being used in new simple and variations tests.
8. Add [polling](https://github.com/puppeteer/puppeteer/blob/master/docs/api.md#pagewaitforfunctionpagefunction-options-args) to `uiUnblocked()` helper function - as a result, we are now polling every 100 milliseconds to attempt to execute the function (timeout in 30 seconds) - this gives us confidence that the function will be executed prior for the test to move forward. Without polling, the function gets tried to be executed once and if the condition of the function is not met (element is not in the DOM yet for any reason), it moves forward with the test causing it to fail. 

### How to test the changes in this Pull Request:

1. Make sure all tests pass in headless mode;
2. Make sure all tests pass in `-dev` mode. 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
