### PR TITLE
update translation file scripts to handle js in WC Admin

### DIFF
--- a/bin/combine-pot-files.php
+++ b/bin/combine-pot-files.php
@@ -1,0 +1,104 @@
+<?php
+/**
+ * Command line script for merging two .pot files.
+ *
+ * @package WooCommerce Admin
+ */
+
+/**
+ * Get the two file names from the command line.
+ */
+if ( $argc < 2 ) {
+	echo "Usage: php -f {$argv[0]} source-file.pot destination-file.pot\n";
+	exit;
+}
+
+for ( $index = 1; $index <= 2; $index++ ) {
+	if ( ! is_file( $argv[ $index ] ) ) {
+		echo "File not found: {$argv[ $index ]}\n";
+		exit;
+	}
+}
+
+/**
+ * Check whether an output locale has been requested.
+ */
+if ( isset( $argv[3] ) && 0 === stripos( $argv[3], 'lang=' ) ) {
+	$locale = substr( $argv[3], 5 );
+	$target_file = preg_replace( '|\.pot?|', "-{$locale}.po", $argv[2] );
+} else {
+	$target_file = $argv[2];
+}
+
+/**
+ * Parse a .pot file into an array.
+ *
+ * @param string $file_name Pot file name.
+ * @return array
+ */
+function woocommerce_admin_parse_pot( $file_name ) {
+	$fh         = fopen( $file_name, 'r' );
+	$originals  = array();
+	$references = array();
+	$messages   = array();
+	$have_msgid = false;
+
+	while ( ! feof( $fh ) ) {
+		$line = trim( fgets( $fh ) );
+		if ( ! $line ) {
+			$message               = implode( "\n", $messages );
+			$originals[ $message ] = $references;
+			$references            = array();
+			$messages              = array();
+			$have_msgid            = false;
+			$message               = '';
+			continue;
+		}
+
+		if ( 'msgid' == substr( $line, 0, 5 ) ) {
+			$have_msgid = true;
+		}
+
+		if ( $have_msgid ) {
+			$messages[]   = $line;
+		} else {
+			$references[] = $line;
+		}
+	}
+
+	fclose( $fh );
+
+	$message               = implode( "\n", $messages );
+	$originals[ $message ] = $references;
+	return $originals;
+}
+
+// Read the translation files.
+$originals_1 = woocommerce_admin_parse_pot( $argv[1] );
+$originals_2 = woocommerce_admin_parse_pot( $argv[2] );
+// Delete the original sources.
+unlink( $argv[1] );
+unlink( $argv[2] );
+// We don't want two .pot headers in the output.
+array_shift( $originals_1 );
+
+$fh = fopen( $target_file, 'w' );
+foreach ( $originals_2 as $message => $original ) {
+	// Use the complete message section to match strings to be translated.
+	if ( isset( $originals_1[ $message ] ) ) {
+		$original = array_merge( $original, $originals_1[ $message ] );
+		unset( $originals_1[ $message ] );
+	}
+
+	fwrite( $fh, implode( "\n", $original ) );
+	fwrite( $fh, "\n" . $message ."\n\n" );
+}
+
+foreach ( $originals_1 as $message => $original ) {
+	fwrite( $fh, implode( "\n", $original ) );
+	fwrite( $fh, "\n" . $message ."\n\n" );
+}
+
+fclose( $fh );
+
+echo "Created {$target_file}\n";

--- a/bin/combine-pot-files.sh
+++ b/bin/combine-pot-files.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Check for required version
+WPCLI_VERSION=`wp cli version | cut -f2 -d' '`
+if [ ${WPCLI_VERSION:0:1} -lt "2" -o ${WPCLI_VERSION:0:1} -eq "2" -a ${WPCLI_VERSION:2:1} -lt "1" ]; then
+	echo WP-CLI version 2.1.0 or greater is required to make JSON translation files
+	exit
+fi
+
+# Substitute JS source references with build references
+for T in `find packages/woocommerce-admin/languages -name "*.pot"`
+	do
+		sed \
+			-e 's/ client\/[^:]*:/ packages\/woocommerce-admin\/dist\/app\/index.js:/gp' \
+			-e 's/ packages\/components[^:]*:/ packages\/woocommerce-admin\/dist\/components\/index.js:/gp' \
+			-e 's/ packages\/date[^:]*:/ packages\/woocommerce-admin\/dist\/date\/index.js:/gp' \
+			-e 's/ src\// packages\/woocommerce-admin\/src\//gp' \
+			-e 's/ includes\// packages\/woocommerce-admin\/includes\//gp' \
+			$T | uniq > $T-build
+		rm $T
+		mv $T-build $T
+	done
+
+# Combine the WooCommerce and WooCommerce Admin translations files
+php bin/combine-pot-files.php packages/woocommerce-admin/languages/woocommerce-admin.pot i18n/languages/woocommerce.pot

--- a/composer.json
+++ b/composer.json
@@ -29,6 +29,7 @@
     },
     "preferred-install": {
         "woocommerce/action-scheduler": "dist",
+        "woocommerce/woocommerce-admin": "dist",
         "woocommerce/woocommerce-rest-api": "dist",
         "woocommerce/woocommerce-blocks": "dist"
     },
@@ -63,10 +64,11 @@
       "phpcbf -p"
     ],
     "makepot-audit": [
-      "wp i18n make-pot . --exclude=\".github,.wordpress-org,bin,sample-data,node_modules,tests\" --slug=woocommerce"
+      "wp i18n make-pot . --include=\"packages\/woocommerce-blocks,packages\/woocommerce-rest-api,packages\/action-scheduler\" --exclude=\".github,.wordpress-org,bin,sample-data,node_modules,tests,packages\" --slug=woocommerce"
     ],
     "makepot": [
-      "@makepot-audit --skip-audit"
+      "@makepot-audit --skip-audit",
+      "./bin/combine-pot-files.sh"
     ]
   },
   "extra": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -6,6 +6,7 @@
 
 	<!-- Exclude paths -->
 	<exclude-pattern>tests/cli/</exclude-pattern>
+	<exclude-pattern>bin/</exclude-pattern>
 	<exclude-pattern>includes/libraries/</exclude-pattern>
 	<exclude-pattern>includes/legacy/</exclude-pattern>
 	<exclude-pattern>includes/api/legacy/</exclude-pattern>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR makes a few changes to the scripts that create `woocommerce.pot`

- Explicitly pull the `dist` WooCommerce Admin package
- Excludes `/bin/` from PHPCS
- Updates the `makepot` command to reduce memory usage
- Adds a copy of `combine-pot-files.php` used in WC Admin. This is used to merge the WC and WC Admin `.pot` files.
- Adds `combine-pot-files.sh` which updates the file path references in `woocommerce-admin.pot` then merges that file into `woocommerce.pot`

The `wp i18n make-json` command uses the js file references in the `.po(t)` file to determine which `.json` file(s) should have the translation. `.mo` files don't require the PHP file reference but GlotPress lists the file references when editing the translation so the PHP references are updated to avoid confusion with translators.

Closes #25920 .

### How to test the changes in this Pull Request:

1. Delete the `packages` folder 
2. Run `composer install`
3. Run `npm run makepot`
4. Check that `i18n/languages/woocommerce.pot` contains references to both WC Admin JS and PHP
- PHP references are to `packages/woocommerce-admin/...`
- JS references are to `packages/woocommerce-admin/dist/...`

5. The JS translations can be tested by adding some translations in the .pot file to strings that have `.js` references
6. Rename the `.pot` to include a locale
7. Run `wp i18n make-json` in the languages folder
8. Copy the generated `.json` files to `/wp-content/languages/plugins`
9. Set the site language to that locale
10. Check the Analytics section for the translation

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix translations in Analytics Dashboard.
