### PR TITLE
Bump Action Scheduler to 3.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "composer/installers": "1.7.0",
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "^3.1",
-    "woocommerce/action-scheduler": "3.1.2",
+    "woocommerce/action-scheduler": "3.1.3",
     "woocommerce/woocommerce-blocks": "2.5.14",
     "woocommerce/woocommerce-rest-api": "1.0.7",
     "woocommerce/woocommerce-admin": "1.0.0"

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "composer/installers": "1.7.0",
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "^3.1",
-    "woocommerce/action-scheduler": "3.1.3",
+    "woocommerce/action-scheduler": "3.1.4",
     "woocommerce/woocommerce-blocks": "2.5.14",
     "woocommerce/woocommerce-rest-api": "1.0.7",
     "woocommerce/woocommerce-admin": "1.0.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ac0daf2f7b34c81ff07267ae2a6a598c",
+    "content-hash": "b6a641ac7aef022a5093107b037fc740",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -383,16 +383,16 @@
         },
         {
             "name": "woocommerce/action-scheduler",
-            "version": "3.1.3",
+            "version": "3.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "d5c799670cffadb2caa0eff7038707a303157cc8"
+                "reference": "5a01f0b549a283dc88c2feeef877650215907a76"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/d5c799670cffadb2caa0eff7038707a303157cc8",
-                "reference": "d5c799670cffadb2caa0eff7038707a303157cc8",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/5a01f0b549a283dc88c2feeef877650215907a76",
+                "reference": "5a01f0b549a283dc88c2feeef877650215907a76",
                 "shasum": ""
             },
             "require-dev": {
@@ -414,7 +414,7 @@
             ],
             "description": "Action Scheduler for WordPress and WooCommerce",
             "homepage": "https://actionscheduler.org/",
-            "time": "2020-03-16T19:16:20+00:00"
+            "time": "2020-03-18T15:05:10+00:00"
         },
         {
             "name": "woocommerce/woocommerce-admin",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec65c77e58450634fa0d3352de33ee4c",
+    "content-hash": "ac0daf2f7b34c81ff07267ae2a6a598c",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -330,16 +330,16 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.4.37",
+            "version": "v3.4.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "e1b3e1a0621d6e48ee46092b4c7d8280f746b3c5"
+                "reference": "ee9b946e7223b11257329a054c64396b19d619e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/e1b3e1a0621d6e48ee46092b4c7d8280f746b3c5",
-                "reference": "e1b3e1a0621d6e48ee46092b4c7d8280f746b3c5",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/ee9b946e7223b11257329a054c64396b19d619e1",
+                "reference": "ee9b946e7223b11257329a054c64396b19d619e1",
                 "shasum": ""
             },
             "require": {
@@ -379,20 +379,20 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-01T11:03:25+00:00"
+            "time": "2020-02-04T08:04:52+00:00"
         },
         {
             "name": "woocommerce/action-scheduler",
-            "version": "3.1.2",
+            "version": "3.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/action-scheduler.git",
-                "reference": "59dbd87de0c8a826b08142fd122279409dffadf7"
+                "reference": "d5c799670cffadb2caa0eff7038707a303157cc8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/59dbd87de0c8a826b08142fd122279409dffadf7",
-                "reference": "59dbd87de0c8a826b08142fd122279409dffadf7",
+                "url": "https://api.github.com/repos/woocommerce/action-scheduler/zipball/d5c799670cffadb2caa0eff7038707a303157cc8",
+                "reference": "d5c799670cffadb2caa0eff7038707a303157cc8",
                 "shasum": ""
             },
             "require-dev": {
@@ -414,7 +414,7 @@
             ],
             "description": "Action Scheduler for WordPress and WooCommerce",
             "homepage": "https://actionscheduler.org/",
-            "time": "2020-03-10T14:45:52+00:00"
+            "time": "2020-03-16T19:16:20+00:00"
         },
         {
             "name": "woocommerce/woocommerce-admin",
@@ -799,16 +799,16 @@
         },
         {
             "name": "mck89/peast",
-            "version": "v1.10.1",
+            "version": "v1.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "461fbe96212ac1b511f527fd11b942e976429398"
+                "reference": "1c3984ba9fc3cb93848748f141f5ddac0a65c5e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/461fbe96212ac1b511f527fd11b942e976429398",
-                "reference": "461fbe96212ac1b511f527fd11b942e976429398",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/1c3984ba9fc3cb93848748f141f5ddac0a65c5e1",
+                "reference": "1c3984ba9fc3cb93848748f141f5ddac0a65c5e1",
                 "shasum": ""
             },
             "require": {
@@ -820,7 +820,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.10.1-dev"
+                    "dev-master": "1.10.2-dev"
                 }
             },
             "autoload": {
@@ -840,7 +840,7 @@
                 }
             ],
             "description": "Peast is PHP library that generates AST for JavaScript code",
-            "time": "2019-12-22T16:46:42+00:00"
+            "time": "2020-03-15T16:03:55+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -1351,16 +1351,16 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "v1.10.2",
+            "version": "v1.10.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9"
+                "reference": "451c3cd1418cf640de218914901e51b064abb093"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
-                "reference": "b4400efc9d206e83138e2bb97ed7f5b14b831cd9",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/451c3cd1418cf640de218914901e51b064abb093",
+                "reference": "451c3cd1418cf640de218914901e51b064abb093",
                 "shasum": ""
             },
             "require": {
@@ -1410,7 +1410,7 @@
                 "spy",
                 "stub"
             ],
-            "time": "2020-01-20T15:57:02+00:00"
+            "time": "2020-03-05T15:02:03+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2416,16 +2416,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.37",
+            "version": "v3.4.38",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "a90a9d3b9f458a5cdeabfa4090b20c000ca3962f"
+                "reference": "5ec813ccafa8164ef21757e8c725d3a57da59200"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/a90a9d3b9f458a5cdeabfa4090b20c000ca3962f",
-                "reference": "a90a9d3b9f458a5cdeabfa4090b20c000ca3962f",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/5ec813ccafa8164ef21757e8c725d3a57da59200",
+                "reference": "5ec813ccafa8164ef21757e8c725d3a57da59200",
                 "shasum": ""
             },
             "require": {
@@ -2461,7 +2461,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2020-01-01T11:03:25+00:00"
+            "time": "2020-02-14T07:34:21+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR bumps the Action Scheduler version to 3.1.3. Changes included in the release are https://github.com/woocommerce/action-scheduler/releases/tag/3.1.3

### Changelog entry

> Update Action Scheduler to 3.1.3.
