### PR TITLE
add customised cart & checkout block settings to wc-tracker snapshot

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -686,11 +686,13 @@ class WC_Tracker {
 		$page_blocks = self::get_all_blocks_from_page( $woo_page_name );
 
 		// Get any instances of the specified block.
-		return array_filter(
-			$page_blocks,
-			function ( $block ) {
-				return $block_name !== $block['blockName'];
-			}
+		return array_values(
+			array_filter(
+				$page_blocks,
+				function ( $block ) use ( $block_name ) {
+					return ( $block_name === $block['blockName'] );
+				}
+			)
 		);
 	}
 

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -659,7 +659,6 @@ class WC_Tracker {
 	 * @return array Array of blocks as returned by parse_blocks().
 	 */
 	private static function get_blocks_from_page( $woo_page_name ) {
-		// Will expose this as a param later.
 		$page_id = wc_get_page_id( $woo_page_name );
 
 		$page = get_post( $page_id );
@@ -667,7 +666,6 @@ class WC_Tracker {
 			return array();
 		}
 
-		// Parse blocks out of checkout page.
 		$blocks = parse_blocks( $page->post_content );
 		if ( ! $blocks ) {
 			return array();

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -652,28 +652,6 @@ class WC_Tracker {
 		return ( '0' !== $result ) ? 'Yes' : 'No';
 	}
 
-	// @todo what's the best way to set up the array_filter in woo PHP version?
-
-	/**
-	 * Return true if specified block is checkout block.
-	 *
-	 * @param object $block Block object (as returned in array from parse_blocks()).
-	 * @return boolean
-	 */
-	public static function is_checkout_block( $block ) {
-		return 'woocommerce/checkout' === $block['blockName'];
-	}
-
-	/**
-	 * Return true if specified block is checkout block.
-	 *
-	 * @param object $block Block object (as returned in array from parse_blocks()).
-	 * @return boolean
-	 */
-	public static function is_cart_block( $block ) {
-		return 'woocommerce/cart' === $block['blockName'];
-	}
-
 	/**
 	 * Get blocks from a woocommerce page.
 	 *
@@ -710,7 +688,12 @@ class WC_Tracker {
 		$blocks = self::get_blocks_from_page( 'checkout' );
 
 		// Get checkout block(s).
-		$checkout_blocks = array_filter( $blocks, array( __CLASS__, 'is_checkout_block' ) );
+		$checkout_blocks = array_filter(
+			$blocks,
+			function ( $block ) {
+				return 'woocommerce/checkout' === $block['blockName'];
+			}
+		);
 		if ( ! $checkout_blocks || ! count( $checkout_blocks ) ) {
 			return array();
 		}
@@ -731,7 +714,12 @@ class WC_Tracker {
 		$blocks = self::get_blocks_from_page( 'cart' );
 
 		// Get cart block(s).
-		$cart_blocks = array_filter( $blocks, array( __CLASS__, 'is_cart_block' ) );
+		$cart_blocks = array_filter(
+			$blocks,
+			function ( $block ) {
+				return 'woocommerce/cart' === $block['blockName'];
+			}
+		);
 		if ( ! $cart_blocks || ! count( $cart_blocks ) ) {
 			return array();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds extra information to the WC Tracker snapshot about the settings used for cart & checkout blocks. If the cart or checkout blocks are used on the relevant pages, any customised attributes are saved to the tracker snapshot. 

For stores that are opted in to tracker, this will allow us to get usage information for how the cart & checkout blocks are being used.

This is a follow up to https://github.com/woocommerce/woocommerce/pull/25932

### How to test the changes in this Pull Request:
1. Install and activate [WooCommerce Blocks plugin from source](https://github.com/woocommerce/woocommerce-gutenberg-products-block) - the cart & checkout block have not been released yet.
2. Add the cart and checkout block to cart & checkout pages and change some settings, e.g. `Show a "return to cart" link`. Ensure those pages are published and are the designated cart & checkout pages (`WooCommerce > Settings > Advanced > Page setup`).
2. Ensure your test site is opted into tracking (`WooCommerce > Settings > Advanced > WooCommerce.com > Usage Tracking`). 

Using `wp shell`, you can call the new method directly to check the results:

- `WC_Tracker::get_cart_checkout_info();` 

This should show the settings you've customised in `checkout_block_attributes` and `cart_block_attributes`, for example:

```
wp> WC_Tracker::get_cart_checkout_info()
=> array(6) {
  ["cart_page_contains_cart_block"]=>
  string(3) "Yes"
  ["cart_page_contains_cart_shortcode"]=>
  string(2) "No"
  ["cart_block_attributes"]=>
  array(1) {
    ["isShippingCalculatorEnabled"]=>
    bool(false)
  }
  ["checkout_page_contains_checkout_block"]=>
  string(3) "Yes"
  ["checkout_page_contains_checkout_shortcode"]=>
  string(2) "No"
  ["checkout_block_attributes"]=>
  array(5) {
    ["showCompanyField"]=>
    bool(true)
    ["requireCompanyField"]=>
    bool(true)
    ["showPhoneField"]=>
    bool(false)
    ["requirePhoneField"]=>
    bool(true)
    ["showPolicyLinks"]=>
    bool(false)
  }
}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Adds usage data for the of cart & checkout blocks (currently in development in WooCommmerce Blocks plugin) to the WC Tracker snapshot.
