### PR TITLE
Update minimum PHP version to 7.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ cache:
 
 # Test main supported versions of PHP against latest WP.
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
@@ -27,7 +26,7 @@ php:
 env:
   - WP_VERSION=latest WP_MULTISITE=0
 
-# Additional tests against stable PHP (min version is 5.6)
+# Additional tests against stable PHP (min version is 7.0)
 # and code coverage report.
 matrix:
   fast_finish: true
@@ -51,7 +50,7 @@ matrix:
     php: 7.4
     env: WP_VERSION=nightly WP_MULTISITE=0
   - name: "Minimum requirements"
-    php: 5.6
+    php: 7.0
     env: WP_VERSION=5.0 WP_MULTISITE=0
   allow_failures:
   - php: 7.4

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
   "prefer-stable": true,
   "minimum-stability": "dev",
   "require": {
-    "php": ">=5.6|>=7.0",
+    "php": ">=7.0",
     "automattic/jetpack-autoloader": "^1.2.0",
     "automattic/jetpack-constants": "^1.1",
     "composer/installers": "1.7.0",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -26,7 +26,7 @@
 
 	<!-- Configs -->
 	<config name="minimum_supported_wp_version" value="5.0" />
-	<config name="testVersion" value="5.6-" />
+	<config name="testVersion" value="7.0-" />
 
 	<!-- Rules -->
 	<rule ref="WooCommerce-Core" />

--- a/src/README.md
+++ b/src/README.md
@@ -2,7 +2,7 @@
 
 This directory is home to new WooCommerce class files under the \Automattic\WooCommerce\ namespace using PSR-4 file naming. This is to take full advantage of autoloading.
 
-Currently, these classes have a PHP 5.6 requirement. No required core classes will be added here until this PHP version is enforced. If running an older version of PHP, these class files will not be used.
+Currently, these classes have a PHP 7.0 requirement. No required core classes will be added here until this PHP version is enforced. If running an older version of PHP, these class files will not be used.
 
 ## Installing Composer
 

--- a/tests/unit-tests/packages/packages.php
+++ b/tests/unit-tests/packages/packages.php
@@ -11,17 +11,6 @@
 class WC_Tests_Packages extends WC_Unit_Test_Case {
 
 	/**
-	 * Setup test class.
-	 *
-	 * @return void
-	 */
-	public function setUp() {
-		if ( version_compare( PHP_VERSION, '5.6.0', '<' ) ) {
-			$this->markTestSkipped( 'Packages are disabled unless running PHP 5.6+' );
-		}
-	}
-
-	/**
 	 * Test packages exist - this requires composer install to have ran.
 	 */
 	public function test_packages_exist() {

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -18,24 +18,14 @@ if ( ! defined( 'WC_PLUGIN_FILE' ) ) {
 	define( 'WC_PLUGIN_FILE', __FILE__ );
 }
 
-/**
- * Load core packages and the autoloader.
- *
- * The new packages and autoloader require PHP 5.6+. If this dependency is not met, do not include them. Users will be warned
- * that they are using an older version of PHP. WooCommerce will continue to load, but some functionality such as the REST API
- * and Blocks will be missing.
- *
- * This requirement will be enforced in future versions of WooCommerce.
- */
-if ( version_compare( PHP_VERSION, '5.6.0', '>=' ) ) {
-	require __DIR__ . '/src/Autoloader.php';
-	require __DIR__ . '/src/Packages.php';
+// Load core packages and the autoloader.
+require __DIR__ . '/src/Autoloader.php';
+require __DIR__ . '/src/Packages.php';
 
-	if ( ! \Automattic\WooCommerce\Autoloader::init() ) {
-		return;
-	}
-	\Automattic\WooCommerce\Packages::init();
+if ( ! \Automattic\WooCommerce\Autoloader::init() ) {
+	return;
 }
+\Automattic\WooCommerce\Packages::init();
 
 // Include the main WooCommerce class.
 if ( ! class_exists( 'WooCommerce', false ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

We've been declaring a PHP 7 requirement since 3.9, but this isn't actually reflected in our codebase. This PR moves forward with the assumption that 7.0 is the minimum version.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Dev - Increased the minimum PHP version to 7.0.
