### PR TITLE
Added pre-push hook to prevent accidental pushes to master

### DIFF
--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+PROTECTED_BRANCH="master"
+REMOTE_REF=$(echo $HUSKY_GIT_STDIN | cut -d " " -f 3)
+
+if [[ "$REMOTE_REF" == *"$PROTECTED_BRANCH"* ]]; then
+	printf "$(tput setaf 3)You're about to push to master, is that what you intended? [y/N]: $(tput sgr0)"
+	read -r PROCEED < /dev/tty
+	echo
+
+	if [ "$(echo "${PROCEED:-n}" | tr "[:upper:]" "[:lower:]")" = "y" ]; then
+		echo "$(tput setaf 2)Brace yourself! Pushing to the master branch...$(tput sgr0)"
+		echo
+		exit 0
+	fi
+
+	echo "$(tput setaf 2)Push to master cancelled!$(tput sgr0)"
+	echo
+	exit 1
+fi

--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -1,20 +1,22 @@
-#!/bin/bash
+#!/bin/sh
 
 PROTECTED_BRANCH="master"
-REMOTE_REF=$(echo $HUSKY_GIT_STDIN | cut -d " " -f 3)
+REMOTE_REF=$(echo "$HUSKY_GIT_STDIN" | cut -d " " -f 3)
 
-if [[ "$REMOTE_REF" == *"$PROTECTED_BRANCH"* ]]; then
-	printf "$(tput setaf 3)You're about to push to master, is that what you intended? [y/N]: $(tput sgr0)"
-	read -r PROCEED < /dev/tty
-	echo
-
-	if [ "$(echo "${PROCEED:-n}" | tr "[:upper:]" "[:lower:]")" = "y" ]; then
-		echo "$(tput setaf 2)Brace yourself! Pushing to the master branch...$(tput sgr0)"
+if [ -n "$REMOTE_REF" ]; then
+	if [ -z "${REMOTE_REF##*$PROTECTED_BRANCH*}" ]; then
+		printf "%sYou're about to push to master, is that what you intended? [y/N]: %s" "$(tput setaf 3)" "$(tput sgr0)"
+		read -r PROCEED < /dev/tty
 		echo
-		exit 0
-	fi
 
-	echo "$(tput setaf 2)Push to master cancelled!$(tput sgr0)"
-	echo
-	exit 1
+		if [ "$(echo "${PROCEED:-n}" | tr "[:upper:]" "[:lower:]")" = "y" ]; then
+			echo "$(tput setaf 2)Brace yourself! Pushing to the master branch...$(tput sgr0)"
+			echo
+			exit 0
+		fi
+
+		echo "$(tput setaf 2)Push to master cancelled!$(tput sgr0)"
+		echo
+		exit 1
+	fi
 fi

--- a/package.json
+++ b/package.json
@@ -77,8 +77,9 @@
   },
   "husky": {
     "hooks": {
+      "post-merge": "./bin/post-merge.sh",
       "pre-commit": "lint-staged",
-      "post-merge": "./bin/post-merge.sh"
+      "pre-push": "./bin/pre-push.sh"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

It introduces a GIT `pre-push` hook to prevent accidental pushes to master.

### How to test the changes in this Pull Request:

1. Make a fork of WooCommerce, after you need to clone and run `git merge update/git-hook-pre-push`, it will apply the changes from this PR on your fork.
2. Now create a `test.txt`, and make a commit.
3. Finally try to push to master and check for message.
4. First test by typing `n` and press Enter, just to test if it gets cancelled correctly.
5. This time type `y`, and check if it gets pushed to master successfully.
6. Create a new branch, like `git checkout -b test/pre-push`.
7. Updated your `test.txt` created in step 2 with any content, and make a new commit.
8. Finally try push to the `test/pre-push`, check that no message gets displayed like does when trying to push to master.
