### PR TITLE
Use WP_CONTENT_DIR string length

### DIFF
--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -117,8 +117,8 @@ class WC_Product_Download implements ArrayAccess {
 		$file_url = $this->get_file();
 		if ( '..' === substr( $file_url, 0, 2 ) || '/' !== substr( $file_url, 0, 1 ) ) {
 			$file_url = realpath( ABSPATH . $file_url );
-		} elseif ( substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) === substr( $file_url, 0, strlen( substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) ) ) ) {
-			$file_url = realpath( WP_CONTENT_DIR . substr( $file_url, 11 ) );
+		} elseif ( 0 === strpos( $file_url, substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) ) ) {
+			$file_url = realpath( WP_CONTENT_DIR . substr( $file_url, strlen( WP_CONTENT_DIR ) ) );
 		}
 		return apply_filters( 'woocommerce_downloadable_file_exists', file_exists( $file_url ), $this->get_file() );
 	}

--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -118,7 +118,7 @@ class WC_Product_Download implements ArrayAccess {
 		if ( '..' === substr( $file_url, 0, 2 ) || '/' !== substr( $file_url, 0, 1 ) ) {
 			$file_url = realpath( ABSPATH . $file_url );
 		} elseif ( 0 === strpos( $file_url, substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) ) ) {
-			$file_url = realpath( WP_CONTENT_DIR . substr( $file_url, strlen( WP_CONTENT_DIR ) ) );
+			$file_url = realpath( WP_CONTENT_DIR . substr( $file_url, strlen( substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) ) ) );
 		}
 		return apply_filters( 'woocommerce_downloadable_file_exists', file_exists( $file_url ), $this->get_file() );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On line 121, the sub string of `$file_url` is extracted using the fixed value `11` which assumes that `WP_CONTENT_DIR` is always `/wp-content`. Since `WP_CONTENT_DIR` can be redefined in the `wp-config.php` file, it is necessary to use `strlen( WP_CONTENT_DIR )` instead of `11`, otherwise the file existence check would fail in those installations where the `WP_CONTENT_DIR` is redefined.

In addition to that, I find the way used on line 120 to check whether the first part of the `$file_url` is equal to `WP_CONTENT_DIR` or not very counterintuitive and convoluted. It is much clearer and more readable to use `strpos`:
```
0 === strpos( $file_url, substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) )
```

instead of checking whether the first part of `$file_url` and the last portion of `WP_CONTENT_DIR` are the same string, as in:
```
substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) === substr( $file_url, 0, strlen( substr( WP_CONTENT_DIR, strlen( untrailingslashit( ABSPATH ) ) ) ) )
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

FIX: The string length of the WP_CONTENT_DIR subpath is now determined dynamically and not hard-coded