### PR TITLE
Order class methods to match cart, and changes to cart::calculate_shipping behaviour

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -447,6 +447,45 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	}
 
 	/**
+	 * Get the total amount of tax for line items.
+	 *
+	 * @return float
+	 */
+	public function get_subtotal_tax() {
+		$total = 0;
+		foreach ( $this->get_items() as $item ) {
+			$total += wc_remove_number_precision( self::round_line_tax( wc_add_number_precision( $item->get_subtotal_tax() ) ) );
+		}
+		return $total;
+	}
+
+	/**
+	 * Get the total amount of fees.
+	 *
+	 * @return float
+	 */
+	public function get_fee_total() {
+		$total = 0;
+		foreach ( $this->get_fees() as $item ) {
+			$total += $item->get_total();
+		}
+		return $total;
+	}
+
+	/**
+	 * Get the total tax of fees.
+	 *
+	 * @return float
+	 */
+	public function get_fee_tax() {
+		$total = 0;
+		foreach ( $this->get_fees() as $item ) {
+			$total += $item->get_total_tax();
+		}
+		return $total;
+	}
+
+	/**
 	 * Get taxes, merged by code, formatted ready for output.
 	 *
 	 * @return array
@@ -1325,7 +1364,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 					}
 
 					$taxes = array_sum( WC_Tax::calc_tax( $item_discount_amount, WC_Tax::get_rates( $item->get_tax_class() ), $this->get_prices_include_tax() ) );
-					if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+					if ( ! self::round_at_subtotal() ) {
 						$taxes = wc_round_tax_total( $taxes );
 					}
 
@@ -1598,7 +1637,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 			foreach ( $taxes['total'] as $tax_rate_id => $tax ) {
 				$tax_amount = (float) $tax;
 
-				if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
+				if ( ! self::round_at_subtotal() ) {
 					$tax_amount = wc_round_tax_total( $tax_amount );
 				}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This branch has some work carried over from the blocks repo which we'd like to get in core.

**Order class methods**

The cart and order classes have a lot in common, including some methods with same names and uses. There are a few missing however, which this PR adds:

- `get_subtotal_tax()`
- `get_fee_total()`
- `get_fee_tax()`

Naming and behaviour match the cart.

**`calculate_shipping` behaviour**

Because of how `calculate_shipping` works, it makes it difficult *just* to get rates for all packages. In our case, we're exposing all rates and all packages via our API. The proposed changes in this PR break it up slightly:

- `get_shipping_packages` gets a new param to return packages hydrated with rates, rather than just packages. This defaults to false to match current behaviour.
- `get_shipping_packages` adds an index/ID to all packages. We needed this to identify rates->packages.
- `get_shipping_packages` returns nothing when shipping is not needed, which should make sense and prevents errors like we found in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2144
- `get_chosen_shipping_methods` returns nothing if given no packages
- `calculate_shipping` uses the above changes and does less of the logic itself

May have to update tests, but waiting on Travis and feedback.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

Smoke test cart and ensure shipping is presented correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Added get_subtotal_tax, get_fee_total, and get_fee_tax methods to order class.
> Made cart::get_shipping_packages() support rate calculation.