### PR TITLE
Fix WooCommerce DB update done notice action

### DIFF
--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -193,16 +193,10 @@ class WC_Notes_Run_Db_Update {
 	 * @param int $note_id Note id to update.
 	 */
 	private static function update_done_notice( $note_id ) {
-		$hide_notices_url = html_entity_decode( // to convert &amp;s to normal &, otherwise produces invalid link.
-			wp_nonce_url(
-				add_query_arg(
-					'wc-hide-notice',
-					'update',
-					admin_url( 'admin.php?page=wc-settings' )
-				),
-				'woocommerce_hide_notices_nonce',
-				'_wc_notice_nonce'
-			)
+		$hide_notices_url = add_query_arg(
+			'wc-hide-notice',
+			'update',
+			admin_url( 'admin.php?page=wc-settings' )
 		);
 
 		$note = new WC_Admin_Note( $note_id );


### PR DESCRIPTION
This resolves https://github.com/woocommerce/woocommerce-admin/issues/3973 (the 'Thanks!' button doesn't work properly after 24 hours) by removing the nonce wrapper from the 'Thanks!' action URL generation.

### Changes proposed in this Pull Request:

Removes the nonce wrapper from the 'Thanks!' action URL generation when generating the final DB update admin note.

Closes https://github.com/woocommerce/woocommerce-admin/issues/3973.

### How to test the changes in this Pull Request:

Edit `includes/admin/notes/class-wc-notes-run-db-update.php` and at the end of the constructor add this:

```
$note_id = $this->update_needed_notice();
$this->update_done_notice($note_id);
```

Refresh the page and the done notice should appear. Remove the added code from the constructor before continuing.

Click the 'Thanks!' button and the notice should disappear. To fully test, repeat and wait for at least 24 hours before clicking 'Thanks!', and the notice should still disappear. That shouldn't be required though as it's pretty obvious that the nonce generation code has just been removed from the action URL.

### Changelog entry

Fix database update complete notice action if the notice has been left for 24+ hours.