### PR TITLE
Correct usage of database sockets in test install script

### DIFF
--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -42,7 +42,7 @@ class WC_Unit_Tests_Bootstrap {
 
 		$this->tests_dir    = dirname( __FILE__ );
 		$this->plugin_dir   = dirname( $this->tests_dir );
-		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib';
+		$this->wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : sys_get_temp_dir() . '/wordpress-tests-lib';
 
 		// load test function so tests_add_filter() is available.
 		require_once $this->wp_tests_dir . '/includes/functions.php';

--- a/tests/includes/listener-loader.php
+++ b/tests/includes/listener-loader.php
@@ -5,5 +5,5 @@
  * @package WooCommerce\UnitTests
  */
 
-$wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : '/tmp/wordpress-tests-lib';
+$wp_tests_dir = getenv( 'WP_TESTS_DIR' ) ? getenv( 'WP_TESTS_DIR' ) : sys_get_temp_dir() . '/wordpress-tests-lib';
 require_once $wp_tests_dir . '/includes/listener-loader.php';

--- a/tests/unit-tests/integrations/maxmind-geolocation/class-wc-tests-maxmind-database.php
+++ b/tests/unit-tests/integrations/maxmind-geolocation/class-wc-tests-maxmind-database.php
@@ -55,7 +55,7 @@ class WC_Tests_MaxMind_Database extends WC_Unit_Test_Case {
 	 */
 	public function test_download_database_works() {
 		$database_service  = new WC_Integration_MaxMind_Database_Service( '' );
-		$expected_database = '/tmp/GeoLite2-Country_20200100/GeoLite2-Country.mmdb';
+		$expected_database = sys_get_temp_dir() . '/GeoLite2-Country_20200100/GeoLite2-Country.mmdb';
 
 		$result = $database_service->download_database( 'testing_license' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In switching from VVV to [Local](https://localwp.com/) I encountered some problems. 

The first is that the socket option for hosts does not work if the path has spaces. Even if you escape the string or spaces it simply doesn't work. I rewrote the evaluation for what options to use to be clearer and work with spaces.

The second is that the default paths for test sources is too strict. We can instead get the system's temp folder location to make a better assumption about where it might be.

This PR also fixes a test that was broken as a result of using Local. Another case of a false expectation about the location of the temp folder.

### How to test the changes in this Pull Request:

1. Set up a site using Local with this PR as a plugin.
2. In Local, Right-Click "Open Site Shell" and navigate to the plugin folder
3. Run the install script and for the DB host option, use the socket listed in Local's interface. You can find this on the "Database" tab for your site. Without the PR this would fail if there were spaces in the file path. After the PR it works!
4. Run the test suite using `vendor/bin/phpunit` using the Terminal opened by Local.
5. Test the install script using a normal host as well as a host with a port. Note the command it executes is what you expect it to.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Updated the unit test install script to support paths to MySQL sockets that contain spaces.
> Dev - Made the default test source folders support the system tmp folder