### PR TITLE
Change string for untested WC extensions to avoid confusion

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -356,12 +356,11 @@ class WC_Admin_Status {
 					$plugin_name = '<a href="' . esc_url( $plugin['url'] ) . '" aria-label="' . esc_attr__( 'Visit plugin homepage', 'woocommerce' ) . '" target="_blank">' . $plugin_name . '</a>';
 				}
 
-				$version_string = '';
-				$network_string = '';
+				$has_newer_version = false;
+				$network_string    = '';
 				if ( strstr( $plugin['url'], 'woothemes.com' ) || strstr( $plugin['url'], 'woocommerce.com' ) ) {
 					if ( ! empty( $plugin['version_latest'] ) && version_compare( $plugin['version_latest'], $plugin['version'], '>' ) ) {
-						/* translators: %s: plugin latest version */
-						$version_string = ' &ndash; <strong style="color:red;">' . sprintf( esc_html__( '%s is available', 'woocommerce' ), $plugin['version_latest'] ) . '</strong>';
+						$has_newer_version = true;
 					}
 
 					if ( false !== $plugin['network_activated'] ) {
@@ -370,7 +369,15 @@ class WC_Admin_Status {
 				}
 				$untested_string = '';
 				if ( array_key_exists( $plugin['plugin'], $untested_plugins ) ) {
-					$untested_string = ' &ndash; <strong style="color:red;">' . esc_html__( 'Not tested with the active version of WooCommerce', 'woocommerce' ) . '</strong>';
+					$untested_string = ' &ndash; <strong style="color:red;">';
+
+					if ( $has_newer_version ) {
+						$untested_string .= esc_html__( 'This version is not tested with the active version of WooCommerce (update is available)', 'woocommerce' );
+					} else {
+						$untested_string .= esc_html__( 'This version is not tested with the active version of WooCommerce', 'woocommerce' );
+					}
+
+					$untested_string .= '</strong>';
 				}
 				?>
 				<tr>

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -387,7 +387,7 @@ class WC_Admin_Status {
 						<?php
 						/* translators: %s: plugin author */
 						printf( esc_html__( 'by %s', 'woocommerce' ), esc_html( $plugin['author_name'] ) );
-						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $untested_string . $network_string; // WPCS: XSS ok.
+						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $untested_string . $network_string; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						?>
 					</td>
 				</tr>

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -350,8 +350,6 @@ class WC_Admin_Status {
 	private static function output_plugins_info( $plugins, $untested_plugins ) {
 		foreach ( $plugins as $plugin ) {
 			if ( ! empty( $plugin['name'] ) ) {
-				$dirname = dirname( $plugin['plugin'] );
-
 				// Link the plugin name to the plugin url if available.
 				$plugin_name = esc_html( $plugin['name'] );
 				if ( ! empty( $plugin['url'] ) ) {

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -338,4 +338,56 @@ class WC_Admin_Status {
 			exit();
 		}
 	}
+
+	/**
+	 * Prints the information about plugins for the system status report.
+	 * Used for both active and inactive plugins sections.
+	 *
+	 * @param array $plugins List of plugins to display.
+	 * @param array $untested_plugins List of plugins that haven't been tested with the current WooCommerce version.
+	 * @return void
+	 */
+	private static function output_plugins_info( $plugins, $untested_plugins ) {
+		foreach ( $plugins as $plugin ) {
+			if ( ! empty( $plugin['name'] ) ) {
+				$dirname = dirname( $plugin['plugin'] );
+
+				// Link the plugin name to the plugin url if available.
+				$plugin_name = esc_html( $plugin['name'] );
+				if ( ! empty( $plugin['url'] ) ) {
+					$plugin_name = '<a href="' . esc_url( $plugin['url'] ) . '" aria-label="' . esc_attr__( 'Visit plugin homepage', 'woocommerce' ) . '" target="_blank">' . $plugin_name . '</a>';
+				}
+
+				$version_string = '';
+				$network_string = '';
+				if ( strstr( $plugin['url'], 'woothemes.com' ) || strstr( $plugin['url'], 'woocommerce.com' ) ) {
+					if ( ! empty( $plugin['version_latest'] ) && version_compare( $plugin['version_latest'], $plugin['version'], '>' ) ) {
+						/* translators: %s: plugin latest version */
+						$version_string = ' &ndash; <strong style="color:red;">' . sprintf( esc_html__( '%s is available', 'woocommerce' ), $plugin['version_latest'] ) . '</strong>';
+					}
+
+					if ( false !== $plugin['network_activated'] ) {
+						$network_string = ' &ndash; <strong style="color:black;">' . esc_html__( 'Network enabled', 'woocommerce' ) . '</strong>';
+					}
+				}
+				$untested_string = '';
+				if ( array_key_exists( $plugin['plugin'], $untested_plugins ) ) {
+					$untested_string = ' &ndash; <strong style="color:red;">' . esc_html__( 'Not tested with the active version of WooCommerce', 'woocommerce' ) . '</strong>';
+				}
+				?>
+				<tr>
+					<td><?php echo wp_kses_post( $plugin_name ); ?></td>
+					<td class="help">&nbsp;</td>
+					<td>
+						<?php
+						/* translators: %s: plugin author */
+						printf( esc_html__( 'by %s', 'woocommerce' ), esc_html( $plugin['author_name'] ) );
+						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $untested_string . $network_string; // WPCS: XSS ok.
+						?>
+					</td>
+				</tr>
+				<?php
+			}
+		}
+	}
 }

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -348,6 +348,8 @@ class WC_Admin_Status {
 	 * @return void
 	 */
 	private static function output_plugins_info( $plugins, $untested_plugins ) {
+		$wc_version = Constants::get_constant( 'WC_VERSION' );
+
 		foreach ( $plugins as $plugin ) {
 			if ( ! empty( $plugin['name'] ) ) {
 				// Link the plugin name to the plugin url if available.
@@ -357,25 +359,24 @@ class WC_Admin_Status {
 				}
 
 				$has_newer_version = false;
+				$version_string    = $plugin['version'];
 				$network_string    = '';
 				if ( strstr( $plugin['url'], 'woothemes.com' ) || strstr( $plugin['url'], 'woocommerce.com' ) ) {
 					if ( ! empty( $plugin['version_latest'] ) && version_compare( $plugin['version_latest'], $plugin['version'], '>' ) ) {
-						$has_newer_version = true;
+						/* translators: 1: current version. 2: latest version */
+						$version_string = sprintf( __( '%1$s (update to version %2$s is available)', 'woocommerce' ), $plugin['version'], $plugin['version_latest'] );
 					}
 
 					if ( false !== $plugin['network_activated'] ) {
-						$network_string = ' &ndash; <strong style="color:black;">' . esc_html__( 'Network enabled', 'woocommerce' ) . '</strong>';
+						$network_string = ' &ndash; <strong style="color: black;">' . esc_html__( 'Network enabled', 'woocommerce' ) . '</strong>';
 					}
 				}
 				$untested_string = '';
 				if ( array_key_exists( $plugin['plugin'], $untested_plugins ) ) {
-					$untested_string = ' &ndash; <strong style="color:red;">';
+					$untested_string = ' &ndash; <strong style="color: #a00;">';
 
-					if ( $has_newer_version ) {
-						$untested_string .= esc_html__( 'This version is not tested with the active version of WooCommerce (update is available)', 'woocommerce' );
-					} else {
-						$untested_string .= esc_html__( 'This version is not tested with the active version of WooCommerce', 'woocommerce' );
-					}
+					/* translators: %s: version */
+					$untested_string .= esc_html( sprintf( __( 'Installed version not tested with active version of WooCommerce %s', 'woocommerce' ), $wc_version ) );
 
 					$untested_string .= '</strong>';
 				}
@@ -387,7 +388,7 @@ class WC_Admin_Status {
 						<?php
 						/* translators: %s: plugin author */
 						printf( esc_html__( 'by %s', 'woocommerce' ), esc_html( $plugin['author_name'] ) );
-						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $untested_string . $network_string; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						echo ' &ndash; ' . esc_html( $version_string ) . $untested_string . $network_string; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 						?>
 					</td>
 				</tr>

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -869,7 +869,7 @@ if ( 0 < count( $dropins_mu_plugins['mu_plugins'] ) ) :
 				<?php
 				if ( version_compare( $theme['version'], $theme['version_latest'], '<' ) ) {
 					/* translators: 1: current version. 2: latest version */
-					echo sprintf( esc_html__( '%1$s (update to version %2$s is available)', 'woocommerce' ), esc_html( $theme['version'] ), esc_html( $theme['version_latest'] ) );
+					echo esc_html( sprintf( __( '%1$s (update to version %2$s is available)', 'woocommerce' ), $theme['version'], $theme['version_latest'] ) );
 				} else {
 					echo esc_html( $theme['version'] );
 				}

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -652,49 +652,7 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 		</tr>
 	</thead>
 	<tbody>
-		<?php
-		foreach ( $active_plugins as $plugin ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			if ( ! empty( $plugin['name'] ) ) {
-				$dirname = dirname( $plugin['plugin'] );
-
-				// Link the plugin name to the plugin url if available.
-				$plugin_name = esc_html( $plugin['name'] );
-				if ( ! empty( $plugin['url'] ) ) {
-					$plugin_name = '<a href="' . esc_url( $plugin['url'] ) . '" aria-label="' . esc_attr__( 'Visit plugin homepage', 'woocommerce' ) . '" target="_blank">' . $plugin_name . '</a>';
-				}
-
-				$version_string = '';
-				$network_string = '';
-				if ( strstr( $plugin['url'], 'woothemes.com' ) || strstr( $plugin['url'], 'woocommerce.com' ) ) {
-					if ( ! empty( $plugin['version_latest'] ) && version_compare( $plugin['version_latest'], $plugin['version'], '>' ) ) {
-						/* translators: %s: plugin latest version */
-						$version_string = ' &ndash; <strong style="color:red;">' . sprintf( esc_html__( '%s is available', 'woocommerce' ), $plugin['version_latest'] ) . '</strong>';
-					}
-
-					if ( false !== $plugin['network_activated'] ) {
-						$network_string = ' &ndash; <strong style="color:black;">' . esc_html__( 'Network enabled', 'woocommerce' ) . '</strong>';
-					}
-				}
-				$untested_string = '';
-				if ( array_key_exists( $plugin['plugin'], $untested_plugins ) ) {
-					$untested_string = ' &ndash; <strong style="color:red;">' . esc_html__( 'Not tested with the active version of WooCommerce', 'woocommerce' ) . '</strong>';
-				}
-				?>
-				<tr>
-					<td><?php echo wp_kses_post( $plugin_name ); ?></td>
-					<td class="help">&nbsp;</td>
-					<td>
-					<?php
-						/* translators: %s: plugin author */
-						printf( esc_html__( 'by %s', 'woocommerce' ), esc_html( $plugin['author_name'] ) );
-						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $untested_string . $network_string; // WPCS: XSS ok.
-					?>
-					</td>
-				</tr>
-				<?php
-			}
-		}
-		?>
+		<?php self::output_plugins_info( $active_plugins, $untested_plugins ); ?>
 	</tbody>
 </table>
 <table class="wc_status_table widefat" cellspacing="0">
@@ -704,49 +662,7 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 		</tr>
 	</thead>
 	<tbody>
-		<?php
-		foreach ( $inactive_plugins as $plugin ) { // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
-			if ( ! empty( $plugin['name'] ) ) {
-				$dirname = dirname( $plugin['plugin'] );
-
-				// Link the plugin name to the plugin url if available.
-				$plugin_name = esc_html( $plugin['name'] );
-				if ( ! empty( $plugin['url'] ) ) {
-					$plugin_name = '<a href="' . esc_url( $plugin['url'] ) . '" aria-label="' . esc_attr__( 'Visit plugin homepage', 'woocommerce' ) . '" target="_blank">' . $plugin_name . '</a>';
-				}
-
-				$version_string = '';
-				$network_string = '';
-				if ( strstr( $plugin['url'], 'woothemes.com' ) || strstr( $plugin['url'], 'woocommerce.com' ) ) {
-					if ( ! empty( $plugin['version_latest'] ) && version_compare( $plugin['version_latest'], $plugin['version'], '>' ) ) {
-						/* translators: %s: plugin latest version */
-						$version_string = ' &ndash; <strong style="color:red;">' . sprintf( esc_html__( '%s is available', 'woocommerce' ), $plugin['version_latest'] ) . '</strong>';
-					}
-
-					if ( false !== $plugin['network_activated'] ) {
-						$network_string = ' &ndash; <strong style="color:black;">' . esc_html__( 'Network enabled', 'woocommerce' ) . '</strong>';
-					}
-				}
-				$untested_string = '';
-				if ( array_key_exists( $plugin['plugin'], $untested_plugins ) ) {
-					$untested_string = ' &ndash; <strong style="color:red;">' . esc_html__( 'Not tested with the active version of WooCommerce', 'woocommerce' ) . '</strong>';
-				}
-				?>
-				<tr>
-					<td><?php echo wp_kses_post( $plugin_name ); ?></td>
-					<td class="help">&nbsp;</td>
-					<td>
-					<?php
-						/* translators: %s: plugin author */
-						printf( esc_html__( 'by %s', 'woocommerce' ), esc_html( $plugin['author_name'] ) );
-						echo ' &ndash; ' . esc_html( $plugin['version'] ) . $version_string . $untested_string . $network_string; // WPCS: XSS ok.
-					?>
-					</td>
-				</tr>
-				<?php
-			}
-		}
-		?>
+		<?php self::output_plugins_info( $inactive_plugins, $untested_plugins ); ?>
 	</tbody>
 </table>
 <?php

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -867,10 +867,11 @@ if ( 0 < count( $dropins_mu_plugins['mu_plugins'] ) ) :
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'The installed version of the current active theme.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td>
 				<?php
-				echo esc_html( $theme['version'] );
 				if ( version_compare( $theme['version'], $theme['version_latest'], '<' ) ) {
-					/* translators: %s: theme latest version */
-					echo ' &ndash; <strong style="color:red;">' . sprintf( esc_html__( '%s is available', 'woocommerce' ), esc_html( $theme['version_latest'] ) ) . '</strong>';
+					/* translators: 1: current version. 2: latest version */
+					echo sprintf( esc_html__( '%1$s (update to version %2$s is available)', 'woocommerce' ), esc_html( $theme['version'] ), esc_html( $theme['version_latest'] ) );
+				} else {
+					echo esc_html( $theme['version'] );
 				}
 				?>
 			</td>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the string that is displayed to the users in the system status page when an old version of a WC extension is installed and it doesn't declare support for the current WC core version.

The original message was:

`WooCommerce Min/Max Quantities - by WooCommerce - 2.4.11 - 2.4.12 is available - Not tested with the active version of WooCommerce`

The new message is:

`WooCommerce Min/Max Quantities - by WooCommerce - 2.4.11 - This version is not tested with the active version of WooCommerce (update is available)`

The problem with the original message is that it gives users the impression that even the newest version (2.4.12 in the example above) is not tested with the active version of WooCommerce. I'm not totally happy with the new sentence and that is why I'm marking this PR as in progress. Suggestions for new sentences are welcome. Maybe we split this phrase in two, the first one stating that the version is not tested and the second talking about the update and mentioning the number of the new version?

Besides updating the message, this PR also removes some code duplication when generating the list of active and inactive plugins in the system status page (see commit b9165c6). Without doing this here, I would have to change the same untested string in two different places.

Here is an example of the changed section with the changes proposed in this PR:

![Screenshot from 2020-03-12 12-10-06](https://user-images.githubusercontent.com/77215/76536062-994cc180-645a-11ea-9c3a-8a4cfa88f0e1.png)


Closes #25073.

### How to test the changes in this Pull Request:

1. Connect your store to WC.com (for some reason we are only displaying the information that there is an update available for WC.com extensions and not for WP.org plugins).
2. Install an outdated version of a WC.com extension. To test I used WooCommerce Subscriptions 2.6.5.
3. Go to the system status page (/wp-admin/admin.php?page=wc-status) and check the new message either in the "Active plugins" or the "Inactive plugins" section.

**Claudio edit:**

There's a simple way of testing it without having to connect your store to wc.com.

1. Download and install WooCommerce Services 1.22.2.
It can be done download from https://downloads.wordpress.org/plugin/woocommerce-services.1.22.2.zip
Or installing with WP-CLI: `wp plugin install woocommerce-services --version=1.22.2`
2. Go to the system status page (/wp-admin/admin.php?page=wc-status) and check the new message either in the "Active plugins" or the "Inactive plugins" section.
### Changelog entry

> Tweak - Improve the string for untested WooCommerce extensions in the system status page to avoid confusion.
