### PR TITLE
Added the get_woocommerce_currency_symbols function to allow develope…

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -503,21 +503,16 @@ function get_woocommerce_currencies() {
 	return $currencies;
 }
 
-
 /**
- * Get Currency symbol.
+ * Get all available Currency symbols.
  *
  * Currency Symbols and mames should follow the Unicode CLDR recommendation (http://cldr.unicode.org/translation/currency-names)
  *
- * @param string $currency Currency. (default: '').
- * @return string
+ * @return array
  */
-function get_woocommerce_currency_symbol( $currency = '' ) {
-	if ( ! $currency ) {
-		$currency = get_woocommerce_currency();
-	}
+function get_woocommerce_currency_symbols() {
 
-	$symbols         = apply_filters(
+	$symbols = apply_filters(
 		'woocommerce_currency_symbols',
 		array(
 			'AED' => '&#x62f;.&#x625;',
@@ -686,6 +681,25 @@ function get_woocommerce_currency_symbol( $currency = '' ) {
 			'ZMW' => 'ZK',
 		)
 	);
+
+	return $symbols;
+}
+
+/**
+ * Get Currency symbol.
+ *
+ * Currency Symbols and mames should follow the Unicode CLDR recommendation (http://cldr.unicode.org/translation/currency-names)
+ *
+ * @param string $currency Currency. (default: '').
+ * @return string
+ */
+function get_woocommerce_currency_symbol( $currency = '' ) {
+	if ( ! $currency ) {
+		$currency = get_woocommerce_currency();
+	}
+
+	$symbols = get_woocommerce_currency_symbols();
+
 	$currency_symbol = isset( $symbols[ $currency ] ) ? $symbols[ $currency ] : '';
 
 	return apply_filters( 'woocommerce_currency_symbol', $currency_symbol, $currency );


### PR DESCRIPTION
Added the get_woocommerce_currency_symbols function to allow develops to get an array of all the currency symbol registered with WooCommerce.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25732.

### How to test the changes in this Pull Request:

1. Check out the branch.
2. Call the function
3. Review the output.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added the get_woocommerce_currency_symbols function to allow develops to get an array of all the currency symbol registered with WooCommerce
 
