### PR TITLE
Pass line item instance to `woocommerce_hidden_order_itemmeta`

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-item-meta.php
+++ b/includes/admin/meta-boxes/views/html-order-item-meta.php
@@ -17,7 +17,8 @@ $hidden_order_itemmeta = apply_filters(
 		'method_id',
 		'cost',
 		'_reduced_stock',
-	)
+	),
+	$item
 );
 ?><div class="view">
 	<?php if ( $meta_data = $item->get_formatted_meta_data( '' ) ) : ?>


### PR DESCRIPTION
This fixes #26342, making the order line item available to filters.