### PR TITLE
Update reserved stock when a row already exists

### DIFF
--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -160,7 +160,7 @@ final class ReserveStock {
 				INSERT INTO {$wpdb->wc_reserved_stock} ( `order_id`, `product_id`, `stock_quantity`, `timestamp`, `expires` )
 				SELECT %d, %d, %d, NOW(), ( NOW() + INTERVAL %d MINUTE ) FROM DUAL
 				WHERE ( $query_for_stock FOR UPDATE ) - ( $query_for_reserved_stock FOR UPDATE ) >= %d
-				ON DUPLICATE KEY UPDATE `expires` = VALUES( `expires` )
+				ON DUPLICATE KEY UPDATE `expires` = VALUES( `expires` ), `stock_quantity` = VALUES( `stock_quantity` )
 				",
 				$order->get_id(),
 				$product_id,


### PR DESCRIPTION
This fix is copied from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2747

See the original report here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2746

### Changes proposed in this Pull Request:

When the wc_reserve_stock table is updated and there is a duplicate row, it was only updating the expires column. It needs to also update the stock_quantity so changes to the cart are respected.

Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2746

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:

1. Add a stock managed product to the cart and go to the Block Checkout, qty 1.
2. See the wc_reserve_stock table has a row with stock reserved.
3. Go back to the cart and increase the qty of the item in your cart.
4. Go back to the Block Checkout.
5. Confirm the row in wc_reserve_stock now has the new qty.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix updating the wc_reserve_stock stock_quantity value after making changes to the cart in between checkouts.
