### PR TITLE
Fixed wc_get_order function name in doc block

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -87,8 +87,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 	/**
 	 * Get the order if ID is passed, otherwise the order is new and empty.
-	 * This class should NOT be instantiated, but the get_order function or new WC_Order_Factory.
-	 * should be used. It is possible, but the aforementioned are preferred and are the only.
+	 * This class should NOT be instantiated, but the wc_get_order function or new WC_Order_Factory
+	 * should be used. It is possible, but the aforementioned are preferred and are the only
 	 * methods that will be maintained going forward.
 	 *
 	 * @param  int|object|WC_Order $order Order to read.


### PR DESCRIPTION
The `WC_Abstract_Order` `__construct()` method doc block had the `wc_get_order()` method referred to as `get_order()`.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `WC_Abstract_Order` constructor method erroneously refers to the `wc_get_order()` function as `get_order`. This can be confusing to anyone reading the source doc blocks.

I also removed two periods, since they were not at the end of sentences.

### Changelog entry

I don't think this is worth space in the changelog.
