### PR TITLE
Fix missing notes table on 4.0.0 upgrade.

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -156,7 +156,7 @@ class WC_Install {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
 		add_action( 'init', array( __CLASS__, 'manual_database_update' ), 20 );
-		add_action( 'plugins_loaded', array( __CLASS__, 'wc_admin_db_update_notice' ), 100 );
+		add_action( 'woocommerce_admin_updated', array( __CLASS__, 'wc_admin_db_update_notice' ) );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
 		add_action( 'admin_init', array( __CLASS__, 'install_actions' ) );
 		add_filter( 'plugin_action_links_' . WC_PLUGIN_BASENAME, array( __CLASS__, 'plugin_action_links' ) );
@@ -261,11 +261,6 @@ class WC_Install {
 			check_admin_referer( 'wc_db_update', 'wc_db_update_nonce' );
 			self::update();
 			WC_Admin_Notices::add_notice( 'update', true );
-			if ( WC()->is_wc_admin_active() ) {
-				// Pre-init data store override to allow storing WC Admin notice during activation (package is not loaded yet).
-				add_filter( 'woocommerce_data_stores', array( '\Automattic\WooCommerce\Admin\API\Init', 'add_data_stores' ) );
-				WC_Notes_Run_Db_Update::show_reminder();
-			}
 		}
 	}
 
@@ -381,12 +376,6 @@ class WC_Install {
 				self::update();
 			} else {
 				WC_Admin_Notices::add_notice( 'update', true );
-
-				// Pre-init data store override to allow storing WC Admin notice during activation (package is not loaded yet).
-				if ( WC()->is_wc_admin_active() ) {
-					add_filter( 'woocommerce_data_stores', array( '\Automattic\WooCommerce\Admin\API\Init', 'add_data_stores' ) );
-					WC_Notes_Run_Db_Update::show_reminder();
-				}
 			}
 		} else {
 			self::update_db_version();

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -194,7 +194,10 @@ class WC_Install {
 	 * @since 4.0.0
 	 */
 	public static function wc_admin_db_update_notice() {
-		if ( WC()->is_wc_admin_active() ) {
+		if (
+			WC()->is_wc_admin_active() &&
+			false !== get_option( 'woocommerce_admin_install_timestamp' )
+		) {
 			new WC_Notes_Run_Db_Update();
 		}
 	}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -156,7 +156,7 @@ class WC_Install {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
 		add_action( 'init', array( __CLASS__, 'manual_database_update' ), 20 );
-		add_action( 'woocommerce_admin_updated', array( __CLASS__, 'wc_admin_db_update_notice' ) );
+		add_action( 'plugins_loaded', array( __CLASS__, 'wc_admin_db_update_notice' ), 100 );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
 		add_action( 'admin_init', array( __CLASS__, 'install_actions' ) );
 		add_filter( 'plugin_action_links_' . WC_PLUGIN_BASENAME, array( __CLASS__, 'plugin_action_links' ) );

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -156,7 +156,7 @@ class WC_Install {
 	public static function init() {
 		add_action( 'init', array( __CLASS__, 'check_version' ), 5 );
 		add_action( 'init', array( __CLASS__, 'manual_database_update' ), 20 );
-		add_action( 'plugins_loaded', array( __CLASS__, 'wc_admin_db_update_notice' ), 100 );
+		add_action( 'admin_init', array( __CLASS__, 'wc_admin_db_update_notice' ) );
 		add_action( 'woocommerce_run_update_callback', array( __CLASS__, 'run_update_callback' ) );
 		add_action( 'admin_init', array( __CLASS__, 'install_actions' ) );
 		add_filter( 'plugin_action_links_' . WC_PLUGIN_BASENAME, array( __CLASS__, 'plugin_action_links' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25876. 

This PR moves the creation of the WC Admin Note to after WC Admin itself has been update - thus insuring the database tables exist.

### How to test the changes in this Pull Request:

1. Create a new site on WC 3.9.3
1. Check out this branch
1. Patch the packaged version of WooCommerce Admin with: https://github.com/woocommerce/woocommerce-admin/pull/3896
1. Verify that no PHP errors result from the `WC_Notes_Run_Db_Update` class

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix admin notes table does not exist errors when upgrading to 4.0.x.