### PR TITLE
Update GitHub issue templates to request more details

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,48 +1,7 @@
-<!-- This form is for reporting bugs and issues specific to the WooCommerce plugin. This is not a support portal. If you need technical support from a human being, please submit a ticket via the helpdesk instead: https://woocommerce.com/contact-us/ -->
+<!-- This form is for other issue types specific to the WooCommerce plugin. This is not a support portal. -->
 
-<!-- Usage questions can also be directed to the public support forum here: https://wordpress.org/support/plugin/woocommerce, unless this is a question about a premium extension in which case you should use the helpdesk. -->
+**Prerequisites (mark completed items with an [x]):**
+- [ ] I have checked that my issue type is not listed here https://github.com/woocommerce/woocommerce/issues/new/choose
+- [ ] My issue is not a security issue, support request, bug report, enhancement or feature request (Please use the link above if it is).
 
-<!-- If you have a feature request, submit it to: http://ideas.woocommerce.com/forums/133476-woocommerce -->
-
-<!-- If you are a developer who needs a new filter/hook raise a PR instead :) -->
-
-<!-- Please be as descriptive as possible; issues lacking the below details, or for any other reason than to report a bug, may be closed without action. -->
-
-## Prerequisites
-
-<!-- MARK COMPLETED ITEMS WITH AN [x] -->
-
-- [ ] I have searched for similar issues in both open and closed tickets and cannot find a duplicate
-- [ ] The issue still exists against the latest `master` branch of WooCommerce on Github (this is **not** the same version as on WordPress.org!)
-- [ ] I have attempted to find the simplest possible steps to reproduce the issue
-- [ ] I have included a failing test as a pull request (Optional)
-
-## Steps to reproduce the issue
-
-<!-- We need to be able to reproduce the bug in order to fix it so please be descriptive! -->
-
-1.
-2.
-3.
-
-## Expected/actual behavior
-
-When I follow those steps, I see...
-
-I was expecting to see...
-
-## Isolating the problem
-
-<!-- MARK COMPLETED ITEMS WITH AN [x] -->
-
-- [ ] This bug happens with only WooCommerce plugin active
-- [ ] This bug happens with a default WordPress theme active, or [Storefront](https://woocommerce.com/storefront/)
-- [ ] I can reproduce this bug consistently using the steps above
-
-## WordPress Environment
-
-<details>
-```
-Copy and paste the system status report from **WooCommerce > System Status** in WordPress admin here.
-```
-</details>
+**Issue Description:**

--- a/.github/ISSUE_TEMPLATE/1-Security-issue.md
+++ b/.github/ISSUE_TEMPLATE/1-Security-issue.md
@@ -1,5 +1,5 @@
 ---
-name: "\U0001F46E‍♂️ Security issue"
+name: "\U+1F512 Security issue"
 about: Please report security issues *only* via https://www.hackerone.com
 title: ''
 labels: ''

--- a/.github/ISSUE_TEMPLATE/1-Security-issue.md
+++ b/.github/ISSUE_TEMPLATE/1-Security-issue.md
@@ -1,5 +1,5 @@
 ---
-name: "\U+1F512 Security issue"
+name: "\U0001F512 Security issue"
 about: Please report security issues *only* via https://www.hackerone.com
 title: ''
 labels: ''

--- a/.github/ISSUE_TEMPLATE/2-External-issues.md
+++ b/.github/ISSUE_TEMPLATE/2-External-issues.md
@@ -1,10 +1,18 @@
 ---
 name: "\U0001F47D External issues"
-about: Please report WooCommerce REST API or WooCommerce Gutenberg Products Blocks issues directly to their respective repositories.
+about: Please report WooCommerce REST API, WooCommerce Admin or WooCommerce Gutenberg Products Blocks issues directly to their respective repositories.
 title: ''
 labels: ''
 assignees: ''
 
 ---
 
-Please report WooCommerce REST API (https://github.com/woocommerce/woocommerce-rest-api) or WooCommerce Gutenberg Products Blocks (https://github.com/woocommerce/woocommerce-gutenberg-products-block) issues directly to their respective repositories.
+Please report issues for the following features directly to their respective repositories.
+
+WooCommerce REST API: https://github.com/woocommerce/woocommerce-rest-api 
+
+WooCommerce Admin: https://github.com/woocommerce/woocommerce-admin
+
+WooCommerce Gutenberg Products Blocks: https://github.com/woocommerce/woocommerce-gutenberg-products-block
+
+Action Scheduler: https://github.com/woocommerce/action-scheduler

--- a/.github/ISSUE_TEMPLATE/3-Support.md
+++ b/.github/ISSUE_TEMPLATE/3-Support.md
@@ -16,10 +16,13 @@ Usage docs can be found here: https://docs.woocommerce.com/
 If you have a problem, you may want to start with the self help guide here: https://docs.woocommerce.com/document/woocommerce-self-service-guide/
 
 **Technical support for premium extensions or if you're a WooCommerce.com customer**
- from a human being - submit a ticket via the helpdesk
+Contact WooCommerce support by opening a ticket.
 https://woocommerce.com/contact-us/ 
+
+**For help with custom code**
+WooCommerce Slack Community: https://woocommerce.com/community-slack/ in the `#developers` channel. 
 
 **General usage and development questions**
 - WooCommerce Slack Community: https://woocommerce.com/community-slack/
 - WordPress.org Forums: https://wordpress.org/support/plugin/woocommerce
-- The WooCommerce Help and Share Facebook group
+- The Official WooCommerce Facebook Group https://www.facebook.com/groups/advanced.woocommerce/

--- a/.github/ISSUE_TEMPLATE/4-Bug-report.md
+++ b/.github/ISSUE_TEMPLATE/4-Bug-report.md
@@ -8,11 +8,30 @@ assignees: ''
 
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is. Please be as descriptive as possible; issues lacking detail, or for any other reason than to report a bug, may be closed without action.
+Please provide us with the information requested in this bug report. Without these details, we won't be able to fully evaluate this issue. 
+Bug reports lacking detail, or for any other reason than to report a bug, may be closed without action.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+<!-- This template is for confirmed bugs only. If you have a support request or custom code related question please see our docs or use our forums, helpdesk, or Slack Community! https://github.com/woocommerce/woocommerce/issues/new?assignees=&labels=&template=3-Support.md&title= -->
+
+<!-- Make sure to look through the existing issues to see whether your bug has already been submitted. Feel free to contribute to any existing issues. -->
+<!-- Search tip: You can filter our issues using our component labels https://github.com/woocommerce/woocommerce/labels?q=component -->
+<!-- Search tip: Make use of GitHub's search syntax to refine your search https://help.github.com/en/github/searching-for-information-on-github/searching-issues-and-pull-requests -->
+
+**Prerequisites (mark completed items with an [x]):**
+- [ ] I have have carried out troubleshooting steps and I believe I have found a bug.
+- [ ] I have searched for similar bugs in both open and closed issues and cannot find a duplicate.
+
+**Describe the bug**
+A clear and concise description of what the bug is. 
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+A clear and concise description of what actually happens. Please be as descriptive as possible; 
+
+**Steps to reproduce the bug (We need to be able to reproduce the bug in order to fix it.)**
+Steps to reproduce the bug:
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -21,8 +40,7 @@ Steps to reproduce the behavior:
 **Screenshots**
 If applicable, add screenshots to help explain your problem.
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+<!-- Please try testing your site for theme and plugins conflict. To do that deactivate all plugins except for WooCommerce and switch to a default WordPress theme or [Storefront](https://en-gb.wordpress.org/themes/storefront/). Then test again. If the issue is resolved with the default theme and all plugins deactivated, it means that one of your plugins or a theme is causing the issue. You will then need to enable it one by one and test every time you do that in order to figure out which plugin is causing the issue. -->
 
 **Isolating the problem (mark completed items with an [x]):**
 - [ ] I have deactivated other plugins and confirmed this bug occurs when only WooCommerce plugin is active.
@@ -30,8 +48,11 @@ A clear and concise description of what you expected to happen.
 - [ ] I can reproduce this bug consistently using the steps above.
 
 **WordPress Environment**
+We use the [WooCommerce System Status Report](https://docs.woocommerce.com/document/understanding-the-woocommerce-system-status-report/) to help us evaluate the issue. 
+Without this report we won't be able to fully evaluate this issue.
 <details>
 ```
-Copy and paste the system status report from **WooCommerce > System Status** in WordPress admin.
+The System Status Report is found in your WordPress admin under **WooCommerce > Status**. 
+Please select “Get system report”, then “Copy for support”, and then paste it here.
 ```
 </details>

--- a/.github/ISSUE_TEMPLATE/5-Enhancement.md
+++ b/.github/ISSUE_TEMPLATE/5-Enhancement.md
@@ -8,6 +8,10 @@ assignees: ''
 
 ---
 
+<!--  Make sure to look through existing issues to see whether your idea is already being discussed. Feel free to contribute to any existing issues. -->
+
+<!-- Search tip: You can filter issues using our enhancement label https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue+label%3Aenhancement -->
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 

--- a/.github/ISSUE_TEMPLATE/6-Feature-request.md
+++ b/.github/ISSUE_TEMPLATE/6-Feature-request.md
@@ -8,6 +8,10 @@ assignees: ''
 
 ---
 
+<!--  Make sure to look through existing issues to see whether your idea is already being discussed. Feel free to contribute to any existing issues. -->
+
+<!-- Search tip: You can filter issues using our enhancement label https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue+label%3Aenhancement -->
+
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Updates the issue templates we use to try get more information included in issues to make them easier and quicker to triage and reduce duplicate issues.
More context here: p7bje6-266-p2

### How to test the changes in this Pull Request:

- View the updated templates here https://github.com/woocommerce/woocommerce/tree/update/wc-issue-templates/.github/ISSUE_TEMPLATE

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

n/a for issue templates