### PR TITLE
Twenty Twenty: remove underline from discounted prices

### DIFF
--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -198,6 +198,7 @@ a.button {
 
 	ins {
 		display: inline-block;
+		text-decoration: none;
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We want to remove the underline from discounted prices in Twenty Twenty.

Closes #26608.

_Before:_
![Screenshot from 2020-05-26 17-36-24](https://user-images.githubusercontent.com/3616980/82927845-9bb2b800-9f81-11ea-8d75-30e4b07f1f38.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/82928333-65296d00-9f82-11ea-8ea6-04baa816565c.png)

### How to test the changes in this Pull Request:

1. Switch your theme to Twenty Twenty.
2. Go to the Shop page and check the styles of a discounted product.
3. Verify the current price is not underlined.

### Changelog entry

> Fix - Discounted prices are no longer underlined in Twenty Twenty.