### PR TITLE
Implement additional tracks take 2

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -113,6 +113,8 @@ class WC_Site_Tracking {
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-settings-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-status-tracking.php';
 		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-coupons-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-order-tracking.php';
+		include_once WC_ABSPATH . 'includes/tracks/events/class-wc-coupon-tracking.php';
 
 		$tracking_classes = array(
 			'WC_Admin_Setup_Wizard_Tracking',
@@ -123,6 +125,8 @@ class WC_Site_Tracking {
 			'WC_Settings_Tracking',
 			'WC_Status_Tracking',
 			'WC_Coupons_Tracking',
+			'WC_Order_Tracking',
+			'WC_Coupon_Tracking',
 		);
 
 		foreach ( $tracking_classes as $tracking_class ) {

--- a/includes/tracks/events/class-wc-coupon-tracking.php
+++ b/includes/tracks/events/class-wc-coupon-tracking.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ * WooCommerce Coupon Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+ /**
+  * This class adds actions to track usage of a WooCommerce Coupon.
+  */
+class WC_Coupon_Tracking {
+	/**
+	 * Init
+	 */
+	public function init() {
+		add_action( 'woocommerce_coupon_object_updated_props', array( $this, 'track_coupon_updated' ), 10, 3 );
+	}
+
+	/**
+	 * Send a Tracks event when a coupon is updated.
+	 *
+	 * @param WC_Coupon $coupon        The coupon that has been updated.
+	 * @param Array     $updated_props The props of the coupon that have been updated.
+	 */
+	public function track_coupon_updated( $coupon, $updated_props ) {
+		$properties = array(
+			'discount_code' => $coupon->get_code(),
+			'free_shipping' => $coupon->get_free_shipping(),
+			'individual_use' => $coupon->get_individual_use(),
+			'exclude_sale_items' => $coupon->get_exclude_sale_items(),
+			'usage_limits_applied' => 0 < intval( $coupon->get_usage_limit() )
+									  || 0 < intval( $coupon->get_usage_limit_per_user() )
+									  || 0 < intval( $coupon->get_limit_usage_to_x_items() ),
+		);
+
+		WC_Tracks::record_event( 'coupon_updated', $properties );
+	}
+}

--- a/includes/tracks/events/class-wc-coupon-tracking.php
+++ b/includes/tracks/events/class-wc-coupon-tracking.php
@@ -5,15 +5,16 @@
  * @package WooCommerce\Tracks
  */
 
- /**
-  * This class adds actions to track usage of a WooCommerce Coupon.
-  */
+/**
+ * This class adds actions to track usage of a WooCommerce Coupon.
+ */
 class WC_Coupon_Tracking {
+
 	/**
-	 * Init
+	 * Init tracking.
 	 */
 	public function init() {
-		add_action( 'woocommerce_coupon_object_updated_props', array( $this, 'track_coupon_updated' ), 10, 3 );
+		add_action( 'woocommerce_coupon_object_updated_props', array( $this, 'track_coupon_updated' ), 10, 2 );
 	}
 
 	/**
@@ -24,13 +25,13 @@ class WC_Coupon_Tracking {
 	 */
 	public function track_coupon_updated( $coupon, $updated_props ) {
 		$properties = array(
-			'discount_code' => $coupon->get_code(),
-			'free_shipping' => $coupon->get_free_shipping(),
-			'individual_use' => $coupon->get_individual_use(),
-			'exclude_sale_items' => $coupon->get_exclude_sale_items(),
+			'discount_code'        => $coupon->get_code(),
+			'free_shipping'        => $coupon->get_free_shipping(),
+			'individual_use'       => $coupon->get_individual_use(),
+			'exclude_sale_items'   => $coupon->get_exclude_sale_items(),
 			'usage_limits_applied' => 0 < intval( $coupon->get_usage_limit() )
-									  || 0 < intval( $coupon->get_usage_limit_per_user() )
-									  || 0 < intval( $coupon->get_limit_usage_to_x_items() ),
+									|| 0 < intval( $coupon->get_usage_limit_per_user() )
+									|| 0 < intval( $coupon->get_limit_usage_to_x_items() ),
 		);
 
 		WC_Tracks::record_event( 'coupon_updated', $properties );

--- a/includes/tracks/events/class-wc-order-tracking.php
+++ b/includes/tracks/events/class-wc-order-tracking.php
@@ -11,6 +11,7 @@ defined( 'ABSPATH' ) || exit;
  * This class adds actions to track usage of a WooCommerce Order.
  */
 class WC_Order_Tracking {
+
 	/**
 	 * Init tracking.
 	 */
@@ -25,9 +26,9 @@ class WC_Order_Tracking {
 	 */
 	public function track_order_viewed( $order ) {
 		$properties = array(
-			'current_status'   => $order->get_status(),
-			'date_created'     => $order->get_date_created()->format( DateTime::ATOM ),
-			'payment_method'   => $order->get_payment_method(),
+			'current_status' => $order->get_status(),
+			'date_created'   => $order->get_date_created()->format( DateTime::ATOM ),
+			'payment_method' => $order->get_payment_method(),
 		);
 
 		WC_Tracks::record_event( 'single_order_view', $properties );

--- a/includes/tracks/events/class-wc-order-tracking.php
+++ b/includes/tracks/events/class-wc-order-tracking.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * WooCommerce Order Tracking
+ *
+ * @package WooCommerce\Tracks
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * This class adds actions to track usage of a WooCommerce Order.
+ */
+class WC_Order_Tracking {
+	/**
+	 * Init tracking.
+	 */
+	public function init() {
+		add_action( 'woocommerce_admin_order_data_after_order_details', array( $this, 'track_order_viewed' ) );
+	}
+
+	/**
+	 * Send a Tracks event when an order is viewed.
+	 *
+	 * @param object $order Order.
+	 */
+	public function track_order_viewed( $order ) {
+		$properties = array(
+			'current_status'   => $order->get_status(),
+			'date_created'     => $order->get_date_created()->format( DateTime::ATOM ),
+			'payment_method'   => $order->get_payment_method(),
+		);
+
+		WC_Tracks::record_event( 'single_order_view', $properties );
+	}
+}
+

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -51,7 +51,7 @@ class WC_Products_Tracking {
 	public function track_product_updated_client_side( $post ) {
 		wc_enqueue_js(
 			"
-			if ( $( 'h1.wp-heading-inline' ).text().trim() === 'Edit product') {
+			if ( $( 'h1.wp-heading-inline' ).text().trim() === '" . __( 'Edit product', 'woocommerce' ) . "') {
 				var initialStockValue = $( '#_stock' ).val();
 				var hasRecordedEvent = false;
 

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -20,13 +20,14 @@ class WC_Products_Tracking {
 		add_action( 'edit_post', array( $this, 'track_product_updated' ), 10, 2 );
 		add_action( 'transition_post_status', array( $this, 'track_product_published' ), 10, 3 );
 		add_action( 'created_product_cat', array( $this, 'track_product_category_created' ) );
+		add_action( 'add_meta_boxes_product', array( $this, 'track_product_updated_client_side' ), 10, 1 );
 	}
 
 	/**
 	 * Send a Tracks event when a product is updated.
 	 *
 	 * @param int    $product_id Product id.
-	 * @param object $post WordPress post.
+	 * @param object $post       WordPress post.
 	 */
 	public function track_product_updated( $product_id, $post ) {
 		if ( 'product' !== $post->post_type ) {
@@ -38,6 +39,42 @@ class WC_Products_Tracking {
 		);
 
 		WC_Tracks::record_event( 'product_edit', $properties );
+	}
+
+	/**
+	 * Track the Update button being clicked on the client side.
+	 * This is needed because `track_product_updated` (using the `edit_post`
+	 * hook) is called in response to a number of other triggers.
+	 *
+	 * @param WP_Post $post The post, not used.
+	 */
+	public function track_product_updated_client_side( $post ) {
+		wc_enqueue_js(
+			"
+			if ( $( 'h1.wp-heading-inline' ).text().trim() === 'Edit product') {
+				var initialStockValue = $( '#_stock' ).val();
+				var hasRecordedEvent = false;
+
+				$( '#publish' ).click( function() {
+					if ( hasRecordedEvent ) {
+						return;
+					}
+
+					var currentStockValue = $( '#_stock' ).val();
+					var properties = {
+						product_type:			$( '#product-type' ).val(),
+						is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Y' : 'N',
+						is_downloadable:		$( '#_downloadable' ).is( ':checked' ) ? 'Y' : 'N',
+						manage_stock:			$( '#_manage_stock' ).is( ':checked' ) ? 'Y' : 'N',
+						stock_quantity_update:	( initialStockValue != currentStockValue ) ? 'Y' : 'N',
+					};
+
+					window.wcTracks.recordEvent( 'product_update', properties );
+					hasRecordedEvent = true;
+				} );
+			}
+			"
+		);
 	}
 
 	/**

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -20,7 +20,7 @@ class WC_Products_Tracking {
 		add_action( 'edit_post', array( $this, 'track_product_updated' ), 10, 2 );
 		add_action( 'transition_post_status', array( $this, 'track_product_published' ), 10, 3 );
 		add_action( 'created_product_cat', array( $this, 'track_product_category_created' ) );
-		add_action( 'add_meta_boxes_product', array( $this, 'track_product_updated_client_side' ), 10, 1 );
+		add_action( 'add_meta_boxes_product', array( $this, 'track_product_updated_client_side' ), 10 );
 	}
 
 	/**


### PR DESCRIPTION
Per [this](https://github.com/woocommerce/woocommerce/pull/25942#issuecomment-607288205) I'm resubmitting this PR.

Changes proposed in this Pull Request:
This adds a few tracks per #25849:

coupon_add: occurs when a coupon is added or modified, which differs from the request which asked for the event to be tracked only on add. This was needed because the saved coupon metadata is only available at the point where the hook is called for both adds and edits.
wcadmin_single_order_view: occurs when an order is viewed.
product_update: occurs when a product is added or updated. It isn't possible to determine if the product stock level was set for this event as requested, hence the next track:
product_stock_level_set: occurs when a product's stock level is set.
How to test the changes in this Pull Request:
add error_log(print_r($properties, TRUE)); above the places where an event is recorded, and monitor the log file
Add or edit a coupon, with the other properties set or unset
view an order
update a product
set the stock level on a product with stock management enabled

### Changelog entry

> Implement some additional tracks for coupons, orders, and products, to satisfy #25942

