### PR TITLE
[4.2] Update WC()->version to 4.2.0 in release/4.2

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -20,7 +20,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '4.1.0';
+	public $version = '4.2.0';
 
 	/**
 	 * The single instance of the class.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

When checking for `WC()->version` in the version 4.2-beta1, the returned value is still `4.1.0`. I suppose it is an omission. I propose to update it to `4.2.0` (a it was done for prevous releases) to facilitate the integration updates before the final release.
