### PR TITLE
Enhancing the scope of Show/Hide password toggle.

### DIFF
--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -80,11 +80,10 @@ jQuery( function( $ ) {
 	};
 
 	// Show password visiblity hover icon on woocommerce forms
-	$( '.woocommerce form .woocommerce-Input[type="password"]' ).wrap( '<span class="password-input"></span>' );
+	$( '.woocommerce-form .woocommerce-Input[type="password"]' ).wrap( '<span class="password-input"></span>' );
 	$( '.password-input' ).prepend( '<span class="show-password-input"></span>' );
 
-	$( '.show-password-input' ).click(
-		function() {
+	$( '.woocommerce-form' ).on('click', '.show-password-input', function() {
 			$( this ).toggleClass( 'display-password' );
 			if ( $( this ).hasClass( 'display-password' ) ) {
 				$( this ).siblings( ['input[name^="password"]', 'input[type="password"]'] ).prop( 'type', 'text' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
I removed the selector <code>.woocommerce form</code> & added <code>.woocommerce-form</code> to avail this show password input script to all pages not only to woocommerce page. Also widen the scope of  <code>.show-password-input</code> also to the ajax form with selectors  <code>.woocommerce-form</code>. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak: I made this change to avail show/hide toggle function to all forms (from custom plugins or theme snippets) which has "woocommerce-form" class/selector.
