### PR TITLE
Port enhancement to reserved stock feature from wc-blocks

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -340,6 +340,29 @@ class WC_Admin_Status {
 	}
 
 	/**
+	 * Prints table info if a base table is not present.
+	 */
+	private static function output_tables_info() {
+		$missing_tables = WC_Install::verify_base_tables( false );
+		if ( 0 === count( $missing_tables ) ) {
+			return;
+		}
+		?>
+
+		<br>
+		<strong style="color:#a00;">
+			<span class="dashicons dashicons-warning"></span>
+			<?php
+				esc_html_e( 'Missing base tables: ', 'woocommerce' );
+				echo esc_html( implode( ', ', $missing_tables ) );
+				esc_html_e( '. Some WooCommerce functionality may not work as expected.', 'woocommerce' );
+			?>
+		</strong>
+
+		<?php
+	}
+
+	/**
 	 * Prints the information about plugins for the system status report.
 	 * Used for both active and inactive plugins sections.
 	 *

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -496,10 +496,17 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 		?>
 	</tbody>
 </table>
-<table class="wc_status_table widefat" cellspacing="0">
+<table id="status-database" class="wc_status_table widefat" cellspacing="0">
 	<thead>
 	<tr>
-		<th colspan="3" data-export-label="Database"><h2><?php esc_html_e( 'Database', 'woocommerce' ); ?></h2></th>
+		<th colspan="3" data-export-label="Database">
+			<h2>
+				<?php
+					esc_html_e( 'Database', 'woocommerce' );
+					self::output_tables_info();
+				?>
+			</h2>
+		</th>
 	</tr>
 	</thead>
 	<tbody>

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -994,8 +994,8 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 	`order_id` bigint(20) NOT NULL,
 	`product_id` bigint(20) NOT NULL,
 	`stock_quantity` double NOT NULL DEFAULT 0,
-	`timestamp` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-	`expires` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+	`timestamp` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
+	`expires` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 	PRIMARY KEY  (`order_id`, `product_id`)
 ) $collate;
 		";

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -124,6 +124,10 @@ final class ReserveStock {
 	public function release_stock_for_order( \WC_Order $order ) {
 		global $wpdb;
 
+		if ( ! $this->is_enabled() ) {
+			return;
+		}
+
 		$wpdb->delete(
 			$wpdb->wc_reserved_stock,
 			array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR port over following changes for wc-blocks:
1. Use '0000-00-00 00:00:00' instead of CURRENT_TIMESTAMP as default value to support MySQL 5.6
2. Return early if DB version is less than 430 because then it would mean that required wc_reserved_stock table might not be present.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #26311.

### How to test the changes in this Pull Request:

1. Update to latest *master* for https://github.com/woocommerce/woocommerce-rest-api/.
2. Create a product and enable stock management.
3. Delete table `wc_reserved_stock` and try to checkout. You should be able to.
4. Add that table back again by going to Status > Tools > Verify DB. You should be able to successfully complete checkout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Allow checkout even if reserved table is not present.

> Dev - Use default timestamp as '0000-00-00 00:00:00' for reserved stock table to support MySQL 5.6
