### PR TITLE
Implement additional tracks

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -113,6 +113,7 @@ class WC_Site_Tracking {
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-settings-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-status-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-coupons-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-order-tracking.php';
 
 		$tracking_classes = array(
 			'WC_Admin_Setup_Wizard_Tracking',
@@ -123,6 +124,7 @@ class WC_Site_Tracking {
 			'WC_Settings_Tracking',
 			'WC_Status_Tracking',
 			'WC_Coupons_Tracking',
+			'WC_Order_Tracking',
 		);
 
 		foreach ( $tracking_classes as $tracking_class ) {

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -114,6 +114,7 @@ class WC_Site_Tracking {
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-status-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-coupons-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-order-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-coupon-tracking.php';
 
 		$tracking_classes = array(
 			'WC_Admin_Setup_Wizard_Tracking',
@@ -125,6 +126,7 @@ class WC_Site_Tracking {
 			'WC_Status_Tracking',
 			'WC_Coupons_Tracking',
 			'WC_Order_Tracking',
+			'WC_Coupon_Tracking',
 		);
 
 		foreach ( $tracking_classes as $tracking_class ) {

--- a/includes/tracks/events/class-wc-coupon-tracking.php
+++ b/includes/tracks/events/class-wc-coupon-tracking.php
@@ -33,6 +33,6 @@ class WC_Coupon_Tracking {
 									  || 0 < intval( $coupon->get_limit_usage_to_x_items() ),
 		);
 
-		WC_Tracks::record_event( 'coupon_add', $properties );
+		WC_Tracks::record_event( 'coupon_updated', $properties );
 	}
 }

--- a/includes/tracks/events/class-wc-coupon-tracking.php
+++ b/includes/tracks/events/class-wc-coupon-tracking.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * WooCommerce Coupon Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+ /**
+  * This class adds actions to track usage of a WooCommerce Coupon.
+  */
+class WC_Coupon_Tracking {
+	/**
+	 * Init
+	 */
+	public function init() {
+		add_action( 'woocommerce_coupon_object_updated_props', array( $this, 'track_coupon_created' ), 10, 3 );
+	}
+
+	/**
+	 * Send a Tracks event when a coupon is updated.
+	 *
+	 * @param WC_Coupon $coupon        The coupon that has been updated.
+	 * @param Array     $updated_props The props of the coupon that have been updated.
+	 */
+	public function track_coupon_updated( $coupon, $updated_props ) {
+		$properties = array(
+			'discount_code' => $coupon->get_code(),
+			'free_shipping' => $coupon->get_free_shipping(),
+			'individual_use' => $coupon->get_individual_use(),
+			'exclude_sale_items' => $coupon->get_exclude_sale_items(),
+			'usage_limits_applied' => 0 < intval( $coupon->get_usage_limit() )
+									  || 0 < intval( $coupon->get_usage_limit_per_user() )
+									  || 0 < intval( $coupon->get_limit_usage_to_x_items() ),
+		);
+
+		WC_Tracks::record_event( 'coupon_add', $properties );
+	}
+}

--- a/includes/tracks/events/class-wc-coupon-tracking.php
+++ b/includes/tracks/events/class-wc-coupon-tracking.php
@@ -13,7 +13,7 @@ class WC_Coupon_Tracking {
 	 * Init
 	 */
 	public function init() {
-		add_action( 'woocommerce_coupon_object_updated_props', array( $this, 'track_coupon_created' ), 10, 3 );
+		add_action( 'woocommerce_coupon_object_updated_props', array( $this, 'track_coupon_updated' ), 10, 3 );
 	}
 
 	/**

--- a/includes/tracks/events/class-wc-order-tracking.php
+++ b/includes/tracks/events/class-wc-order-tracking.php
@@ -25,7 +25,6 @@ class WC_Order_Tracking {
 	 */
 	public function track_order_viewed( $order ) {
 		$properties = array(
-			'order_id'         => $order->get_id(),
 			'current_status'   => $order->get_status(),
 			'date_created'     => $order->get_date_created(),
 			'payment_method'   => $order->get_payment_method(),

--- a/includes/tracks/events/class-wc-order-tracking.php
+++ b/includes/tracks/events/class-wc-order-tracking.php
@@ -31,7 +31,7 @@ class WC_Order_Tracking {
 			'payment_method'   => $order->get_payment_method(),
 		);
 
-		WC_Tracks::record_event( 'wcadmin_single_order_view', $properties );
+		WC_Tracks::record_event( 'single_order_view', $properties );
 	}
 }
 

--- a/includes/tracks/events/class-wc-order-tracking.php
+++ b/includes/tracks/events/class-wc-order-tracking.php
@@ -26,7 +26,7 @@ class WC_Order_Tracking {
 	public function track_order_viewed( $order ) {
 		$properties = array(
 			'current_status'   => $order->get_status(),
-			'date_created'     => $order->get_date_created(),
+			'date_created'     => $order->get_date_created()->format( DateTime::ATOM ),
 			'payment_method'   => $order->get_payment_method(),
 		);
 

--- a/includes/tracks/events/class-wc-order-tracking.php
+++ b/includes/tracks/events/class-wc-order-tracking.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * WooCommerce Order Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of a WooCommerce Order.
+ */
+class WC_Order_Tracking {
+	/**
+	 * Init tracking.
+	 */
+	public function init() {
+		add_action( 'woocommerce_admin_order_data_after_order_details', array( $this, 'track_order_viewed' ) );
+	}
+
+	/**
+	 * Send a Tracks event when an order is viewed.
+	 *
+	 * @param object $order Order.
+	 */
+	public function track_order_viewed( $order ) {
+		$properties = array(
+			'order_id'         => $order->get_id(),
+			'current_status'   => $order->get_status(),
+			'date_created'     => $order->get_date_created(),
+			'payment_method'   => $order->get_payment_method(),
+		);
+
+		WC_Tracks::record_event( 'wcadmin_single_order_view', $properties );
+	}
+}
+

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -49,8 +49,6 @@ class WC_Products_Tracking {
 			'is_virtual'            => $product->get_virtual(),
 			'is_downloadable'       => $product->get_downloadable(),
 			'manage_stock'          => 0 == $product->get_manage_stock() ? 'N' : 'Y',
-			// 'stock_quantity_update' => 'Y'	TODO this may require hooking in to product edit at a lower level, which doesn't seem possible for an extension.
-			// You can only get the current product, not the product before the update...
 		);
 
 		WC_Tracks::record_event( 'product_update', $update_properties );

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -26,7 +26,7 @@ class WC_Products_Tracking {
 	}
 
 	/**
-	 * Send some Tracks events when a product is updated.
+	 * Send a Tracks event when a product is updated.
 	 *
 	 * @param int    $product_id Product id.
 	 * @param object $post       WordPress post.

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -6,6 +6,7 @@
  */
 
 use Automattic\Jetpack\Constants;
+use \Automattic\WooCommerce\Admin\API\Reports\Products\DataStore as ProductsDataStore;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -23,7 +24,7 @@ class WC_Products_Tracking {
 	}
 
 	/**
-	 * Send a Tracks event when a product is updated.
+	 * Send some Tracks events when a product is updated.
 	 *
 	 * @param int    $product_id Product id.
 	 * @param object $post WordPress post.
@@ -38,6 +39,18 @@ class WC_Products_Tracking {
 		);
 
 		WC_Tracks::record_event( 'product_edit', $properties );
+
+		$product = new WC_Product( $product_id );
+		$update_properties = array(
+			'product_id'            => $product_id,
+			// 'product_type'          => TODO where does this come from?? there is no product type, only category ids.
+			'category_ids'          => $product->get_category_ids(),
+			'manage_stock'          => 0 == $product->get_manage_stock() ? 'N' : 'Y',
+			// 'stock_quantity_update' => 'Y'	TODO this may require hooking in to product edit at a lower level, which doesn't seem possible for an extension.
+			// You can only get the current product, not the product before the update...
+		);
+
+		WC_Tracks::record_event( 'product_update', $update_properties );
 	}
 
 	/**

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -20,6 +20,8 @@ class WC_Products_Tracking {
 		add_action( 'edit_post', array( $this, 'track_product_updated' ), 10, 2 );
 		add_action( 'transition_post_status', array( $this, 'track_product_published' ), 10, 3 );
 		add_action( 'created_product_cat', array( $this, 'track_product_category_created' ) );
+		add_action( 'woocommerce_variation_set_stock', array( $this, 'track_product_stock_level_set' ), 10, 1 );
+		add_action( 'woocommerce_product_set_stock', array( $this, 'track_product_stock_level_set' ), 10, 1 );
 	}
 
 	/**
@@ -52,6 +54,19 @@ class WC_Products_Tracking {
 		);
 
 		WC_Tracks::record_event( 'product_update', $update_properties );
+	}
+
+	/**
+	 * Send a Tracks event when a product's stock level is adjusted.
+	 *
+	 * @param WC_Product $product Product.
+	 */
+	public function track_product_stock_level_set( $product ) {
+		$properties = array(
+			'product_id' => $product->get_id(),
+		);
+
+		WC_Tracks::record_event( 'product_stock_level_set', $properties );
 	}
 
 	/**

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -39,11 +39,13 @@ class WC_Products_Tracking {
 
 		WC_Tracks::record_event( 'product_edit', $properties );
 
-		$product = new WC_Product( $product_id );
+		$product_factory = new WC_Product_Factory();
+		$product = $product_factory->get_product( $product_id );
 		$update_properties = array(
 			'product_id'            => $product_id,
-			// 'product_type'          => TODO where does this come from?? there is no product type, only category ids.
-			'category_ids'          => $product->get_category_ids(),
+			'product_type'          => $product->get_type(),
+			'is_virtual'            => $product->get_virtual(),
+			'is_downloadable'       => $product->get_downloadable(),
 			'manage_stock'          => 0 == $product->get_manage_stock() ? 'N' : 'Y',
 			// 'stock_quantity_update' => 'Y'	TODO this may require hooking in to product edit at a lower level, which doesn't seem possible for an extension.
 			// You can only get the current product, not the product before the update...

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -20,8 +20,6 @@ class WC_Products_Tracking {
 		add_action( 'edit_post', array( $this, 'track_product_updated' ), 10, 2 );
 		add_action( 'transition_post_status', array( $this, 'track_product_published' ), 10, 3 );
 		add_action( 'created_product_cat', array( $this, 'track_product_category_created' ) );
-		add_action( 'woocommerce_variation_set_stock', array( $this, 'track_product_stock_level_set' ), 10, 1 );
-		add_action( 'woocommerce_product_set_stock', array( $this, 'track_product_stock_level_set' ), 10, 1 );
 		add_action( 'add_meta_boxes_product', array( $this, 'track_product_updated_client_side' ), 10, 1 );
 	}
 
@@ -77,19 +75,6 @@ class WC_Products_Tracking {
 			}
 			"
 		);
-	}
-
-	/**
-	 * Send a Tracks event when a product's stock level is adjusted.
-	 *
-	 * @param WC_Product $product Product.
-	 */
-	public function track_product_stock_level_set( $product ) {
-		$properties = array(
-			'product_id' => $product->get_id(),
-		);
-
-		WC_Tracks::record_event( 'product_stock_level_set', $properties );
 	}
 
 	/**

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -54,16 +54,16 @@ class WC_Products_Tracking {
 		wc_enqueue_js(
 			"
 			if ( $( 'h1.wp-heading-inline' ).text().trim() === 'Edit product') {
-				const initialStockValue = $( '#_stock' ).val();
-				let hasRecordedEvent = false;
+				var initialStockValue = $( '#_stock' ).val();
+				var hasRecordedEvent = false;
 
 				$( '#publish' ).click( function() {
 					if ( hasRecordedEvent ) {
 						return;
 					}
 
-					const currentStockValue = $( '#_stock' ).val();
-					const properties = {
+					var currentStockValue = $( '#_stock' ).val();
+					var properties = {
 						product_type:			$( '#product-type' ).val(),
 						is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Y' : 'N',
 						is_downloadable:		$( '#_downloadable' ).is( ':checked' ) ? 'Y' : 'N',

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -6,7 +6,6 @@
  */
 
 use Automattic\Jetpack\Constants;
-use \Automattic\WooCommerce\Admin\API\Reports\Products\DataStore as ProductsDataStore;
 
 defined( 'ABSPATH' ) || exit;
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This adds a few tracks per #25849:

- `coupon_add`: occurs when a coupon is added _or modified_, which differs from the request which asked for the event to be tracked only on add. This was needed because the saved coupon metadata is only available at the point where the hook is called for both adds and edits.
- `wcadmin_single_order_view`: occurs when an order is viewed.
- `product_update`: occurs when a product is added or updated. It isn't possible to determine if the product stock level was set for this event as requested, hence the next track:
- `product_stock_level_set`: occurs when a product's stock level is set.

### How to test the changes in this Pull Request:

1. add `error_log(print_r($properties, TRUE));` above the places where an event is recorded, and monitor the log file
2. Add or edit a coupon, with the other properties set or unset
3. view an order
4. update a product
5. set the stock level on a product with stock management enabled

### Changelog entry

Implement some additional tracks for coupons, orders, and products, to satisfy #25942 