### PR TITLE
Fix e2e default config for admin state address

### DIFF
--- a/tests/e2e/env/config/default.json
+++ b/tests/e2e/env/config/default.json
@@ -27,7 +27,7 @@
         "country": "United States (US)",
         "addressfirstline": "addr 1",
         "addresssecondline": "addr 2",
-        "countryandstate": "United States (US) -- California",
+        "countryandstate": "United States (US) — California",
         "city": "San Francisco",
         "state": "CA",
         "postcode": "94107"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

According to wc admin, we should we em dash instead of double dash between country name and state. https://github.com/woocommerce/woocommerce-admin/blob/d15e9ed808b65f3c75f5be9385959f0fa0801c4f/client/dashboard/components/settings/general/store-address.js#L69

Without em dash, admin state won't be selected during e2e testing.

### How to test the changes in this Pull Request:

The change can seen during e2e testing running the tests written in `setup-wizard.test.js`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix e2e default config for admin state address
