### PR TITLE
[WC4.1 RC] WP 5.3 select2 css fixes broken in WP 5.4

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -637,7 +637,7 @@ mark.amount {
 	}
 }
 
-.branch-5-3 {
+.wc-wp-version-gte-53 {
 
 	.woocommerce-help-tip {
 		font-size: 1.2em;
@@ -2167,7 +2167,7 @@ ul.wc_coupon_list_block {
 	}
 }
 
-.branch-5-3 {
+.wc-wp-version-gte-53 {
 
 	.widefat {
 
@@ -4123,7 +4123,7 @@ img.help_tip {
 	}
 }
 
-.branch-5-3 {
+.wc-wp-version-gte-53 {
 
 	.woocommerce {
 
@@ -6694,7 +6694,7 @@ table.bar_chart {
 	min-width: 400px !important;
 }
 
-.branch-5-3 {
+.wc-wp-version-gte-53 {
 
 	.select2-results {
 
@@ -6831,7 +6831,7 @@ table.bar_chart {
 
 	@each $name, $color in $wp_admin_colors {
 
-		&-#{$name}.branch-5-3 {
+		&-#{$name}.wc-wp-version-gte-53 {
 
 			.select2-dropdown {
 				border-color: $color;

--- a/assets/css/wc-setup.scss
+++ b/assets/css/wc-setup.scss
@@ -1185,7 +1185,7 @@ h3.jetpack-reasons {
 }
 
 .branch-5-2,
-.branch-5-3 {
+.wc-wp-version-gte-53 {
 
 	.location-input {
 		margin: 0;
@@ -1415,7 +1415,7 @@ p.jetpack-terms {
 }
 
 .branch-5-2,
-.branch-5-3 {
+.wc-wp-version-gte-53 {
 
 	.wc-wizard-service-setting-stripe_create_account,
 	.wc-wizard-service-setting-ppec_paypal_reroute_requests {

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -35,7 +35,7 @@ class WC_Admin {
 		add_filter( 'action_scheduler_post_type_args', array( $this, 'disable_webhook_post_export' ) );
 
 		// Add body class for WP 5.3+ compatibility.
-		add_filter( 'admin_body_class', array( $this, 'include_admin_body_classes' ) );
+		add_filter( 'admin_body_class', array( $this, 'include_admin_body_class' ) );
 	}
 
 	/**

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -315,7 +315,7 @@ class WC_Admin {
 	 *
 	 * @since 4.1.1
 	 *
-	 * @param String $classes
+	 * @param String $classes Body classes string.
 	 *
 	 * @return String
 	 */

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -33,6 +33,9 @@ class WC_Admin {
 
 		// Disable WXR export of schedule action posts.
 		add_filter( 'action_scheduler_post_type_args', array( $this, 'disable_webhook_post_export' ) );
+
+		// Add body class for WP 5.3+ compatibility.
+		add_filter( 'admin_body_class', array( $this, 'include_admin_body_classes' ) );
 	}
 
 	/**
@@ -305,6 +308,32 @@ class WC_Admin {
 	public function disable_webhook_post_export( $args ) {
 		$args['can_export'] = false;
 		return $args;
+	}
+
+	/**
+	 * Include admin classes.
+	 *
+	 * @since  4.1.1
+	 *
+	 * @param  String  $classes
+	 * @return String
+	 */
+	public function include_admin_body_classes( $classes ) {
+
+		// Add WP 5.3+ compatibility class.
+		if ( strpos( $classes, 'wc-wp-version-gte-53' ) !== false ) {
+			return $classes;
+		}
+
+		global $wp_version;
+		$version_parts = explode( '-', $wp_version );
+		$version       = sizeof( $version_parts ) > 1 ? $version_parts[ 0 ] : $wp_version;
+
+		if ( $wp_version && version_compare( $version, '5.3', '>=' ) ) {
+			$classes .= ' wc-wp-version-gte-53';
+		}
+
+		return $classes;
 	}
 }
 

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -318,17 +318,17 @@ class WC_Admin {
 	 * @param  String  $classes
 	 * @return String
 	 */
-	public function include_admin_body_classes( $classes ) {
+	public function include_admin_body_class( $classes ) {
 
-		// Add WP 5.3+ compatibility class.
-		if ( strpos( $classes, 'wc-wp-version-gte-53' ) !== false ) {
+		if ( false !== strpos( $classes, 'wc-wp-version-gte-53' ) ) {
 			return $classes;
 		}
 
 		global $wp_version;
 		$version_parts = explode( '-', $wp_version );
-		$version       = sizeof( $version_parts ) > 1 ? $version_parts[ 0 ] : $wp_version;
+		$version       = count( $version_parts ) > 1 ? $version_parts[0] : $wp_version;
 
+		// Add WP 5.3+ compatibility class.
 		if ( $wp_version && version_compare( $version, '5.3', '>=' ) ) {
 			$classes .= ' wc-wp-version-gte-53';
 		}

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -313,9 +313,10 @@ class WC_Admin {
 	/**
 	 * Include admin classes.
 	 *
-	 * @since  4.1.1
+	 * @since 4.1.1
 	 *
-	 * @param  String  $classes
+	 * @param String $classes
+	 *
 	 * @return String
 	 */
 	public function include_admin_body_class( $classes ) {

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -313,24 +313,21 @@ class WC_Admin {
 	/**
 	 * Include admin classes.
 	 *
-	 * @since 4.1.1
-	 *
-	 * @param String $classes Body classes string.
-	 *
-	 * @return String
+	 * @since 4.2.0
+	 * @param string $classes Body classes string.
+	 * @return string
 	 */
 	public function include_admin_body_class( $classes ) {
-
 		if ( false !== strpos( $classes, 'wc-wp-version-gte-53' ) ) {
 			return $classes;
 		}
 
-		global $wp_version;
-		$version_parts = explode( '-', $wp_version );
-		$version       = count( $version_parts ) > 1 ? $version_parts[0] : $wp_version;
+		$raw_version   = get_bloginfo( 'version' );
+		$version_parts = explode( '-', $raw_version );
+		$version       = count( $version_parts ) > 1 ? $version_parts[0] : $raw_version;
 
 		// Add WP 5.3+ compatibility class.
-		if ( $wp_version && version_compare( $version, '5.3', '>=' ) ) {
+		if ( $raw_version && version_compare( $version, '5.3', '>=' ) ) {
 			$classes .= ' wc-wp-version-gte-53';
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Introduced a new `wc-wp-version-gte-53` body CSS class. This class is added in the admin body when WordPress 5.3+ is currently active.

Closes #26249 

### Changelog entry

> Fix - Introduced a new admin body class for supporting styling issues in WP 5.3+.
