### PR TITLE
Add note to Products Importer description that TXT files are also supported.

### DIFF
--- a/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/includes/admin/importers/views/html-product-csv-import-form.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <form class="wc-progress-form-content woocommerce-importer" enctype="multipart/form-data" method="post">
 	<header>
 		<h2><?php esc_html_e( 'Import products from a CSV file', 'woocommerce' ); ?></h2>
-		<p><?php esc_html_e( 'This tool allows you to import (or merge) product data to your store from a CSV file.', 'woocommerce' ); ?></p>
+		<p><?php esc_html_e( 'This tool allows you to import (or merge) product data to your store from a CSV or TXT file.', 'woocommerce' ); ?></p>
 	</header>
 	<section>
 		<table class="form-table woocommerce-importer-options">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently, we allow Products Import from CSV and TXT files (see [here](https://github.com/woocommerce/woocommerce/blob/a7d57a248ed03dac7bad119e71f83dd961f43cb3/includes/admin/importers/class-wc-product-csv-importer-controller.php#L108-L121)) but we don't specify it anywhere in the UI to let users know that TXT files are also supported. The default is the CSV and not everyone knows that the TXT file can also be used. 

We do, however, let the user know that TXT file is supported in the error message that is shown if a file of any other format than CSV or TXT is tried to be used for the import:

![error_message](https://user-images.githubusercontent.com/19143190/83549934-0f9a1680-a4d4-11ea-8062-6a54befd94da.png)

This PR adds a note to the existing importer description that the TXT file is also supported. 

Closes https://github.com/woocommerce/woocommerce/issues/26123. 

### How to test the changes in this Pull Request:

1. Before testing the branch of this PR, navigate to `Products / All Products` and click on the `Import` button at the top of the screen. Note that the description of the importer references the CSV file format to be used for the import:

![csv_before](https://user-images.githubusercontent.com/19143190/83550419-d1512700-a4d4-11ea-8297-57f465603a2e.jpg)

2. Checkout the branch of this PR - in the same section the reference to TXT file is now added:

![csv_after](https://user-images.githubusercontent.com/19143190/83550462-e29a3380-a4d4-11ea-8994-aa89492eafde.jpg)

**NOTE:**

I considered adding `TXT` everywhere where CSV is mentioned. For example, see below:

![csv_everywhere](https://user-images.githubusercontent.com/19143190/83550735-4a507e80-a4d5-11ea-97ea-3458303c83dc.jpg)

But I decided against it because it is a CSV Importer after all. It is convenient that we also support TXT but I think it should stay as an add-on rather than the main feature so to speak. But I don't hold to this opinion strongly. 

If you think otherwise, I can update the messages everywhere with TXT reference. That will include:

- Updating the import form
- Updating the column mapping form
- Updating `Tools / Import / WooCommerce products (CSV)`
- Updating setup wizard
- Perhaps more places (will need to do a proper search)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Add note to Products Importer description that TXT files are also supported.
