### PR TITLE
Add template cache clearing

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -270,7 +270,7 @@ function wc_get_template_part( $slug, $name = '' ) {
 		// Don't cache the absolute path so that it can be shared between web servers with different paths.
 		$cache_path = wc_tokenize_path( $template, wc_get_path_define_tokens() );
 
-		wp_cache_set( $cache_key, $cache_path, 'woocommerce' );
+		wc_set_template_cache( $cache_key, $cache_path );
 	} else {
 		// Make sure that the absolute path to the template is resolved.
 		$template = wc_untokenize_path( $template, wc_get_path_define_tokens() );
@@ -302,7 +302,7 @@ function wc_get_template( $template_name, $args = array(), $template_path = '', 
 		// Don't cache the absolute path so that it can be shared between web servers with different paths.
 		$cache_path = wc_tokenize_path( $template, wc_get_path_define_tokens() );
 
-		wp_cache_set( $cache_key, $cache_path, 'woocommerce' );
+		wc_set_template_cache( $cache_key, $cache_path );
 	} else {
 		// Make sure that the absolute path to the template is resolved.
 		$template = wc_untokenize_path( $template, wc_get_path_define_tokens() );
@@ -401,6 +401,42 @@ function wc_locate_template( $template_name, $template_path = '', $default_path 
 
 	// Return what we found.
 	return apply_filters( 'woocommerce_locate_template', $template, $template_name, $template_path );
+}
+
+/**
+ * Add a template to the template cache.
+ *
+ * @since 4.3.0
+ * @param string $cache_key Object cache key.
+ * @param string $template Located template.
+ */
+function wc_set_template_cache( $cache_key, $template ) {
+	wp_cache_set( $cache_key, $template, 'woocommerce' );
+
+	$cached_templates = wp_cache_get( 'cached_templates', 'woocommerce' );
+	if ( is_array( $cached_templates ) ) {
+		$cached_templates[] = $cache_key;
+	} else {
+		$cached_templates = array( $cache_key );
+	}
+
+	wp_cache_set( 'cached_templates', $cached_templates, 'woocommerce' );
+}
+
+/**
+ * Clear the template cache.
+ *
+ * @since 4.3.0
+ */
+function wc_clear_template_cache() {
+	$cached_templates = wp_cache_get( 'cached_templates', 'woocommerce' );
+	if ( is_array( $cached_templates ) ) {
+		foreach ( $cached_templates as $cache_key ) {
+			wp_cache_delete( $cache_key, 'woocommerce' );
+		}
+
+		wp_cache_delete( 'cached_templates', 'woocommerce' );
+	}
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds `wc_set_template_cache()` and `wc_clear_template_cache()` to support clearing the template cache. The reason for using the second cache entry to maintain the list of cached items is that retrieving arrays from cache is expensive. On a site with persistent cache, once primed the `cached_templates` will only be retrieved from cache when the cache is being cleared.

This PR requires a companion PR to add template cache clearing to the REST api tools.

See #25143 .

### How to test the changes in this Pull Request:

1. Install `redis` and a redis plugin
1. Checkout https://github.com/woocommerce/woocommerce-rest-api/pull/212
1. Browse one or more shop pages
1. Run the following commands
```
$ wp cache get cached_templates woocommerce
array (
  0 => 'template-globalbreadcrumbphp---430',
  1 => 'template-part-content-single-product-430',
  2 => 'template-single-productsale-flashphp---430',
....

$ wp cache get template-globalbreadcrumbphp---430 woocommerce
{{WP_PLUGIN_DIR}}/woocommerce/templates/global/breadcrumb.php
```
5. Go to WooCommerce -> Status -> Tools
6. Clear the template cache
7. Re-run the above commands
```
$ wp cache get template-globalbreadcrumbphp---430 woocommerce
Error: Object with key 'template-globalbreadcrumbphp---430' and group 'woocommerce' not found.
$ wp cache get cached_templates woocommerce
Error: Object with key 'cached_templates' and group 'woocommerce' not found.
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add template cache clearing
