### PR TITLE
Update Action Scheduler to version 3.1.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "composer/installers": "1.7.0",
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "^3.1",
-    "woocommerce/action-scheduler": "3.1.1",
+    "woocommerce/action-scheduler": "3.1.2",
     "woocommerce/woocommerce-blocks": "2.5.14",
     "woocommerce/woocommerce-rest-api": "1.0.7",
     "woocommerce/woocommerce-admin": "1.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e898688ce51e75e7a48094cfdecfb959",
+    "content-hash": "ec65c77e58450634fa0d3352de33ee4c",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -383,16 +383,16 @@
         },
         {
             "name": "woocommerce/action-scheduler",
-            "version": "3.1.1",
+            "version": "3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "ca6f65cca0aa6bdc02e6939c93fd439c5a552b76"
+                "reference": "59dbd87de0c8a826b08142fd122279409dffadf7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/ca6f65cca0aa6bdc02e6939c93fd439c5a552b76",
-                "reference": "ca6f65cca0aa6bdc02e6939c93fd439c5a552b76",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/59dbd87de0c8a826b08142fd122279409dffadf7",
+                "reference": "59dbd87de0c8a826b08142fd122279409dffadf7",
                 "shasum": ""
             },
             "require-dev": {
@@ -414,7 +414,7 @@
             ],
             "description": "Action Scheduler for WordPress and WooCommerce",
             "homepage": "https://actionscheduler.org/",
-            "time": "2020-02-25T02:28:35+00:00"
+            "time": "2020-03-10T14:45:52+00:00"
         },
         {
             "name": "woocommerce/woocommerce-admin",


### PR DESCRIPTION
This is a trick to avoid function conflict with MailChimp 2.3.4 and how it hooks its own version of Action Scheduler during the autoloader function.

This is what happens:
1. `\WooCommerce::includes` calls `include package/AS` 3.1.1
2. function `action_scheduler_register_3_dot_1_dot_1` does not exist yet, all good
3. however, `class_exists` loads autoloading routine from MailChimp, which includes their AS, which in turn initiates another AS loading
4. function `action_scheduler_register_3_dot_1_dot_1` still does not exist, so let’s declare & define it in MailChimp
5. coming back from `class_exists`, AS pkg code called from WC is trying to declare & define the function again

This does not happen always always, but sometimes always, so until MCh includes the loading the autoloader, we avoid the fatal error by bumping AS version.