### PR TITLE
Added markup to display Database name under System Report -> Database

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -515,6 +515,13 @@ $untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, 'min
 			<td class="help"><?php echo wc_help_tip( esc_html__( 'The version of WooCommerce that the database is formatted for. This should be the same as your WooCommerce version.', 'woocommerce' ) ); /* phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped */ ?></td>
 			<td><?php echo esc_html( $database['wc_database_version'] ); ?></td>
 		</tr>
+
+		<tr>
+			<td data-export-label="WC Database Name"><?php esc_html_e( 'Database name', 'woocommerce' ); ?></td>
+			<td class="help">&nbsp;</td>
+			<td><?php echo esc_html( $database['database_name'] ); ?></td>
+		</tr>
+
 		<tr>
 			<td data-export-label="WC Database Prefix"><?php esc_html_e( 'Database prefix', 'woocommerce' ); ?></td>
 			<td class="help">&nbsp;</td>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds markup to display `Database name` under System Status Report -> Database. 

This PR requires changes made to `woocommerce-rest-api` package - https://github.com/woocommerce/woocommerce-rest-api/pull/221

Closes #26995.

Screenshot: https://d.pr/i/K7eNay

### How to test the changes in this Pull Request:

1. Replace `packages/woocommerce-rest-api` with the fork `git@github.com:achyuthajoy/woocommerce-rest-api.git` and switch to the branch `issue-woo-26995` and install required dependencies
2. On WooCommerce, checkout the branch `issue-26995`
3. Go to WooCommerce -> System Status to confirm that Database name is showing up just like the screenshot shared above.

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Adds Database name to System Status Report -> Database section
