### PR TITLE
Addons/Helper: fix toggles in RTL mode 

### DIFF
--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -471,6 +471,7 @@ class WC_Helper {
 
 		if ( $wc_screen_id . '_page_wc-addons' === $screen_id && isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
 			wp_enqueue_style( 'woocommerce-helper', WC()->plugin_url() . '/assets/css/helper.css', array(), Constants::get_constant( 'WC_VERSION' ) );
+			wp_style_add_data( 'woocommerce-helper', 'rtl', 'replace' );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The RTL file for `woocommerce-helper` wasn't being loaded because it wasn't properly registered.
This fixes it.

Before:
<img width="1204" alt="Screen Shot 2020-04-05 at 11 07 16" src="https://user-images.githubusercontent.com/844866/78469873-a1341480-772d-11ea-90a1-7ccf1761be10.png">

After:

<img width="1202" alt="Screen Shot 2020-04-05 at 10 59 49" src="https://user-images.githubusercontent.com/844866/78469862-88c3fa00-772d-11ea-82da-38102912ae30.png">


### How to test the changes in this Pull Request:

1. Set your site language to a RTL language (or use the rtl-tester plugin)
2. Connect the site to Woocomerce.com
3. Visit the addons page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix google in WooComerce.com addons screen in RTL languages.
