### PR TITLE
Reset cache before retrieving plugin list on WooCommerce.com Subscriptions tab

### DIFF
--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -1149,6 +1149,8 @@ class WC_Helper {
 			require_once ABSPATH . 'wp-admin/includes/plugin.php';
 		}
 
+		// Reset plugin cache before retrieving plugin list.
+		wp_clean_plugins_cache();
 		$plugins     = get_plugins();
 		$woo_plugins = array();
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

WooCommerce adds a hook to `extra_plugin_headers` filter to obtain extra headers from the installed plugins. This enables a check for `Woo` header presence, which is used by Woo helper to identify the Woo.com products.

The `get_plugins()` function, if called before the `extra_plugin_headers` hook added, will cache the plugins list without the `Woo` header present. Hence blocking Woo helper from identifying Woo.com products among installed plugins and breaking purchased items activation and update on WooCommerce.com Subscriptions tab.

### How to test the changes in this Pull Request:
To test this change, you need to have a Woo.com account with a subscription to one of the products, which are confirmed to be affected by the issue, e.g. [AutomateWoo](https://woocommerce.com/products/automatewoo/) or [Shipment Tracking](https://woocommerce.com/products/shipment-tracking/).

1. Check out master branch.
2. Go to **WooCommerce -> Extensions -> WooCommerce.com Subscriptions**  and connect your store to WooCommerce.com. 
3. Install one of the target Woo.com products (AutomateWoo or Shipment Tracking). Confirm that activation toggle is displayed for that product
![image](https://user-images.githubusercontent.com/2803994/80018265-704e3080-84de-11ea-9ef2-e2b804f6c043.png)
4. For the sake of testing, install a [Meta Box](https://wordpress.org/plugins/meta-box/) plugin. This extension makes a call to `get_plugins()` before WooCommerce adds its hook to `extra_plugin_headers` filter and thus triggers the malfunction of purchased products management. 
5. Activate the Meta Box plugin and confirm there is activation toggle for the Woo.com product is replaced by a Download button. 
![image](https://user-images.githubusercontent.com/2803994/80018548-d5098b00-84de-11ea-8655-14fec24a0034.png)
6. Check out this branch (`fix/wccom-helper-plugins-cache`).
7. Confirm that activation toggle is displayed again for the product
![image](https://user-images.githubusercontent.com/2803994/80018265-704e3080-84de-11ea-9ef2-e2b804f6c043.png).


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Improve the stability of WooCommerce.com Subscriptions activations and updates.
