### PR TITLE
Updated .distignore to exclude directories only from root

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -1,17 +1,18 @@
 .*
 .*/
+./bin/
+./build/
+./node_modules/
+./tests/
 *.lock
 *.md
 *.zip
 babel.config.js
-bin/
-build/
 CHANGELOG.txt
 composer.*
 docker-compose.yaml
 Dockerfile
 Gruntfile.js
-node_modules/
 none
 package-lock.json
 package.json
@@ -21,4 +22,4 @@ phpunit.xml
 phpunit.xml.dist
 README.md
 renovate.json
-tests
+webpack.config.js


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updated .distignore to exclude directories only from root and excludes `webpack.config.js` file now.

### How to test the changes in this Pull Request:

1. Checkout this branch
2. Run `npm run build:zip`
3. Check if `webpack.config.js` got excluded from the zip file, and also if `packages/woocommerce-blocks/build` exists.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->


