### PR TITLE
Introduce a `reserved stock` class and database table to prevent race conditions during checkout

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -340,6 +340,29 @@ class WC_Admin_Status {
 	}
 
 	/**
+	 * Prints table info if a base table is not present.
+	 */
+	private static function output_tables_info() {
+		$missing_tables = WC_Install::verify_base_tables( false );
+		if ( 0 === count( $missing_tables ) ) {
+			return;
+		}
+		?>
+
+		<br>
+		<strong style="color:#a00;">
+			<span class="dashicons dashicons-warning"></span>
+			<?php
+				esc_html_e( 'Missing base tables: ', 'woocommerce' );
+				echo esc_html( implode( ', ', $missing_tables ) );
+				esc_html_e( '. Some WooCommerce functionality may not work as expected.', 'woocommerce' );
+			?>
+		</strong>
+
+		<?php
+	}
+
+	/**
 	 * Prints the information about plugins for the system status report.
 	 * Used for both active and inactive plugins sections.
 	 *

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -353,9 +353,13 @@ class WC_Admin_Status {
 		<strong style="color:#a00;">
 			<span class="dashicons dashicons-warning"></span>
 			<?php
-				esc_html_e( 'Missing base tables: ', 'woocommerce' );
-				echo esc_html( implode( ', ', $missing_tables ) );
-				esc_html_e( '. Some WooCommerce functionality may not work as expected.', 'woocommerce' );
+				echo esc_html(
+					sprintf(
+					// translators: Comma seperated list of missing tables.
+						__( 'Missing base tables: %s. Some WooCommerce functionality may not work as expected.', 'woocommerce' ),
+						implode( ', ', $missing_tables )
+					)
+				);
 			?>
 		</strong>
 

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -496,10 +496,17 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 		?>
 	</tbody>
 </table>
-<table class="wc_status_table widefat" cellspacing="0">
+<table id="status-database" class="wc_status_table widefat" cellspacing="0">
 	<thead>
 	<tr>
-		<th colspan="3" data-export-label="Database"><h2><?php esc_html_e( 'Database', 'woocommerce' ); ?></h2></th>
+		<th colspan="3" data-export-label="Database">
+			<h2>
+				<?php
+					esc_html_e( 'Database', 'woocommerce' );
+					self::output_tables_info();
+				?>
+			</h2>
+		</th>
 	</tr>
 	</thead>
 	<tbody>

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -765,7 +765,6 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function check_cart_item_stock() {
 		$error                    = new WP_Error();
 		$product_qty_in_cart      = $this->get_cart_item_quantities();
-		$hold_stock_minutes       = (int) get_option( 'woocommerce_hold_stock_minutes', 0 );
 		$current_session_order_id = isset( WC()->session->order_awaiting_payment ) ? absint( WC()->session->order_awaiting_payment ) : 0;
 
 		foreach ( $this->get_cart() as $cart_item_key => $values ) {
@@ -784,7 +783,7 @@ class WC_Cart extends WC_Legacy_Cart {
 			}
 
 			// Check stock based on all items in the cart and consider any held stock within pending orders.
-			$held_stock     = ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product, $current_session_order_id ) : 0;
+			$held_stock     = wc_get_held_stock_quantity( $product, $current_session_order_id );
 			$required_stock = $product_qty_in_cart[ $product->get_stock_managed_by_id() ];
 
 			if ( $product->get_stock_quantity() < ( $held_stock + $required_stock ) ) {

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -388,12 +388,30 @@ class WC_Checkout {
 			// Save the order.
 			$order_id = $order->save();
 
+			/**
+			 * Action hook fired after an order is created used to add custom meta to the order.
+			 *
+			 * @since 3.0.0
+			 */
 			do_action( 'woocommerce_checkout_update_order_meta', $order_id, $data );
+
+			/**
+			 * Action hook fired after an order is created.
+			 *
+			 * @since 4.1.0
+			 */
+			do_action( 'woocommerce_checkout_order_created', $order );
 
 			return $order_id;
 		} catch ( Exception $e ) {
 			if ( $order && $order instanceof WC_Order ) {
 				$order->get_data_store()->release_held_coupons( $order );
+				/**
+				 * Action hook fired when an order is discarded due to Exception.
+				 *
+				 * @since 4.1.0
+				 */
+				do_action( 'woocommerce_checkout_order_exception', $order );
 			}
 			return new WP_Error( 'checkout-error', $e->getMessage() );
 		}

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -398,7 +398,7 @@ class WC_Checkout {
 			/**
 			 * Action hook fired after an order is created.
 			 *
-			 * @since 4.1.0
+			 * @since 4.3.0
 			 */
 			do_action( 'woocommerce_checkout_order_created', $order );
 
@@ -409,7 +409,7 @@ class WC_Checkout {
 				/**
 				 * Action hook fired when an order is discarded due to Exception.
 				 *
-				 * @since 4.1.0
+				 * @since 4.3.0
 				 */
 				do_action( 'woocommerce_checkout_order_exception', $order );
 			}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -990,6 +990,14 @@ CREATE TABLE {$wpdb->prefix}wc_tax_rate_classes (
   PRIMARY KEY  (tax_rate_class_id),
   UNIQUE KEY slug (slug($max_index_length))
 ) $collate;
+CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
+	`order_id` bigint(20) NOT NULL,
+	`product_id` bigint(20) NOT NULL,
+	`stock_quantity` double NOT NULL DEFAULT 0,
+	`timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`expires` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	PRIMARY KEY  (`order_id`, `product_id`)
+) $collate;
 		";
 
 		return $tables;
@@ -1023,6 +1031,7 @@ CREATE TABLE {$wpdb->prefix}wc_tax_rate_classes (
 			"{$wpdb->prefix}woocommerce_shipping_zones",
 			"{$wpdb->prefix}woocommerce_tax_rate_locations",
 			"{$wpdb->prefix}woocommerce_tax_rates",
+			"{$wpdb->prefix}wc_reserved_stock",
 		);
 
 		/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -994,8 +994,8 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 	`order_id` bigint(20) NOT NULL,
 	`product_id` bigint(20) NOT NULL,
 	`stock_quantity` double NOT NULL DEFAULT 0,
-	`timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	`expires` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`timestamp` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+	`expires` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 	PRIMARY KEY  (`order_id`, `product_id`)
 ) $collate;
 		";

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -255,6 +255,7 @@ final class WooCommerce {
 			'order_itemmeta'         => 'woocommerce_order_itemmeta',
 			'wc_product_meta_lookup' => 'wc_product_meta_lookup',
 			'wc_tax_rate_classes'    => 'wc_tax_rate_classes',
+			'wc_reserved_stock'      => 'wc_reserved_stock',
 		);
 
 		foreach ( $tables as $name => $table ) {

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -881,8 +881,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$outofstock_where = ' AND exclude_join.object_id IS NULL';
 		}
 
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		return $wpdb->get_results(
-			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 			"
 			SELECT posts.ID as id, posts.post_parent as parent_id
 			FROM {$wpdb->posts} AS posts
@@ -900,8 +900,8 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			)
 			GROUP BY posts.ID
 			"
-			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 	}
 
 	/**
@@ -1603,7 +1603,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 			foreach ( $search_terms as $search_term ) {
 				$like              = '%' . $wpdb->esc_like( $search_term ) . '%';
-				$term_group_query .= $wpdb->prepare( " {$searchand} ( ( posts.post_title LIKE %s) OR ( posts.post_excerpt LIKE %s) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s ) )", $like, $like, $like, $like ); // @codingStandardsIgnoreLine.
+				$term_group_query .= $wpdb->prepare( " {$searchand} ( ( posts.post_title LIKE %s) OR ( posts.post_excerpt LIKE %s) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s ) )", $like, $like, $like, $like ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$searchand         = ' AND ';
 			}
 
@@ -2061,5 +2061,24 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			return 'product_id';
 		}
 		return '';
+	}
+
+	/**
+	 * Returns query statement for getting current `_stock` of a product.
+	 *
+	 * @internal MAX function below is used to make sure result is a scalar.
+	 * @param int $product_id Product ID.
+	 * @return string|void Query statement.
+	 */
+	public function get_query_for_stock( $product_id ) {
+		global $wpdb;
+		return $wpdb->prepare(
+			"
+			SELECT COALESCE ( MAX( meta_value ), 0 ) FROM $wpdb->postmeta as meta_table
+			WHERE meta_table.meta_key = '_stock'
+			AND meta_table.post_id = %d
+			",
+			$product_id
+		);
 	}
 }

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -84,9 +84,8 @@ class WC_Shortcode_Checkout {
 		// Pay for existing order.
 		if ( isset( $_GET['pay_for_order'], $_GET['key'] ) && $order_id ) { // WPCS: input var ok, CSRF ok.
 			try {
-				$order_key          = isset( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // WPCS: input var ok, CSRF ok.
-				$order              = wc_get_order( $order_id );
-				$hold_stock_minutes = (int) get_option( 'woocommerce_hold_stock_minutes', 0 );
+				$order_key = isset( $_GET['key'] ) ? wc_clean( wp_unslash( $_GET['key'] ) ) : ''; // WPCS: input var ok, CSRF ok.
+				$order     = wc_get_order( $order_id );
 
 				// Order or payment link is invalid.
 				if ( ! $order || $order->get_id() !== $order_id || ! hash_equals( $order->get_order_key(), $order_key ) ) {
@@ -158,7 +157,7 @@ class WC_Shortcode_Checkout {
 							}
 
 							// Check stock based on all items in the cart and consider any held stock within pending orders.
-							$held_stock     = ( $hold_stock_minutes > 0 ) ? wc_get_held_stock_quantity( $product, $order->get_id() ) : 0;
+							$held_stock     = wc_get_held_stock_quantity( $product, $order->get_id() );
 							$required_stock = $quantities[ $product->get_stock_managed_by_id() ];
 
 							if ( ! apply_filters( 'woocommerce_pay_order_product_has_enough_stock', ( $product->get_stock_quantity() >= ( $held_stock + $required_stock ) ), $product, $order ) ) {

--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -299,32 +299,79 @@ function wc_increase_stock_levels( $order_id ) {
  * @param integer    $exclude_order_id Order ID to exclude.
  * @return int
  */
-function wc_get_held_stock_quantity( $product, $exclude_order_id = 0 ) {
-	global $wpdb;
+function wc_get_held_stock_quantity( WC_Product $product, $exclude_order_id = 0 ) {
+	/**
+	 * Filter: woocommerce_hold_stock_for_checkout
+	 * Allows enable/disable hold stock functionality on checkout.
+	 *
+	 * @since 4.1.0
+	 * @param bool $enabled Default to true if managing stock globally.
+	 */
+	if ( ! apply_filters( 'woocommerce_hold_stock_for_checkout', wc_string_to_bool( get_option( 'woocommerce_manage_stock', 'yes' ) ) ) ) {
+		return 0;
+	}
 
-	return $wpdb->get_var(
-		$wpdb->prepare(
-			"
-			SELECT SUM( order_item_meta.meta_value ) AS held_qty
-			FROM {$wpdb->posts} AS posts
-			LEFT JOIN {$wpdb->postmeta} as postmeta ON posts.ID = postmeta.post_id
-			LEFT JOIN {$wpdb->prefix}woocommerce_order_items as order_items ON posts.ID = order_items.order_id
-			LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta ON order_items.order_item_id = order_item_meta.order_item_id
-			LEFT JOIN {$wpdb->prefix}woocommerce_order_itemmeta as order_item_meta2 ON order_items.order_item_id = order_item_meta2.order_item_id
-			WHERE 	order_item_meta.meta_key    = '_qty'
-			AND 	order_item_meta2.meta_key   = %s
-			AND 	order_item_meta2.meta_value = %d
-			AND		postmeta.meta_key			= '_created_via'
-			AND		postmeta.meta_value			= 'checkout'
-			AND 	posts.post_type             IN ( '" . implode( "','", wc_get_order_types() ) . "' )
-			AND 	posts.post_status           = 'wc-pending'
-			AND		posts.ID                    != %d;",
-			'product_variation' === get_post_type( $product->get_stock_managed_by_id() ) ? '_variation_id' : '_product_id',
-			$product->get_stock_managed_by_id(),
-			$exclude_order_id
-		)
-	); // WPCS: unprepared SQL ok.
+	return ( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->get_reserved_stock( $product, $exclude_order_id );
 }
+
+/**
+ * Hold stock for an order.
+ *
+ * @throws ReserveStockException If reserve stock fails.
+ *
+ * @since 4.1.0
+ * @param \WC_Order|int $order Order ID or instance.
+ */
+function wc_reserve_stock_for_order( $order ) {
+	/**
+	 * Filter: woocommerce_hold_stock_for_checkout
+	 * Allows enable/disable hold stock functionality on checkout.
+	 *
+	 * @since @since 4.1.0
+	 * @param bool $enabled Default to true if managing stock globally.
+	 */
+	if ( ! apply_filters( 'woocommerce_hold_stock_for_checkout', wc_string_to_bool( get_option( 'woocommerce_manage_stock', 'yes' ) ) ) ) {
+		return;
+	}
+
+	$order = $order instanceof WC_Order ? $order : wc_get_order( $order );
+
+	if ( $order ) {
+		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->reserve_stock_for_order( $order );
+	}
+}
+add_action( 'woocommerce_checkout_order_created', 'wc_reserve_stock_for_order' );
+
+/**
+ * Release held stock for an order.
+ *
+ * @since 4.1.0
+ * @param \WC_Order|int $order Order ID or instance.
+ */
+function wc_release_stock_for_order( $order ) {
+	/**
+	 * Filter: woocommerce_hold_stock_for_checkout
+	 * Allows enable/disable hold stock functionality on checkout.
+	 *
+	 * @since 4.1.0
+	 * @param bool $enabled Default to true if managing stock globally.
+	 */
+	if ( ! apply_filters( 'woocommerce_hold_stock_for_checkout', wc_string_to_bool( get_option( 'woocommerce_manage_stock', 'yes' ) ) ) ) {
+		return;
+	}
+
+	$order = $order instanceof WC_Order ? $order : wc_get_order( $order );
+
+	if ( $order ) {
+		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->release_stock_for_order( $order );
+	}
+}
+add_action( 'woocommerce_checkout_order_exception', 'wc_release_stock_for_order' );
+add_action( 'woocommerce_payment_complete', 'wc_release_stock_for_order', 11 );
+add_action( 'woocommerce_order_status_cancelled', 'wc_release_stock_for_order', 11 );
+add_action( 'woocommerce_order_status_completed', 'wc_release_stock_for_order', 11 );
+add_action( 'woocommerce_order_status_processing', 'wc_release_stock_for_order', 11 );
+add_action( 'woocommerce_order_status_on-hold', 'wc_release_stock_for_order', 11 );
 
 /**
  * Return low stock amount to determine if notification needs to be sent

--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -304,7 +304,7 @@ function wc_get_held_stock_quantity( WC_Product $product, $exclude_order_id = 0 
 	 * Filter: woocommerce_hold_stock_for_checkout
 	 * Allows enable/disable hold stock functionality on checkout.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 * @param bool $enabled Default to true if managing stock globally.
 	 */
 	if ( ! apply_filters( 'woocommerce_hold_stock_for_checkout', wc_string_to_bool( get_option( 'woocommerce_manage_stock', 'yes' ) ) ) ) {
@@ -345,7 +345,7 @@ add_action( 'woocommerce_checkout_order_created', 'wc_reserve_stock_for_order' )
 /**
  * Release held stock for an order.
  *
- * @since 4.1.0
+ * @since 4.3.0
  * @param \WC_Order|int $order Order ID or instance.
  */
 function wc_release_stock_for_order( $order ) {
@@ -353,7 +353,7 @@ function wc_release_stock_for_order( $order ) {
 	 * Filter: woocommerce_hold_stock_for_checkout
 	 * Allows enable/disable hold stock functionality on checkout.
 	 *
-	 * @since 4.1.0
+	 * @since 4.3.0
 	 * @param bool $enabled Default to true if managing stock globally.
 	 */
 	if ( ! apply_filters( 'woocommerce_hold_stock_for_checkout', wc_string_to_bool( get_option( 'woocommerce_manage_stock', 'yes' ) ) ) ) {

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -1,0 +1,176 @@
+<?php
+/**
+ * Handle product stock reservation during checkout.
+ *
+ * @package Automattic/WooCommerce
+ */
+
+namespace Automattic\WooCommerce\Checkout\Helpers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Stock Reservation class.
+ */
+final class ReserveStock {
+	/**
+	 * Query for any existing holds on stock for this item.
+	 *
+	 * @param \WC_Product $product Product to get reserved stock for.
+	 * @param integer     $exclude_order_id Optional order to exclude from the results.
+	 *
+	 * @return integer Amount of stock already reserved.
+	 */
+	public function get_reserved_stock( \WC_Product $product, $exclude_order_id = 0 ) {
+		global $wpdb;
+
+		// phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+		return (int) $wpdb->get_var( $this->get_query_for_reserved_stock( $product->get_stock_managed_by_id(), $exclude_order_id ) );
+	}
+
+	/**
+	 * Put a temporary hold on stock for an order if enough is available.
+	 *
+	 * @throws ReserveStockException If stock cannot be reserved.
+	 *
+	 * @param \WC_Order $order Order object.
+	 * @param int       $minutes How long to reserve stock in minutes. Defaults to woocommerce_hold_stock_minutes.
+	 */
+	public function reserve_stock_for_order( \WC_Order $order, $minutes = 0 ) {
+		$minutes = $minutes ? $minutes : (int) get_option( 'woocommerce_hold_stock_minutes', 60 );
+
+		if ( ! $minutes ) {
+			return;
+		}
+
+		try {
+			$items = array_filter(
+				$order->get_items(),
+				function( $item ) {
+					return $item->is_type( 'line_item' ) && $item->get_product() instanceof \WC_Product && $item->get_quantity() > 0;
+				}
+			);
+			$rows  = array();
+
+			foreach ( $items as $item ) {
+				$product = $item->get_product();
+
+				if ( ! $product->is_in_stock() ) {
+					throw new ReserveStockException(
+						'woocommerce_product_out_of_stock',
+						sprintf(
+							/* translators: %s: product name */
+							__( '&quot;%s&quot; is out of stock and cannot be purchased.', 'woocommerce' ),
+							$product->get_name()
+						),
+						403
+					);
+				}
+
+				// If stock management is off, no need to reserve any stock here.
+				if ( ! $product->managing_stock() || $product->backorders_allowed() ) {
+					continue;
+				}
+
+				$managed_by_id          = $product->get_stock_managed_by_id();
+				$rows[ $managed_by_id ] = isset( $rows[ $managed_by_id ] ) ? $rows[ $managed_by_id ] + $item->get_quantity() : $item->get_quantity();
+			}
+
+			if ( ! empty( $rows ) ) {
+				foreach ( $rows as $product_id => $quantity ) {
+					$this->reserve_stock_for_product( $product_id, $quantity, $order, $minutes );
+				}
+			}
+		} catch ( ReserveStockException $e ) {
+			$this->release_stock_for_order( $order );
+			throw $e;
+		}
+	}
+
+	/**
+	 * Release a temporary hold on stock for an order.
+	 *
+	 * @param \WC_Order $order Order object.
+	 */
+	public function release_stock_for_order( \WC_Order $order ) {
+		global $wpdb;
+
+		$wpdb->delete(
+			$wpdb->wc_reserved_stock,
+			array(
+				'order_id' => $order->get_id(),
+			)
+		);
+	}
+
+	/**
+	 * Reserve stock for a product by inserting rows into the DB.
+	 *
+	 * @throws ReserveStockException If a row cannot be inserted.
+	 *
+	 * @param int       $product_id Product ID which is having stock reserved.
+	 * @param int       $stock_quantity Stock amount to reserve.
+	 * @param \WC_Order $order Order object which contains the product.
+	 * @param int       $minutes How long to reserve stock in minutes.
+	 */
+	private function reserve_stock_for_product( $product_id, $stock_quantity, \WC_Order $order, $minutes ) {
+		global $wpdb;
+
+		$product_data_store       = \WC_Data_Store::load( 'product' );
+		$query_for_stock          = $product_data_store->get_query_for_stock( $product_id );
+		$query_for_reserved_stock = $this->get_query_for_reserved_stock( $product_id, $order->get_id() );
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+		$result = $wpdb->query(
+			$wpdb->prepare(
+				"
+				REPLACE INTO {$wpdb->wc_reserved_stock} ( order_id, product_id, stock_quantity, expires )
+				SELECT %d, %d, %d, ( NOW() + INTERVAL %d MINUTE ) from DUAL
+				WHERE ( $query_for_stock FOR UPDATE ) - ( $query_for_reserved_stock FOR UPDATE ) >= %d
+				",
+				$order->get_id(),
+				$product_id,
+				$stock_quantity,
+				$minutes,
+				$stock_quantity
+			)
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQL.NotPrepared
+
+		if ( ! $result ) {
+			$product = wc_get_product( $product_id );
+			throw new ReserveStockException(
+				'woocommerce_product_not_enough_stock',
+				sprintf(
+					/* translators: %s: product name */
+					__( 'Not enough units of %s are available in stock to fulfil this order.', 'woocommerce' ),
+					$product ? $product->get_name() : '#' . $product_id
+				),
+				403
+			);
+		}
+	}
+
+	/**
+	 * Returns query statement for getting reserved stock of a product.
+	 *
+	 * @param int     $product_id Product ID.
+	 * @param integer $exclude_order_id Optional order to exclude from the results.
+	 * @return string|void Query statement.
+	 */
+	private function get_query_for_reserved_stock( $product_id, $exclude_order_id = 0 ) {
+		global $wpdb;
+		return $wpdb->prepare(
+			"
+			SELECT COALESCE( SUM( stock_table.`stock_quantity` ), 0 ) FROM $wpdb->wc_reserved_stock stock_table
+			LEFT JOIN $wpdb->posts posts ON stock_table.`order_id` = posts.ID
+			WHERE posts.post_status IN ( 'wc-checkout-draft', 'wc-pending' )
+			AND stock_table.`expires` > NOW()
+			AND stock_table.`product_id` = %d
+			AND stock_table.`order_id` != %d
+			",
+			$product_id,
+			$exclude_order_id
+		);
+	}
+}

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -124,6 +124,10 @@ final class ReserveStock {
 	public function release_stock_for_order( \WC_Order $order ) {
 		global $wpdb;
 
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
 		$wpdb->delete(
 			$wpdb->wc_reserved_stock,
 			array(

--- a/src/Checkout/Helpers/ReserveStockException.php
+++ b/src/Checkout/Helpers/ReserveStockException.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Exceptions for stock reservation.
+ *
+ * @package Automattic/WooCommerce
+ */
+
+namespace Automattic\WooCommerce\Checkout\Helpers;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * ReserveStockException class.
+ */
+class ReserveStockException extends \Exception {
+	/**
+	 * Sanitized error code.
+	 *
+	 * @var string
+	 */
+	protected $error_code;
+
+	/**
+	 * Error extra data.
+	 *
+	 * @var array
+	 */
+	protected $error_data;
+
+	/**
+	 * Setup exception.
+	 *
+	 * @param string $code             Machine-readable error code, e.g `woocommerce_invalid_product_id`.
+	 * @param string $message          User-friendly translated error message, e.g. 'Product ID is invalid'.
+	 * @param int    $http_status_code Proper HTTP status code to respond with, e.g. 400.
+	 * @param array  $data             Extra error data.
+	 */
+	public function __construct( $code, $message, $http_status_code = 400, $data = array() ) {
+		$this->error_code = $code;
+		$this->error_data = $data;
+
+		parent::__construct( $message, $http_status_code );
+	}
+
+	/**
+	 * Returns the error code.
+	 *
+	 * @return string
+	 */
+	public function getErrorCode() {
+		return $this->error_code;
+	}
+
+	/**
+	 * Returns error data.
+	 *
+	 * @return array
+	 */
+	public function getErrorData() {
+		return $this->error_data;
+	}
+}

--- a/tests/legacy/unit-tests/order/class-wc-tests-orders.php
+++ b/tests/legacy/unit-tests/order/class-wc-tests-orders.php
@@ -8,7 +8,7 @@
 /**
  * Class WC_Tests_Order.
  */
-class WC_Tests_Order extends WC_Unit_Test_Case {
+class WC_Tests_Orders extends WC_Unit_Test_Case {
 
 	/**
 	 * Test for total when round at subtotal is enabled.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We reverted #25708 earlier because checkout would fail if for some reason reserve stock table failed to be created, for example when WordPress DB user do not have create permission on database. 

We now aim to re-introduce this, after building some protection, where this feature will not be enabled if the table fails to be created (see #26454 for database check and #26705 for feature disabling) with the caveat that hold stock functionality will not work. But now checkout will still be successful and the merchant will be able to see a notice which will say that table was not created.

### How to test the changes in this Pull Request:

Same as #25708 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - Updated stock handling to prevent race conditions when orders come in at the same time.
