### PR TITLE
Fixes tax rounding issues

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1594,11 +1594,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		foreach ( $this->get_items( array( 'line_item', 'fee' ) ) as $item_id => $item ) {
 			$taxes = $item->get_taxes();
 			foreach ( $taxes['total'] as $tax_rate_id => $tax ) {
-				$tax_amount = (float) $tax;
-
-				if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
-					$tax_amount = wc_round_tax_total( $tax_amount );
-				}
+				$tax_amount = $this->round_line_tax( $tax, false );
 
 				$cart_taxes[ $tax_rate_id ] = isset( $cart_taxes[ $tax_rate_id ] ) ? $cart_taxes[ $tax_rate_id ] + $tax_amount : $tax_amount;
 			}
@@ -1640,8 +1636,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->add_item( $item );
 		}
 
-		$this->set_shipping_tax( wc_round_tax_total( array_sum( $shipping_taxes ) ) );
-		$this->set_cart_tax( wc_round_tax_total( array_sum( $cart_taxes ) ) );
+		$this->set_shipping_tax( $this->round_line_tax( array_sum( $shipping_taxes ) ) );
+		$this->set_cart_tax( $this->round_line_tax( array_sum( $cart_taxes ) ) );
 		$this->save();
 	}
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -676,7 +676,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @throws WC_Data_Exception Exception may be thrown if value is invalid.
 	 */
 	protected function set_total_tax( $value ) {
-		$this->set_prop( 'total_tax', wc_format_decimal( $value ) );
+		// We round here because this is a total entry, as opposed to line items in other setters.
+		$this->set_prop( 'total_tax', wc_format_decimal( wc_round_tax_total( $value ) ) );
 	}
 
 	/**
@@ -1636,8 +1637,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->add_item( $item );
 		}
 
-		$this->set_shipping_tax( $this->round_line_tax( array_sum( $shipping_taxes ) ) );
-		$this->set_cart_tax( $this->round_line_tax( array_sum( $cart_taxes ) ) );
+		$this->set_shipping_tax( $this->round_line_tax( array_sum( $shipping_taxes ), false ) );
+		$this->set_cart_tax( $this->round_line_tax( array_sum( $cart_taxes ), false ) );
 		$this->save();
 	}
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1637,8 +1637,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			$this->add_item( $item );
 		}
 
-		$this->set_shipping_tax( $this->round_line_tax( array_sum( $shipping_taxes ), false ) );
-		$this->set_cart_tax( $this->round_line_tax( array_sum( $cart_taxes ), false ) );
+		$this->set_shipping_tax( array_sum( $shipping_taxes ) );
+		$this->set_cart_tax( array_sum( $cart_taxes ) );
 		$this->save();
 	}
 

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -684,7 +684,7 @@ final class WC_Cart_Totals {
 
 		$items_total = $this->get_rounded_items_total( $this->get_values_for_total( 'total' ) );
 
-		$this->set_total( 'items_total', round( $items_total ) );
+		$this->set_total( 'items_total', $items_total );
 		$this->set_total( 'items_total_tax', array_sum( array_values( wp_list_pluck( $this->items, 'total_tax' ) ) ) );
 
 		$this->cart->set_cart_contents_total( $this->get_total( 'items_total' ) );

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -606,10 +606,8 @@ final class WC_Cart_Totals {
 	 * @return array
 	 */
 	protected function round_merged_taxes( $taxes ) {
-		if ( $this->round_at_subtotal() ) {
-			foreach ( $taxes as $rate_id => $tax ) {
-				$taxes[ $rate_id ] = wc_round_tax_total( $tax, 0 );
-			}
+		foreach ( $taxes as $rate_id => $tax ) {
+			$taxes[ $rate_id ] = $this->round_line_tax( $tax );
 		}
 
 		return $taxes;

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -448,7 +448,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_subtotal_tax( $value ) {
-		$this->totals['subtotal_tax'] = wc_round_tax_total( $value );
+		$this->totals['subtotal_tax'] = $value;
 	}
 
 	/**
@@ -458,7 +458,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_discount_total( $value ) {
-		$this->totals['discount_total'] = wc_cart_round_discount( $value, wc_get_price_decimals() );
+		$this->totals['discount_total'] = $value;
 	}
 
 	/**
@@ -468,7 +468,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_discount_tax( $value ) {
-		$this->totals['discount_tax'] = wc_round_tax_total( $value );
+		$this->totals['discount_tax'] = $value;
 	}
 
 	/**
@@ -488,7 +488,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_shipping_tax( $value ) {
-		$this->totals['shipping_tax'] = wc_round_tax_total( $value );
+		$this->totals['shipping_tax'] = $value;
 	}
 
 	/**
@@ -508,7 +508,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_cart_contents_tax( $value ) {
-		$this->totals['cart_contents_tax'] = wc_round_tax_total( $value );
+		$this->totals['cart_contents_tax'] = $value;
 	}
 
 	/**
@@ -528,6 +528,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_total_tax( $value ) {
+		// We round here because this is a total entry, as opposed to line items in other setters.
 		$this->totals['total_tax'] = wc_round_tax_total( $value );
 	}
 
@@ -548,7 +549,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_fee_tax( $value ) {
-		$this->totals['fee_tax'] = wc_round_tax_total( $value );
+		$this->totals['fee_tax'] = $value;
 	}
 
 	/**

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -370,25 +370,13 @@ class WC_Checkout {
 			$order->set_created_via( 'checkout' );
 			$order->set_cart_hash( $cart_hash );
 			$order->set_customer_id( apply_filters( 'woocommerce_checkout_customer_id', get_current_user_id() ) );
-			$order_vat_exempt = WC()->cart->get_customer()->get_is_vat_exempt() ? 'yes' : 'no';
-			$order->add_meta_data( 'is_vat_exempt', $order_vat_exempt, true );
 			$order->set_currency( get_woocommerce_currency() );
 			$order->set_prices_include_tax( 'yes' === get_option( 'woocommerce_prices_include_tax' ) );
 			$order->set_customer_ip_address( WC_Geolocation::get_ip_address() );
 			$order->set_customer_user_agent( wc_get_user_agent() );
 			$order->set_customer_note( isset( $data['order_comments'] ) ? $data['order_comments'] : '' );
 			$order->set_payment_method( isset( $available_gateways[ $data['payment_method'] ] ) ? $available_gateways[ $data['payment_method'] ] : $data['payment_method'] );
-			$order->set_shipping_total( WC()->cart->get_shipping_total() );
-			$order->set_discount_total( WC()->cart->get_discount_total() );
-			$order->set_discount_tax( WC()->cart->get_discount_tax() );
-			$order->set_cart_tax( WC()->cart->get_cart_contents_tax() + WC()->cart->get_fee_tax() );
-			$order->set_shipping_tax( WC()->cart->get_shipping_tax() );
-			$order->set_total( WC()->cart->get_total( 'edit' ) );
-			$this->create_order_line_items( $order, WC()->cart );
-			$this->create_order_fee_lines( $order, WC()->cart );
-			$this->create_order_shipping_lines( $order, WC()->session->get( 'chosen_shipping_methods' ), WC()->shipping()->get_packages() );
-			$this->create_order_tax_lines( $order, WC()->cart );
-			$this->create_order_coupon_lines( $order, WC()->cart );
+			$this->set_data_from_cart( $order );
 
 			/**
 			 * Action hook to adjust order before save.
@@ -411,6 +399,28 @@ class WC_Checkout {
 		}
 	}
 
+	/**
+	 * Copy line items, tax, totals data from cart to order.
+	 *
+	 * @param WC_Order $order Order object.
+	 *
+	 * @throws Exception When unable to create order.
+	 */
+	public function set_data_from_cart( &$order ) {
+		$order_vat_exempt = WC()->cart->get_customer()->get_is_vat_exempt() ? 'yes' : 'no';
+		$order->add_meta_data( 'is_vat_exempt', $order_vat_exempt, true );
+		$order->set_shipping_total( WC()->cart->get_shipping_total() );
+		$order->set_discount_total( WC()->cart->get_discount_total() );
+		$order->set_discount_tax( WC()->cart->get_discount_tax() );
+		$order->set_cart_tax( WC()->cart->get_cart_contents_tax() + WC()->cart->get_fee_tax() );
+		$order->set_shipping_tax( WC()->cart->get_shipping_tax() );
+		$order->set_total( WC()->cart->get_total( 'edit' ) );
+		$this->create_order_line_items( $order, WC()->cart );
+		$this->create_order_fee_lines( $order, WC()->cart );
+		$this->create_order_shipping_lines( $order, WC()->session->get( 'chosen_shipping_methods' ), WC()->shipping()->get_packages() );
+		$this->create_order_tax_lines( $order, WC()->cart );
+		$this->create_order_coupon_lines( $order, WC()->cart );
+	}
 	/**
 	 * Add line items to the order.
 	 *

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -2010,6 +2010,57 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test rounding with fees as described in Github issue 25629.
+	 */
+	public function test_rounding_with_fees_25629() {
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+
+		WC()->cart->empty_cart();
+		$tax_rate    = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '10.0000',
+			'tax_rate_name'     => 'TAX10',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '10percent',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 71.50 );
+		$product->set_tax_class( '10percent' );
+		$product->save();
+
+		WC_Helper_Coupon::create_coupon(
+			'3percent',
+			array(
+				'discount_type' => 'percent',
+				'coupon_amount' => 3,
+			)
+		);
+
+		add_action( 'woocommerce_cart_calculate_fees', array( $this, 'add_fee_1_5_to_cart' ) );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->apply_coupon( '3percent' );
+		WC()->cart->calculate_totals();
+		remove_action( 'woocommerce_cart_calculate_fees', array( $this, 'add_fee_1_5_to_cart' ) );
+
+		$this->assertEquals( 70.86, WC()->cart->get_total( 'edit' ) );
+	}
+
+	/**
+	 * Helper function. Adds 1.5 taxable fees to cart.
+	 */
+	public function add_fee_1_5_to_cart() {
+		WC()->cart->add_fee( 'Dummy fee', 1.5 / 1.1, true );
+	}
+
+	/**
 	 * Change tax class.
 	 *
 	 * @return string

--- a/tests/unit-tests/cart/cart.php
+++ b/tests/unit-tests/cart/cart.php
@@ -2027,13 +2027,11 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 			'tax_rate_compound' => '0',
 			'tax_rate_shipping' => '1',
 			'tax_rate_order'    => '1',
-			'tax_rate_class'    => '10percent',
 		);
 		WC_Tax::_insert_tax_rate( $tax_rate );
 
 		$product = WC_Helper_Product::create_simple_product();
 		$product->set_regular_price( 71.50 );
-		$product->set_tax_class( '10percent' );
 		$product->save();
 
 		WC_Helper_Coupon::create_coupon(

--- a/tests/unit-tests/order/class-wc-tests-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-orders.php
@@ -71,7 +71,6 @@ class WC_Tests_Order extends WC_Unit_Test_Case {
 			'tax_rate_compound' => '0',
 			'tax_rate_shipping' => '1',
 			'tax_rate_order'    => '1',
-			'tax_rate_class'    => 'tax_1',
 		);
 		WC_Tax::_insert_tax_rate( $tax_rate );
 

--- a/tests/unit-tests/order/class-wc-tests-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-orders.php
@@ -142,15 +142,7 @@ class WC_Tests_Order extends WC_Unit_Test_Case {
 		$product->set_regular_price( 22.99 );
 		$product->save();
 
-		$flat_rate_settings = array(
-			'enabled'      => 'yes',
-			'title'        => 'Flat rate',
-			'availability' => 'all',
-			'countries'    => '',
-			'tax_status'   => 'taxable',
-			'cost'         => '10',
-		);
-		update_option( 'woocommerce_flat_rate_settings', $flat_rate_settings );
+		WC_Helper_Shipping::create_simple_flat_rate();
 
 		WC()->cart->empty_cart();
 		WC()->customer->set_is_vat_exempt( false );

--- a/tests/unit-tests/order/class-wc-tests-orders.php
+++ b/tests/unit-tests/order/class-wc-tests-orders.php
@@ -52,4 +52,118 @@ class WC_Tests_Order extends WC_Unit_Test_Case {
 		$this->assertEquals( 0.79, $order->get_total_tax() );
 	}
 
+	/**
+	 * Test shipping is added and rounded correctly when addedd to total.
+	 *
+	 * @throws WC_Data_Exception When lines cannot be added to order.
+	 */
+	public function test_order_rounding_with_shipping_25748() {
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '21.0000',
+			'tax_rate_name'     => 'CGST',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => 'tax_1',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 23.85 );
+		$product->save();
+
+		$shipping_rate   = new WC_Shipping_Rate( 'flat_rate_shipping', 'Flat rate shipping', '9.5', array(), 'flat_rate' );
+		$shipping_item   = new WC_Order_Item_Shipping();
+		$shipping_item->set_props(
+			array(
+				'method_title' => $shipping_rate->label,
+				'method_id'    => $shipping_rate->id,
+				'total'        => wc_format_decimal( $shipping_rate->cost ),
+				'taxes'        => $shipping_rate->taxes,
+			)
+		);
+
+		foreach ( $shipping_rate->get_meta_data() as $key => $value ) {
+			$shipping_item->add_meta_data( $key, $value, true );
+		}
+
+		$order = new WC_Order();
+		$order->add_product( $product, 1 );
+		$order->add_item( $shipping_item );
+
+		$order->calculate_totals( true );
+
+		$this->assertEquals( 7, $order->get_total_tax() );
+		$this->assertEquals( 40.35, $order->get_total() );
+	}
+
+	/**
+	 * Testing rounding when lines are copied over to order.
+	 *
+	 * @throws Exception When lines cannot be added to order.
+	 */
+	public function test_order_rounding_addition_25641() {
+		update_option( 'woocommerce_prices_include_tax', 'no' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+
+		$tax_rate1 = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '7.0000',
+			'tax_rate_name'     => 'CGST',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate1 );
+
+		$tax_rate2 = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '2.2500',
+			'tax_rate_name'     => 'SGST',
+			'tax_rate_priority' => '2',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '1',
+			'tax_rate_order'    => '1',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate2 );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 22.99 );
+		$product->save();
+
+		$flat_rate_settings = array(
+			'enabled'      => 'yes',
+			'title'        => 'Flat rate',
+			'availability' => 'all',
+			'countries'    => '',
+			'tax_status'   => 'taxable',
+			'cost'         => '10',
+		);
+		update_option( 'woocommerce_flat_rate_settings', $flat_rate_settings );
+
+		WC()->cart->empty_cart();
+		WC()->customer->set_is_vat_exempt( false );
+
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->session->set( 'chosen_shipping_method', array( 'flat_rate' ) );
+		WC()->cart->calculate_totals();
+
+		$checkout = WC_Checkout::instance();
+		$order = new WC_Order();
+		$checkout->set_data_from_cart( $order );
+		$this->assertEquals( 3.05, $order->get_total_tax() );
+		$this->assertEquals( 36.04, $order->get_total() );
+	}
+
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR is a follow up from #24828, ultimately the goal is to have shared logic for rounding in both orders and cart. In this PR, I am removing individual rounding logic from multiple places and relying on logic added in #24828 . I am also relying on unit tests heavily to make sure that we don't add any regressions and calculations are correct for majority of use cases.

Another notable change is that some logic from `create_order` is not refactored into `set_data_from_cart`. This is to make that method better unit-testable. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25629, #25748, #25641

### How to test the changes in this Pull Request:

There are multiple parts to testing this PR:

Part 1 (for 25629):
1. Set setting `Yes, I will enter prices inclusive of tax`, and `Round tax at subtotal level, instead of rounding per line ` to true.
2. Add a tax rate for 10percent.
3. Add following snippet to your theme;s function.php
```
add_action('woocommerce_cart_calculate_fees', 'set_box_fee', 10);
function set_box_fee($cart) {
    $boxFee = 1.5/1.1; // 1.5€ fee, of which we only need the net part
    $cart->add_fee(__('Packaging', 'woocommerce'), $boxFee, true);
}
```
4. Create a Product for 71.50.
5. Create a coupon for a 3 percent cart discount.
6. In a cart, try to checkout with the product added in step 4, apply the coupon. Without this patch, the total should be 70.85, with this patch it should be 70.86.

Part 2 (for #25748):
1.  Set setting `No, I will enter prices exclusive of tax`.
2. Set setting `Round tax at subtotal level, instead of rounding per line ` to true.
3. Add a tax rate of 21%.
4. Create a product for 23.85.
5. Create a manual order with the product added in step 4, and add a shipping rate for 9.5.
6. Click on recalculate, without this patch, the total will be 40.36, with this patch, it should be 40.35.

Part 3 (for #25641 )
1. Set setting `No, I will enter prices exclusive of tax`.
2. Set setting `Round tax at subtotal level, instead of rounding per line` to true.
3. Add a tax rate for 7%
4. Add another tax rate for 2.25 %. Make sure these two rates have different priorities.
5. Create a product for 22.99.
6. Add a shipping flat rate for 10.
7. Set setting `Display tax totals ` to `As a single total`.
8. Check out the product created in step 5, in the Place order page, verify that tax total is 3.05.
9. Place the order. In the order details screen, without this patch, order total will change to 3.06,  whereas with this patch, it will stay at 3.05



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Remove some of the individual rounding logic to make sure we round at certain places only.