### PR TITLE
Translate woocommerce-admin domain in Blocks package

### DIFF
--- a/bin/package-update.sh
+++ b/bin/package-update.sh
@@ -34,6 +34,7 @@ output 2 "Done!"
 
 output 3 "Updating package JS textdomains..."
 find ./packages/woocommerce-blocks -iname '*.js' -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" -e "s/\"woo-gutenberg-products-block\"/'woocommerce'/g" {} \;
+find ./packages/woocommerce-blocks -iname '*.js' -exec sed -i.bak -e "s/'woocommerce-admin'/'woocommerce'/g" -e "s/\"woocommerce-admin\"/'woocommerce'/g" {} \;
 find ./packages/woocommerce-admin -iname '*.js' -exec sed -i.bak -e "s/'woocommerce-admin'/'woocommerce'/g" -e "s/\"woocommerce-admin\"/'woocommerce'/g" {} \;
 
 # Cleanup backup files


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Based on a [forum post](https://wordpress.org/support/topic/wrong-js-translations-loading/) I checked our 4.2 package and see there are a bunch of translate strings with `woocommerce-admin` domain in `packages/woocommerce-blocks/build/vendors.js` and `packages/woocommerce-blocks/build/vendors-legacy.js`, so I think we need to change the domain for those as well, so I've added one more translation rule.


### How to test the changes in this Pull Request:

1. Download WC 4.2
2. Grep all the files to search for ['"]woocommerce-admin['"]
3. See `packages/woocommerce-blocks/build/vendors.js` includes some translation strings with `woocommerce-admin` domain. 
4. Apply this branch
5. Run `composer install`
6. Run the same grep, it should no longer show those occurrences.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Domain update script now replaces woocommerce-admin domain also in Blocks package.
