### PR TITLE
Prune elements with display none to fix regression.

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -567,6 +567,9 @@ class WC_Email extends WC_Settings_API {
 					do_action( 'woocommerce_emogrifier', $emogrifier, $this );
 
 					$content    = $emogrifier->emogrify();
+					$html_prune = \Pelago\Emogrifier\HtmlProcessor\HtmlPruner::fromHtml( $content );
+					$html_prune->removeElementsWithDisplayNone();
+					$content    = $html_prune->render();
 				} catch ( Exception $e ) {
 					$logger = wc_get_logger();
 					$logger->error( $e->getMessage(), array( 'source' => 'emogrifier' ) );

--- a/tests/unit-tests/email/emails.php
+++ b/tests/unit-tests/email/emails.php
@@ -50,4 +50,17 @@ class WC_Tests_WC_Emails extends WC_Unit_Test_Case {
 		$this->assertEquals( $expected, $result );
 	}
 
+	/**
+	 * Test that we remove elemets with style display none from html mails.
+	 */
+	public function test_remove_display_none_elements() {
+		$email = new WC_Email();
+		$email->email_type = 'html';
+		$str_present = 'Should be present!';
+		$str_removed = 'Should be removed!';
+		$result = $email->style_inline( "<div><div class='text'>$str_present</div><div style='display: none'>$str_removed</div> </div>" );
+		$this->assertTrue( false !== strpos( $result, $str_present ) );
+		$this->assertTrue( false === strpos( $result, $str_removed ) );
+	}
+
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In an earlier emogridier version (til WC 3.9.3) this was happening by
default, however now we have to do this explicitly since we update
emogrifier to > 3.x.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #26015 

Note that #26015 can also be addressed by removing structured data from email, and we should eventually do it, however, this is the correct fix for the regression added in 4.0. We should remove structured data from email in a separate PR.

### How to test the changes in this Pull Request:

1. Apply this patch and trigger any WC mail (order note, order complete etc).
2. When issue is reproducible, Inspect the email source, and make sure that formatting is correct.
3. When issue is not reproducible, inspect the email source and make sure that there is no line with `display: none`. Note that display:none might be broken into chunks if the patch is not working as expected, so be sure to try to search some substring as well.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Remove elements with style=display:none explicitly to address a regression causing broken email html.