### PR TITLE
Removed wildcards from branch name match.

### DIFF
--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -4,7 +4,7 @@ PROTECTED_BRANCH="master"
 REMOTE_REF=$(echo "$HUSKY_GIT_STDIN" | cut -d " " -f 3)
 
 if [ -n "$REMOTE_REF" ]; then
-	if [ -z "${REMOTE_REF##*$PROTECTED_BRANCH*}" ]; then
+	if [ -z "${REMOTE_REF##$PROTECTED_BRANCH}" ]; then
 		printf "%sYou're about to push to master, is that what you intended? [y/N]: %s" "$(tput setaf 3)" "$(tput sgr0)"
 		read -r PROCEED < /dev/tty
 		echo

--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -4,7 +4,7 @@ PROTECTED_BRANCH="master"
 REMOTE_REF=$(echo "$HUSKY_GIT_STDIN" | cut -d " " -f 3)
 
 if [ -n "$REMOTE_REF" ]; then
-	if [ -z "${REMOTE_REF##$PROTECTED_BRANCH}" ]; then
+	if [ "refs/heads/${PROTECTED_BRANCH}" == "$REMOTE_REF" ]; then
 		printf "%sYou're about to push to master, is that what you intended? [y/N]: %s" "$(tput setaf 3)" "$(tput sgr0)"
 		read -r PROCEED < /dev/tty
 		echo

--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -5,6 +5,11 @@ REMOTE_REF=$(echo "$HUSKY_GIT_STDIN" | cut -d " " -f 3)
 
 if [ -n "$REMOTE_REF" ]; then
 	if [ "refs/heads/${PROTECTED_BRANCH}" == "$REMOTE_REF" ]; then
+		if [ "$TERM" == "dumb" ]; then
+			>&2 echo "Sorry, you are unable to push to master using a GUI client! Please use git CLI."
+			exit 1
+		fi
+
 		printf "%sYou're about to push to master, is that what you intended? [y/N]: %s" "$(tput setaf 3)" "$(tput sgr0)"
 		read -r PROCEED < /dev/tty
 		echo


### PR DESCRIPTION
https://github.com/woocommerce/woocommerce/pull/26742 added protection against accidental push to master branch, however, I believe this now also prevents branches like `fix/update-master-branch` from being pushed as well. I think matching without using wildcards should be sufficient?

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->



### How to test the changes in this Pull Request:

1. Create a branch called `fix/update-master-branch`, commit a test commit, try to push it.
2. It should not work (either ask for confirmation to push to master or fail from GUI clients)
3. Check out this branch, try to push, now it should work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> N/A, tooling update.
