### PR TITLE
Add `woocommerce_order_note_added` action

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1731,6 +1731,8 @@ class WC_Order extends WC_Abstract_Order {
 			);
 		}
 
+		do_action( 'woocommerce_order_note_added', $comment_id, $this );
+
 		return $comment_id;
 	}
 

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1731,6 +1731,14 @@ class WC_Order extends WC_Abstract_Order {
 			);
 		}
 
+		/**
+		 * Action hook fired after an order note is added.
+		 *
+		 * @param int      $order_note_id Order note ID.
+		 * @param WC_Order $order         Order data.
+		 *
+		 * @since 4.4.0
+		 */
 		do_action( 'woocommerce_order_note_added', $comment_id, $this );
 
 		return $comment_id;


### PR DESCRIPTION
Add a `woocommerce_order_note_added` action after the order note has been completely added. This action provides a _much_ easier way to perform an action when a non-customer order note is added.

Question: would it be better to pass the `WP_Comment` object rather than the `$comment_id`?

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Add `woocommerce_order_note_added` action
