### PR TITLE
fix #25808

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -633,8 +633,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		// Syncing Prices of child product stored in Groupe Product.
 		if ( ! $product->is_type( 'grouped' ) ) {
 			$grouped_product_ids = wc_get_product_parent_groups( $product );
-			foreach ( $grouped_product_ids as $key => $value ) {
-				WC_Product_Grouped::sync( $value );
+			foreach ( $grouped_product_ids as $id ) {
+				WC_Product_Grouped::sync( $id );
 			}
 		}
 

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -628,14 +628,13 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					$product->set_price( $product->get_regular_price( 'edit' ) );
 				}
 			}
+		}
 
-			/* Syncing Prices of child product store in Groupe Product */
-			$grouped_product_ids = wc_get_parent_grouped_id( $product );
-			if ( ! empty( $grouped_product_ids ) ) {
-				foreach ( $grouped_product_ids as $key => $value ) {
-					$wc_post_data = new WC_Post_Data();
-					$wc_post_data->deferred_product_sync( $value );
-				}
+		// Syncing Prices of child product stored in Groupe Product.
+		if ( ! $product->is_type( 'grouped' ) ) {
+			$grouped_product_ids = wc_get_product_parent_groups( $product );
+			foreach ( $grouped_product_ids as $key => $value ) {
+				WC_Product_Grouped::sync( $value );
 			}
 		}
 

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -628,6 +628,15 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 					$product->set_price( $product->get_regular_price( 'edit' ) );
 				}
 			}
+
+			/* Syncing Prices of child product store in Groupe Product */
+			$grouped_product_ids = wc_get_parent_grouped_id( $product );
+			if ( ! empty( $grouped_product_ids ) ) {
+				foreach ( $grouped_product_ids as $key => $value ) {
+					$wc_post_data = new WC_Post_Data();
+					$wc_post_data->deferred_product_sync( $value );
+				}
+			}
 		}
 
 		if ( in_array( 'stock_quantity', $this->updated_props, true ) ) {

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -201,6 +201,39 @@ function wc_get_featured_product_ids() {
 }
 
 /**
+ * Populate a batch of rating count lookup table data for products.
+ *
+ * @since 4.0.1
+ * @param int $id Product ID.
+ */
+function wc_get_parent_grouped_id( $id ) {
+
+	global $wpdb;
+
+	if ( $product->is_type( array( 'simple' ) ) ) {
+		$product_id = $product->get_id();
+		$group_ids  = array();
+
+		$group_data = $wpdb->get_col(
+			$wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.QuotedDynamicPlaceholderGeneration
+				"SELECT post_id
+				FROM $wpdb->postmeta
+				WHERE meta_key = '_children' 
+				AND meta_value LIKE %s",
+				'%' . $wpdb->esc_like( $product_id ) . '%'
+			)
+		);
+
+		if ( is_array( $group_data ) && count( $group_data ) > 0 ) {
+			foreach ( $group_data as $group_data_key => $group_data_value ) {
+				$group_ids[] = $group_data_value;
+			}
+		}
+	}
+	return $group_ids;
+}
+
+/**
  * Filter to allow product_cat in the permalinks for products.
  *
  * @param  string  $permalink The existing permalink URL.

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -201,37 +201,34 @@ function wc_get_featured_product_ids() {
 }
 
 /**
- * Populate a batch of rating count lookup table data for products.
+ * Returns a list of product groups that a specific product belongs to.
  *
- * @since 4.0.1
+ * @since 4.2.0
  * @param int $product Product Object.
+ * @return int[] a list of product groups that a specific product belongs to
  */
-function wc_get_parent_grouped_id( $product ) {
+function wc_get_product_parent_groups( $product ) {
 
 	global $wpdb;
 
-	$group_ids = array();
+	$group_ids  = array();
+	$product_id = $product->get_id();
 
-	if ( $product->is_type( array( 'simple' ) ) ) {
+	$group_data = $wpdb->get_col(
+		$wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.QuotedDynamicPlaceholderGeneration
+			"SELECT post_id
+			FROM $wpdb->postmeta
+			WHERE meta_key = '_children' 
+			AND meta_value LIKE %s",
+			'%:' . $wpdb->esc_like( $product_id ) . ';%'
+		)
+	);
 
-		$product_id = $product->get_id();
-		$group_data = $wpdb->get_col(
-			$wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.QuotedDynamicPlaceholderGeneration
-				"SELECT post_id
-				FROM $wpdb->postmeta
-				WHERE meta_key = '_children' 
-				AND meta_value LIKE %s",
-				'%' . $wpdb->esc_like( $product_id ) . '%'
-			)
-		);
-
-		if ( is_array( $group_data ) && count( $group_data ) > 0 ) {
-			foreach ( $group_data as $group_data_key => $group_data_value ) {
-				$group_ids[] = $group_data_value;
-			}
-		}
+	foreach ( $group_data as $group_data_key => $group_data_value ) {
+		$group_ids[] = $group_data_value;
 	}
-	return $group_ids;
+
+	return wp_parse_id_list( $group_ids );
 }
 
 /**

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -204,9 +204,9 @@ function wc_get_featured_product_ids() {
  * Populate a batch of rating count lookup table data for products.
  *
  * @since 4.0.1
- * @param int $id Product ID.
+ * @param int $product Product Object.
  */
-function wc_get_parent_grouped_id( $id ) {
+function wc_get_parent_grouped_id( $product ) {
 
 	global $wpdb;
 

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -210,10 +210,11 @@ function wc_get_parent_grouped_id( $product ) {
 
 	global $wpdb;
 
-	if ( $product->is_type( array( 'simple' ) ) ) {
-		$product_id = $product->get_id();
-		$group_ids  = array();
+	$group_ids = array();
 
+	if ( $product->is_type( array( 'simple' ) ) ) {
+
+		$product_id = $product->get_id();
 		$group_data = $wpdb->get_col(
 			$wpdb->prepare( // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQLPlaceholders.QuotedDynamicPlaceholderGeneration
 				"SELECT post_id

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -203,7 +203,7 @@ function wc_get_featured_product_ids() {
 /**
  * Returns a list of product groups that a specific product belongs to.
  *
- * @since 4.2.0
+ * @since 4.4.0
  * @param int $product Product Object.
  * @return int[] a list of product groups that a specific product belongs to
  */


### PR DESCRIPTION
When updating price of the child product syncing of the Grouped product was not being performed. In this commit, I have implemented a function to get the Group product Ids in which the child product is linked. And upon updating the property of product, I have executed the syncing grouped product so that the _price will get updated in the grouped product.

### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25808 .

### How to test the changes in this Pull Request:

1. Create two Simple products with price 100 and 200 respectively. 
2. Create a Grouped product and link these two products to it and publish it.
3. Now go to one of the child products and change the Regular price and update it.
4. Go to post_meta table and query by Grouped product's ID(post_id) and '_price' Meta Key(meta_key).
5. Price in the _price meta key should be updated according to the price of child products.

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Synced the grouped product upon updation of child product so that in the backend, price information for Grouped product will get saved correctly. 
