### PR TITLE
Add tracking events on products view and search.

### DIFF
--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -35,14 +35,22 @@ class WC_Products_Tracking {
 		// Otherwise, we would double-record the view and search events.
 
 		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
-		if ( isset( $_GET['post_type'] )
+		if (
+			isset( $_GET['post_type'] )
 			&& 'product' === wp_unslash( $_GET['post_type'] )
-			&& ! isset( $_GET['_wp_http_referer'] ) ) {
+			&& ! isset( $_GET['_wp_http_referer'] )
+		) {
 			// phpcs:enable
 
 			WC_Tracks::record_event( 'products_view' );
 
-			if ( isset( $_GET['s'] ) ) {
+			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
+			if (
+				isset( $_GET['s'] )
+				&& 0 < strlen( sanitize_text_field( wp_unslash( $_GET['s'] ) ) )
+			) {
+				// phpcs:enable
+
 				WC_Tracks::record_event( 'products_search' );
 			}
 		}

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -28,8 +28,23 @@ class WC_Products_Tracking {
 	 * Send a Tracks event when the Products page is viewed.
 	 */
 	public function track_products_view() {
-		if ( isset( $_GET['post_type'] ) && 'product' === wp_unslash( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		// We only record Tracks event when no `_wp_http_referer` query arg is set, since
+		// when searching, the request gets sent from the browser twice,
+		// once with the `_wp_http_referer` and once without it.
+		//
+		// Otherwise, we would double-record the view and search events.
+
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
+		if ( isset( $_GET['post_type'] )
+			&& 'product' === wp_unslash( $_GET['post_type'] )
+			&& ! isset( $_GET['_wp_http_referer'] ) ) {
+			// phpcs:enable
+
 			WC_Tracks::record_event( 'products_view' );
+
+			if ( isset( $_GET['s'] ) ) {
+				WC_Tracks::record_event( 'products_search' );
+			}
 		}
 	}
 

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -17,11 +17,22 @@ class WC_Products_Tracking {
 	 * Init tracking.
 	 */
 	public function init() {
+		add_action( 'load-edit.php', array( $this, 'track_products_view' ), 10 );
 		add_action( 'edit_post', array( $this, 'track_product_updated' ), 10, 2 );
 		add_action( 'transition_post_status', array( $this, 'track_product_published' ), 10, 3 );
 		add_action( 'created_product_cat', array( $this, 'track_product_category_created' ) );
 		add_action( 'add_meta_boxes_product', array( $this, 'track_product_updated_client_side' ), 10 );
 	}
+
+	/**
+	 * Send a Tracks event when the Products page is viewed.
+	 */
+	public function track_products_view() {
+		if ( isset( $_GET['post_type'] ) && 'product' === wp_unslash( $_GET['post_type'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			WC_Tracks::record_event( 'products_view' );
+		}
+	}
+
 
 	/**
 	 * Send a Tracks event when a product is updated.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

For #26381 - This branch adds in a new tracking events when users view the products listing page and execute a Search on the products listing page.

### How to test the changes in this Pull Request:
It might be helpful to [add in this code](https://gist.github.com/timmyc/edf820bded9a805a0746751a421bfb8a#file-woo-tracks-filter-examples-php-L42) to your local install to easily see track events being recorded in your local error log. Also be sure your local site is opted in to usage tracking via `WooCommerce > Settings > Advanced > WooCommerce.com`

1. Tail your log file
2. Navigate to the Products Listing Page `wp-admin/edit.php?post_type=products`
3. Verify that `wcadmin_products_view` Tracks event has been recorded
4. Enter a search in the "Search Products" box
5. On the subsequent page load, note that two tracks have been recorded: `wcadmin_products_view` and `wcadmin_products_search`

### Other information:

I used an approach similar to used for `wcadmin_coupons_view` and `wcadmin_coupons_search`. I'm not totally enthused with my checking of `_wp_http_referer` to avoid double logging (coupons double-logs its events and should be corrected in a separate PR), so if anyone reviewing this knows of a more proper way of handling this, please let me know and I'll modify this PR. Relatedly, if anybody can explain to me why the double request happens in the first place when searching, I'd really appreciate it!

### Changelog entry

Dev: Add tracking events to products listing view and searches.