### PR TITLE
Add a woocommerce_check_cart_item_stock_ignore_ids filter to allow bypass of check_cart_item_stock()

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -763,7 +763,7 @@ class WC_Cart extends WC_Legacy_Cart {
 		foreach ( $this->get_cart() as $cart_item_key => $values ) {
 			$product = $values['data'];
 			
-			if ( in_array($product->get_id(), $cart_item_ids_to_ignore) ) {
+			if ( in_array( $product->get_id(), $cart_item_ids_to_ignore ) ) {
 				continue;
 			}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -758,9 +758,14 @@ class WC_Cart extends WC_Legacy_Cart {
 		$error                    = new WP_Error();
 		$product_qty_in_cart      = $this->get_cart_item_quantities();
 		$current_session_order_id = isset( WC()->session->order_awaiting_payment ) ? absint( WC()->session->order_awaiting_payment ) : 0;
+		$cart_item_ids_to_ignore = apply_filters( 'woocommerce_check_cart_item_stock_ignore_ids', array() );
 
 		foreach ( $this->get_cart() as $cart_item_key => $values ) {
 			$product = $values['data'];
+			
+			if ( in_array($product->get_id(), $cart_item_ids_to_ignore) ) {
+				continue;
+			}
 
 			// Check stock based on stock-status.
 			if ( ! $product->is_in_stock() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

check_cart_item_stock() is used to deal with cart items that are no longer available.

In some custom development scenarios you may want to omit specific cart items from this check. It uses $this->get_cart() as a means of getting the cart items and therefore we can't see a way to manipulate this other than using wp_debug_backtrace_summary to find out if do_action('woocommerce_check_cart_items') is a caller (which eventually fires the check_cart_item_stock function).

This adds a `woocommerce_check_cart_item_stock_ignore_ids` filter that allows you to pass an array of IDs for the check to ignore.

Closes #26944 .

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add a `woocommerce_check_cart_item_stock_ignore_ids` filter so you can ignore certain products when `check_cart_item_stock()` is ran.
