### PR TITLE
Trigger removed_coupon_in_checkout event after coupon removal on checkout

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -657,6 +657,7 @@ jQuery( function( $ ) {
 					if ( code ) {
 						$( 'form.woocommerce-checkout' ).before( code );
 
+						$( document.body ).trigger( 'removed_coupon_in_checkout', [ data.coupon_code ] );
 						$( document.body ).trigger( 'update_checkout', { update_shipping_method: false } );
 
 						// Remove coupon code from coupon field


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I've added a line of code that triggers the `removed_coupon_in_checkout` event on `document.body` on the Checkout page, the same way as `applied_coupon_in_checkout` is triggered. Literally 5 minutes ago I needed to add a custom behavior on my website after a coupon is removed and couldn't find a nice way to do it. So I decided to send a PR which fixes it.

I think adding `removed_coupon_in_checkout` makes it more consistent because there is an `applied_coupon_in_checkout` event triggered already. Also, on the Cart page, there are both "applied" and "removed" events triggered. So it looks like only the `removed_coupon_in_checkout` is missing here.

Note: I couldn't find test files that would be responsible for this part so I haven't created any tests. If there is any place where I should add a test, please point me there.

### How to test the changes in this Pull Request:

1. Create a custom script which listens for the `removed_coupon_in_checkout` event on the `document.body`:

```javascript
$( document.body ).on( 'removed_coupon_in_checkout', function (e) {
    console.log('It works', e);
} );
```
2. Visit the Checkout page
3. Apply a coupon
4. Remove a coupon
5. Check the console and see if the `console.log()` above has fired

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Added the `removed_coupon_in_checkout` event that is triggered on the Checkout page after a coupon is removed using `.woocommerce-remove-coupon` button.