### PR TITLE
introduce woocommerce_enable_nocache_headers filter

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -40,8 +40,15 @@ class WC_Cache_Helper {
 	 * @since 3.6.0
 	 */
 	public static function additional_nocache_headers( $headers ) {
-		// no-transform: Opt-out of Google weblight if page is dynamic e.g. cart/checkout. https://support.google.com/webmasters/answer/6211428?hl=en.
-		$headers['Cache-Control'] = 'no-transform, no-cache, no-store, must-revalidate';
+		/**
+		 * Allow CDN plugins to disable nocache headers.
+		 *
+		 * @param bool $enable_nocache_headers Flag indicating whether to add nocache headers. Default: true.
+		 */
+		if ( apply_filters( 'woocommerce_enable_nocache_headers', true ) ) {
+			// no-transform: Opt-out of Google weblight if page is dynamic e.g. cart/checkout. https://support.google.com/webmasters/answer/6211428?hl=en.
+			$headers['Cache-Control'] = 'no-transform, no-cache, no-store, must-revalidate';
+		}
 		return $headers;
 	}
 

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -46,7 +46,7 @@ class WC_Cache_Helper {
 		 * @param bool $enable_nocache_headers Flag indicating whether to add nocache headers. Default: true.
 		 */
 		if ( apply_filters( 'woocommerce_enable_nocache_headers', true ) ) {
-			// no-transform: Opt-out of Google weblight if page is dynamic e.g. cart/checkout. https://support.google.com/webmasters/answer/6211428?hl=en.
+			// no-transform: Opt-out of Google weblight. https://support.google.com/webmasters/answer/6211428?hl=en.
 			$headers['Cache-Control'] = 'no-transform, no-cache, no-store, must-revalidate';
 		}
 		return $headers;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds a `woocommerce_enable_nocache_headers` filter to allow CDN plugins to disable adding the WC nocache headers.

Closes # .

### How to test the changes in this Pull Request:

1. Open the network tab in your browser console.
2. Navigate to the shop page.
3. Check the headers for `cache-control: no-transform, no-cache, no-store, must-revalidate`
4. Add the filter `add_filter( 'woocommerce_enable_nocache_headers', '__return_false' );`
5. Reload the page
6. Check the headers for `cache-control: no-cache, no-store, must-revalidate`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Add filter to allow disabling `nocache headers`.
