### PR TITLE
allow custom fields on csv export to fetch variations

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -176,9 +176,11 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 		$this->row_data    = array();
 		$variable_products = array();
 
+		$fetch_variations = apply_filters( "woocommerce_product_export_{$this->export_type}_fetch_variations", ! empty( $args['category'] ), $args );
+
 		foreach ( $products->products as $product ) {
-			// Check if the category is set, this means we need to fetch variations seperately as they are not tied to a category.
-			if ( ! empty( $args['category'] ) && $product->is_type( 'variable' ) ) {
+			// Check if the category is set, this means we need to fetch variations separately as they are not tied to a category.
+			if ( $product->is_type( 'variable' ) && $fetch_variations ) {
 				$variable_products[] = $product->get_id();
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Allows developers to use the existing process that fetches variations on the product csv export with custom arguments.

This allow one to add a new filter field with 'woocommerce_product_export_row' action, and use it to filter the products exported including variations.

My use case was to add a 'supplier' data to our products, and later export a single supplier.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Add a custom filter to the csv export page with 'woocommerce_product_export_row' action;
2. Setup the query with the 'woocommerce_product_export_product_query_args' filter;
3. Hook into 'woocommerce_product_export_product_fetch_variations' filter to check for the custom filter param, and eventually force variations to be fetched.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
*Sorry, I don't know how*

* [x] Have you successfully run tests with your changes locally?
*We're using this change in production at http://laleblu.com.br*

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev: Add a filter to force fetch variations on the product csv export
