### PR TITLE
Mark AS migration pending when updating WC to ensure migration happens.

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -146,6 +146,7 @@ class WC_Install {
 			'wc_update_product_lookup_tables',
 			'wc_update_400_increase_size_of_column',
 			'wc_update_400_db_version',
+			'wc_reset_action_scheduler_migration_status',
 		),
 	);
 

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2095,7 +2095,12 @@ function wc_update_400_increase_size_of_column() {
  * Reset ActionScheduler migration status. Needs AS >= 3.0 shipped with WC >= 4.0.
  */
 function wc_reset_action_scheduler_migration_status() {
-	\ActionScheduler_DataController::mark_migration_incomplete();
+	if (
+		class_exists( 'ActionScheduler_DataController' ) &&
+		method_exists( 'ActionScheduler_DataController', 'mark_migration_incomplete' )
+	) {
+		\ActionScheduler_DataController::mark_migration_incomplete();
+	}
 }
 
 /**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2092,6 +2092,13 @@ function wc_update_400_increase_size_of_column() {
 }
 
 /**
+ * Reset ActionScheduler migration status. Needs AS >= 3.0 shipped with WC >= 4.0.
+ */
+function wc_reset_action_scheduler_migration_status() {
+	\ActionScheduler_DataController::mark_migration_incomplete();
+}
+
+/**
  * Update DB version.
  */
 function wc_update_400_db_version() {


### PR DESCRIPTION
# All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
See https://github.com/woocommerce/action-scheduler/issues/460 for issue details.
Ideally https://github.com/woocommerce/action-scheduler/pull/470 should take care of this issue, but since we have AS 3.x in the wild without fix in the PR, we need to also mark migration incomplete during WC 4.0 update.

This needs to https://github.com/woocommerce/action-scheduler/pull/470 be merged and released to work.

### How to test the changes in this Pull Request:

1. Install WC 3.9 on a clean site. Also install but don't activate https://github.com/woocommerce/action-scheduler-disable-default-runner to make testing easier.
2. Install AS plugin with changes from https://github.com/woocommerce/action-scheduler/pull/470 applied but don't activate the plugin.
3. Install WC Services, browse around couple of pages so that migration completes. Make sure by checking value of `action_scheduler_migration_status` is set to `complete`.
4. Deactivate WC Services. Activate `action-scheduler-disable-default-runner` we installed in first step.
5. Schedule some actions (easiest is to add a WebHook and create some product/order). Make sure there are some scheduled actions in `wp-admin/tools.php?page=action-scheduler`
6. Activate AS plugin. Update WC to 4.x package with changes in PR applied.
7. Go to scheduled actions and you should see an pending action with one of the arguments `wc_reset_action_scheduler_migration_status`. Run that action, and run all migration-related action manually in any order. 

You would see all scheduled actions would have been migrated from previous version. Without this batch, they won't be migrated.

You would be able t

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Fix - Unmark completed AS migration during the update to make sure AS migration happens.