### PR TITLE
Added the WC Admin enabled db update notice.

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -102,25 +102,31 @@ class WC_Admin_Notices {
 	 * Show a notice.
 	 *
 	 * @param string $name Notice name.
+	 * @param bool   $force_save Force saving inside this method instead of at the 'shutdown'.
 	 */
-	public static function add_notice( $name ) {
+	public static function add_notice( $name, $force_save = false ) {
 		self::$notices = array_unique( array_merge( self::get_notices(), array( $name ) ) );
 
-		// Adding early save to prevent more race conditions with notices.
-		self::store_notices();
+		if ( $force_save ) {
+			// Adding early save to prevent more race conditions with notices.
+			self::store_notices();
+		}
 	}
 
 	/**
 	 * Remove a notice from being displayed.
 	 *
 	 * @param string $name Notice name.
+	 * @param bool   $force_save Force saving inside this method instead of at the 'shutdown'.
 	 */
-	public static function remove_notice( $name ) {
+	public static function remove_notice( $name, $force_save = false ) {
 		self::$notices = array_diff( self::get_notices(), array( $name ) );
 		delete_option( 'woocommerce_admin_notice_' . $name );
 
-		// Adding early save to prevent more race conditions with notices.
-		self::store_notices();
+		if ( $force_save ) {
+			// Adding early save to prevent more race conditions with notices.
+			self::store_notices();
+		}
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -105,6 +105,9 @@ class WC_Admin_Notices {
 	 */
 	public static function add_notice( $name ) {
 		self::$notices = array_unique( array_merge( self::get_notices(), array( $name ) ) );
+
+		// Adding early save to prevent more race conditions with notices.
+		self::store_notices();
 	}
 
 	/**
@@ -115,6 +118,9 @@ class WC_Admin_Notices {
 	public static function remove_notice( $name ) {
 		self::$notices = array_diff( self::get_notices(), array( $name ) );
 		delete_option( 'woocommerce_admin_notice_' . $name );
+
+		// Adding early save to prevent more race conditions with notices.
+		self::store_notices();
 	}
 
 	/**
@@ -218,7 +224,7 @@ class WC_Admin_Notices {
 	}
 
 	/**
-	 * If we need to update, include a message with the update button.
+	 * If we need to update the database, include a message with the DB update button.
 	 */
 	public static function update_notice() {
 		if ( WC_Install::needs_db_update() ) {

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -2454,7 +2454,7 @@ class WC_Admin_Setup_Wizard {
 	 */
 	public function wc_setup_ready() {
 		// We've made it! Don't prompt the user to run the wizard again.
-		WC_Admin_Notices::remove_notice( 'install' );
+		WC_Admin_Notices::remove_notice( 'install', true );
 
 		$user_email   = $this->get_current_user_email();
 		$videos_url   = 'https://docs.woocommerce.com/document/woocommerce-guided-tour-videos/?utm_source=setupwizard&utm_medium=product&utm_content=videos&utm_campaign=woocommerceplugin';

--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -22,13 +22,17 @@ class WC_Notes_Run_Db_Update {
 	 * Attach hooks.
 	 */
 	public function __construct() {
-		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+		// If the old notice gets dismissed, also hide this new one.
+		add_action( 'woocommerce_hide_update_notice', array( __CLASS__, 'set_notice_actioned' ) );
+
+		// Not using Jetpack\Constants here as it can run before 'plugin_loaded' is done.
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX
+			|| defined( 'DOING_CRON' ) && DOING_CRON
+			|| ! is_admin() ) {
 			return;
 		}
 
 		add_action( 'admin_init', array( __CLASS__, 'show_reminder' ) );
-		// If the old notice gets dismissed, also hide this new one.
-		add_action( 'woocommerce_hide_update_notice', array( __CLASS__, 'set_notice_actioned' ) );
 	}
 
 	/**

--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -1,0 +1,312 @@
+<?php
+/**
+ * WooCommerce: Db update note.
+ *
+ * Adds a note to complete the WooCommerce db update after the upgrade in the WC Admin context.
+ *
+ * @package WooCommerce
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use \Automattic\Jetpack\Constants;
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+
+/**
+ * WC_Notes_Run_Db_Update.
+ */
+class WC_Notes_Run_Db_Update {
+	const NOTE_NAME = 'wc-update-db-reminder';
+
+	/**
+	 * Attach hooks.
+	 */
+	public function __construct() {
+		if ( defined( 'DOING_AJAX' ) && DOING_AJAX ) {
+			return;
+		}
+
+		add_action( 'admin_init', array( __CLASS__, 'show_reminder' ) );
+		// If the old notice gets dismissed, also hide this new one.
+		add_action( 'woocommerce_hide_update_notice', array( __CLASS__, 'set_notice_actioned' ) );
+	}
+
+	/**
+	 * Get current notice id from the database.
+	 *
+	 * Retrieves the first notice of this type.
+	 *
+	 * @return int|void Note id or null in case no note was found.
+	 */
+	private static function get_current_notice() {
+		try {
+			$data_store = \WC_Data_Store::load( 'admin-note' );
+		} catch ( Exception $e ) {
+			return;
+		}
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+
+		if ( empty( $note_ids ) ) {
+			return;
+		}
+
+		return current( $note_ids );
+	}
+
+	/**
+	 * Set this notice to an actioned one, so that it's no longer displayed.
+	 */
+	public static function set_notice_actioned() {
+		$note_id = self::get_current_notice();
+
+		if ( ! $note_id ) {
+			return;
+		}
+
+		$note = new WC_Admin_Note( $note_id );
+		$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
+		$note->save();
+	}
+
+	/**
+	 * Check whether the note is up to date for a fresh display.
+	 *
+	 * The check tests if
+	 *  - actions are set up for the first 'Update database' notice, and
+	 *  - URL for note's action is equal to the given URL (to check for potential nonce update).
+	 *
+	 * @param WC_Admin_Note $note Note to check.
+	 * @param string        $update_url  URL to check the note against.
+	 * @return bool
+	 */
+	private static function note_up_to_date( $note, $update_url ) {
+		$actions = $note->get_actions();
+		if ( 2 === count( array_intersect( wp_list_pluck( $actions, 'name' ), array( 'update-db_run', 'update-db_learn-more' ) ) )
+			&& in_array( $update_url, wp_list_pluck( $actions, 'query' ) ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * Create and set up the first (out of 3) 'Database update needed' notice and store it in the database.
+	 *
+	 * If a $note_id is given, the method updates the note instead of creating a new one.
+	 *
+	 * @param integer $note_id Note db record to update.
+	 * @return int Created/Updated note id
+	 */
+	private static function update_needed_notice( $note_id = null ) {
+		$update_url = html_entity_decode(
+			wp_nonce_url(
+				add_query_arg( 'do_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ),
+				'wc_db_update',
+				'wc_db_update_nonce'
+			)
+		);
+
+		if ( $note_id ) {
+			$note = new WC_Admin_Note( $note_id );
+		} else {
+			$note = new WC_Admin_Note();
+		}
+
+		// Check if the note needs to be updated (e.g. expired nonce or different note type stored in the previous run).
+		if ( self::note_up_to_date( $note, $update_url ) ) {
+			return $note_id;
+		}
+
+		$note->set_title( __( 'WooCommerce database update required', 'woocommerce' ) );
+		$note->set_content(
+			__( 'WooCommerce has been updated! To keep things running smoothly, we have to update your database to the newest version.', 'woocommerce' )
+			/* translators: %1$s: opening <a> tag %2$s: closing </a> tag*/
+			. sprintf( ' ' . esc_html__( 'The database update process runs in the background and may take a little while, so please be patient. Advanced users can alternatively update via %1$sWP CLI%2$s.', 'woocommerce' ), '<a href="https://github.com/woocommerce/woocommerce/wiki/Upgrading-the-database-using-WP-CLI">', '</a>' )
+		);
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
+		$note->set_icon( 'info' );
+		$note->set_name( self::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-core' );
+		// In case db version is out of sync with WC version or during the next update, the notice needs to show up again,
+		// so set it to unactioned.
+		$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED );
+
+		// Set new actions.
+		$note->clear_actions();
+		$note->add_action(
+			'update-db_run',
+			__( 'Update WooCommerce Database', 'woocommerce' ),
+			$update_url,
+			'unactioned',
+			true
+		);
+		$note->add_action(
+			'update-db_learn-more',
+			__( 'Learn more about updates', 'woocommerce' ),
+			'https://docs.woocommerce.com/document/how-to-update-woocommerce/',
+			'unactioned',
+			false
+		);
+
+		return $note->save();
+	}
+
+	/**
+	 * Update the existing note with $note_id with information about the db upgrade being in progress.
+	 *
+	 * This is the second out of 3 notices displayed to the user.
+	 *
+	 * @param int $note_id Note id to update.
+	 */
+	private static function update_in_progress_notice( $note_id ) {
+		// Same actions as in includes/admin/views/html-notice-updating.php.
+		$pending_actions_url = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=woocommerce_run_update&status=pending' );
+		$cron_disabled       = Constants::is_true( 'DISABLE_WP_CRON' );
+		$cron_cta            = $cron_disabled ? __( 'You can manually run queued updates here.', 'woocommerce' ) : __( 'View progress →', 'woocommerce' );
+
+		$note = new WC_Admin_Note( $note_id );
+		$note->set_title( __( 'WooCommerce database update in progress', 'woocommerce' ) );
+		$note->set_content( __( 'WooCommerce is updating the database in the background. The database update process may take a little while, so please be patient.', 'woocommerce' ) );
+
+		$note->clear_actions();
+		$note->add_action(
+			'update-db_see-progress',
+			$cron_cta,
+			$pending_actions_url,
+			'unactioned',
+			false
+		);
+
+		$note->save();
+	}
+
+	/**
+	 * Update the existing note with $note_id with information that db upgrade is done.
+	 *
+	 * This is the last notice (3 out of 3 notices) displayed to the user.
+	 *
+	 * @param int $note_id Note id to update.
+	 */
+	private static function update_done_notice( $note_id ) {
+		$hide_notices_url = html_entity_decode( // to convert &amp;s to normal &, otherwise produces invalid link.
+			wp_nonce_url(
+				add_query_arg(
+					'wc-hide-notice',
+					'update',
+					admin_url( 'admin.php?page=wc-settings' )
+				),
+				'woocommerce_hide_notices_nonce',
+				'_wc_notice_nonce'
+			)
+		);
+
+		$note = new WC_Admin_Note( $note_id );
+		$note->set_title( __( 'WooCommerce database update done', 'woocommerce' ) );
+		$note->set_content( __( 'WooCommerce database update complete. Thank you for updating to the latest version!', 'woocommerce' ) );
+
+		$actions = $note->get_actions();
+		if ( ! in_array( 'update-db_done', wp_list_pluck( $actions, 'name' ) ) ) {
+			$note->clear_actions();
+			$note->add_action(
+				'update-db_done',
+				__( 'Thanks!', 'woocommerce' ),
+				$hide_notices_url,
+				'actioned',
+				true
+			);
+
+			$note->save();
+		}
+	}
+
+	/**
+	 * Return true if db update notice should be shown, false otherwise.
+	 *
+	 * If the db needs an update, the notice should be always shown.
+	 * If the db does not need an update, but the notice has *not* been actioned (i.e. after the db update, when
+	 * store owner hasn't acknowledged the successful db update), still show the notice.
+	 * If the db does not need an update, and the notice has been actioned, then notice should *not* be shown.
+	 * The same is true if the db does not need an update and the notice does not exist.
+	 *
+	 * @return bool
+	 */
+	private static function should_show_notice() {
+		if ( ! \WC_Install::needs_db_update() ) {
+			try {
+				$data_store = \WC_Data_Store::load( 'admin-note' );
+			} catch ( Exception $e ) {
+				// Bail out in case of incorrect use.
+				return false;
+			}
+			$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+
+			if ( ! empty( $note_ids ) ) {
+				// Db update not needed && note actioned -> don't show it.
+				$note = new WC_Admin_Note( $note_ids[0] );
+				if ( $note::E_WC_ADMIN_NOTE_ACTIONED === $note->get_status() ) {
+					return false;
+				}
+			} else {
+				// Db update not needed && note does not exist -> don't show it.
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
+	 * Create a note to remind store owners to complete the db update.
+	 */
+	public static function add_reminder() {
+		try {
+			$data_store = \WC_Data_Store::load( 'admin-note' );
+		} catch ( Exception $e ) {
+			if ( Constants::is_true( 'WP_DEBUG' ) ) {
+				error_log( 'WC_Notes_Run_Db_Update::add_reminder was called before the respective Data Store got registered. Database update notice will not be displayed.' );
+			}
+		}
+		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+
+		if ( empty( $note_ids ) ) {
+			// Create a new db update notice.
+			self::update_needed_notice();
+		} else {
+			// Refresh the nonce action if needed, so can't be stored just once.
+			self::update_needed_notice( $note_ids[0] );
+		}
+	}
+
+	/**
+	 * Prepare the correct content of the db update note to be displayed by WC Admin.
+	 *
+	 * This one gets called on each page load, so try to bail quickly.
+	 */
+	public static function show_reminder() {
+		if ( ! self::should_show_notice() ) {
+			return;
+		}
+
+		$note_id = self::get_current_notice();
+
+		if ( \WC_Install::needs_db_update() && empty( $note_id ) ) {
+			// Db needs update && no notice exists -> create one.
+			$note_id = self::update_needed_notice();
+		}
+
+		if ( \WC_Install::needs_db_update() ) {
+			$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_run_update_callback', null, 'woocommerce-db-updates' );
+
+			if ( $next_scheduled_date || ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok, CSRF ok.
+				self::update_in_progress_notice( $note_id );
+			} else {
+				self::update_needed_notice( $note_id );
+			}
+		} else {
+			// Not running update_db_version() here unlike \WC_Admin_Notices::update_notice, as it runs over there.
+			self::update_done_notice( $note_id );
+		}
+	}
+
+}

--- a/includes/class-wc-autoloader.php
+++ b/includes/class-wc-autoloader.php
@@ -90,6 +90,8 @@ class WC_Autoloader {
 			$path = $this->include_path . 'log-handlers/';
 		} elseif ( 0 === strpos( $class, 'wc_integration' ) ) {
 			$path = $this->include_path . 'integrations/' . substr( str_replace( '_', '-', $class ), 15 ) . '/';
+		} elseif ( 0 === strpos( $class, 'wc_notes_' ) ) {
+			$path = $this->include_path . 'admin/notes/';
 		}
 
 		if ( empty( $path ) || ! $this->load_file( $path . $file ) ) {

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -364,7 +364,7 @@ class WC_Install {
 	 */
 	private static function maybe_enable_setup_wizard() {
 		if ( apply_filters( 'woocommerce_enable_setup_wizard', true ) && self::is_new_install() ) {
-			WC_Admin_Notices::add_notice( 'install' );
+			WC_Admin_Notices::add_notice( 'install', true );
 			set_transient( '_wc_activation_redirect', 1, 30 );
 		}
 	}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -259,7 +259,7 @@ class WC_Install {
 		if ( ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok.
 			check_admin_referer( 'wc_db_update', 'wc_db_update_nonce' );
 			self::update();
-			WC_Admin_Notices::add_notice( 'update' );
+			WC_Admin_Notices::add_notice( 'update', true );
 			if ( WC()->is_wc_admin_active() ) {
 				// Pre-init data store override to allow storing WC Admin notice during activation (package is not loaded yet).
 				add_filter( 'woocommerce_data_stores', array( '\Automattic\WooCommerce\Admin\API\Init', 'add_data_stores' ) );
@@ -379,7 +379,7 @@ class WC_Install {
 			if ( apply_filters( 'woocommerce_enable_auto_update_db', false ) ) {
 				self::update();
 			} else {
-				WC_Admin_Notices::add_notice( 'update' );
+				WC_Admin_Notices::add_notice( 'update', true );
 
 				// Pre-init data store override to allow storing WC Admin notice during activation (package is not loaded yet).
 				if ( WC()->is_wc_admin_active() ) {

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -155,6 +155,7 @@ class WC_Install {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
 		add_action( 'init', array( __CLASS__, 'manual_database_update' ), 20 );
+		add_action( 'plugins_loaded', array( __CLASS__, 'wc_admin_db_update_notice' ), 100 );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
 		add_action( 'admin_init', array( __CLASS__, 'install_actions' ) );
 		add_filter( 'plugin_action_links_' . WC_PLUGIN_BASENAME, array( __CLASS__, 'plugin_action_links' ) );
@@ -184,6 +185,17 @@ class WC_Install {
 		$blog_id = get_current_blog_id();
 
 		add_action( 'wp_' . $blog_id . '_wc_updater_cron', array( __CLASS__, 'run_manual_database_update' ) );
+	}
+
+	/**
+	 * Add WC Admin based db update notice.
+	 *
+	 * @since 4.0.0
+	 */
+	public static function wc_admin_db_update_notice() {
+		if ( WC()->is_wc_admin_active() ) {
+			new WC_Notes_Run_Db_Update();
+		}
 	}
 
 	/**
@@ -248,6 +260,11 @@ class WC_Install {
 			check_admin_referer( 'wc_db_update', 'wc_db_update_nonce' );
 			self::update();
 			WC_Admin_Notices::add_notice( 'update' );
+			if ( WC()->is_wc_admin_active() ) {
+				// Pre-init data store override to allow storing WC Admin notice during activation (package is not loaded yet).
+				add_filter( 'woocommerce_data_stores', array( '\Automattic\WooCommerce\Admin\API\Init', 'add_data_stores' ) );
+				WC_Notes_Run_Db_Update::add_reminder();
+			}
 		}
 	}
 
@@ -363,6 +380,12 @@ class WC_Install {
 				self::update();
 			} else {
 				WC_Admin_Notices::add_notice( 'update' );
+
+				// Pre-init data store override to allow storing WC Admin notice during activation (package is not loaded yet).
+				if ( WC()->is_wc_admin_active() ) {
+					add_filter( 'woocommerce_data_stores', array( '\Automattic\WooCommerce\Admin\API\Init', 'add_data_stores' ) );
+					WC_Notes_Run_Db_Update::add_reminder();
+				}
 			}
 		} else {
 			self::update_db_version();

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -882,4 +882,14 @@ final class WooCommerce {
 		);
 		printf( '<div class="error"><p>%s %s</p></div>', $message_one, $message_two ); /* WPCS: xss ok. */
 	}
+
+	/**
+	 * Is the WooCommerce Admin actively included in the WooCommerce core?
+	 * Based on presence of a basic WC Admin function.
+	 *
+	 * @return boolean
+	 */
+	public function is_wc_admin_active() {
+		return function_exists( 'wc_admin_url' );
+	}
 }

--- a/includes/cli/class-wc-cli-update-command.php
+++ b/includes/cli/class-wc-cli-update-command.php
@@ -73,7 +73,7 @@ class WC_CLI_Update_Command {
 
 		$progress->finish();
 
-		WC_Admin_Notices::remove_notice( 'update' );
+		WC_Admin_Notices::remove_notice( 'update', true );
 
 		/* translators: 1: Number of database updates performed 2: Database version number */
 		WP_CLI::success( sprintf( __( '%1$d update functions completed. Database version is %2$s', 'woocommerce' ), absint( $update_count ), get_option( 'woocommerce_db_version' ) ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/25646 .

### How to test the changes in this Pull Request:

1. Create a package out of this branch.
2. Create a new JN site, install and activate WC, load sample products and create an order.
3. Upgrade WC using package from step 1.
4. There should be 3 new notices on the WC Admin pages (e.g. Orders, Coupons, etc), while the old notices appear on all the other pages (e.g. list of plugins). They should correspond 1:1, i.e. when the old "Update in progress" notice appears, the new one should also appear and vice versa. If the new notice is dismissed, old ones should no longer appear, and vice versa. 

DB update needed, notice 1 of 3:
<img width="1678" alt="Screenshot 2020-02-23 at 22 12 15" src="https://user-images.githubusercontent.com/2207451/75120167-b37c5680-5689-11ea-8982-6660b43d69b3.png">

DB update in progress, notice 2 of 3:
<img width="1678" alt="Screenshot 2020-02-23 at 22 12 27" src="https://user-images.githubusercontent.com/2207451/75120173-becf8200-5689-11ea-9015-9266b7687e49.png">

DB update done, notice 3 of 3:
<img width="1678" alt="Screenshot 2020-02-23 at 22 12 56" src="https://user-images.githubusercontent.com/2207451/75120176-c68f2680-5689-11ea-9eb6-da936dca54a4.png">


4. Test this with WP 5.3 and WP 5.2 to make sure old notices still work in WP 5.2 and new ones appear with WC Admin on WP 5.3.
5. After updating, try to change the db version back to see if the notice gets triggered again (e.g. run `UPDATE wp_options SET option_value='3.9.2' where option_name='woocommerce_db_version';`)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added new db update notice for WC Admin screens.
