### PR TITLE
Fixed the accessibility of WC_Cart::is_tax_displayed()

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1935,7 +1935,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 *
 	 * @return string
 	 */
-	private function is_tax_displayed() {
+	public function is_tax_displayed() {
 		if ( $this->get_customer() && $this->get_customer()->get_is_vat_exempt() ) {
 			return 'excl';
 		}

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -353,9 +353,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @return bool
 	 */
 	public function display_prices_including_tax() {
-		$customer_exempt = $this->get_customer() && $this->get_customer()->get_is_vat_exempt();
-
-		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, 'incl' === $this->is_tax_displayed() && ! $customer_exempt );
+		return apply_filters( 'woocommerce_cart_' . __FUNCTION__, 'incl' === $this->get_tax_price_display_mode() );
 	}
 
 	/*
@@ -1935,7 +1933,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 *
 	 * @return string
 	 */
-	public function is_tax_displayed() {
+	public function get_tax_price_display_mode() {
 		if ( $this->get_customer() && $this->get_customer()->get_is_vat_exempt() ) {
 			return 'excl';
 		}

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -200,8 +200,8 @@ abstract class WC_Legacy_Cart {
 				$value = 0;
 				break;
 			case 'tax_display_cart':
-				wc_deprecated_argument( 'WC_Cart->tax_display_cart', '4.3', 'Use WC_Cart->is_tax_displayed() instead.' );
-				$value = $this->is_tax_displayed();
+				wc_deprecated_argument( 'WC_Cart->tax_display_cart', '4.4', 'Use WC_Cart->get_tax_price_display_mode() instead.' );
+				$value = $this->get_tax_price_display_mode();
 				break;
 		}
 		return $value;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When we deprecated `WC_Legacy_Cart::tax_display_cart` in #26400 we introduced a fatal exception caused by the access modifier of `WC_Cart::is_tax_displayed()`. I've changed the access modifier on the method so that the parent class will be able to call it as well as users who have been directed to use it instead of the public property.

I discovered this because Subscriptions seems to be using the deprecated property.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?