### PR TITLE
Add tracking events on product categories and tags view and search

### DIFF
--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -18,6 +18,7 @@ class WC_Products_Tracking {
 	 */
 	public function init() {
 		add_action( 'load-edit.php', array( $this, 'track_products_view' ), 10 );
+		add_action( 'load-edit-tags.php', array( $this, 'track_categories_and_tags_view' ), 10, 2 );
 		add_action( 'edit_post', array( $this, 'track_product_updated' ), 10, 2 );
 		add_action( 'transition_post_status', array( $this, 'track_product_published' ), 10, 3 );
 		add_action( 'created_product_cat', array( $this, 'track_product_category_created' ) );
@@ -56,6 +57,47 @@ class WC_Products_Tracking {
 		}
 	}
 
+	/**
+	 * Send a Tracks event when the Products Categories and Tags page is viewed.
+	 */
+	public function track_categories_and_tags_view() {
+		// We only record Tracks event when no `_wp_http_referer` query arg is set, since
+		// when searching, the request gets sent from the browser twice,
+		// once with the `_wp_http_referer` and once without it.
+		//
+		// Otherwise, we would double-record the view and search events.
+
+		// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
+		if (
+			isset( $_GET['post_type'] )
+			&& 'product' === wp_unslash( $_GET['post_type'] )
+			&& isset( $_GET['taxonomy'] )
+			&& ! isset( $_GET['_wp_http_referer'] )
+		) {
+			$taxonomy = wp_unslash( $_GET['taxonomy'] );
+			// phpcs:enable
+
+			if ( 'product_cat' === $taxonomy ) {
+				WC_Tracks::record_event( 'categories_view' );
+			} elseif ( 'product_tag' === $taxonomy ) {
+				WC_Tracks::record_event( 'tags_view' );
+			}
+
+			// phpcs:disable WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPress.Security.NonceVerification
+			if (
+				isset( $_GET['s'] )
+				&& 0 < strlen( sanitize_text_field( wp_unslash( $_GET['s'] ) ) )
+			) {
+				// phpcs:enable
+
+				if ( 'product_cat' === $taxonomy ) {
+					WC_Tracks::record_event( 'categories_search' );
+				} elseif ( 'product_tag' === $taxonomy ) {
+					WC_Tracks::record_event( 'tags_search' );
+				}
+			}
+		}
+	}
 
 	/**
 	 * Send a Tracks event when a product is updated.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

For #26381 - This branch adds in a new tracking events when users view the categories and tags listing pages and execute a Search on the categories and tags listing pages.

### How to test the changes in this Pull Request:
It might be helpful to [add in this code](https://gist.github.com/timmyc/edf820bded9a805a0746751a421bfb8a#file-woo-tracks-filter-examples-php-L42) to your local install to easily see track events being recorded in your local error log. Also be sure your local site is opted in to usage tracking via `WooCommerce > Settings > Advanced > WooCommerce.com`

1. Tail your log file
2. Navigate to the Categories Listing Page `wp-admin/edit-tags.php?taxonomy=product_cat&post_type=product`
3. Verify that `wcadmin_categories_view` Tracks event has been recorded
4. Enter a search in the "Search Categories" box
5. On the subsequent page load, note that two tracks have been recorded: `wcadmin_categories_view` and `wcadmin_categories_search`
6. Navigate to the Tags Listing Page `wp-admin/edit-tags.php?taxonomy=product_tag&post_type=product`
7. Verify that `wcadmin_tags_view` Tracks event has been recorded
8. Enter a search in the "Search Tags" box
9. On the subsequent page load, note that two tracks have been recorded: `wcadmin_tags_view` and `wcadmin_tags_search`

### Other information:

Utilized the same approach as #26417.

### Changelog entry

Dev: Add tracking events to product categories and tags listing views and searches.