### PR TITLE
Fixed caching for order item on deletion

### DIFF
--- a/includes/data-stores/class-wc-order-item-data-store.php
+++ b/includes/data-stores/class-wc-order-item-data-store.php
@@ -158,4 +158,21 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 
 		return $order_item_type;
 	}
+
+	/**
+	 * Clear meta cache.
+	 *
+	 * @param int      $item_id Item ID.
+	 * @param int|null $order_id Order ID. If not set, it will be loaded using the item ID.
+	 */
+	protected function clear_cache( $item_id, $order_id ) {
+		wp_cache_delete( 'item-' . $item_id, 'order-items' );
+
+		if ( ! $order_id ) {
+			$order_id = $this->get_order_id_by_order_item_id( $item_id );
+		}
+		if ( $order_id ) {
+			wp_cache_delete( 'order-items-' . $order_id, 'orders' );
+		}
+	}
 }

--- a/includes/data-stores/class-wc-order-item-data-store.php
+++ b/includes/data-stores/class-wc-order-item-data-store.php
@@ -40,7 +40,11 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 			)
 		);
 
-		return absint( $wpdb->insert_id );
+		$item_id = absint( $wpdb->insert_id );
+
+		$this->clear_cache( $item_id, $order_id );
+
+		return $item_id;
 	}
 
 	/**
@@ -53,7 +57,9 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 */
 	public function update_order_item( $item_id, $item ) {
 		global $wpdb;
-		return $wpdb->update( $wpdb->prefix . 'woocommerce_order_items', $item, array( 'order_item_id' => $item_id ) );
+		$updated = $wpdb->update( $wpdb->prefix . 'woocommerce_order_items', $item, array( 'order_item_id' => $item_id ) );
+		$this->clear_cache( $item_id, null );
+		return $updated;
 	}
 
 	/**
@@ -63,6 +69,8 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * @param  int $item_id Item ID.
 	 */
 	public function delete_order_item( $item_id ) {
+		$this->clear_cache( $item_id, null );
+
 		global $wpdb;
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d", $item_id ) );
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id = %d", $item_id ) );

--- a/includes/data-stores/class-wc-order-item-data-store.php
+++ b/includes/data-stores/class-wc-order-item-data-store.php
@@ -42,7 +42,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 
 		$item_id = absint( $wpdb->insert_id );
 
-		$this->clear_cache( $item_id, $order_id );
+		$this->clear_caches( $item_id, $order_id );
 
 		return $item_id;
 	}
@@ -58,7 +58,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	public function update_order_item( $item_id, $item ) {
 		global $wpdb;
 		$updated = $wpdb->update( $wpdb->prefix . 'woocommerce_order_items', $item, array( 'order_item_id' => $item_id ) );
-		$this->clear_cache( $item_id, null );
+		$this->clear_caches( $item_id, null );
 		return $updated;
 	}
 
@@ -69,7 +69,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * @param  int $item_id Item ID.
 	 */
 	public function delete_order_item( $item_id ) {
-		$this->clear_cache( $item_id, null );
+		$this->clear_caches( $item_id, null );
 
 		global $wpdb;
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d", $item_id ) );
@@ -173,7 +173,7 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * @param int      $item_id Item ID.
 	 * @param int|null $order_id Order ID. If not set, it will be loaded using the item ID.
 	 */
-	protected function clear_cache( $item_id, $order_id ) {
+	protected function clear_caches( $item_id, $order_id ) {
 		wp_cache_delete( 'item-' . $item_id, 'order-items' );
 
 		if ( ! $order_id ) {

--- a/includes/data-stores/class-wc-order-item-data-store.php
+++ b/includes/data-stores/class-wc-order-item-data-store.php
@@ -69,11 +69,14 @@ class WC_Order_Item_Data_Store implements WC_Order_Item_Data_Store_Interface {
 	 * @param  int $item_id Item ID.
 	 */
 	public function delete_order_item( $item_id ) {
-		$this->clear_caches( $item_id, null );
+		// Load the order ID before the deletion, since after, it won't exist in the database.
+		$order_id = $this->get_order_id_by_order_item_id( $item_id );
 
 		global $wpdb;
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_items WHERE order_item_id = %d", $item_id ) );
 		$wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->prefix}woocommerce_order_itemmeta WHERE order_item_id = %d", $item_id ) );
+
+		$this->clear_caches( $item_id, $order_id );
 	}
 
 	/**

--- a/tests/unit-tests/order-items/class-wc-tests-order-item-data-store.php
+++ b/tests/unit-tests/order-items/class-wc-tests-order-item-data-store.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Unit tests for the WC_Order_Item_Data_Store class.
+ *
+ * @package WooCommerce\Tests\Order_Items
+ * @since 4.0.0
+ */
+
+/**
+ * Order Item data store unit tests.
+ *
+ * @since 4.0.0
+ */
+class WC_Tests_Order_Item_Data_Store extends WC_Unit_Test_Case {
+
+	/**
+	 * Tests that the cache is cleared when an order item is added.
+	 */
+	public function test_cache_cleared_on_item_addition() {
+		$data_store = WC_Data_Store::load( 'order-item' );
+		$order      = WC_Helper_Order::create_order();
+
+		// Set something to the cache that should be cleared.
+		wp_cache_set( 'order-items-' . $order->get_id(), 'test', 'orders' );
+
+		$data_store->add_order_item(
+			$order->get_id(),
+			array(
+				'order_item_name' => 'Test Item',
+				'order_item_type' => 'line_item',
+			)
+		);
+
+		$cached = wp_cache_get( 'order-items-' . $order->get_id(), 'orders' );
+		$this->assertNotEquals( 'test', $cached );
+	}
+	/**
+	 * Tests that the cache is cleared when an order item is updated.
+	 */
+	public function test_cache_cleared_on_item_update() {
+		$data_store = WC_Data_Store::load( 'order-item' );
+		$order      = WC_Helper_Order::create_order();
+		$items      = $order->get_items();
+		$order_item = reset( $items );
+
+		// Set something to the cache that should be cleared.
+		wp_cache_set( 'item-' . $order_item->get_id(), 'test_item', 'order-items' );
+		wp_cache_set( 'order-items-' . $order->get_id(), 'test', 'orders' );
+
+		$data_store->update_order_item( $order_item->get_id(), array( 'order_item_name' => 'Test Item' ) );
+
+		$cached = wp_cache_get( 'item-' . $order_item->get_id(), 'order-items' );
+		$this->assertNotEquals( 'test_item', $cached );
+		$cached = wp_cache_get( 'order-items-' . $order->get_id(), 'orders' );
+		$this->assertNotEquals( 'test', $cached );
+	}
+
+	/**
+	 * Tests that the cache is cleared when an order item is deleted.
+	 */
+	public function test_cache_cleared_on_item_deletion() {
+		$data_store = WC_Data_Store::load( 'order-item' );
+		$order      = WC_Helper_Order::create_order();
+		$items      = $order->get_items();
+		$order_item = reset( $items );
+
+		// Set something to the cache that should be cleared.
+		wp_cache_set( 'item-' . $order_item->get_id(), 'test_item', 'order-items' );
+		wp_cache_set( 'order-items-' . $order->get_id(), 'test', 'orders' );
+
+		$data_store->delete_order_item( $order_item->get_id() );
+
+		$cached = wp_cache_get( 'item-' . $order_item->get_id(), 'order-items' );
+		$this->assertNotEquals( 'test_item', $cached );
+		$cached = wp_cache_get( 'order-items-' . $order->get_id(), 'orders' );
+		$this->assertNotEquals( 'test', $cached );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Unlike some of our other data stores, the `WC_Order_Item_Data_Store` class lacked any means for clearing the cache when performing an action that should require it. The consequence of this is that the order items would not be invalidated unless the order object itself was saved, leading to some strange behavior during order item deletion.

This PR adds that functionality and fixes the related issue that led to the creation of it. Note that I didn't add any clearing to the metadata methods. We act on the order metadata directly in a lot of places and so I felt like that should be its own PR with refactoring around related usages.

Closes #25650.

### How to test the changes in this Pull Request:

1. Make sure your WP installation includes a plugin that enables object caching. In my testing I used the [WP File Cache Plugin](https://wordpress.org/plugins/wp-file-cache/).
2. Create an order with nothing in it and save it.
3. Add a line item to the order and then remove it. Without this PR, the line item will still be present. With this PR, the line item will be removed. (Note that the item is actually deleted, and if you refresh without the PR, it will not be there anymore)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Corrected the cache invalidation behavior of order item CRUD actions.
