### PR TITLE
Add asterisk to star rating if 'Star ratings should be required, not optional' checkbox is enabled

### DIFF
--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -121,7 +121,7 @@ if ( ! comments_open() ) {
 				}
 
 				if ( wc_review_ratings_enabled() ) {
-					$comment_form['comment_field'] = '<div class="comment-form-rating"><label for="rating">' . esc_html__( 'Your rating', 'woocommerce' ) . '</label><select name="rating" id="rating" required>
+					$comment_form['comment_field'] = '<div class="comment-form-rating"><label for="rating">' . esc_html__( 'Your rating', 'woocommerce' ) . ( wc_review_ratings_required() ? '&nbsp;<span class="required">*</span>' : '' ) . '</label><select name="rating" id="rating" required>
 						<option value="">' . esc_html__( 'Rate&hellip;', 'woocommerce' ) . '</option>
 						<option value="5">' . esc_html__( 'Perfect', 'woocommerce' ) . '</option>
 						<option value="4">' . esc_html__( 'Good', 'woocommerce' ) . '</option>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently, an asterisk is not being displayed next to `Your rating` in the product's review section on the site if `Star ratings should be required, not optional` option is enabled. This PR fixes this issue. It adds an asterisk next to `Your rating` in the product's review section on the site if `Star ratings should be required, not optional` option is enabled. 

Closes https://github.com/woocommerce/woocommerce/issues/26511.

### How to test the changes in this Pull Request:

1. Create any type of product. For example, a simple product;  
2. In `Settings / Product / General`, enable reviews;
3. In the `Product ratings` section on the same page, make sure `Enable star rating on reviews` is **enabled** & `Star ratings should be required, not optional` is **disabled**:

![Screen Shot 2020-05-24 at 6 48 01 PM](https://user-images.githubusercontent.com/19143190/82766702-20b99800-9def-11ea-8b76-6c6572306272.png)

3. In the `Reviews` section of the product (created in step 1) page on the site, verify that `Your ratings` string doesn't have an asterisk (*) symbol next to it indicating that star rating is optional:

![asterisk_no](https://user-images.githubusercontent.com/19143190/82766630-b4d72f80-9dee-11ea-8a80-a00bb9fe1a2d.jpg)

3. Write your review in the `Your review` section but don't give any star rating - you should be able to successfully submit a review;

4. Back in `Settings / Product / General`, keep `Enable star rating on reviews` **enabled** and also **enable** `Star ratings should be required, not optional`:

![Screen Shot 2020-05-24 at 6 50 58 PM](https://user-images.githubusercontent.com/19143190/82766758-873eb600-9def-11ea-988a-052ba6bd471f.png)

5. In the `Reviews` section of the product (created in step 1) page on the site, verify that `Your ratings` string has an asterisk (*) symbol next to it indicating that star rating is required:

![asterisk_yes](https://user-images.githubusercontent.com/19143190/82766783-c1a85300-9def-11ea-832e-50d538f55934.jpg)

6. Write your review in the `Your review` section but don't give any star rating - you should not be able to submit a review. A pop-up window should appear letting you know that rating is required;

7. Give your review a star rating is submit a review - it should be successfully posted. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Add asterisk to star rating if 'Star ratings should be required, not optional' checkbox is enabled
