### PR TITLE
Encode HTML entities in product attributes

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -244,7 +244,7 @@ class WC_Meta_Box_Product_Data {
 					continue;
 				}
 				$attribute_id   = 0;
-				$attribute_name = wc_clean( $attribute_names[ $i ] );
+				$attribute_name = wc_clean( esc_html( $attribute_names[ $i ] ) );
 
 				if ( 'pa_' === substr( $attribute_name, 0, 3 ) ) {
 					$attribute_id = wc_attribute_taxonomy_id_by_name( $attribute_name );
@@ -257,7 +257,7 @@ class WC_Meta_Box_Product_Data {
 					$options = wp_parse_id_list( $options );
 				} else {
 					// Terms or text sent in textarea.
-					$options = 0 < $attribute_id ? wc_sanitize_textarea( wc_sanitize_term_text_based( $options ) ) : wc_sanitize_textarea( $options );
+					$options = 0 < $attribute_id ? wc_sanitize_textarea( esc_html( wc_sanitize_term_text_based( $options ) ) ) : wc_sanitize_textarea( esc_html( $options ) );
 					$options = wc_get_text_attributes( $options );
 				}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25544.

### How to test the changes in this Pull Request:

1. Create a new variable product.
2. Add a new custom product attribute, giving it a name containing HTML entities, such as `Weights < and > measures`.
3. Include attribute values also containing entities, such as `<30g | 30-50g | 50-70g | >70g`.
![image](https://user-images.githubusercontent.com/363749/84429401-add15f00-abed-11ea-8cbe-e5d44ba2d310.png)
4. Save the attributes and verify that the name and values are persisted correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Encode HTML entities for product attribute name and values.
