### PR TITLE
Fix #26633 - Adds Custom Messages Upon WC Taxonomies Update

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -23,6 +23,7 @@ class WC_Post_Types {
 		add_action( 'init', array( __CLASS__, 'register_post_types' ), 5 );
 		add_action( 'init', array( __CLASS__, 'register_post_status' ), 9 );
 		add_action( 'init', array( __CLASS__, 'support_jetpack_omnisearch' ) );
+		add_filter( 'term_updated_messages', array( __CLASS__, 'updated_term_messages' ) );
 		add_filter( 'rest_api_allowed_post_types', array( __CLASS__, 'rest_api_allowed_post_types' ) );
 		add_action( 'woocommerce_after_register_post_type', array( __CLASS__, 'maybe_flush_rewrite_rules' ) );
 		add_action( 'woocommerce_flush_rewrite_rules', array( __CLASS__, 'flush_rewrite_rules' ) );
@@ -477,6 +478,68 @@ class WC_Post_Types {
 		}
 
 		do_action( 'woocommerce_after_register_post_type' );
+	}
+
+	/**
+	 * Customize taxonomies update messages.
+	 *
+	 * @access public
+	 * @param array $messages The list of available messages.
+	 * @since 4.1.2
+	 * @return bool
+	 */
+	public function updated_term_messages( $messages ) {
+
+		$messages['product_cat'] = array(
+			0 => '',
+			1 => __( 'Category added.', 'woocommerce' ),
+			2 => __( 'Category deleted.', 'woocommerce' ),
+			3 => __( 'Category updated.', 'woocommerce' ),
+			4 => __( 'Category not added.', 'woocommerce' ),
+			5 => __( 'Category not updated.', 'woocommerce-' ),
+			6 => __( 'Category not deleted.', 'woocommerce' ),
+		);
+
+		$messages['product_tag'] = array(
+			0 => '',
+			1 => __( 'Tag added.', 'woocommerce' ),
+			2 => __( 'Tag deleted.', 'woocommerce' ),
+			3 => __( 'Tag updated.', 'woocommerce' ),
+			4 => __( 'Tag not added.', 'woocommerce' ),
+			5 => __( 'Tag not updated.', 'woocommerce' ),
+			6 => __( 'Tag not deleted.', 'woocommerce' ),
+		);
+
+		$wc_product_attributes = array();
+		$attribute_taxonomies  = wc_get_attribute_taxonomies();
+
+		if ( $attribute_taxonomies ) {
+			foreach ( $attribute_taxonomies as $tax ) {
+				$name = wc_attribute_taxonomy_name( $tax->attribute_name );
+
+				if ( $name ) {
+					$label = ! empty( $tax->attribute_label ) ? $tax->attribute_label : $tax->attribute_name;
+
+					$messages[$name] = array(
+						0 => '',
+						/* translators: %s: taxonomy label */
+						1 => sprintf( __( '%s added', 'woocommerce' ), $label ),
+						/* translators: %s: taxonomy label */
+						2 => sprintf( __( '%s deleted', 'woocommerce' ), $label ),
+						/* translators: %s: taxonomy label */
+						3 => sprintf( __( '%s updated', 'woocommerce' ), $label ),
+						/* translators: %s: taxonomy label */
+						4 => sprintf( __( '%s not added', 'woocommerce' ), $label ),
+						/* translators: %s: taxonomy label */
+						5 => sprintf( __( '%s not updated', 'woocommerce' ), $label ),
+						/* translators: %s: taxonomy label */
+						6 => sprintf( __( '%s not deleted', 'woocommerce' ), $label ),
+					);
+				}
+			}
+		}
+
+		return $messages;
 	}
 
 	/**

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -519,19 +519,19 @@ class WC_Post_Types {
 					$label = ! empty( $tax->attribute_label ) ? $tax->attribute_label : $tax->attribute_name;
 
 					$messages[ $name ] = array(
-						0 => '',
+						0 => ''
 						/* translators: %s: taxonomy label */
-						1 => sprintf( __( '%s added', 'woocommerce' ), $label ),
+						1 => sprintf( _x( '%s added', 'taxonomy term messages', 'woocommerce' ), $label ),
 						/* translators: %s: taxonomy label */
-						2 => sprintf( __( '%s deleted', 'woocommerce' ), $label ),
+						2 => sprintf( _x( '%s deleted', 'taxonomy term messages', 'woocommerce' ), $label ),
 						/* translators: %s: taxonomy label */
-						3 => sprintf( __( '%s updated', 'woocommerce' ), $label ),
+						3 => sprintf( _x( '%s updated', 'taxonomy term messages', 'woocommerce' ), $label ),
 						/* translators: %s: taxonomy label */
-						4 => sprintf( __( '%s not added', 'woocommerce' ), $label ),
+						4 => sprintf( _x( '%s not added', 'taxonomy term messages', 'woocommerce' ), $label ),
 						/* translators: %s: taxonomy label */
-						5 => sprintf( __( '%s not updated', 'woocommerce' ), $label ),
+						5 => sprintf( _x( '%s not updated', 'taxonomy term messages', 'woocommerce' ), $label ),
 						/* translators: %s: taxonomy label */
-						6 => sprintf( __( '%s not deleted', 'woocommerce' ), $label ),
+						6 => sprintf( _x( '%s not deleted', 'taxonomy term messages', 'woocommerce' ), $label ),
 					);
 				}
 			}

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -483,20 +483,18 @@ class WC_Post_Types {
 	/**
 	 * Customize taxonomies update messages.
 	 *
-	 * @access public
 	 * @param array $messages The list of available messages.
-	 * @since 4.1.2
+	 * @since 4.4.0
 	 * @return bool
 	 */
 	public function updated_term_messages( $messages ) {
-
 		$messages['product_cat'] = array(
 			0 => '',
 			1 => __( 'Category added.', 'woocommerce' ),
 			2 => __( 'Category deleted.', 'woocommerce' ),
 			3 => __( 'Category updated.', 'woocommerce' ),
 			4 => __( 'Category not added.', 'woocommerce' ),
-			5 => __( 'Category not updated.', 'woocommerce-' ),
+			5 => __( 'Category not updated.', 'woocommerce' ),
 			6 => __( 'Category not deleted.', 'woocommerce' ),
 		);
 
@@ -520,7 +518,7 @@ class WC_Post_Types {
 				if ( $name ) {
 					$label = ! empty( $tax->attribute_label ) ? $tax->attribute_label : $tax->attribute_name;
 
-					$messages[$name] = array(
+					$messages[ $name ] = array(
 						0 => '',
 						/* translators: %s: taxonomy label */
 						1 => sprintf( __( '%s added', 'woocommerce' ), $label ),


### PR DESCRIPTION
Adds custom message upon taxonomies update

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds custom messages upon taxonomy CRUD actions

![](https://d.pr/i/0HmkJl+)

![](https://d.pr/i/vliaPJ+)

Closes #26633

### How to test the changes in this Pull Request:

1. update a product category
2. update a product tag
3. update a product attribute

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Custom vendor taxonomy update messages.
