### PR TITLE
Add label to unlabelled taxonomies

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -59,6 +59,7 @@ class WC_Post_Types {
 					'query_var'         => is_admin(),
 					'rewrite'           => false,
 					'public'            => false,
+					'label'             => _x( 'Product type', 'Taxonomy name', 'woocommerce' ),
 				)
 			)
 		);
@@ -75,6 +76,7 @@ class WC_Post_Types {
 					'query_var'         => is_admin(),
 					'rewrite'           => false,
 					'public'            => false,
+					'label'             => _x( 'Product visibility', 'Taxonomy name', 'woocommerce' ),
 				)
 			)
 		);


### PR DESCRIPTION
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds "label" to the Product Type, and Product Visibility taxonomy definitions. This allows extensions that want to generate lists of product-related taxonomies to do so, and use a sensible label for those taxonomies.

For example, in the Google Product Feed plugin we effectively allow users to choose how to map data stored in WooCommerce onto Google's feed format. Part of this involves giving them a list of all taxonomies associated with the product post type. Currently, the Product type and Product Visibility taxonomies both just show up as "Tags" since that's the default taxonomy label.

After this PR, the taxonomies will have a label that clearly describes what they are.

Note: This PR only sets the `label` property in the `register_taxonomy()`, not `labels` since the taxonomies aren't exposed in the UI, so those additional strings shouldn't be necessary.

### How to test the changes in this Pull Request:

1. Use WP-CLI to confirm that `get_taxonomy('product_visibility')` returns a sensible `label` property, e.g. check the output of `get_taxonomy('product_visibility')->label;`
2. Use WP-CLI to confirm that `get_taxonomy('product_type')` returns a sensible `label` property, e.g. check the output of `get_taxonomy('product_type')->label;`

### Changelog

> Dev - Added labels to taxonomies that lacked one.