### PR TITLE
Fix tooltip flashing

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -123,7 +123,8 @@ jQuery( function ( $ ) {
 				'attribute': 'data-tip',
 				'fadeIn': 50,
 				'fadeOut': 50,
-				'delay': 200
+				'delay': 200,
+				'keepAlive': true
 			});
 		},
 

--- a/assets/js/admin/meta-boxes.js
+++ b/assets/js/admin/meta-boxes.js
@@ -9,7 +9,8 @@ jQuery( function ( $ ) {
 			'attribute': 'data-tip',
 			'fadeIn': 50,
 			'fadeOut': 50,
-			'delay': 200
+			'delay': 200,
+			'keepAlive': true
 		});
 	}
 

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -188,7 +188,8 @@
 					'attribute': 'data-tip',
 					'fadeIn': 50,
 					'fadeOut': 50,
-					'delay': 200
+					'delay': 200,
+					'keepAlive': true
 				} );
 
 				$( '.column-wc_actions .wc-action-button' ).tipTip( {
@@ -203,7 +204,8 @@
 						'attribute': 'data-tip',
 						'fadeIn': 50,
 						'fadeOut': 50,
-						'delay': 200
+						'delay': 200,
+						'keepAlive': true
 					} ).css( 'cursor', 'help' );
 				});
 			});

--- a/assets/js/jquery-tiptip/jquery.tipTip.js
+++ b/assets/js/jquery-tiptip/jquery.tipTip.js
@@ -66,7 +66,7 @@
 					org_elem.hover(function(){
 						active_tiptip();
 					}, function(){
-						if(!opts.keepAlive){
+						if(!opts.keepAlive || !tiptip_holder.is(':hover')){
 							deactive_tiptip();
 						}
 					});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
The keepAlive option is added to jQuery tiptip options to fix the tooltip flashing problem. I believe it also provides a better user experience because the tooltip is not closed when the user hovers over the tooltip box. Also includes a small change to close the tooltip if the user leaves the help icon without hovering over the tooltip box.

Closes #26555  .

### How to test the changes in this Pull Request:

1. Build assets
2. Visit any page with a tooltip and help icon
3. Hover over the bottom part of the help icon
4. Tooltip should be show and not flash
5. Be sure to test in Firefox too

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed Tooltip flashing.