### PR TITLE
Update readme.txt tags to include 'woo'

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,6 +1,6 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, kloon, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony
-Tags: ecommerce, e-commerce, store, sales, sell, shop, cart, checkout, downloadable, downloads, payments, paypal, storefront, stripe, woo commerce, woo
+Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, downloads, payments, paypal, storefront, stripe, woo commerce
 Requires at least: 5.0
 Tested up to: 5.3
 Requires PHP: 7.0


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR supersedes #25236

As discussed in p6q8Tx-1qz-p2, when users search for 'woo' on the WP.org plugin repository, WooCommerce does not appear in the list of results. This is happening because 'woo' is not mentioned in the content, excerpt, title, or tags. It was suggested that we start using the tags fields for synonyms like 'woo'. Since WP.org only stores the first 5 tags, in this commit, I'm removing the tag ecommerce tag (which is a word that appears both in the excerpt and the content) and replacing it with 'woo'.

In the future, we might want to evaluate the other four tags that WP.org is considering: e-commerce, store, sales, sell.