### PR TITLE
Fix minor inconsistencies in the WC 4.0 database update routines

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -146,7 +146,7 @@ class WC_Install {
 			'wc_update_product_lookup_tables',
 			'wc_update_400_increase_size_of_column',
 			'wc_update_400_db_version',
-			'wc_reset_action_scheduler_migration_status',
+			'wc_update_400_reset_action_scheduler_migration_status',
 		),
 	);
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -145,8 +145,8 @@ class WC_Install {
 		'4.0.0' => array(
 			'wc_update_product_lookup_tables',
 			'wc_update_400_increase_size_of_column',
-			'wc_update_400_db_version',
 			'wc_update_400_reset_action_scheduler_migration_status',
+			'wc_update_400_db_version',
 		),
 	);
 

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2095,7 +2095,7 @@ function wc_update_400_increase_size_of_column() {
 /**
  * Reset ActionScheduler migration status. Needs AS >= 3.0 shipped with WC >= 4.0.
  */
-function wc_reset_action_scheduler_migration_status() {
+function wc_update_400_reset_action_scheduler_migration_status() {
 	if (
 		class_exists( 'ActionScheduler_DataController' ) &&
 		method_exists( 'ActionScheduler_DataController', 'mark_migration_incomplete' )


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the order of the WC 4.0 database update routines to make sure that the routine that updates the db version is the last one to be called and changes the name of one of the routines to include the `wc_update_400_` prefix.