### PR TITLE
Don't allow redirection while checking for uploads directory

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -569,7 +569,7 @@ class WC_Admin_Notices {
 
 		// Check for the "uploads/woocommerce_uploads" directory.
 		$response         = wp_safe_remote_get(
-			esc_url_raw( $uploads['baseurl'] . '/woocommerce_uploads' ),
+			esc_url_raw( $uploads['baseurl'] . '/woocommerce_uploads/' ),
 			array(
 				'redirection' => 0,
 			)

--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -568,7 +568,12 @@ class WC_Admin_Notices {
 		$uploads = wp_get_upload_dir();
 
 		// Check for the "uploads/woocommerce_uploads" directory.
-		$response         = wp_safe_remote_get( esc_url_raw( $uploads['baseurl'] . '/woocommerce_uploads' ) );
+		$response         = wp_safe_remote_get(
+			esc_url_raw( $uploads['baseurl'] . '/woocommerce_uploads' ),
+			array(
+				'redirection' => 0,
+			)
+		);
 		$response_code    = intval( wp_remote_retrieve_response_code( $response ) );
 		$response_content = wp_remote_retrieve_body( $response );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Don't follow redirections while checking if the uploads directory is secure.

Note: Don't need a changelog entry since is a patch for a feature introduce in 4.2.

Closes #26599.

### How to test the changes in this Pull Request:

Same steps as #26207

1. Now create a 301 redirection from your 301 directory and test again with this patch.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
