### PR TITLE
Allow schedule coupons via CRUD

### DIFF
--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -69,7 +69,9 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 	 * @param WC_Coupon $coupon Coupon object.
 	 */
 	public function create( &$coupon ) {
-		$coupon->set_date_created( time() );
+		if ( ! $coupon->get_date_created( 'edit' ) ) {
+			$coupon->set_date_created( time() );
+		}
 
 		$coupon_id = wp_insert_post(
 			apply_filters(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Using our CRUD isn't possible to schedule a coupon, since we replace it to `time()`, so every coupon created will be automatically published at the same time.

This PR fix this behavior allowing coupons to get scheduled by WordPress.

Closes #26329.

### How to test the changes in this Pull Request:

1. Try the sample code from https://github.com/woocommerce/woocommerce/issues/26329
2. Apply this patch and try the sample code again (probably will need to update the coupon code)
3. Now check that the coupon gets scheduled as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Allow schedule coupons via CRUD.
