### PR TITLE
Update system status info about WC Admin.

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -127,8 +127,7 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'The WooCommerce Admin package running on your site.', 'woocommerce' ) ); ?></td>
 			<td>
 				<?php
-				// To prevent $path from previous package to leak into the conditions in this section.
-				$path = null; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+				$wc_admin_path = null;
 				if ( defined( 'WC_ADMIN_VERSION_NUMBER' ) ) {
 					// Plugin version of WC Admin.
 					$version        = WC_ADMIN_VERSION_NUMBER;
@@ -144,20 +143,20 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 						$version       .= \Automattic\WooCommerce\Admin\Composer\Package::VERSION;
 						$package_active = false;
 					}
-					$path           = \Automattic\WooCommerce\Admin\Composer\Package::get_path(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+					$wc_admin_path = \Automattic\WooCommerce\Admin\Composer\Package::get_path();
 				} else {
 					$version = null;
 				}
 
 				if ( ! is_null( $version ) ) {
-					if ( ! isset( $path ) ) {
+					if ( ! isset( $wc_admin_path ) ) {
 						if ( defined( 'WC_ADMIN_PLUGIN_FILE' ) ) {
-							$path = dirname( WC_ADMIN_PLUGIN_FILE ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+							$wc_admin_path = dirname( WC_ADMIN_PLUGIN_FILE );
 						} else {
-							$path = __( 'Active Plugin', 'woocommerce' ); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+							$wc_admin_path = __( 'Active Plugin', 'woocommerce' );
 						}
 					}
-					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> ' . esc_html( $version ) . ' <code class="private">' . esc_html( $path ) . '</code></mark> ';
+					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> ' . esc_html( $version ) . ' <code class="private">' . esc_html( $wc_admin_path ) . '</code></mark> ';
 				} else {
 					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Unable to detect the WC Admin package.', 'woocommerce' ) . '</mark>';
 				}

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -156,7 +156,11 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 							$wc_admin_path = __( 'Active Plugin', 'woocommerce' );
 						}
 					}
-					echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> ' . esc_html( $version ) . ' <code class="private">' . esc_html( $wc_admin_path ) . '</code></mark> ';
+					if ( WC()->is_wc_admin_active() ) {
+						echo '<mark class="yes"><span class="dashicons dashicons-yes"></span> ' . esc_html( $version ) . ' <code class="private">' . esc_html( $wc_admin_path ) . '</code></mark> ';
+					} else {
+						echo '<span class="dashicons dashicons-no-alt"></span> ' . esc_html( $version ) . ' <code class="private">' . esc_html( $wc_admin_path ) . '</code> ';
+					}
 				} else {
 					echo '<mark class="error"><span class="dashicons dashicons-warning"></span> ' . esc_html__( 'Unable to detect the WC Admin package.', 'woocommerce' ) . '</mark>';
 				}


### PR DESCRIPTION
The check now also tests whether wc admin is active to prevent notice about undefined constant when running on WP 5.2 and older, or with inactive WC Admin.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Get a testing machine with WP 5.2
2. Install WC 4.0-rc.1
3. Go to system status and observe the error 
![Screenshot 2020-03-05 at 15 48 03](https://user-images.githubusercontent.com/2207451/76004679-2dbe9d80-5f0a-11ea-8d7f-84b24b2f8f3f.png)
4. apply this branch
5. check again, it should show the WC Admin is inactive:
![Screenshot 2020-03-05 at 17 39 30](https://user-images.githubusercontent.com/2207451/76004776-58105b00-5f0a-11ea-9b98-f48947df33d5.png)
6. Update to WP 5.3
7. Check that WC Admin becomes active:
![Screenshot 2020-03-05 at 17 39 16](https://user-images.githubusercontent.com/2207451/76004942-9e65ba00-5f0a-11ea-866d-5c3d88367d10.png)

6. Try installing & activating the WC Admin plugin, check that the **version** and **path** are correctly pointing to the plugin:
![Screenshot 2020-03-05 at 17 40 04](https://user-images.githubusercontent.com/2207451/76004965-a9204f00-5f0a-11ea-9f20-674f53829869.png)

7. Deactivate the plugin, it should, again, show the included package info.
8. Use a snippet to deactivate WC Admin package (`add_filter( 'woocommerce_admin_disabled', '__return_true' );` to wc-core-functions.php)
9. It should show **Inactive** package in the system status report.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - System status report should correctly identify inactive package.
