### PR TITLE
Fixed typo in WC_Product_CSV_Importer class

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -592,7 +592,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Just skip current field.
 	 *
 	 * By default is applied wc_clean() to all not listed fields
-	 * in self::get_formating_callback(), use this method to skip any formating.
+	 * in self::get_formatting_callback(), use this method to skip any formatting.
 	 *
 	 * @param string $value Field value.
 	 *
@@ -674,11 +674,22 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	}
 
 	/**
-	 * Get formatting callback.
+	 * Deprecated get formatting callback method.
 	 *
+	 * @deprecated 4.3.0
 	 * @return array
 	 */
 	protected function get_formating_callback() {
+		return $this->get_formatting_callback();
+	}
+
+	/**
+	 * Get formatting callback.
+	 *
+	 * @since 4.3.0
+	 * @return array
+	 */
+	protected function get_formatting_callback() {
 
 		/**
 		 * Columns not mentioned here will get parsed with 'wc_clean'.
@@ -935,7 +946,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 * Map and format raw data to known fields.
 	 */
 	protected function set_parsed_data() {
-		$parse_functions = $this->get_formating_callback();
+		$parse_functions = $this->get_formatting_callback();
 		$mapped_keys     = $this->get_mapped_keys();
 		$use_mb          = function_exists( 'mb_convert_encoding' );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Just fixing a typo, and soft deprecating the old method.
I haven't included any warning at this time, but we could deprecate it and throw warnings.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced new `WC_Product_CSV_Importer::get_formatting_callback()` fixing a typo in the method name.
