### PR TITLE
Correct grammar mistake in the help tip of the `Connected to WooCommerce.com` field of System Status Report

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -792,7 +792,7 @@ if ( 0 < count( $dropins_mu_plugins['mu_plugins'] ) ) :
 		</tr>
 		<tr>
 			<td data-export-label="Connected to WooCommerce.com"><?php esc_html_e( 'Connected to WooCommerce.com', 'woocommerce' ); ?>:</td>
-			<td class="help"><?php echo wc_help_tip( esc_html__( 'Are your site connected to WooCommerce.com?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
+			<td class="help"><?php echo wc_help_tip( esc_html__( 'Is your site connected to WooCommerce.com?', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo 'yes' === $settings['woocommerce_com_connected'] ? '<mark class="yes"><span class="dashicons dashicons-yes"></span></mark>' : '<mark class="no">&ndash;</mark>'; ?></td>
 		</tr>
 	</tbody>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently, the help tip of the `Connected to WooCommerce.com` field of the System Status Report contains a grammar mistake. It says "Are your site connected to WooCommerce.com?". Instead, it should say "Is your site connected to WooCommerce.com?". 

Closes https://github.com/woocommerce/woocommerce/issues/26664. 

### How to test the changes in this Pull Request:

1. Before testing this PR, navigate to `WooCommerce / Status / System Status`, scroll down to `Settings` section, hover over help tip next to `Connected to WooCommerce.com` field and see that it says "Are your site connected to WooCommerce.com?" (incorrect):

![ssr_before](https://user-images.githubusercontent.com/19143190/83537737-f76dcb80-a4c2-11ea-8420-2138025bbd9d.jpg)

2. Checkout the branch of this PR to test and verify that the message was corrected to "Is your site connected to WooCommerce.com?" (correct):

![ssr_after](https://user-images.githubusercontent.com/19143190/83537800-0d7b8c00-a4c3-11ea-8669-ae7d21370839.jpg)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Correct grammar mistake in the help tip of the `Connected to WooCommerce.com` field of the System Status Report
