### PR TITLE
E2E: Fix OBW e2e test to account for the new Home Screen

### DIFF
--- a/tests/e2e/env/config/default.json
+++ b/tests/e2e/env/config/default.json
@@ -27,7 +27,7 @@
         "country": "United States (US)",
         "addressfirstline": "addr 1",
         "addresssecondline": "addr 2",
-        "countryandstate": "United States (US) -- California",
+        "countryandstate": "United States (US) — California",
         "city": "San Francisco",
         "state": "CA",
         "postcode": "94107"

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -6,20 +6,17 @@
  * Internal dependencies
  */
 import { StoreOwnerFlow } from '../../utils/flows';
-import { completeOldSetupWizard, completeOnboardingWizard } from '../../utils/components';
+import { completeOnboardingWizard } from '../../utils/components';
 import {
 	permalinkSettingsPageSaveChanges,
 	setCheckbox,
 	settingsPageSaveChanges,
 	verifyCheckboxIsSet,
-	verifyCheckboxIsUnset, verifyValueOfInputField
+	verifyValueOfInputField
 } from '../../utils';
 
-const config = require( 'config' );
-
 describe( 'Store owner can login and make sure WooCommerce is activated', () => {
-
-	it( 'can login', async () => {
+	beforeAll( async () => {
 		await StoreOwnerFlow.login();
 	} );
 
@@ -56,24 +53,15 @@ describe( 'Store owner can go through setup Task List', () => {
 	it( 'can setup shipping', async () => {
 		// Query for all tasks on the list
 		const taskListItems = await page.$$( '.woocommerce-list__item-title' );
-		expect( taskListItems ).toHaveLength( 5 );
+		expect( taskListItems ).toHaveLength( 6 );
 
 		await Promise.all( [
 			// Click on "Set up shipping" task to move to the next step
-			taskListItems[2].click(),
+			taskListItems[3].click(),
 
 			// Wait for shipping setup section to load
 			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 		] );
-
-		// Query for store location fields
-		const storeLocationFields = await page.$$( '.components-text-control__input' );
-		expect( storeLocationFields ).toHaveLength( 4 );
-
-		// Wait for "Continue" button to become active
-		await page.waitForSelector( 'button.is-primary:not(:disabled)' );
-		// Click on "Continue" button to move to the shipping cost section
-		await page.click( 'button.is-primary' );
 
 		// Wait for "Proceed" button to become active
 		await page.waitForSelector( 'button.is-primary:not(:disabled)' );

--- a/tests/e2e/utils/components.js
+++ b/tests/e2e/utils/components.js
@@ -121,11 +121,11 @@ const completeOnboardingWizard = async () => {
 	}
 
 	// Wait for "Continue" button to become active
-	await page.waitForSelector( 'button.woocommerce-profile-wizard__continue:not(:disabled)' );
+	await page.waitForSelector( 'button.is-primary:not(:disabled)' );
 
 	await Promise.all( [
 		// Click on "Continue" button to move to the next step
-		page.click( 'button.woocommerce-profile-wizard__continue' ),
+		page.click( 'button.is-primary' ),
 
 		// Wait for "Tell us about your business" section to load
 		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
@@ -186,9 +186,9 @@ const completeOnboardingWizard = async () => {
 	await page.waitForSelector( '.woocommerce-profile-wizard__header-title' );
 
 	// Wait for "No thanks" button to become active
-	await page.waitForSelector( 'button.is-default:not(:disabled)' );
+	await page.waitForSelector( 'button.is-secondary:not(:disabled)' );
 	// Click on "No thanks" button to move to the next step
-	await page.click( 'button.is-default' );
+	await page.click( 'button.is-secondary' );
 
 	// End of onboarding wizard
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adjust various conditions of the OBW e2e test to account for the new Home Screen and other changes introduced with it in order make the test pass. 

### How to test the changes in this Pull Request:

1. Make sure e2e tests pass locally and on Travis. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A. 
