### PR TITLE
Fix 25666 - Schema rating markup is missing required bestRating and worstRating

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -304,10 +304,10 @@ class WC_Structured_Data {
 					$markup['review'][] = array(
 						'@type'         => 'Review',
 						'reviewRating'  => array(
-                            '@type'		=> 'Rating',
-                            'bestRating'	=> '5',
-                            'ratingValue'	=> get_comment_meta( $comment->comment_ID, 'rating', true ),
-                            'worstRating'	=> '1',
+							'@type'       => 'Rating',
+							'bestRating'  => '5',
+							'ratingValue' => get_comment_meta( $comment->comment_ID, 'rating', true ),
+							'worstRating' => '1',
 						),
 						'author'        => array(
 							'@type' => 'Person',

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -304,10 +304,10 @@ class WC_Structured_Data {
 					$markup['review'][] = array(
 						'@type'         => 'Review',
 						'reviewRating'  => array(
-							'@type'       => 'Rating',
-                                                         'bestRating'  => '5',
-							'ratingValue' => get_comment_meta( $comment->comment_ID, 'rating', true ),
-                                                         'worstRating' => '1',
+                            '@type'		=> 'Rating',
+                            'bestRating'	=> '5',
+                            'ratingValue'	=> get_comment_meta( $comment->comment_ID, 'rating', true ),
+                            'worstRating'	=> '1',
 						),
 						'author'        => array(
 							'@type' => 'Person',

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -305,7 +305,9 @@ class WC_Structured_Data {
 						'@type'         => 'Review',
 						'reviewRating'  => array(
 							'@type'       => 'Rating',
+                                                         'bestRating'  => '5',
 							'ratingValue' => get_comment_meta( $comment->comment_ID, 'rating', true ),
+                                                         'worstRating' => '1',
 						),
 						'author'        => array(
 							'@type' => 'Person',
@@ -350,7 +352,9 @@ class WC_Structured_Data {
 		if ( $rating ) {
 			$markup['reviewRating'] = array(
 				'@type'       => 'Rating',
+				'bestRating'  => '5',
 				'ratingValue' => $rating,
+				'worstRating' => '1',
 			);
 		} elseif ( $comment->comment_parent ) {
 			return;


### PR DESCRIPTION
Adds `bestRating` and `worstRating` params to structured data of product reviews as per Schema.org

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Ads `bestRating` and `worstRating` to `reviewRating` section of product reviews' structure data, in order to avoid Google Search Console errors as illustrated below.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25666  .

### How to test the changes in this Pull Request:

1. Add 1 or more ratings to a product
2. Test in Google's Structured Data Testing Tool
3. Look for addition of `bestRating` and `worstRating` as per https://schema.org/AggregateRating

![image](https://user-images.githubusercontent.com/15178758/74475301-d3549300-4eaf-11ea-9980-633f39cee9fa.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Added the missing "bestRating" and "worstRating" params to structured schema data.
