### PR TITLE
Remove check for existing term when parsing category via CSV & instead catch an existing term error when adding new category to the database

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -384,7 +384,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 *
 	 * @param string $value Field value.
 	 *
-	 * @return array|WP_Error
+	 * @return array of arrays with "parent" and "name" keys.
 	 */
 	public function parse_categories_field( $value ) {
 		if ( empty( $value ) ) {

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -384,7 +384,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 	 *
 	 * @param string $value Field value.
 	 *
-	 * @return array of arrays with "parent" and "name" keys.
+	 * @return array|WP_Error
 	 */
 	public function parse_categories_field( $value ) {
 		if ( empty( $value ) ) {
@@ -400,21 +400,22 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			$total  = count( $_terms );
 
 			foreach ( $_terms as $index => $_term ) {
-				// Check if category exists. Parent must be empty string or null if doesn't exists.
-				$term = term_exists( $_term, 'product_cat', $parent );
-
-				if ( is_array( $term ) ) {
-					$term_id = $term['term_id'];
-					// Don't allow users without capabilities to create new categories.
-				} elseif ( ! current_user_can( 'manage_product_terms' ) ) {
+				// Don't allow users without capabilities to create new categories.
+				if ( ! current_user_can( 'manage_product_terms' ) ) {
 					break;
-				} else {
-					$term = wp_insert_term( $_term, 'product_cat', array( 'parent' => intval( $parent ) ) );
+				}
 
-					if ( is_wp_error( $term ) ) {
-						break; // We cannot continue if the term cannot be inserted.
+				$term = wp_insert_term( $_term, 'product_cat', array( 'parent' => intval( $parent ) ) );
+
+				if ( is_wp_error( $term ) ) {
+					if ( $term->get_error_code() === 'term_exists' ) {
+						// When term exists, error data should contain existing term id.
+						$term_id = $term->get_error_data();
+					} else {
+						break; // We cannot continue on any other error.
 					}
-
+				} else {
+					// New term.
 					$term_id = $term['term_id'];
 				}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/26665. 

Currently, when products are being imported via CSV file, one of the following happens:

- If there is no category with the same name but no semicolon or a dot exists (for example, `Clothing;`) - the category is created when CSV import is completed;
- If there is already a product category with the same name except for a dot or a semicolon exists (for example `Clothing` exists and we are trying to import `Clothing;`) - the product will be added to the existing category `Clothing`. `Clothing;` won't get created. 

<hr>

The reason why the above happens is that we rely on WordPress's functions `term_exists()` and `wp_insert_term()` to check for existing categories during import and add a new term (category) to the database if the category doesn't exist. Both of these functions sanitize the initial entry differently. 

See https://github.com/woocommerce/woocommerce/issues/26665#issuecomment-639145714 for my explanation of what happens in each case in code. 

<hr>

Since `term_exists()` and `wp_insert_term()` are separated from each other and run different queries, for consistency we should not use `term_exists()`. Instead, we should call `wp_insert_term()` and catch error if term exists. Which is what this PR does. 


### How to test the changes in this Pull Request:

1. Before testing this PR, create 2 products with category `Music`.
2. Export products via CSV using a built-in product Importer/Exporter.
3. Delete one of the products completely from the site (including Trash).
3. Open CSV file and edit a category of the deleted product to `Music;`.
4. Add more row for the new product. Fill out all the needed details. Assign it category `Dance;`. 
4. Import edited CSV file back to the site. 
5. Note that category `Music;` didn't get created. Instead, the product that had category `Music;` assigned to it in CSV got added to the existing category `Music`.
6. Note that category `Dance;` did get created. 
7. Now check out this branch and repeat steps 1-6. 
8. Upon importing products via CSV back to the site, both categories `Music;` and `Dance;` should be created in addition to the existing category `Music`. 

<hr>

Pinging @peterfabian and @claudiosanches here for review since I spoke to both of you regarding this issue but anyone else can review as well of course. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Remove check for the existing term when parsing category via CSV & instead catch an existing term error when adding a new category to the database
