### PR TITLE
Allow heading filter for cross sells component.

### DIFF
--- a/templates/cart/cross-sells.php
+++ b/templates/cart/cross-sells.php
@@ -20,8 +20,13 @@ defined( 'ABSPATH' ) || exit;
 if ( $cross_sells ) : ?>
 
 	<div class="cross-sells">
+		<?php
+		$heading = apply_filters( 'woocommerce_product_cross_sells_products_heading', __( 'You may be interested in&hellip;', 'woocommerce' ) );
 
-		<h2><?php esc_html_e( 'You may be interested in&hellip;', 'woocommerce' ); ?></h2>
+		if ( $heading ) :
+			?>
+			<h2><?php echo esc_html( $heading ); ?></h2>
+		<?php endif; ?>
 
 		<?php woocommerce_product_loop_start(); ?>
 


### PR DESCRIPTION
### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

Copying a similar change to templates/single-product/up-sells.php by @jacobarriola on 2020-02-10.
https://github.com/woocommerce/woocommerce/commit/eea787e0e8efe732761715af181c191079c6faeb#diff-26fe493bd38552d971b507f64e87a879
I do not have a use case for this but saw a blog post this morning that used 'gettext' filter to change this text (I suggested a custom PO file with just this string).

### How to test the changes in this Pull Request:

1. Write add_filter function to set a new string.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced `woocommerce_product_cross_sells_products_heading` filter.