### PR TITLE
fixed #26860

### DIFF
--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -268,7 +268,11 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 			'publish' => 1,
 		);
 
-		$status = $product->get_status( 'edit' );
+		if ( 'variation' === $product->get_type() ) {
+			$status = $product->get_parent_data()['status'];
+		} else {
+			$status = $product->get_status( 'edit' );
+		}
 
 		return isset( $statuses[ $status ] ) ? $statuses[ $status ] : -1;
 	}


### PR DESCRIPTION
As per https://github.com/woocommerce/woocommerce/issues/26860 

Variants should really inherit their parents 'Published' status when exporting as they're always set to published anyway.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WooCommerce always sets product_variations 'Published' column to public (even when its parent is marked as draft). I guess the reason for this is because logic is executed elsewhere to stop people from viewing the variant. 

When exporting as CSV, the product_variation 'Published' column is always '1' (published), while this is true, reading a product CSVs and seeing it marked as published when it's a draft will cause confusion. This just ensures when exporting as CSV, product_variation uses it's parents 'Published' status value.

Closes #26860.

### How to test the changes in this Pull Request:

1. Create a new variable product and don't publish it (save as draft).
2. Export as CSV and see that product_variation's status now mimicks the parent status

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Changelog entry

> When exporting draft variable products as CSV, the 'Published' column is inherited from the parent product.
