### PR TITLE
Avoid `Automattic\Jetpack\Constants` in main woocommerce class

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -6,8 +6,6 @@
  * @since   3.2.0
  */
 
-use Automattic\Jetpack\Constants;
-
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -299,11 +297,11 @@ final class WooCommerce {
 			case 'admin':
 				return is_admin();
 			case 'ajax':
-				return Constants::is_defined( 'DOING_AJAX' );
+				return defined( 'DOING_AJAX' );
 			case 'cron':
-				return Constants::is_defined( 'DOING_CRON' );
+				return defined( 'DOING_CRON' );
 			case 'frontend':
-				return ( ! is_admin() || Constants::is_defined( 'DOING_AJAX' ) ) && ! Constants::is_defined( 'DOING_CRON' ) && ! $this->is_rest_api_request();
+				return ( ! is_admin() || defined( 'DOING_AJAX' ) ) && ! defined( 'DOING_CRON' ) && ! $this->is_rest_api_request();
 		}
 	}
 
@@ -452,7 +450,7 @@ final class WooCommerce {
 		 */
 		include_once WC_ABSPATH . 'packages/action-scheduler/action-scheduler.php';
 
-		if ( Constants::is_true( 'WP_CLI' ) ) {
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
 			include_once WC_ABSPATH . 'includes/class-wc-cli.php';
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/25516 introduced usage of a Jetpack library for looking up constants. 

Woo core (and other projects) also make use of the Jetpack Autoloader class. This is used when `class-woocommerce.php` calls `use Automattic\Jetpack\Constants;`.

Previously, Jetpack Autoloader had a bunch of exclusion rules so that some classes, such as `Automattic\Jetpack\Constants`, could be used before `plugins_loaded`. This however is no longer the case:

https://github.com/Automattic/jetpack-autoloader/commit/3cb0ad8496d04a648435ebee7c2a652c80eaf550#diff-e0ef674d7fb0e2a134b65bb8b1afba9c

(thanks for finding that commit @peterfabian)

Because `class-woocommerce.php` is loaded immediately when WooCommerce loads, it doesn't wait for `plugins_loaded`, and will now throw a notice:

> Notice: Automattic\Jetpack\Constants was called incorrectly. Not all plugins have loaded yet but we requested the class Automattic\Jetpack\Constants Please see Debugging in WordPress for more information. (This message was added in version 1.1.3.0.) in /srv/www/wordpress-local/public_html/wp-includes/functions.php on line 5041

This PR reverts the change to `class-woocommerce.php` to avoid the notice.

cc @ObliviousHarmony 

## How to test the changes in this Pull Request:

- Run `composer update` to get the latest jetpack autoloader which is 1.4.1.
- Visit a page in admin and see the notice
- Apply PR, confirm no notices are thrown.