### PR TITLE
Fix undefined index PHP warning

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -96,7 +96,7 @@ class WC_Site_Tracking {
 	public static function add_enable_tracking_function() {
 		global $wp_scripts;
 		
-		if( ! isset( $wp_scripts->registered['woo-tracks'] ) ) {
+		if ( ! isset( $wp_scripts->registered['woo-tracks'] ) ) {
 			return;
 		}
 		

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -95,6 +95,11 @@ class WC_Site_Tracking {
 	 */
 	public static function add_enable_tracking_function() {
 		global $wp_scripts;
+		
+		if( ! isset( $wp_scripts->registered['woo-tracks'] ) ) {
+			return;
+		}
+		
 		$woo_tracks_script = $wp_scripts->registered['woo-tracks']->src;
 
 		?>


### PR DESCRIPTION
![](https://i.gravityview.co/gtGvNE+)

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Check whether the `woo-tracks` script is registered before trying to access its object.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #26657

### How to test the changes in this Pull Request:

1. Apply patch
2. Reload page
3. Notice is gone!

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Possible PHP undefined index notice before WooCommerce has been configured