### PR TITLE
Tweaks to e2e tests suite README

### DIFF
--- a/tests/e2e/env/README.md
+++ b/tests/e2e/env/README.md
@@ -15,7 +15,7 @@ The `@woocommerce/e2e-environment` package exports configuration objects that ca
 
 ### Babel Config
 
-Extend your project's Babel config to contain the expected presets for E2E testing.
+Extend your project's `babel.config.js` to contain the expected presets for E2E testing.
 
 ```js
 const { babelConfig: e2eBabelConfig } = require( '@woocommerce/e2e-environment' );
@@ -185,3 +185,7 @@ Stop Docker
 ```bash
 npm explore @woocommerce/e2e-environment -- npm run docker:down
 ```
+
+## Additional information
+
+Refer to [`tests/e2e/specs`](https://github.com/woocommerce/woocommerce/tree/master/tests/e2e/specs) for some test examples, and [`tests/e2e`](https://github.com/woocommerce/woocommerce/tree/master/tests/e2e) for general information on e2e tests.

--- a/tests/e2e/env/README.md
+++ b/tests/e2e/env/README.md
@@ -109,7 +109,7 @@ module.exports = {
 The E2E environment will look for a `docker-compose.yaml` file in your project root. This will be combined with the base Docker config in the package. This is where you'll map your local project files into the Docker container(s).
 
 ```yaml
-version: '3.7'
+version: '3.3'
 
 services:
 

--- a/tests/e2e/env/README.md
+++ b/tests/e2e/env/README.md
@@ -15,7 +15,7 @@ The `@woocommerce/e2e-environment` package exports configuration objects that ca
 
 ### Babel Config
 
-Extend your project's `babel.config.js` to contain the expected presets for E2E testing.
+Make sure you `npm install @babel/preset-env --save` if you have not already done so. Afterwards, extend your project's `babel.config.js` to contain the expected presets for E2E testing.
 
 ```js
 const { babelConfig: e2eBabelConfig } = require( '@woocommerce/e2e-environment' );


### PR DESCRIPTION
Updates to the `README.md` to make some things clearer.

My other suggestion was to provide an example (very basic) test along with file location to put it, etc. in the docs as a headstart. This would be very useful.