### PR TITLE
Add cart_viewed tracks event (proof of concept)

### DIFF
--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -29,7 +29,6 @@ class WC_Admin {
 		add_action( 'admin_footer', 'wc_print_js', 25 );
 		add_filter( 'admin_footer_text', array( $this, 'admin_footer_text' ), 1 );
 		add_action( 'wp_ajax_setup_wizard_check_jetpack', array( $this, 'setup_wizard_check_jetpack' ) );
-		add_action( 'init', array( 'WC_Site_Tracking', 'init' ) );
 
 		// Disable WXR export of schedule action posts.
 		add_filter( 'action_scheduler_post_type_args', array( $this, 'disable_webhook_post_export' ) );
@@ -59,12 +58,6 @@ class WC_Admin {
 		include_once dirname( __FILE__ ) . '/class-wc-admin-pointers.php';
 		include_once dirname( __FILE__ ) . '/class-wc-admin-importers.php';
 		include_once dirname( __FILE__ ) . '/class-wc-admin-exporters.php';
-
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
-		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
 
 		// Help Tabs.
 		if ( apply_filters( 'woocommerce_enable_admin_help_tab', true ) ) {

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -446,6 +446,15 @@ final class WooCommerce {
 		include_once WC_ABSPATH . 'includes/wccom-site/class-wc-wccom-site.php';
 
 		/**
+		 * Tracks (originally from wc-admin).
+		 */
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-client.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-footer-pixel.php';
+		include_once WC_ABSPATH . 'includes/tracks/class-wc-site-tracking.php';
+
+		/**
 		 * Libraries and packages.
 		 */
 		include_once WC_ABSPATH . 'packages/action-scheduler/action-scheduler.php';

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -175,6 +175,8 @@ class WC_Site_Tracking {
 				call_user_func( $tracker_init_method );
 			}
 		}
+
+		do_action( 'woocommerce_init_frontend_tracks' );
 	}
 
 	/**

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -91,6 +91,8 @@ class WC_Site_Tracking {
 	 * @param string $event_name_prefix Prefix to add to all triggered events.
 	 */
 	public static function render_tracking_function( $event_name_prefix ) {
+		// Note: When adding/removing default event properties here, consider
+		// also adding them in WC_Tracks::get_blog_details() or record_event().
 		?>
 		<!-- WooCommerce Tracks -->
 		<script type="text/javascript">
@@ -98,7 +100,8 @@ class WC_Site_Tracking {
 			window.wcTracks.recordEvent = function( name, properties ) {
 				var eventName = '<?php echo esc_attr( $event_name_prefix ); ?>' + name;
 				var eventProperties = properties || {};
-				eventProperties.url = '<?php echo esc_html( home_url() ); ?>'
+				eventProperties.url = '<?php echo esc_js( home_url() ); ?>'
+				eventProperties.woo_version = '<?php echo esc_js( WC()->version ); ?>'
 				eventProperties.products_count = '<?php echo intval( WC_Tracks::get_products_count() ); ?>';
 				window._tkq = window._tkq || [];
 				window._tkq.push( [ 'recordEvent', eventName, eventProperties ] );

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -39,8 +39,12 @@ class WC_Tracks {
 	public static function get_blog_details( $user_id ) {
 		$blog_details = get_transient( 'wc_tracks_blog_details' );
 		if ( false === $blog_details ) {
+			// Store default store metadata props for adding to all events.
+			// If props are added / removed here you may also need to update
+			// the JS api in WC_Site_Tracking::render_tracking_function().
 			$blog_details = array(
 				'url'            => home_url(),
+				'woo_version'    => WC()->version,
 				'blog_lang'      => get_user_locale( $user_id ),
 				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
 				'products_count' => self::get_products_count(),

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -11,9 +11,14 @@
 class WC_Tracks {
 
 	/**
-	 * Tracks event name prefix.
+	 * Event name prefix for admin tracks.
 	 */
-	const PREFIX = 'wcadmin_';
+	const ADMIN_PREFIX = 'wcadmin_';
+
+	/**
+	 * Event name prefix for front-end tracks.
+	 */
+	const FRONTEND_PREFIX = 'wcstore_';
 
 	/**
 	 * Get total product counts.
@@ -88,7 +93,7 @@ class WC_Tracks {
 		}
 
 		$data = array(
-			'_en' => self::PREFIX . $event_name,
+			'_en' => self::ADMIN_PREFIX . $event_name,
 			'_ts' => WC_Tracks_Client::build_timestamp(),
 		);
 

--- a/includes/tracks/events/frontend/class-wc-cart-tracking.php
+++ b/includes/tracks/events/frontend/class-wc-cart-tracking.php
@@ -16,9 +16,6 @@ class WC_Cart_Tracking {
 	 * Init tracking.
 	 */
 	public function init() {
-
-		echo 'WC_Cart_Tracking::init';
-
 		add_action( 'woocommerce_after_cart', array( $this, 'track_cart_events' ) );
 	}
 
@@ -26,7 +23,6 @@ class WC_Cart_Tracking {
 	 * Add Tracks events to the cart page.
 	 */
 	public function track_cart_events() {
-		echo 'WC_Cart_Tracking::track_cart_events';
 		wc_enqueue_js(
 			"
 				window.wcTracks.recordEvent( 'cart_viewed' );

--- a/includes/tracks/events/frontend/class-wc-cart-tracking.php
+++ b/includes/tracks/events/frontend/class-wc-cart-tracking.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * WooCommerce Status Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to trigger tracks events related to the cart.
+ */
+class WC_Cart_Tracking {
+
+	/**
+	 * Init tracking.
+	 */
+	public function init() {
+
+		echo 'WC_Cart_Tracking::init';
+
+		add_action( 'woocommerce_after_cart', array( $this, 'track_cart_events' ) );
+	}
+
+	/**
+	 * Add Tracks events to the cart page.
+	 */
+	public function track_cart_events() {
+		echo 'WC_Cart_Tracking::track_cart_events';
+		wc_enqueue_js(
+			"
+				window.wcTracks.recordEvent( 'cart_viewed' );
+			"
+		);
+	}
+}

--- a/includes/tracks/events/frontend/class-wc-cart-tracking.php
+++ b/includes/tracks/events/frontend/class-wc-cart-tracking.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * WooCommerce Status Tracking
+ * WooCommerce Cart Tracking
  *
  * @package WooCommerce\Tracks
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This PR adds a tracks event when the cart page is viewed. To allow this, various tracks code has been moved around.

- The PHP includes for core tracks facilities have moved from `WC_Admin` to `WooCommerce`.
- The entry point for tracking (`WC_Site_Tracking:init()`) is now triggered from `WC_Site_Tracking` constructor.
- There are two event prefixes defined in `WC_Tracks` - the existing `wcadmin_` and (proposed) `wcstore_` for front-end events.
- In `WC_Site_Tracking`, the JS tracks API is rendered on the front end and admin with the appropriate prefix baked in. 
- The front end tracks can be disabled with a filter - e.g. `add_filter( 'woocommerce_apply_frontend_user_tracking', __return_false );`

This is then used to trigger an example event from the cart page - see `WC_Cart_Tracking` for details.

In addition, I've added some default props (`url woo_version`) to all tracks events to do things like filter based on WooCommerce version. These props could be added in a separate PR; I've included them here because it's useful to have them on `cart_viewed`.

pb0Spc-ou-p2

### How to test the changes in this Pull Request:

1. Opt in to tracking in `WooCommerce > Settings > Advanced > WooCommerce.com`.
2. Perform various admin actions and check events are fired, with appropriate props. You can see events in Network tab - filter by `t.gif` and look at the query params.
3. Add something to cart and view cart page. Confirm a `cart_viewed` event is sent and that the props are all sensible.
4. Repeat tests with more interesting scenarios – anon user, logged in as customer, different browsers, etc.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
