### PR TITLE
Made the is_package_shippable check more permissive

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -279,28 +279,19 @@ class WC_Shipping {
 	/**
 	 * See if package is shippable.
 	 *
-	 * Packages must have a valid destination to be shipped.
+	 * Packages are shippable until proven otherwise e.g. after getting a shipping country.
 	 *
 	 * @param  array $package Package of cart items.
 	 * @return bool
 	 */
 	public function is_package_shippable( $package ) {
+		// Packages are shippable until proven otherwise.
 		if ( empty( $package['destination']['country'] ) ) {
-			return false;
-		}
-		$country = $package['destination']['country'];
-
-		$countries = array_keys( WC()->countries->get_shipping_countries() );
-		if ( ! in_array( $country, $countries, true ) ) {
-			return false;
+			return true;
 		}
 
-		$states = WC()->countries->get_states( $country );
-		if ( is_array( $states ) && ! empty( $states ) && ! isset( $states[ $package['destination']['state'] ] ) ) {
-			return false;
-		}
-
-		return true;
+		$allowed = array_keys( WC()->countries->get_shipping_countries() );
+		return in_array( $package['destination']['country'], $allowed, true );
 	}
 
 	/**

--- a/tests/unit-tests/shipping/shipping.php
+++ b/tests/unit-tests/shipping/shipping.php
@@ -21,7 +21,7 @@ class WC_Tests_Shipping extends WC_Unit_Test_Case {
 	public function test_is_package_shippable() {
 		$shipping = new WC_Shipping();
 
-		// Failure for no country.
+		// Success for no country.
 		$result = $shipping->is_package_shippable(
 			array(
 				'destination' => array(
@@ -32,7 +32,7 @@ class WC_Tests_Shipping extends WC_Unit_Test_Case {
 				),
 			)
 		);
-		$this->assertFalse( $result );
+		$this->assertTrue( $result );
 
 		// Failure for disallowed country.
 		$result = $shipping->is_package_shippable(
@@ -47,26 +47,13 @@ class WC_Tests_Shipping extends WC_Unit_Test_Case {
 		);
 		$this->assertFalse( $result );
 
-		// Failure for no state when required.
+		// Success for correct country.
 		$result = $shipping->is_package_shippable(
 			array(
 				'destination' => array(
 					'country'  => 'US',
 					'state'    => '',
-					'postcode' => '99999',
-					'address'  => '',
-				),
-			)
-		);
-		$this->assertFalse( $result );
-
-		// Success for correct address.
-		$result = $shipping->is_package_shippable(
-			array(
-				'destination' => array(
-					'country'  => 'US',
-					'state'    => 'CA',
-					'postcode' => '99999',
+					'postcode' => '',
 					'address'  => '',
 				),
 			)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Due to a handful of bugs it has become necessary to revert #25128. While the checkout page gives a nice error when you haven't filled out the text, the cart page gives a confusing one. Since the error messaging is in the template file as opposed to a string returned by core, there's no way to know how many themes have a confusing error.

Closes #25854.
Closes #25912. 
### How to test the changes in this Pull Request:

1. Create a shipping zone
2. Add something to your cart and use the pricing estimator on the cart page
3. Before the patch, it would not resolve until a state was chosen if the country requires states. After the patch, it will resolve if there is no country selected, or a valid country set.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Made the package shipping check more permissive.