### PR TITLE
fix typo in variable

### DIFF
--- a/includes/admin/settings/views/html-keys-edit.php
+++ b/includes/admin/settings/views/html-keys-edit.php
@@ -35,8 +35,8 @@ defined( 'ABSPATH' ) || exit;
 				</th>
 				<td class="forminp">
 					<?php
-					$curent_user_id = get_current_user_id();
-					$user_id        = ! empty( $key_data['user_id'] ) ? absint( $key_data['user_id'] ) : $curent_user_id;
+					$current_user_id = get_current_user_id();
+					$user_id        = ! empty( $key_data['user_id'] ) ? absint( $key_data['user_id'] ) : $current_user_id;
 					$user           = get_user_by( 'id', $user_id );
 					$user_string    = sprintf(
 						/* translators: 1: user display name 2: user ID 3: user email */


### PR DESCRIPTION
### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Corrected spelling in variable name for `current_user_id`.
