### PR TITLE
Version bump wc-admin 1.3.0-beta.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.2.3",
+    "woocommerce/woocommerce-admin": "1.3.0-beta.1",
     "woocommerce/woocommerce-blocks": "2.7.0",
     "woocommerce/woocommerce-rest-api": "1.0.8"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f636539bc4e30e964818d3ff9c2b50e1",
+    "content-hash": "54a9544c30551fad5ada14b872fc0c84",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -380,20 +380,6 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-16T08:31:04+00:00"
         },
         {
@@ -686,20 +672,6 @@
             "keywords": [
                 "constructor",
                 "instantiate"
-            ],
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-05-29T17:27:14+00:00"
         },
@@ -2487,20 +2459,6 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-02-14T07:34:21+00:00"
         },
         {
@@ -2559,20 +2517,6 @@
                 "polyfill",
                 "portable"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-05-12T16:14:59+00:00"
         },
         {
@@ -2617,16 +2561,16 @@
         },
         {
             "name": "webmozart/assert",
-            "version": "1.8.0",
+            "version": "1.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/webmozart/assert.git",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6"
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/webmozart/assert/zipball/ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
-                "reference": "ab2cb0b3b559010b75981b1bdce728da3ee90ad6",
+                "url": "https://api.github.com/repos/webmozart/assert/zipball/9dc4f203e36f2b486149058bade43c851dd97451",
+                "reference": "9dc4f203e36f2b486149058bade43c851dd97451",
                 "shasum": ""
             },
             "require": {
@@ -2634,6 +2578,7 @@
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
+                "phpstan/phpstan": "<0.12.20",
                 "vimeo/psalm": "<3.9.1"
             },
             "require-dev": {
@@ -2661,7 +2606,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2020-04-18T12:12:48+00:00"
+            "time": "2020-06-16T10:16:42+00:00"
         },
         {
             "name": "woocommerce/woocommerce-sniffs",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "674dae676cb4905418f7930391e8dcf2",
+    "content-hash": "f636539bc4e30e964818d3ff9c2b50e1",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -331,7 +331,7 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.4.40",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -380,20 +380,6 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-16T08:31:04+00:00"
         },
         {
@@ -433,16 +419,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "v1.2.3",
+            "version": "v1.3.0-beta.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "5560c9b6e31e1d794a55a0eb4ccf040fd2cee4c7"
+                "reference": "be22cb889e541caa9a38ec97182a004e9ab1a5c7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/5560c9b6e31e1d794a55a0eb4ccf040fd2cee4c7",
-                "reference": "5560c9b6e31e1d794a55a0eb4ccf040fd2cee4c7",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/be22cb889e541caa9a38ec97182a004e9ab1a5c7",
+                "reference": "be22cb889e541caa9a38ec97182a004e9ab1a5c7",
                 "shasum": ""
             },
             "require": {
@@ -476,7 +462,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-05-22T18:45:16+00:00"
+            "time": "2020-06-16T02:44:45+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -635,20 +621,20 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1"
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/ae466f726242e637cebdd526a7d991b9433bacf1",
-                "reference": "ae466f726242e637cebdd526a7d991b9433bacf1",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/f350df0268e904597e3bd9c4685c53e0e333feea",
+                "reference": "f350df0268e904597e3bd9c4685c53e0e333feea",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
                 "doctrine/coding-standard": "^6.0",
@@ -687,7 +673,7 @@
                 "constructor",
                 "instantiate"
             ],
-            "time": "2019-10-21T16:45:58+00:00"
+            "time": "2020-05-29T17:27:14+00:00"
         },
         {
             "name": "gettext/gettext",
@@ -2428,7 +2414,7 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.40",
+            "version": "v3.4.42",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
@@ -2477,16 +2463,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.16.0",
+            "version": "v1.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "1aab00e39cebaef4d8652497f46c15c1b7e45294"
+                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/1aab00e39cebaef4d8652497f46c15c1b7e45294",
-                "reference": "1aab00e39cebaef4d8652497f46c15c1b7e45294",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
+                "reference": "e94c8b1bbe2bc77507a1056cdb06451c75b427f9",
                 "shasum": ""
             },
             "require": {
@@ -2498,7 +2484,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.16-dev"
+                    "dev-master": "1.17-dev"
                 }
             },
             "autoload": {
@@ -2531,21 +2517,7 @@
                 "polyfill",
                 "portable"
             ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-05-08T16:50:20+00:00"
+            "time": "2020-05-12T16:14:59+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2677,16 +2649,16 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.2.2",
+            "version": "v2.2.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "2804c5246d9338da59951737b03c54d257be8e47"
+                "reference": "7a5d483d872dfec1b89d88d348666ecd59454d52"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/2804c5246d9338da59951737b03c54d257be8e47",
-                "reference": "2804c5246d9338da59951737b03c54d257be8e47",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/7a5d483d872dfec1b89d88d348666ecd59454d52",
+                "reference": "7a5d483d872dfec1b89d88d348666ecd59454d52",
                 "shasum": ""
             },
             "require": {
@@ -2730,7 +2702,7 @@
             ],
             "description": "Provides internationalization tools for WordPress projects.",
             "homepage": "https://github.com/wp-cli/i18n-command",
-            "time": "2019-12-13T09:00:43+00:00"
+            "time": "2020-06-04T07:07:10+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -2949,6 +2921,5 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }

--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -156,7 +156,6 @@ class WC_Notes_Run_Db_Update {
 			. sprintf( ' ' . esc_html__( 'The database update process runs in the background and may take a little while, so please be patient. Advanced users can alternatively update via %1$sWP CLI%2$s.', 'woocommerce' ), '<a href="https://github.com/woocommerce/woocommerce/wiki/Upgrading-the-database-using-WP-CLI">', '</a>' )
 		);
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
-		$note->set_icon( 'info' );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-core' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce",
-  "version": "4.1.0",
+  "version": "4.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -17934,7 +17934,7 @@
           }
         },
         "prettier": {
-          "version": "npm:wp-prettier@1.19.1",
+          "version": "npm:prettier@1.19.1",
           "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
           "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
           "dev": true

--- a/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
+++ b/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
@@ -91,7 +91,6 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 		$note->set_title( 'WooCommerce database update required' );
 		$note->set_content( 'To keep things running smoothly, we have to update your database to the newest version.' );
 		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
-		$note->set_icon( 'info' );
 		$note->set_name( WC_Notes_Run_Db_Update::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-core' );


### PR DESCRIPTION
Version bump wc-admin 1.3.0-beta.1

## Notable Changes and Testing Instructions

### Onboarding Wizard

Changes to the Onboarding Wizard include a refactor of the handling of underlying data and a reorder of the flow such that the Jetpack connection flow happens later and an explanation of the benefits are given. We've also updated our components to the latest `@wordpress/components` which let the G2 color scheme come through.

<img width="1440" alt="Screen Shot 2020-06-16 at 8 05 17 PM" src="https://user-images.githubusercontent.com/1922453/84748762-2b8dd400-b00d-11ea-9c0a-705b034fb8f4.png">

#### Testing Instructions

1. Go through the Wizard and make sure no JavaScript errors occur. 
2. Note the colors and color accents of buttons, toggles, and checkboxes.
3. Bonus test: Change your color scheme by going to Users > your username > Edit > Admin Color Scheme and change your preference.

<img width="1242" alt="Screen Shot 2020-06-16 at 8 10 36 PM" src="https://user-images.githubusercontent.com/1922453/84749167-b8389200-b00d-11ea-98c5-784495309971.png">

5. Go through the Wizard once more and see the control colors adjust accordingly.

**Known Issues**: https://github.com/woocommerce/woocommerce-admin/issues/4588

### Homepage

A new home screen is now the default for new users and opt-in for existing users.

<img width="1440" alt="Screen Shot 2020-06-16 at 8 16 40 PM" src="https://user-images.githubusercontent.com/1922453/84749645-562c5c80-b00e-11ea-99b7-cf948bba8ab0.png">

An inbox occupies the left screen while the Task List, stats overview, and a quick links section occupy the right. This screen allows you to quickly access important information, stats, tasks, or relevant links depending on how far along the store is setup.

#### Testing Instructions

1. On new installs, Homescreen will now be the default screen for WooCommerce. For existing stores, go to WooCommerce > Settings > Advanced > Features > Homescreen to toggle the feature.
2. If you haven't already, complete the Task List. Ensure no errors occur.
3. Play around with the Stats overview section. If you haven't connected to Jetpack yet, follow the prompts to see Visitors and Views stats. You can toggle stats you'd like to see. Visible stats will persist on page refresh.
4. Finish the setup or hide it by clicking "Hide this" found in the ellipsis menu on the upper right of the section.
5. The Store management section will appear at the bottom of the column. This section provides useful links, especially for existing stores to quickly get to often used WooCommerce screens.
6. Go through the links and make sure they work as intended.
7. Take a look at the Inbox notes. They will be the same ones in the Inbox with identical functionality.
8. Dismiss a note.
9. Dismiss all notes. There will now be only a single column which is centered.

### General Testing

1. Note all buttons, toggles, checkboxes for correct colors, alignment, centering, hover + focus styles, and positioning.