### PR TITLE
Improve system status translatability

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -139,8 +139,11 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 						$package_active = \Automattic\WooCommerce\Admin\Composer\Package::is_package_active();
 					} else {
 						// with WP version < 5.3, package is present, but inactive.
-						$version        = __( 'Inactive ', 'woocommerce' );
-						$version       .= \Automattic\WooCommerce\Admin\Composer\Package::VERSION;
+						$version = sprintf(
+							/* translators: %s: Version number of wc-admin package */
+							__( 'Inactive %s', 'woocommerce' ),
+							\Automattic\WooCommerce\Admin\Composer\Package::VERSION
+						);
 						$package_active = false;
 					}
 					$wc_admin_path = \Automattic\WooCommerce\Admin\Composer\Package::get_path();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Improve the translatability of the version number string by providing more context and use standard `sprintf` instead of string concatenation.

### How to test the changes in this Pull Request:

1. Check that version string for wc-admin package is displayed correctly in the system status report.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added context for wc-admin version info translation.
