### PR TITLE
Call callback on tracking script load error

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -115,7 +115,14 @@ class WC_Site_Tracking {
 				// Callback after scripts have loaded.
 				script.onload = function() {
 					if ( 'function' === typeof callback ) {
-						callback();
+						callback( true );
+					}
+				}
+
+				// Callback triggered if the script fails to load.
+				script.onerror = function() {
+					if ( 'function' === typeof callback ) {
+						callback( false );
 					}
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Calls the callback function when the tracking script loading results in an error.

### How to test the changes in this Pull Request:

1. Make sure tracking is not enabled on your site.
1.  Install uBlock Origin to block the script from loading.
1.  Enable the onboarding profiler and walk through the steps, opting into tracking.
1. Note the script was blocked, but the profiler allows you to continue to the next step.