### PR TITLE
Adds a prompt to confirm if should run tools in the Status page.

### DIFF
--- a/assets/js/admin/system-status.js
+++ b/assets/js/admin/system-status.js
@@ -114,6 +114,11 @@ jQuery( function ( $ ) {
 
 	wcSystemStatus.init();
 
+	$( '.wc_status_table' ).on( 'click', '.run-tool .button', function( evt ) {
+		evt.stopImmediatePropagation();
+		return window.confirm( woocommerce_admin_system_status.run_tool_confirmation );
+	});
+
 	$( '#log-viewer-select' ).on( 'click', 'h2 a.page-title-action', function( evt ) {
 		evt.stopImmediatePropagation();
 		return window.confirm( woocommerce_admin_system_status.delete_log_confirmation );

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -430,7 +430,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'woocommerce_admin_system_status',
 					array(
 						'delete_log_confirmation' => esc_js( __( 'Are you sure you want to delete this log?', 'woocommerce' ) ),
-						'run_tool_confirmation'   => esc_js( __( 'Are you sure you want to run this tool?.', 'woocommerce' ) ),
+						'run_tool_confirmation'   => esc_js( __( 'Are you sure you want to run this tool?', 'woocommerce' ) ),
 					)
 				);
 			}

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -430,6 +430,7 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 					'woocommerce_admin_system_status',
 					array(
 						'delete_log_confirmation' => esc_js( __( 'Are you sure you want to delete this log?', 'woocommerce' ) ),
+						'run_tool_confirmation'   => esc_js( __( 'Are you sure you want to run this tool?.', 'woocommerce' ) ),
 					)
 				);
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently there's nothing to stop if some tool in the WooCommerce > Status > Tools page get triggered by accident. This PR introduced a prompt to confirm before running any tool.

### How to test the changes in this Pull Request:

1. Apply this patch
2. Go to `wp-admin/admin.php?page=wc-status&tab=tools`
3. Trigger any tool and check browser alert.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Confirm before running any tool from the WooCommerce Status settings.