### PR TITLE
Set usage count before usages query

### DIFF
--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -509,6 +509,13 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 			return null;
 		}
 
+		// Make sure we have usage_count meta key for this coupon because its required for `$query_for_usages`.
+		// We are not directly modifying `$query_for_usages` to allow for `usage_count` not present only keep that query simple.
+		if ( ! metadata_exists( 'post', $coupon->get_id(), 'usage_count' ) ) {
+			$coupon->set_usage_count( $coupon->get_usage_count() ); // Use `get_usage_count` here to write default value, which may changed by a filter.
+			$coupon->save();
+		}
+
 		$query_for_usages = $wpdb->prepare(
 			"
 			SELECT meta_value from $wpdb->postmeta


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This makes sure that the `usage_count` meta key is present before creating the usage query. I am adding the key beforehand, instead of modifying the query beforehand because to keep the already complicated query as simple as possible.

Closes #25845.

### How to test the changes in this Pull Request:

1. Create a coupon with some usage limits.
2. Delete the meta `usage_count` for that coupon from DB.
3. Try to checkout with that coupon applied. Without this patch, you will see an error. With this patch, you should be able to successfully able to checkout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Add `usage_count` meta before using it in a query.
