### PR TITLE
Fix set cache loop when no attributes exist

### DIFF
--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -51,7 +51,7 @@ function wc_get_attribute_taxonomies() {
 	$cache_key   = $prefix . 'attributes';
 	$cache_value = wp_cache_get( $cache_key, 'woocommerce-attributes' );
 
-	if ( $cache_value ) {
+	if ( false !== $cache_value ) {
 		return $cache_value;
 	}
 


### PR DESCRIPTION
Currently on sites which are not using the attribute taxonomies the `wc_get_attribute_taxonomies` method is called on every page with a simple test for existing cache. Because and empty array is automatically cast to false within a simple test by PHP, the cache is always considered unset and therefore `wp_cache_set` is called on every page load.

This simply change to the test prevents said redundant calls to `wp_cache_set`. 

### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Test strictly for false to prevent an endless set cache loop when
you are not using attribute taxonomies or don't have any set.
Prevents `wc_get_attribute_taxonomies` function from calling `wp_cache_set` 
on every page load.

### How to test the changes in this Pull Request:

1. Browser an install which has no attributes and has persistent object cache.
2. Load any page on the site.
3. Verify there are not redundant object cache values being set.

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix redundant setting of object cache when attribute taxonomies are not being used. 
