### PR TITLE
Use admin_url instead of using absolute url to support subfolder 

### DIFF
--- a/includes/admin/views/html-notice-redirect-only-download.php
+++ b/includes/admin/views/html-notice-redirect-only-download.php
@@ -16,7 +16,14 @@ defined( 'ABSPATH' ) || exit;
 			sprintf(
 				/* translators: %s: Link to settings page. */
 				__( 'Your store is configured to serve digital products using "Redirect only" method. This method is deprecated, <a href="%s">please switch to  a different method instead.</a>', 'woocommerce' ),
-				admin_url( 'admin.php?page=wc-settings&tab=products&section=downloadable' )
+				add_query_arg(
+					array(
+						'page'    => 'wc-settings',
+						'tab'     => 'products',
+						'section' => 'downloadable',
+					),
+					admin_url( 'admin.php' )
+				)
 			)
 		);
 		?>

--- a/includes/admin/views/html-notice-redirect-only-download.php
+++ b/includes/admin/views/html-notice-redirect-only-download.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 		echo wp_kses_post(
 			sprintf(
 				/* translators: %s: Link to settings page. */
-				__( 'Your store is configured to serve digital products using "Redirect only" method. This method is deprecated, <a href="%s">please switch to  a different method instead.</a>', 'woocommerce' ),
+				__( 'Your store is configured to serve digital products using "Redirect only" method. This method is deprecated, <a href="%s">please switch to  a different method instead.</a><br><em>If you use a remote server for downloadable files (such as Google Drive, Dropbox, Amazon S3), the right method will automatically be used, so select any of the other options to make this notice go away.</em>', 'woocommerce' ),
 				add_query_arg(
 					array(
 						'page'    => 'wc-settings',

--- a/includes/admin/views/html-notice-redirect-only-download.php
+++ b/includes/admin/views/html-notice-redirect-only-download.php
@@ -16,7 +16,7 @@ defined( 'ABSPATH' ) || exit;
 			sprintf(
 				/* translators: %s: Link to settings page. */
 				__( 'Your store is configured to serve digital products using "Redirect only" method. This method is deprecated, <a href="%s">please switch to  a different method instead.</a>', 'woocommerce' ),
-				'/wp-admin/admin.php?page=wc-settings&tab=products&section=downloadable'
+				admin_url( 'admin.php?page=wc-settings&tab=products&section=downloadable' )
 			)
 		);
 		?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Use standard `admin_url` function to link downloadable products settings page.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25875 

### How to test the changes in this Pull Request:

1. Create a site with multisite enabled on a subdirectory (Recommend to use JN for this)
2. Create a new site within this multisite network in a subdirectory.
3. Network Install and activate WooCommerce. then go to download the product settings page to set download method to Redirect Only (Insecure) on the site created in step 2.
3. Go to the dashboard, you will see a notice about redirect only methods. Without this patch, the notice will link to root domain, with this patch it will link to the site installed in the subdirectory.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Use standard `admin_url` function instead of absolute path.
