### PR TITLE
Allows avoiding performance bottlenecks caused by get_available_variation().

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -282,9 +282,10 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Get an array of available variations for the current product.
 	 *
+	 * @param bool $render_variations Allows avoiding performance bottlenecks caused by get_available_variation().
 	 * @return array
 	 */
-	public function get_available_variations() {
+	public function get_available_variations($render_variations = true) {
 
 		$variation_ids        = $this->get_children();
 		$available_variations = array();
@@ -307,10 +308,17 @@ class WC_Product_Variable extends WC_Product {
 				continue;
 			}
 
-			$available_variations[] = $this->get_available_variation( $variation );
+			if ( $render_variations ) {
+				$available_variations[] = $this->get_available_variation( $variation );
+			} else {
+				$available_variations[] = $variation;
+			}
+
 		}
 
-		$available_variations = array_values( array_filter( $available_variations ) );
+		if ( $render_variations ) {
+			$available_variations = array_values( array_filter( $available_variations ) );
+		}
 
 		return $available_variations;
 	}

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -282,10 +282,10 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Get an array of available variations for the current product.
 	 *
-	 * @param bool $render_variations Allows avoiding performance bottlenecks caused by get_available_variation().
+	 * @param bool $render_variations Prepares a data array for each variant for output in the add to cart form. Pass `false` to only return the available variations as objects.
 	 * @return array
 	 */
-	public function get_available_variations($render_variations = true) {
+	public function get_available_variations( $render_variations = true ) {
 
 		$variation_ids        = $this->get_children();
 		$available_variations = array();

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -313,7 +313,6 @@ class WC_Product_Variable extends WC_Product {
 			} else {
 				$available_variations[] = $variation;
 			}
-
 		}
 
 		if ( $render_variations ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Follow-up to https://github.com/woocommerce/woocommerce/pull/23148

Problem

- A site's page loading performance (TTFB) can increase to 10 seconds and more when a product has a lot of variations, because various plugins are using `WC_Product_Variable::get_available_variations()` to retrieve the available variations for e.g. displaying product image galleries, the lowest/highest price of variations, and so on.

Details

- After the original issue linked above was closed, `_prime_post_caches()` was added to `get_available_variations()` in the meantime, in order to speed up loading of variation objects in case an object cache is installed.

- However, the preparation and rendering of many output snippets in the subsequently called `WC_Product_Variable::get_available_variation()` (singular) is still causing a major slowdown due to many expensive operations, which are unnecessary for the vast majority of cases in which only the SKU, thumbnail IDs, or other fragments are needed.

Proposed solution

1. Leave the function as it is by default, but allow to pass a parameter to avoid the preparation of the data array by get_available_variation().

Notes

- Unlike `WC_Product_Variable::get_visible_children()` this still applies the same filters and hooks as `get_available_variations(true)` and returns the full product variation objects to the caller, ready to work with.

- Applying the new parameter to two plugins on our sites shaved off more than 10 seconds of the generation time of pages in which products with a very high amount of variations were involved.

### How to test the changes in this Pull Request:

1.  Create or import variable products containing a high number of variations.
2. Call get_available_variations() and get_available_variations(false) on a category page and compare render time using a a profiler or debug tool.

### Changelog entry

> Dev - Add an optional `$render_variations` argument to in `WC_Product_Variable::get_available_variation()` in order to allow plugins to avoid performance bottlenecks.
