### PR TITLE
Removed Features settings and home screen option

### DIFF
--- a/includes/admin/settings/class-wc-settings-advanced.php
+++ b/includes/admin/settings/class-wc-settings-advanced.php
@@ -42,7 +42,6 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 			'webhooks'        => __( 'Webhooks', 'woocommerce' ),
 			'legacy_api'      => __( 'Legacy API', 'woocommerce' ),
 			'woocommerce_com' => __( 'WooCommerce.com', 'woocommerce' ),
-			'features'        => __( 'Features', 'woocommerce' ),
 		);
 
 		return apply_filters( 'woocommerce_get_sections_' . $this->id, $sections );
@@ -395,28 +394,6 @@ class WC_Settings_Advanced extends WC_Settings_Page {
 					array(
 						'type' => 'sectionend',
 						'id'   => 'legacy_api_options',
-					),
-				)
-			);
-		} elseif ( 'features' === $current_section ) {
-			$settings = apply_filters(
-				'woocommerce_settings_features',
-				array(
-					array(
-						'title' => __( 'Features', 'woocommerce' ),
-						'type'  => 'title',
-						'desc'  => __( 'Start using new features that are being progressively rolled out to improve the store management experience.', 'woocommerce' ),
-						'id'    => 'features_options',
-					),
-					array(
-						'title'   => __( 'Home Screen', 'woocommerce' ),
-						'desc'    => __( 'Displays analytical insights, inbox notifications, and handy shortcuts in a single screen', 'woocommerce' ),
-						'id'      => 'woocommerce_homescreen_enabled',
-						'type'    => 'checkbox',
-					),
-					array(
-						'type' => 'sectionend',
-						'id'   => 'features_options',
 					),
 				)
 			);

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -298,7 +298,6 @@ class WC_Install {
 		self::maybe_enable_setup_wizard();
 		self::update_wc_version();
 		self::maybe_update_db_version();
-		self::maybe_enable_homescreen();
 
 		delete_transient( 'wc_installing' );
 
@@ -341,17 +340,6 @@ class WC_Install {
 			delete_option( 'woocommerce_schema_missing_tables' );
 		}
 		return $missing_tables;
-	}
-
-	/**
-	 * Check if the homepage should be enabled and set the appropriate option if thats the case.
-	 *
-	 * @since 4.3.0
-	 */
-	private static function maybe_enable_homescreen() {
-		if ( self::is_new_install() && ! get_option( 'woocommerce_homescreen_enabled' ) ) {
-			add_option( 'woocommerce_homescreen_enabled', 'yes' );
-		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Removes the Features settings as requested in #26972
It also removes the home screen option set during the installation, since it should be become a default for 4.5, see https://github.com/woocommerce/woocommerce-admin/issues/4761

Closes #26972.

### How to test the changes in this Pull Request:

1. Apply this patch, go to `wp-admin/admin.php?page=wc-settings&tab=advanced`
2. Check that there's no more a "Features" menu item in the Advanced Settings page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Removed the "Features" settings page.
