### PR TITLE
Allow different notice types with WC_Admin_Notices

### DIFF
--- a/assets/css/activation.scss
+++ b/assets/css/activation.scss
@@ -9,7 +9,10 @@
 div.woocommerce-message {
 	overflow: hidden;
 	position: relative;
-	border-left-color: #cc99c2 !important;
+
+	&.updated {
+		border-left-color: #cc99c2 !important;
+	}
 }
 
 p.woocommerce-actions,

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -541,8 +541,11 @@
 
 .woocommerce-message {
 	position: relative;
-	border-left-color: #cc99c2 !important;
 	overflow: hidden;
+
+	&.updated {
+		border-left-color: #cc99c2 !important;
+	}
 
 	a.skip,
 	a.docs {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently we force the same border color (#cc99c2) for all types of notices generated by `WC_Admin_Notices`, making impossible to use classes like `notice-error`, `notice-warning`, and so on.

![Screenshot from 2020-05-07 16-20-59](https://user-images.githubusercontent.com/1264099/81336287-6e0fd880-907f-11ea-9c77-891aec9106da.png)

This PR allows the use of other classes, forcing to display as #cc99c2 only if uses the `.updated` class.

### How to test the changes in this Pull Request:

1. First you need to trigger some message on WooCommerce, it's easier if you are testing on a clean install, but you can also test it on localhost without HTTPS, and restore WooCommerce's notice about HTTPS with:
```php
delete_user_meta( get_current_user_id(), 'dismissed_no_secure_connection_notice', true ); // Allow message to display again for your user
WC_Admin_Notices::reset_admin_notices(); // Reset all admin notices.
```
2. Now you can try change any WooCommerce notice class using your browser console, you can try replace `updated` to `notice notice-error` and check that the notice border color it's still the same.
3. Checkout this branch and run `grunt css`.
4. Reload your admin page and try again change those classes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Allow set different notice types with `WC_Admin_Notices`.
