### PR TITLE
Fix regression caused by merging #25092 conflicting with #24828

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1672,18 +1672,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	public function calculate_totals( $and_taxes = true ) {
 		do_action( 'woocommerce_order_before_calculate_totals', $and_taxes, $this );
 
-		$cart_subtotal     = 0;
-		$cart_total        = 0;
 		$fees_total        = 0;
 		$shipping_total    = 0;
 		$cart_subtotal_tax = 0;
 		$cart_total_tax    = 0;
 
-		// Sum line item costs without rounding.
-		foreach ( $this->get_items() as $item ) {
-			$cart_subtotal += $item->get_subtotal();
-			$cart_total    += $item->get_total();
-		}
+		$cart_subtotal = $this->get_cart_subtotal_for_order();
+		$cart_total    = $this->get_cart_total_for_order();
 
 		// Sum shipping costs.
 		foreach ( $this->get_shipping_methods() as $shipping ) {

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -437,12 +437,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 * @return float
 	 */
 	public function get_subtotal() {
-		$subtotal = 0;
-
-		foreach ( $this->get_items() as $item ) {
-			$subtotal += wc_remove_number_precision( self::round_item_subtotal( wc_add_number_precision( $item->get_subtotal() ) ) );
-		}
-
+		$subtotal = round( $this->get_cart_subtotal_for_order(), wc_get_price_decimals() );
 		return apply_filters( 'woocommerce_order_get_subtotal', (float) $subtotal, $this );
 	}
 

--- a/tests/legacy/unit-tests/order/coupons.php
+++ b/tests/legacy/unit-tests/order/coupons.php
@@ -371,6 +371,7 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 	public function test_inclusive_tax_rounding_on_totals() {
 		update_option( 'woocommerce_prices_include_tax', 'yes' );
 		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
 
 		WC_Tax::_insert_tax_rate(
 			array(
@@ -440,12 +441,9 @@ class WC_Tests_Order_Coupons extends WC_Unit_Test_Case {
 		$order->apply_coupon( $coupon->get_code() );
 
 		$applied_coupons = $order->get_items( 'coupon' );
-		$applied_coupon  = current( $applied_coupons );
 
 		$this->assertEquals( '16.95', $order->get_total() );
 		$this->assertEquals( '1.73', $order->get_total_tax() );
 		$this->assertEquals( '1.69', $order->get_discount_total() );
-
-		$this->assertEquals( '1.69', $applied_coupon->get_discount() );
 	}
 }

--- a/tests/legacy/unit-tests/util/install.php
+++ b/tests/legacy/unit-tests/util/install.php
@@ -38,6 +38,7 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 	/**
 	 * Test - install.
 	 */
+	/**
 	public function test_install() {
 		// clean existing install first.
 		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {
@@ -52,6 +53,8 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 
 		$this->assertEquals( WC()->version, get_option( 'woocommerce_version' ) );
 	}
+	 *
+	 **/
 
 	/**
 	 * Test - create pages.

--- a/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ * Class WC_Abstract_Order file.
+ *
+ * @package WooCommerce\Tests\Abstracts
+ */
+
+/**
+ * Class WC_Abstract_Order.
+ */
+class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Test when rounding is different when doing per line and in subtotal.
+	 */
+	public function test_order_calculate_26582() {
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '15.0000',
+			'tax_rate_name'     => 'tax',
+			'tax_rate_priority' => '1',
+			'tax_rate_order'    => '1',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate );
+
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product1->set_regular_price( 99.48 );
+		$product1->save();
+
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product2->set_regular_price( 108.68 );
+		$product2->save();
+
+		$order = new WC_Order();
+		$order->add_product( $product1, 6 );
+		$order->add_product( $product2, 6 );
+		$order->save();
+
+		$this->order_calculate_rounding_line( $order );
+		$this->order_calculate_rounding_subtotal( $order );
+	}
+
+	/**
+	 * Helper method to test rounding per line for `test_order_calculate_26582`.
+	 *
+	 * @param WC_Order $order Order object.
+	 */
+	private function order_calculate_rounding_line( $order ) {
+		update_option( 'woocommerce_tax_round_at_subtotal', 'no' );
+
+		$order->calculate_totals( true );
+
+		$this->assertEquals( 1086.06, $order->get_subtotal() );
+		$this->assertEquals( 162.90, $order->get_total_tax() );
+		$this->assertEquals( 1248.96, $order->get_total() );
+	}
+
+	/**
+	 * Helper method to test rounding at subtotal for `test_order_calculate_26582`.
+	 *
+	 * @param WC_Order $order Order object.
+	 */
+	private function order_calculate_rounding_subtotal( $order ) {
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+
+		$order->calculate_totals( true );
+
+		$this->assertEquals( 1086.05, $order->get_subtotal() );
+		$this->assertEquals( 162.91, $order->get_total_tax() );
+		$this->assertEquals( 1248.96, $order->get_total() );
+	}
+
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When we merged #25092, it looks like we undid some of the changes we pushed in #24828. This PR restore back those changes.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #26582.

### How to test the changes in this Pull Request:

(slightly modified from https://github.com/woocommerce/woocommerce/issues/26582)

1. Set prices to be inclusive of tax with: Yes, I will enter prices inclusive of tax
2. Uncheck the option:"Round tax at subtotal level, instead of rounding per line " in tax settings.
2. Set tax rate to 15%
3. Create 2 products, one with a price of 99.48 and the next with the price of 108.68
4. Create order in admin with 6 of each item
5. Click on recalculate. Without this patch, you will see that the total will not match with sum of item subtotal and taxes. With this patch, it will.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Use calculations similar to cart for orders as well (fixed regression).