### PR TITLE
Make renovate ignore WooCommerce packages

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,12 @@
   "extends": [
     "config:base"
   ],
+  "ignoreDeps": [
+    "woocommerce/action-scheduler",
+    "woocommerce/woocommerce-admin",
+    "woocommerce/woocommerce-blocks",
+    "woocommerce/woocommerce-rest-api"
+  ],
   "packageRules": [
     {
       "packageNames": ["automattic/jetpack-autoloader"],


### PR DESCRIPTION
This changes the renovate settings to ignore Action Scheduler, WooCommerce Blocks, WooCommerce Admin and REST API packages, since those packages requires manual updates.