### PR TITLE
Preserve qty input val when changing variations

### DIFF
--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -293,7 +293,18 @@
 			$qty.find( 'input.qty' ).val( '1' ).attr( 'min', '1' ).attr( 'max', '' ).change();
 			$qty.hide();
 		} else {
-			$qty.find( 'input.qty' ).attr( 'min', variation.min_qty ).attr( 'max', variation.max_qty ).val( variation.min_qty ).change();
+
+			var $qty_input = $qty.find( 'input.qty' ),
+				qty_val    = parseFloat( $qty_input.val() );
+
+			if ( isNaN( qty_val ) ) {
+				qty_val = variation.min_qty;
+			} else {
+				qty_val = qty_val > parseFloat( variation.max_qty ) ? variation.max_qty : qty_val;
+				qty_val = qty_val < parseFloat( variation.min_qty ) ? variation.min_qty : qty_val;
+			}
+
+			$qty_input.attr( 'min', variation.min_qty ).attr( 'max', variation.max_qty ).val( qty_val ).change();
 			$qty.show();
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Preserve quantity input value when changing variations.

Closes https://github.com/woocommerce/woocommerce/issues/26799.

### How to test the changes in this Pull Request:

1. Create a variable product and add some variations
2. Make sure that at least 1 variation manages stock and has a remaining stock qty = 5
3. Go to the single product page
4. Set qty = 10
4. Switch between variations. 

The quantity value (10) should be preserved, unless you choose the variation with 5 units remaining. In this case, the input value should change to 5.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Preserve quantity input value when changing variations.
