### PR TITLE
Fixes #26540 - Sets Select a country option value as default on shipping-calculator …

### DIFF
--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -28,7 +28,7 @@ do_action( 'woocommerce_before_shipping_calculator' ); ?>
 		<?php if ( apply_filters( 'woocommerce_shipping_calculator_enable_country', true ) ) : ?>
 			<p class="form-row form-row-wide" id="calc_shipping_country_field">
 				<select name="calc_shipping_country" id="calc_shipping_country" class="country_to_state country_select" rel="calc_shipping_state">
-					<option value=""><?php esc_html_e( 'Select a country / region&hellip;', 'woocommerce' ); ?></option>
+					<option value="default"><?php esc_html_e( 'Select a country / region&hellip;', 'woocommerce' ); ?></option>
 					<?php
 					foreach ( WC()->countries->get_shipping_countries() as $key => $value ) {
 						echo '<option value="' . esc_attr( $key ) . '"' . selected( WC()->customer->get_shipping_country(), esc_attr( $key ), false ) . '>' . esc_html( $value ) . '</option>';


### PR DESCRIPTION
Fixes #26540 - Sets Select a country option value as default on shipping-calculator.php country select input.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #26540 (together with https://github.com/woocommerce/woocommerce/pull/26554).

Sets the value attribute to "default" on the select box option element that serves as instructions for the Country select box input on the shipping calculator. This ensure the select box will show the instructional option when the select element is rendered, and improves user experience.

### How to test the changes in this Pull Request:

See #26540.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Changelog entry

> Fix - Default option "Select a country..." will now display accurately on Country select box in Cart shipping calculator.