### PR TITLE
Removed type hints from src folder.

### DIFF
--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -41,12 +41,12 @@ final class ReserveStock {
 	/**
 	 * Query for any existing holds on stock for this item.
 	 *
-	 * @param \WC_Product $product Product to get reserved stock for.
-	 * @param integer     $exclude_order_id Optional order to exclude from the results.
+	 * @param \WC_Product|object $product Product to get reserved stock for.
+	 * @param integer            $exclude_order_id Optional order to exclude from the results.
 	 *
 	 * @return integer Amount of stock already reserved.
 	 */
-	public function get_reserved_stock( \WC_Product $product, $exclude_order_id = 0 ) {
+	public function get_reserved_stock( $product, $exclude_order_id = 0 ) {
 		global $wpdb;
 
 		if ( ! $this->is_enabled() ) {
@@ -62,10 +62,10 @@ final class ReserveStock {
 	 *
 	 * @throws ReserveStockException If stock cannot be reserved.
 	 *
-	 * @param \WC_Order $order Order object.
-	 * @param int       $minutes How long to reserve stock in minutes. Defaults to woocommerce_hold_stock_minutes.
+	 * @param \WC_Order|object $order Order object.
+	 * @param int              $minutes How long to reserve stock in minutes. Defaults to woocommerce_hold_stock_minutes.
 	 */
-	public function reserve_stock_for_order( \WC_Order $order, $minutes = 0 ) {
+	public function reserve_stock_for_order( $order, $minutes = 0 ) {
 		$minutes = $minutes ? $minutes : (int) get_option( 'woocommerce_hold_stock_minutes', 60 );
 
 		if ( ! $minutes || ! $this->is_enabled() ) {
@@ -119,9 +119,9 @@ final class ReserveStock {
 	/**
 	 * Release a temporary hold on stock for an order.
 	 *
-	 * @param \WC_Order $order Order object.
+	 * @param \WC_Order|object $order Order object.
 	 */
-	public function release_stock_for_order( \WC_Order $order ) {
+	public function release_stock_for_order( $order ) {
 		global $wpdb;
 
 		if ( ! $this->is_enabled() ) {
@@ -141,12 +141,12 @@ final class ReserveStock {
 	 *
 	 * @throws ReserveStockException If a row cannot be inserted.
 	 *
-	 * @param int       $product_id Product ID which is having stock reserved.
-	 * @param int       $stock_quantity Stock amount to reserve.
-	 * @param \WC_Order $order Order object which contains the product.
-	 * @param int       $minutes How long to reserve stock in minutes.
+	 * @param int              $product_id Product ID which is having stock reserved.
+	 * @param int              $stock_quantity Stock amount to reserve.
+	 * @param \WC_Order|object $order Order object which contains the product.
+	 * @param int              $minutes How long to reserve stock in minutes.
 	 */
-	private function reserve_stock_for_product( $product_id, $stock_quantity, \WC_Order $order, $minutes ) {
+	private function reserve_stock_for_product( $product_id, $stock_quantity, $order, $minutes ) {
 		global $wpdb;
 
 		$product_data_store       = \WC_Data_Store::load( 'product' );


### PR DESCRIPTION
Based on the design committee, we've decided not to refer 'old' classes from the includes folder in interfaces used in new code in the 'src' directory. Thus removing those type hints, but leaving them in the docblock to not lose the information.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Removal of type hints to keep the interface in `src` folder not polluted by the old classes from `includes`. There were some questions around docblocks and code itself referring to those objects when doing type checking or instantiating data stores. 

fyi @mikejolley 

More info in p2 once it's written by @ObliviousHarmony .

### How to test the changes in this Pull Request:

1. This change should have no visible effects.
2. Check that you can check out using 2 different customers, ideally also with Blocks checkout
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Removed type hints from src folder.
