### PR TITLE
Revert deprecation of $type on the get_european_union_countries method

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -350,18 +350,20 @@ class WC_Countries {
 	/**
 	 * Gets an array of countries in the EU.
 	 *
-	 * @param  string $deprecated Function used to return VAT countries based on this.
+	 * @param  string $type Type of countries to retrieve. Blank for EU member countries. eu_vat for EU VAT countries.
 	 * @return string[]
 	 */
-	public function get_european_union_countries( $deprecated = '' ) {
+	public function get_european_union_countries( $type = '' ) {
 		$countries = array( 'AT', 'BE', 'BG', 'CY', 'CZ', 'DE', 'DK', 'EE', 'ES', 'FI', 'FR', 'GR', 'HU', 'HR', 'IE', 'IT', 'LT', 'LU', 'LV', 'MT', 'NL', 'PL', 'PT', 'RO', 'SE', 'SI', 'SK' );
 
-		if ( ! empty( $deprecated ) ) {
-			wc_deprecated_argument( 'type', '4.0.0', 'Use the WC_Countries::get_vat_countries method instead.' );
-			$countries = $this->get_vat_countries();
+		if ( 'eu_vat' === $type ) {
+			$countries[] = 'MC';
+			$countries[] = 'IM';
+			//The UK is still part of the EU VAT zone
+			$countries[] = 'GB';
 		}
 
-		return apply_filters( 'woocommerce_european_union_countries', $countries, $deprecated );
+		return apply_filters( 'woocommerce_european_union_countries', $countries, $type );
 	}
 
 	/**

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -359,7 +359,7 @@ class WC_Countries {
 		if ( 'eu_vat' === $type ) {
 			$countries[] = 'MC';
 			$countries[] = 'IM';
-			//The UK is still part of the EU VAT zone
+			// The UK is still part of the EU VAT zone.
 			$countries[] = 'GB';
 		}
 


### PR DESCRIPTION
Closes #26105 

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Revert deprecation of $type parameter on the WC_Countries get_european_union_countries method.

Closes #26105 

### How to test the changes in this Pull Request:

1. Call WC()->countries->get_european_union_countries('eu_vat') and make sure you get the EU countries + Monaco + Isle of Man + Greaat Britain instead of a list of 80 countries

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Revert deprecation of $type parameter on the WC_Countries get_european_union_countries method