### PR TITLE
Removed the notice for untested minor version updates

### DIFF
--- a/includes/admin/plugin-updates/class-wc-plugin-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugin-updates.php
@@ -46,13 +46,6 @@ class WC_Plugin_Updates {
 	protected $major_untested_plugins = array();
 
 	/**
-	 * Array of plugins lacking testing with the minor version.
-	 *
-	 * @var array
-	 */
-	protected $minor_untested_plugins = array();
-
-	/**
 	 * Common JS for initializing and managing thickbox-based modals.
 	 */
 	protected function generic_modal_js() {
@@ -102,29 +95,6 @@ class WC_Plugin_Updates {
 	|
 	| Methods for getting messages.
 	*/
-
-	/**
-	 * Get the inline warning notice for minor version updates.
-	 *
-	 * @return string
-	 */
-	protected function get_extensions_inline_warning_minor() {
-		$upgrade_type  = 'minor';
-		$plugins       = ! empty( $this->major_untested_plugins ) ? array_diff_key( $this->minor_untested_plugins, $this->major_untested_plugins ) : $this->minor_untested_plugins;
-		$version_parts = explode( '.', $this->new_version );
-		$new_version   = $version_parts[0] . '.' . $version_parts[1];
-
-		if ( empty( $plugins ) ) {
-			return;
-		}
-
-		/* translators: %s: version number */
-		$message = sprintf( __( "<strong>Heads up!</strong> The versions of the following plugins you're running haven't been tested with the latest version of WooCommerce (%s).", 'woocommerce' ), $new_version );
-
-		ob_start();
-		include 'views/html-notice-untested-extensions-inline.php';
-		return ob_get_clean();
-	}
 
 	/**
 	 * Get the inline warning notice for major version updates.

--- a/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
@@ -45,7 +45,6 @@ class WC_Plugins_Screen_Updates extends WC_Plugin_Updates {
 		$this->new_version            = $response->new_version;
 		$this->upgrade_notice         = $this->get_upgrade_notice( $response->new_version );
 		$this->major_untested_plugins = $this->get_untested_plugins( $response->new_version, 'major' );
-		$this->minor_untested_plugins = $this->get_untested_plugins( $response->new_version, 'minor' );
 
 		$current_version_parts = explode( '.', Constants::get_constant( 'WC_VERSION' ) );
 		$new_version_parts     = explode( '.', $this->new_version );
@@ -57,10 +56,6 @@ class WC_Plugins_Screen_Updates extends WC_Plugin_Updates {
 
 		if ( ! empty( $this->major_untested_plugins ) ) {
 			$this->upgrade_notice .= $this->get_extensions_inline_warning_major();
-		}
-
-		if ( ! empty( $this->minor_untested_plugins ) ) {
-			$this->upgrade_notice .= $this->get_extensions_inline_warning_minor();
 		}
 
 		if ( ! empty( $this->major_untested_plugins ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

With the increased cadence of releases it becomes necessary that we address the `WC tested up to` header's usefulness. It isn't practical to require everyone to update their extensions every month, especially given that we are only doing backwards compatible minor releases. The only case I can think of where we might want to check the minor version is if the Stable tag on Core is downgraded, but due to the naming of the header, this doesn't make any sense.

I considered making this a wildcard of some kind but I think most would bind to a full major version anyway and so this isn't worth the time to add it. As an aside, the tests in `plugin-updates.php` seem to indicate that a header of `WC tested up to: 4` would apply to the entire major version cycle, so wildcards already exist!

Closes #26248 

### How to test the changes in this Pull Request:

1. Add this dummy plugin to your test site:
```
<?php
/**
 * Plugin Name: Version Test Plugin
 * Version: 1.0.0
 * Requires at least: 5.2
 * Requires PHP: 7.0
 *
 * WC tested up to: 4.1
 */
```
2. Change the version in the `woocommerce.php` header to `4.0.0` and the version string in `includes/class-woocommerce.php` to `4.0.0`. Without the PR there is a notice for "Version Test Plugin" under the WooCommerce Update on the plugins page. With the PR, the notice does not appear.
3. Change the version in the WooCommerce files to `3.9.0`. Also change the tested header in the plugin you created above to `3.9.0` as well. Both with and without the PR the plugin update will list the notice for the plugin as a major update.

As a bonus, try doing all of the above without this PR but the tested version as a major only. `WC tested up to: 3` when looking at the major update and `WC tested up to: 4` when looking at the minor update. We've always supported wildcards 😄 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Adjusted the `WC tested up to` check to only apply to major versions.
