### PR TITLE
bugfix for show password icon and password hint

### DIFF
--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -81,7 +81,7 @@ jQuery( function( $ ) {
 
 	// Show password visiblity hover icon on woocommerce forms
 	$( '.woocommerce form .woocommerce-Input[type="password"]' ).wrap( '<span class="password-input"></span>' );
-	$( '.password-input' ).append( '<span class="show-password-input"></span>' );
+	$( '.password-input' ).prepend( '<span class="show-password-input"></span>' );
 
 	$( '.show-password-input' ).click(
 		function() {


### PR DESCRIPTION
changed append show-password-span to use jquery `.prepend()` to fix bug with password strength hint

### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. change password and use weak password
2. enter password on any password field

### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Fix - Password visibility toggle when password strength check fails.


