### PR TITLE
Install WooCommerce Admin feature plugin when using new OBW

### DIFF
--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -133,17 +133,17 @@ class WC_Admin_Setup_Wizard {
 	}
 
 	/**
-	 * Is the WooCommerce Admin actively included in the WooCommerce core?
-	 * Based on presence of a basic WC Admin function.
+	 * Is the WooCommerce Admin feature plugin installed and active?
 	 *
 	 * @return boolean
 	 */
-	protected function is_wc_admin_active() {
-		return function_exists( 'wc_admin_url' );
+	protected function is_wc_admin_feature_plugin_active() {
+		return is_plugin_active( 'woocommerce-admin/woocommerce-admin.php' );
 	}
 
 	/**
-	 * Should we show the WooCommerce Admin install option?
+	 * Can the WooCommerce Admin feature plugin be installed?
+	 *
 	 * True only if the user can install plugins,
 	 * and is running the correct version of WordPress.
 	 *
@@ -151,9 +151,9 @@ class WC_Admin_Setup_Wizard {
 	 *
 	 * @return boolean
 	 */
-	protected function should_show_wc_admin() {
+	protected function can_install_wc_admin_plugin() {
 		$wordpress_minimum_met = version_compare( get_bloginfo( 'version' ), $this->wc_admin_plugin_minimum_wordpress_version, '>=' );
-		return current_user_can( 'install_plugins' ) && $wordpress_minimum_met && ! $this->is_wc_admin_active();
+		return current_user_can( 'install_plugins' ) && $wordpress_minimum_met && ! $this->is_wc_admin_feature_plugin_active();
 	}
 
 	/**
@@ -162,7 +162,7 @@ class WC_Admin_Setup_Wizard {
 	 * @return boolean
 	 */
 	protected function should_show_wc_admin_onboarding() {
-		if ( ! $this->should_show_wc_admin() && ! $this->is_wc_admin_active() ) {
+		if ( ! $this->can_install_wc_admin_plugin() ) {
 			return false;
 		}
 
@@ -488,9 +488,7 @@ class WC_Admin_Setup_Wizard {
 						<button class="button-primary button button-large" value="<?php esc_attr_e( 'Yes please', 'woocommerce' ); ?>" name="save_step"><?php esc_html_e( 'Yes please', 'woocommerce' ); ?></button>
 					</p>
 				</form>
-				<?php if ( ! $this->is_wc_admin_active() ) : ?>
-					<p class="wc-setup-step__new_onboarding-plugin-info"><?php esc_html_e( 'The "WooCommerce Admin" plugin will be installed and activated', 'woocommerce' ); ?></p>
-				<?php endif; ?>
+				<p class="wc-setup-step__new_onboarding-plugin-info"><?php esc_html_e( 'The "WooCommerce Admin" plugin will be installed and activated', 'woocommerce' ); ?></p>
 			</div>
 		<?php
 	}
@@ -501,7 +499,7 @@ class WC_Admin_Setup_Wizard {
 	public function wc_setup_new_onboarding_save() {
 		check_admin_referer( 'wc-setup' );
 
-		if ( $this->is_wc_admin_active() ) {
+		if ( $this->is_wc_admin_feature_plugin_active() ) {
 			$this->wc_setup_redirect_to_wc_admin_onboarding();
 		}
 
@@ -514,7 +512,7 @@ class WC_Admin_Setup_Wizard {
 		);
 
 		// The plugin was not successfully installed, so continue with normal setup.
-		if ( ! $this->is_wc_admin_active() ) {
+		if ( ! $this->is_wc_admin_feature_plugin_active() ) {
 			wp_safe_redirect( esc_url_raw( $this->get_next_step_link() ) );
 			exit;
 		}
@@ -526,7 +524,7 @@ class WC_Admin_Setup_Wizard {
 	 * Redirects to the onboarding wizard in WooCommerce Admin.
 	 */
 	private function wc_setup_redirect_to_wc_admin_onboarding() {
-		if ( ! $this->is_wc_admin_active() ) {
+		if ( ! $this->is_wc_admin_feature_plugin_active() ) {
 			return;
 		}
 

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -187,8 +187,7 @@ class WC_Admin_Setup_Wizard {
 		return $this->should_show_theme()
 			|| $this->should_show_automated_tax()
 			|| $this->should_show_mailchimp()
-			|| $this->should_show_facebook()
-			|| $this->should_show_wc_admin();
+			|| $this->should_show_facebook();
 	}
 
 	/**
@@ -2082,17 +2081,6 @@ class WC_Admin_Setup_Wizard {
 						'img_url'     => WC()->plugin_url() . '/assets/images/obw-taxes-icon.svg',
 						'img_alt'     => __( 'automated taxes icon', 'woocommerce' ),
 						'plugins'     => $this->get_wcs_requisite_plugins(),
-					) );
-				endif;
-
-				if ( $this->should_show_wc_admin() ) :
-					$this->display_recommended_item( array(
-						'type'        => 'wc_admin',
-						'title'       => __( 'WooCommerce Admin', 'woocommerce' ),
-						'description' => __( 'Manage your store\'s reports and monitor key metrics with a new and improved interface and dashboard.', 'woocommerce' ),
-						'img_url'     => WC()->plugin_url() . '/assets/images/obw-woocommerce-admin-icon.svg',
-						'img_alt'     => __( 'WooCommerce Admin icon', 'woocommerce' ),
-						'plugins'     => array( array( 'name' => __( 'WooCommerce Admin', 'woocommerce' ), 'slug' => 'woocommerce-admin' ) ),
 					) );
 				endif;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Supersedes https://github.com/woocommerce/woocommerce/pull/25831.

This PR seeks to always install the latest version of the WooCommerce Admin feature plugin when the new onboarding experience is selected. It uses `is_plugin_active()` to check for WC-Admin instead of looking for a function (which is a false positive in `4.0.0`+).

It also removes WooCommerce Admin from the recommended plugins step, since a version of it will always be included with core now.

### How to test the changes in this Pull Request:

1. Create a new store with only WooCommerce active on this branch
2. Force the A/B test to show the new OBW opt in step
3. Verify that clicking "yes please" installs the WooCommerce Admin plugin and redirects to the new OBW
4. Verify that the WC-Admin assets are served from the `/plugins` dir (use inspector or view page source)

### Other information:

p7bje6-1SU-p2#comment-4087

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
