### PR TITLE
Fixed remainder application for percent coupons

### DIFF
--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -549,10 +549,7 @@ class WC_Discounts {
 		foreach ( $items_to_apply as $item ) {
 			for ( $i = 0; $i < $item->quantity; $i ++ ) {
 				// Find out how much price is available to discount for the item.
-				$discounted_price = $this->get_discounted_price_in_cents( $item );
-
-				// Get the price we actually want to discount, based on settings.
-				$price_to_discount = ( 'yes' === get_option( 'woocommerce_calc_discounts_sequentially', 'no' ) ) ? $discounted_price : $item->price;
+				$price_to_discount = $this->get_discounted_price_in_cents( $item );
 
 				// Run coupon calculations.
 				$discount = min( $price_to_discount, 1 );

--- a/tests/unit-tests/coupon/coupon.php
+++ b/tests/unit-tests/coupon/coupon.php
@@ -224,6 +224,44 @@ class WC_Tests_Coupon extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that the remainder is handled correctly and does not turn the total negative.
+	 *
+	 * @since 4.1
+	 */
+	public function test_percent_discount_handles_remainder_correctly() {
+
+		// Create product.
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 18 );
+		$product->save();
+
+		// Create coupon.
+		$coupon = WC_Helper_Coupon::create_coupon( '20off' );
+		update_post_meta( $coupon->get_id(), 'discount_type', 'percent' );
+		update_post_meta( $coupon->get_id(), 'coupon_amount', '20' );
+		$coupon_2 = WC_Helper_Coupon::create_coupon( '100off' );
+		update_post_meta( $coupon_2->get_id(), 'discount_type', 'percent' );
+		update_post_meta( $coupon_2->get_id(), 'coupon_amount', '100' );
+
+		// Create a flat rate method.
+		WC_Helper_Shipping::create_simple_flat_rate();
+
+		// Add product to cart.
+		WC()->cart->add_to_cart( $product->get_id(), 4 );
+
+		// Add coupon.
+		WC()->cart->add_discount( $coupon->get_code() );
+		WC()->cart->add_discount( $coupon_2->get_code() );
+
+		// Set the flat_rate shipping method.
+		WC()->session->set( 'chosen_shipping_methods', array( 'flat_rate' ) );
+		WC()->cart->calculate_totals();
+
+		// Test if the cart total amount is equal 29.5.
+		$this->assertEquals( 10, WC()->cart->total );
+	}
+
+	/**
 	 * Test date setters/getters.
 	 *
 	 * @since 3.0.0


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `WC_Discounts::apply_coupon_remainder()` method is used to spread any remainder from percent coupons out across the rest of the items to ensure that the correct total discount is given. This method however doesn't care about whether or not there's any discount left to give an item. This can lead to minor excess discounts that bleed into other line items.

Closes #25810.

### How to test the changes in this Pull Request:

1. Create a 100% off and then a 20% off coupon. Add them to your cart along with some items. In my local testing I have an item in my cart that costs $18 and has a quantity of 4. There's also a flat rate shipping set at 4.99.
2. Notice that before the patch, the remaining balance will be 4.95 (despite the shipping being 4.99, we discount by an additional 4 cents because of the quantity and the minimum of 1 cent in apply_coupon_remainder.
3. With the patch the remaining balance will be 4.99 as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Corrected the way percent coupons apply remainders across the order