### PR TITLE
[Tracker] Added order_total to orders_edit_status_change

### DIFF
--- a/includes/tracks/events/class-wc-orders-tracking.php
+++ b/includes/tracks/events/class-wc-orders-tracking.php
@@ -80,6 +80,7 @@ class WC_Orders_Tracking {
 			'previous_status' => $previous_status,
 			'date_created'    => $order->get_date_created() ? $order->get_date_created()->date( 'Y-m-d' ) : '',
 			'payment_method'  => $order->get_payment_method(),
+			'order_total'     => $order->get_total(),
 		);
 
 		WC_Tracks::record_event( 'orders_edit_status_change', $properties );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Includes `order_total` per request in #26822

Closes #26822.

### How to test the changes in this Pull Request:

1. Go to `wp-admin/admin.php?page=wc-settings&tab=advanced&section=woocommerce_com` and enable the tracker.
2. Checkout this branch.
3. Include `error_log( 'TRACKER [orders_edit_status_change]: ' . print_r( $properties, true ) );` before `WC_Tracks::record_event( 'orders_edit_status_change', $properties );`
4. Enable the WP error logger with adding the follow lines to your `wp-config.php` file.
```php
define( 'WP_DEBUG', true );
define( 'WP_DEBUG_LOG', true );
define( 'WP_DEBUG_DISPLAY', true );
```
5. Update the status of some orders using bulk actions, editing orders or with the quick view buttons.
6. Check the log for the new `order_total` key.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Added "order_total" to the `wcadmin_orders_edit_status_change` tracker event.
