### PR TITLE
add template cache unit test

### DIFF
--- a/tests/legacy/unit-tests/core/template-cache.php
+++ b/tests/legacy/unit-tests/core/template-cache.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * Template cache tests class.
+ *
+ * @package WooCommerce\Tests\Core
+ */
+
+/**
+ * WC_Template_Cache class.
+ */
+class WC_Template_Cache extends WC_Unit_Test_Case {
+	/**
+	 * Test wc_get_template_part().
+	 */
+	public function test_wc_get_template_part() {
+		// Clear cache to start.
+		$this->clear_template_cache();
+
+		// Prevent template being loaded.
+		add_filter( 'wc_get_template_part', '__return_false' );
+		// Use content-* templates.
+		$templates = array();
+		foreach ( glob( dirname( WC_PLUGIN_FILE ) . '/templates/content*.php' ) as $template ) {
+			$name                    = preg_replace( '|content-(.*)\.php|', '$1', basename( $template ) );
+			$cache_key               = sanitize_key(
+				implode(
+					'-',
+					array(
+						'template-part',
+						'content',
+						$name,
+						WC_VERSION,
+					)
+				)
+			);
+			$templates[ $cache_key ] = $template;
+			wc_get_template_part( 'content', $name );
+		}
+		remove_filter( 'wc_get_template_part', '__return_false' );
+
+		// Check cached template list.
+		$this->assertEquals( array_keys( $templates ), wp_cache_get( 'cached_templates', 'woocommerce' ) );
+
+		// Check individual templates.
+		foreach ( $templates as $cache_key => $template ) {
+			$this->assertEquals( $template, wp_cache_get( $cache_key, 'woocommerce' ) );
+		}
+
+		// Clear cache.
+		$this->clear_template_cache();
+	}
+
+	/**
+	 * Clear the template cache.
+	 */
+	protected function clear_template_cache() {
+		$cached_templates = wp_cache_get( 'cached_templates', 'woocommerce' );
+		wc_clear_template_cache();
+
+		foreach ( (array) $cached_templates as $template ) {
+			$this->assertEmpty( wp_cache_get( $template, 'woocommerce' ) );
+		}
+		$this->assertEmpty( wp_cache_get( 'cached_templates', 'woocommerce' ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Followup to #26752. This PR adds a unit test for `wc_get_template_part()` and cache clearing. `wc_get_template()` is not tested because there isn't a way to short circuit loading the templates.

### How to test the changes in this Pull Request:

1. Unit tests should pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Add tests for template cache
