### PR TITLE
Fix > Undefined property error when updating the coupon post meta

### DIFF
--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -55,6 +55,11 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	);
 
 	/**
+	 * @var array
+	 */
+	protected $updated_props = array();
+
+	/**
 	 * Method to create a new coupon in the database.
 	 *
 	 * @since 3.0.0

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -55,6 +55,9 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	);
 
 	/**
+	 * The updated coupon properties
+	 *
+	 * @since TBD
 	 * @var array
 	 */
 	protected $updated_props = array();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25730 .

### How to test the changes in this Pull Request:

- Add the following to your test site:
```
add_action( 'init', function () {
	$coupon = new \WC_Coupon( 'test' );
	$coupon->set_date_expires( null );
	$coupon->save();
} );
```
- This action should not result in errors. The following Notice should be fixed/not visible in your error log:

`PHP Notice:  Undefined property: WC_Coupon_Data_Store_CPT::$updated_props in /wp-content/plugins/woocommerce/includes/data-stores/class-wc-coupon-data-store-cpt.php on line 280`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Undefined property error when attempting to modify the coupon post meta.
