### PR TITLE
Move contents of a deleted inactive user to admin

### DIFF
--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -407,7 +407,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 					$deleted_user = get_user_by( 'ID', $user_id );
 					wp_delete_user( $user_id );
 					$subject = __( 'Contents of a deleted inactive user transferred to admin', 'woocommerce' );
-					$message = '<h1>' . $subject . '</h1><p>' . sprintf(
+					$message = '<h1>' . esc_html( $subject ) . '</h1><p>' . sprintf(
 						/* translators: 1: deleted user username 2: deleted user email 3: list of all post types 4: admin username 5: admin email */
 						__( 'An inactive user (%1$s - %2$s) who had published content (%3$s), before to be demoted to subscriber or customer role, was automatically deleted by WooCommerce data retention policy. All the contents of the deleted user were transferred to the administrator: %4$s - %5$s.', 'woocommerce' ),
 						esc_html( $deleted_user->user_login ),
@@ -415,7 +415,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 						esc_html( implode( ', ', $post_types_to_assign ) ),
 						esc_html( $admin_users[0]->user_login ),
 						esc_html( $admin_users[0]->user_email )
-					) . '</p><h2>' . __( 'Transferred contents list', 'woocommerce' ) . '</h2>' . $posts_made_prior_list;
+					) . '</p><h2>' . esc_html__( 'Transferred contents list', 'woocommerce' ) . '</h2>' . $posts_made_prior_list;
 
 					foreach ( $admin_users as $admin ) {
 						wc_mail( $admin->user_email, $subject, $message );

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -382,8 +382,9 @@ class WC_Privacy extends WC_Abstract_Privacy {
 			foreach ( $user_ids as $user_id ) {
 				$posts_made_prior = get_posts(
 					array(
-						'post_type' => $post_types_to_assign,
-						'author'    => $user_id,
+						'post_type'   => $post_types_to_assign,
+						'author'      => $user_id,
+						'numberposts' => -1,
 					)
 				);
 

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -375,6 +375,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 			/**
 			 * Filter post types that should be assign to an admin user prior user exclusion.
 			 *
+			 * @since 5.3.0
 			 * @param array $post_types List of post types to assign to an admin. Defaults to WordPress builtin post types.
 			 */
 			$post_types_to_assign = apply_filters( 'woocommerce_delete_inactive_account_post_types_to_assign', array_values( $builtin_post_types ) );

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -391,22 +391,16 @@ class WC_Privacy extends WC_Abstract_Privacy {
 				if ( empty( $posts_made_prior ) ) {
 					wp_delete_user( $user_id );
 				} else {
-					$admin_users = get_users( array( 'role' => 'administrator' ) );
+					$admin_users  = get_users( array( 'role' => 'administrator' ) );
+					$deleted_user = get_user_by( 'ID', $user_id );
+					wp_delete_user( $user_id, $admin_users[0]->ID ); // Delete user and reassign content to admin.
 
 					$posts_made_prior_list = '<ul>';
 					foreach ( $posts_made_prior as $post ) {
-						wp_update_post(
-							array(
-								'ID'          => $post->ID,
-								'post_author' => $admin_users[0]->ID,
-							)
-						);
 						$posts_made_prior_list .= '<li><a href="' . esc_attr( $post->guid ) . '">' . esc_html( $post->post_title ) . '</a></li>';
 					}
 					$posts_made_prior_list .= '</ul>';
 
-					$deleted_user = get_user_by( 'ID', $user_id );
-					wp_delete_user( $user_id );
 					$subject = __( 'Contents of a deleted inactive user transferred to admin', 'woocommerce' );
 					$message = '<h1>' . esc_html( $subject ) . '</h1><p>' . sprintf(
 						/* translators: 1: deleted user username 2: deleted user email 3: list of all post types 4: admin username 5: admin email */
@@ -422,6 +416,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 						wc_mail( $admin->user_email, $subject, $message );
 					}
 				}
+
 				$count ++;
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Move contents of a deleted inactive user to admin

It also sends an email to all site administrators informing the user that
was deleted and the list of contents (posts and pages) previously published
by the deleted user that was assigned to one of the administrators.

Thus, we avoid that these contents are lost when an inactive user (maybe a
old admin or author who had published this before to be demoted to subscriber
or customer role) is automatically deleted by WooCommerce data retention policy.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24432

### How to test the changes in this Pull Request:

1. Create a new user with the administrator role.
2. Assign (as author) pages and posts to the new administrator user created in the previous step.
3. Change the role of the user created in the first step to subscribe or costumer.
4. Inside the plugin folder, locate and open the file "woocommerce/includes/class-wc-privacy.php" in your code editor. Then comment out the lines from 347 to 361.
5. Type in your browser's address bar "example.com/?privacy=test" (replace "example.com" with the address of your local testing website) after you have already added the following code in a custom plugin or in the " function.php "of your theme:

function wootests_privacy() {
	if ( isset( $_GET['privacy'] ) && 'test' === $_GET['privacy'] && class_exists( 'WC_Privacy' ) && in_array( 'woocommerce/woocommerce.php', apply_filters( 'active_plugins', get_option( 'active_plugins' ) ), true ) ) {		
		$p = new WC_Privacy();
		$p->delete_inactive_accounts();
	}
}
add_action( 'init', 'wootests_privacy' );

6. Check if the user created in step 1 has been deleted and if the content published by him (pages and posts) has been transferred to a site administrator.
7. To test whether the email informing administrators about the change is being sent correctly, use something like "MailHog" in your development environment.
8. After completing the test, remember to uncomment the lines of code commented on in step 4 and remove the custom code that was presented in step 5 of this guide.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Move contents of a deleted inactive user to admin
