### PR TITLE
Add woocommerce_can_restock_refunded_items filter

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -683,6 +683,10 @@ function wc_refund_payment( $order, $amount, $reason = '' ) {
  * @param array    $refunded_line_items Refunded items list.
  */
 function wc_restock_refunded_items( $order, $refunded_line_items ) {
+	if ( ! apply_filters( 'woocommerce_can_restock_refunded_items', true, $order, $refunded_line_items ) ) {
+		return;
+	}
+
 	$line_items = $order->get_items();
 
 	foreach ( $line_items as $item_id => $item ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

this PR adds **woocommerce_can_restock_refunded_items** filter to `wc_restock_refunded_items` function. In this way, it's possible to filter when the restock for a refund can be executed by that function: this can be useful, for example, if you want to create a plugin that uses a specific way to restock items (i.e. a plugin for managing Multi Stock for products). 

### How to test the changes in this Pull Request:

1. use the **woocommerce_can_restock_refunded_items** filter to disable the restock when refunding an order 
2. try to refund an order 
3. in this case, the product stock should not change.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Dev: added woocommerce_can_restock_refunded_items filter
