### PR TITLE
remove privacy page dropdown

### DIFF
--- a/includes/admin/settings/class-wc-settings-accounts.php
+++ b/includes/admin/settings/class-wc-settings-accounts.php
@@ -32,12 +32,14 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 	 */
 	public function get_settings() {
 		$erasure_text = esc_html__( 'account erasure request', 'woocommerce' );
+		$privacy_text = esc_html__( 'privacy page', 'woocommerce' );
 		if ( current_user_can( 'manage_privacy_options' ) ) {
 			if ( version_compare( get_bloginfo( 'version' ), '5.3', '<' ) ) {
 				$erasure_text = sprintf( '<a href="%s">%s</a>', esc_url( admin_url( 'tools.php?page=remove_personal_data' ) ), $erasure_text );
 			} else {
 				$erasure_text = sprintf( '<a href="%s">%s</a>', esc_url( admin_url( 'erase-personal-data.php' ) ), $erasure_text );
 			}
+			$privacy_text = sprintf( '<a href="%s">%s</a>', esc_url( admin_url( 'options-privacy.php' ) ), $privacy_text );
 		}
 
 		$account_settings = array(
@@ -136,18 +138,8 @@ class WC_Settings_Accounts extends WC_Settings_Page {
 				'title' => __( 'Privacy policy', 'woocommerce' ),
 				'type'  => 'title',
 				'id'    => 'privacy_policy_options',
-				'desc'  => __( 'This section controls the display of your website privacy policy. The privacy notices below will not show up unless a privacy page is first set.', 'woocommerce' ),
-			),
-
-			array(
-				'title'    => __( 'Privacy page', 'woocommerce' ),
-				'desc'     => __( 'Choose a page to act as your privacy policy.', 'woocommerce' ),
-				'id'       => 'wp_page_for_privacy_policy',
-				'type'     => 'single_select_page',
-				'default'  => '',
-				'class'    => 'wc-enhanced-select-nostd',
-				'css'      => 'min-width:300px;',
-				'desc_tip' => true,
+				/* translators: %s: privacy page link. */
+				'desc'  => sprintf( esc_html__( 'This section controls the display of your website privacy policy. The privacy notices below will not show up unless a %s is set.', 'woocommerce' ), $privacy_text ),
 			),
 
 			array(

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -762,10 +762,16 @@ class WC_Shop_Customizer {
 			)
 		);
 
-		$choose_pages = array(
-			'wp_page_for_privacy_policy' => __( 'Privacy policy', 'woocommerce' ),
-			'woocommerce_terms_page_id'  => __( 'Terms and conditions', 'woocommerce' ),
-		);
+		if ( current_user_can( 'manage_privacy_options' ) ) {
+			$choose_pages = array(
+				'wp_page_for_privacy_policy' => __( 'Privacy policy', 'woocommerce' ),
+				'woocommerce_terms_page_id'  => __( 'Terms and conditions', 'woocommerce' ),
+			);
+		} else {
+			$choose_pages = array(
+				'woocommerce_terms_page_id'  => __( 'Terms and conditions', 'woocommerce' ),
+			);
+		}
 		$pages        = get_pages(
 			array(
 				'post_type'   => 'page',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR removes the privacy page dropdown from the Accounts & Privacy page and add a link to the WordPress privacy settings page for shop owners.

Closes #25606 .

### How to test the changes in this Pull Request:

1. Store owners should have a link to the privacy page in the description of the privacy settings.
2. Shop manager should have the same description without `privacy page` linking to the privacy settings.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - Remove the privacy page dropdown from the Accounts & Privacy page.
