### PR TITLE
Add existing meta keys to woocommerce_duplicate_product_exclude_meta filter

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,8 +45,8 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "Automattic\\WooCommerce\\Tests\\": "tests/php/src",
-      "Automattic\\WooCommerce\\Testing\\Tools\\": "tests/Tools"
+      "Automattic\\WooCommerce\\Tests\\": "tests/php/src/",
+      "Automattic\\WooCommerce\\Testing\\Tools\\": "tests/Tools/"
     }
   },
   "scripts": {

--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -129,11 +129,24 @@ class WC_Admin_Duplicate_Product {
 	 */
 	public function product_duplicate( $product ) {
 		/**
-		 * Filter to allow us to unset/remove data we don't want to copy to the duplicate.
+		 * Filter to allow us to exclude meta keys from product duplication..
 		 *
+		 * @param array $exclude_meta The keys to exclude from the duplicate.
+		 * @param array $existing_meta_keys The meta keys that the product already has.
 		 * @since 2.6
 		 */
-		$meta_to_exclude = array_filter( apply_filters( 'woocommerce_duplicate_product_exclude_meta', array() ) );
+		$meta_to_exclude = array_filter(
+			apply_filters(
+				'woocommerce_duplicate_product_exclude_meta',
+				array(),
+				array_map(
+					function ( $datum ) {
+						return $datum->key;
+					},
+					$product->get_meta_data()
+				)
+			)
+		);
 
 		$duplicate = clone $product;
 		$duplicate->set_id( 0 );

--- a/tests/legacy/unit-tests/admin/class-wc-tests-admin-duplicate-product.php
+++ b/tests/legacy/unit-tests/admin/class-wc-tests-admin-duplicate-product.php
@@ -97,6 +97,27 @@ class WC_Tests_Admin_Duplicate_Product extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests that the filter will exclude metadata from the duplicate as-expected.
+	 */
+	public function test_filter_allows_excluding_metadata_from_duplicate() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->add_meta_data( 'test_data', 'test' );
+
+		$filter = function ( $exclude_meta, $existing_meta_keys ) {
+			$this->assertContains( 'test_data', $existing_meta_keys );
+			return array( 'test_data' );
+		};
+		add_filter( 'woocommerce_duplicate_product_exclude_meta', $filter, 10, 2 );
+
+		$duplicate = ( new WC_Admin_Duplicate_Product() )->product_duplicate( $product );
+
+		remove_filter( 'woocommerce_duplicate_product_exclude_meta', $filter );
+
+		$this->assertNotEquals( $product->get_id(), $duplicate->get_id() );
+		$this->assertEmpty( $duplicate->get_meta_data() );
+	}
+
+	/**
 	 * Asserts that the product was correctly reset after duplication.
 	 *
 	 * @param WC_Product $duplicate The duplicate product to evaluate.

--- a/tests/legacy/unit-tests/admin/class-wc-tests-admin-duplicate-product.php
+++ b/tests/legacy/unit-tests/admin/class-wc-tests-admin-duplicate-product.php
@@ -97,27 +97,6 @@ class WC_Tests_Admin_Duplicate_Product extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Tests that the filter will exclude metadata from the duplicate as-expected.
-	 */
-	public function test_filter_allows_excluding_metadata_from_duplicate() {
-		$product = WC_Helper_Product::create_simple_product();
-		$product->add_meta_data( 'test_data', 'test' );
-
-		$filter = function ( $exclude_meta, $existing_meta_keys ) {
-			$this->assertContains( 'test_data', $existing_meta_keys );
-			return array( 'test_data' );
-		};
-		add_filter( 'woocommerce_duplicate_product_exclude_meta', $filter, 10, 2 );
-
-		$duplicate = ( new WC_Admin_Duplicate_Product() )->product_duplicate( $product );
-
-		remove_filter( 'woocommerce_duplicate_product_exclude_meta', $filter );
-
-		$this->assertNotEquals( $product->get_id(), $duplicate->get_id() );
-		$this->assertEmpty( $duplicate->get_meta_data() );
-	}
-
-	/**
 	 * Asserts that the product was correctly reset after duplication.
 	 *
 	 * @param WC_Product $duplicate The duplicate product to evaluate.

--- a/tests/php/includes/admin/class-wc-admin-duplicate-product-test.php
+++ b/tests/php/includes/admin/class-wc-admin-duplicate-product-test.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Unit tests for the WC_Admin_Duplicate_Product class.
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+
+/**
+ * Class WC_Admin_Duplicate_Product_Test
+ */
+class WC_Admin_Duplicate_Product_Test extends WC_Unit_Test_Case {
+	/**
+	 * Tests that the filter will exclude metadata from the duplicate as-expected.
+	 */
+	public function test_filter_allows_excluding_metadata_from_duplicate() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->add_meta_data( 'test_data', 'test' );
+
+		$filter = function ( $exclude_meta, $existing_meta_keys ) {
+			$this->assertContains( 'test_data', $existing_meta_keys );
+			return array( 'test_data' );
+		};
+		add_filter( 'woocommerce_duplicate_product_exclude_meta', $filter, 10, 2 );
+
+		$duplicate = ( new WC_Admin_Duplicate_Product() )->product_duplicate( $product );
+
+		remove_filter( 'woocommerce_duplicate_product_exclude_meta', $filter );
+
+		$this->assertNotEquals( $product->get_id(), $duplicate->get_id() );
+		$this->assertEmpty( $duplicate->get_meta_data() );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds the existing product's meta keys to the `woocommerce_duplicate_product_exclude_meta` filter so that developers can decide what keys to exclude from a list of known-values.

Closes #26192.

### How to test the changes in this Pull Request:

1. Run the `WC_Tests_Admin_Duplicate_Product::test_filter_allows_excluding_metadata_from_duplicate` test
2. Alternative you can create a snippet that adds a filter and test it on product duplication that way

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Added a second `$existing_meta_keys` parameter to the `woocommerce_duplicate_product_exclude_meta` filter.
