### PR TITLE
Allow set "date_created" while creating orders via CRUD

### DIFF
--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -57,8 +57,10 @@ abstract class Abstract_WC_Order_Data_Store_CPT extends WC_Data_Store_WP impleme
 	 */
 	public function create( &$order ) {
 		$order->set_version( Constants::get_constant( 'WC_VERSION' ) );
-		$order->set_date_created( time() );
 		$order->set_currency( $order->get_currency() ? $order->get_currency() : get_woocommerce_currency() );
+		if ( ! $order->get_date_created( 'edit' ) ) {
+			$order->set_date_created( time() );
+		}
 
 		$id = wp_insert_post(
 			apply_filters(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Using our CRUD isn't possible to set "date_created" while creating an order, since we replace it with `time()`.

This PR fix this behavior allowing to set any date like we allow in the administrative interface.

Closes #26510.

### How to test the changes in this Pull Request:

1. Open your WP-CLI shell and try:
```php
$order = new WC_Order();
$order->set_date_created( strtotime( '+1 week' ) );
$order->get_date_created() // Check for the correct output.
$order->save(); // Order saved, "date_created" got replaced.
$order->get_date_created() // Incorrect output.
```
2. Now apply this patch and try to create an order again using `wp shell`.
3. And look that now after saving the order will keep the correct created date.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Allow set "date_created" while creating orders via CRUD.
