### PR TITLE
Fix unbalanced tag

### DIFF
--- a/templates/auth/form-grant-access.php
+++ b/templates/auth/form-grant-access.php
@@ -50,6 +50,7 @@ defined( 'ABSPATH' ) || exit;
 		printf( esc_html__( 'Logged in as %s', 'woocommerce' ), esc_html( $user->display_name ) );
 		?>
 		<a href="<?php echo esc_url( $logout_url ); ?>" class="wc-auth-logout"><?php esc_html_e( 'Logout', 'woocommerce' ); ?></a>
+	</p>
 </div>
 
 <p class="wc-auth-actions">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Close open `<p>` tag in auth template file.
### Changelog entry

Close unbalanced `<p>` tag in auth "Grant Access" form template file.