### PR TITLE
wc-admin: bump version to 1.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "woocommerce/action-scheduler": "3.1.2",
     "woocommerce/woocommerce-blocks": "2.5.14",
     "woocommerce/woocommerce-rest-api": "1.0.7",
-    "woocommerce/woocommerce-admin": "1.0.0"
+    "woocommerce/woocommerce-admin": "1.0.2"
   },
   "require-dev": {
     "phpunit/phpunit": "7.5.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ec65c77e58450634fa0d3352de33ee4c",
+    "content-hash": "cc14a87475b17453c9b1a5bd9e223ba7",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -418,16 +418,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "v1.0.0",
+            "version": "v1.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "62854c9efb6a7acaaac7b88a64923029dc940b57"
+                "reference": "9f527e6d5006554a196488319983fdd22e5a2546"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/62854c9efb6a7acaaac7b88a64923029dc940b57",
-                "reference": "62854c9efb6a7acaaac7b88a64923029dc940b57",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/9f527e6d5006554a196488319983fdd22e5a2546",
+                "reference": "9f527e6d5006554a196488319983fdd22e5a2546",
                 "shasum": ""
             },
             "require": {
@@ -461,7 +461,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-03-05T01:54:43+00:00"
+            "time": "2020-03-17T22:04:38+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Bump Woocommerce Admin dependency to version 1.0.2

### How to test the changes in this Pull Request:

1. `composer install`
2. Woocommerce > Status > WooCommerce Admin package:
3. See version 1.0.2

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Here are the changelogs since the previous version

= 1.0.2 2020-03-18 =

- Enhancement: Onboarding: business step: add Google Ads extension install 
- Dev: Update prestart script so readme.txt stable tag is updated 
- Tweak: create database tables on an earlier hook to avoid conflicts with core WooCommerce. 

= 1.0.1 2020-03-12 =

- Fix: Add Report Extension Example: Add default props to ReportFilters
- Fix: Product report sorting by SKU when some products don't have SKUs
- Dev: Add Changelog script
- Fix: type warning on install timestamp in PHP 7.4
- Fix: PHP error when WooCommerce core is Network Active on Multisites.
- Fix: missing database table errors on WooCommerce upgrade.
- Fix: undefined const WC_ADMIN_VERSION_NUMBER when WP < 5.3
- Dev: Fix failing tests after WC core merge.
- Dev: Bump WooCommerce tested up to tag

<!-- Mark completed items with an [x] -->

### Changelog entry

Bump Woocommerce Admin dependency to version 1.0.2
