### PR TITLE
Updated the Jetpack Autoloader

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": ">=7.0",
-    "automattic/jetpack-autoloader": "^1.6.0",
+    "automattic/jetpack-autoloader": "^1.7.0",
     "automattic/jetpack-constants": "^1.1",
     "composer/installers": "1.7.0",
     "maxmind-db/reader": "1.6.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "9548fdb91087ffaa8f14374698bf402e",
+    "content-hash": "94c4cc4a9a0fc2ad6758cc6c7cb069bb",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -2517,6 +2517,20 @@
                 "polyfill",
                 "portable"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-05-08T16:50:20+00:00"
         },
         {
@@ -2921,5 +2935,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Jetpack made a change that requires some extra ignore entries from the latest release of the autoloader, otherwise debug logging warnings are thrown. This PR updates us to the latest version of the autoloader so that these warnings go away.

Closes https://github.com/Automattic/jetpack/issues/15844.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?