### PR TITLE
Update slug for generating the i18n file

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -63,7 +63,7 @@
       "phpcbf -p"
     ],
     "makepot-audit": [
-      "wp i18n make-pot . --exclude=\".github,.wordpress-org,bin,sample-data,node_modules,tests\""
+      "wp i18n make-pot . --exclude=\".github,.wordpress-org,bin,sample-data,node_modules,tests\" --slug=woocommerce"
     ],
     "makepot": [
       "@makepot-audit --skip-audit"


### PR DESCRIPTION
When running from the release directory, slug is auto-detected incorrectly, so specify it explicitly.

Reference docs: https://developer.wordpress.org/cli/commands/i18n/make-pot/

Closes #25784 