### PR TITLE
`wc_load_cart` should load it's own dependencies and include required core files

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2285,8 +2285,15 @@ function wc_load_cart() {
 		return;
 	}
 
+	// Ensure dependencies are loaded in all contexts.
+	include_once WC_ABSPATH . 'includes/wc-cart-functions.php';
+	include_once WC_ABSPATH . 'includes/wc-notice-functions.php';
+
 	WC()->initialize_session();
 	WC()->initialize_cart();
+
+	// Make sure cart is loaded from session.
+	WC()->cart->get_cart();
 }
 
 /**

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2291,9 +2291,6 @@ function wc_load_cart() {
 
 	WC()->initialize_session();
 	WC()->initialize_cart();
-
-	// Make sure cart is loaded from session.
-	WC()->cart->get_cart();
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Core functions contains a function named `wc_load_cart` which ensures cart functionality can be used, should core not load the cart automatically. This is useful in other contexts than frontend.

The issue is however, `wc_load_cart` has some dependencies, namely some cart and notice functions, which might not be loaded.

In my use case, I used `wc_load_cart` to ensure the cart exists as part of a REST request, however, in order for this to work I need to do the following:

```php
	public static function maybe_init_cart_session( $return ) {
		if ( ! function_exists( 'wc_load_cart' ) || \is_wp_error( $return ) || ! self::is_request_to_store_api() ) {
			return $return;
		}
		// @todo Core should ensure these functions load with wc_load_cart() so we don't need to manually include.
		include_once WC_ABSPATH . 'includes/wc-cart-functions.php';
		include_once WC_ABSPATH . 'includes/wc-notice-functions.php';

		// Initializes the cart and session.
		wc_load_cart();

		// @todo Core should also do this inside wc_load_cart so the cart is loaded from session.
		wc()->cart->get_cart();

		return $return;
	}
```

This change would mean the `wc_load_cart` can be used without including core files first.

### How to test the changes in this Pull Request:

Try using `wc_load_cart` in a non-frontend context such as in a rest api endpoint. See errors.

### Changelog entry

> Dev - Ensure `wc_load_cart` loads its own dependencies.
