### PR TITLE
Removed  legacy notification to connect with WooCommerce

### DIFF
--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -1527,12 +1527,6 @@ class WC_Helper {
 
 		$active_woo_plugins = array_intersect_key( $woo_plugins, array_flip( $active_plugins ) );
 
-		if ( count( $active_woo_plugins ) > 0 ) {
-			/* translators: %s: helper screen url */
-			$notice = __( '<a href="%s">Connect your store</a> to WooCommerce.com to receive extensions updates and support.', 'woocommerce' );
-			$notice = sprintf( $notice, admin_url( 'admin.php?page=wc-addons&section=helper' ) );
-			echo '<div class="updated woocommerce-message"><p>' . wp_kses_post( $notice ) . '</p></div>';
-		}
 	}
 
 	/**

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -1467,8 +1467,6 @@ class WC_Helper {
 		$screen    = get_current_screen();
 		$screen_id = $screen ? $screen->id : '';
 
-		self::_prompt_helper_connect( $screen_id );
-
 		if ( 'update-core' !== $screen_id ) {
 			return;
 		}
@@ -1483,50 +1481,6 @@ class WC_Helper {
 		if ( ! empty( $notice ) ) {
 			echo '<div class="updated woocommerce-message"><p>' . $notice . '</p></div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
-	}
-
-	/**
-	 * Prompt a Helper connection if the user has WooCommerce.com extensions.
-	 *
-	 * @param string $screen_id Current screen ID.
-	 */
-	private static function _prompt_helper_connect( $screen_id ) {
-		if ( apply_filters( 'woocommerce_helper_suppress_connect_notice', false ) ) {
-			return;
-		}
-
-		$screens   = wc_get_screen_ids();
-		$screens[] = 'plugins';
-
-		if ( ! in_array( $screen_id, $screens, true ) ) {
-			return;
-		}
-
-		// Don't show the notice on the Helper screens.
-		$screen_addons = sanitize_title( __( 'WooCommerce', 'woocommerce' ) ) . '_page_wc-addons';
-
-		if ( $screen_addons === $screen_id && ! empty( $_REQUEST['section'] ) && 'helper' === $_REQUEST['section'] ) {
-			return;
-		}
-
-		// We believe we have an active connection.
-		$auth = WC_Helper_Options::get( 'auth' );
-		if ( ! empty( $auth['access_token'] ) ) {
-			return;
-		}
-
-		$active_plugins = apply_filters( 'active_plugins', get_option( 'active_plugins' ) );
-		if ( empty( $active_plugins ) ) {
-			return;
-		}
-
-		$woo_plugins = self::get_local_woo_plugins();
-		if ( empty( $woo_plugins ) ) {
-			return;
-		}
-
-		$active_woo_plugins = array_intersect_key( $woo_plugins, array_flip( $active_plugins ) );
-
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR removes a legacy JITM for connecting with WooCommerce.com. This message is now a part of `WC Admin` bar via `Inbox`.

Closes #25889 .

### How to test the changes in this Pull Request:

1. Go to a WooCommerce wp-admin dashboard for a store that's not yet connected to WooCommerce.com
2. The JITM `Connect your store to WooCommerce.com to reveice extensions updates and support.` message shouldn't be visible.

### Other information:

* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
