### PR TITLE
Update woocommerce/woocommerce-blocks to v2.7.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "1.2.3",
-    "woocommerce/woocommerce-blocks": "2.5.16",
+    "woocommerce/woocommerce-blocks": "2.7.0",
     "woocommerce/woocommerce-rest-api": "1.0.8"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -480,16 +480,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v2.5.16",
+            "version": "v2.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "3bd91b669247000fd3f5277954701d0b148d3f1a"
+                "reference": "161be65dbff230862fe52a18ea7c9a01557169c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/3bd91b669247000fd3f5277954701d0b148d3f1a",
-                "reference": "3bd91b669247000fd3f5277954701d0b148d3f1a",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/161be65dbff230862fe52a18ea7c9a01557169c2",
+                "reference": "161be65dbff230862fe52a18ea7c9a01557169c2",
                 "shasum": ""
             },
             "require": {
@@ -523,7 +523,7 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2020-04-07T11:47:19+00:00"
+            "time": "2020-06-09T09:29:00+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",


### PR DESCRIPTION
Bump WooCommerce Blocks version to the last released one: 2.7.0.

Some parts of this PR are based on the release PRs from WC Blocks:
* 2.6.0: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2554
* 2.6.1: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2601
* 2.7.0: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2666

## Communication

This update (including 2.6 and 2.7 releases) introduces:

* A new status for orders (“draft”).
* HTML editing is no longer supported in several blocks.
* Error notice in the All Products block if the product could not be added to the Cart.
* Some fixes to the Filter Products by Price block when handling prices with taxes.
* Active Filters block now reflects the type of relation being queried for selected filters.
* Dropdown styles for the Filter Products by Attribute block.
* Option to add a _Apply Filter_ button to the Filter Products by Attribute block.
* Featured Product block will now update the url on the button when the featured product is changed.
* Product Categories List block now has an option to display product images.
* Better compatibility of several blocks with Twenty Twenty.
* Performance and styling improvements to several blocks.

There are some changes that are present in the development mode and in the feature plugin but should not be available in WooCommerce Core:
* It should not be possible to add the _Cart_ and _Checkout_ blocks. They are only available in the feature plugin.
* It should not be possible to add the _Single Product_ block. It's currently in development and only available in dev builds.

You can see the release announcements in the developer blog:

* [2.6.0](https://woocommerce.wordpress.com/2020/05/27/woocommerce-blocks-2-6-0-release-notes/)
* [2.7.0](https://woocommerce.wordpress.com/2020/06/09/woocommerce-blocks-2-7-release-notes/)

### Prepared Updates

**Developer Notes** - The following issues require developer notes in the release post:

* All product grid blocks now default to three rows instead of one like in previous versions (see https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/1613).
* Some styles of live blocks were modified in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2428. That PR has some notes about the changes included and how to revert them. Those notes are also included in the plugin [theming docs](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/master/docs/theming/product-grid-270.md).

**Relevant developer documentation:**

[Documentation for the new APIs](https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/release/2.7/docs/block-client-apis) is included in the repo.

**Happiness Engineer:** a post was written in p6q7sZ-7ck-p2.

## Quality

* [x] Changes in this release are covered by Automated Tests.
     * [x] Unit tests
     * [x] E2E tests
     * [x] for each supported WordPress and WooCommerce core versions.

**Note**: Our automated test coverage is still being improved. 

- The REST API Store routes have full coverage on the routes.
- There is limited coverage of blocks editor/frontend flows.

* This release has been tested on the following platforms:
     * [x] mobile
     * [x] desktop

* [x] This release affects public facing REST APIs.

Current REST API is internal only. The public API surface for integrations etc has not changed.

* [x] Link to **testing instructions** for this release: https://github.com/woocommerce/woocommerce/wiki/Release-Testing-Instructions-WooCommerce-4.3#updates-to-woocommerce-product-blocks

* [x] The release has a negative performance impact on sites.
    * [x] There is an increase to the size of JavaScrip or CSS bundles) <!-- please include rationale for this increase -->

The All Products block frontend script size increased from 14,85KB to 38,41KB, that's due to the inclusion of the `Notice` component from `@wordpress/components`. As stated in https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2280 we consider those to be acceptable file increases, even though we will keep investigating other opportunities to reduce the bundle size.

* [x] The release has positive performance impact on sites. If checked, please document these improvements here.

Some bundle size improvements were introduced in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2577 for several block scripts used in the editor.