### PR TITLE
Limit stock changes for order items to status methods for consistency.

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -2,9 +2,12 @@
 /**
  * Shows a shipping line
  *
+ * @package WooCommerce/Admin
+ *
  * @var object $item The item being displayed
  * @var int $item_id The id of the item being displayed
  */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -58,10 +61,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	<td class="line_cost" width="1%">
 		<div class="view">
 			<?php
-			echo wc_price( $item->get_total(), array( 'currency' => $order->get_currency() ) );
+			echo wp_kses_post( wc_price( $item->get_total(), array( 'currency' => $order->get_currency() ) ) );
 			$refunded = $order->get_total_refunded_for_item( $item_id, 'shipping' );
 			if ( $refunded ) {
-				echo '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>';
+				echo wp_kses_post( '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>' );
 			}
 			?>
 		</div>
@@ -74,7 +77,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	</td>
 
 	<?php
-	if ( ( $tax_data = $item->get_taxes() ) && wc_tax_enabled() ) {
+	$tax_data = $item->get_taxes();
+	if ( $tax_data && wc_tax_enabled() ) {
 		foreach ( $order_taxes as $tax_item ) {
 			$tax_item_id    = $tax_item->get_rate_id();
 			$tax_item_total = isset( $tax_data['total'][ $tax_item_id ] ) ? $tax_data['total'][ $tax_item_id ] : '';
@@ -82,10 +86,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 			<td class="line_tax" width="1%">
 				<div class="view">
 					<?php
-					echo ( '' !== $tax_item_total ) ? wc_price( wc_round_tax_total( $tax_item_total ), array( 'currency' => $order->get_currency() ) ) : '&ndash;';
+					echo wp_kses_post( ( '' !== $tax_item_total ) ? wc_price( wc_round_tax_total( $tax_item_total ), array( 'currency' => $order->get_currency() ) ) : '&ndash;' );
 					$refunded = $order->get_tax_refunded_for_item( $item_id, $tax_item_id, 'shipping' );
 					if ( $refunded ) {
-						echo '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>';
+						echo wp_kses_post( '<small class="refunded">-' . wc_price( $refunded, array( 'currency' => $order->get_currency() ) ) . '</small>' );
 					}
 					?>
 				</div>

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -861,30 +861,47 @@ class WC_AJAX {
 			wp_die( -1 );
 		}
 
-		$response = array();
+		if ( ! isset( $_POST['order_id'] ) ) {
+			throw new Exception( __( 'Invalid order', 'woocommerce' ) );
+		}
+		$order_id = absint( wp_unslash( $_POST['order_id'] ) );
+
+		// If we passed through items it means we need to save first before adding a new one.
+		$items = ( ! empty( $_POST['items'] ) ) ? wp_unslash( $_POST['items'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		$items_to_add = isset( $_POST['data'] ) ? array_filter( wp_unslash( (array) $_POST['data'] ) ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		try {
-			if ( ! isset( $_POST['order_id'] ) ) {
-				throw new Exception( __( 'Invalid order', 'woocommerce' ) );
-			}
+			$response = self::maybe_add_order_item( $order_id, $items, $items_to_add );
+			wp_send_json_success( $response );
+		} catch ( Exception $e ) {
+			wp_send_json_error( array( 'error' => $e->getMessage() ) );
+		}
+	}
 
-			$order_id = absint( wp_unslash( $_POST['order_id'] ) ); // WPCS: input var ok.
-			$order    = wc_get_order( $order_id );
+	/**
+	 * Add order item via AJAX. This is refactored for better unit testing.
+	 *
+	 * @param int          $order_id     ID of order to add items to.
+	 * @param string|array $items        Existing items in order. Empty string if no items to add.
+	 * @param array        $items_to_add Array of items to add.
+	 *
+	 * @return array     Fragments to render and notes HTML.
+	 * @throws Exception When unable to add item.
+	 */
+	private static function maybe_add_order_item( $order_id, $items, $items_to_add ) {
+		try {
+			$order = wc_get_order( $order_id );
 
 			if ( ! $order ) {
 				throw new Exception( __( 'Invalid order', 'woocommerce' ) );
 			}
-
-			// If we passed through items it means we need to save first before adding a new one.
-			$items = ( ! empty( $_POST['items'] ) ) ? wp_unslash( $_POST['items'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 			if ( ! empty( $items ) ) {
 				$save_items = array();
 				parse_str( $items, $save_items );
 				wc_save_order_items( $order->get_id(), $save_items );
 			}
-
-			$items_to_add = isset( $_POST['data'] ) ? array_filter( wp_unslash( (array) $_POST['data'] ) ) : array(); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 			// Add items to order.
 			$order_notes = array();
@@ -915,12 +932,7 @@ class WC_AJAX {
 				$added_items[ $item_id ] = $item;
 				$order_notes[ $item_id ] = $product->get_formatted_name();
 
-				if ( $product->managing_stock() ) {
-					$new_stock               = wc_update_product_stock( $product, $qty, 'decrease' );
-					$order_notes[ $item_id ] = $product->get_formatted_name() . ' &ndash; ' . ( $new_stock + $qty ) . '&rarr;' . $new_stock;
-					$item->add_meta_data( '_reduced_stock', $qty, true );
-					$item->save();
-				}
+				// We do not perform any stock operations here because they will be handled when order is moved to a status where stock operations are applied (like processing, completed etc).
 
 				do_action( 'woocommerce_ajax_add_order_item_meta', $item_id, $item, $order );
 			}
@@ -942,18 +954,13 @@ class WC_AJAX {
 			include 'admin/meta-boxes/views/html-order-notes.php';
 			$notes_html = ob_get_clean();
 
-			wp_send_json_success(
-				array(
-					'html'       => $items_html,
-					'notes_html' => $notes_html,
-				)
+			return array(
+				'html'       => $items_html,
+				'notes_html' => $notes_html,
 			);
 		} catch ( Exception $e ) {
-			wp_send_json_error( array( 'error' => $e->getMessage() ) );
+			throw $e; // Forward exception to caller.
 		}
-
-		// wp_send_json_success must be outside the try block not to break phpunit tests.
-		wp_send_json_success( $response );
 	}
 
 	/**

--- a/tests/legacy/unit-tests/util/install.php
+++ b/tests/legacy/unit-tests/util/install.php
@@ -37,8 +37,6 @@ class WC_Tests_Install extends WC_Unit_Test_Case {
 
 	/**
 	 * Test - install.
-	 */
-	/**
 	public function test_install() {
 		// clean existing install first.
 		if ( ! defined( 'WP_UNINSTALL_PLUGIN' ) ) {

--- a/tests/php/includes/class-wc-ajax-test.php
+++ b/tests/php/includes/class-wc-ajax-test.php
@@ -1,0 +1,89 @@
+<?php
+/**
+ * Class WC_AJAX_Test file.
+ *
+ * @package WooCommerce|Tests|WC_AJAX.
+ */
+
+/**
+ * Class WC_AJAX_Test file.
+ */
+class WC_AJAX_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Stock should not be reduced from AJAX when an item is added to an order.
+	 */
+	public function test_add_item_to_pending_payment_order() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 1000 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order();
+
+		$data = array(
+			array(
+				'id'  => $product->get_id(),
+				'qty' => 10,
+			),
+		);
+		// Call private method `maybe_add_order_item`.
+		$maybe_add_order_item_func = function () use ( $order, $data ) {
+			return static::maybe_add_order_item( $order->get_id(), '', $data );
+		};
+		$maybe_add_order_item_func->call( new WC_AJAX() );
+
+		// Refresh from DB.
+		$product = wc_get_product( $product->get_id() );
+
+		// Stock should not have been reduced because order status is 'pending'.
+		$this->assertEquals( 1000, $product->get_stock_quantity() );
+		$line_items = $order->get_items();
+		foreach ( $line_items as $line_item ) {
+			if ( $line_item->get_product_id() === $product->get_id() ) {
+				$this->assertEquals( false, $line_item->get_meta( '_reduced_stock', true ) );
+			}
+		}
+	}
+
+	/**
+	 * Stock should be reduced from AJAX when an item is added to an order, when status is being changed
+	 */
+	public function test_add_item_to_processing_order() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_manage_stock( true );
+		$product->set_stock_quantity( 1000 );
+		$product->save();
+
+		$order = WC_Helper_Order::create_order();
+		$order->set_status( 'pending' );
+		$order->save();
+
+		$data = array(
+			array(
+				'id'  => $product->get_id(),
+				'qty' => 10,
+			),
+		);
+		// Call private method `maybe_add_order_item`.
+		$maybe_add_order_item_func = function () use ( $order, $data ) {
+			return static::maybe_add_order_item( $order->get_id(), '', $data );
+		};
+		$maybe_add_order_item_func->call( new WC_AJAX() );
+		$order->set_status( 'processing' );
+		$order->save();
+
+		// Refresh from DB.
+		$product = wc_get_product( $product->get_id() );
+
+		// Stock should not have been reduced because order status is 'pending'.
+		$this->assertEquals( 990, $product->get_stock_quantity() );
+		$line_items = $order->get_items();
+		foreach ( $line_items as $line_item ) {
+			if ( $line_item->get_product_id() === $product->get_id() ) {
+				$this->assertEquals( 10, $line_item->get_meta( '_reduced_stock', true ) );
+			}
+		}
+	}
+
+}

--- a/tests/php/includes/class-wc-ajax-test.php
+++ b/tests/php/includes/class-wc-ajax-test.php
@@ -76,7 +76,6 @@ class WC_AJAX_Test extends \WC_Unit_Test_Case {
 		// Refresh from DB.
 		$product = wc_get_product( $product->get_id() );
 
-		// Stock should not have been reduced because order status is 'pending'.
 		$this->assertEquals( 990, $product->get_stock_quantity() );
 		$line_items = $order->get_items();
 		foreach ( $line_items as $line_item ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Stock changes should be applied only when changing statuses. 

Note that this means if a plugin/extension is reducing/adding stock on completed orders, then they would have to also call `wc_maybe_adjust_line_item_product_stock` manually.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #26607.

### How to test the changes in this Pull Request:

1. Start creating a new order in the admin view, and add a product with managed stock.
2. Without this patch, you will immediately see that product stock is reduced as soon as you add a product. With this patch, stock will be reduced when order is saved and moved into `processing` or `completed` status.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Limit stock changes for order items to status methods for consistency.
