### PR TITLE
use wp_timezone_string when available

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -713,6 +713,11 @@ function wc_string_to_datetime( $time_string ) {
  * @return string PHP timezone string for the site
  */
 function wc_timezone_string() {
+	// Added in WordPress 5.3 Ref https://developer.wordpress.org/reference/functions/wp_timezone_string/.
+	if ( function_exists( 'wp_timezone_string' ) ) {
+		return wp_timezone_string();
+	}
+
 	// If site timezone string exists, return it.
 	$timezone = get_option( 'timezone_string' );
 	if ( $timezone ) {
@@ -720,13 +725,13 @@ function wc_timezone_string() {
 	}
 
 	// Get UTC offset, if it isn't set then return UTC.
-	$utc_offset = intval( get_option( 'gmt_offset', 0 ) );
-	if ( 0 === $utc_offset ) {
+	$utc_offset = floatval( get_option( 'gmt_offset', 0 ) );
+	if ( ! is_numeric( $utc_offset ) || 0.0 === $utc_offset ) {
 		return 'UTC';
 	}
 
 	// Adjust UTC offset from hours to seconds.
-	$utc_offset *= 3600;
+	$utc_offset = (int) ( $utc_offset * 3600 );
 
 	// Attempt to guess the timezone string from the UTC offset.
 	$timezone = timezone_name_from_abbr( '', $utc_offset );

--- a/tests/legacy/unit-tests/formatting/functions.php
+++ b/tests/legacy/unit-tests/formatting/functions.php
@@ -699,15 +699,15 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
 		// Test with missing UTC offset.
 		delete_option( 'gmt_offset' );
-		$this->assertEquals( '+00:00', wc_timezone_string() );
+		$this->assertContains( wc_timezone_string(), array( '+00:00', 'UTC' ) );
 
 		// Test with manually set UTC offset.
 		update_option( 'gmt_offset', -4 );
-		$this->assertNotEquals( 'UTC', wc_timezone_string() );
+		$this->assertNotContains( wc_timezone_string(), array( '+00:00', 'UTC' ) );
 
 		// Test with invalid offset.
 		update_option( 'gmt_offset', 'invalid' );
-		$this->assertEquals( '+00:00', wc_timezone_string() );
+		$this->assertContains( wc_timezone_string(), array( '+00:00', 'UTC' ) );
 
 		// Restore default.
 		update_option( 'gmt_offset', '0' );

--- a/tests/legacy/unit-tests/formatting/functions.php
+++ b/tests/legacy/unit-tests/formatting/functions.php
@@ -699,15 +699,15 @@ class WC_Tests_Formatting_Functions extends WC_Unit_Test_Case {
 
 		// Test with missing UTC offset.
 		delete_option( 'gmt_offset' );
-		$this->assertEquals( 'UTC', wc_timezone_string() );
+		$this->assertEquals( '+00:00', wc_timezone_string() );
 
 		// Test with manually set UTC offset.
 		update_option( 'gmt_offset', -4 );
 		$this->assertNotEquals( 'UTC', wc_timezone_string() );
 
 		// Test with invalid offset.
-		update_option( 'gmt_offset', 99 );
-		$this->assertEquals( 'UTC', wc_timezone_string() );
+		update_option( 'gmt_offset', 'invalid' );
+		$this->assertEquals( '+00:00', wc_timezone_string() );
 
 		// Restore default.
 		update_option( 'gmt_offset', '0' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR supersedes #24863. It implements the same logic changes as https://github.com/woocommerce/action-scheduler/pull/562 which used a modified version of `wc_timezone_string()`:

- use `wp_timezone_string()` when available
- otherwise support `float` in existing `wc_timezone_string()` logic
- unit test updated due to `wp_timezone_string()` in WP 5.4
  - returns `+00:00` instead of `UTC`
  - allows `gmt_offset` setting to be greater than the 24 hour clock

### How to test the changes in this Pull Request:

1. Unit tests should pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Allow float value timezone offsets to display the correct float values.

