### PR TITLE
Update woocommerce/woocommerce-blocks to v2.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "1.3.0-rc.1",
-    "woocommerce/woocommerce-blocks": "2.7.1",
+    "woocommerce/woocommerce-blocks": "2.8.0",
     "woocommerce/woocommerce-rest-api": "1.0.10"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c35209de8f965f88aa5121e3ba76fc65",
+    "content-hash": "d8f470c3f720e9c73365e4cec229049b",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -466,16 +466,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v2.7.1",
+            "version": "v2.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "0025c5cda83892c6f566fffd05197006f230d16c"
+                "reference": "129c69963d761f62e9aefd938eabd202347a95ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/0025c5cda83892c6f566fffd05197006f230d16c",
-                "reference": "0025c5cda83892c6f566fffd05197006f230d16c",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/129c69963d761f62e9aefd938eabd202347a95ed",
+                "reference": "129c69963d761f62e9aefd938eabd202347a95ed",
                 "shasum": ""
             },
             "require": {
@@ -509,7 +509,7 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2020-06-16T13:34:29+00:00"
+            "time": "2020-06-24T18:49:28+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",


### PR DESCRIPTION
This is the release pull request for 2.8.0 of the WooCommerce Blocks plugin.

## Communication

<!--
  This section is for any notes related to communicating the release.
  Please include any extra details with each item as needed.
-->

This release introduces:

> This release introduces several improvements to how our blocks work with different themes. Blocks will inherit font colors of your theme, as well as interpolate border colors from the text color. Along with several updates and fixes to styles, this release also fixes an issue with Product Categories List block when used on full width, addresses respecting the tax settings in the shipping methods, and adds the ability to use cropped images in the All Products, and All Reviews blocks.

A full changelog:

_Note: This changelog does not include updates to the Cart and Checkout blocks which are not exposed for use in Woo Core yet._

- Fix an error appearing in the Product Categories List block with Full Width align. [2700](https://github.com/woocommerce/woocommerce-gutenberg-products-block#2700)
- Update some class names to match the new guidelines. Check the docs in order to see which class names have been updated. [2691](https://github.com/woocommerce/woocommerce-gutenberg-products-block#2691)
- Blocks now respect the product image cropping settings. For the All Products block, the user can switch between the cropped thumbnail and the full size image. [2755](https://github.com/woocommerce/woocommerce-gutenberg-products-block#2755)

### Prepared Updates

The following documentation, blog posts, and changelog updates are prepared for the release:

<!--
In this section you are highlighting all the public facing documentation that is related to the
release. Feel free to remove anything that doesn't apply for this release.
-->

**Release announcement:** <!-- Link to release announcement post on developer.woocommerce.com (published after release) -->

**Developer Notes** - The following issues require developer notes in the release post:
This PR needs a dev note in the release post
https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2691


**Relevant developer documentation:** <!-- Link(s) to any developer documentation related to the release -->
[Class names update in 2.8.0](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/docs/theming/class-names-update-280.md)


* [x] The release includes a changelog entry in the readme.txt?


## Quality

* [x] Changes in this release are covered by Automated Tests.
Those changes are not covered by any tests we have because they mostly target styling features.

* This release has been tested on the following platforms:
     * [x] mobile
     * [x] desktop

* [x] Link to **testing instructions** for this release: [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/6378e908b45b8065b4cc0a16bfc2d7692a12737a/docs/testing/releases/280.md)

* [x] The release has a negative performance impact on sites.
We have a small bundle increase in some of our files, the increase is minimal so we didn't investigate into it. 

| Bundle                               | Release 2 7 | Release 2 8 | Diff   |
| ------------------------------------ | ----------- | ----------- | ------ |
| `./build/all-products.js`            | 20.34KB     | 24.4KB      | 4.06KB |
| `./build/single-product.js`          | 14.67KB     | 17.9KB      | 3.23KB |
| `./build/all-products-frontend.js`   | 37.61KB     | 40.35KB     | 2.75KB |
| `./build/single-product-frontend.js` | 40.36KB     | 43.11KB     | 2.74KB |
| `./build/vendors.js`                 | 404.93KB    | 405.99KB    | 1.06KB |

