### PR TITLE
Move package @jest/test-sequencer to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/polyfill": "7.8.3",
     "@babel/preset-env": "7.8.6",
     "@babel/register": "7.8.6",
+    "@jest/test-sequencer": "^25.0.0",
     "@wordpress/e2e-test-utils": "4.3.0",
     "autoprefixer": "9.7.4",
     "babel-eslint": "10.1.0",
@@ -94,8 +95,5 @@
     "> 0.1%",
     "ie 8",
     "ie 9"
-  ],
-  "dependencies": {
-    "@jest/test-sequencer": "^25.0.0"
-  }
+  ]
 }


### PR DESCRIPTION
The package @jest/test-sequencer was added to the dependencies section
by mistake. This package is used only to run the e2e tests so it should
live in the devDependencies.