### PR TITLE
add site tracking setting check to tracks data send

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -44,6 +44,11 @@ class WC_Tracker {
 			return;
 		}
 
+		// Don't send if site is opted out of tracking.
+		if ( 'yes' !== get_option( 'woocommerce_allow_tracking', 'no' ) ) {
+			return;
+		}
+
 		if ( ! apply_filters( 'woocommerce_tracker_send_override', $override ) ) {
 			// Send a maximum of once per week by default.
 			$last_send = self::get_last_send_time();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a check for the `allow_tracking` setting being set to `yes` to the tracks cron handler.

Closes #26689 .

### How to test the changes in this Pull Request:

1. Activate the WP Crontrol plugin
2. Check that the `woocommerce_tracker_send_event` job will not run during the test
3. Enable tracking in your WC settings
4. Navigate to a few WooCommerce screens
5. Disable tracking
6. Delete the option `woocommerce_tracker_last_send`
7. Use WP Crontrol to run `woocommerce_tracker_send_event`
8. The option `woocommerce_tracker_last_send` should not be set

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Observe tracking data setting in weekly tracking cron task.
