### PR TITLE
Allow onFindVariation to accept custom attributes

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -43,7 +43,7 @@
 		// Init after gallery.
 		setTimeout( function() {
 			$form.trigger( 'check_variations' );
-			$form.trigger( 'wc_variation_form' );
+			$form.trigger( 'wc_variation_form', self );
 			self.loading = false;
 		}, 100 );
 	};

--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -165,7 +165,7 @@
 			attributes        = 'undefined' !== typeof chosenAttributes ? chosenAttributes : form.getChosenAttributes(),
 			currentAttributes = attributes.data;
 
-		if ( attributes.count === attributes.chosenCount ) {
+		if ( attributes.count && attributes.count === attributes.chosenCount ) {
 			if ( form.useAjax ) {
 				if ( form.xhr ) {
 					form.xhr.abort();

--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -160,9 +160,9 @@
 	/**
 	 * Looks for matching variations for current selected attributes.
 	 */
-	VariationForm.prototype.onFindVariation = function( event ) {
+	VariationForm.prototype.onFindVariation = function( event, chosenAttributes ) {
 		var form              = event.data.variationForm,
-			attributes        = form.getChosenAttributes(),
+			attributes        = 'undefined' !== typeof chosenAttributes ? chosenAttributes : form.getChosenAttributes(),
 			currentAttributes = attributes.data;
 
 		if ( attributes.count === attributes.chosenCount ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Provide an early way to access the `VariationForm` object.
Provide a way to trigger `onFindVariation` with custom attribute configuration.

### How to test the changes in this Pull Request:

I'll try to get my "Radio buttons" code up as a plugin if you want to test it. But here's the result:

![Screen Recording 2020-05-15 at 06 15 09 31 AM](https://user-images.githubusercontent.com/507025/82049499-a6ad4480-9673-11ea-8fe7-f2dbe76e558d.gif)

The crux of it is that the variations script is tied to `<select>` inputs. But with this PR a plugin can use whatever they want for inputs, collect the attribute data in whatever custom way they want but still leverage the find/show variations aspect of the core script.

Currently plugins that convert attributes to radio buttons and/or swatches must dequeue and replace the entire `add-to-cart-variation.js`. This PR makes the script extensible in a way that would allow plugins to send any `chosenAttributes` to `onFindVariation` via:

`$(this).trigger( 'check_variations', chosenAttributes );`

And if I'm looking at this correctly, existing functionality is not effected at all. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Trigger `check_variations` with custom values