### PR TITLE
Disable directory listing for redirect download method

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1215,7 +1215,7 @@ CREATE TABLE {$wpdb->prefix}wc_tax_rate_classes (
 
 		foreach ( $files as $file ) {
 			if ( wp_mkdir_p( $file['base'] ) && ! file_exists( trailingslashit( $file['base'] ) . $file['file'] ) ) {
-				$file_handle = @fopen( trailingslashit( $file['base'] ) . $file['file'], 'w' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_read_fopen
+				$file_handle = @fopen( trailingslashit( $file['base'] ) . $file['file'], 'wb' ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged, WordPress.WP.AlternativeFunctions.file_system_read_fopen
 				if ( $file_handle ) {
 					fwrite( $file_handle, $file['content'] ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fwrite
 					fclose( $file_handle ); // phpcs:ignore WordPress.WP.AlternativeFunctions.file_system_read_fclose

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1187,7 +1187,7 @@ CREATE TABLE {$wpdb->prefix}wc_tax_rate_classes (
 		}
 
 		// Install files and folders for uploading files and prevent hotlinking.
-		$upload_dir      = wp_upload_dir();
+		$upload_dir      = wp_get_upload_dir();
 		$download_method = get_option( 'woocommerce_file_download_method', 'force' );
 
 		$files = array(

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1206,15 +1206,12 @@ CREATE TABLE {$wpdb->prefix}wc_tax_rate_classes (
 				'file'    => 'index.html',
 				'content' => '',
 			),
-		);
-
-		if ( 'redirect' !== $download_method ) {
-			$files[] = array(
+			array(
 				'base'    => $upload_dir['basedir'] . '/woocommerce_uploads',
 				'file'    => '.htaccess',
-				'content' => 'deny from all',
-			);
-		}
+				'content' => 'redirect' === $download_method ? 'Options -Indexes' : 'deny from all',
+			),
+		);
 
 		foreach ( $files as $file ) {
 			if ( wp_mkdir_p( $file['base'] ) && ! file_exists( trailingslashit( $file['base'] ) . $file['file'] ) ) {

--- a/tests/legacy/unit-tests/admin/settings.php
+++ b/tests/legacy/unit-tests/admin/settings.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Checkout tests.
+ *
+ * @package WooCommerce\Tests\Checkout
+ */
+
+/**
+ * Class WC_Tests_Admin_Settings.
+ */
+class WC_Tests_Admin_Settings extends WC_Unit_Test_Case {
+
+	/**
+	 * Test WC_Admin_Settings::check_download_folder_protection().
+	 */
+	public function test_check_download_folder_protection() {
+		$default    = get_option( 'woocommerce_file_download_method' );
+		$upload_dir = wp_get_upload_dir();
+		$file_path  = $upload_dir['basedir'] . '/woocommerce_uploads/.htaccess';
+
+		// Test with "force" downloads method.
+		update_option( 'woocommerce_file_download_method', 'force' );
+		WC_Admin_Settings::check_download_folder_protection();
+		$file_content = @file_get_contents( $file_path );
+		$this->assertEquals( 'deny from all', $file_content );
+
+		// Test with "redirect" downloads method.
+		update_option( 'woocommerce_file_download_method', 'redirect' );
+		WC_Admin_Settings::check_download_folder_protection();
+		$file_content = @file_get_contents( $file_path );
+		$this->assertEquals( 'Options -Indexes', $file_content );
+
+		update_option( 'woocommerce_file_download_method', $default );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently we remove our `.htaccess` from `wp-content/uploads/woocommerce_uploads` if using the "Redirect" download method.
While the `index.html` will still keep some files save, we should still disable directory listing.

### How to test the changes in this Pull Request:

1. Checkout this branch.
2. Go to `wp-admin/admin.php?page=wc-settings&tab=products&section=downloadable`.
3. Set "File download method" to "Redirect only (Insecure)"
4. Open `wp-content/uploads/woocommerce_uploads/.htaccess` and check if it contains `Options -Indexes`.
5. Set "File download method" to any other option and check if the `.htaccess`  content changed to `deny from all`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Disallow directory listing in `woocommerce_uploads` when "Redirect only" it's the selected download method.
