### PR TITLE
Display only wc-admin notices when enabled to avoid duplicate notices

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -233,7 +233,9 @@ class WC_Admin_Notices {
 	 * If we need to update the database, include a message with the DB update button.
 	 */
 	public static function update_notice() {
-		if ( WC()->is_wc_admin_active() ) {
+		$screen    = get_current_screen();
+		$screen_id = $screen ? $screen->id : '';
+		if ( WC()->is_wc_admin_active() && in_array( $screen_id, wc_get_screen_ids(), true ) ) {
 			return;
 		}
 

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -233,6 +233,10 @@ class WC_Admin_Notices {
 	 * If we need to update the database, include a message with the DB update button.
 	 */
 	public static function update_notice() {
+		if ( WC()->is_wc_admin_active() ) {
+			return;
+		}
+
 		if ( WC_Install::needs_db_update() ) {
 			$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_run_update_callback', null, 'woocommerce-db-updates' );
 

--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -32,7 +32,7 @@ class WC_Notes_Run_Db_Update {
 			return;
 		}
 
-		add_action( 'admin_init', array( __CLASS__, 'show_reminder' ) );
+		add_action( 'current_screen', array( __CLASS__, 'show_reminder' ) );
 	}
 
 	/**
@@ -261,28 +261,6 @@ class WC_Notes_Run_Db_Update {
 	}
 
 	/**
-	 * Create a note to remind store owners to complete the db update.
-	 */
-	public static function add_reminder() {
-		try {
-			$data_store = \WC_Data_Store::load( 'admin-note' );
-		} catch ( Exception $e ) {
-			if ( Constants::is_true( 'WP_DEBUG' ) ) {
-				error_log( 'WC_Notes_Run_Db_Update::add_reminder was called before the respective Data Store got registered. Database update notice will not be displayed.' );
-			}
-		}
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
-
-		if ( empty( $note_ids ) ) {
-			// Create a new db update notice.
-			self::update_needed_notice();
-		} else {
-			// Refresh the nonce action if needed, so can't be stored just once.
-			self::update_needed_notice( $note_ids[0] );
-		}
-	}
-
-	/**
 	 * Prepare the correct content of the db update note to be displayed by WC Admin.
 	 *
 	 * This one gets called on each page load, so try to bail quickly.
@@ -308,7 +286,7 @@ class WC_Notes_Run_Db_Update {
 				self::update_needed_notice( $note_id );
 			}
 		} else {
-			// Not running update_db_version() here unlike \WC_Admin_Notices::update_notice, as it runs over there.
+			\WC_Install::update_db_version();
 			self::update_done_notice( $note_id );
 		}
 	}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -264,7 +264,7 @@ class WC_Install {
 			if ( WC()->is_wc_admin_active() ) {
 				// Pre-init data store override to allow storing WC Admin notice during activation (package is not loaded yet).
 				add_filter( 'woocommerce_data_stores', array( '\Automattic\WooCommerce\Admin\API\Init', 'add_data_stores' ) );
-				WC_Notes_Run_Db_Update::add_reminder();
+				WC_Notes_Run_Db_Update::show_reminder();
 			}
 		}
 	}
@@ -385,7 +385,7 @@ class WC_Install {
 				// Pre-init data store override to allow storing WC Admin notice during activation (package is not loaded yet).
 				if ( WC()->is_wc_admin_active() ) {
 					add_filter( 'woocommerce_data_stores', array( '\Automattic\WooCommerce\Admin\API\Init', 'add_data_stores' ) );
-					WC_Notes_Run_Db_Update::add_reminder();
+					WC_Notes_Run_Db_Update::show_reminder();
 				}
 			}
 		} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

With wc-admin 1.0, we are showing notices prominently on WooCommerce screens (with hidden only on Analytics and Dashboard screen). Therefore, there is no need to display normal update notification anymore if WC_Admin is loaded, because it will show the notification anyway.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Trigger notice by running `wp option set woocommerce_version 3.8.0` and `wp option set woocommerce_db_version 3.8.0`
2. Make sure a notice for updating DB is displayed on all Woo Screens.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Don't show duplicated update notifications on Woo Screens.
