### PR TITLE
Tracks: Add Ability to Filter Event Props

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -70,7 +70,6 @@ class WC_Site_Tracking {
 				var eventProperties = properties || {};
 				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
 					eventProperties = window.wp.hooks.applyFilters( 'woocommerceTracksEventProperties', eventProperties, eventName );
-					console.log( 'new', eventProperties );
 				}
 				eventProperties.url = '<?php echo esc_html( home_url() ); ?>'
 				eventProperties.products_count = '<?php echo intval( WC_Tracks::get_products_count() ); ?>';

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -50,7 +50,7 @@ class WC_Site_Tracking {
 	public static function enqueue_scripts() {
 
 		// Add w.js to the page.
-		wp_enqueue_script( 'woo-tracks', 'https://stats.wp.com/w.js', array(), gmdate( 'YW' ), true );
+		wp_enqueue_script( 'woo-tracks', 'https://stats.wp.com/w.js', array( 'wp-hooks' ), gmdate( 'YW' ), false );
 
 		// Expose tracking via a function in the wcTracks global namespace directly before wc_print_js.
 		add_filter( 'admin_footer', array( __CLASS__, 'add_tracking_function' ), 24 );
@@ -68,6 +68,10 @@ class WC_Site_Tracking {
 			window.wcTracks.recordEvent = function( name, properties ) {
 				var eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
 				var eventProperties = properties || {};
+				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
+					eventProperties = window.wp.hooks.applyFilters( 'woocommerceTracksEventProperties', eventProperties, eventName );
+					console.log( 'new', eventProperties );
+				}
 				eventProperties.url = '<?php echo esc_html( home_url() ); ?>'
 				eventProperties.products_count = '<?php echo intval( WC_Tracks::get_products_count() ); ?>';
 				window._tkq = window._tkq || [];

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -68,11 +68,13 @@ class WC_Site_Tracking {
 			window.wcTracks.recordEvent = function( name, properties ) {
 				var eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
 				var eventProperties = properties || {};
-				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
-					eventProperties = window.wp.hooks.applyFilters( 'woocommerceTracksEventProperties', eventProperties, eventName );
-				}
 				eventProperties.url = '<?php echo esc_html( home_url() ); ?>'
 				eventProperties.products_count = '<?php echo intval( WC_Tracks::get_products_count() ); ?>';
+				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
+					eventProperties = window.wp.hooks.applyFilters( 'woocommerceTracksEventProperties', eventProperties, eventName );
+					delete( eventProperties._ui );
+					delete( eventProperties._ut );
+				}
 				window._tkq = window._tkq || [];
 				window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );
 			}

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -71,7 +71,7 @@ class WC_Site_Tracking {
 				eventProperties.url = '<?php echo esc_html( home_url() ); ?>'
 				eventProperties.products_count = '<?php echo intval( WC_Tracks::get_products_count() ); ?>';
 				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
-					eventProperties = window.wp.hooks.applyFilters( 'woocommerceTracksEventProperties', eventProperties, eventName );
+					eventProperties = window.wp.hooks.applyFilters( 'woocommerce_tracks_client_event_properties', eventProperties, eventName );
 					delete( eventProperties._ui );
 					delete( eventProperties._ut );
 				}

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -98,7 +98,11 @@ class WC_Tracks {
 		$blog_details   = self::get_blog_details( $user->ID );
 
 		// Allow event props to be filtered to enable adding site-wide props.
-		$filtered_properties = apply_filters( 'woocommerce-tracks-event-properties', $properties, $prefixed_event_name );
+		$filtered_properties = apply_filters( 'woocommerce_tracks_event_properties', $properties, $prefixed_event_name );
+
+		// Delete _ui and _ut protected properties.
+		unset( $filtered_properties['_ui'] );
+		unset( $filtered_properties['_ut'] );
 
 		$event_obj = new WC_Tracks_Event( array_merge( $data, $server_details, $identity, $blog_details, $filtered_properties ) );
 

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -86,9 +86,10 @@ class WC_Tracks {
 		if ( $user instanceof WP_User && 'wptests_capabilities' === $user->cap_key ) {
 			return false;
 		}
+		$prefixed_event_name = self::PREFIX . $event_name;
 
 		$data = array(
-			'_en' => self::PREFIX . $event_name,
+			'_en' => $prefixed_event_name,
 			'_ts' => WC_Tracks_Client::build_timestamp(),
 		);
 
@@ -96,7 +97,10 @@ class WC_Tracks {
 		$identity       = WC_Tracks_Client::get_identity( $user->ID );
 		$blog_details   = self::get_blog_details( $user->ID );
 
-		$event_obj = new WC_Tracks_Event( array_merge( $data, $server_details, $identity, $blog_details, $properties ) );
+		// Allow event props to be filtered to enable adding site-wide props.
+		$filtered_properties = apply_filters( 'woocommerce-tracks-event-properties', $properties, $prefixed_event_name );
+
+		$event_obj = new WC_Tracks_Event( array_merge( $data, $server_details, $identity, $blog_details, $filtered_properties ) );
 
 		if ( is_wp_error( $event_obj->error ) ) {
 			return $event_obj->error;


### PR DESCRIPTION
This branch seeks to add two new filters to the tracks utilities in WooCommerce. For full details behind this proposed change, please see: p7bje6-1Uy-p2

But TL;DR; this change allows us, or anyone to modify the event properties of usage tracks within WooCommerce and WooCommerce Admin functionality.

To ease in testing out this PR, I've create [an example plugin](https://gist.github.com/timmyc/edf820bded9a805a0746751a421bfb8a) that implements both track event properties filters, and has some logging for you to see things in action.

__To Test PHP Filter__
- Download and activate the example plugin: https://gist.github.com/timmyc/edf820bded9a805a0746751a421bfb8a
- tail your PHP error log file, and then navigate to the order listing page
- verify you see the following in your log file:

```
[13-Mar-2020 23:46:44 UTC] Event Name: wcadmin_orders_view
[13-Mar-2020 23:46:44 UTC] Array
(
    [status] => all
    [host] => isorex
    [amaze] => stuff
)
```

- Open an order, and edit it  ( i.e. change the status )
- Verify you see something like the following in your log:

```
[13-Mar-2020 23:48:44 UTC] Event Name: wcadmin_order_edit_date_created
[13-Mar-2020 23:48:44 UTC] Array
(
    [order_id] => 2594
    [status] => completed
    [host] => isorex
)

[13-Mar-2020 23:48:45 UTC] Event Name: wcadmin_orders_edit_status_change
[13-Mar-2020 23:48:45 UTC] Array
(
    [order_id] => 2594
    [next_status] => cancelled
    [previous_status] => completed
    [date_created] => 2020-03-06
    [payment_method] => cod
    [host] => isorex
)
```

__To Test JS Filter__
- With the example plugin installed, open up dev tools in your browser to the console
- Visit the status page `wp-admin/admin.php?page=wc-status`
- Click on the "Get System Report" button:
![image](https://user-images.githubusercontent.com/22080/76669874-dabc9a00-654a-11ea-8ae0-aa4050df354f.png)
- Verify you see the following in your JS console:
![image](https://user-images.githubusercontent.com/22080/76670405-91ba1500-654d-11ea-9565-054a0e4f1835.png)


