### PR TITLE
Bump wc-admin version 1.3.0-rc.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.3.0-rc.1",
+    "woocommerce/woocommerce-admin": "1.3.0-rc.2",
     "woocommerce/woocommerce-blocks": "2.7.1",
     "woocommerce/woocommerce-rest-api": "1.0.10"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c35209de8f965f88aa5121e3ba76fc65",
+    "content-hash": "fbf33d1f1bf847639d9871512aaf0158",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -419,16 +419,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "v1.3.0-rc.1",
+            "version": "v1.3.0-rc.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "12bc8bf522298a099bb725990cd50bae944e667f"
+                "reference": "241b8b14a40f1fb426b57747fd72e245a86cd608"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/12bc8bf522298a099bb725990cd50bae944e667f",
-                "reference": "12bc8bf522298a099bb725990cd50bae944e667f",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/241b8b14a40f1fb426b57747fd72e245a86cd608",
+                "reference": "241b8b14a40f1fb426b57747fd72e245a86cd608",
                 "shasum": ""
             },
             "require": {
@@ -462,7 +462,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-06-23T02:57:05+00:00"
+            "time": "2020-06-25T01:22:20+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
Bump wc-admin version 1.3.0-rc.2

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce-admin/pull/4680 Fix Fatal when older versions of wc-admin are installed
https://github.com/woocommerce/woocommerce-admin/pull/4691 Removes un-needed rest_api_init() which was causing issues in CSV exports
https://github.com/woocommerce/woocommerce-admin/pull/4668 Fix for missing db update callback to set db version to 1.3.0
https://github.com/woocommerce/woocommerce-admin/pull/4664 CSS Tweak for task list ellipsis on home screen
https://github.com/woocommerce/woocommerce-admin/pull/4622 CSS Updates to the embed css to prevent nav bar from hiding other elements on various woo core views
https://github.com/woocommerce/woocommerce-admin/pull/4690 CSS Fix for Unread Indicator in inbox and home screen
https://github.com/woocommerce/woocommerce-admin/pull/4681 CSS Fix for missing margin between stats and quick links on home screen
https://github.com/woocommerce/woocommerce-admin/pull/4682 CSS Fix for loading indicators on summary numbers

