### PR TITLE
Make WC_Cart::display_prices_including_tax() aware of tax display changes

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -95,9 +95,8 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * Constructor for the cart class. Loads options and hooks in the init method.
 	 */
 	public function __construct() {
-		$this->session          = new WC_Cart_Session( $this );
-		$this->fees_api         = new WC_Cart_Fees( $this );
-		$this->tax_display_cart = $this->is_tax_displayed();
+		$this->session  = new WC_Cart_Session( $this );
+		$this->fees_api = new WC_Cart_Fees( $this );
 
 		// Register hooks for the objects.
 		$this->session->init();

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -363,7 +363,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	public function display_prices_including_tax() {
 		$customer_exempt = $this->get_customer() && $this->get_customer()->get_is_vat_exempt();
 
-		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, 'incl' === $this->tax_display_cart && ! $customer_exempt );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, 'incl' === $this->is_tax_displayed() && ! $customer_exempt );
 	}
 
 	/*

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -42,13 +42,6 @@ class WC_Cart extends WC_Legacy_Cart {
 	public $applied_coupons = array();
 
 	/**
-	 * Are prices in the cart displayed inc or excl tax?
-	 *
-	 * @var string
-	 */
-	public $tax_display_cart = 'incl';
-
-	/**
 	 * This stores the chosen shipping methods for the cart item packages.
 	 *
 	 * @var array

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -100,6 +100,8 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Magic getters.
 	 *
+	 * If you add/remove cases here please update $legacy_keys in __isset accordingly.
+	 *
 	 * @param string $name Property name.
 	 * @return mixed
 	 */

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -60,8 +60,32 @@ abstract class WC_Legacy_Cart {
 	public function __isset( $name ) {
 		$legacy_keys = array_merge(
 			array(
-				'tax_display_cart',
+				'dp',
+				'prices_include_tax',
+				'round_at_subtotal',
+				'cart_contents_total',
+				'total',
+				'subtotal',
+				'subtotal_ex_tax',
+				'tax_total',
+				'fee_total',
+				'discount_cart',
+				'discount_cart_tax',
+				'shipping_total',
+				'shipping_tax_total',
+				'display_totals_ex_tax',
+				'display_cart_ex_tax',
+				'cart_contents_weight',
+				'cart_contents_count',
+				'coupons',
+				'taxes',
+				'shipping_taxes',
+				'coupon_discount_amounts',
+				'coupon_discount_tax_amounts',
 				'fees',
+				'tax',
+				'discount_total',
+				'tax_display_cart',
 			),
 			is_array( $this->cart_session_data ) ? array_keys( $this->cart_session_data ) : array()
 		);

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -58,9 +58,18 @@ abstract class WC_Legacy_Cart {
 	 * @param mixed  $value Value to set.
 	 */
 	public function __isset( $name ) {
-		if ( array_key_exists( $name, $this->cart_session_data ) || 'fees' === $name ) {
+		$legacy_keys = array_merge(
+			array(
+				'tax_display_cart',
+				'fees',
+			),
+			array_keys( $this->cart_session_data )
+		);
+
+		if ( in_array( $key, $legacy_keys, true ) ) {
 			return true;
 		}
+
 		return false;
 	}
 
@@ -163,6 +172,10 @@ abstract class WC_Legacy_Cart {
 			case 'discount_total':
 				wc_deprecated_argument( 'WC_Cart->discount_total', '2.3', 'After tax coupons are no longer supported. For more information see: https://woocommerce.wordpress.com/2014/12/upcoming-coupon-changes-in-woocommerce-2-3/' );
 				$value = 0;
+				break;
+			case 'tax_display_cart':
+				wc_deprecated_argument( 'WC_Cart->tax_display_cart', '4.3', 'Use WC_Cart->is_tax_displayed() instead.' );
+				$value = $this->is_tax_displayed();
 				break;
 		}
 		return $value;

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -63,10 +63,10 @@ abstract class WC_Legacy_Cart {
 				'tax_display_cart',
 				'fees',
 			),
-			array_keys( $this->cart_session_data )
+			is_array( $this->cart_session_data ) ? array_keys( $this->cart_session_data ) : array()
 		);
 
-		if ( in_array( $key, $legacy_keys, true ) ) {
+		if ( in_array( $name, $legacy_keys, true ) ) {
 			return true;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

By default we set `WC_Cart::$tax_display_cart` as the value of `WC_Cart::is_tax_displayed` in the `WC_Cart::constructor`, and it's used only inside `WC_Cart::display_prices_including_tax`.
Now note that both `WC_Cart::is_tax_displayed` and `WC_Cart::display_prices_including_tax` calls `WC_Customer::get_is_vat_exempt()`, but this value may change after the cart is initialized causing incorrect display of taxes.

Since `WC_Cart::$tax_display_cart` it's used only inside `WC_Cart::display_prices_including_tax` maybe we could deprecate it.

Closes #26242.

### How to test the changes in this Pull Request:

See #26242

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Make `WC_Cart::display_prices_including_tax` aware of tax display changes.
Dev - Deprecated `WC_Legacy_Cart::tax_display_cart` in favor of `WC_Cart:: get_tax_price_display_mode()`.