### PR TITLE
Removed feature plugin packages from renovate updated

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,11 @@
       "depTypeList": ["devDependencies"],
       "extends": ["schedule:monthly"]
     }
+  ],
+  "ignoreDeps": [
+    "woocommerce/action-scheduler",
+    "woocommerce/woocommerce-admin",
+    "woocommerce/woocommerce-blocks",
+    "woocommerce/woocommerce-rest-api"
   ]
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Since we're going to require package updates to follow a specific PR template, it doesn't make much sense to automatically submit a PR for this through renovate. This was updated [according to the Renovate documentation](https://docs.renovatebot.com/configuration-options/#ignoredeps).
