### PR TITLE
Fix WooCommerce Admin textdomain replacement in build script.

### DIFF
--- a/bin/package-update.sh
+++ b/bin/package-update.sh
@@ -34,7 +34,7 @@ output 2 "Done!"
 
 output 3 "Updating package JS textdomains..."
 find ./packages/woocommerce-blocks -iname '*.js' -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" -e "s/\"woo-gutenberg-products-block\"/'woocommerce'/g" {} \;
-find ./packages/woocommerce-admin -iname '*.js' -exec sed -i.bak -e "s/, 'woocommerce-admin'/, 'woocommerce'/g" {} \;
+find ./packages/woocommerce-admin -iname '*.js' -exec sed -i.bak -e "s/'woocommerce-admin'/'woocommerce'/g" -e "s/\"woocommerce-admin\"/'woocommerce'/g" {} \;
 
 # Cleanup backup files
 find ./packages -name "*.bak" -type f -delete


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes the issue with translations pointed out on the dev blog: https://woocommerce.wordpress.com/2020/04/28/april-30-community-chat-9/#comment-6618

The packages built in WooCommerce Admin occasionally use double quoted strings (like in `packages/woocommerce-admin/dist/date/index.js`) and the `bin/package-update.sh` script's `sed` command wasn't looking for them.

### How to test the changes in this Pull Request:

1. Run `composer install`
2. Verify that no `woocommerce-admin` strings exists in any file

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix translations issue with Dashboard, Analytics, and Marketing screens.