### PR TITLE
Fix adding product variant to cart using `add-to-cart` parameter (#24000)

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -907,7 +907,7 @@ class WC_Form_Handler {
 			}
 
 			// Merge variation attributes and posted attributes.
-			$posted_and_variation_attributes = array_merge( $posted_attributes, $variation_attributes );
+			$posted_and_variation_attributes = array_merge( $variation_attributes, $posted_attributes );
 
 			// If no variation ID is set, attempt to get a variation ID from posted attributes.
 			if ( empty( $variation_id ) ) {

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -862,11 +862,12 @@ class WC_Form_Handler {
 	 */
 	private static function add_to_cart_handler_variable( $product_id ) {
 		try {
-			$variation_id       = empty( $_REQUEST['variation_id'] ) ? '' : absint( wp_unslash( $_REQUEST['variation_id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$quantity           = empty( $_REQUEST['quantity'] ) ? 1 : wc_stock_amount( wp_unslash( $_REQUEST['quantity'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-			$missing_attributes = array();
-			$variations         = array();
-			$adding_to_cart     = wc_get_product( $product_id );
+			$variation_id         = empty( $_REQUEST['variation_id'] ) ? '' : absint( wp_unslash( $_REQUEST['variation_id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$quantity             = empty( $_REQUEST['quantity'] ) ? 1 : wc_stock_amount( wp_unslash( $_REQUEST['quantity'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$missing_attributes   = array();
+			$variations           = array();
+			$variation_attributes = array();
+			$adding_to_cart       = wc_get_product( $product_id );
 
 			if ( ! $adding_to_cart ) {
 				return false;
@@ -874,6 +875,7 @@ class WC_Form_Handler {
 
 			// If the $product_id was in fact a variation ID, update the variables.
 			if ( $adding_to_cart->is_type( 'variation' ) ) {
+				$variation_attributes = $adding_to_cart->get_variation_attributes();
 				$variation_id   = $product_id;
 				$product_id     = $adding_to_cart->get_parent_id();
 				$adding_to_cart = wc_get_product( $product_id );
@@ -904,6 +906,9 @@ class WC_Form_Handler {
 				}
 			}
 
+			// Merge variation attributes and posted attributes.
+			$posted_and_variation_attributes = array_merge( $posted_attributes, $variation_attributes );
+
 			// If no variation ID is set, attempt to get a variation ID from posted attributes.
 			if ( empty( $variation_id ) ) {
 				$data_store   = WC_Data_Store::load( 'product' );
@@ -932,8 +937,8 @@ class WC_Form_Handler {
 				 *
 				 * If no attribute was posted, only error if the variation has an 'any' attribute which requires a value.
 				 */
-				if ( isset( $posted_attributes[ $attribute_key ] ) ) {
-					$value = $posted_attributes[ $attribute_key ];
+				if ( isset( $posted_and_variation_attributes[ $attribute_key ] ) ) {
+					$value = $posted_and_variation_attributes[ $attribute_key ];
 
 					// Allow if valid or show error.
 					if ( $valid_value === $value ) {

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -876,6 +876,8 @@ class WC_Form_Handler {
 			// If the $product_id was in fact a variation ID, update the variables.
 			if ( $adding_to_cart->is_type( 'variation' ) ) {
 				$variation_attributes = $adding_to_cart->get_variation_attributes();
+				// Filter out 'any' variations, which are empty, as they need to be explicitly specified while adding to cart.
+				$variation_attributes = array_filter( $variation_attributes );
 				$variation_id   = $product_id;
 				$product_id     = $adding_to_cart->get_parent_id();
 				$adding_to_cart = wc_get_product( $product_id );

--- a/tests/legacy/unit-tests/cart/cart.php
+++ b/tests/legacy/unit-tests/cart/cart.php
@@ -2084,7 +2084,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 			$variation['variation_id'],
 			array(
 				'attribute_pa_size'   => 'huge',
-				'attribute_pa_color'  => 'red',
+				'attribute_pa_colour'  => 'red',
 				'attribute_pa_number' => '2',
 			)
 		);

--- a/tests/legacy/unit-tests/cart/cart.php
+++ b/tests/legacy/unit-tests/cart/cart.php
@@ -2095,6 +2095,36 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that adding a variation via URL parameter fails when specifying a value for the attribute
+	 * that differs from a value belonging to that variant.
+	 */
+	public function test_add_variation_with_invalid_attribute() {
+		add_filter( 'woocommerce_add_to_cart_redirect', '__return_false' );
+		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
+		WC()->cart->empty_cart();
+
+		$product    = WC_Helper_Product::create_variation_product();
+		$variations = $product->get_available_variations();
+		$variation  = array_pop( $variations );
+
+		// Attempt adding variation with add_to_cart_action, specifying a different colour.
+		$_REQUEST['add-to-cart'] = $variation['variation_id'];
+		$_REQUEST['attribute_pa_colour'] = 'green';
+		WC_Form_Handler::add_to_cart_action( false );
+		$notices = WC()->session->get( 'wc_notices', array() );
+
+		// Reset filter / REQUEST variables.
+		unset( $_REQUEST['add-to-cart'] );
+		unset( $_REQUEST['attribute_pa_colour'] );
+		remove_filter( 'woocommerce_add_to_cart_redirect', '__return_false' );
+
+		// Check that the notices contain an error message about an invalid colour.
+		$this->assertArrayHasKey( 'error', $notices );
+		$this->assertCount( 1, $notices['error'] );
+		$this->assertEquals( 'Invalid value posted for colour', $notices['error'][0]['notice'] );
+	}
+
+	/**
 	 * Helper function. Adds 1.5 taxable fees to cart.
 	 */
 	public function add_fee_1_5_to_cart() {

--- a/tests/legacy/unit-tests/cart/cart.php
+++ b/tests/legacy/unit-tests/cart/cart.php
@@ -2074,7 +2074,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		remove_filter( 'woocommerce_add_to_cart_redirect', '__return_false' );
 
 		// Check if the item is in the cart.
-		$this->assertEquals( 1, count( WC()->cart->get_cart_contents() ) );
+		$this->assertCount( 1, WC()->cart->get_cart_contents() );
 		$this->assertEquals( 1, WC()->cart->get_cart_contents_count() );
 
 		// Add variation using parent id.
@@ -2090,7 +2090,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		);
 
 		// Check that the second add to cart call increases the quantity of the existing cart-item.
-		$this->assertEquals( 1, count( WC()->cart->get_cart_contents() ) );
+		$this->assertCount( 1, WC()->cart->get_cart_contents() );
 		$this->assertEquals( 2, WC()->cart->get_cart_contents_count() );
 	}
 

--- a/tests/legacy/unit-tests/cart/cart.php
+++ b/tests/legacy/unit-tests/cart/cart.php
@@ -2077,6 +2077,9 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		$this->assertCount( 1, WC()->cart->get_cart_contents() );
 		$this->assertEquals( 1, WC()->cart->get_cart_contents_count() );
 
+		// Check that there are no error notices.
+		$this->assertArrayNotHasKey( 'error', $notices );
+
 		// Add variation using parent id.
 		WC()->cart->add_to_cart(
 			$product->get_id(),
@@ -2088,10 +2091,14 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 				'attribute_pa_number' => '2',
 			)
 		);
+		$notices = WC()->session->get( 'wc_notices', array() );
 
 		// Check that the second add to cart call increases the quantity of the existing cart-item.
 		$this->assertCount( 1, WC()->cart->get_cart_contents() );
 		$this->assertEquals( 2, WC()->cart->get_cart_contents_count() );
+
+		// Check that there are no error notices.
+		$this->assertArrayNotHasKey( 'error', $notices );
 	}
 
 	/**

--- a/tests/legacy/unit-tests/cart/cart.php
+++ b/tests/legacy/unit-tests/cart/cart.php
@@ -2059,6 +2059,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_add_to_cart_redirect', '__return_false' );
 		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
 		WC()->cart->empty_cart();
+		WC()->session->set( 'wc_notices', null );
 
 		$product    = WC_Helper_Product::create_variation_product();
 		$variations = $product->get_available_variations();
@@ -2109,6 +2110,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_add_to_cart_redirect', '__return_false' );
 		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
 		WC()->cart->empty_cart();
+		WC()->session->set( 'wc_notices', null );
 
 		$product    = WC_Helper_Product::create_variation_product();
 		$variations = $product->get_available_variations();
@@ -2139,6 +2141,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		add_filter( 'woocommerce_add_to_cart_redirect', '__return_false' );
 		update_option( 'woocommerce_cart_redirect_after_add', 'no' );
 		WC()->cart->empty_cart();
+		WC()->session->set( 'wc_notices', null );
 
 		$product    = WC_Helper_Product::create_variation_product();
 		$variations = $product->get_available_variations();

--- a/tests/legacy/unit-tests/cart/cart.php
+++ b/tests/legacy/unit-tests/cart/cart.php
@@ -2154,6 +2154,12 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 		WC_Form_Handler::add_to_cart_action( false );
 		$notices = WC()->session->get( 'wc_notices', array() );
 
+		// Reset filter / REQUEST variables.
+		unset( $_REQUEST['add-to-cart'] );
+		unset( $_REQUEST['attribute_pa_colour'] );
+		unset( $_REQUEST['attribute_pa_number'] );
+		remove_filter( 'woocommerce_add_to_cart_redirect', '__return_false' );
+
 		// Check if the item is in the cart.
 		$this->assertCount( 1, WC()->cart->get_cart_contents() );
 		$this->assertEquals( 1, WC()->cart->get_cart_contents_count() );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
* Update the `add_to_cart_handler_variable` form handler method such that when a variant `product_id` is supplied, the attributes for the variant are populated for the `add_to_cart` call.

Closes #24000.

### How to test the changes in this Pull Request:

1. Start with an empty cart.
1. Create a product variant and note its variant id.
1. Add that variant to the cart using the `add-to-cart` parameter.
1. Note that the quantity of that item in your cart is now 1.
1. From the parent product page, add the variant to the cart.
1. Note that the existing cart-item is updated and that its new quantity is 2. (Prior to this PR, a new cart-item was created, and both lines had individual quantities of 1).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Using the `add-to-cart` parameter with a product variant id will now have the variation attributes populated correctly.
