### PR TITLE
Conditionally change my account dashboard desc

### DIFF
--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -99,7 +99,7 @@ function wc_get_account_menu_items() {
 		'dashboard'       => __( 'Dashboard', 'woocommerce' ),
 		'orders'          => __( 'Orders', 'woocommerce' ),
 		'downloads'       => __( 'Downloads', 'woocommerce' ),
-		'edit-address'    => _n( 'Address', 'Addresses', (int) wc_shipping_enabled(), 'woocommerce' ),
+		'edit-address'    => _n( 'Addresses', 'Address', (int) wc_shipping_enabled(), 'woocommerce' ),
 		'payment-methods' => __( 'Payment methods', 'woocommerce' ),
 		'edit-account'    => __( 'Account details', 'woocommerce' ),
 		'customer-logout' => __( 'Logout', 'woocommerce' ),

--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -95,16 +95,11 @@ function wc_get_account_menu_items() {
 		'customer-logout' => get_option( 'woocommerce_logout_endpoint', 'customer-logout' ),
 	);
 
-	$edit_address = __( 'Address', 'woocommerce' );
-	if ( get_option( 'woocommerce_ship_to_countries' ) !== 'disabled' ) {
-		$edit_address = __( 'Addresses', 'woocommerce' );
-	}
-
 	$items = array(
 		'dashboard'       => __( 'Dashboard', 'woocommerce' ),
 		'orders'          => __( 'Orders', 'woocommerce' ),
 		'downloads'       => __( 'Downloads', 'woocommerce' ),
-		'edit-address'    => $edit_address,
+		'edit-address'    => _n( 'Address', 'Addresses', (int) wc_shipping_enabled(), 'woocommerce' ),
 		'payment-methods' => __( 'Payment methods', 'woocommerce' ),
 		'edit-account'    => __( 'Account details', 'woocommerce' ),
 		'customer-logout' => __( 'Logout', 'woocommerce' ),

--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -95,11 +95,16 @@ function wc_get_account_menu_items() {
 		'customer-logout' => get_option( 'woocommerce_logout_endpoint', 'customer-logout' ),
 	);
 
+	$edit_address = __( 'Address', 'woocommerce' );
+	if ( get_option( 'woocommerce_ship_to_countries' ) !== 'disabled' ) {
+		$edit_address = __( 'Addresses', 'woocommerce' );
+	}
+
 	$items = array(
 		'dashboard'       => __( 'Dashboard', 'woocommerce' ),
 		'orders'          => __( 'Orders', 'woocommerce' ),
 		'downloads'       => __( 'Downloads', 'woocommerce' ),
-		'edit-address'    => __( 'Addresses', 'woocommerce' ),
+		'edit-address'    => $edit_address,
 		'payment-methods' => __( 'Payment methods', 'woocommerce' ),
 		'edit-account'    => __( 'Account details', 'woocommerce' ),
 		'customer-logout' => __( 'Logout', 'woocommerce' ),

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -18,7 +18,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 ?>
 

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -12,23 +12,24 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
- * @version     4.3.0
+ * @see     https://docs.woocommerce.com/document/template-structure/
+ * @package WooCommerce/Templates
+ * @version 4.4.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
+
+$allowed_html = array(
+	'a' => array(
+		'href' => array(),
+	),
+);
 ?>
 
 <p>
 	<?php
-	$allowed_html = array(
-		'a' => array(
-			'href' => array(),
-		),
-	);
 	printf(
 		/* translators: 1: user display name 2: logout url */
 		wp_kses( __( 'Hello %1$s (not %1$s? <a href="%2$s">Log out</a>)', 'woocommerce' ), $allowed_html ),

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -26,7 +26,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<?php
 	printf(
 		/* translators: 1: user display name 2: logout url */
-		__( 'Hello %1$s (not %1$s? <a href="%2$s">Log out</a>)', 'woocommerce' ),
+		esc_html__( 'Hello %1$s (not %1$s? <a href="%2$s">Log out</a>)', 'woocommerce' ),
 		'<strong>' . esc_html( $current_user->display_name ) . '</strong>',
 		esc_url( wc_logout_url() )
 	);
@@ -35,12 +35,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <p>
 	<?php
+	/* translators: 1: Orders URL 2: Address URL 3: Account URL. */
 	$dashboard_desc = __( 'From your account dashboard you can view your <a href="%1$s">recent orders</a>, manage your <a href="%2$s">billing address</a>, and <a href="%3$s">edit your password and account details</a>.', 'woocommerce' );
 	if ( wc_shipping_enabled() ) {
+		/* translators: 1: Orders URL 2: Addresses URL 3: Account URL. */
 		$dashboard_desc = __( 'From your account dashboard you can view your <a href="%1$s">recent orders</a>, manage your <a href="%2$s">shipping and billing addresses</a>, and <a href="%3$s">edit your password and account details</a>.', 'woocommerce' );
 	}
 	printf(
-		$dashboard_desc,
+		esc_html( $dashboard_desc ),
 		esc_url( wc_get_endpoint_url( 'orders' ) ),
 		esc_url( wc_get_endpoint_url( 'edit-address' ) ),
 		esc_url( wc_get_endpoint_url( 'edit-account' ) )

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -36,7 +36,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <p>
 	<?php
 	$dashboard_desc = __( 'From your account dashboard you can view your <a href="%1$s">recent orders</a>, manage your <a href="%2$s">billing address</a>, and <a href="%3$s">edit your password and account details</a>.', 'woocommerce' );
-	if ( get_option( 'woocommerce_ship_to_countries' ) !== 'disabled' ) {
+	if ( wc_shipping_enabled() ) {
 		$dashboard_desc = __( 'From your account dashboard you can view your <a href="%1$s">recent orders</a>, manage your <a href="%2$s">shipping and billing addresses</a>, and <a href="%3$s">edit your password and account details</a>.', 'woocommerce' );
 	}
 	printf(

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -24,9 +24,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <p>
 	<?php
+	$allowed_html = array(
+		'a' => array(
+			'href' => array(),
+		),
+	);
 	printf(
 		/* translators: 1: user display name 2: logout url */
-		esc_html__( 'Hello %1$s (not %1$s? <a href="%2$s">Log out</a>)', 'woocommerce' ),
+		wp_kses( __( 'Hello %1$s (not %1$s? <a href="%2$s">Log out</a>)', 'woocommerce' ), $allowed_html ),
 		'<strong>' . esc_html( $current_user->display_name ) . '</strong>',
 		esc_url( wc_logout_url() )
 	);
@@ -42,7 +47,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		$dashboard_desc = __( 'From your account dashboard you can view your <a href="%1$s">recent orders</a>, manage your <a href="%2$s">shipping and billing addresses</a>, and <a href="%3$s">edit your password and account details</a>.', 'woocommerce' );
 	}
 	printf(
-		esc_html( $dashboard_desc ),
+		wp_kses( $dashboard_desc, $allowed_html ),
 		esc_url( wc_get_endpoint_url( 'orders' ) ),
 		esc_url( wc_get_endpoint_url( 'edit-address' ) ),
 		esc_url( wc_get_endpoint_url( 'edit-account' ) )

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -35,8 +35,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 <p>
 	<?php
+	$dashboard_desc = __( 'From your account dashboard you can view your <a href="%1$s">recent orders</a>, manage your <a href="%2$s">billing address</a>, and <a href="%3$s">edit your password and account details</a>.', 'woocommerce' );
+	if ( get_option( 'woocommerce_ship_to_countries' ) !== 'disabled' ) {
+		$dashboard_desc = __( 'From your account dashboard you can view your <a href="%1$s">recent orders</a>, manage your <a href="%2$s">shipping and billing addresses</a>, and <a href="%3$s">edit your password and account details</a>.', 'woocommerce' );
+	}
 	printf(
-		__( 'From your account dashboard you can view your <a href="%1$s">recent orders</a>, manage your <a href="%2$s">shipping and billing addresses</a>, and <a href="%3$s">edit your password and account details</a>.', 'woocommerce' ),
+		$dashboard_desc,
 		esc_url( wc_get_endpoint_url( 'orders' ) ),
 		esc_url( wc_get_endpoint_url( 'edit-address' ) ),
 		esc_url( wc_get_endpoint_url( 'edit-account' ) )

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -14,7 +14,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce/Templates
- * @version     2.6.0
+ * @version     4.3.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
Conditionally change My account dashboard description to reflect whether or not shipping has been disabled in WooCommerce > Settings > General > General options.

When WooCommerce > Settings > General > General options > Shipping location(s) is not set to "Disable shipping & shipping calculations", the Home > My account > Addresses has both billing and shipping addresses. When WooCommerce > Settings > General > General options > Shipping location(s) is set to "Disable shipping & shipping calculations", the Home > My account > Addresses only has a billing address. The dashboard description describes managing both the shipping and billing address even if the shipping address has been removed. this pull request remedies the possible discrepancy.

Signed-off-by: Leon Francis Shelhamer <leon@211j.com>

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In the `dasboard.php` template file assign the dashboard description string to `$dashboard_desc`. This string assumes that WooCommerce > Settings > General > General options > Shipping is disabled. Within an `if` statement check if WooCommerce > Settings > General > General options > Shipping  is not disabled. If WooCommerce > Settings > General > General options > Shipping  is not disabled assign the original dashboard description string to `$dashboard_desc`. Use $dashboard_desc` as the first parameter for `printf()`.

Assign the entire dashboard description text to `$dashboard_desc` for translation purposes.

Also, take similar steps in the `wc-account-function.php` file to conditional change the "Addresses" tab to "Address".

Closes # .

### How to test the changes in this Pull Request:

1. Navigate to Home > My account on the frontend
2. Set WooCommerce > Settings > General > General options > Shipping location(s) to "Disable shipping & shipping calculations"
3. Repeat step 1.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Conditionally change the text in My account to reflect if shipping is disabled.
