### PR TITLE
Add defensive checks because `configure` is not present in older jetp…

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -2429,7 +2429,10 @@ class WC_Admin_Setup_Wizard {
 
 		Jetpack::maybe_set_version_option();
 		$jetpack = Jetpack::init();
-		$jetpack->configure();
+		// Older versions of jetpack may not have this method.
+		if ( method_exists( $jetpack, 'configure' ) ) {
+			$jetpack->configure();
+		}
 		$register_result = Jetpack::try_registration();
 
 		if ( is_wp_error( $register_result ) ) {


### PR DESCRIPTION
…ack version

Follow up from #25742 

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added checks around `configure` method which is not present in JP < 8. Earlier we didn't need `configure` to be manually called, so with this patch, there won't be any error in the latest or in earlier versions.

### How to test the changes in this Pull Request:

1. Create a new JN site with JetPack < 8, for egs 7.9.1. Deactivate JP.
2. Install WooCommerce with this patch 
3. Go to old OBW and complete the Jetpack connection step. Without this patch, there will be a fatal error when you connect to JP.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Check `configure` exists before calling to support older JP versions.