### PR TITLE
Fix syntax error due to missing comma

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -521,7 +521,7 @@ class WC_Post_Types {
 					$label = ! empty( $tax->attribute_label ) ? $tax->attribute_label : $tax->attribute_name;
 
 					$messages[ $name ] = array(
-						0 => ''
+						0 => '',
 						/* translators: %s: taxonomy label */
 						1 => sprintf( _x( '%s added', 'taxonomy term messages', 'woocommerce' ), $label ),
 						/* translators: %s: taxonomy label */


### PR DESCRIPTION
This syntax error caused a pipeline to fail on our side (WooCommerce Mulitlingual).

Introduced by https://github.com/woocommerce/woocommerce/commit/101a8ae243fbf9da0da28ecf0f09e38fb1f1a8f2.