### PR TITLE
Send dummy parameters so that cost is evaluated correctly.

### DIFF
--- a/includes/libraries/class-wc-eval-math.php
+++ b/includes/libraries/class-wc-eval-math.php
@@ -318,7 +318,7 @@ if ( ! class_exists( 'WC_Eval_Math', false ) ) {
 		 */
 		private static function trigger( $msg ) {
 			self::$last_error = $msg;
-			if ( Constants::is_true( 'WP_DEBUG' ) ) {
+			if ( ! Constants::is_true( 'DOING_AJAX' ) && Constants::is_true( 'WP_DEBUG' ) ) {
 				echo "\nError found in:";
 				self::debugPrintCallingFunction();
 				trigger_error( $msg, E_USER_WARNING );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Send dummy parameters so that cost is evaluated correctly. Also added a warning for subclasses that cost and qty are required keys. Note that we are still keeping `array()` as default params because of backward compatibility with classes that may have inherited this class.

Note: This change also includes change  for not echoing error when doing AJAX because it invalidates JSON.
We already append errors in JSON response in `error` array, so echoing separately is not required.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25928 and 
Closes #25927 

### How to test the changes in this Pull Request:

From: #25928 

> Go to WooCommerce>Settings>Shipping>Shipping Zone
> Click on the Flat Rate shipping method
> Scroll down to Advanced Costs
> Add 10 + ( 2 * [qty] ), and save

With this patch, you should be able to save this string. Without this patch, this will cause an error.

For  #25927

1. Add another shipping class.
2. Edit a zone from WooCommerce>Settings>Shipping>Shipping Zone, in the flat rate method save with empty string.
3. Make sure there are  no warnings in debug log.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Send dummy params to evaluate_cost method to detect validation errors.

> Dev - Add a doing_it_wrong warning to evaluate_cost method if cost and qty are not passed.
