### PR TITLE
Export: properly escape commas in attribute values

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -656,10 +656,10 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 
 						if ( 0 === strpos( $attribute_name, 'pa_' ) ) {
 							$option_term = get_term_by( 'slug', $attribute, $attribute_name ); // @codingStandardsIgnoreLine.
-							$row[ 'attributes:value' . $i ]    = $option_term && ! is_wp_error( $option_term ) ? str_replace( ',', '\\,', $option_term->name ) : $attribute;
+							$row[ 'attributes:value' . $i ]    = $option_term && ! is_wp_error( $option_term ) ? str_replace( ',', '\\,', $option_term->name ) : str_replace( ',', '\\,', $attribute );
 							$row[ 'attributes:taxonomy' . $i ] = 1;
 						} else {
-							$row[ 'attributes:value' . $i ]    = $attribute;
+							$row[ 'attributes:value' . $i ]    = str_replace( ',', '\\,', $attribute );
 							$row[ 'attributes:taxonomy' . $i ] = 0;
 						}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When the export CSV is generated, the attribute value isn't always properly escaped. This PR updates the escaping so that values containing a comma are permitted.

Closes #24800.

### How to test the changes in this Pull Request:

1. Create a variable product with an attribute whose values contain commas. For example: `red, blue | black, white | green, purple`. Select "used for variations" for that attribute.
![image](https://user-images.githubusercontent.com/363749/84199836-6f139b80-aa6b-11ea-8258-2cf4113fbb94.png)
2. Create one (or more) variations using the attributes containing commas.
3. Export a CSV containing those products.
4. Verify that in the CSV output, the commas for the attribute values are escaped properly. Using the example above, for the variable product, they should look like `"red\, blue, black\, white, green\, purple"` and for the variations they should look like `"red\, blue"`, `"black\, white"`, and `"green\, purple"` respectively.
5. Verify that if you import the CSV that you exported that the variations are configured correctly on the newly-imported products.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixes an issue with attribute value escaping in product CSV exports.
