### PR TITLE
use nonced logout link for store owner logout

### DIFF
--- a/tests/e2e/utils/flows.js
+++ b/tests/e2e/utils/flows.js
@@ -241,16 +241,15 @@ const StoreOwnerFlow = {
 	},
 
 	logout: async () => {
-		await page.goto(baseUrl + 'wp-login.php?action=logout', {
+		// Log out link in admin bar is not visible so can't be clicked directly.
+		const logoutLinks = await page.$$eval(
+			'#wp-admin-bar-logout a',
+			( am ) => am.filter( ( e ) => e.href ).map( ( e ) => e.href )
+		);
+
+		await page.goto( logoutLinks[ 0 ], {
 			waitUntil: 'networkidle0',
-		});
-
-		await expect(page).toMatch('You are attempting to log out');
-
-		await Promise.all([
-			page.waitForNavigation({ waitUntil: 'networkidle0' }),
-			page.click('a'),
-		]);
+		} );
 	},
 
 	openAllOrdersView: async () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The E2E test suite emits a few `403` errors. These come from `wp-login.php?action=logout` used to log out the store owner. This PR changes the store owner logout to get the logout URL with the nonce from the admin bar and navigate to that URL.

### How to test the changes in this Pull Request:

1. Check Travis E2E log to see that no 403s are emitted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix 403s logged in E2E tests.
