### PR TITLE
Homescreen: Enable for new stores and add Features Setting section

### DIFF
--- a/includes/admin/settings/class-wc-settings-advanced.php
+++ b/includes/admin/settings/class-wc-settings-advanced.php
@@ -42,6 +42,7 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 			'webhooks'        => __( 'Webhooks', 'woocommerce' ),
 			'legacy_api'      => __( 'Legacy API', 'woocommerce' ),
 			'woocommerce_com' => __( 'WooCommerce.com', 'woocommerce' ),
+			'features'        => __( 'Features', 'woocommerce' ),
 		);
 
 		return apply_filters( 'woocommerce_get_sections_' . $this->id, $sections );
@@ -394,6 +395,28 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 					array(
 						'type' => 'sectionend',
 						'id'   => 'legacy_api_options',
+					),
+				)
+			);
+		} elseif ( 'features' === $current_section ) {
+			$settings = apply_filters(
+				'woocommerce_settings_features',
+				array(
+					array(
+						'title' => __( 'Features', 'woocommerce' ),
+						'type'  => 'title',
+						'desc'  => __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce' ),
+						'id'    => 'features_options',
+					),
+					array(
+						'title'   => __( 'Home Screen', 'woocommerce' ),
+						'desc'    => __( 'Displays analytical insights, inbox notifications, and handy shortcuts in a single screen', 'woocommerce' ),
+						'id'      => 'woocommerce_homescreen_enabled',
+						'type'    => 'checkbox',
+					),
+					array(
+						'type' => 'sectionend',
+						'id'   => 'features_options',
 					),
 				)
 			);

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -297,6 +297,7 @@ class WC_Install {
 		self::maybe_enable_setup_wizard();
 		self::update_wc_version();
 		self::maybe_update_db_version();
+		self::maybe_enable_homescreen();
 
 		delete_transient( 'wc_installing' );
 
@@ -339,6 +340,17 @@ class WC_Install {
 			delete_option( 'woocommerce_schema_missing_tables' );
 		}
 		return $missing_tables;
+	}
+
+	/**
+	 * Check if the homepage should be enabled and set the appropriate option if thats the case.
+	 *
+	 * @since 4.3.0
+	 */
+	private static function maybe_enable_homescreen() {
+		if ( self::is_new_install() && ! get_option( 'woocommerce_homescreen_enabled' ) ) {
+			add_option( 'woocommerce_homescreen_enabled', 'yes' );
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce-admin/issues/4303

On new installs, set an option `woocommerce_homescreen_enabled` to "yes". Existing users won't have the option set, but will be able to access it from WooCommerce > Settings > Advanced > Features.

![Screen Shot 2020-05-28 at 2 09 03 PM](https://user-images.githubusercontent.com/1922453/83091045-5cee4080-a0ee-11ea-9233-4c0a5571012b.png)

The Homescreen feature is set to be included in WC 4.3

### How to test the changes in this Pull Request:

1. Visit WooCommerce > Settings > Advanced > Features. The feature should not be enabled for an existing store.
2. Check the language match the design https://github.com/woocommerce/woocommerce-admin/issues/4303#issuecomment-625212472.
2. Modify and save to make sure the option persists. You can even check the DB if so inclined.
2. Confirm that a fresh install sets the option to "yes".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Add a new Features settings section, enabling `woocommerce_homescreen_enabled` for all new stores.


