### PR TITLE
add Google weblight user agent check

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -40,12 +40,14 @@ class WC_Cache_Helper {
 	 * @since 3.6.0
 	 */
 	public static function additional_nocache_headers( $headers ) {
+		$agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		/**
-		 * Allow CDN plugins to disable nocache headers.
+		 * Allow plugins to enable nocache headers. Enabled for Google weblight.
 		 *
-		 * @param bool $enable_nocache_headers Flag indicating whether to add nocache headers. Default: true.
+		 * @see   https://support.google.com/webmasters/answer/1061943?hl=en
+		 * @param bool $enable_nocache_headers Flag indicating whether to add nocache headers. Default: false.
 		 */
-		if ( apply_filters( 'woocommerce_enable_nocache_headers', true ) ) {
+		if ( false !== strpos( $agent, 'googleweblight' ) || apply_filters( 'woocommerce_enable_nocache_headers', false ) ) {
 			// no-transform: Opt-out of Google weblight. https://support.google.com/webmasters/answer/6211428?hl=en.
 			$headers['Cache-Control'] = 'no-transform, no-cache, no-store, must-revalidate';
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the logic in #26802 to add a user agent check for `googleweblight` and changes the value passed to the filter to `false`.

Closes #25833 .

### How to test the changes in this Pull Request:

1. Open the network tab in your browser console.
2. Navigate to the shop page.
3. Check the headers for `cache-control: no-cache, no-store, must-revalidate`
4. Add the filter `add_filter( 'woocommerce_enable_nocache_headers', '__return_true' );`
5. Reload the page
6. Check the headers for `cache-control: no-transform, no-cache, no-store, must-revalidate`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Limit nocache headers to googleweblight by default.
