### PR TITLE
add rating count to order by rating clause

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -598,7 +598,7 @@ class WC_Query {
 	 */
 	public function order_by_rating_post_clauses( $args ) {
 		$args['join']    = $this->append_product_sorting_table_join( $args['join'] );
-		$args['orderby'] = ' wc_product_meta_lookup.average_rating DESC, wc_product_meta_lookup.product_id DESC ';
+		$args['orderby'] = ' wc_product_meta_lookup.average_rating DESC, wc_product_meta_lookup.rating_count DESC, wc_product_meta_lookup.product_id DESC ';
 		return $args;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix: Add `rating_count` to order by rating clause.

Closes #24604  .

### How to test the changes in this Pull Request:

1. Create a new page with the shortcode `[products limit="6" orderby="rating" category="category-slug"]`
2. Rate randomly 4 of them, each one multiple times. For example like this:
Product # 1: 4 opinions, all of them have 5 stars - Average rating is 5.
Product # 2: 1 opinion that have 4 stars - Average rating is 4.
Product # 3: 2 opinions, all of them have 5 stars - Average rating is 5.
Product # 4: 3 opinions, 2 of them have 5 stars, 1 of them have 3 stars - Average rating is 4,3.
3. View in `master`
4. Use query monitor to find the transient for the query & delete the transient
5. View in this branch

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Add `rating_count` to order by rating clause.
