### PR TITLE
Add method to get base data from order object.

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -420,6 +420,19 @@ class WC_Order extends WC_Abstract_Order {
 	*/
 
 	/**
+	 * Get basic order data in array format.
+	 *
+	 * @return array
+	 */
+	public function get_base_data() {
+		return array_merge(
+			array( 'id'     => $this->get_id() ),
+			$this->data,
+			array( 'number' => $this->get_order_number() )
+		);
+	}
+
+	/**
 	 * Get all class data in array format.
 	 *
 	 * @since 3.0.0
@@ -427,12 +440,8 @@ class WC_Order extends WC_Abstract_Order {
 	 */
 	public function get_data() {
 		return array_merge(
+			$this->get_base_data(),
 			array(
-				'id' => $this->get_id(),
-			),
-			$this->data,
-			array(
-				'number'         => $this->get_order_number(),
 				'meta_data'      => $this->get_meta_data(),
 				'line_items'     => $this->get_items( 'line_item' ),
 				'tax_lines'      => $this->get_items( 'tax' ),


### PR DESCRIPTION
# All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This method can be used when we need basic data about the object without
querying for lot more (and expensive) data from DB.

### How to test the changes in this Pull Request:

1. In wp cli, fetch an order.
2. run `$order->get_base_data()`.
3. Make sure that expected data object is returned.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Add a way to fetch basic object data.
