### PR TITLE
Add function to allow client-side enabling of tracks

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -102,13 +102,13 @@ class WC_Site_Tracking {
 			window.wcTracks.enable = function( callback = null ) {
 				window.wcTracks.isEnabled = true;
 
-				const scriptUrl = '<?php echo esc_url( $woo_tracks_script ); ?>';
-				const existingScript = document.querySelector( `script[src="${ scriptUrl }"]` );
+				var scriptUrl = '<?php echo esc_url( $woo_tracks_script ); ?>';
+				var existingScript = document.querySelector( `script[src="${ scriptUrl }"]` );
 				if ( existingScript ) {
 					return;
 				}
 
-				const script = document.createElement('script');
+				var script = document.createElement('script');
 				script.src = scriptUrl;
 				document.body.append(script);
 

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -83,28 +83,14 @@ class WC_Site_Tracking {
 	}
 
 	/**
-	 * Add empty tracking function to admin footer when tracking is disabled in case
-	 * it's called without checking if it's defined beforehand.
-	 */
-	public static function add_empty_tracking_function() {
-		?>
-		<script type="text/javascript">
-			window.wcTracks = window.wcTracks || {};
-			window.wcTracks.recordEvent = function() {};
-		</script>
-		<?php
-	}
-
-	/**
 	 * Init tracking.
 	 */
 	public static function init() {
 
+		// Define window.wcTracks.recordEvent in case it is enabled client-side.
+		add_filter( 'admin_footer', array( __CLASS__, 'add_tracking_function' ), 24 );
+
 		if ( ! self::is_tracking_enabled() ) {
-
-			// Define window.wcTracks.recordEvent in case there is an attempt to use it when tracking is turned off.
-			add_filter( 'admin_footer', array( __CLASS__, 'add_empty_tracking_function' ), 24 );
-
 			return;
 		}
 

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -65,7 +65,12 @@ class WC_Site_Tracking {
 		<!-- WooCommerce Tracks -->
 		<script type="text/javascript">
 			window.wcTracks = window.wcTracks || {};
+			window.wcTracks.isEnabled = <?php echo self::is_tracking_enabled() ? 'true' : 'false'; ?>;
 			window.wcTracks.recordEvent = function( name, properties ) {
+				if ( ! window.wcTracks.isEnabled ) {
+					return;
+				}
+
 				var eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
 				var eventProperties = properties || {};
 				eventProperties.url = '<?php echo esc_html( home_url() ); ?>'


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This adds a property `wcTracks.isEnabled` that can be toggled on and off to allow tracking without a roundtrip to the server.

It also adds a function to dynamically enable and inject the stats scripts so they can be loaded on the fly.

Closes #26466 

### How to test the changes in this Pull Request:

1. Set `woocommerce_allow_tracking` to `no` in your options table.
1. Make sure that `window.wcTracks.recordEvent` does not actually record any events and returns early.
1. Open your console and call `window.wcTracks.enable()` and make sure the `https://stats.wp.com/w.js` is appended to the body.
1. Call `window.wcTracks.enable()` again to make sure the script is not double appended.
1. Make a call to `window.wcTracks.recordEvent('your_event_name', {} )`.
1. Make sure the event is tracked and no errors occur.
1. Optionally, use a callback argument to `enable()`:

```
window.wcTracks.enable( () => {
    alert( 'Finished loading!' );
    window.wcTracs.recordEvent( 'your_custom_event', {} );
}
```

You can also check out this branch of wc-admin to see how this will be used - https://github.com/woocommerce/woocommerce-admin/pull/4368