### PR TITLE
Corrected error messaging on update for expired WooCommerce.com subscriptions

### DIFF
--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -1,4 +1,11 @@
 <?php
+/**
+ * The update helper for WooCommerce.com plugins.
+ *
+ * @class WC_Helper_Updater
+ * @package WooCommerce/Admin.
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -18,6 +25,7 @@ class WC_Helper_Updater {
 		add_action( 'pre_set_site_transient_update_plugins', array( __CLASS__, 'transient_update_plugins' ), 21, 1 );
 		add_action( 'pre_set_site_transient_update_themes', array( __CLASS__, 'transient_update_themes' ), 21, 1 );
 		add_action( 'upgrader_process_complete', array( __CLASS__, 'upgrader_process_complete' ) );
+		add_action( 'upgrader_pre_download', array( __CLASS__, 'block_expired_updates' ), 10, 2 );
 	}
 
 	/**
@@ -45,12 +53,15 @@ class WC_Helper_Updater {
 				'plugin'         => $filename,
 				'new_version'    => $data['version'],
 				'url'            => $data['url'],
-				'package'        => '',
+				'package'        => $data['package'],
 				'upgrade_notice' => $data['upgrade_notice'],
 			);
 
-			if ( self::_has_active_subscription( $plugin['_product_id'] ) ) {
-				$item['package'] = $data['package'];
+			// We don't want to deliver a valid upgrade package when their subscription has expired.
+			// To avoid the generic "no_package" error that empty strings give, we will store an
+			// indication of expiration for the `upgrader_pre_download` filter to error on.
+			if ( ! self::_has_active_subscription( $plugin['_product_id'] ) ) {
+				$item['package'] = 'woocommerce-com-expired-' . $plugin['_product_id'];
 			}
 
 			if ( version_compare( $plugin['Version'], $data['version'], '<' ) ) {
@@ -137,7 +148,7 @@ class WC_Helper_Updater {
 			$payload[ $data['_product_id'] ]['file_id'] = $data['_file_id'];
 		}
 
-		// Scan local themes
+		// Scan local themes.
 		foreach ( WC_Helper::get_local_woo_themes() as $data ) {
 			if ( ! isset( $payload[ $data['_product_id'] ] ) ) {
 				$payload[ $data['_product_id'] ] = array(
@@ -157,6 +168,7 @@ class WC_Helper_Updater {
 	 * The call is cached based on the payload (product ids, file ids). If
 	 * the payload changes, the cache is going to miss.
 	 *
+	 * @param array $payload Information about the plugin to update.
 	 * @return array Update data for each requested product.
 	 */
 	private static function _update_check( $payload ) {
@@ -164,7 +176,8 @@ class WC_Helper_Updater {
 		$hash = md5( wp_json_encode( $payload ) );
 
 		$cache_key = '_woocommerce_helper_updates';
-		if ( false !== ( $data = get_transient( $cache_key ) ) ) {
+		$data      = get_transient( $cache_key );
+		if ( false !== $data ) {
 			if ( hash_equals( $hash, $data['hash'] ) ) {
 				return $data['products'];
 			}
@@ -240,7 +253,8 @@ class WC_Helper_Updater {
 	 */
 	public static function get_updates_count() {
 		$cache_key = '_woocommerce_helper_updates_count';
-		if ( false !== ( $count = get_transient( $cache_key ) ) ) {
+		$count     = get_transient( $cache_key );
+		if ( false !== $count ) {
 			return $count;
 		}
 
@@ -317,6 +331,37 @@ class WC_Helper_Updater {
 	 */
 	public static function upgrader_process_complete() {
 		delete_transient( '_woocommerce_helper_updates_count' );
+	}
+
+	/**
+	 * Hooked into the upgrader_pre_download filter in order to better handle error messaging around expired
+	 * plugin updates. Initially we were using an empty string, but the error message that no_package
+	 * results in does not fit the cause.
+	 *
+	 * @since 4.1.0
+	 * @param bool   $reply Holds the current filtered response.
+	 * @param string $package The path to the package file for the update.
+	 * @return false|WP_Error False to proceed with the update as normal, anything else to be returned instead of updating.
+	 */
+	public static function block_expired_updates( $reply, $package ) {
+		// Don't override a reply that was set already.
+		if ( false !== $reply ) {
+			return $reply;
+		}
+
+		// Only for packages with expired subscriptions.
+		if ( 0 !== strpos( $package, 'woocommerce-com-expired-' ) ) {
+			return false;
+		}
+
+		return new WP_Error(
+			'woocommerce_subscription_expired',
+			sprintf(
+				// translators: %s: URL of WooCommerce.com subscriptions tab.
+				__( 'Please visit the <a href="%s" target="_blank">subscriptions page</a> and renew to continue receiving updates.', 'woocommerce' ),
+				esc_url( admin_url( 'admin.php?page=wc-addons&section=helper' ) )
+			)
+		);
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Prior to this PR, the default `no_package` error message was delivered when a user attempted to update a WooCommerce.com plugin that had an expired subscription. This PR adds better messaging to that error case through the use of the `upgrader_pre_download` filter. This filter is executed as a way to override the download mechanism for the update package, and we can use it here to give a custom error for expired subscriptions.

### How to test the changes in this Pull Request:

1. Add a WooCommerce.com paid plugin to your shop. Edit the version manually so that it is older and an update is available.
2. Perform the update, should work great!
3. Edit the version again and then, when the subscription is expired, update again.
4. Without the PR it will tell you that the package was unavailable. With the PR it will tell you that it has expired and direct you to the subscriptions page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Clarified the error messaging for WooCommerce.com package update failures
