### PR TITLE
Add `verify_base_db` method to check if all base tables are present.

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -40,6 +40,7 @@ class WC_Admin_Notices {
 		'maxmind_license_key'              => 'maxmind_missing_license_key_notice',
 		'redirect_download_method'         => 'redirect_download_method_notice',
 		'uploads_directory_is_unprotected' => 'uploads_directory_is_unprotected_notice',
+		'base_tables_missing'              => 'base_tables_missing_notice',
 	);
 
 	/**
@@ -504,6 +505,21 @@ class WC_Admin_Notices {
 		}
 
 		include dirname( __FILE__ ) . '/views/html-notice-uploads-directory-is-unprotected.php';
+	}
+
+	/**
+	 * Notice about base tables missing.
+	 */
+	public static function base_tables_missing_notice() {
+		$notice_dismissed = apply_filters(
+			'woocommerce_hide_base_tables_missing_nag',
+			get_user_meta( get_current_user_id(), 'dismissed_base_tables_missing_notice', true )
+		);
+		if ( $notice_dismissed ) {
+			self::remove_notice( 'base_tables_missing' );
+		}
+
+		include dirname( __FILE__ ) . '/views/html-notice-base-table-missing.php';
 	}
 
 	/**

--- a/includes/admin/views/html-notice-base-table-missing.php
+++ b/includes/admin/views/html-notice-base-table-missing.php
@@ -19,14 +19,26 @@ defined( 'ABSPATH' ) || exit;
 	</p>
 	<p>
 		<?php
+		$verify_db_tool_available = array_key_exists( 'verify_db_tables', WC_Admin_Status::get_tools() );
+		$missing_tables = get_option( 'woocommerce-db-missing-tables' );
+		if ( $verify_db_tool_available ) {
 			echo wp_kses_post(
 				sprintf(
-				/* translators: %1%s: WooCommerce status page %2$s: Link to check again */
-					__( 'One or more tables required for WooCommerce to function are missing, some features may not work as expected. Please visit <a href="%1$s">WooCommerce status page</a> to see details, or <a href="%2$s"> check again.</a>', 'woocommerce' ),
-					admin_url( 'admin.php?page=wc-status#status-database' ),
+				/* translators: %1%s: Missing tables (seperated by ",") %2$s: Link to check again */
+					__( 'One or more tables required for WooCommerce to function are missing, some features may not work as expected. Missing tables: %1$s. <a href="%2$s">Check again.</a>', 'woocommerce' ),
+					esc_html( implode( ', ', $missing_tables ) ),
 					wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=verify_db_tables' ), 'debug_action' )
 				)
 			);
-			?>
+		} else {
+			echo wp_kses_post(
+				sprintf(
+				/* translators: %1%s: Missing tables (seperated by ",") */
+					__( 'One or more tables required for WooCommerce to function are missing, some features may not work as expected. Missing tables: %1$s.', 'woocommerce' ),
+					esc_html( implode( ', ', $missing_tables ) )
+				)
+			);
+		}
+		?>
 	</p>
 </div>

--- a/includes/admin/views/html-notice-base-table-missing.php
+++ b/includes/admin/views/html-notice-base-table-missing.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Admin View: Notice - Base table missing.
+ *
+ * @package WooCommerce\Admin
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+?>
+<div class="updated woocommerce-message">
+	<a class="woocommerce-message-close notice-dismiss"
+	   href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'base_tables_missing' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>">
+			<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
+	</a>
+
+	<p>
+		<strong><?php esc_html_e( 'Database tables missing', 'woocommerce' ); ?></strong>
+	</p>
+	<p>
+		<?php
+			echo wp_kses_post(
+				sprintf(
+				/* translators: %1%s: WooCommerce status page %2$s: Link to check again */
+					__( 'One or more tables required for WooCommerce to function are missing, some features may not work as expected. Please visit <a href="%1$s">WooCommerce status page</a> to see details, or <a href="%2$s"> check again.</a>', 'woocommerce' ),
+					admin_url( 'admin.php?page=wc-status#status-database' ),
+					wp_nonce_url( admin_url( 'admin.php?page=wc-status&tab=tools&action=verify_db_tables' ), 'debug_action' )
+				)
+			);
+			?>
+	</p>
+</div>

--- a/includes/admin/views/html-notice-base-table-missing.php
+++ b/includes/admin/views/html-notice-base-table-missing.php
@@ -9,9 +9,8 @@ defined( 'ABSPATH' ) || exit;
 
 ?>
 <div class="updated woocommerce-message">
-	<a class="woocommerce-message-close notice-dismiss"
-	   href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'base_tables_missing' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>">
-			<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
+	<a class="woocommerce-message-close notice-dismiss" href="<?php echo esc_url( wp_nonce_url( add_query_arg( 'wc-hide-notice', 'base_tables_missing' ), 'woocommerce_hide_notices_nonce', '_wc_notice_nonce' ) ); ?>">
+		<?php esc_html_e( 'Dismiss', 'woocommerce' ); ?>
 	</a>
 
 	<p>

--- a/includes/admin/views/html-notice-base-table-missing.php
+++ b/includes/admin/views/html-notice-base-table-missing.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 	<p>
 		<?php
 		$verify_db_tool_available = array_key_exists( 'verify_db_tables', WC_Admin_Status::get_tools() );
-		$missing_tables = get_option( 'woocommerce-db-missing-tables' );
+		$missing_tables           = get_option( 'woocommerce-schema-missing-tables' );
 		if ( $verify_db_tool_available ) {
 			echo wp_kses_post(
 				sprintf(

--- a/includes/admin/views/html-notice-base-table-missing.php
+++ b/includes/admin/views/html-notice-base-table-missing.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 	<p>
 		<?php
 		$verify_db_tool_available = array_key_exists( 'verify_db_tables', WC_Admin_Status::get_tools() );
-		$missing_tables           = get_option( 'woocommerce-schema-missing-tables' );
+		$missing_tables           = get_option( 'woocommerce_schema_missing_tables' );
 		if ( $verify_db_tool_available ) {
 			echo wp_kses_post(
 				sprintf(

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -762,7 +762,7 @@ class WC_Install {
 	 *
 	 * @return string
 	 */
-	private static function get_schema() {
+	public static function get_schema() {
 		global $wpdb;
 
 		$collate = '';

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -326,11 +326,13 @@ class WC_Install {
 			if ( $modify_notice ) {
 				WC_Admin_Notices::add_notice( 'base_tables_missing' );
 			}
+			update_option( 'woocommerce-db-missing-tables', $missing_tables );
 		} else {
 			if ( $modify_notice ) {
 				WC_Admin_Notices::remove_notice( 'base_tables_missing' );
 			}
 			update_option( 'woocommerce-db-verified', WC()->version );
+			delete_option( 'woocommerce-db-missing-tables' );
 		}
 		return $missing_tables;
 	}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -335,7 +335,7 @@ class WC_Install {
 			if ( $modify_notice ) {
 				WC_Admin_Notices::remove_notice( 'base_tables_missing' );
 			}
-			update_option( 'woocommerce_schema_version', WC()->version );
+			update_option( 'woocommerce_schema_version', WC()->db_version );
 			delete_option( 'woocommerce_schema_missing_tables' );
 		}
 		return $missing_tables;

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -330,13 +330,13 @@ class WC_Install {
 			if ( $modify_notice ) {
 				WC_Admin_Notices::add_notice( 'base_tables_missing' );
 			}
-			update_option( 'woocommerce-schema-missing-tables', $missing_tables );
+			update_option( 'woocommerce_schema_missing_tables', $missing_tables );
 		} else {
 			if ( $modify_notice ) {
 				WC_Admin_Notices::remove_notice( 'base_tables_missing' );
 			}
-			update_option( 'woocommerce-schema-version', WC()->version );
-			delete_option( 'woocommerce-schema-missing-tables' );
+			update_option( 'woocommerce_schema_version', WC()->version );
+			delete_option( 'woocommerce_schema_missing_tables' );
 		}
 		return $missing_tables;
 	}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -674,7 +674,7 @@ class WC_Install {
 	 *      woocommerce_tax_rates - Tax Rates are stored inside 2 tables making tax queries simple and efficient.
 	 *      woocommerce_tax_rate_locations - Each rate can be applied to more than one postcode/city hence the second table.
 	 */
-	public static function create_tables() {
+	private static function create_tables() {
 		global $wpdb;
 
 		$wpdb->hide_errors();
@@ -770,7 +770,7 @@ class WC_Install {
 	 *
 	 * @return string
 	 */
-	public static function get_schema() {
+	private static function get_schema() {
 		global $wpdb;
 
 		$collate = '';

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -318,7 +318,7 @@ class WC_Install {
 		if ( $execute ) {
 			self::create_tables();
 		}
-		$queries = dbDelta( self::get_schema(), false );
+		$queries        = dbDelta( self::get_schema(), false );
 		$missing_tables = array();
 		foreach ( $queries as $table_name => $result ) {
 			if ( "Created table $table_name" === $result ) {

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -23,6 +23,15 @@ final class WooCommerce {
 	public $version = '4.3.0';
 
 	/**
+	 * WooCommerce Schema version.
+	 *
+	 * @since 4.3 started with version string 430.
+	 *
+	 * @var string
+	 */
+	public $db_version = '430';
+
+	/**
 	 * The single instance of the class.
 	 *
 	 * @var WooCommerce

--- a/tests/php/includes/WCInstallTest.php
+++ b/tests/php/includes/WCInstallTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Class WCInstallTest file.
+ *
+ * @package WooCommerce|Tests|WCInstallTest.
+ */
+
+namespace Automattic\WooCommerce;
+
+/**
+ * Class WC_Tests_WC_Helper.
+ */
+class WCInstallTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * Test if verify base table can detect missing table and adds/remove a notice.
+	 */
+	public function test_verify_base_tables_adds_and_remove_notice() {
+		global $wpdb;
+
+		// Remove drop filter because we do want to drop temp table if it exists.
+		// This filter was added to only allow dropping temporary tables which will then be rollbacked after the test.
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		$original_table_name = "{$wpdb->prefix}wc_tax_rate_classes";
+		$changed_table_name = "{$wpdb->prefix}wc_tax_rate_classes_2";
+
+		$clear_query = 'DROP TABLE IF EXISTS %s;';
+		$rename_table_query = 'RENAME TABLE %s to %s;';
+
+		// Rename a base table to simulate it as non-existing.
+		dbDelta( \WC_Install::get_schema() ); // Restore correct state.
+		$wpdb->query( sprintf( $clear_query, $changed_table_name ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( sprintf( $rename_table_query, $original_table_name, $changed_table_name ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		$missing_tables = \WC_Install::verify_base_tables();
+
+		$wpdb->query( sprintf( $rename_table_query, $changed_table_name, $original_table_name ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		add_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		$this->assertContains( $original_table_name, $missing_tables );
+		$this->assertContains( 'base_tables_missing', \WC_Admin_Notices::get_notices() );
+
+		// Ideally, no missing table anymore because we have switched back table name.
+		$missing_tables = \WC_Install::verify_base_tables();
+
+		$this->assertNotContains( $original_table_name, $missing_tables );
+		$this->assertNotContains( 'base_tables_missing', \WC_Admin_Notices::get_notices() );
+	}
+
+}

--- a/tests/php/includes/WCInstallTest.php
+++ b/tests/php/includes/WCInstallTest.php
@@ -28,8 +28,13 @@ class WCInstallTest extends \WC_Unit_Test_Case {
 		$clear_query = 'DROP TABLE IF EXISTS %s;';
 		$rename_table_query = 'RENAME TABLE %s to %s;';
 
+		// Workaround to call a private function.
+		$schema = function () {
+			return static::get_schema();
+		};
+
 		// Rename a base table to simulate it as non-existing.
-		dbDelta( \WC_Install::get_schema() ); // Restore correct state.
+		dbDelta( $schema->call( new \WC_Install() ) ); // Restore correct state.
 		$wpdb->query( sprintf( $clear_query, $changed_table_name ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 		$wpdb->query( sprintf( $rename_table_query, $original_table_name, $changed_table_name ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
 
@@ -44,6 +49,44 @@ class WCInstallTest extends \WC_Unit_Test_Case {
 		// Ideally, no missing table anymore because we have switched back table name.
 		$missing_tables = \WC_Install::verify_base_tables();
 
+		$this->assertNotContains( $original_table_name, $missing_tables );
+		$this->assertNotContains( 'base_tables_missing', \WC_Admin_Notices::get_notices() );
+	}
+
+
+	/**
+	 * Test if verify base table can fix the table as well.
+	 */
+	public function test_verify_base_tables_fix_tables() {
+		global $wpdb;
+
+		// Remove drop filter because we do want to drop temp table if it exists.
+		// This filter was added to only allow dropping temporary tables which will then be rollbacked after the test.
+		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		$original_table_name = "{$wpdb->prefix}wc_tax_rate_classes";
+		$changed_table_name = "{$wpdb->prefix}wc_tax_rate_classes_2";
+
+		$clear_query = 'DROP TABLE IF EXISTS %s;';
+		$rename_table_query = 'RENAME TABLE %s to %s;';
+
+		// Workaround to call a private function.
+		$schema = function () {
+			return static::get_schema();
+		};
+
+		// Rename a base table to simulate it as non-existing.
+		dbDelta( $schema->call( new \WC_Install() ) ); // Restore correct state.
+		$wpdb->query( sprintf( $clear_query, $changed_table_name ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( sprintf( $rename_table_query, $original_table_name, $changed_table_name ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+
+		$missing_tables = \WC_Install::verify_base_tables( true, true );
+
+		$wpdb->query( sprintf( $clear_query, $original_table_name ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query( sprintf( $rename_table_query, $changed_table_name, $original_table_name ) ); // phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
+		add_filter( 'query', array( $this, '_drop_temporary_tables' ) );
+
+		// Ideally, no missing table because verify base tables created the table as well.
 		$this->assertNotContains( $original_table_name, $missing_tables );
 		$this->assertNotContains( 'base_tables_missing', \WC_Admin_Notices::get_notices() );
 	}

--- a/tests/php/includes/WCInstallTest.php
+++ b/tests/php/includes/WCInstallTest.php
@@ -23,10 +23,9 @@ class WCInstallTest extends \WC_Unit_Test_Case {
 		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
 
 		$original_table_name = "{$wpdb->prefix}wc_tax_rate_classes";
-		$changed_table_name = "{$wpdb->prefix}wc_tax_rate_classes_2";
-
-		$clear_query = 'DROP TABLE IF EXISTS %s;';
-		$rename_table_query = 'RENAME TABLE %s to %s;';
+		$changed_table_name  = "{$wpdb->prefix}wc_tax_rate_classes_2";
+		$clear_query         = 'DROP TABLE IF EXISTS %s;';
+		$rename_table_query  = 'RENAME TABLE %s to %s;';
 
 		// Workaround to call a private function.
 		$schema = function () {
@@ -65,10 +64,9 @@ class WCInstallTest extends \WC_Unit_Test_Case {
 		remove_filter( 'query', array( $this, '_drop_temporary_tables' ) );
 
 		$original_table_name = "{$wpdb->prefix}wc_tax_rate_classes";
-		$changed_table_name = "{$wpdb->prefix}wc_tax_rate_classes_2";
-
-		$clear_query = 'DROP TABLE IF EXISTS %s;';
-		$rename_table_query = 'RENAME TABLE %s to %s;';
+		$changed_table_name  = "{$wpdb->prefix}wc_tax_rate_classes_2";
+		$clear_query         = 'DROP TABLE IF EXISTS %s;';
+		$rename_table_query  = 'RENAME TABLE %s to %s;';
 
 		// Workaround to call a private function.
 		$schema = function () {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Adding another flag `woocommerce-schema-version`.

One of the notable changes in this PR is that we are creating another flag: `woocommerce-schema-version` to store the version till which we have verified that base schema DB is installed.

Even though we already have similar flags:

1. `woocommerce_version` to store the WooCommerce Version

2. `woocommerce_db_version` to store the version point till where we have run the update function.

I wanted to use `woocommerce_db_version` but it was not suitable because having not run update callbacks is quite different from base schema structure mismatch. Also, I did not want to prevent update callback here because this responsibility of erroring and scheduling themselves again should fall to the callback code itself.

### Changes proposed in this Pull Request:

 Add `verify_base_db` method to check if all base tables are present.

Optionally, it also adds a notice in case all DB tables are not present.

Note that we only check missing tables and don't care about exact table structure because many time tables are modified by merchants to better suit their needs (indexes, collations, etc).

### How to test the changes in this Pull Request:

Part 1

1. Rename a base table, maybe `{prefix}wc_tax_rate_classes` to `wc_tax_rate_classes_2`.
1. Comment out `self::create_tables();` line to make sure table is not created on refresh.
1. Delete option `woocommerce_version` and `woocommerce_db_version` to trigger update flow.
1. You should be able to see notice similar to 
``` 
One or more tables required for WooCommerce to functions are missing, some features may not work as expected. Missing tables: wc_wc_tax_rate_classes. 
```
Don't dismiss the notice just yet.
1. Apply the patch in https://github.com/woocommerce/woocommerce-rest-api/pull/188
1. Rename the table back to `{prefix}wc_tax_rate_classes`.
1. Refresh the page.
1. Click on "Check again" text in the notice.
1. Notice will go away on refresh.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Add `verify_base_db` method to check if all base tables are present.
