### PR TITLE
add/update correct deprecated notices on existing deprecations

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -892,9 +892,10 @@ class WC_Admin_Post_Types {
 	 * @param int   $product_id product identifier.
 	 * @param int   $variation_id optional product variation identifier.
 	 * @param array $downloadable_files newly set files.
-	 * @deprecated and moved to post-data class.
+	 * @deprecated 3.3.0 and moved to post-data class.
 	 */
 	public function process_product_file_download_paths( $product_id, $variation_id, $downloadable_files ) {
+		wc_deprecated_function( 'WC_Admin_Post_Types::process_product_file_download_paths', '3.3', 'WC_Post_Data::process_product_file_download_paths' );
 		WC_Post_Data::process_product_file_download_paths( $product_id, $variation_id, $downloadable_files );
 	}
 

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -895,7 +895,7 @@ class WC_Admin_Post_Types {
 	 * @deprecated 3.3.0 and moved to post-data class.
 	 */
 	public function process_product_file_download_paths( $product_id, $variation_id, $downloadable_files ) {
-		wc_deprecated_function( 'WC_Admin_Post_Types::process_product_file_download_paths', '3.3', 'WC_Post_Data::process_product_file_download_paths' );
+		wc_deprecated_function( 'WC_Admin_Post_Types::process_product_file_download_paths', '3.3', '' );
 		WC_Post_Data::process_product_file_download_paths( $product_id, $variation_id, $downloadable_files );
 	}
 

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -395,11 +395,12 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 	/**
 	 * Search by SKU or ID for products.
 	 *
-	 * @deprecated Logic moved to query_filters.
+	 * @deprecated 4.4.0 Logic moved to query_filters.
 	 * @param string $where Where clause SQL.
 	 * @return string
 	 */
 	public function sku_search( $where ) {
+		wc_deprecated_function( 'WC_Admin_List_Table_Products::sku_search', '4.4.0', 'Logic moved to query_filters.' );
 		return $where;
 	}
 

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -6,7 +6,7 @@
  * @var int $variation_id
  * @var WP_POST $variation
  * @var WC_Product_Variation $variation_object
- * @var array $variation_data array of variation data @deprecated.
+ * @var array $variation_data array of variation data @deprecated 4.4.0.
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -38,7 +38,7 @@ if ( ! $tab_exists ) {
 			self::show_messages();
 
 			do_action( 'woocommerce_settings_' . $current_tab );
-			do_action( 'woocommerce_settings_tabs_' . $current_tab ); // @deprecated hook. @todo remove in 4.0.
+			do_action( 'woocommerce_settings_tabs_' . $current_tab ); // @deprecated 3.4.0 hook. @todo remove in 4.6.0.
 		?>
 		<p class="submit">
 			<?php if ( empty( $GLOBALS['hide_save_button'] ) ) : ?>

--- a/includes/admin/views/html-admin-settings.php
+++ b/includes/admin/views/html-admin-settings.php
@@ -38,7 +38,7 @@ if ( ! $tab_exists ) {
 			self::show_messages();
 
 			do_action( 'woocommerce_settings_' . $current_tab );
-			do_action( 'woocommerce_settings_tabs_' . $current_tab ); // @deprecated 3.4.0 hook. @todo remove in 4.6.0.
+			do_action( 'woocommerce_settings_tabs_' . $current_tab ); // @deprecated 3.4.0 hook.
 		?>
 		<p class="submit">
 			<?php if ( empty( $GLOBALS['hide_save_button'] ) ) : ?>

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -454,8 +454,8 @@ class WC_Checkout {
 			 */
 			$item                       = apply_filters( 'woocommerce_checkout_create_order_line_item_object', new WC_Order_Item_Product(), $cart_item_key, $values, $order );
 			$product                    = $values['data'];
-			$item->legacy_values        = $values; // @deprecated For legacy actions.
-			$item->legacy_cart_item_key = $cart_item_key; // @deprecated For legacy actions.
+			$item->legacy_values        = $values; // @deprecated 4.4.0 For legacy actions.
+			$item->legacy_cart_item_key = $cart_item_key; // @deprecated 4.4.0 For legacy actions.
 			$item->set_props(
 				array(
 					'quantity'     => $values['quantity'],
@@ -502,8 +502,8 @@ class WC_Checkout {
 	public function create_order_fee_lines( &$order, $cart ) {
 		foreach ( $cart->get_fees() as $fee_key => $fee ) {
 			$item                 = new WC_Order_Item_Fee();
-			$item->legacy_fee     = $fee; // @deprecated For legacy actions.
-			$item->legacy_fee_key = $fee_key; // @deprecated For legacy actions.
+			$item->legacy_fee     = $fee; // @deprecated 4.4.0 For legacy actions.
+			$item->legacy_fee_key = $fee_key; // @deprecated 4.4.0 For legacy actions.
 			$item->set_props(
 				array(
 					'name'      => $fee->name,
@@ -541,7 +541,7 @@ class WC_Checkout {
 			if ( isset( $chosen_shipping_methods[ $package_key ], $package['rates'][ $chosen_shipping_methods[ $package_key ] ] ) ) {
 				$shipping_rate            = $package['rates'][ $chosen_shipping_methods[ $package_key ] ];
 				$item                     = new WC_Order_Item_Shipping();
-				$item->legacy_package_key = $package_key; // @deprecated For legacy actions.
+				$item->legacy_package_key = $package_key; // @deprecated 4.4.0 For legacy actions.
 				$item->set_props(
 					array(
 						'method_title' => $shipping_rate->label,

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -191,10 +191,12 @@ class WC_Download_Handler {
 	/**
 	 * Count download.
 	 *
-	 * @deprecated unknown
+	 * @deprecated 4.4.0
 	 * @param array $download_data Download data.
 	 */
-	public static function count_download( $download_data ) {}
+	public static function count_download( $download_data ) {
+		wc_deprecated_function( 'WC_Download_Handler::count_download', '4.4.0', '' );
+	}
 
 	/**
 	 * Download a file - hook into init function.

--- a/includes/class-wc-order-item-coupon.php
+++ b/includes/class-wc-order-item-coupon.php
@@ -136,11 +136,12 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	/**
 	 * OffsetGet for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated Add deprecation notices in future release.
+	 * @deprecated 4.4.0
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
 	public function offsetGet( $offset ) {
+		wc_deprecated_function( 'WC_Order_Item_Coupon::offsetGet', '4.4.0', '' );
 		if ( 'discount_amount' === $offset ) {
 			$offset = 'discount';
 		} elseif ( 'discount_amount_tax' === $offset ) {
@@ -152,11 +153,12 @@ class WC_Order_Item_Coupon extends WC_Order_Item {
 	/**
 	 * OffsetSet for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated Add deprecation notices in future release.
+	 * @deprecated 4.4.0
 	 * @param string $offset Offset.
 	 * @param mixed  $value  Value.
 	 */
 	public function offsetSet( $offset, $value ) {
+		wc_deprecated_function( 'WC_Order_Item_Coupon::offsetSet', '4.4.0', '' );
 		if ( 'discount_amount' === $offset ) {
 			$offset = 'discount';
 		} elseif ( 'discount_amount_tax' === $offset ) {

--- a/includes/class-wc-order-item-fee.php
+++ b/includes/class-wc-order-item-fee.php
@@ -290,12 +290,10 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 	/**
 	 * OffsetGet for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated 4.4.0
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
 	public function offsetGet( $offset ) {
-		wc_deprecated_function( 'WC_Order_Item_Fee::offsetGet', '4.4.0', '' );
 		if ( 'line_total' === $offset ) {
 			$offset = 'total';
 		} elseif ( 'line_tax' === $offset ) {

--- a/includes/class-wc-order-item-fee.php
+++ b/includes/class-wc-order-item-fee.php
@@ -290,11 +290,12 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 	/**
 	 * OffsetGet for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated Add deprecation notices in future release.
+	 * @deprecated 4.4.0
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
 	public function offsetGet( $offset ) {
+		wc_deprecated_function( 'WC_Order_Item_Fee::offsetGet', '4.4.0', '' );
 		if ( 'line_total' === $offset ) {
 			$offset = 'total';
 		} elseif ( 'line_tax' === $offset ) {
@@ -308,11 +309,12 @@ class WC_Order_Item_Fee extends WC_Order_Item {
 	/**
 	 * OffsetSet for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated Add deprecation notices in future release.
+	 * @deprecated 4.4.0
 	 * @param string $offset Offset.
 	 * @param mixed  $value  Value.
 	 */
 	public function offsetSet( $offset, $value ) {
+		wc_deprecated_function( 'WC_Order_Item_Fee::offsetSet', '4.4.0', '' );
 		if ( 'line_total' === $offset ) {
 			$offset = 'total';
 		} elseif ( 'line_tax' === $offset ) {

--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -163,13 +163,11 @@ class WC_Order_Item_Meta {
 	 * Return an array of formatted item meta in format e.g.
 	 * Handles @deprecated args.
 	 *
-	 * @deprecated 4.4.0
 	 * @param string $hideprefix Hide prefix.
 	 *
 	 * @return array
 	 */
 	public function get_formatted_legacy( $hideprefix = '_' ) {
-		wc_deprecated_function( 'WC_Order_Item_Product::get_formatted_legacy', '4.4.0', '' );
 		if ( ! is_ajax() ) {
 			wc_deprecated_argument( 'WC_Order_Item_Meta::get_formatted', '2.4', 'Item Meta Data is being called with legacy arguments' );
 		}

--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -163,11 +163,13 @@ class WC_Order_Item_Meta {
 	 * Return an array of formatted item meta in format e.g.
 	 * Handles @deprecated args.
 	 *
+	 * @deprecated 4.4.0
 	 * @param string $hideprefix Hide prefix.
 	 *
 	 * @return array
 	 */
 	public function get_formatted_legacy( $hideprefix = '_' ) {
+		wc_deprecated_function( 'WC_Order_Item_Product::get_formatted_legacy', '4.4.0', '' );
 		if ( ! is_ajax() ) {
 			wc_deprecated_argument( 'WC_Order_Item_Meta::get_formatted', '2.4', 'Item Meta Data is being called with legacy arguments' );
 		}

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -425,11 +425,12 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	/**
 	 * OffsetGet for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated Add deprecation notices in future release.
+	 * @deprecated 4.4.0
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
 	public function offsetGet( $offset ) {
+		wc_deprecated_function( 'WC_Order_Item_Shipping::offsetGet', '4.4.0', '' );
 		if ( 'line_subtotal' === $offset ) {
 			$offset = 'subtotal';
 		} elseif ( 'line_subtotal_tax' === $offset ) {
@@ -449,11 +450,12 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	/**
 	 * OffsetSet for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated Add deprecation notices in future release.
+	 * @deprecated 4.4.0
 	 * @param string $offset Offset.
 	 * @param mixed  $value  Value.
 	 */
 	public function offsetSet( $offset, $value ) {
+		wc_deprecated_function( 'WC_Order_Item_Shipping::offsetSet', '4.4.0', '' );
 		if ( 'line_subtotal' === $offset ) {
 			$offset = 'subtotal';
 		} elseif ( 'line_subtotal_tax' === $offset ) {

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -425,12 +425,10 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	/**
 	 * OffsetGet for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated 4.4.0
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
 	public function offsetGet( $offset ) {
-		wc_deprecated_function( 'WC_Order_Item_Shipping::offsetGet', '4.4.0', '' );
 		if ( 'line_subtotal' === $offset ) {
 			$offset = 'subtotal';
 		} elseif ( 'line_subtotal_tax' === $offset ) {
@@ -455,7 +453,7 @@ class WC_Order_Item_Product extends WC_Order_Item {
 	 * @param mixed  $value  Value.
 	 */
 	public function offsetSet( $offset, $value ) {
-		wc_deprecated_function( 'WC_Order_Item_Shipping::offsetSet', '4.4.0', '' );
+		wc_deprecated_function( 'WC_Order_Item_Product::offsetSet', '4.4.0', '' );
 		if ( 'line_subtotal' === $offset ) {
 			$offset = 'subtotal';
 		} elseif ( 'line_subtotal_tax' === $offset ) {

--- a/includes/class-wc-order-item-shipping.php
+++ b/includes/class-wc-order-item-shipping.php
@@ -276,12 +276,10 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 	/**
 	 * Offset get: for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated 4.4.0
 	 * @param string $offset Key.
 	 * @return mixed
 	 */
 	public function offsetGet( $offset ) {
-		wc_deprecated_function( 'WC_Order_Item_Shipping::offsetGet', '4.4.0', '' );
 		if ( 'cost' === $offset ) {
 			$offset = 'total';
 		}

--- a/includes/class-wc-order-item-shipping.php
+++ b/includes/class-wc-order-item-shipping.php
@@ -276,11 +276,12 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 	/**
 	 * Offset get: for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated Add deprecation notices in future release.
+	 * @deprecated 4.4.0
 	 * @param string $offset Key.
 	 * @return mixed
 	 */
 	public function offsetGet( $offset ) {
+		wc_deprecated_function( 'WC_Order_Item_Shipping::offsetGet', '4.4.0', '' );
 		if ( 'cost' === $offset ) {
 			$offset = 'total';
 		}
@@ -290,11 +291,12 @@ class WC_Order_Item_Shipping extends WC_Order_Item {
 	/**
 	 * Offset set: for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated Add deprecation notices in future release.
+	 * @deprecated 4.4.0
 	 * @param string $offset Key.
 	 * @param mixed  $value Value to set.
 	 */
 	public function offsetSet( $offset, $value ) {
+		wc_deprecated_function( 'WC_Order_Item_Shipping::offsetSet', '4.4.0', '' );
 		if ( 'cost' === $offset ) {
 			$offset = 'total';
 		}

--- a/includes/class-wc-order-item-tax.php
+++ b/includes/class-wc-order-item-tax.php
@@ -244,11 +244,12 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	/**
 	 * O for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated Add deprecation notices in future release.
+	 * @deprecated 4.4.0
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
 	public function offsetGet( $offset ) {
+		wc_deprecated_function( 'WC_Order_Item_Tax::offsetGet', '4.4.0', '' );
 		if ( 'tax_amount' === $offset ) {
 			$offset = 'tax_total';
 		} elseif ( 'shipping_tax_amount' === $offset ) {
@@ -260,11 +261,12 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	/**
 	 * OffsetSet for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated Add deprecation notices in future release.
+	 * @deprecated 4.4.0
 	 * @param string $offset Offset.
 	 * @param mixed  $value  Value.
 	 */
 	public function offsetSet( $offset, $value ) {
+		wc_deprecated_function( 'WC_Order_Item_Tax::offsetSet', '4.4.0', '' );
 		if ( 'tax_amount' === $offset ) {
 			$offset = 'tax_total';
 		} elseif ( 'shipping_tax_amount' === $offset ) {

--- a/includes/class-wc-order-item-tax.php
+++ b/includes/class-wc-order-item-tax.php
@@ -244,12 +244,10 @@ class WC_Order_Item_Tax extends WC_Order_Item {
 	/**
 	 * O for ArrayAccess/Backwards compatibility.
 	 *
-	 * @deprecated 4.4.0
 	 * @param string $offset Offset.
 	 * @return mixed
 	 */
 	public function offsetGet( $offset ) {
-		wc_deprecated_function( 'WC_Order_Item_Tax::offsetGet', '4.4.0', '' );
 		if ( 'tax_amount' === $offset ) {
 			$offset = 'tax_total';
 		} elseif ( 'shipping_tax_amount' === $offset ) {

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -1411,8 +1411,7 @@ class WC_Order extends WC_Abstract_Order {
 		$needs_address = false;
 
 		foreach ( $this->get_shipping_methods() as $shipping_method ) {
-			// Remove any instance IDs after ":".
-			$shipping_method_id = current( explode( ':', $shipping_method['method_id'] ) );
+			$shipping_method_id = $shipping_method->get_method_id();
 
 			if ( ! in_array( $shipping_method_id, $hide, true ) ) {
 				$needs_address = true;

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -216,7 +216,7 @@ class WC_Structured_Data {
 
 		if ( '' !== $product->get_price() ) {
 			// Assume prices will be valid until the end of next year, unless on sale and there is an end date.
-			$price_valid_until = date( 'Y-12-31', time() + YEAR_IN_SECONDS );
+			$price_valid_until = gmdate( 'Y-12-31', time() + YEAR_IN_SECONDS );
 
 			if ( $product->is_type( 'variable' ) ) {
 				$lowest  = $product->get_variation_price( 'min', false );
@@ -243,7 +243,7 @@ class WC_Structured_Data {
 				}
 			} else {
 				if ( $product->is_on_sale() && $product->get_date_on_sale_to() ) {
-					$price_valid_until = date( 'Y-m-d', $product->get_date_on_sale_to()->getTimestamp() );
+					$price_valid_until = gmdate( 'Y-m-d', $product->get_date_on_sale_to()->getTimestamp() );
 				}
 				$markup_offer = array(
 					'@type'              => 'Offer',
@@ -459,7 +459,7 @@ class WC_Structured_Data {
 				continue;
 			}
 
-			$product        = $order->get_product_from_item( $item );
+			$product        = $item->get_product();
 			$product_exists = is_object( $product );
 			$is_visible     = $product_exists && $product->is_visible();
 
@@ -472,12 +472,12 @@ class WC_Structured_Data {
 					'priceCurrency'    => $order->get_currency(),
 					'eligibleQuantity' => array(
 						'@type' => 'QuantitativeValue',
-						'value' => apply_filters( 'woocommerce_email_order_item_quantity', $item['qty'], $item ),
+						'value' => apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item ),
 					),
 				),
 				'itemOffered'        => array(
 					'@type' => 'Product',
-					'name'  => apply_filters( 'woocommerce_order_item_name', $item['name'], $item, $is_visible ),
+					'name'  => apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, $is_visible ),
 					'sku'   => $product_exists ? $product->get_sku() : '',
 					'image' => $product_exists ? wp_get_attachment_image_url( $product->get_image_id() ) : '',
 					'url'   => $is_visible ? get_permalink( $product->get_id() ) : get_home_url(),

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -653,7 +653,7 @@ final class WooCommerce {
 		/**
 		 * Legacy image sizes.
 		 *
-		 * @deprecated These sizes will be removed in 4.0.
+		 * @deprecated 3.3.0 These sizes will be removed in 4.6.0.
 		 */
 		add_image_size( 'shop_catalog', $thumbnail['width'], $thumbnail['height'], $thumbnail['crop'] );
 		add_image_size( 'shop_single', $single['width'], $single['height'], $single['crop'] );

--- a/includes/legacy/abstract-wc-legacy-order.php
+++ b/includes/legacy/abstract-wc-legacy-order.php
@@ -312,11 +312,12 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 
 	/**
 	 * Get a product (either product or variation).
-	 * @deprecated Add deprecation notices in future release. Replaced with $item->get_product()
+	 * @deprecated 4.4.0
 	 * @param object $item
 	 * @return WC_Product|bool
 	 */
 	public function get_product_from_item( $item ) {
+		wc_deprecated_function( 'WC_Abstract_Legacy_Order::get_product_from_item', '4.4.0', '$item->get_product()' );
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
 			$product = $item->get_product();
 		} else {
@@ -461,7 +462,7 @@ abstract class WC_Abstract_Legacy_Order extends WC_Data {
 	 * has_meta function for order items. This is different to the WC_Data
 	 * version and should be removed in future versions.
 	 *
-	 * @deprecated
+	 * @deprecated 3.0
 	 *
 	 * @param int $order_item_id
 	 *

--- a/includes/legacy/class-wc-legacy-api.php
+++ b/includes/legacy/class-wc-legacy-api.php
@@ -274,14 +274,14 @@ class WC_Legacy_API {
 	/**
 	 * Rest API Init.
 	 *
-	 * @deprecated since 3.7.0 - REST API clases autoload.
+	 * @deprecated 3.7.0 - REST API clases autoload.
 	 */
 	public function rest_api_init() {}
 
 	/**
 	 * Include REST API classes.
 	 *
-	 * @deprecated since 3.7.0 - REST API clases autoload.
+	 * @deprecated 3.7.0 - REST API clases autoload.
 	 */
 	public function rest_api_includes() {
 		$this->rest_api_init();
@@ -289,9 +289,10 @@ class WC_Legacy_API {
 	/**
 	 * Register REST API routes.
 	 *
-	 * @deprecated since 3.7.0 - Not used.
+	 * @deprecated 3.7.0
 	 */
 	public function register_rest_routes() {
+		wc_deprecated_function( 'WC_Legacy_API::register_rest_routes', '3.7.0', '' );
 		$this->register_wp_admin_settings();
 	}
 }

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -326,7 +326,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Function to apply discounts to a product and get the discounted price (before tax is applied).
 	 *
-	 * @deprecated Calculation and coupon logic is handled in WC_Cart_Totals.
+	 * @deprecated 3.2.0 Calculation and coupon logic is handled in WC_Cart_Totals.
 	 * @param mixed $values Cart item.
 	 * @param mixed $price Price of item.
 	 * @param bool  $add_totals Legacy.
@@ -377,17 +377,18 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Coupons enabled function. Filterable.
 	 *
-	 * @deprecated 2.5.0 in favor to wc_coupons_enabled()
+	 * @deprecated 2.5.0
 	 * @return bool
 	 */
 	public function coupons_enabled() {
+		wc_deprecated_function( 'WC_Legacy_Cart::coupons_enabled', '2.5.0', 'wc_coupons_enabled' );
 		return wc_coupons_enabled();
 	}
 
 	/**
 	 * Gets the total (product) discount amount - these are applied before tax.
 	 *
-	 * @deprecated Order discounts (after tax) removed in 2.3 so multiple methods for discounts are no longer required.
+	 * @deprecated 2.3.0 Order discounts (after tax) removed in 2.3 so multiple methods for discounts are no longer required.
 	 * @return mixed formatted price or false if there are none.
 	 */
 	public function get_discounts_before_tax() {
@@ -403,7 +404,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Get the total of all order discounts (after tax discounts).
 	 *
-	 * @deprecated Order discounts (after tax) removed in 2.3.
+	 * @deprecated 2.3.0 Order discounts (after tax) removed in 2.3.
 	 * @return int
 	 */
 	public function get_order_discount_total() {
@@ -414,7 +415,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Function to apply cart discounts after tax.
 	 *
-	 * @deprecated Coupons can not be applied after tax.
+	 * @deprecated 2.3.0 Coupons can not be applied after tax.
 	 * @param $values
 	 * @param $price
 	 */
@@ -425,7 +426,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Function to apply product discounts after tax.
 	 *
-	 * @deprecated Coupons can not be applied after tax.
+	 * @deprecated 2.3.0 Coupons can not be applied after tax.
 	 *
 	 * @param $values
 	 * @param $price
@@ -437,7 +438,7 @@ abstract class WC_Legacy_Cart {
 	/**
 	 * Gets the order discount amount - these are applied after tax.
 	 *
-	 * @deprecated Coupons can not be applied after tax.
+	 * @deprecated 2.3.0 Coupons can not be applied after tax.
 	 */
 	public function get_discounts_after_tax() {
 		wc_deprecated_function( 'get_discounts_after_tax', '2.3' );

--- a/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
+++ b/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
@@ -78,7 +78,7 @@ class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 		$this->tax_status   = $this->get_option( 'tax_status' );
 		$this->cost         = $this->get_option( 'cost' );
 		$this->type         = $this->get_option( 'type', 'class' );
-		$this->options      = $this->get_option( 'options', false ); // @deprecated in 2.4.0
+		$this->options      = $this->get_option( 'options', false ); // @deprecated 2.4.0
 	}
 
 	/**

--- a/includes/wc-deprecated-functions.php
+++ b/includes/wc-deprecated-functions.php
@@ -885,8 +885,7 @@ function woocommerce_track_product_view() {
 }
 
 /**
- * @since 2.3
- * @deprecated has no replacement
+ * @deprecated 2.3 has no replacement
  */
 function woocommerce_compile_less_styles() {
 	wc_deprecated_function( 'woocommerce_compile_less_styles', '2.3' );
@@ -895,7 +894,7 @@ function woocommerce_compile_less_styles() {
 /**
  * woocommerce_calc_shipping was an option used to determine if shipping was enabled prior to version 2.6.0. This has since been replaced with wc_shipping_enabled() function and
  * the woocommerce_ship_to_countries setting.
- * @since 2.6.0
+ * @deprecated 2.6.0
  * @return string
  */
 function woocommerce_calc_shipping_backwards_compatibility( $value ) {

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -822,7 +822,7 @@ function wc_update_total_sales_counts( $order_id ) {
 
 			if ( $product_id ) {
 				$data_store = WC_Data_Store::load( 'product' );
-				$data_store->update_product_sales( $product_id, absint( $item['qty'] ), 'increase' );
+				$data_store->update_product_sales( $product_id, absint( $item->get_quantity() ), 'increase' );
 			}
 		}
 	}

--- a/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-product.php
+++ b/tests/legacy/unit-tests/order-items/class-wc-tests-order-item-product.php
@@ -222,33 +222,35 @@ class WC_Tests_Order_Item_Product extends WC_Unit_Test_Case {
 
 		// Test line_subtotal.
 		$this->assertTrue( isset( $item['line_subtotal'] ) );
-		$item['line_subtotal'] = 50;
+		$item->set_subtotal( 50 );
 		$this->assertEquals( 50, $item->get_subtotal() );
 		$this->assertEquals( $item->get_subtotal(), $item['line_subtotal'] );
 
 		// Test line_subtotal_tax.
 		$this->assertTrue( isset( $item['line_subtotal_tax'] ) );
-		$item['line_subtotal_tax'] = 5;
+		$item->set_subtotal_tax( 5 );
 		$this->assertEquals( 5, $item->get_subtotal_tax() );
 		$this->assertEquals( $item->get_subtotal_tax(), $item['line_subtotal_tax'] );
 
 		// Test line_total.
 		$this->assertTrue( isset( $item['line_total'] ) );
-		$item['line_total'] = 55;
+		$item->set_total( 55 );
 		$this->assertEquals( 55, $item->get_total() );
 		$this->assertEquals( $item->get_total(), $item['line_total'] );
 
 		// Test line_tax.
 		$this->assertTrue( isset( $item['line_tax'] ) );
-		$item['line_tax'] = 5;
+		$item->set_total_tax( 5 );
 		$this->assertEquals( 5, $item->get_total_tax() );
 		$this->assertEquals( $item->get_total_tax(), $item['line_tax'] );
 
 		// Test line_tax_data.
 		$this->assertTrue( isset( $item['line_tax_data'] ) );
-		$item['line_tax_data'] = array(
-			'total'    => array( 5 ),
-			'subtotal' => array( 5 ),
+		$item->set_taxes(
+			array(
+				'total'    => array( 5 ),
+				'subtotal' => array( 5 ),
+			)
 		);
 		$this->assertEquals(
 			array(
@@ -261,26 +263,21 @@ class WC_Tests_Order_Item_Product extends WC_Unit_Test_Case {
 
 		// Test qty.
 		$this->assertTrue( isset( $item['qty'] ) );
-		$item['qty'] = 150;
+		$item->set_quantity( 150 );
 		$this->assertEquals( 150, $item->get_quantity() );
 		$this->assertEquals( $item->get_quantity(), $item['qty'] );
 
 		// Test item_meta_array.
 		$this->assertTrue( isset( $item['item_meta_array'] ) );
-		$item['item_meta_array'] = array(
-			0 => (object) array(
-				'key'   => 'test',
-				'value' => 'val',
-			),
-		);
+		$item->update_meta_data( 'test', 'val', 0 );
 		$this->assertInstanceOf( 'WC_Meta_Data', current( $item->get_meta_data() ) );
 		$this->assertEquals( current( $item->get_meta_data() ), $item['item_meta_array'][''] );
 		unset( $item['item_meta_array'] );
 		$this->assertEquals( array(), $item->get_meta_data() );
 
 		// Test default.
-		$this->assertFalse( isset( $item['foo'] ) );
-		$item['foo'] = 'bar';
+		$this->assertFalse( $item->meta_exists( 'foo' ) );
+		$item->add_meta_data( 'foo', 'bar' );
 		$this->assertEquals( 'bar', $item->get_meta( 'foo' ) );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds/updates deprecated documentation and notices on existing deprecated functions where missing. It removes the deprecated docs on `offsetGet()` in some classes as the function in the base class had not been deprecated and is still used internally in base classes. It contains some PHPCS fixes.

Closes #27036 .

### How to test the changes in this Pull Request:

1. Review code changes
2. Verify unit test pass
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> clean up deprecated documentation.
