### PR TITLE
Introduces nightly builds workflow

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -17,7 +17,7 @@ jobs:
           ref: ${{ matrix.build }}
       - name: Build
         id: build
-        uses: woocommerce/woocommerce-build-action@master
+        uses: woocommerce/action-build@master
         with:
           generate-zip: true
       - name: Deploy nightly build

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -1,0 +1,43 @@
+name: Nightly builds
+on:
+  schedule:
+    - cron: '0 0 * * *' # Run at 12 AM UTC.
+jobs:
+  build:
+    name: Nightly builds
+    strategy:
+      fail-fast: false
+      matrix:
+        build: [master]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ matrix.build }}
+      - name: Build
+        id: build
+        uses: woocommerce/woocommerce-build-action@master
+        with:
+          generate-zip: true
+      - name: Deploy nightly build
+        uses: WebFreak001/deploy-nightly@v1.0.3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/25945111/assets{?name,label}
+          release_id: 25945111
+          asset_path: ${{ steps.build.outputs.zip_path }}
+          asset_name: ${{ github.event.repository.name }}-${{ matrix.build }}-nightly.zip
+          asset_content_type: application/zip
+          max_releases: 1
+  update:
+    name: Update nightly tag commit ref
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update nightly tag
+        uses: richardsimko/github-tag-action@1.0.0
+        with:
+          tag_name: nightly
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -28,7 +28,7 @@ jobs:
           upload_url: https://uploads.github.com/repos/${{ github.repository }}/releases/25945111/assets{?name,label}
           release_id: 25945111
           asset_path: ${{ steps.build.outputs.zip_path }}
-          asset_name: ${{ github.event.repository.name }}-${{ matrix.build }}-nightly.zip
+          asset_name: woocommerce-${{ matrix.build }}-nightly.zip
           asset_content_type: application/zip
           max_releases: 1
   update:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

It introduces a workflow to generate nightly builds that have two jobs:

1. Build - Generates a zip file based on the matrix (currently only generating for master branch)
2. Update - It updates the GIT tag commit ref to force GitHub generate new `Source code (zip)` and `Source code (tar.gz)` files, not to mention that having the latest commit ref in the release page helps a lot while debugging.

Note that this PR depends on some dev files from #26314.

### How to test the changes in this Pull Request:

1. To test it you need to fork WooCommerce on GitHub and create a pre-release with a tag called `nightly` (feel free to put any title or description).
2. Merge `add/build-workflow` and `add/nightly-builds-workflow` branches into master.
3. Search for your "nightly" release ID in `https://api.github.com/repos/<your_username>/woocommerce/releases`, and replace the `25945111` in `.github/workflows/nightly-builds.yml` (there's two places to replace).
4. Now everything is ready to run the nightly release at 12 am UTC.

Don't want to wait?

5. Edit `.github/workflows/nightly-builds.yml` changing:
```yml
on:
  schedule:
    - cron: '0 0 * * *' # Run at 12 AM UTC.
```

to:

```yml
on: 
  release:
    types: [published]
```
Now you can create a new release on GitHub just to trigger this workflow.

6. After saved your release you can watch everything in the `/actions` page, it generally takes 4 minutes to complete, after that you can check for the zip file in the nightly release page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->


