### PR TITLE
Update persistent cart on total recalculation.

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -51,11 +51,10 @@ final class WC_Cart_Session {
 		add_action( 'woocommerce_cart_loaded_from_session', array( $this, 'set_session' ) );
 		add_action( 'woocommerce_removed_coupon', array( $this, 'set_session' ) );
 
-		// Persistent cart stored to usermeta.
-		add_action( 'woocommerce_add_to_cart', array( $this, 'persistent_cart_update' ) );
-		add_action( 'woocommerce_cart_item_removed', array( $this, 'persistent_cart_update' ) );
-		add_action( 'woocommerce_cart_item_restored', array( $this, 'persistent_cart_update' ) );
-		add_action( 'woocommerce_cart_item_set_quantity', array( $this, 'persistent_cart_update' ) );
+		// After cart totals are recalculated, update the persistent cart.
+		// This gets triggered on add to/remove from cart, or other cart updates that affect totals,
+		// which is stored in the persistent cart.
+		add_action( 'woocommerce_after_calculate_totals', array( $this, 'persistent_cart_update' ) );
 
 		// Cookie events - cart cookies need to be set before headers are sent.
 		add_action( 'woocommerce_add_to_cart', array( $this, 'maybe_set_cart_cookies' ) );


### PR DESCRIPTION
This is to trigger the update of persistent cart on other udpates than just quantity updates and add to cart/remove from cart.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #[26374](https://github.com/woocommerce/woocommerce/tree/fix/26374) .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
