### PR TITLE
Add requires headers in plugin

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -8,6 +8,8 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce
  * Domain Path: /i18n/languages/
+ * Requires WP: 5.2
+ * Requires PHP: 7.0
  *
  * @package WooCommerce
  */

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -8,7 +8,7 @@
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce
  * Domain Path: /i18n/languages/
- * Requires WP: 5.2
+ * Requires at least: 5.2
  * Requires PHP: 7.0
  *
  * @package WooCommerce


### PR DESCRIPTION
For reference, it seems this was added in WordPress 5.4 here:
https://core.trac.wordpress.org/ticket/46938