### PR TITLE
Fix parameter type and add an empty line in wc_update_product_stock_s…

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -66,10 +66,11 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
  * Update a product's stock status.
  *
  * @param  int $product_id Product ID.
- * @param  int $status     Status.
+ * @param  string $status     Status.
  */
 function wc_update_product_stock_status( $product_id, $status ) {
 	$product = wc_get_product( $product_id );
+
 	if ( $product ) {
 		$product->set_stock_status( $status );
 		$product->save();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes PHPDoc parameter type for `wc_update_product_stock_status()`. The `WC_Product->set_stock_status()` method requres string parameter, so `wc_update_product_stock_status()` should require string as well.

### How to test the changes in this Pull Request:

1. Check the `wc_update_product_stock_status()` function. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
> Correct PHPDoc parameter type for `wc_update_product_stock_status()`.
