### PR TITLE
Use tax location from order while computing tax in discount.

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1270,6 +1270,8 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 	 */
 	protected function set_item_discount_amounts( $discounts ) {
 		$item_discounts = $discounts->get_discounts_by_item();
+		$tax_location   = $this->get_tax_location();
+		$tax_location   = array( $tax_location['country'], $tax_location['state'], $tax_location['postcode'], $tax_location['city'] );
 
 		if ( $item_discounts ) {
 			foreach ( $item_discounts as $item_id => $amount ) {
@@ -1277,7 +1279,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 				// If the prices include tax, discounts should be taken off the tax inclusive prices like in the cart.
 				if ( $this->get_prices_include_tax() && wc_tax_enabled() && 'taxable' === $item->get_tax_status() ) {
-					$taxes = WC_Tax::calc_tax( $amount, WC_Tax::get_rates( $item->get_tax_class() ), true );
+					$taxes = WC_Tax::calc_tax( $amount, WC_Tax::get_rates_from_location( $item->get_tax_class(), $tax_location ), true );
 
 					// Use unrounded taxes so totals will be re-calculated accurately, like in cart.
 					$amount = $amount - array_sum( $taxes );
@@ -1299,6 +1301,13 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		$coupon_code_to_id = wc_list_pluck( $coupons, 'get_id', 'get_code' );
 		$all_discounts     = $discounts->get_discounts();
 		$coupon_discounts  = $discounts->get_discounts_by_coupon();
+		$tax_location      = $this->get_tax_location();
+		$tax_location      = array(
+			$tax_location['country'],
+			$tax_location['state'],
+			$tax_location['postcode'],
+			$tax_location['city'],
+		);
 
 		if ( $coupon_discounts ) {
 			foreach ( $coupon_discounts as $coupon_code => $amount ) {
@@ -1321,7 +1330,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 						continue;
 					}
 
-					$taxes = array_sum( WC_Tax::calc_tax( $item_discount_amount, WC_Tax::get_rates( $item->get_tax_class() ), $this->get_prices_include_tax() ) );
+					$taxes = array_sum( WC_Tax::calc_tax( $item_discount_amount, WC_Tax::get_rates_from_location( $item->get_tax_class(), $tax_location ), $this->get_prices_include_tax() ) );
 					if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
 						$taxes = wc_round_tax_total( $taxes );
 					}

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1279,7 +1279,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 
 				// If the prices include tax, discounts should be taken off the tax inclusive prices like in the cart.
 				if ( $this->get_prices_include_tax() && wc_tax_enabled() && 'taxable' === $item->get_tax_status() ) {
-					$taxes = WC_Tax::calc_tax( $amount, WC_Tax::get_rates_from_location( $item->get_tax_class(), $tax_location ), true );
+					$taxes = WC_Tax::calc_tax( $amount, $this->get_tax_rates( $item->get_tax_class(), $tax_location ), true );
 
 					// Use unrounded taxes so totals will be re-calculated accurately, like in cart.
 					$amount = $amount - array_sum( $taxes );
@@ -1330,7 +1330,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 						continue;
 					}
 
-					$taxes = array_sum( WC_Tax::calc_tax( $item_discount_amount, WC_Tax::get_rates_from_location( $item->get_tax_class(), $tax_location ), $this->get_prices_include_tax() ) );
+					$taxes = array_sum( WC_Tax::calc_tax( $item_discount_amount, $this->get_tax_rates( $item->get_tax_class(), $tax_location ), $this->get_prices_include_tax() ) );
 					if ( 'yes' !== get_option( 'woocommerce_tax_round_at_subtotal' ) ) {
 						$taxes = wc_round_tax_total( $taxes );
 					}
@@ -1522,6 +1522,21 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 		}
 
 		return apply_filters( 'woocommerce_order_get_tax_location', $args, $this );
+	}
+
+	/**
+	 * Get tax rates for an order. Use order's shipping or billing address, defaults to base location.
+	 *
+	 * @param string $tax_class     Tax class to get rates for.
+	 * @param array  $location_args Location to compute rates for. Should be in form: array( country, state, postcode, city).
+	 * @param object $customer      Only used to maintain backward compatibility for filter `woocommerce-matched_rates`.
+	 *
+	 * @return mixed|void Tax rates.
+	 */
+	protected function get_tax_rates( $tax_class, $location_args = array(), $customer = null ) {
+		$tax_location = $this->get_tax_location( $location_args );
+		$tax_location = array( $tax_location['country'], $tax_location['state'], $tax_location['postcode'], $tax_location['city'] );
+		return WC_Tax::get_rates_from_location( $tax_class, $tax_location, $customer );
 	}
 
 	/**

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -491,7 +491,7 @@ class WC_Tax {
 	 * @param array  $location  Location to compute rates for. Should be in form: array( country, state, postcode, city).
 	 * @param object $customer  Only used to maintain backward compatibility for filter `woocommerce-matched_rates`.
 	 *
-	 * @return mixed|void
+	 * @return mixed|void Tax rates.
 	 */
 	public static function get_rates_from_location( $tax_class, $location, $customer = null ) {
 		$tax_class         = sanitize_title( $tax_class );

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -405,7 +405,7 @@ class WC_Tax {
 
 		$criteria_string = implode( ' AND ', $criteria );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$found_rates = $wpdb->get_results(
 			"
 			SELECT tax_rates.*, COUNT( locations.location_id ) as postcode_count, COUNT( locations2.location_id ) as city_count
@@ -479,8 +479,22 @@ class WC_Tax {
 	 * @return  array
 	 */
 	public static function get_rates( $tax_class = '', $customer = null ) {
+		$tax_class = sanitize_title( $tax_class );
+		$location  = self::get_tax_location( $tax_class, $customer );
+		return self::get_rates_from_location( $tax_class, $location, $customer );
+	}
+
+	/**
+	 * Get's an arrau of matching rates from location and tax class. $customer parameter is used to preserve backward compatibility for filter.
+	 *
+	 * @param string $tax_class Tax class to get rates for.
+	 * @param array  $location  Location to compute rates for. Should be in form: array( country, state, postcode, city).
+	 * @param object $customer  Only used to maintain backward compatibility for filter `woocommerce-matched_rates`.
+	 *
+	 * @return mixed|void
+	 */
+	public static function get_rates_from_location( $tax_class, $location, $customer = null ) {
 		$tax_class         = sanitize_title( $tax_class );
-		$location          = self::get_tax_location( $tax_class, $customer );
 		$matched_tax_rates = array();
 
 		if ( count( $location ) === 4 ) {

--- a/tests/php/includes/abstracts/class-wc-abstract-order-test.php
+++ b/tests/php/includes/abstracts/class-wc-abstract-order-test.php
@@ -73,4 +73,68 @@ class WC_Abstract_Order_Test extends WC_Unit_Test_Case {
 		$this->assertEquals( 1248.96, $order->get_total() );
 	}
 
+	/**
+	 * Test that coupon taxes are not affected by logged in admin user.
+	 */
+	public function test_apply_coupon_for_correct_location_taxes() {
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+		update_option( 'woocommerce_tax_based_on', 'billing' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		$password = wp_generate_password( 8, false, false );
+		$admin_id = wp_insert_user(
+			array(
+				'user_login' => "test_admin$password",
+				'user_pass'  => $password,
+				'user_email' => "admin$password@example.com",
+				'role'       => 'administrator',
+			)
+		);
+
+		update_user_meta( $admin_id, 'billing_country', 'MV' ); // Different than customer's address and base location.
+		wp_set_current_user( $admin_id );
+		WC()->customer = null;
+		WC()->initialize_cart();
+
+		update_option( 'woocommerce_default_country', 'IN:AP' );
+
+		$tax_rate = array(
+			'tax_rate_country'  => 'IN',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '25.0000',
+			'tax_rate_name'     => 'tax',
+			'tax_rate_order'    => '1',
+			'tax_rate_class'    => '',
+		);
+		WC_Tax::_insert_tax_rate( $tax_rate );
+
+		$product = WC_Helper_Product::create_simple_product();
+		$product->set_regular_price( 100 );
+		$product->save();
+
+		$order = wc_create_order();
+		$order->set_billing_country( 'IN' );
+		$order->add_product( $product, 1 );
+		$order->save();
+		$order->calculate_totals();
+
+		$this->assertEquals( 100, $order->get_total() );
+		$this->assertEquals( 80, $order->get_subtotal() );
+		$this->assertEquals( 20, $order->get_total_tax() );
+
+		$coupon = new WC_Coupon();
+		$coupon->set_code( '10off' );
+		$coupon->set_discount_type( 'percent' );
+		$coupon->set_amount( 10 );
+		$coupon->save();
+
+		$order->apply_coupon( '10off' );
+
+		$this->assertEquals( 8, $order->get_discount_total() );
+		$this->assertEquals( 90, $order->get_total() );
+		$this->assertEquals( 18, $order->get_total_tax() );
+		$this->assertEquals( 2, $order->get_discount_tax() );
+	}
+
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We were not passing tax location while computing discount in orders, hence it was defaulting to the shop's base address resulting in incorrect tax calculation.

This was causing #25082 since the order's address is not passed, it was defaulting to address with what current admin user had.

This commit refactors `get_rates` method into another method that allows getting rates from the location directly.

Closes #25082.

### How to test the changes in this Pull Request:

1. Set price inclusive of taxes and any rate for a specific country other than your shop base address. For example, shop's base address could be `US`, then enter prices for `India` (@25%), make sure that there is no other tax applied like so:
![Screenshot 2020-07-09 at 1 48 47 AM](https://user-images.githubusercontent.com/7571618/86966233-6f947480-c186-11ea-8bc8-645e66ac8440.png)
2. Add a coupon for 10% and add a product for a price of 242. (This could be any price -- if it's different then modify numbers in next step accordingly).
3. Complete an order for this product as a guest user (in an incognito window). Make sure to use `Indian` address 
4. Open this order in the admin view, set the order status to Pending Payment and update.
5. Add the coupon, without this patch, discount will be calculated on the final amount instead of pre-tax amount (so the discount will be more than it should be). With this patch, the discount will be calculated before taxes are applied.
In above case, after the patch, the discount should be 19.36 (193.6 @ 10%), whereas before this patch discount will be 24.20 (242.2 @ 10%, which is incorrect as in this case, discount on tax will be applied twice).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Calculate discount based on order location in the admin view.
