### PR TITLE
Edit wrong hooked function, issue #25996

### DIFF
--- a/templates/content-single-product.php
+++ b/templates/content-single-product.php
@@ -22,7 +22,7 @@ global $product;
 /**
  * Hook: woocommerce_before_single_product.
  *
- * @hooked wc_print_notices - 10
+ * @hooked woocommerce_output_all_notices - 10
  */
 do_action( 'woocommerce_before_single_product' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
There was a comment written incorrectly in the content-single-product.php (line 25). Change the ```wc_print_notices``` to ```woocommerce_output_all_notices``` according to [this line](https://github.com/woocommerce/woocommerce/blob/1926a5042622980ce9b520e63b8cc30d917d4a07/includes/wc-template-hooks.php#L306).

Closes #25996 .

### How to test the changes in this Pull Request:

1. Just run unit tests

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Updated inline docs for `woocommerce_before_single_product` in  `content-single-product.php`.