### PR TITLE
CSS fix for issue 27009

### DIFF
--- a/assets/css/photoswipe/photoswipe.css
+++ b/assets/css/photoswipe/photoswipe.css
@@ -56,6 +56,18 @@ button.pswp__button--zoom:hover {
   .pswp img {
     max-width: none; }
 
+  /* adjust for admin bar */
+  .admin-bar .pswp {
+    height: calc(100% - 32px);
+    top: 32px;
+  }
+  @media screen and (max-width: 782px) {
+    .admin-bar .pswp {
+      height: calc(100% - 46px);
+      top: 46px;
+    }
+  }
+
 /* style is added when JS option showHideOpacity is set to true */
 .pswp--animate_opacity {
   /* 0.001, because opacity:0 doesn't trigger Paint action, which causes lag at start of transition */


### PR DESCRIPTION
# All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes #27009 


### How to test the changes in this Pull Request:

1. Ensure you are logged in to the WooCommerce site with an admin account
2. Go to a product page
3. Select the Magnifier icon at the top right of the main image
4. Check if the zoom/full-screen/close icons at the top right are _below_ the admin bar, not **under**

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

> Fix - Fixes Photoswipe action buttons being obscured by admin bar.