### PR TITLE
Prevent percent coupon remainder from discounting more than the item totals

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -343,7 +343,7 @@ class WC_Discounts {
 	 */
 	protected function apply_coupon_percent( $coupon, $items_to_apply ) {
 		$total_discount        = 0;
-		$cart_total            = 0;
+		$discounted_cart_total = 0;
 		$limit_usage_qty       = 0;
 		$applied_count         = 0;
 		$adjust_final_discount = true;
@@ -379,17 +379,17 @@ class WC_Discounts {
 				}
 			}
 
-			$discount       = wc_round_discount( min( $discounted_price, $discount ), 0 );
-			$cart_total     = $cart_total + $price_to_discount;
-			$total_discount = $total_discount + $discount;
-			$applied_count  = $applied_count + $apply_quantity;
+			$discount               = wc_round_discount( min( $discounted_price, $discount ), 0 );
+			$discounted_cart_total += $discounted_price;
+			$total_discount        += $discount;
+			$applied_count         += $apply_quantity;
 
 			// Store code and discount amount per item.
 			$this->discounts[ $coupon->get_code() ][ $item->key ] += $discount;
 		}
 
 		// Work out how much discount would have been given to the cart as a whole and compare to what was discounted on all line items.
-		$cart_total_discount = wc_round_discount( $cart_total * ( $coupon_amount / 100 ), 0 );
+		$cart_total_discount = wc_round_discount( $discounted_cart_total * ( $coupon_amount / 100 ), 0 );
 
 		if ( $total_discount < $cart_total_discount && $adjust_final_discount ) {
 			$total_discount += $this->apply_coupon_remainder( $coupon, $items_to_apply, $cart_total_discount - $total_discount );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `WC_Discounts::apply_coupon_remainder()` method is used to spread any remainder from percent coupons out across the rest of the items to ensure that the correct total discount is given. This method however doesn't care about whether or not too much of a discount has been given. This leads to issues like #25810.

Initially I had thought about adding a 0 check based on the `$discounted_price` to prevent applying a remainder to something free, but I felt like this might cause problems with the other place `apply_coupon_remainder` is used. Instead I've opted to change the remainder check to respect the total discount possible with present cart values. This shouldn't have any significant impact on the `woocommerce_calc_discounts_sequentially` option's behavior since we're already dealing in tiny cents, and based on some of my own math, the discounts don't always line up perfectly anyway!

Closes #25810.

### How to test the changes in this Pull Request:

1. Create a 100% off and then a 20% off coupon. Add them to your cart along with some items. In my local testing I have an item in my cart that costs $18 and has a quantity of 4. There's also a flat rate shipping set at 4.99.
2. Notice that before the patch, the remaining balance will be 4.95 (despite the shipping being 4.99, we discount by an additional 4 because of the quantity and the minimum of 1 in `apply_coupon_remainder`.
3. With the patch the remaining balance will be 4.99 as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Corrected the handling of discount remainders for percent coupons.
