### PR TITLE
Add hooks to "Add payment method form" to show additional fields and validate input

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -459,6 +459,10 @@ class WC_Form_Handler {
 				return;
 			}
 
+			if ( ! apply_filters( 'woocommerce_add_payment_method_validation', true) ) {
+				return;
+			}
+
 			// Test rate limit.
 			$current_user_id = get_current_user_id();
 			$rate_limit_id   = 'add_payment_method_' . $current_user_id;

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -459,7 +459,7 @@ class WC_Form_Handler {
 				return;
 			}
 
-			if ( ! apply_filters( 'woocommerce_add_payment_method_validation', true) ) {
+			if ( ! apply_filters( 'woocommerce_add_payment_method_form_is_valid', true ) ) {
 				return;
 			}
 

--- a/templates/myaccount/form-add-payment-method.php
+++ b/templates/myaccount/form-add-payment-method.php
@@ -47,7 +47,7 @@ if ( $available_gateways ) : ?>
 				?>
 			</ul>
 
-			<?php do_action( 'woocommerce_add_payment_method_before_save' ); ?>
+			<?php do_action( 'woocommerce_add_payment_method_form_bottom' ); ?>
 
 			<div class="form-row">
 				<?php wp_nonce_field( 'woocommerce-add-payment-method', 'woocommerce-add-payment-method-nonce' ); ?>

--- a/templates/myaccount/form-add-payment-method.php
+++ b/templates/myaccount/form-add-payment-method.php
@@ -47,6 +47,8 @@ if ( $available_gateways ) : ?>
 				?>
 			</ul>
 
+			<?php do_action( 'woocommerce_add_payment_method_before_save' ); ?>
+
 			<div class="form-row">
 				<?php wp_nonce_field( 'woocommerce-add-payment-method', 'woocommerce-add-payment-method-nonce' ); ?>
 				<button type="submit" class="woocommerce-Button woocommerce-Button--alt button alt" id="place_order" value="<?php esc_attr_e( 'Add payment method', 'woocommerce' ); ?>"><?php esc_html_e( 'Add payment method', 'woocommerce' ); ?></button>


### PR DESCRIPTION
### All Submissions:

* [ x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #26414

### How to test the changes in this Pull Request:

1. Copy https://gist.github.com/tsteur/59f233312635e31f26d3d8c16973b179 into your theme
2. Enter 20 into the shown form field in add payment method page
3. It should show an error message and not add the card vs if you type any other number it will do it. This allows us implementation of captcha see issue description.

### Other information:

* [ x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? -> None written. Maybe not needed?
* [ x ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Dev - Added action before the "Add payment method" save button.
Dev - Added filter to validate manually added fields when adding payment method 