### PR TITLE
Hide Postcode/Zip field on billing/shipping form when Ghana is selected

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -946,12 +946,11 @@ class WC_Countries {
 					),
 					'GH' => array(
 						'postcode' => array(
-							'label'    => __( 'Postcode', 'woocommerce' ),
 							'required' => false,
 							'hidden'   => true,
 						),
 						'state'    => array(
-							'label' => __( 'State', 'woocommerce' ),
+							'label' => __( 'Region', 'woocommerce' ),
 						),
 					),
 					'GP' => array(

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -947,7 +947,6 @@ class WC_Countries {
 					'GH' => array(
 						'postcode' => array(
 							'required' => false,
-							'hidden'   => true,
 						),
 						'state'    => array(
 							'label' => __( 'Region', 'woocommerce' ),

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -944,6 +944,16 @@ class WC_Countries {
 							'required' => false,
 						),
 					),
+					'GH' => array(
+						'postcode' => array(
+							'label'    => __( 'Postcode', 'woocommerce' ),
+							'required' => false,
+							'hidden'   => true,
+						),
+						'state'    => array(
+							'label' => __( 'State', 'woocommerce' ),
+						),
+					),
 					'GP' => array(
 						'state' => array(
 							'required' => false,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #26270.

### How to test the changes in this Pull Request:

See #26270.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Hides the Postcode/Zip field on the billing/shipping form when Ghana is selected.