### PR TITLE
Fix typo in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -86,8 +86,8 @@
       "test": "Run unit tests",
       "phpcs": "Analyze code against the WordPress coding standards with PHP_CodeSniffer",
       "phpcbf": "Fix coding standards warnings/errors automatically with PHP Code Beautifier",
-      "makepot-audit": "Generate i18n/langauges/woocommerce.pot file and run audit",
-      "makepot": "Generate i18n/langauges/woocommerce.pot file"
+      "makepot-audit": "Generate i18n/languages/woocommerce.pot file and run audit",
+      "makepot": "Generate i18n/languages/woocommerce.pot file"
     }
   }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes two typos in composer.json: 'langauges' -> 'languages'.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Typo in composer.json for makepot