### PR TITLE
Apply new filter in MaxMind database migration

### DIFF
--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2063,6 +2063,7 @@ function wc_update_390_move_maxmind_database() {
 	$uploads_dir = wp_upload_dir();
 	$new_path    = trailingslashit( $uploads_dir['basedir'] ) . 'woocommerce_uploads/' . $prefix . '-GeoLite2-Country.mmdb';
 	$new_path    = apply_filters( 'woocommerce_geolocation_local_database_path', $new_path, 2 );
+	$new_path    = apply_filters( 'woocommerce_maxmind_geolocation_database_path', $new_path );
 
 	@rename( $old_path, $new_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The migration script doesn't include the new `woocommerce_maxmind_geolocation_database_path` filter, it may be a problem if the user have some plugin or code changing this filter and then runs the 3.9 migration script.

Closes #25638.

### How to test the changes in this Pull Request:

See #25638

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Applies `woocommerce_maxmind_geolocation_database_path` in MaxMind database migration.