### PR TITLE
fix #26209 - email link color clash

### DIFF
--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -164,7 +164,7 @@ body {
 }
 
 .link {
-	color: <?php echo esc_attr( $base ); ?>;
+	color: <?php echo esc_attr( $link_color ); ?>;
 }
 
 #header_wrapper {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Sets the color CSS styling for elements in email templates with the "link" class to $link_color, rather than $base. This prevents links in emails from being difficult to see/invisible when the base and body background color email settings are both light/dark/the same.

### How to test the changes in this Pull Request:

Issue #26209 appeared in reset password emails (the reset password link) and the order details section in admin emails (a link to the relevant order). 

**Reset Password Email Test**

1. Access the Woocommerce email settings and set both the base color and body background colors to dark/light colors (or the same color).
2. Click on the lost password link and enter the email address of an account that exists. 
3. Check an email client for the reset password email and check to see if the reset link is visible/easy to see.

**Admin Order Details Email Test**

1. Access the Woocommerce email settings and set both the base color and body background colors to dark/light colors (or the same color).
2. Place an order.
3. Check an email client for the admin order received email to see if the order link in the email is visible/easy to see.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Email link color clash.
