### PR TITLE
Fixed filter widgets showing terms containing out of stock products

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -355,6 +355,14 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			}
 		}
 
+		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
+			$meta_query[] = array(
+				'key'     => '_stock_status',
+				'value'   => 'outofstock',
+				'compare' => 'NOT LIKE',
+			);
+		}
+
 		$meta_query     = new WP_Meta_Query( $meta_query );
 		$tax_query      = new WP_Tax_Query( $tax_query );
 		$meta_query_sql = $meta_query->get_sql( 'post', $wpdb->posts, 'ID' );

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -51,6 +51,14 @@ class WC_Widget_Rating_Filter extends WC_Widget {
 			}
 		}
 
+		if ( 'yes' === get_option( 'woocommerce_hide_out_of_stock_items' ) ) {
+			$meta_query[] = array(
+				'key'     => '_stock_status',
+				'value'   => 'outofstock',
+				'compare' => 'NOT LIKE',
+			);
+		}
+
 		// Set new rating filter.
 		$product_visibility_terms = wc_get_product_visibility_term_ids();
 		$tax_query[]              = array(


### PR DESCRIPTION
Even though Hide Out of stock option is enabled.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
