### PR TITLE
Select2 CSS adjustment is affecting other plugins

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -6680,6 +6680,7 @@ table.bar_chart {
 	.select2-selection__clear {
 		color: #999;
 		margin-top: -1px;
+		z-index: 1;
 	}
 
 	.select2-search--inline .select2-search__field {
@@ -6773,7 +6774,7 @@ table.bar_chart {
 			.select2-selection__arrow {
 				right: 1px;
 				height: 28px;
-				width: 28px;
+				width: 23px;
 				background: url("data:image/svg+xml;charset=US-ASCII,%3Csvg%20width%3D%2220%22%20height%3D%2220%22%20xmlns%3D%22http%3A%2F%2Fwww.w3.org%2F2000%2Fsvg%22%3E%3Cpath%20d%3D%22M5%206l5%205%205-5%202%201-7%207-7-7%202-1z%22%20fill%3D%22%23555%22%2F%3E%3C%2Fsvg%3E") no-repeat right 5px top 55%;
 				background-size: 16px 16px;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This PR solves a problem with the remove button in some dropdown menus. This button was overlapped by the menu's arrow and wasn't accessible.
A `z-index` was added to the remove button and also the arrow was made smaller.

 
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25427 .

### How to test the changes in this Pull Request:

1. Go to `WooCommerce` | `Orders`, and press `Add order` (URL: `/wp-admin/post-new.php?post_type=shop_order`)
2. Add a customer in the `Customer` selector
3. Remove the customer from the selector. Verify the remove button (`x`) is clickable.
![Screen Capture on 2020-04-16 at 17-38-19](https://user-images.githubusercontent.com/1314156/79504385-34f8c100-8009-11ea-803f-280192ebcfc3.gif)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Added a `z-index` to the remove button (x) to set the z-order of the element.
> Enhancement - Dropdown arrow width was made smaller.
