### PR TITLE
Add language packs automatic delivery code.

### DIFF
--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -205,6 +205,11 @@ class WC_Helper_Updater {
 			}
 		);
 
+		// Nothing to check for, exit.
+		if ( empty( $active_for_translations ) ) {
+			return array();
+		}
+
 		if ( wp_doing_cron() ) {
 			$timeout = 30;
 		} else {

--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -175,7 +175,7 @@ class WC_Helper_Updater {
 	 * @return array Update data {product_id => data}
 	 */
 	public static function get_translations_update_data() {
-			$payload = array();
+		$payload = array();
 
 		$installed_translations = wp_get_installed_translations( 'plugins' );
 

--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -223,8 +223,8 @@ class WC_Helper_Updater {
 					continue;
 				}
 
-				$is_plugin_locale_installe = in_array( $plugin['slug'], $installed_translations ) && array_key_exists( $set['wp_locale'], $installed_translations[ $plugin['slug'] ] );
-				if ( $is_plugin_locale_installe ) {
+				$is_plugin_locale_installed = in_array( $plugin['slug'], $installed_translations ) && array_key_exists( $set['wp_locale'], $installed_translations[ $plugin['slug'] ] );
+				if ( $is_plugin_locale_installed ) {
 					$installed_translation_revision_time = new DateTime( $installed_translations[ $plugin['slug'] ][ $set['wp_locale'] ]['PO-Revision-Date'] );
 					$new_translation_revision_time       = new DateTime( $set['last_modified'] );
 					// Skip if translation set is not newer than what is installed already.

--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -175,7 +175,7 @@ class WC_Helper_Updater {
 	 * @return array Update data {product_id => data}
 	 */
 	public static function get_translations_update_data() {
-		$payload = array();
+			$payload = array();
 
 		$installed_translations = wp_get_installed_translations( 'plugins' );
 
@@ -254,7 +254,7 @@ class WC_Helper_Updater {
 		foreach ( $response['data'] as $plugin_name => $language_packs ) {
 			foreach ( $language_packs as $language_pack ) {
 				// Maybe we have this language pack already installed so lets check revision date.
-				if ( array_key_exists( $plugin_name, $installed_translations ) ) {
+				if ( array_key_exists( $plugin_name, $installed_translations ) && array_key_exists( $language_pack['wp_locale'], $installed_translations[ $plugin_name ] ) ) {
 					$installed_translation_revision_time = new DateTime( $installed_translations[ $plugin_name ][ $language_pack['wp_locale'] ]['PO-Revision-Date'] );
 					$new_translation_revision_time       = new DateTime( $language_pack['last_modified'] );
 					// Skip if translation language pack is not newer than what is installed already.

--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -223,7 +223,7 @@ class WC_Helper_Updater {
 		}
 
 		$raw_response = wp_remote_post(
-			'https://translate.wordpress.com/api/translations_updates/woocommerce',
+			'https://translate.wordpress.com/api/translations-updates/woocommerce',
 			array(
 				'body'        => json_encode( $request_body ),
 				'headers'     => array( 'Content-Type: application/json' ),

--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -237,11 +237,6 @@ class WC_Helper_Updater {
 			return array();
 		}
 
-		// General error.
-		if ( is_wp_error( $raw_response ) ) {
-			return array();
-		}
-
 		$response = json_decode( wp_remote_retrieve_body( $raw_response ), true );
 
 		// API error, api returned but something was wrong.


### PR DESCRIPTION
# Automatic translations delivery code.
WooCommerce is leveraging WordPress Core automatic updates system to submit update information from woocommerce.com for WooCommerce plugins and themes. This PR further extends this system with the ability to automatically update language packs for plugins that are coming from `woocommerce.com` . This code cooperates with `translate.wordpress.com` GlotPress server. 

In short, the code collects information about which plugins from `woocommerce.com` are installed and active on the site. Then it checks if those plugins are activated for automatic translations ( filter on the plugin site ). Then using that information plus information about locales used on the site a request if formed and passed to `translate.wordpress.com` updates endpoint. Using returned information the `update_plugins` transient is populated. `update_plugins` transient is a part of WordPress core updates system. All updates are then performed without WooCommerce plugging interaction. 

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:
Unfortunately, the translate.wordpress.com work is ongoing so to fully test this a wpcom  sandbox is required.

1. Use this branch.
2. Install and activate WooCommerce Bookings from this branch: https://github.com/woocommerce/woocommerce-bookings/tree/add/subscribe-to-automatic-translations . It has a filter that enables translations updates for this plugin.
3. Use wpcom sanbox with following patch D45269-code. Point following urls to your sandbox IP ( in /etc/hosts ): 
-- public-api.wordpress.com
-- wordpress.com
-- translate.wordpress.com
4. Everything is happening quite automatically but usually, a visit to the `wp-admin/update-core.php` triggers the update flow.
5. Change language to for example Spanish.
6. Do point 4 again.
7. The `/wp-content/languages/plugins` folder should have WooCommerce Bookings locale files:
![image](https://user-images.githubusercontent.com/17271089/87958898-64a8e080-cab2-11ea-9ccb-0e2fe8ffef97.png)
This ^ is from my setup where I have Italian, German, and Spanish files.

This is a complicated setup. I am more than happy to help test this out or provide additional guidance.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - Added automatic language pack updates for WooCommerce.com extensions.