### PR TITLE
Add tracking event on order search.

### DIFF
--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -21,6 +21,26 @@ class WC_Orders_Tracking {
 		// WC_Meta_Box_Order_Actions::save() hooks in at priority 50.
 		add_action( 'woocommerce_process_shop_order_meta', array( $this, 'track_order_action' ), 51 );
 		add_action( 'load-post-new.php', array( $this, 'track_add_order_from_edit' ), 10 );
+		add_filter( 'woocommerce_shop_order_search_results', array( $this, 'track_order_search' ), 10, 3 );
+	}
+
+	/**
+	 * Send a track event when on the Order Listing page, and search results are being displayed.
+	 *
+	 * @param array  $order_ids Array of order_ids that are matches for the search.
+	 * @param string $term The string that was used in the search.
+	 * @param array  $search_fields Fields that were used in the original search.
+	 */
+	public function track_order_search( $order_ids, $term, $search_fields ) {
+		$screen = get_current_screen();
+
+		// We only want to record this track when the filter is executed on the order listing page.
+		if ( 'edit-shop_order' === $screen->id ) {
+			// we are on the order listing page, and query results are being shown.
+			WC_Tracks::record_event( 'orders_view_search' );
+		}
+
+		return $order_ids;
 	}
 
 	/**

--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -32,6 +32,11 @@ class WC_Orders_Tracking {
 	 * @param array  $search_fields Fields that were used in the original search.
 	 */
 	public function track_order_search( $order_ids, $term, $search_fields ) {
+		// Since `woocommerce_shop_order_search_results` can run in the front-end context, exit if get_current_screen isn't defined.
+		if ( ! function_exists( 'get_current_screen' ) ) {
+			return $order_ids;
+		}
+
 		$screen = get_current_screen();
 
 		// We only want to record this track when the filter is executed on the order listing page.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

For #26381 - This branch adds in a new tracking event when users execute a Search on the order listing page.

### How to test the changes in this Pull Request:
It might be helpful to [add in this code](https://gist.github.com/timmyc/edf820bded9a805a0746751a421bfb8a#file-woo-tracks-filter-examples-php-L42) to your local install to easily see track events being recorded in your local error log. Also be sure your local site is opted in to usage tracking via `WooCommerce > Settings > Advanced > WooCommerce.com`

1. Navigate to the Order Listing Page `wp-admin/edit.php?post_type=shop_order`
2. Tail your log file, then enter a search in the "Search Orders" box
3. On the subsequent page load, note that two tracks have been recorded: `wcadmin_orders_view`, and the new one added in this PR `wcadmin_orders_view_search`

### Other information:

The filter used here was the best one I could find personally ( after quite a bit of hunting ) but if anyone reviewing knows of a similar hook that I could use instead, I'd be happy to adjust!

### Changelog entry

Dev: Add tracking event to order searches.
