### PR TITLE
move edited attribute message to consistent location

### DIFF
--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -16,6 +16,13 @@ defined( 'ABSPATH' ) || exit;
 class WC_Admin_Attributes {
 
 	/**
+	 * Edited attribute ID.
+	 *
+	 * @var int
+	 */
+	private static $edited_attribute_id;
+
+	/**
 	 * Handles output of the attributes page in admin.
 	 *
 	 * Shows the created attributes and lets you add new ones or edit existing ones.
@@ -135,7 +142,7 @@ class WC_Admin_Attributes {
 			return $id;
 		}
 
-		echo '<div class="updated"><p>' . esc_html__( 'Attribute updated successfully', 'woocommerce' ) . '</p><p><a href="' . esc_url( admin_url( 'edit.php?post_type=product&amp;page=product_attributes' ) ) . '">' . esc_html__( 'Back to Attributes', 'woocommerce' ) . '</a></p></div>';
+		self::$edited_attribute_id = $id;
 
 		return true;
 	}
@@ -180,6 +187,10 @@ class WC_Admin_Attributes {
 			if ( ! $attribute_to_edit ) {
 				echo '<div id="woocommerce_errors" class="error"><p>' . esc_html__( 'Error: non-existing attribute ID.', 'woocommerce' ) . '</p></div>';
 			} else {
+				if ( self::$edited_attribute_id > 0 ) {
+					echo '<div id="message" class="updated"><p>' . esc_html__( 'Attribute updated successfully', 'woocommerce' ) . '</p><p><a href="' . esc_url( admin_url( 'edit.php?post_type=product&amp;page=product_attributes' ) ) . '">' . esc_html__( 'Back to Attributes', 'woocommerce' ) . '</a></p></div>';
+					self::$edited_attribute_id = null;
+				}
 				$att_type    = $attribute_to_edit->attribute_type;
 				$att_label   = format_to_edit( $attribute_to_edit->attribute_label );
 				$att_name    = $attribute_to_edit->attribute_name;


### PR DESCRIPTION
This PR moves the edited attribute message to a location in the WP `wrap` that is consist with edit products, orders, etc. By moving the notice to this location, it is not included the notice handling in WC Admin.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Move the edited/updated attribute notice to later in the page output.

Closes #25756 .

### How to test the changes in this Pull Request:

1. Activate WC Admin
2. Edit and save a product attribute
3. Notice should remain visible

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Prevent edited attribute notice being hidden by new dashboard..
