### PR TITLE
Run configure for Jetpack plugin before attempting to try_registration.

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -2428,6 +2428,8 @@ class WC_Admin_Setup_Wizard {
 		}
 
 		Jetpack::maybe_set_version_option();
+		$jetpack = Jetpack::init();
+		$jetpack->configure();
 		$register_result = Jetpack::try_registration();
 
 		if ( is_wp_error( $register_result ) ) {


### PR DESCRIPTION
This should prevent the fatal error otherwise occuring when connecting with Jetpack
during the OBW if Jetpack is inactive/not installed.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25651  .

### How to test the changes in this Pull Request:

1. Create a new JN site, deactivate Jetpack.
2. Install WC, go through the old OBW and don't install anything (ie no payment gateways or plugins), just click on "Continue with Jetpack" button.
3. See the Fatal error.
4. Try 1-3 with the package from this PR, you should see no fatal errors and the site should successfully connect.

For more context, please see p1582184027465300-slack-CBG1CP4EN

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - configure Jetpack plugin before trying to connect/register.
