### PR TITLE
Update saving of comment_type for reviews to account for WP 5.5 changes

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -146,7 +146,7 @@ class WC_Comments {
 	 */
 	public static function check_comment_rating( $comment_data ) {
 		// If posting a comment (not trackback etc) and not logged in.
-		if ( ! is_admin() && isset( $_POST['comment_post_ID'], $_POST['rating'], $comment_data['comment_type'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) && empty( $_POST['rating'] ) && '' === $comment_data['comment_type'] && wc_review_ratings_enabled() && wc_review_ratings_required() ) { // WPCS: input var ok, CSRF ok.
+		if ( ! is_admin() && isset( $_POST['comment_post_ID'], $_POST['rating'], $comment_data['comment_type'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) && empty( $_POST['rating'] ) && self::is_default_comment_type( $comment_data['comment_type'] ) && wc_review_ratings_enabled() && wc_review_ratings_required() ) { // WPCS: input var ok, CSRF ok.
 			wp_die( esc_html__( 'Please rate the product.', 'woocommerce' ) );
 			exit;
 		}
@@ -406,11 +406,25 @@ class WC_Comments {
 	 * @return array
 	 */
 	public static function update_comment_type( $comment_data ) {
-		if ( ! is_admin() && isset( $_POST['comment_post_ID'], $comment_data['comment_type'] ) && '' === $comment_data['comment_type'] && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) ) { // WPCS: input var ok, CSRF ok.
+		if ( ! is_admin() && isset( $_POST['comment_post_ID'], $comment_data['comment_type'] ) && self::is_default_comment_type( $comment_data['comment_type'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) ) { // WPCS: input var ok, CSRF ok.
 			$comment_data['comment_type'] = 'review';
 		}
 
 		return $comment_data;
+	}
+
+	/**
+	 * Determines if a comment is of the default type.
+	 *
+	 * Prior to WordPress 5.5, '' was the default comment type.
+	 * As of 5.5, the default type is 'comment'.
+	 *
+	 * @since 4.3.0
+	 * @param string $comment_type Comment type.
+	 * @return bool
+	 */
+	private static function is_default_comment_type( $comment_type ) {
+		return ( '' === $comment_type || 'comment' === $comment_type );
 	}
 }
 


### PR DESCRIPTION
# All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Updates the method to ensure a rating has been selected (`check_comment_rating`) and the method that updates the `comment_type` for reviews (`update_comment_type`) so that each is aware of the new default comment type in WP 5.5 (`comment`).

Closes #26367 .

### How to test the changes in this Pull Request:

1. Using a WordPress install prior to 5.5, leave a review on a product from your site.
2. Check the comments table for that review and ensure that `comment_type` is "review".
3. Use the [WordPress Beta Tester plugin](https://wordpress.org/plugins/wordpress-beta-tester/) to install WordPress 5.5 (or install it via some other means).
4. Leave a review on a product from your site.
5. Verify that the `comment_type` is "review".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix comment_type value for reviews created with WordPress 5.5
