### PR TITLE
Fixes typo in download help text 

### DIFF
--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -272,7 +272,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 						'default' => 'yes',
 						'desc_tip' => sprintf(
 							// translators: Link to WooCommerce Docs.
-							__( "Not required if you download directory is protected. <a href='%s'>See this guide</a> for more details. Files already uploaded will not be affected.", 'woocommerce' ),
+							__( "Not required if your download directory is protected. <a href='%s'>See this guide</a> for more details. Files already uploaded will not be affected.", 'woocommerce' ),
 							'https://docs.woocommerce.com/document/digital-downloadable-product-handling#unique-string'
 						),
 					),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixes a typo -- `you` to `your` in download help text unique string setting

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25881 .

### How to test the changes in this Pull Request:

1. Go to /wp-admin/admin.php?page=wc-settings&tab=products&section=downloadable
2. See that help text for `Append a unique string to filename for security ` has corrected typo after this patch

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

_Not needed because its a minor typo fix and does not change any functionality_
