### PR TITLE
Pass the result of _n() through sprintf() to ensure placeholders are replaced

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -466,12 +466,15 @@ class WC_Form_Handler {
 
 			if ( WC_Rate_Limiter::retried_too_soon( $rate_limit_id ) ) {
 				wc_add_notice(
-					/* translators: %d number of seconds */
-					_n(
-						'You cannot add a new payment method so soon after the previous one. Please wait for %d second.',
-						'You cannot add a new payment method so soon after the previous one. Please wait for %d seconds.',
-						$delay,
-						'woocommerce'
+					sprintf(
+						/* translators: %d number of seconds */
+						_n(
+							'You cannot add a new payment method so soon after the previous one. Please wait for %d second.',
+							'You cannot add a new payment method so soon after the previous one. Please wait for %d seconds.',
+							$delay,
+							'woocommerce'
+						),
+						$delay
 					),
 					'error'
 				);


### PR DESCRIPTION
In relation to this message:

> You cannot add a new payment method so soon after the previous one. Please wait for **%d** seconds.

The `%d` placeholder is output because we don't do any further processing with `sprintf()` or other function. This change fixes that, making the above render as:

> You cannot add a new payment method so soon after the previous one. Please wait for **20** seconds.

(Or whatever number of seconds is appropriate.)

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Acting as a customer, set up a payment method.
2. Try adding an additional payment method (do this quickly!).
3. Confirm the above noted error message displays appropriately and the message contains the correct number of seconds, not `%d`.

### Changelog entry

> Fix - Fixes the display of a warning message in the payment methods area.
