### PR TITLE
Puerto Rico: Remove "City" field and rename "State" to "Municipality"

### DIFF
--- a/i18n/states.php
+++ b/i18n/states.php
@@ -1062,7 +1062,6 @@ return array(
 		'SD' => __( 'Sindh', 'woocommerce' ),
 	),
 	'PL' => array(),
-	'PR' => array(),
 	'PT' => array(),
 	'PY' => array( // Paraguay states.
 		'PY-ASU' => __( 'Asunci&oacute;n', 'woocommerce' ),

--- a/i18n/states.php
+++ b/i18n/states.php
@@ -1062,6 +1062,7 @@ return array(
 		'SD' => __( 'Sindh', 'woocommerce' ),
 	),
 	'PL' => array(),
+	'PR' => array(),
 	'PT' => array(),
 	'PY' => array( // Paraguay states.
 		'PY-ASU' => __( 'Asunci&oacute;n', 'woocommerce' ),

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -527,6 +527,7 @@ class WC_Countries {
 					'NZ'      => "{name}\n{company}\n{address_1}\n{address_2}\n{city} {postcode}\n{country}",
 					'NO'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'PL'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
+					'PR'      => "{company}\n{name}\n{address_1} {address_2}\n{city} {postcode}\n{country}",
 					'PT'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'SK'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'RS'      => "{name}\n{company}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
@@ -1147,6 +1148,12 @@ class WC_Countries {
 						),
 						'state'    => array(
 							'required' => false,
+						),
+					),
+					'PR' => array(
+						'state' => array(
+							'required' => false,
+							'hidden'   => true,
 						),
 					),
 					'PT' => array(

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -527,7 +527,7 @@ class WC_Countries {
 					'NZ'      => "{name}\n{company}\n{address_1}\n{address_2}\n{city} {postcode}\n{country}",
 					'NO'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'PL'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
-					'PR'      => "{company}\n{name}\n{address_1} {address_2}\n{state} {postcode}\n{country}",
+					'PR'      => "{company}\n{name}\n{address_1} {address_2}\n{state} \n{country} {postcode}",
 					'PT'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'SK'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'RS'      => "{name}\n{company}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -527,7 +527,7 @@ class WC_Countries {
 					'NZ'      => "{name}\n{company}\n{address_1}\n{address_2}\n{city} {postcode}\n{country}",
 					'NO'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'PL'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
-					'PR'      => "{company}\n{name}\n{address_1} {address_2}\n{city} {postcode}\n{country}",
+					'PR'      => "{company}\n{name}\n{address_1} {address_2}\n{state} {postcode}\n{country}",
 					'PT'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'SK'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'RS'      => "{name}\n{company}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
@@ -1151,9 +1151,12 @@ class WC_Countries {
 						),
 					),
 					'PR' => array(
-						'state' => array(
+						'city'  => array(
 							'required' => false,
 							'hidden'   => true,
+						),
+						'state' => array(
+							'label' => __( 'Municipality', 'woocommerce' ),
 						),
 					),
 					'PT' => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR rename "State" to "Municipality" and remove "City" from Puerto Rico addresses, also improves the formatting based on: https://pe.usps.com/text/pub28/28c2_041.htm

Closes #26643.

### How to test the changes in this Pull Request:

1. Checkout this branch.
2. Add a product to the cart and to go the checkout page.
3. Select "Puerto Rico", and check for the "Municipality" field.
4. Place an order and check for the address generated in the "order received page".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Localization - Improved Puerto Rico addresses and improve address formatting.
