### PR TITLE
Update add precision function when pass empty string parameter

### DIFF
--- a/plugins/woocommerce/changelog/add-type-hints-to-wc_add_number_precision
+++ b/plugins/woocommerce/changelog/add-type-hints-to-wc_add_number_precision
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Add type hints in the signature of wc_add_number_precision to prevent invalid inputs.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1884,9 +1884,9 @@ function wc_get_rounding_precision() {
  * @param  bool  $round If should round after adding precision.
  * @return int|float
  */
-function wc_add_number_precision( $value, $round = true ) {
+function wc_add_number_precision( float $value, bool $round = true ) {
 	$cent_precision = pow( 10, wc_get_price_decimals() );
-	$value          = '' === $value ? 0.0 : $value * $cent_precision;
+	$value          = $value * $cent_precision;
 	return $round ? NumberUtil::round( $value, wc_get_rounding_precision() - wc_get_price_decimals() ) : $value;
 }
 

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -1886,7 +1886,7 @@ function wc_get_rounding_precision() {
  */
 function wc_add_number_precision( $value, $round = true ) {
 	$cent_precision = pow( 10, wc_get_price_decimals() );
-	$value          = $value * $cent_precision;
+	$value          = '' === $value ? 0.0 : $value * $cent_precision;
 	return $round ? NumberUtil::round( $value, wc_get_rounding_precision() - wc_get_price_decimals() ) : $value;
 }
 


### PR DESCRIPTION
### Changelog entry

> Tweak - Protect against errors in wc_add_number_precision() when an empty string is passed as the $value.
