### PR TITLE
Remove TwentyTwenty Block styles

### DIFF
--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -169,27 +169,6 @@ a.button {
 	z-index: 1;
 }
 
-.wc-block-grid__products {
-
-	.wc-block-grid__product-onsale {
-		position: absolute;
-		right: 4px;
-		top: 4px;
-		display: inline-block;
-		background: $highlights-color;
-		color: #fff;
-		font-family: $headings;
-		font-weight: 700;
-		letter-spacing: -0.02em;
-		line-height: 1.2;
-		text-transform: uppercase;
-		z-index: 1;
-		font-size: 1.5rem;
-		margin: 0;
-		padding: 1rem;
-	}
-}
-
 .price {
 	font-family: $headings;
 
@@ -2109,36 +2088,6 @@ a.reset_variations {
 	}
 }
 
-.wc-block-grid__product {
-
-	.wc-block-grid__product-link {
-		color: #000;
-	}
-
-	.wc-block-grid__product-title {
-		font-family: $headings;
-		color: #000;
-		font-size: 2.5rem;
-	}
-
-	.wc-block-grid__product-price {
-
-		.wc-block-grid__product-price__value,
-		.woocommerce-Price-amount {
-			font-family: $headings;
-			font-size: 1.8rem;
-		}
-	}
-
-	.wc-block-grid__product-rating {
-
-		.wc-block-grid__product-rating__stars,
-		.star-rating {
-			font-size: 0.7em;
-		}
-	}
-}
-
 @media only screen and (max-width: 600px) {
 
 	.woocommerce {
@@ -2428,14 +2377,6 @@ a.reset_variations {
 		}
 	}
 
-	.wc-block-grid__products {
-
-		.wc-block-grid__product-onsale {
-			font-size: 1.5rem;
-			padding: 1rem;
-		}
-	}
-
 	/**
 	* Shop page
 	*/
@@ -2584,14 +2525,6 @@ a.reset_variations {
 		}
 
 		.onsale {
-			font-size: 1.7rem;
-			padding: 1.5rem;
-		}
-	}
-
-	.wc-block-grid__products {
-
-		.wc-block-grid__product-onsale {
 			font-size: 1.7rem;
 			padding: 1.5rem;
 		}

--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -2126,6 +2126,10 @@ ul.wc-block-grid__products {
 
 .wc-block-grid__product {
 
+	.wc-block-grid__product-link {
+		color: #000;
+	}
+
 	.wc-block-grid__product-title {
 		font-family: $headings;
 		color: #000;

--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -2138,14 +2138,16 @@ ul.wc-block-grid__products {
 
 	.wc-block-grid__product-price {
 
+		.wc-block-grid__product-price__value,
 		.woocommerce-Price-amount {
-
+			font-family: $headings;
 			font-size: 1.8rem;
 		}
 	}
 
 	.wc-block-grid__product-rating {
 
+		.wc-block-grid__product-rating__stars,
 		.star-rating {
 			font-size: 0.7em;
 		}

--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -2109,21 +2109,6 @@ a.reset_variations {
 	}
 }
 
-ul.wc-block-grid__products {
-	display: flex;
-	align-items: stretch;
-	flex-direction: row;
-	flex-wrap: wrap;
-
-	li.wc-block-grid__product {
-		display: flex;
-		flex-direction: column;
-		justify-content: space-between;
-		align-items: center;
-		margin-bottom: 5em;
-	}
-}
-
 .wc-block-grid__product {
 
 	.wc-block-grid__product-link {

--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -173,7 +173,8 @@ a.button {
 
 	.wc-block-grid__product-onsale {
 		position: absolute;
-		top: 0;
+		right: 4px;
+		top: 4px;
 		display: inline-block;
 		background: $highlights-color;
 		color: #fff;
@@ -184,6 +185,7 @@ a.button {
 		text-transform: uppercase;
 		z-index: 1;
 		font-size: 1.5rem;
+		margin: 0;
 		padding: 1rem;
 	}
 }


### PR DESCRIPTION
In https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2513 we moved Twenty Twenty specific styles relative to blocks to the WC Blocks repo.

Now that WC Blocks 2.7 has been merged into Core (#26732), it's safe to remove them from Core.

### How to test the changes in this Pull Request:

This PR should only cause one visual difference: elements in the product card shouldn't have space between them but instead they should be aligned to the top. That's because [the styles responsible for that](https://github.com/woocommerce/woocommerce/pull/26516/files#diff-9ca78524330467eb31672f64bb04f02aL2110) had been removed from Blocks, so removing them from Core fixes the issue. (See https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2418 for this specific issue filled in WC Blocks repo).

- Make sure the WC Blocks plugin is disabled in your store.
- Change your store theme to Twenty Twenty.
- Add an All Products and a Hand-picked Products block to a page.
- Visit it in the frontend page and verify items in the product card are aligned to the top, instead of having space between them (see screenshots below).
- Try toggling the 'Align Last Block' attribute to make sure it still works and the button is aligned when selected.

| Before | After |
|---|---|
| ![imatge](https://user-images.githubusercontent.com/3616980/84887713-77389000-b096-11ea-93ae-60a986f5fe31.png) | ![imatge](https://user-images.githubusercontent.com/3616980/84887742-83bce880-b096-11ea-8573-dccbbbbe2b3f.png) |

### Changelog entry

> Dev - Remove no longer used styles from TwentyTwenty.