### PR TITLE
Add option to override element tag container in checkout forms

### DIFF
--- a/assets/js/frontend/country-select.js
+++ b/assets/js/frontend/country-select.js
@@ -93,7 +93,7 @@ jQuery( function( $ ) {
 
 		var country     = $( this ).val(),
 			$statebox     = $wrapper.find( '#billing_state, #shipping_state, #calc_shipping_state' ),
-			$parent       = $statebox.closest( 'p.form-row' ),
+			$parent       = $statebox.closest( '.form-row' ),
 			input_name    = $statebox.attr( 'name' ),
 			input_id      = $statebox.attr('id'),
 			input_classes = $statebox.attr('data-input-classes'),


### PR DESCRIPTION
With this option, there is not bugs if we change the tag elements on checkout forms from "p" to "div"

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Make jQuery selector less strict while changing checkout fields based on a country.