### PR TITLE
Removed the nonce_user_logged_out filter usage

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -73,10 +73,6 @@ class WC_Session_Handler extends WC_Session {
 		add_action( 'woocommerce_set_cart_cookies', array( $this, 'set_customer_session_cookie' ), 10 );
 		add_action( 'shutdown', array( $this, 'save_data' ), 20 );
 		add_action( 'wp_logout', array( $this, 'destroy_session' ) );
-
-		if ( ! is_user_logged_in() ) {
-			add_filter( 'nonce_user_logged_out', array( $this, 'nonce_user_logged_out' ) );
-		}
 	}
 
 	/**
@@ -283,16 +279,6 @@ class WC_Session_Handler extends WC_Session {
 		$this->_data        = array();
 		$this->_dirty       = false;
 		$this->_customer_id = $this->generate_customer_id();
-	}
-
-	/**
-	 * When a user is logged out, ensure they have a unique nonce by using the customer/session ID.
-	 *
-	 * @param int $uid User ID.
-	 * @return string
-	 */
-	public function nonce_user_logged_out( $uid ) {
-		return $this->has_session() && $this->_customer_id ? $this->_customer_id : $uid;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This filter is used to prevent CSRF attacks for unregistered users. This however causes problems because after a wc-ajax cart action, a session is initialized, and any nonce stored on the page becomes unusable. Since giving everyone a session would pose a number of problems, we will just remove the filter usage.

Closes #23682.

### How to test the changes in this Pull Request:

1.  Add a plugin containing this code:
```
add_action( 'wp_footer', function() {
	?>
	<script>
		function ajax_test_call() {
			jQuery.ajax( {
				url: '<?php echo esc_url_raw( rest_url() ) . 'wp/v2/product'; ?>',
				method: 'GET',
				beforeSend: function ( xhr ) {
					xhr.setRequestHeader( 'X-WP-Nonce', '<?php echo wp_create_nonce( 'wp_rest' ); ?>' );
				},
			} ).done( function ( response ) {
				console.log( response );
			} );
		}
	</script>
	<?php
} );
```
2. Visit the shop in an incognito window.
3. Open the developer console and run the `ajax_test_call()` function. It should print a list of the products.
4. Add an item to the cart.
5. Run the `ajax_test_call()` function again. Without this PR it should return 403, and with it, the products will be returned as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Corrected the user associated with nonces after cart actions.