### PR TITLE
Skip 2 failing variations e2e tests (until fixed)

### DIFF
--- a/tests/e2e-tests/specs/front-end/front-end-single-product.test.js
+++ b/tests/e2e-tests/specs/front-end/front-end-single-product.test.js
@@ -39,7 +39,7 @@ describe( 'Single Product Page', () => {
 	} );
 } );
 
-describe( 'Variable Product Page', () => {
+describe.skip( 'Variable Product Page', () => {
 	beforeAll( async () => {
 		await StoreOwnerFlow.login();
 		variablePostIdValue = await createVariableProduct();

--- a/tests/e2e-tests/specs/wp-admin/wp-admin-product-new.test.js
+++ b/tests/e2e-tests/specs/wp-admin/wp-admin-product-new.test.js
@@ -60,7 +60,7 @@ describe( 'Add New Simple Product Page', () => {
 	} );
 } );
 
-describe( 'Add New Variable Product Page', () => {
+describe.skip( 'Add New Variable Product Page', () => {
 	it( 'can create product with variations', async () => {
 		// Go to "add product" page
 		await StoreOwnerFlow.openNewProduct();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Temporary skip 2 currently failing variations e2e tests until fixed. Fix PR is in progress: https://github.com/woocommerce/woocommerce/pull/25643

### How to test the changes in this Pull Request:

1. Make sure all tests pass in headless mode locally and on Travis. 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
