### PR TITLE
[4.3.0] Add filter for the query for reserved stock

### DIFF
--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -80,7 +80,7 @@ final class ReserveStock {
 			 * Filter: woocommerce_reserve_stock_for_products
 			 * Allows to filter the product ids and the quantity to reserve stock.
 			 *
-			 * @since @since 4.1.0
+			 * @since 4.1.0
 			 * @param array     $rows An array with ordered product id as key and quantity as value.
 			 * @param \WC_Order $order Order object.
 			 * @param int       $minutes How long to reserve stock in minutes.

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -76,17 +76,6 @@ final class ReserveStock {
 				$rows[ $managed_by_id ] = isset( $rows[ $managed_by_id ] ) ? $rows[ $managed_by_id ] + $item->get_quantity() : $item->get_quantity();
 			}
 
-			/**
-			 * Filter: woocommerce_reserve_stock_for_products
-			 * Allows to filter the product ids and the quantity to reserve stock.
-			 *
-			 * @since 4.1.0
-			 * @param array     $rows An array with ordered product id as key and quantity as value.
-			 * @param \WC_Order $order Order object.
-			 * @param int       $minutes How long to reserve stock in minutes.
-			 */
-			$rows = apply_filters( 'woocommerce_reserve_stock_for_products', $rows, $order, $minutes );
-
 			if ( ! empty( $rows ) ) {
 				foreach ( $rows as $product_id => $quantity ) {
 					$this->reserve_stock_for_product( $product_id, $quantity, $order, $minutes );
@@ -171,7 +160,7 @@ final class ReserveStock {
 	 */
 	private function get_query_for_reserved_stock( $product_id, $exclude_order_id = 0 ) {
 		global $wpdb;
-		return $wpdb->prepare(
+		$query = $wpdb->prepare(
 			"
 			SELECT COALESCE( SUM( stock_table.`stock_quantity` ), 0 ) FROM $wpdb->wc_reserved_stock stock_table
 			LEFT JOIN $wpdb->posts posts ON stock_table.`order_id` = posts.ID
@@ -183,5 +172,16 @@ final class ReserveStock {
 			$product_id,
 			$exclude_order_id
 		);
+
+		/**
+		 * Filter: woocommerce_query_for_reserved_stock
+		 * Allows to filter the query for getting reserved stock of a product.
+		 *
+		 * @since 4.3.0
+		 * @param string $query            The query for getting reserved stock of a product.
+		 * @param int    $product_id       Product ID.
+		 * @param int    $exclude_order_id Order to exclude from the results.
+		 */
+		return apply_filters( 'woocommerce_query_for_reserved_stock', $query, $product_id, $exclude_order_id );
 	}
 }

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -177,7 +177,7 @@ final class ReserveStock {
 		 * Filter: woocommerce_query_for_reserved_stock
 		 * Allows to filter the query for getting reserved stock of a product.
 		 *
-		 * @since 4.3.0
+		 * @since 4.4.0
 		 * @param string $query            The query for getting reserved stock of a product.
 		 * @param int    $product_id       Product ID.
 		 * @param int    $exclude_order_id Order to exclude from the results.

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -76,6 +76,17 @@ final class ReserveStock {
 				$rows[ $managed_by_id ] = isset( $rows[ $managed_by_id ] ) ? $rows[ $managed_by_id ] + $item->get_quantity() : $item->get_quantity();
 			}
 
+			/**
+			 * Filter: woocommerce_reserve_stock_for_products
+			 * Allows to filter the product ids and the quantity to reserve stock.
+			 *
+			 * @since @since 4.1.0
+			 * @param array     $rows An array with ordered product id as key and quantity as value.
+			 * @param \WC_Order $order Order object.
+			 * @param int       $minutes How long to reserve stock in minutes.
+			 */
+			$rows = apply_filters( 'woocommerce_reserve_stock_for_products', $rows, $order, $minutes );
+
 			if ( ! empty( $rows ) ) {
 				foreach ( $rows as $product_id => $quantity ) {
 					$this->reserve_stock_for_product( $product_id, $quantity, $order, $minutes );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Background: Multilingual plugins such as WPML and Polylang have one product per language and maintain a synchronization of the stock across products translations. 

#25708 introduces a way to reserve stock for a product. To allow a perfect synchronization with the product translations, we should be able to reserve stock for a product and its translations at the same time.

I propose to add this new filter to allow multilingual plugins to add the product translations in the list of products to reserve stock.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
