### PR TITLE
Bump Action Scheduler to 3.1.1 + unit tests 

### DIFF
--- a/bin/package-update.sh
+++ b/bin/package-update.sh
@@ -39,10 +39,3 @@ find ./packages/woocommerce-admin -iname '*.js' -exec sed -i.bak -e "s/, 'woocom
 # Cleanup backup files
 find ./packages -name "*.bak" -type f -delete
 output 2 "Done!"
-
-# Apply patches
-output 2 "Applying patch #450 to Action Schduler"
-cd packages/action-scheduler
-curl -O https://patch-diff.githubusercontent.com/raw/woocommerce/action-scheduler/pull/450.patch
-patch -p1 < 450.patch
-output 2 "Done!"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "composer/installers": "1.7.0",
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "^3.1",
-    "woocommerce/action-scheduler": "3.0.1",
+    "woocommerce/action-scheduler": "3.1.1",
     "woocommerce/woocommerce-blocks": "2.5.12",
     "woocommerce/woocommerce-rest-api": "1.0.7",
     "woocommerce/woocommerce-admin": "0.25.1"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c674cf272eafa6cfdb1bf5d82004c974",
+    "content-hash": "0f417cae197a09b0d1723fb3ebb43f19",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -383,16 +383,16 @@
         },
         {
             "name": "woocommerce/action-scheduler",
-            "version": "3.0.1",
+            "version": "3.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "3847b7c97032ca92abed6c6f154e548437dc5803"
+                "reference": "ca6f65cca0aa6bdc02e6939c93fd439c5a552b76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/3847b7c97032ca92abed6c6f154e548437dc5803",
-                "reference": "3847b7c97032ca92abed6c6f154e548437dc5803",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/ca6f65cca0aa6bdc02e6939c93fd439c5a552b76",
+                "reference": "ca6f65cca0aa6bdc02e6939c93fd439c5a552b76",
                 "shasum": ""
             },
             "require-dev": {
@@ -414,7 +414,7 @@
             ],
             "description": "Action Scheduler for WordPress and WooCommerce",
             "homepage": "https://actionscheduler.org/",
-            "time": "2020-01-14T01:30:08+00:00"
+            "time": "2020-02-25T02:28:35+00:00"
         },
         {
             "name": "woocommerce/woocommerce-admin",

--- a/tests/unit-tests/queue/queue.php
+++ b/tests/unit-tests/queue/queue.php
@@ -1,0 +1,117 @@
+<?php
+/**
+ * Test for the queue class.
+ * @package WooCommerce\Tests\Queue
+ */
+
+ /**
+  * WC_Tests_Discounts.
+  */
+class WC_Tests_Queue extends WC_Unit_Test_Case {
+
+	/**
+	 * Test scheduling and retrieving actions.
+	 */
+	public function test_schedule_and_get_actions() {
+		$queue = WC_Queue::instance();
+
+		// Set up action arguments.
+		$current_time = time();
+		$timestamp    = $current_time + HOUR_IN_SECONDS;
+		$args         = range( 100, 130 );
+		$args         = array_flip( $args );
+		$unique_hash  = md5( wp_json_encode( $args ) );
+		$args[119]    = $unique_hash;
+		$group        = 'wc-unit-tests';
+
+		// Schedule a single action.
+		$hook   = 'single_test_action';
+		$single = $queue->schedule_single( $timestamp, $hook, $args, $group );
+
+		// Test next schedule is specified timestamp.
+		$schedule = $queue->get_next( $hook, $args, $group );
+		$this->assertEquals( $schedule->getTimestamp(), $timestamp );
+
+		// Test that the action can be found.
+		$action_ids = $queue->search(
+			array(
+				'hook' => $hook,
+				'args' => $args,
+				'group' => $group,
+			),
+			'ids'
+		);
+		$this->assertContains( $single, $action_ids );
+		$action_ids = $queue->search(
+			array(
+				'hook' => $hook,
+				'search' => $unique_hash,
+				'group' => $group,
+			),
+			'ids'
+		);
+		$this->assertContains( $single, $action_ids );
+
+		// Schedule a recurring action.
+		$hook      = 'recurring_test_action';
+		$recurring = $queue->schedule_recurring( $timestamp, DAY_IN_SECONDS, $hook, $args, $group );
+
+		// Test next schedule is specified timestamp.
+		$schedule = $queue->get_next( $hook, $args, $group );
+		$this->assertEquals( $schedule->getTimestamp(), $timestamp );
+
+		// Test that the action can be found.
+		$action_ids = $queue->search(
+			array(
+				'hook' => $hook,
+				'args' => $args,
+				'group' => $group,
+			),
+			'ids'
+		);
+		$this->assertContains( $recurring, $action_ids );
+		$action_ids = $queue->search(
+			array(
+				'hook' => $hook,
+				'search' => $unique_hash,
+				'group' => $group,
+			),
+			'ids'
+		);
+		$this->assertContains( $recurring, $action_ids );
+
+		// Schedule a cron action on a daily midnight schedule starting at the next midnight.
+		$hook          = 'recurring_cron_action';
+		$cron_schedule = '0 0 * * *';
+		$timestamp     = $current_time + DAY_IN_SECONDS - ( $current_time % DAY_IN_SECONDS );
+		$cron_action   = $queue->schedule_cron( $timestamp - HOUR_IN_SECONDS, $cron_schedule, $hook, $args, $group );
+
+		// Test next schedule is specified timestamp.
+		$schedule = $queue->get_next( $hook, $args, $group );
+		$this->assertEquals( $schedule->getTimestamp(), $timestamp );
+
+		// Test that the action can be found.
+		$action_ids = $queue->search(
+			array(
+				'hook' => $hook,
+				'args' => $args,
+				'group' => $group,
+			),
+			'ids'
+		);
+		$this->assertContains( $cron_action, $action_ids );
+		$action_ids = $queue->search(
+			array(
+				'hook' => $hook,
+				'search' => $unique_hash,
+				'group' => $group,
+			),
+			'ids'
+		);
+		$this->assertContains( $cron_action, $action_ids );
+
+		// Test wildcard search.
+		$action_ids = $queue->search( array( 'search' => $unique_hash ), 'ids' );
+		$this->assertEquals( count( $action_ids ), 3 );
+	}
+}


### PR DESCRIPTION
This PR bumps the Action Scheduler version to 3.1.1 in composer.json and adds unit tests for the WC_Queue class to ensure the queue and underlying action scheduler package are functioning properly.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Add the following snippet
```
add_action( 'init', function() {
	$action_id = as_schedule_single_action( time() + 50, 'test_action', range( 100, 150 ) );
	error_log( 'test_action: ' . $action_id );
	$found_action = as_next_scheduled_action( 'test_action', range( 100, 150 ) );
	error_log( 'Schedule: ' . gmdate( 'Y-m-d H:i:s O', $found_action ) );
} );
```
2. Debug log should have
```
[24-Feb-2020 19:48:04 UTC] test_action: 12345
[24-Feb-2020 19:48:04 UTC] Schedule: 2020-02-24 19:48:54 +0000
```
3. go to Tools -> Scheduled actions
4. enter 149 in the search box
5. test_action actions should be found

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update Action Scheduler to version 3.1.1.
