### PR TITLE
Count and display CSV imported, updated, skipped and failed products excluding variations when CSV Import is completed

### DIFF
--- a/includes/admin/class-wc-admin-importers.php
+++ b/includes/admin/class-wc-admin-importers.php
@@ -282,9 +282,9 @@ class WC_Admin_Importers {
 					'position'   => 'done',
 					'percentage' => 100,
 					'url'        => add_query_arg( array( '_wpnonce' => wp_create_nonce( 'woocommerce-csv-importer' ) ), admin_url( 'edit.php?post_type=product&page=product_importer&step=done' ) ),
-					'imported'   => $results['distinct_count'],
+					'imported'   => $results['imported_distinct_count'],
 					'failed'     => count( $results['failed'] ),
-					'updated'    => count( $results['updated'] ),
+					'updated'    => $results['updated_distinct_count'],
 					'skipped'    => count( $results['skipped'] ),
 				)
 			);
@@ -293,9 +293,9 @@ class WC_Admin_Importers {
 				array(
 					'position'   => $importer->get_file_position(),
 					'percentage' => $percent_complete,
-					'imported'   => $results['distinct_count'],
+					'imported'   => $results['imported_distinct_count'],
 					'failed'     => count( $results['failed'] ),
-					'updated'    => count( $results['updated'] ),
+					'updated'    => $results['updated_distinct_count'],
 					'skipped'    => count( $results['skipped'] ),
 				)
 			);

--- a/includes/admin/class-wc-admin-importers.php
+++ b/includes/admin/class-wc-admin-importers.php
@@ -282,7 +282,7 @@ class WC_Admin_Importers {
 					'position'   => 'done',
 					'percentage' => 100,
 					'url'        => add_query_arg( array( '_wpnonce' => wp_create_nonce( 'woocommerce-csv-importer' ) ), admin_url( 'edit.php?post_type=product&page=product_importer&step=done' ) ),
-					'imported'   => count( $results['imported'] ),
+					'imported'   => $results['distinct_count'],
 					'failed'     => count( $results['failed'] ),
 					'updated'    => count( $results['updated'] ),
 					'skipped'    => count( $results['skipped'] ),
@@ -293,7 +293,7 @@ class WC_Admin_Importers {
 				array(
 					'position'   => $importer->get_file_position(),
 					'percentage' => $percent_complete,
-					'imported'   => count( $results['imported'] ),
+					'imported'   => $results['distinct_count'],
 					'failed'     => count( $results['failed'] ),
 					'updated'    => count( $results['updated'] ),
 					'skipped'    => count( $results['skipped'] ),

--- a/includes/admin/class-wc-admin-importers.php
+++ b/includes/admin/class-wc-admin-importers.php
@@ -151,7 +151,7 @@ class WC_Admin_Importers {
 			return;
 		}
 
-		$id          = absint( $_POST['import_id'] ); // PHPCS: input var ok.
+		$id          = absint( $_POST['import_id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		$file        = get_attached_file( $id );
 		$parser      = new WXR_Parser();
 		$import_data = $parser->parse( $file );

--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -149,7 +149,7 @@ class WC_Product_CSV_Importer_Controller {
 
 		$this->steps = apply_filters( 'woocommerce_product_csv_importer_steps', $default_steps );
 
-		// phpcs:disable WordPress.Security.NonceVerification.Missing
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
 		$this->step            = isset( $_REQUEST['step'] ) ? sanitize_key( $_REQUEST['step'] ) : current( array_keys( $this->steps ) );
 		$this->file            = isset( $_REQUEST['file'] ) ? wc_clean( wp_unslash( $_REQUEST['file'] ) ) : '';
 		$this->update_existing = isset( $_REQUEST['update_existing'] ) ? (bool) $_REQUEST['update_existing'] : false;

--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -149,7 +149,7 @@ class WC_Product_CSV_Importer_Controller {
 
 		$this->steps = apply_filters( 'woocommerce_product_csv_importer_steps', $default_steps );
 
-		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		$this->step            = isset( $_REQUEST['step'] ) ? sanitize_key( $_REQUEST['step'] ) : current( array_keys( $this->steps ) );
 		$this->file            = isset( $_REQUEST['file'] ) ? wc_clean( wp_unslash( $_REQUEST['file'] ) ) : '';
 		$this->update_existing = isset( $_REQUEST['update_existing'] ) ? (bool) $_REQUEST['update_existing'] : false;

--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -279,6 +279,7 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 			return array(
 				'id'      => $object->get_id(),
 				'updated' => $updating,
+				'type'    => $object->get_type(),
 			);
 		} catch ( Exception $e ) {
 			return new WP_Error( 'woocommerce_product_importer_error', $e->getMessage(), array( 'status' => $e->getCode() ) );

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -1024,7 +1024,8 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			'failed'         => array(),
 			'updated'        => array(),
 			'skipped'        => array(),
-			'distinct_count' => 0, // Counts imported products excluding variations.
+			'imported_distinct_count' => 0, // Counts imported products excluding variations.
+			'updated_distinct_count'  => 0, // Counts imported products excluding variations.
 		);
 
 		foreach ( $this->parsed_data as $parsed_data_key => $parsed_data ) {
@@ -1090,11 +1091,15 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				$data['failed'][] = $result;
 			} elseif ( $result['updated'] ) {
 				$data['updated'][] = $result['id'];
+
+				if ( 'variation' !== $result['type'] ) {
+					$data['updated_distinct_count'] ++;
+				}
 			} else {
 				$data['imported'][] = $result['id'];
 
 				if ( 'variation' !== $result['type'] ) {
-					$data['distinct_count'] ++;
+					$data['imported_distinct_count'] ++;
 				}
 			}
 

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -1025,7 +1025,7 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 			'updated'        => array(),
 			'skipped'        => array(),
 			'imported_distinct_count' => 0, // Counts imported products excluding variations.
-			'updated_distinct_count'  => 0, // Counts imported products excluding variations.
+			'updated_distinct_count'  => 0, // Counts updated products excluding variations.
 		);
 
 		foreach ( $this->parsed_data as $parsed_data_key => $parsed_data ) {

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -1019,11 +1019,12 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 		$this->start_time = time();
 		$index            = 0;
 		$update_existing  = $this->params['update_existing'];
-		$data             = array(
-			'imported' => array(),
-			'failed'   => array(),
-			'updated'  => array(),
-			'skipped'  => array(),
+		$data = array(
+			'imported'       => array(),
+			'failed'         => array(),
+			'updated'        => array(),
+			'skipped'        => array(),
+			'distinct_count' => 0, // Counts imported products excluding variations.
 		);
 
 		foreach ( $this->parsed_data as $parsed_data_key => $parsed_data ) {
@@ -1091,6 +1092,10 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				$data['updated'][] = $result['id'];
 			} else {
 				$data['imported'][] = $result['id'];
+
+				if ( 'variation' !== $result['type'] ) {
+					$data['distinct_count'] ++;
+				}
 			}
 
 			$index ++;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/26631. 

Currently, once, for example, [sample products](https://github.com/woocommerce/woocommerce/blob/master/sample-data/sample_products.csv) CSV file is imported to the site, a message will be displayed letting the user know that 25 products were imported when in fact only 18 products were imported but the rest of the 7 items were variations. 

This PR counts products that have been imported excluding variations and displays a message to the user letting them know the number of products imported (without variations).  

### How to test the changes in this Pull Request:

<hr>

**TESTING "IMPORTED" PRODUCTS:**

1. Before testing this PR, download the [sample products](https://github.com/woocommerce/woocommerce/blob/master/sample-data/sample_products.csv) CSV file. Note that it contains 18 products + 7 variations = total of 25 items:

![csv](https://user-images.githubusercontent.com/19143190/84338047-10344c00-ab69-11ea-9ac5-8a1d7ffbe25c.jpg)

2. Using built-in CSV Importer, import the sample products CSV file to the site by navigating to `Products / All Products / Import`. Don't select `Update existing products` option in the file upload section. Proceed with the CSV Import. Upon completion, you will see a message letting you know that 25 products were imported:

![csv2](https://user-images.githubusercontent.com/19143190/84338272-a0729100-ab69-11ea-8f5e-5b1cbbdec8d8.png)

3. Navigate to `All Products` page and note that only 18 products have indeed been imported:

![csv3](https://user-images.githubusercontent.com/19143190/84338338-c39d4080-ab69-11ea-9b9a-aa63187a34ea.jpg)

4. Delete all the imported products permanently from the site to prepare for testing this PR. 

5. Checkout the branch of this PR and repeat steps 1 and 2. You should now see the message letting you know that 18 products have been imported which is a correct number:

![Screen Shot 2020-06-10 at 10 32 40 PM](https://user-images.githubusercontent.com/19143190/84338525-4d4d0e00-ab6a-11ea-861c-2ae902589dc8.png)

<hr>

**TESTING "UPDATED" PRODUCTS:**

1. Before testing further, you'd need to again first see how updating products currently works without the change. To do that, you'd need to import sample products file to the site first. Then export it and change the prices of variations or anything else really. Save the file and import it back to the site. Select `Update existing products` option since we indeed need to update existing products. Proceed with an update and see that you'd get a message that 25 products were updated:

![Screen Shot 2020-06-11 at 3 48 56 PM](https://user-images.githubusercontent.com/19143190/84436093-e0388780-ac00-11ea-8701-f3c1a36ada1a.png)

2. After checking out the branch of this PR and repeating the same steps described above in step 1, you should see a message letting you know that only 18 products were updated:

![Screen Shot 2020-06-11 at 4 29 10 PM](https://user-images.githubusercontent.com/19143190/84436242-18d86100-ac01-11ea-9285-b2350092cde1.png)

<hr>

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Count and display CSV imported products excluding variations when CSV Import is completed.
