### PR TITLE
Escape MaxMind database URL

### DIFF
--- a/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-database-service.php
+++ b/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-database-service.php
@@ -88,7 +88,7 @@ class WC_Integration_MaxMind_Database_Service {
 		$download_uri = add_query_arg(
 			array(
 				'edition_id'  => self::DATABASE,
-				'license_key' => wc_clean( $license_key ),
+				'license_key' => urlencode( wc_clean( $license_key ) ),
 				'suffix'      => 'tar.gz',
 			),
 			'https://download.maxmind.com/app/geoip_download'

--- a/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-database-service.php
+++ b/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-database-service.php
@@ -97,7 +97,7 @@ class WC_Integration_MaxMind_Database_Service {
 		// Needed for the download_url call right below.
 		require_once ABSPATH . 'wp-admin/includes/file.php';
 
-		$tmp_archive_path = download_url( $download_uri );
+		$tmp_archive_path = download_url( esc_url_raw( $download_uri ) );
 		if ( is_wp_error( $tmp_archive_path ) ) {
 			// Transform the error into something more informative.
 			$error_data = $tmp_archive_path->get_error_data();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While `wc_clean()` may clean almost all bad things from an user input, we still should use `esc_url_raw()` while generating URLs.

Closes #25637.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Escape MaxMind database URL.
