### PR TITLE
Preventing to add product in JSON search products

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1574,6 +1574,10 @@ class WC_AJAX {
 				continue;
 			}
 
+			if ( $product_object->get_backorders() === 'no' && $product_object->get_stock_quantity() <= 0 ) {
+				continue;
+			}
+
 			if ( $managing_stock && ! empty( $_GET['display_stock'] ) ) {
 				$stock_amount    = $product_object->get_stock_quantity();
 				/* Translators: %d stock amount */


### PR DESCRIPTION
Preventing to add product in JSON search products list when product stock zero and backorder not allowed

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25518 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Preventing to add product in JSON search products list when product stock zero and backorder not allowed.
