### PR TITLE
Add login link for existing account

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -44,7 +44,7 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 		}
 
 		if ( email_exists( $email ) ) {
-			return new WP_Error( 'registration-error-email-exists', apply_filters( 'woocommerce_registration_error_email_exists', __( 'An account is already registered with your email address. Please log in.', 'woocommerce' ), $email ) );
+			return new WP_Error( 'registration-error-email-exists', apply_filters( 'woocommerce_registration_error_email_exists', __( 'An account is already registered with your email address. <a href="#" class="showlogin">Please log in.</a>', 'woocommerce' ), $email ) );
 		}
 
 		if ( 'yes' === get_option( 'woocommerce_registration_generate_username', 'yes' ) && empty( $username ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a logged-out user tries to check out with an email address associated with an existing account, they are prompted to log in. This PR updates that prompt with a link to the login form. Though other opportunities to log in should already exist elsewhere on the checkout page (such as `form-login.php`'s "Returning customer?" [prompt](https://github.com/woocommerce/woocommerce/blob/master/templates/checkout/form-login.php#L26), off which this change is based), this PR makes it more explicit and intuitive.

This proposal comes in response to feedback from a potential customer:

> Today I couldn’t purchase anything from the store … I was instructed to log in using my username. I’m using mobile on iOS and can not locate the login menu? How may I log-in? Frustrating but it’s probably somewhere obvious.

### How to test the changes in this Pull Request:

1. Attempt to log in with an email address associated with an existing account.
2. When the screen refreshes, click the "Please log in" link.
3. Proceed to log in.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Tested in my store's production environment in private browsing windows in Safari (both macOS 10.12.6 & iOS 13.5.1). Screenshots:

**Existing UI**
![gb-woo-1](https://user-images.githubusercontent.com/12199101/85309477-e4ba3700-b46f-11ea-993d-5d8905bb495a.jpg)

**UI with hyperlink added**
![gb-woo-2](https://user-images.githubusercontent.com/12199101/85309492-e8e65480-b46f-11ea-8575-3046252286b2.jpg)

**Login form expanded**
![gb-woo-3](https://user-images.githubusercontent.com/12199101/85309494-e97eeb00-b46f-11ea-8ea3-ff6941ae8673.jpg)

**Checkout page after completing login process**
![gb-woo-4](https://user-images.githubusercontent.com/12199101/85309496-ea178180-b46f-11ea-903e-7c32509ba36a.jpg)

**UI with hyperlink added — iOS**
![gb-woo-ios-1](https://user-images.githubusercontent.com/12199101/85310107-d882a980-b470-11ea-8d25-5519185f5a9c.png)

**Login form expanded — iOS**
![gb-woo-ios-2](https://user-images.githubusercontent.com/12199101/85310117-db7d9a00-b470-11ea-98ce-b71988fc3465.png)

### Changelog entry

> Fix - Make the "Please log in" message displayed to users with an existing account a hyperlink.