### PR TITLE
"Hidden" field type added to woocommerce_form_field() #26468

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2770,7 +2770,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				break;
 			case 'hidden':
-			$field .= '<input type="' . esc_attr( $args['type'] ) . '" class="input-hidden ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '"  value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
+				$field .= '<input type="' . esc_attr( $args['type'] ) . '" class="input-hidden ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '"  value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
 
 				break;
 			case 'select':

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2770,7 +2770,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				break;
 			case 'hidden':
-				$field .= '<input type="' . esc_attr( $args['type'] ) . '" class="input-hidden ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '"  value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
+				$field .= '<input type="' . esc_attr( $args['type'] ) . '" class="input-hidden ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
 
 				break;
 			case 'select':

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2769,6 +2769,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 				$field .= '<input type="' . esc_attr( $args['type'] ) . '" class="input-text ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" placeholder="' . esc_attr( $args['placeholder'] ) . '"  value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
 
 				break;
+			case 'hidden':
+			$field .= '<input type="' . esc_attr( $args['type'] ) . '" class="input-hidden ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '"  value="' . esc_attr( $value ) . '" ' . implode( ' ', $custom_attributes ) . ' />';
+
+				break;
 			case 'select':
 				$field   = '';
 				$options = '';

--- a/tests/legacy/unit-tests/templates/functions.php
+++ b/tests/legacy/unit-tests/templates/functions.php
@@ -178,4 +178,14 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 
 		$this->assertEquals( $expected_html, $actual_html );
 	}
+
+	public function test_hidden_field() {
+		$actual_html = woocommerce_form_field('test',
+		array(
+			'type' => 'hidden',
+			'class' => 'test-field',
+			'id' => 'test_field',
+		), 'test value');
+		$expected_html = '<input type="hidden" class="input-hidden test-field" name="test" id="test_field"  value="test value" />';
+	}
 }

--- a/tests/legacy/unit-tests/templates/functions.php
+++ b/tests/legacy/unit-tests/templates/functions.php
@@ -184,8 +184,11 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		array(
 			'type' => 'hidden',
 			'id' => 'test_field',
+			'input_class' => array( 'test-field' ),
+			'custom_attributes' => array( 'data-total' => '10' ),
+			'return' => true
 		), 'test value');
-		$expected_html = '<input type="hidden" class="input-hidden" name="test" id="test_field"  value="test value" />';
+		$expected_html = '<p class="form-row " id="test_field_field" data-priority=""><span class="woocommerce-input-wrapper"><input type="hidden" class="input-hidden test-field" name="test" id="test_field" value="test value" data-total="10" /></span></p>';
 
 		$this->assertEquals( $expected_html, $actual_html );
 

--- a/tests/legacy/unit-tests/templates/functions.php
+++ b/tests/legacy/unit-tests/templates/functions.php
@@ -183,9 +183,11 @@ class WC_Tests_Template_Functions extends WC_Unit_Test_Case {
 		$actual_html = woocommerce_form_field('test',
 		array(
 			'type' => 'hidden',
-			'class' => 'test-field',
 			'id' => 'test_field',
 		), 'test value');
-		$expected_html = '<input type="hidden" class="input-hidden test-field" name="test" id="test_field"  value="test value" />';
+		$expected_html = '<input type="hidden" class="input-hidden" name="test" id="test_field"  value="test value" />';
+
+		$this->assertEquals( $expected_html, $actual_html );
+
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In response to @lkraav, you can now specify 'hidden' as the field type to produce a hidden field.

Closes #26468 .

### How to test the changes in this Pull Request:

1. Spin up a WooCommerce store and add a product
2. Add woocommerce_form_field() to a hook within the theme's funtions.php specifying 'type' as "Hidden".
3. View the website at the point where the hook should be called.

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x ] Have you written new tests for your changes, as applicable?
* [ x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Hidden type added to woocommerce_form_field()
