### PR TITLE
remove state for country liechtenstein

### DIFF
--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -9,15 +9,6 @@
 defined( 'ABSPATH' ) || exit;
 
 return array(
-	'AT' => array(
-		'currency_code'  => 'EUR',
-		'currency_pos'   => 'left',
-		'thousand_sep'   => '.',
-		'decimal_sep'    => ',',
-		'num_decimals'   => 2,
-		'weight_unit'    => 'kg',
-		'dimension_unit' => 'cm',
-	),
 	'AU' => array(
 		'currency_code'  => 'AUD',
 		'currency_pos'   => 'left',

--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -9,6 +9,15 @@
 defined( 'ABSPATH' ) || exit;
 
 return array(
+	'AT' => array(
+		'currency_code'  => 'EUR',
+		'currency_pos'   => 'left',
+		'thousand_sep'   => '.',
+		'decimal_sep'    => ',',
+		'num_decimals'   => 2,
+		'weight_unit'    => 'kg',
+		'dimension_unit' => 'cm',
+	),
 	'AU' => array(
 		'currency_code'  => 'AUD',
 		'currency_pos'   => 'left',

--- a/i18n/states.php
+++ b/i18n/states.php
@@ -837,6 +837,7 @@ return array(
 		'XS' => __( 'Xaisomboun', 'woocommerce' ),
 	),
 	'LB' => array(),
+	'LI' => array(),
 	'LR' => array( // Liberia provinces.
 		'BM' => __( 'Bomi', 'woocommerce' ),
 		'BN' => __( 'Bong', 'woocommerce' ),

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1245,8 +1245,8 @@ class WC_Countries {
 							'priority' => 65,
 						),
 						'state'    => array(
-							'label'    => __( 'Municipality', 'woocommerce' ),
 							'required' => false,
+							'hidden'   => true,
 						),
 					),
 					'LK' => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
see github issue here: https://github.com/woocommerce/woocommerce/issues/27056
goal is to remove the state field if the country liechtenstein is choosen on checkout

Closes #27056.

### How to test the changes in this Pull Request:

1. add a product on your shop page
2. go to the cart -> click on next to get to the checkout
3. on the checkout choose country liechtenstein
4. state field should now be hidden

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
see github issue here: https://github.com/woocommerce/woocommerce/issues/27056
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
remove state for country liechtenstein
