### PR TITLE
Removed "Avannaata Kommunia" from Ghanaian regions

### DIFF
--- a/i18n/states.php
+++ b/i18n/states.php
@@ -352,7 +352,6 @@ return array(
 	'GH' => array( // Ghanaian Regions.
 		'AF' => __( 'Ahafo', 'woocommerce' ),
 		'AH' => __( 'Ashanti', 'woocommerce' ),
-		'AV' => __( 'Avannaata Kommunia', 'woocommerce' ),
 		'BA' => __( 'Brong-Ahafo', 'woocommerce' ),
 		'BO' => __( 'Bono', 'woocommerce' ),
 		'BE' => __( 'Bono East', 'woocommerce' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

By accident "Avannaata Kommunia" a municipality of Greenland got introduced in the Ghanaian regions in #26273.
This happened because the CLDR includes "Avannaata Kommunia"  in the "Ghana" section of the list: 

https://github.com/unicode-org/cldr/blob/release-37/common/subdivisions/en.xml#L1845-L1867

### How to test the changes in this Pull Request:

1. Apply this patch, and go to WooCommerce > Settings > General, and set "Selling location(s)" as "Sell to all countries".
2. On the front-end add some product to the cart and go to the checkout.
3. On the billing section in the checkout page change the "Country" to "Ghana" and check the dropbox "Region" if now includes only the correct list of regions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Remove "Avannaata Kommunia" from Ghanaian regions.
