### PR TITLE
Added number of decimals in price-slider.js

### DIFF
--- a/includes/widgets/class-wc-widget-price-filter.php
+++ b/includes/widgets/class-wc-widget-price-filter.php
@@ -41,7 +41,7 @@ class WC_Widget_Price_Filter extends WC_Widget {
 			'wc-price-slider',
 			'woocommerce_price_slider_params',
 			array(
-				'currency_format_num_decimals' => 0,
+				'currency_format_num_decimals' => esc_attr( wc_get_price_decimals() ),
 				'currency_format_symbol'       => get_woocommerce_currency_symbol(),
 				'currency_format_decimal_sep'  => esc_attr( wc_get_price_decimal_separator() ),
 				'currency_format_thousand_sep' => esc_attr( wc_get_price_thousand_separator() ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Added number of decimals in price-slider.js

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:

1. Added number of decimals in price-slider.js instead of passing 0.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added number of decimals in price-slider.js