### PR TITLE
Update woocommerce/woocommerce-blocks to v2.7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "1.3.0-beta.1",
-    "woocommerce/woocommerce-blocks": "2.7.0",
+    "woocommerce/woocommerce-blocks": "2.7.1",
     "woocommerce/woocommerce-rest-api": "1.0.10"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54a9544c30551fad5ada14b872fc0c84",
+    "content-hash": "e1718510b3bc480974ac78bd69e2124a",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -466,16 +466,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v2.7.0",
+            "version": "v2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "161be65dbff230862fe52a18ea7c9a01557169c2"
+                "reference": "0025c5cda83892c6f566fffd05197006f230d16c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/161be65dbff230862fe52a18ea7c9a01557169c2",
-                "reference": "161be65dbff230862fe52a18ea7c9a01557169c2",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/0025c5cda83892c6f566fffd05197006f230d16c",
+                "reference": "0025c5cda83892c6f566fffd05197006f230d16c",
                 "shasum": ""
             },
             "require": {
@@ -509,7 +509,7 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2020-06-09T09:29:00+00:00"
+            "time": "2020-06-16T13:34:29+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",


### PR DESCRIPTION
Bump WooCommerce Blocks version to the last released one: 2.7.1.

See previous PR updating it to 2.7.0: #26732.

This point release introduces:

* An update to Dashicons replacement code to make it IE11 friendly.
* Fixes to avoid several PHP notices.

Link to [changelog](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/readme.txt#L123).

### Prepared Updates

The following documentation, blog posts, and changelog updates are prepared for the release:

**Release announcement:** _It's a small point release, so we will not do a release announcement._

**Developer Notes:** _N/A_

**Relevant developer documentation:** _N/A_

**Happiness Engineer:** _N/A_

## Quality

* [ ] Changes in this release are covered by Automated Tests.
_The fixes included in this release are specific to IE11 and PHP warnings that were missed before releasing 2.7.0. There aren't specific tests added for them._

* This release has been tested on the following platforms:
     * [x] mobile
     * [x] desktop

* [x] Link to **testing instructions** for this release:

https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/docs/testing/releases/271.md

I don't think we need to add them to the WC 4.3 testing instructions. However, I updated the previous instructions to add IE11 as a browser to test the All Products block:

https://github.com/woocommerce/woocommerce/wiki/Release-Testing-Instructions-WooCommerce-4.3#all-products