### PR TITLE
Fix PHP docblock for WC_Plugin_Updates::get_untested_plugins()

### DIFF
--- a/includes/admin/plugin-updates/class-wc-plugin-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugin-updates.php
@@ -173,7 +173,7 @@ class WC_Plugin_Updates {
 	*/
 
 	/**
-	 * Get active plugins that have a tested version lower than the input version.
+	 * Get installed plugins that have a tested version lower than the input version.
 	 *
 	 * In case of testing major version compatibility and if current WC version is >= major version part
 	 * of the $new_version, no plugins are returned, even if they don't explicitly declare compatibility


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The documentation of the method WC_Plugin_Updates::get_untested_plugins() said that it only considers active plugins when getting the list of untested plugins, but it actually considers all installed plugins. This commit simply updates the documentation to reflect the method behavior.

### How to test the changes in this Pull Request:

1. Check the behavior described in the updated version of the documentation is correct. WC_Plugin_Updates::get_untested_plugins() calls WC_Plugin_Updates::get_plugins_with_header() and WC_Plugin_Updates::get_plugins_for_woocommerce() to get the list of plugins, and both methods use get_plugins() which return all installed plugins and not just the active ones.