### PR TITLE
Pass $customer to woocommerce_match_rates hook.

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -495,7 +495,7 @@ class WC_Tax {
 			);
 		}
 
-		return apply_filters( 'woocommerce_matched_rates', $matched_tax_rates, $tax_class );
+		return apply_filters( 'woocommerce_matched_rates', $matched_tax_rates, $tax_class, $customer );
 	}
 
 	/**


### PR DESCRIPTION
This allows tax related plugins to get more data on the customer and make better decisions on the correct tax rate to apply. See full discussion in #25787.

Fixes #25787

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Enhancement - Added the customer as a third argument to the woocommerce_matched_rates filter.
