### PR TITLE
Updated jetpack-autoloader to ^1.6 and woocommerce-blocks to 2.5.16

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,13 @@
   "minimum-stability": "dev",
   "require": {
     "php": ">=5.6|>=7.0",
-    "automattic/jetpack-autoloader": "^1.2.0",
+    "automattic/jetpack-autoloader": "^1.6.0",
     "automattic/jetpack-constants": "^1.1",
     "composer/installers": "1.7.0",
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.4",
-    "woocommerce/woocommerce-blocks": "2.5.15",
+    "woocommerce/woocommerce-blocks": "2.5.16",
     "woocommerce/woocommerce-rest-api": "1.0.7",
     "woocommerce/woocommerce-admin": "1.1.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "28d6b301b701cac76bf626f6eca7bdc3",
+    "content-hash": "c6614272bcca35438d16632daecaff0a",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v1.3.2",
+            "version": "v1.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e"
+                "reference": "3bcbe1ae19febd6beeb181cf11af0bf0b7abe7e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/301c2fbcf070d4f0147753447616b6e982bda09e",
-                "reference": "301c2fbcf070d4f0147753447616b6e982bda09e",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/3bcbe1ae19febd6beeb181cf11af0bf0b7abe7e7",
+                "reference": "3bcbe1ae19febd6beeb181cf11af0bf0b7abe7e7",
                 "shasum": ""
             },
             "require": {
@@ -40,7 +40,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2019-09-24T06:39:29+00:00"
+            "time": "2020-03-26T07:57:53+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
@@ -465,20 +465,20 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v2.5.15",
+            "version": "v2.5.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "7f06902c5557b9673ffb5682035f4ed5f4af430f"
+                "reference": "3bd91b669247000fd3f5277954701d0b148d3f1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/7f06902c5557b9673ffb5682035f4ed5f4af430f",
-                "reference": "7f06902c5557b9673ffb5682035f4ed5f4af430f",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/3bd91b669247000fd3f5277954701d0b148d3f1a",
+                "reference": "3bd91b669247000fd3f5277954701d0b148d3f1a",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "1.3.2",
+                "automattic/jetpack-autoloader": "^1.6.0",
                 "composer/installers": "1.7.0"
             },
             "require-dev": {
@@ -508,7 +508,7 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2020-03-31T12:36:20+00:00"
+            "time": "2020-04-07T11:47:19+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",
@@ -2923,6 +2923,5 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }

--- a/readme.txt
+++ b/readme.txt
@@ -184,6 +184,7 @@ INTERESTED IN DEVELOPMENT?
 **WooCommerce**
 * Enhancement - Update dependency woocommerce/woocommerce-admin to v1.1.0 #26057
 * Enhancement - Update dependency woocommerce/woocommerce-blocks to v2.5.15. #26043
+* Enhancement - Updated jetpack-autoloader to 1.6 and woocommerce-blocks to 2.5.16. #26099
 * Enhancement - Added option to ignore discounts from cart's total amount to enable free shipping. #24776
 * Enhancement - Changed show password icon color to a darker grey hue. #25625
 * Enhancement - Use new Setup Wizard for all users. #26016


### PR DESCRIPTION
Dependencies updated in one go as Blocks bumped version for JP autoloader.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updated dependencies.

### How to test the changes in this Pull Request:

1. Check that blocks, WC Admin and REST API works
2. Apply branch
3. Check that all 3 packages still work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Updated jetpack-autoloader to 1.6 and woocommerce-blocks to 2.5.16.
