### PR TITLE
Proof of concept: Replace global functions with a class

### DIFF
--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -8,6 +8,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Loop;
+
 /**
  * Breadcrumb class.
  */
@@ -19,6 +21,20 @@ class WC_Breadcrumb {
 	 * @var array
 	 */
 	protected $crumbs = array();
+
+	/**
+	 * @var Loop Reference to the instance of the Loop class.
+	 */
+	protected $loop;
+
+	/**
+	 * Create an instance of the class.
+	 *
+	 * @param string $loop Usually null, a mocked instance of Loop can be passed for unit testing.
+	 */
+	public function __construct( $loop = null ) {
+		$this->loop = is_null( $loop ) ? Loop::get_instance() : $loop;
+	}
 
 	/**
 	 * Add a crumb so we don't get lost.
@@ -371,7 +387,7 @@ class WC_Breadcrumb {
 	 * Add a breadcrumb for pagination.
 	 */
 	protected function paged_trail() {
-		if ( get_query_var( 'paged' ) && 'subcategories' !== woocommerce_get_loop_display_mode() ) {
+		if ( get_query_var( 'paged' ) && 'subcategories' !== $this->loop->get_loop_display_mode() ) {
 			/* translators: %d: page number */
 			$this->add_crumb( sprintf( __( 'Page %d', 'woocommerce' ), get_query_var( 'paged' ) ) );
 		}

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -150,6 +150,8 @@ class WC_Shortcodes {
 	 * @return string
 	 */
 	public static function product_categories( $atts ) {
+		$loop = Loop::get_instance();
+
 		if ( isset( $atts['number'] ) ) {
 			$atts['limit'] = $atts['number'];
 		}
@@ -210,13 +212,13 @@ class WC_Shortcodes {
 
 		$columns = absint( $atts['columns'] );
 
-		wc_set_loop_prop( 'columns', $columns );
-		wc_set_loop_prop( 'is_shortcode', true );
+		$loop->set_loop_prop( 'columns', $columns );
+		$loop->set_loop_prop( 'is_shortcode', true );
 
 		ob_start();
 
 		if ( $product_categories ) {
-			woocommerce_product_loop_start();
+			$loop->product_loop_start();
 
 			foreach ( $product_categories as $category ) {
 				wc_get_template(
@@ -227,10 +229,10 @@ class WC_Shortcodes {
 				);
 			}
 
-			woocommerce_product_loop_end();
+			$loop->product_loop_end();
 		}
 
-		woocommerce_reset_loop();
+		$loop->reset_loop();
 
 		return '<div class="woocommerce columns-' . $columns . '">' . ob_get_clean() . '</div>';
 	}

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -8,6 +8,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Loop;
+
 /**
  * Main WooCommerce Class.
  *
@@ -154,6 +156,7 @@ final class WooCommerce {
 		$this->define_constants();
 		$this->define_tables();
 		$this->includes();
+		$this->init_singletons();
 		$this->init_hooks();
 	}
 
@@ -470,6 +473,10 @@ final class WooCommerce {
 		$this->query = new WC_Query();
 		$this->api   = new WC_API();
 		$this->api->init();
+	}
+
+	private function init_singletons() {
+		Loop::get_instance();
 	}
 
 	/**

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -49,4 +49,7 @@
 	<listeners>
 		<listener class="SpeedTrapListener" file="tests/legacy/includes/listener-loader.php" />
 	</listeners>
+	<php>
+		<const name="RUNNING_UNIT_TESTS" value="true"/>
+	</php>
 </phpunit>

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -9,6 +9,8 @@ namespace Automattic\WooCommerce;
 
 defined( 'ABSPATH' ) || exit;
 
+require_once dirname( __DIR__ ) . '/src/Loop.php';
+
 /**
  * Autoloader class.
  *

--- a/src/Loop.php
+++ b/src/Loop.php
@@ -1,0 +1,255 @@
+<?php
+
+
+namespace Automattic\WooCommerce;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Class that handles the product loop.
+ *
+ * @package Automattic\WooCommerce
+ */
+class Loop {
+	/**
+	 * @var Loop Holds the only existing instance of the class.
+	 */
+	private static $instance = null;
+
+	/**
+	 * @return Loop Get the only existing instance of the class.
+	 */
+	public static function get_instance() {
+		if ( is_null( self::$instance ) ) {
+			self::$instance = new self();
+		}
+
+		return self::$instance;
+	}
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		add_action( 'woocommerce_before_shop_loop', array( $this, 'setup_loop' ) );
+		add_action( 'woocommerce_after_shop_loop', array( $this, 'reset_loop' ), 999 );
+	}
+
+	/**
+	 * Set the value of the only existing instance of the class. Intended for unit tests only.
+	 *
+	 * @param Loop $instance Instance to set.
+	 *
+	 * @throws \Exception Method invoked outside a unit testing session.
+	 */
+	public static function set_instance( $instance ) {
+		if ( ! defined( 'RUNNING_UNIT_TESTS' ) ) {
+			throw new \Exception( 'set_instance can be used only when running unit tests.' );
+		}
+		self::$instance = $instance;
+	}
+
+	/**
+	 * Sets up the woocommerce_loop global from the passed args or from the main query.
+	 *
+	 * @since 3.3.0
+	 * @param array $args Args to pass into the global.
+	 */
+	public function setup_loop( $args = array() ) {
+		$default_args = array(
+			'loop'         => 0,
+			'columns'      => wc_get_default_products_per_row(),
+			'name'         => '',
+			'is_shortcode' => false,
+			'is_paginated' => true,
+			'is_search'    => false,
+			'is_filtered'  => false,
+			'total'        => 0,
+			'total_pages'  => 0,
+			'per_page'     => 0,
+			'current_page' => 1,
+		);
+
+		// If this is a main WC query, use global args as defaults.
+		if ( $GLOBALS['wp_query']->get( 'wc_query' ) ) {
+			$default_args = array_merge(
+				$default_args,
+				array(
+					'is_search'    => $GLOBALS['wp_query']->is_search(),
+					'is_filtered'  => is_filtered(),
+					'total'        => $GLOBALS['wp_query']->found_posts,
+					'total_pages'  => $GLOBALS['wp_query']->max_num_pages,
+					'per_page'     => $GLOBALS['wp_query']->get( 'posts_per_page' ),
+					'current_page' => max( 1, $GLOBALS['wp_query']->get( 'paged', 1 ) ),
+				)
+			);
+		}
+
+		// Merge any existing values.
+		if ( isset( $GLOBALS['woocommerce_loop'] ) ) {
+			$default_args = array_merge( $default_args, $GLOBALS['woocommerce_loop'] );
+		}
+
+		$GLOBALS['woocommerce_loop'] = wp_parse_args( $args, $default_args );
+	}
+
+	/**
+	 * Resets the woocommerce_loop global.
+	 *
+	 * @since 3.3.0
+	 */
+	public function reset_loop() {
+		unset( $GLOBALS['woocommerce_loop'] );
+	}
+
+	/**
+	 * Gets a property from the woocommerce_loop global.
+	 *
+	 * @since 3.3.0
+	 * @param string $prop Prop to get.
+	 * @param string $default Default if the prop does not exist.
+	 * @return mixed
+	 */
+	public function get_loop_prop( $prop, $default = '' ) {
+		$this->setup_loop(); // Ensure shop loop is setup.
+
+		return isset( $GLOBALS['woocommerce_loop'], $GLOBALS['woocommerce_loop'][ $prop ] ) ? $GLOBALS['woocommerce_loop'][ $prop ] : $default;
+	}
+
+	/**
+	 * Sets a property in the woocommerce_loop global.
+	 *
+	 * @since 3.3.0
+	 * @param string $prop Prop to set.
+	 * @param string $value Value to set.
+	 */
+	public function set_loop_prop( $prop, $value = '' ) {
+		if ( ! isset( $GLOBALS['woocommerce_loop'] ) ) {
+			$this->setup_loop();
+		}
+		$GLOBALS['woocommerce_loop'][ $prop ] = $value;
+	}
+
+	/**
+	 * See what is going to display in the loop.
+	 *
+	 * @since 3.3.0
+	 * @return string Either products, subcategories, or both, based on current page.
+	 */
+	public function get_loop_display_mode() {
+		// Only return products when filtering things.
+		if ( $this->get_loop_prop( 'is_search' ) || $this->get_loop_prop( 'is_filtered' ) ) {
+			return 'products';
+		}
+
+		$parent_id    = 0;
+		$display_type = '';
+
+		if ( is_shop() ) {
+			$display_type = get_option( 'woocommerce_shop_page_display', '' );
+		} elseif ( is_product_category() ) {
+			$parent_id    = get_queried_object_id();
+			$display_type = get_term_meta( $parent_id, 'display_type', true );
+			$display_type = '' === $display_type ? get_option( 'woocommerce_category_archive_display', '' ) : $display_type;
+		}
+
+		if ( ( ! is_shop() || 'subcategories' !== $display_type ) && 1 < wc_get_loop_prop( 'current_page' ) ) {
+			return 'products';
+		}
+
+		// Ensure valid value.
+		if ( '' === $display_type || ! in_array( $display_type, array( 'products', 'subcategories', 'both' ), true ) ) {
+			$display_type = 'products';
+		}
+
+		// If we're showing categories, ensure we actually have something to show.
+		if ( in_array( $display_type, array( 'subcategories', 'both' ), true ) ) {
+			$subcategories = woocommerce_get_product_subcategories( $parent_id );
+
+			if ( empty( $subcategories ) ) {
+				$display_type = 'products';
+			}
+		}
+
+		return $display_type;
+	}
+
+	/**
+	 * Should the WooCommerce loop be displayed?
+	 *
+	 * This will return true if we have posts (products) or if we have subcats to display.
+	 *
+	 * @since 3.4.0
+	 * @return bool
+	 */
+	public function in_product_loop() {
+		return have_posts() || 'products' !== $this->get_loop_display_mode();
+	}
+
+	/**
+	 * Get classname for woocommerce loops.
+	 *
+	 * @since 2.6.0
+	 * @return string
+	 * @deprecated Use get_loop_class in Loop class instead.
+	 */
+	public function get_loop_class() {
+		$loop_index = $this->get_loop_prop( 'loop', 0 );
+		$columns    = absint( max( 1, wc_get_loop_prop( 'columns', wc_get_default_products_per_row() ) ) );
+
+		$loop_index ++;
+		$this->set_loop_prop( 'loop', $loop_index );
+
+		if ( 0 === ( $loop_index - 1 ) % $columns || 1 === $columns ) {
+			return 'first';
+		}
+
+		if ( 0 === $loop_index % $columns ) {
+			return 'last';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Output the start of a product loop. By default this is a UL.
+	 *
+	 * @param bool $echo Should echo?.
+	 * @return string
+	 */
+	public function product_loop_start( $echo = true ) {
+		ob_start();
+
+		$this->set_loop_prop( 'loop', 0 );
+
+		wc_get_template( 'loop/loop-start.php' );
+
+		$loop_start = apply_filters( 'woocommerce_product_loop_start', ob_get_clean() );
+
+		if ( $echo ) {
+			echo $loop_start; // WPCS: XSS ok.
+		} else {
+			return $loop_start;
+		}
+	}
+
+	/**
+	 * Output the end of a product loop. By default this is a UL.
+	 *
+	 * @param bool $echo Should echo?.
+	 * @return string
+	 */
+	public function product_loop_end( $echo = true ) {
+		ob_start();
+
+		wc_get_template( 'loop/loop-end.php' );
+
+		$loop_end = apply_filters( 'woocommerce_product_loop_end', ob_get_clean() );
+
+		if ( $echo ) {
+			echo $loop_end; // WPCS: XSS ok.
+		} else {
+			return $loop_end;
+		}
+	}
+}

--- a/templates/archive-product.php
+++ b/templates/archive-product.php
@@ -17,6 +17,8 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Loop;
+
 get_header( 'shop' );
 
 /**
@@ -27,6 +29,8 @@ get_header( 'shop' );
  * @hooked WC_Structured_Data::generate_website_data() - 30
  */
 do_action( 'woocommerce_before_main_content' );
+
+$loop = Loop::get_instance();
 
 ?>
 <header class="woocommerce-products-header">
@@ -45,7 +49,7 @@ do_action( 'woocommerce_before_main_content' );
 	?>
 </header>
 <?php
-if ( woocommerce_product_loop() ) {
+if ( $loop->in_product_loop() ) {
 
 	/**
 	 * Hook: woocommerce_before_shop_loop.
@@ -56,9 +60,9 @@ if ( woocommerce_product_loop() ) {
 	 */
 	do_action( 'woocommerce_before_shop_loop' );
 
-	woocommerce_product_loop_start();
+	$loop->product_loop_start();
 
-	if ( wc_get_loop_prop( 'total' ) ) {
+	if ( $loop->get_loop_prop( 'total' ) ) {
 		while ( have_posts() ) {
 			the_post();
 
@@ -71,7 +75,7 @@ if ( woocommerce_product_loop() ) {
 		}
 	}
 
-	woocommerce_product_loop_end();
+	$loop->product_loop_end();
 
 	/**
 	 * Hook: woocommerce_after_shop_loop.

--- a/templates/cart/cross-sells.php
+++ b/templates/cart/cross-sells.php
@@ -17,13 +17,17 @@
 
 defined( 'ABSPATH' ) || exit;
 
+use Automattic\WooCommerce\Loop;
+
 if ( $cross_sells ) : ?>
 
 	<div class="cross-sells">
 
 		<h2><?php esc_html_e( 'You may be interested in&hellip;', 'woocommerce' ); ?></h2>
 
-		<?php woocommerce_product_loop_start(); ?>
+		<?php $loop = Loop::get_instance(); ?>
+
+		<?php $loop->product_loop_start(); ?>
 
 			<?php foreach ( $cross_sells as $cross_sell ) : ?>
 
@@ -37,7 +41,7 @@ if ( $cross_sells ) : ?>
 
 			<?php endforeach; ?>
 
-		<?php woocommerce_product_loop_end(); ?>
+		<?php $loop->product_loop_end(); ?>
 
 	</div>
 	<?php

--- a/templates/loop/loop-start.php
+++ b/templates/loop/loop-start.php
@@ -15,8 +15,10 @@
  * @version     3.3.0
  */
 
+use Automattic\WooCommerce\Loop;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<ul class="products columns-<?php echo esc_attr( wc_get_loop_prop( 'columns' ) ); ?>">
+<ul class="products columns-<?php echo esc_attr( Loop::get_instance()->get_loop_prop( 'columns' ) ); ?>">

--- a/templates/loop/pagination.php
+++ b/templates/loop/pagination.php
@@ -19,8 +19,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$total   = isset( $total ) ? $total : wc_get_loop_prop( 'total_pages' );
-$current = isset( $current ) ? $current : wc_get_loop_prop( 'current_page' );
+use Automattic\WooCommerce\Loop;
+
+$loop    = Loop::get_instance();
+$total   = isset( $total ) ? $total : $loop->get_loop_prop( 'total_pages' );
+$current = isset( $current ) ? $current : $loop->get_loop_prop( 'current_page' );
 $base    = isset( $base ) ? $base : esc_url_raw( str_replace( 999999999, '%#%', remove_query_arg( 'add-to-cart', get_pagenum_link( 999999999, false ) ) ) );
 $format  = isset( $format ) ? $format : '';
 

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -19,19 +19,22 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Loop;
+
 if ( $related_products ) : ?>
 
 	<section class="related products">
 
 		<?php
+		$loop    = Loop::get_instance();
 		$heading = apply_filters( 'woocommerce_product_related_products_heading', __( 'Related products', 'woocommerce' ) );
 
 		if ( $heading ) :
 			?>
 			<h2><?php echo esc_html( $heading ); ?></h2>
 		<?php endif; ?>
-		
-		<?php woocommerce_product_loop_start(); ?>
+
+		<?php $loop->product_loop_start(); ?>
 
 			<?php foreach ( $related_products as $related_product ) : ?>
 
@@ -45,7 +48,7 @@ if ( $related_products ) : ?>
 
 			<?php endforeach; ?>
 
-		<?php woocommerce_product_loop_end(); ?>
+		<?php $loop->product_loop_end(); ?>
 
 	</section>
 	<?php

--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -19,6 +19,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+use Automattic\WooCommerce\Loop;
+
 if ( $upsells ) : ?>
 
 	<section class="up-sells upsells products">
@@ -30,7 +32,9 @@ if ( $upsells ) : ?>
 			<h2><?php echo esc_html( $heading ); ?></h2>
 		<?php endif; ?>
 
-		<?php woocommerce_product_loop_start(); ?>
+		<?php $loop = Loop::get_instance(); ?>
+
+		<?php $loop->product_loop_start(); ?>
 
 			<?php foreach ( $upsells as $upsell ) : ?>
 
@@ -44,7 +48,7 @@ if ( $upsells ) : ?>
 
 			<?php endforeach; ?>
 
-		<?php woocommerce_product_loop_end(); ?>
+		<?php $loop->product_loop_end(); ?>
 
 	</section>
 


### PR DESCRIPTION
## What?

This commit shows how standalone functions could be replaced with a class (keeping the functions but deprecating them) by doing that with the product loop related functions (except those that render HTML).

## Why?

To ease unit testing. Functions aren't easy to mock, classes are.

## How?

1. Create a class inside `src` containing the code for all the functions.
   - Remove `woocommerce_` or `woo_` prefixes from the names.
     Enhance the resulting names if appropriate (e.g. `product_loop` -> `in_product_loop`).
   - Include actions/filters hooking that target the functions in the constructor.
   - Include a private `instance` property and a static `get_instance` method that instantiates the class the first time it is invoked.
   - Include a `set_instance` method intended for unit tests only (this can be enforced via constant, more on that later).

2. Mark the original functions as deprecated, and have them just invoke the method in the singleton instance of the class.

3. Replace usages of the functions with usages of the class.
   - Usages in functions and static methods of classes: `Class::get_instance()->method()`.
   - Usages in instance methods of classes:
     - Pass the instance of the class in the class constructor, store it in a private property.
     - Default to null and in that case store `Class::get_instance()` instead.
     - Use as needed as `$this->instance->method()`.

4. Do `Class::get_instance()` in the constructor of the `WooCommerce` class, so that actions/filters are properly hooked.

5. Create the `RUNNING_UNIT_TESTS` constant in `phpunit.xml`, `set_instance` in the class checks this constant so that the method works in unit test sessions only (and throws an exception otherwise).

Now inside your unit tests you can create a mock of the class and use one of these approaches to "inject" the mock in the tested code:

- Pass the mock to the constructor of the tested class, if you are testing a class.
- Use `Class::set_instance($mock)` if your tests involve invoking functions or static methods.

## When?

The most sensible approach would be replacing a function (and other related functions for consistency) with a class when you find yourself having a hard time writing a unit test because you need to mock some functionality but you can't because that functionality is provided by the offending function.