### PR TITLE
Add postcode validation for Bosnia and Herzegovina

### DIFF
--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -18,6 +18,15 @@ return array(
 		'weight_unit'    => 'kg',
 		'dimension_unit' => 'cm',
 	),
+	'BA' => array(
+		'currency_code'  => 'BAM',
+		'currency_pos'   => 'right',
+		'thousand_sep'   => '.',
+		'decimal_sep'    => ',',
+		'num_decimals'   => 2,
+		'weight_unit'    => 'kg',
+		'dimension_unit' => 'cm',
+	),
 	'BD' => array(
 		'currency_code'  => 'BDT',
 		'currency_pos'   => 'left',

--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -20,7 +20,7 @@ return array(
 	),
 	'BA' => array(
 		'currency_code'  => 'BAM',
-		'currency_pos'   => 'right',
+		'currency_pos'   => 'right_space',
 		'thousand_sep'   => '.',
 		'decimal_sep'    => ',',
 		'num_decimals'   => 2,

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -820,6 +820,19 @@ class WC_Countries {
 							'required' => false,
 						),
 					),
+					'BA' => array(
+						'country' => array(
+							'label' => __('Country'),
+						),
+						'postcode' => array(
+							'priority' => 65,
+						),
+						'state'    => array(
+							'label'    => __( 'Canton', 'woocommerce' ),
+							'required' => false,
+							'hidden' => true,
+						),
+					),
 					'BD' => array(
 						'postcode' => array(
 							'required' => false,

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -821,9 +821,6 @@ class WC_Countries {
 						),
 					),
 					'BA' => array(
-						'country' => array(
-							'label' => __('Country'),
-						),
 						'postcode' => array(
 							'priority' => 65,
 						),

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -827,7 +827,7 @@ class WC_Countries {
 						'state'    => array(
 							'label'    => __( 'Canton', 'woocommerce' ),
 							'required' => false,
-							'hidden' => true,
+							'hidden'   => true,
 						),
 					),
 					'BD' => array(

--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -53,6 +53,9 @@ class WC_Validation {
 			case 'AT':
 				$valid = (bool) preg_match( '/^([0-9]{4})$/', $postcode );
 				break;
+			case 'BA':
+				$valid = (bool) preg_match( '/^([7-8]{1})([0-9]{4})$/', $postcode );
+				break;
 			case 'BR':
 				$valid = (bool) preg_match( '/^([0-9]{5})([-])?([0-9]{3})$/', $postcode );
 				break;

--- a/tests/legacy/unit-tests/util/validation.php
+++ b/tests/legacy/unit-tests/util/validation.php
@@ -115,7 +115,15 @@ class WC_Tests_Validation extends WC_Unit_Test_Case {
 			array( false, WC_Validation::is_postcode( '0123', 'SI' ) ),
 		);
 
-		return array_merge( $it, $gb, $us, $ch, $br, $ca, $nl, $si );
+		$ba = array(
+			array( true, WC_Validation::is_postcode( '71000', 'BA' ) ),
+			array( true, WC_Validation::is_postcode( '78256', 'BA' ) ),
+			array( true, WC_Validation::is_postcode( '89240', 'BA' ) ),
+			array( false, WC_Validation::is_postcode( '61000', 'BA' ) ),
+			array( false, WC_Validation::is_postcode( '7850', 'BA' ) ),
+		);
+
+		return array_merge( $it, $gb, $us, $ch, $br, $ca, $nl, $si, $ba );
 	}
 
 	/**


### PR DESCRIPTION
Postcode in Bosnia and Herzegovina consists of 5 numbers. First number is 7 or 8 and the rest 4 numbers can be in range 0-9.

https://bs.wikipedia.org/wiki/Spisak_po%C5%A1tanskih_brojeva_u_Bosni_i_Hercegovini

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Localization - Added postcode validation for Bosnia and Herzegovina.
