### PR TITLE
Fix/26002

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1476,6 +1476,16 @@ class WC_Cart extends WC_Legacy_Cart {
 					$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_NOT_YOURS_REMOVED );
 					$this->remove_coupon( $code );
 				}
+
+				$coupon_usage_limit = $coupon->get_usage_limit_per_user();
+				if ( 0 < $coupon_usage_limit && 0 === get_current_user_id() ) {
+					// For guest, usage per user has not been enforced yet. Enforce it now.
+					$coupon_data_store = $coupon->get_data_store();
+					$billing_email = strtolower( sanitize_email( $billing_email ) );
+					if ( $coupon_data_store && $coupon_data_store->get_usage_by_email( $coupon, $billing_email ) >= $coupon_usage_limit ) {
+						$coupon->add_coupon_message( WC_Coupon::E_WC_COUPON_USAGE_LIMIT_REACHED );
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In a previous commit, a regression was introduced where we were no
longer checking for usage limit of guest user in an install. This
commit adds back that check.

Note that for logged in users, we were already enforcing this in `$coupon->is_valid()`.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #26002 .

### How to test the changes in this Pull Request:

1. Create a coupon with per user usage limit set to 1.
2. Checkout and successfully complete an order using the coupon created in step 1 as a guest (non logged in user). Remember the email used in this step.
3. Checkout and try to complete another order using the coupon from step 1 and email from step 2. Without this patch, you will be able to complete the order, with this patch you will see an error message.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Enforce per user usage limit check for a coupon on guest users based on email.
