### PR TITLE
Change "products" argument type from array to object in plugin installer API

### DIFF
--- a/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
+++ b/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
@@ -54,7 +54,7 @@ class WC_REST_WCCOM_Site_Installer_Controller extends WC_REST_Controller {
 					'args'                => array(
 						'products' => array(
 							'required' => true,
-							'type'     => 'array',
+							'type'     => 'object',
 						),
 					),
 				),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The "products" argument type should be an object, not an array. Otherwise, causes:
```
PHP Notice:  Undefined index: items in /var/www/html/wp-includes/rest-api.php on line 1152
```

### How to test the changes in this Pull Request:

1. Make an in-app purchase and follow plugin auto-install flow.
2. Confirm the installation succeeds.
3. Confirm there are no warnings or notices in `debug.log`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Corrected argument type validation in plugin installer API
