### PR TITLE
Fix upsell layout issue when no product description and reviews is set in twenty twenty theme

### DIFF
--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -2058,6 +2058,10 @@ a.reset_variations {
  */
 .woocommerce {
 
+	&.single-product .product section {
+		float: left;
+	}
+
 	section {
 		padding-top: 2rem;
 		padding-bottom: 0;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
The `float: left` css propery is added to the upsell section.

Closes #26334  .

### How to test the changes in this Pull Request:

1. Check out the master branch.
2. Make sure you disable the product reviews `wp-admin/admin.php?page=wc-settings&tab=products` and no product description.
3. Check whether the upsell section is fixed.
![screencapture-woocommerce-test-product-simple-product-2020-04-30-20_40_04](https://user-images.githubusercontent.com/8264719/80729098-7a4be100-8b27-11ea-9fc9-5c34d328a195.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix upsell layout issue when no product description and reviews are set in twenty twenty theme
