### PR TITLE
Fixed the `shipping_zone_method` CLI command's instance_id parameter

### DIFF
--- a/includes/cli/class-wc-cli-runner.php
+++ b/includes/cli/class-wc-cli-runner.php
@@ -114,6 +114,7 @@ class WC_CLI_Runner {
 			'attribute_id' => __( 'Attribute ID.', 'woocommerce' ),
 			'zone_id'      => __( 'Zone ID.', 'woocommerce' ),
 			'id'           => __( 'ID.', 'woocommerce' ),
+			'instance_id'  => __( 'Instance ID.', 'woocommerce' ),
 		);
 		$rest_command->set_supported_ids( $supported_ids );
 		$positional_args = array_keys( $supported_ids );

--- a/includes/cli/class-wc-cli-runner.php
+++ b/includes/cli/class-wc-cli-runner.php
@@ -113,8 +113,8 @@ class WC_CLI_Runner {
 			'refund_id'    => __( 'Refund ID.', 'woocommerce' ),
 			'attribute_id' => __( 'Attribute ID.', 'woocommerce' ),
 			'zone_id'      => __( 'Zone ID.', 'woocommerce' ),
-			'id'           => __( 'ID.', 'woocommerce' ),
 			'instance_id'  => __( 'Instance ID.', 'woocommerce' ),
+			'id'           => __( 'The ID for the resource.', 'woocommerce' ),
 		);
 		$rest_command->set_supported_ids( $supported_ids );
 		$positional_args = array_keys( $supported_ids );
@@ -166,14 +166,6 @@ class WC_CLI_Runner {
 					);
 					$ids[]      = $id_name;
 				}
-			}
-			if ( in_array( $command, array( 'delete', 'get', 'update' ), true ) && ! in_array( 'id', $ids, true ) ) {
-				$synopsis[] = array(
-					'name'        => 'id',
-					'type'        => 'positional',
-					'description' => __( 'The id for the resource.', 'woocommerce' ),
-					'optional'    => false,
-				);
 			}
 
 			foreach ( $endpoint_args as $name => $args ) {

--- a/tests/cli/bin/install-package-tests.sh
+++ b/tests/cli/bin/install-package-tests.sh
@@ -3,6 +3,7 @@
 set -ex
 
 PACKAGE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )"/../ && pwd )"
+WP_CLI_BIN_DIR="${PACKAGE_DIR}/bin"
 
 download() {
     if [ `which curl` ]; then


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The first part of this PR is that I've added the missing `instance_id` supporting ID to the REST CLI command runner. This parameter is used instead of `<id>` for the shipping method routes and is necessary for the command to run.

The second part of this PR comes from a discovery fixing the above. Currently there is an `id` appended to the command's argument list if one was not already found in the supplemental list. Since we already have an ID in the supplemental list we don't actually need to do this, and in cases where the route doesn't actually have an <id> parameter this results in an extra parameter that doesn't do anything. This PR removes the extra `id` parameter.

Closes #25480.

### How to test the changes in this Pull Request:

1. Run the `shipping_zone_method update` CLI command
2. Note that without the PR it will give an error, but with the PR, it will work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Removed the extra `id` parameter added to CLI commands that shouldn't have one. 
Fix - Added the missing `instance_id` to the REST CLI command so that shipping zone method commands will work.
