### PR TITLE
Add RTL style to the onboarding wizard

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -226,6 +226,7 @@ class WC_Admin_Setup_Wizard {
 		);
 		wp_enqueue_style( 'woocommerce_admin_styles', WC()->plugin_url() . '/assets/css/admin.css', array(), $version );
 		wp_enqueue_style( 'wc-setup', WC()->plugin_url() . '/assets/css/wc-setup.css', array( 'dashicons', 'install' ), $version );
+		wp_style_add_data( 'wc-setup', 'rtl', 'replace' );
 
 		wp_register_script( 'wc-setup', WC()->plugin_url() . '/assets/js/admin/wc-setup' . $suffix . '.js', array( 'jquery', 'wc-enhanced-select', 'jquery-blockui', 'wp-util', 'jquery-tiptip', 'backbone', 'wc-backbone-modal' ), $version );
 		wp_localize_script(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Add RTL style to the onboarding wizard. Before this change, if using an RTL language, the phrases on the onboarding wizard will be aligned on the wrong side.

Kudos to @kadimi who is the original author of this change (see #24623).
I'm creating this PR as we were not able to merge the original PR due to a
conflict and we were also not able to cherry-pick the original commit as GitHub
is reporting that the PR was created from an unknown repository.

### How to test the changes in this Pull Request:

1. Set WordPress and WooCommerce to use an RTL language
2. Go to the onboarding wizard (/wp-admin/admin.php?page=wc-setup) and check that the alignment of the phrases is incorrect on master and correct on this branch.

### Changelog entry

> Fix: Add RTL style to the onboarding wizard
