### PR TITLE
New hook to be able to override shipping_tax_class in calculate_taxes

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1532,7 +1532,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		do_action( 'woocommerce_order_before_calculate_taxes', $args, $this );
 
 		$calculate_tax_for  = $this->get_tax_location( $args );
-		$shipping_tax_class = get_option( 'woocommerce_shipping_tax_class' );
+		
+		$shipping_tax_class = apply_filters( 'woocommerce_shipping_get_tax_class', get_option( 'woocommerce_shipping_tax_class' ), $args );
 
 		if ( 'inherit' === $shipping_tax_class ) {
 			$found_classes      = array_intersect( array_merge( array( '' ), WC_Tax::get_tax_class_slugs() ), $this->get_items_tax_classes() );


### PR DESCRIPTION
In some situations, we need a filter to override default woocommerce_shipping_tax_class.

For example in Spain we have to do it for different customers (for "Recargo de equivalencia" tax).

We can change the quantity in a different hook, but not the class, and this is way I suggest it.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Call this hook in a theme or plugin: _add_filter( 'woocommerce_shipping_get_tax_class', 'mytest_woocommerce_shipping_get_tax_class', 10, 2 );_
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
* Dev - Added filter to tweak whether a shipping has a different class depends on the customer or other situation