### PR TITLE
Add all supported WP versions to Travis CI check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,6 @@ php:
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
-  - WP_VERSION=5.3 WP_MULTISITE=0
-  - WP_VERSION=5.2 WP_MULTISITE=0
-  - WP_VERSION=5.1 WP_MULTISITE=0
-  - WP_VERSION=5.0 WP_MULTISITE=0
 
 # Additional tests against stable PHP (min version is 5.6)
 # and code coverage report.
@@ -53,6 +49,18 @@ matrix:
   - name: "WooCommerce unit tests using WordPress nightly"
     php: 7.4
     env: WP_VERSION=nightly WP_MULTISITE=0
+  - name: "WP latest - 1"
+    php: 7.2
+    env: WP_VERSION=5.3 WP_MULTISITE=0
+  - name: "WP latest - 2"
+    php: 7.2
+    env: WP_VERSION=5.2 WP_MULTISITE=0
+  - name: "WP 5.1"
+    php: 7.2
+    env: WP_VERSION=5.1 WP_MULTISITE=0
+  - name: "WP 5.0"
+    php: 7.0
+    env: WP_VERSION=5.0 WP_MULTISITE=0
   allow_failures:
   - php: 7.4
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,10 @@ php:
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
+  - WP_VERSION=5.3 WP_MULTISITE=0
+  - WP_VERSION=5.2 WP_MULTISITE=0
+  - WP_VERSION=5.1 WP_MULTISITE=0
+  - WP_VERSION=5.0 WP_MULTISITE=0
 
 # Additional tests against stable PHP (min version is 5.6)
 # and code coverage report.
@@ -49,9 +53,6 @@ matrix:
   - name: "WooCommerce unit tests using WordPress nightly"
     php: 7.4
     env: WP_VERSION=nightly WP_MULTISITE=0
-  - name: "Minimum requirements"
-    php: 7.0
-    env: WP_VERSION=5.0 WP_MULTISITE=0
   allow_failures:
   - php: 7.4
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,6 @@ cache:
 
 # Test main supported versions of PHP against latest WP.
 php:
-  - 5.6
   - 7.0
   - 7.1
   - 7.2
@@ -51,7 +50,7 @@ matrix:
     php: 7.4
     env: WP_VERSION=nightly WP_MULTISITE=0
   - name: "Minimum requirements"
-    php: 5.6
+    php: 7.0
     env: WP_VERSION=5.0 WP_MULTISITE=0
   allow_failures:
   - php: 7.4


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Based on p7bje6-1Xe-p2, adding test matrix for all supported WP versions.

### How to test the changes in this Pull Request:

1. Check that tests for WP 5.0 - WP 5.4 run on Travis and are green.
2. Done!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

