### PR TITLE
Adds two filters to retrieve_password journey

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -302,15 +302,23 @@ class WC_Shortcode_My_Account {
 		}
 
 		if ( ! $user_data ) {
-			wc_add_notice( __( 'Invalid username or email.', 'woocommerce' ), 'error' );
+			$filter_outcome = apply_filters( 'retrieve_password_no_user_data_found', false, $errors );
 
-			return false;
+			if ( false === $filter_outcome ) {
+				wc_add_notice( __( 'Invalid username or email.', 'woocommerce' ), 'error' );
+			}
+
+			return $filter_outcome;
 		}
 
 		if ( is_multisite() && ! is_user_member_of_blog( $user_data->ID, get_current_blog_id() ) ) {
-			wc_add_notice( __( 'Invalid username or email.', 'woocommerce' ), 'error' );
+			$filter_outcome = apply_filters( 'retrieve_password_user_not_a_member_of_this_multisite_blog', false, $errors, $user_data, get_current_blog_id() );
 
-			return false;
+			if ( false === $filter_outcome ) {
+				wc_add_notice( __( 'Invalid username or email.', 'woocommerce' ), 'error' );
+			}
+
+			return $filter_outcome;
 		}
 
 		// Redefining user_login ensures we return the right case in the email.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If a user requests a password reset and provides either a valid username or email address, the outcome would be that the user is redirected to "reset link sent" page : https://github.com/woocommerce/woocommerce/blob/0883b5b97713477a92329c66de65c816a4a057a7/includes/class-wc-form-handler.php#L1045

However, if a user requests a password reset and provides either an invalid username or email address, instead they are not redirected and see the same form again with an error message: "Invalid username or email.".

This suggested change retains the existing behaviour as default, but allows some extra flexibility through use of two new filters.

Given this change, we could then hook into both new filters and return `true`. This would allow us to mimic the outcome of a successful password reset request - i.e. proceed with the redirect - whilst not actually sending the password reset notification email. 

### How to test the changes in this Pull Request:

1. Requesting a password reset should behave identical to current `master` behaviour by default.
2. Add a filter to the new filters, and return `true`. You should now see the "happy path" outcome, regardless of whether your username / email was associated with a registered user. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? (manual)

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Adds two new filters to `retrieve_password`, allowing more granular modification of the "reset password" journey.