### PR TITLE
Add actions before/after shipping calculation

### DIFF
--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -230,7 +230,9 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	public function get_rates_for_package( $package ) {
 		$this->rates = array();
 		if ( $this->is_available( $package ) && ( empty( $package['ship_via'] ) || in_array( $this->id, $package['ship_via'] ) ) ) {
+			do_action( 'woocommerce_before_calculate_shipping', $package, $this );
 			$this->calculate_shipping( $package );
+			do_action( 'woocommerce_after_calculate_shipping', $package, $this );
 		}
 		return $this->rates;
 	}

--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -230,9 +230,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 	public function get_rates_for_package( $package ) {
 		$this->rates = array();
 		if ( $this->is_available( $package ) && ( empty( $package['ship_via'] ) || in_array( $this->id, $package['ship_via'] ) ) ) {
-			do_action( 'woocommerce_before_calculate_shipping', $package, $this );
 			$this->calculate_shipping( $package );
-			do_action( 'woocommerce_after_calculate_shipping', $package, $this );
 		}
 		return $this->rates;
 	}

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -332,7 +332,9 @@ class WC_Shipping {
 			if ( ! is_array( $stored_rates ) || $package_hash !== $stored_rates['package_hash'] || 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
 				foreach ( $this->load_shipping_methods( $package ) as $shipping_method ) {
 					if ( ! $shipping_method->supports( 'shipping-zones' ) || $shipping_method->get_instance_id() ) {
+						do_action( 'woocommerce_before_get_rates_for_package', $package, $shipping_method, $this );
 						$package['rates'] = $package['rates'] + $shipping_method->get_rates_for_package( $package ); // + instead of array_merge maintains numeric keys
+						do_action( 'woocommerce_after_get_rates_for_package', $package, $shipping_method, $this );
 					}
 				}
 

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -332,9 +332,26 @@ class WC_Shipping {
 			if ( ! is_array( $stored_rates ) || $package_hash !== $stored_rates['package_hash'] || 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
 				foreach ( $this->load_shipping_methods( $package ) as $shipping_method ) {
 					if ( ! $shipping_method->supports( 'shipping-zones' ) || $shipping_method->get_instance_id() ) {
-						do_action( 'woocommerce_before_get_rates_for_package', $package, $shipping_method, $this );
-						$package['rates'] = $package['rates'] + $shipping_method->get_rates_for_package( $package ); // + instead of array_merge maintains numeric keys
-						do_action( 'woocommerce_after_get_rates_for_package', $package, $shipping_method, $this );
+						/**
+						 * Fires before getting shipping rates for a package.
+						 *
+						 * @since 4.3.0
+						 * @param array $package Package of cart items.
+						 * @param WC_Shipping_Method $shipping_method Shipping method instance.
+						 */
+						do_action( 'woocommerce_before_get_rates_for_package', $package, $shipping_method );
+
+						// Use + instead of array_merge to maintain numeric keys.
+						$package['rates'] = $package['rates'] + $shipping_method->get_rates_for_package( $package );
+
+						/**
+						 * Fires after getting shipping rates for a package.
+						 *
+						 * @since 4.3.0
+						 * @param array $package Package of cart items.
+						 * @param WC_Shipping_Method $shipping_method Shipping method instance.
+						 */
+						do_action( 'woocommerce_after_get_rates_for_package', $package, $shipping_method );
 					}
 				}
 


### PR DESCRIPTION
Make shipping calculations more flexible by providing actions.

See https://github.com/woocommerce/woocommerce-extension-library/issues/124 for additional details.