### PR TITLE
Normalize parameters for woocommerce_product_importer_parsed_data filter

### DIFF
--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -120,7 +120,13 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	 * @return array
 	 */
 	public function get_parsed_data() {
-		return apply_filters( 'woocommerce_product_importer_parsed_data', $this->parsed_data, $this->get_raw_data() );
+		/**
+		 * Filter product importer parsed data.
+		 *
+		 * @param array $parsed_data Parsed data.
+		 * @param WC_Product_Importer $importer Importer instance.
+		 */
+		return apply_filters( 'woocommerce_product_importer_parsed_data', $this->parsed_data, $this );
 	}
 
 	/**

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -973,6 +973,12 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				$data[ $mapped_keys[ $id ] ] = call_user_func( $parse_functions[ $id ], $value );
 			}
 
+			/**
+			 * Filter product importer parsed data.
+			 *
+			 * @param array $parsed_data Parsed data.
+			 * @param WC_Product_Importer $importer Importer instance.
+			 */
 			$this->parsed_data[] = apply_filters( 'woocommerce_product_importer_parsed_data', $this->expand_data( $data ), $this );
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We pass different kinds of parameters for `woocommerce_product_importer_parsed_data`.
This is a problem because developers should check for the parameter type every time that are using this filter.

```php
add_filter(
    'woocommerce_product_importer_parsed_data',
    function( $parsed_data, $importer ) {
        $row_data = '';
        if ( is_a( $importer, 'WC_Product_Importer' ) ) {
                $row_data = $importer->get_raw_data();
        } else {
                $row_data = $importer;
        }
        // Code...
    },
    10,
    2
);
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Normalized parameters of `woocommerce_product_importer_parsed_data` filter.
