### PR TITLE
Fix - wrong capabilities use on add order note issue fixed

### DIFF
--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1688,7 +1688,7 @@ class WC_Order extends WC_Abstract_Order {
 			return 0;
 		}
 
-		if ( is_user_logged_in() && current_user_can( 'edit_shop_order', $this->get_id() ) && $added_by_user ) {
+		if ( is_user_logged_in() && current_user_can( 'edit_shop_orders', $this->get_id() ) && $added_by_user ) {
 			$user                 = get_user_by( 'id', get_current_user_id() );
 			$comment_author       = $user->display_name;
 			$comment_author_email = $user->user_email;


### PR DESCRIPTION
### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When you try to add custom note from front-end by a user then database inserting default author name as WooCommerce, Here have all capabilities added for that users with `edit_shop_orders` also. But not worked properly. After this changes it working perfectly.

Closes # .

### How to test the changes in this Pull Request:

1. Try to add a order note from front-end with make that user have access `edit_shop_orders` capabilities with using `add_order_note` method with added by user true parameter
2. Then check the comment author where you will see author name added WooCommerce and email as a blank

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x ] Have you written new tests for your changes, as applicable?
* [x ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Incorrect capability used on add order note while creating an user note.
