### PR TITLE
Allow custom values in wc_generate_order_key()

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -149,13 +149,18 @@ function wc_get_order_status_name( $status ) {
 }
 
 /**
- * Generate an order key.
+ * Generate an order key with prefix.
  *
  * @since 3.5.4
+ * @param string $key Order key without a prefix. By default generates a 13 digit secret.
  * @return string The order key.
  */
-function wc_generate_order_key() {
-	return 'wc_' . apply_filters( 'woocommerce_generate_order_key', 'order_' . wp_generate_password( 13, false ) );
+function wc_generate_order_key( $key = '' ) {
+	if ( '' === $key ) {
+		$key = wp_generate_password( 13, false );
+	}
+
+	return 'wc_' . apply_filters( 'woocommerce_generate_order_key', 'order_' . $key );
 }
 
 /**

--- a/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -1520,4 +1520,23 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 
 		remove_filter( 'woocommerce_hold_stock_for_checkout', '__return_false' );
 	}
+
+	/**
+	 * Test wc_generate_order_key().
+	 *
+	 * @since 4.3.0
+	 */
+	public function test_wc_generate_order_key() {
+		// Test custom key.
+		$key       = 'foo123bar';
+		$order_key = wc_generate_order_key( $key );
+		$expected  = 'wc_' . apply_filters( 'woocommerce_generate_order_key', 'order_' . $key );
+		$this->assertEquals( $expected, $order_key );
+
+		// Test default key.
+		$order_key = wc_generate_order_key();
+		$prefix    = 'wc_' . apply_filters( 'woocommerce_generate_order_key', 'order_' );
+		$this->assertStringStartsWith( $prefix, $order_key );
+		$this->assertEquals( 13, strlen( str_replace( $prefix, '', $order_key ) ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We allow set `order_key` in orders via CRUD, but we don't give helper for 3rd party developers that like to set they own custom key per order.

Related to #26510.

### How to test the changes in this Pull Request:

1. Apply this patch and using WP-CLI try:
```php
wc_generate_order_key(); // Expected output: wc_order_xxxxxxxxxxxxx
wc_generate_order_key( 'foo' ); // Expected output: wc_order_foo
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Allow set a custom as order key using `wc_generate_order_key()`.
