### PR TITLE
Add $enabled_only argument to wc_get_shipping_method_count()

### DIFF
--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -286,7 +286,7 @@ class WC_Settings_Shipping extends WC_Settings_Page {
 	 * Show zones
 	 */
 	protected function zones_screen() {
-		$method_count = wc_get_shipping_method_count();
+		$method_count = wc_get_shipping_method_count( false, true );
 
 		wp_localize_script(
 			'wc-shipping-zones',

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1506,7 +1506,7 @@ function wc_get_shipping_method_count( $include_legacy = false ) {
 		return absint( $transient_value['value'] );
 	}
 
-	$method_count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods" ) );
+	$method_count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE is_enabled=true" ) );
 
 	if ( $include_legacy ) {
 		// Count activated methods that don't support shipping zones.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1493,9 +1493,12 @@ function wc_postcode_location_matcher( $postcode, $objects, $object_id_key, $obj
  *
  * @since  2.6.0
  * @param  bool $include_legacy Count legacy shipping methods too.
+ * @param  bool $enabled_only   Whether non-legacy shipping methods should be
+ *                              restricted to enabled ones. It doesn't affect
+ *                              legacy shipping methods. @since 4.2.0.
  * @return int
  */
-function wc_get_shipping_method_count( $include_legacy = false ) {
+function wc_get_shipping_method_count( $include_legacy = false, $enabled_only = false ) {
 	global $wpdb;
 
 	$transient_name    = $include_legacy ? 'wc_shipping_method_count_legacy' : 'wc_shipping_method_count';
@@ -1506,7 +1509,8 @@ function wc_get_shipping_method_count( $include_legacy = false ) {
 		return absint( $transient_value['value'] );
 	}
 
-	$method_count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE is_enabled=1" ) );
+	$where_clause = $enabled_only ? 'WHERE is_enabled=1' : '';
+	$method_count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods ${where_clause}" ) );
 
 	if ( $include_legacy ) {
 		// Count activated methods that don't support shipping zones.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1506,7 +1506,7 @@ function wc_get_shipping_method_count( $include_legacy = false ) {
 		return absint( $transient_value['value'] );
 	}
 
-	$method_count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE is_enabled=true" ) );
+	$method_count = absint( $wpdb->get_var( "SELECT COUNT(*) FROM {$wpdb->prefix}woocommerce_shipping_zone_methods WHERE is_enabled=1" ) );
 
 	if ( $include_legacy ) {
 		// Count activated methods that don't support shipping zones.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1495,7 +1495,7 @@ function wc_postcode_location_matcher( $postcode, $objects, $object_id_key, $obj
  * @param  bool $include_legacy Count legacy shipping methods too.
  * @param  bool $enabled_only   Whether non-legacy shipping methods should be
  *                              restricted to enabled ones. It doesn't affect
- *                              legacy shipping methods. @since 4.2.0.
+ *                              legacy shipping methods. @since 4.3.0.
  * @return int
  */
 function wc_get_shipping_method_count( $include_legacy = false, $enabled_only = false ) {


### PR DESCRIPTION
According to [`wc_get_shipping_method_count()` docs](https://github.com/woocommerce/woocommerce/blob/master/includes/wc-core-functions.php#L1475-L1515):
```
 * Gets number of shipping methods currently enabled. Used to identify if
 * shipping is configured.
```

However, the SQL query didn't have a check to verify shipping methods were enabled. This PR adds an `$enabled_only` param to do that check.

Closes #25752.

### How to test the changes in this Pull Request:

1. Remove all shipping methods from _WooCommerce_ > _Settings_ > _Shipping_.
2. Keep one shipping method but set it to be disabled:
![imatge](https://user-images.githubusercontent.com/3616980/75255945-0a497380-57e3-11ea-9d52-7ee3dcf5dd2c.png)
3. Verify the shipping zones banner appears indicating shipping zones must be created:
![imatge](https://user-images.githubusercontent.com/3616980/75256052-28af6f00-57e3-11ea-8273-2442900d7359.png)

### Changelog entry

> `wc_get_shipping_method_count()` has a new argument (`$enabled_only`) which allows restricting the non-legacy shipping methods to the enabled ones.
