### PR TITLE
add package build to build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "license": "GPL-3.0+",
   "main": "Gruntfile.js",
   "scripts": {
-    "build": "grunt && npm run makepot",
+    "build": "grunt && npm run makepot && npm run build:packages",
     "build-watch": "grunt watch",
     "build:packages": "node ./tests/e2e/bin/build.js",
     "build:zip": "./bin/build-zip.sh",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds `npm run build:packages` to the `npm run build` script

Closes # .

### How to test the changes in this Pull Request:

1. Delete the `tests/e2e/env/build`, `tests/e2e/env/build-modules`, and `tests/e2e/env/node_modules` folders
2. Run 
```
npm install
npm run docker:up
npm run test:e2e
# Get error
Validation Error:
  Module <rootDir>/build/setup/jest.setup.js in the setupFilesAfterEnv option was not found.
         <rootDir> is: /Users/juliaamosova/src/woocommerce/tests/e2e/env
``` 
3. Run 
```
npm run build
npm run test:e2e
# Tests should run
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Add `npm run build:packages` to `npm run build`.
