### PR TITLE
Bug when create attribute value using rest api

### DIFF
--- a/includes/legacy/api/v3/class-wc-api-products.php
+++ b/includes/legacy/api/v3/class-wc-api-products.php
@@ -2842,7 +2842,7 @@ class WC_API_Products extends WC_API_Resource {
 	 */
 	public function create_product_attribute_term( $attribute_id, $data ) {
 		global $wpdb;
-
+		$attribute_id = absint( $attribute_id );
 		try {
 			if ( ! isset( $data['product_attribute_term'] ) ) {
 				throw new WC_API_Exception( 'woocommerce_api_missing_product_attribute_term_data', sprintf( __( 'No %1$s data specified to create %1$s', 'woocommerce' ), 'product_attribute_term' ), 400 );


### PR DESCRIPTION
file
wp-content/plugins/woocommerce/includes/wc-attribute-functions.php
use array_search. attribute_id must be int, but it is string
$attribute_name = (string) array_search( $attribute_id, $taxonomy_ids, true );

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
