### PR TITLE
Refresh db update nonce on the Thank you notice

### DIFF
--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -278,7 +278,7 @@ class WC_Notes_Run_Db_Update {
 			}
 		}
 
-		// Db update needed -> show notice.
+		// Db update needed or notice not actioned -> show notice.
 		return true;
 	}
 

--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -48,7 +48,7 @@ class WC_Notes_Run_Db_Update {
 		} catch ( Exception $e ) {
 			return;
 		}
-		$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
+		$note_ids = $data_store->get_notes_with_name( self::NOTE_NAME );
 
 		if ( empty( $note_ids ) ) {
 			return;
@@ -89,15 +89,15 @@ class WC_Notes_Run_Db_Update {
 	 *  - actions are set up for the first 'Update database' notice, and
 	 *  - URL for note's action is equal to the given URL (to check for potential nonce update).
 	 *
-	 * @param WC_Admin_Note $note Note to check.
-	 * @param string        $update_url  URL to check the note against.
-	 * @param array(string) $current_actions List of actions to check for.
+	 * @param WC_Admin_Note   $note            Note to check.
+	 * @param string          $update_url      URL to check the note against.
+	 * @param array( string ) $current_actions List of actions to check for.
 	 * @return bool
 	 */
 	private static function note_up_to_date( $note, $update_url, $current_actions ) {
 		$actions = $note->get_actions();
 		if ( count( $current_actions ) === count( array_intersect( wp_list_pluck( $actions, 'name' ), $current_actions ) )
-			&& in_array( $update_url, wp_list_pluck( $actions, 'query' ) ) ) {
+			&& in_array( $update_url, wp_list_pluck( $actions, 'query' ), true ) ) {
 			return true;
 		}
 
@@ -302,7 +302,7 @@ class WC_Notes_Run_Db_Update {
 		if ( \WC_Install::needs_db_update() ) {
 			$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_run_update_callback', null, 'woocommerce-db-updates' );
 
-			if ( $next_scheduled_date || ! empty( $_GET['do_update_woocommerce'] ) ) { // WPCS: input var ok, CSRF ok.
+			if ( $next_scheduled_date || ! empty( $_GET['do_update_woocommerce'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				self::update_in_progress_notice( $note_id );
 			} else {
 				self::update_needed_notice( $note_id );

--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -54,6 +54,16 @@ class WC_Notes_Run_Db_Update {
 			return;
 		}
 
+		if ( count( $note_ids ) > 1 ) {
+			// Remove weird duplicates. Leave the first one.
+			$current_notice = array_shift( $note_ids );
+			foreach ( $note_ids as $note_id ) {
+				$note = new WC_Admin_Note( $note_id );
+				$data_store->delete( $note );
+			}
+			return $current_notice;
+		}
+
 		return current( $note_ids );
 	}
 

--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -181,7 +181,7 @@ class WC_Notes_Run_Db_Update {
 	 * @param int $note_id Note id to update.
 	 */
 	private static function update_in_progress_notice( $note_id ) {
-		// Same actions as in includes/admin/views/html-notice-updating.php.
+		// Same actions as in includes/admin/views/html-notice-updating.php. This just redirects, performs no action, so without nonce.
 		$pending_actions_url = admin_url( 'admin.php?page=wc-status&tab=action-scheduler&s=woocommerce_run_update&status=pending' );
 		$cron_disabled       = Constants::is_true( 'DISABLE_WP_CRON' );
 		$cron_cta            = $cron_disabled ? __( 'You can manually run queued updates here.', 'woocommerce' ) : __( 'View progress →', 'woocommerce' );

--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -263,26 +263,22 @@ class WC_Notes_Run_Db_Update {
 	 */
 	private static function should_show_notice() {
 		if ( ! \WC_Install::needs_db_update() ) {
-			try {
-				$data_store = \WC_Data_Store::load( 'admin-note' );
-			} catch ( Exception $e ) {
-				// Bail out in case of incorrect use.
+
+			$note_id = self::get_current_notice();
+
+			// Db update not needed && note does not exist -> don't show it.
+			if ( ! $note_id ) {
 				return false;
 			}
-			$note_ids   = $data_store->get_notes_with_name( self::NOTE_NAME );
 
-			if ( ! empty( $note_ids ) ) {
-				// Db update not needed && note actioned -> don't show it.
-				$note = new WC_Admin_Note( $note_ids[0] );
-				if ( $note::E_WC_ADMIN_NOTE_ACTIONED === $note->get_status() ) {
-					return false;
-				}
-			} else {
-				// Db update not needed && note does not exist -> don't show it.
+			// Db update not needed && note actioned -> don't show it.
+			$note = new WC_Admin_Note( $note_id );
+			if ( $note::E_WC_ADMIN_NOTE_ACTIONED === $note->get_status() ) {
 				return false;
 			}
 		}
 
+		// Db update needed -> show notice.
 		return true;
 	}
 

--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -222,23 +222,32 @@ class WC_Notes_Run_Db_Update {
 			)
 		);
 
+		$note_actions = array(
+			array(
+				'name'    => 'update-db_done',
+				'label'   => __( 'Thanks!', 'woocommerce' ),
+				'url'     => $hide_notices_url,
+				'status'  => 'actioned',
+				'primary' => true,
+			),
+		);
+
 		$note = new WC_Admin_Note( $note_id );
+
+		// Check if the note needs to be updated (e.g. expired nonce or different note type stored in the previous run).
+		if ( self::note_up_to_date( $note, $hide_notices_url, wp_list_pluck( $note_actions, 'name' ) ) ) {
+			return $note_id;
+		}
+
 		$note->set_title( __( 'WooCommerce database update done', 'woocommerce' ) );
 		$note->set_content( __( 'WooCommerce database update complete. Thank you for updating to the latest version!', 'woocommerce' ) );
 
-		$actions = $note->get_actions();
-		if ( ! in_array( 'update-db_done', wp_list_pluck( $actions, 'name' ) ) ) {
-			$note->clear_actions();
-			$note->add_action(
-				'update-db_done',
-				__( 'Thanks!', 'woocommerce' ),
-				$hide_notices_url,
-				'actioned',
-				true
-			);
-
-			$note->save();
+		$note->clear_actions();
+		foreach ( $note_actions as $note_action ) {
+			$note->add_action( ...array_values( $note_action ) );
 		}
+
+		$note->save();
 	}
 
 	/**

--- a/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
+++ b/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
@@ -35,7 +35,7 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 	/**
 	 * Returns a list of note ids with name 'wc-update-db-reminder' from the database.
 	 *
-	 * @return array(int) List of note ids with name 'wc-update-db-reminder'.
+	 * @return array( int ) List of note ids with name 'wc-update-db-reminder'.
 	 */
 	private static function get_db_update_notes() {
 		$data_store = \WC_Data_Store::load( 'admin-note' );

--- a/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
+++ b/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
@@ -1,0 +1,191 @@
+<?php
+/**
+ * Class WC_Notes_Run_Db_Update file.
+ *
+ * @package WooCommerce\Tests\Admin\Notes
+ */
+
+use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+
+/**
+ * Tests for the WC_Notes_Run_Db_Update class.
+ */
+class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
+
+	/**
+	 * Load the necessary files, as they're not automatically loaded by WooCommerce.
+	 *
+	 */
+	public static function setUpBeforeClass() {
+		include_once WC_Unit_Tests_Bootstrap::instance()->plugin_dir . '/includes/admin/notes/class-wc-notes-run-db-update.php';
+
+	}
+
+	/**
+	 * Clean up before each test.
+	 */
+	public function setUp() {
+		self::remove_db_update_notes();
+	}
+
+	/**
+	 * Returns a list of note ids with name 'wc-update-db-reminder' from the database.
+	 *
+	 * @return array(int) List of note ids with name 'wc-update-db-reminder'.
+	 */
+	private static function get_db_update_notes() {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( WC_Notes_Run_Db_Update::NOTE_NAME );
+		return $note_ids;
+	}
+
+	/**
+	 * Removes all the notes with name 'wc-update-db-reminder' from the database.
+	 */
+	private static function remove_db_update_notes() {
+		$data_store = \WC_Data_Store::load( 'admin-note' );
+		$note_ids   = $data_store->get_notes_with_name( WC_Notes_Run_Db_Update::NOTE_NAME );
+		foreach ( $note_ids as $note_id ) {
+			$note = new WC_Admin_Note( $note_id );
+			$data_store->delete( $note );
+		}
+	}
+
+	/**
+	 * Creates a sample note with name 'wc-update-db-reminder'.
+	 *
+	 * @return int Newly create note's id.
+	 */
+	private static function create_db_update_note() {
+		$update_url = html_entity_decode(
+			wp_nonce_url(
+				add_query_arg( 'do_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ),
+				'wc_db_update',
+				'wc_db_update_nonce'
+			)
+		);
+
+		$note_actions = array(
+			array(
+				'name'    => 'update-db_run',
+				'label'   => __( 'Update WooCommerce Database', 'woocommerce' ),
+				'url'     => $update_url,
+				'status'  => 'unactioned',
+				'primary' => true,
+			),
+			array(
+				'name'    => 'update-db_learn-more',
+				'label'   => __( 'Learn more about updates', 'woocommerce' ),
+				'url'     => 'https://docs.woocommerce.com/document/how-to-update-woocommerce/',
+				'status'  => 'unactioned',
+				'primary' => false,
+			),
+		);
+
+		$note = new WC_Admin_Note();
+
+		$note->set_title( 'WooCommerce database update required' );
+		$note->set_content( 'To keep things running smoothly, we have to update your database to the newest version.' );
+		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
+		$note->set_icon( 'info' );
+		$note->set_name( WC_Notes_Run_Db_Update::NOTE_NAME );
+		$note->set_content_data( (object) array() );
+		$note->set_source( 'woocommerce-core' );
+		$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED );
+
+		// Set new actions.
+		$note->clear_actions();
+		foreach ( $note_actions as $note_action ) {
+			$note->add_action( ...array_values( $note_action ) );
+		}
+
+		return $note->save();
+	}
+
+	/**
+	 * No note should be created/exist if db version is equal to WC code version.
+	 */
+	public function test_noop_db_update_note() {
+		update_option( 'woocommerce_db_version', WC()->version );
+
+		// No notes initially.
+		$this->assertEquals( 0, count( self::get_db_update_notes() ), 'There should be no db update notes initially.' );
+
+		WC_Notes_Run_Db_Update::show_reminder();
+
+		// No notice should be created.
+		$this->assertEquals( 0, count( self::get_db_update_notes() ), 'There should be no db update notes created if db is up to date.' );
+	}
+
+
+	/**
+	 * Note should be created if there is none and WC is updated.
+	 */
+	public function test_create_db_update_note() {
+		// No notes initially.
+		$this->assertEquals( 0, count( self::get_db_update_notes() ), 'There should be no db update notes initially.' );
+
+		// Make it appear as if db version is lower than WC version, i.e. db update is required.
+		update_option( 'woocommerce_db_version', '3.9.0' );
+
+		WC_Notes_Run_Db_Update::show_reminder();
+
+		// A notice should be created.
+		$this->assertEquals( 1, count( self::get_db_update_notes() ), 'A db update note should be created if db is NOT up to date.' );
+
+		// Update the db option back.
+		update_option( 'woocommerce_db_version', WC()->version );
+	}
+
+	/**
+	 * Note should be created if there is none and WC is updated.
+	 */
+	public function test_clean_up_multiple_db_update_notes() {
+		// No notes initially.
+		$this->assertEquals( 0, count( self::get_db_update_notes() ), 'There should be no db update notes initially.' );
+
+		$note_1 = self::create_db_update_note();
+		$note_2 = self::create_db_update_note();
+
+		$this->assertEquals( 2, count( self::get_db_update_notes() ), 'There should be 2 db update notes after I created 2.' );
+
+		WC_Notes_Run_Db_Update::show_reminder();
+
+		// Only one notice should remain, in case 2 were created under some weird circumstances.
+		$this->assertEquals( 1, count( self::get_db_update_notes() ), 'A db update note should be created if db is NOT up to date.' );
+
+	}
+
+	/**
+	 * Test switch from db update needed to thanks note.
+	 */
+	public function test_db_update_note_to_thanks_note() {
+		// No notes initially.
+		$this->assertEquals( 0, count( self::get_db_update_notes() ), 'There should be no db update notes initially.' );
+
+		// Make it appear as if db version is lower than WC version, i.e. db update is required.
+		update_option( 'woocommerce_db_version', '3.9.0' );
+
+		// Magic 1: nothing to update-db note.
+		WC_Notes_Run_Db_Update::show_reminder();
+
+		$note_ids = self::get_db_update_notes();
+		// An 'update required' notice should be created.
+		$this->assertEquals( 1, count( $note_ids ), 'A db update note should be created if db is NOT up to date.' );
+
+		$note = new WC_Admin_Note( $note_ids[0] );
+		$actions = $note->get_actions();
+		$this->assertEquals( 'update-db_run', $actions[0]->name, 'A db update note to update the database should be displayed now.' );
+
+		// Simulate database update has been performed.
+		update_option( 'woocommerce_db_version', WC()->version );
+
+		// Magic 2: update-db note to thank you note.
+		WC_Notes_Run_Db_Update::show_reminder();
+
+		$note = new WC_Admin_Note( $note_ids[0] );
+		$actions = $note->get_actions();
+		$this->assertEquals( 'update-db_done', $actions[0]->name, 'A db update note--Thanks for the update--should be displayed now.' );
+	}
+
+}

--- a/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
+++ b/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
@@ -25,6 +25,10 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 	 * Clean up before each test.
 	 */
 	public function setUp() {
+		if ( ! WC()->is_wc_admin_active() ) {
+			$this->markTestSkipped( 'WC Admin is not active on WP versions < 5.3' );
+			return;
+		}
 		self::remove_db_update_notes();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Closes #26443 
- Closes https://github.com/woocommerce/woocommerce-admin/issues/3973
- Supersedes https://github.com/woocommerce/woocommerce/pull/26031

The nonce should be updated whenever a new one is generated. Unified the nonce update code in `update_done_notice` with the `update_needed_notice`. Hopefully now both will work fine.

I have a vague memory someone also mentioned seeing duplicate records for this notice, so added a clean up to `get_current_notice` method.

### How to test the changes in this Pull Request:

1. Run a recent WC version.
2. Run `UPDATE wp_wc_admin_notes SET status = 'unactioned' WHERE name = 'wc-update-db-reminder';`
3. This should display your DB update notice in WooCommerce screens
<img width="1861" alt="Screenshot 2020-05-13 at 20 11 31" src="https://user-images.githubusercontent.com/2207451/81848816-f85fad00-9555-11ea-8dcc-24fff59e4022.png">
4. Find the respective action for the notice, e.g. by running the following query`SELECT wp_wc_admin_note_actions.query FROM wp_wc_admin_notes JOIN wp_wc_admin_note_actions ON wp_wc_admin_notes.note_id = wp_wc_admin_note_actions.note_id WHERE wp_wc_admin_notes.name='wc-update-db-reminder'`

5. To simulate expired nonce, Update the nonce in the query column for this action to nonsense (noncens?) value.
4. Try to click on Thanks! to make it go away--it should show you a nonce error (action not allowed)
5. Switch to this branch, refresh
6. Try to click on Thanks, it should now correctly make the notice go away.
7. You can try setting a wrong nonce in the db into `wp_wc_admin_note_actions`, e.g. `UPDATE wp_wc_admin_note_actions SET query = 'http://one.wordpress.test/wp-admin/admin.php?page=wc-settings&wc-hide-notice=update&_wc_notice_nonce=123wrongNonce456' WHERE wp_wc_admin_note_actions.note_id = XYZ;` (replace XYZ with nonce_id from step 2).
8. On page refresh, the db record should show new nonce and again it should be possible to dismiss the notice.
9. Test also the case when db version option is smaller than WC version (e.g. set woocommerce_db_version to 3.9), to simulate WC update--a notice to update database should be displayed.
<img width="1861" alt="Screenshot 2020-05-13 at 20 34 36" src="https://user-images.githubusercontent.com/2207451/81851055-2e526080-9559-11ea-8709-db9004187497.png">
10. Test on multisite.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added correct handling of nonces to database update notice dismissal.
