### PR TITLE
Add a put method to the WC_Helper_API

### DIFF
--- a/includes/admin/helper/class-wc-helper-api.php
+++ b/includes/admin/helper/class-wc-helper-api.php
@@ -97,10 +97,11 @@ class WC_Helper_API {
 			$args['headers'] = array();
 		}
 
-		$args['headers'] = array(
+		$headers         = array(
 			'Authorization'   => 'Bearer ' . $auth['access_token'],
 			'X-Woo-Signature' => $signature,
 		);
+		$args['headers'] = wp_parse_args( $headers, $args['headers'] );
 
 		$url = add_query_arg(
 			array(

--- a/includes/admin/helper/class-wc-helper-api.php
+++ b/includes/admin/helper/class-wc-helper-api.php
@@ -141,6 +141,19 @@ class WC_Helper_API {
 	}
 
 	/**
+	 * Wrapper for self::request().
+	 *
+	 * @param string $endpoint The helper API endpoint to request.
+	 * @param array  $args Arguments passed to wp_remote_request().
+	 *
+	 * @return array The response object from wp_safe_remote_request().
+	 */
+	public static function put( $endpoint, $args = array() ) {
+		$args['method'] = 'PUT';
+		return self::request( $endpoint, $args );
+	}
+
+	/**
 	 * Using the API base, form a request URL from a given endpoint.
 	 *
 	 * @param string $endpoint The endpoint to request.

--- a/tests/unit-tests/helper/class-wc-helper-api.php
+++ b/tests/unit-tests/helper/class-wc-helper-api.php
@@ -1,0 +1,99 @@
+<?php
+/**
+ * Class WC_Helper_API unit tests.
+ *
+ * @package WooCommerce\Tests\Importer
+ */
+
+/**
+ * Test class for WC_Helper_API.
+ */
+class WC_Tests_Helper_API extends WC_Unit_Test_Case {
+
+	/**
+	 * Set up mock responses for all API calls.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		// Callback used by WP_HTTP_TestCase to decide whether to perform HTTP requests or to provide a mocked response.
+		$this->http_responder = array( $this, 'mock_http_responses' );
+	}
+
+	/**
+	 * Test a GET request through the WC_Helper_API.
+	 *
+	 * @return void
+	 */
+	public function test_get_request() {
+		$request = WC_Helper_API::get(
+			'test-get'
+		);
+
+		$this->assertEquals( '200', $request['response']['code'] );
+	}
+
+	/**
+	 * Test a POST request through the WC_Helper_API.
+	 *
+	 * @return void
+	 */
+	public function test_post_request() {
+		$request = WC_Helper_API::post(
+			'test-post'
+		);
+
+		$this->assertEquals( '200', $request['response']['code'] );
+	}
+
+	/**
+	 * Test a PUT request through the WC_Helper_API.
+	 *
+	 * @return void
+	 */
+	public function test_put_request() {
+		$request = WC_Helper_API::put(
+			'test-put'
+		);
+
+		$this->assertEquals( '200', $request['response']['code'] );
+	}
+
+	/**
+	 * Provides a mocked response for various paths and request methods.
+	 *
+	 * This function is called by WP_HTTP_TestCase::http_request_listner().
+	 *
+	 * @param array  $request Request arguments.
+	 * @param string $url URL of the request.
+	 *
+	 * @return array|false mocked response or false to let WP perform a regular request.
+	 */
+	protected function mock_http_responses( $request, $url ) {
+		$mocked_response = false;
+
+		if ( 'GET' === $request['method'] && 'https://woocommerce.com/wp-json/helper/1.0/test-get' === $url ) {
+			$mocked_response = array(
+				'body'     => 'Mocked response',
+				'response' => array( 'code' => 200 ),
+			);
+		}
+
+		if ( 'POST' === $request['method'] && 'https://woocommerce.com/wp-json/helper/1.0/test-post' === $url ) {
+			$mocked_response = array(
+				'body'     => 'Mocked response',
+				'response' => array( 'code' => 200 ),
+			);
+		}
+
+		if ( 'PUT' === $request['method'] && 'https://woocommerce.com/wp-json/helper/1.0/test-put' === $url ) {
+			$mocked_response = array(
+				'body'     => 'Mocked response',
+				'response' => array( 'code' => 200 ),
+			);
+		}
+
+		return $mocked_response;
+	}
+
+}

--- a/tests/unit-tests/helper/class-wc-helper-api.php
+++ b/tests/unit-tests/helper/class-wc-helper-api.php
@@ -21,6 +21,16 @@ class WC_Tests_Helper_API extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test that the url method returns the correct WooCommerce.com path.
+	 *
+	 * @return void
+	 */
+	public function test_api_url() {
+		$url = WC_Helper_API::url( '/test-path' );
+		$this->assertEquals( 'https://woocommerce.com/wp-json/helper/1.0/test-path', $url );
+	}
+
+	/**
 	 * Test a GET request through the WC_Helper_API.
 	 *
 	 * @return void
@@ -72,21 +82,21 @@ class WC_Tests_Helper_API extends WC_Unit_Test_Case {
 	protected function mock_http_responses( $request, $url ) {
 		$mocked_response = false;
 
-		if ( 'GET' === $request['method'] && 'https://woocommerce.com/wp-json/helper/1.0/test-get' === $url ) {
+		if ( 'GET' === $request['method'] && WC_Helper_API::url( 'test-get' ) === $url ) {
 			$mocked_response = array(
 				'body'     => 'Mocked response',
 				'response' => array( 'code' => 200 ),
 			);
 		}
 
-		if ( 'POST' === $request['method'] && 'https://woocommerce.com/wp-json/helper/1.0/test-post' === $url ) {
+		if ( 'POST' === $request['method'] && WC_Helper_API::url( 'test-post' ) === $url ) {
 			$mocked_response = array(
 				'body'     => 'Mocked response',
 				'response' => array( 'code' => 200 ),
 			);
 		}
 
-		if ( 'PUT' === $request['method'] && 'https://woocommerce.com/wp-json/helper/1.0/test-put' === $url ) {
+		if ( 'PUT' === $request['method'] && WC_Helper_API::url( 'test-put' ) === $url ) {
 			$mocked_response = array(
 				'body'     => 'Mocked response',
 				'response' => array( 'code' => 200 ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a put method to the WC_Helper_API and allows custom headers to be passed to the method.

This allows the usage of the wccom endpoint created in https://github.com/Automattic/woocommerce.com/pull/6895.

Closes #26261  .

### How to test the changes in this Pull Request:

1. Call the newly added method with expected parameters:
```
WC_Helper_API::put(
	'profile',
	array(
		'authenticated' => true,
		'body'                => wp_json_encode( $body ),
		'headers'           => array(
			'plugins'             => 'skipped',
			'industry'            => array(),
			'product_types'       => array(),
			'product_count'       => '0',
			'selling_venues'      => 'no',
			'revenue'             => 'none',
			'other_platform'      => 'none',
			'business_extensions' => array(),
			'theme'               => get_stylesheet(),
			'setup_client'        => false,
			'store_location'      => $base_location['country'],
			'default_currency'    => get_woocommerce_currency(),
		),
	),
);
```
2. Make sure a successful response is received from the API.
3. Optionally check out this PR ( https://github.com/woocommerce/woocommerce-admin/pull/4177 ) and follow testing instructions provided.