### PR TITLE
Schedule a deferred product sync for products with parent on delete.

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1378,9 +1378,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 			$this->data_store->create( $this );
 		}
 
-		if ( $this->get_parent_id() ) {
-			wc_deferred_product_sync( $this->get_parent_id() );
-		}
+		$this->maybe_defer_product_sync();
 
 		/**
 		 * Trigger action after saving to the DB.
@@ -1391,6 +1389,32 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
 
 		return $this->get_id();
+	}
+
+	/**
+	 * Delete the product, set its ID to 0, and return result.
+	 *
+	 * @param  bool $force_delete Should the product be deleted permanently.
+	 * @return bool result
+	 */
+	public function delete( $force_delete = false ) {
+		$deleted = parent::delete( $force_delete );
+
+		if ( $deleted ) {
+			$this->maybe_defer_product_sync();
+		}
+
+		return $deleted;
+	}
+
+	/**
+	 * If this is a child product, queue its parent for syncing at the end of the request.
+	 */
+	protected function maybe_defer_product_sync() {
+		$parent_id = $this->get_parent_id();
+		if ( $parent_id ) {
+			wc_deferred_product_sync( $parent_id );
+		}
 	}
 
 	/*
@@ -1871,7 +1895,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return string
 	 */
 	public function get_shipping_class() {
-		if ( $class_id = $this->get_shipping_class_id() ) { // @phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found, WordPress.CodeAnalysis.AssignmentInCondition.Found
+		$class_id = $this->get_shipping_class_id();
+		if ( $class_id ) {
 			$term = get_term_by( 'id', $class_id, 'product_shipping_class' );
 
 			if ( $term && ! is_wp_error( $term ) ) {
@@ -1963,7 +1988,8 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	public function get_price_suffix( $price = '', $qty = 1 ) {
 		$html = '';
 
-		if ( ( $suffix = get_option( 'woocommerce_price_display_suffix' ) ) && wc_tax_enabled() && 'taxable' === $this->get_tax_status() ) { // @phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found, WordPress.CodeAnalysis.AssignmentInCondition.Found
+		$suffix = get_option( 'woocommerce_price_display_suffix' );
+		if ( $suffix && wc_tax_enabled() && 'taxable' === $this->get_tax_status() ) {
 			if ( '' === $price ) {
 				$price = $this->get_price();
 			}

--- a/tests/legacy/unit-tests/product/class-wc-tests-product.php
+++ b/tests/legacy/unit-tests/product/class-wc-tests-product.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * Unit tests for the base product class.
+ *
+ * @package WooCommerce\Tests\Product
+ */
+
+/**
+ * Tests for Product class.
+ * @package WooCommerce\Tests\Product
+ * @since 2.3
+ */
+class WC_Tests_Product extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox When a product is saved or deleted its parent should be scheduled for sync at the end of the request.
+	 *
+	 * @testWith ["save"]
+	 *           ["delete"]
+	 *
+	 * @param string $operation The method to test, "save" or "delete".
+	 */
+	public function test_deferred_sync_on_save_and_delete( $operation ) {
+		$defer_sync_invoked = false;
+
+		$defer_product_callback = function() use ( &$defer_sync_invoked ) {
+			$defer_sync_invoked = true;
+		};
+
+		$product = $this->getMockBuilder( WC_Product::class )
+						->setMethods( array( 'maybe_defer_product_sync' ) )
+						->getMock();
+
+		$product->method( 'maybe_defer_product_sync' )
+				->will( $this->returnCallback( $defer_product_callback ) );
+
+		$product->$operation();
+
+		$this->assertTrue( $defer_sync_invoked );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Right now, when a product having a parent (e.g. a variation having a parent variable product) is saved, `wc_deferred_product_sync` is executed so that product sync is performed at the end of the request. This commit implements the same when the product is deleted.

Closes #25552.

### How to test the changes in this Pull Request:

Follow the repro steps in https://github.com/woocommerce/woocommerce/issues/25552 and verify that this time the mentioned action is triggered on variation deletion as well.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - A deferred product sync is now scheduled when a product having a parent (e.g. a variation product) is deleted, not only when it's saved.
