### PR TITLE
Update woocommerce/woocommerce-blocks to v2.7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "1.3.0",
-    "woocommerce/woocommerce-blocks": "2.7.1",
+    "woocommerce/woocommerce-blocks": "2.7.2",
     "woocommerce/woocommerce-rest-api": "1.0.10"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -466,16 +466,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v2.7.1",
+            "version": "v2.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "0025c5cda83892c6f566fffd05197006f230d16c"
+                "reference": "22a19698c5d0bf0029f10d39928d6fa54fc50ffd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/0025c5cda83892c6f566fffd05197006f230d16c",
-                "reference": "0025c5cda83892c6f566fffd05197006f230d16c",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/22a19698c5d0bf0029f10d39928d6fa54fc50ffd",
+                "reference": "22a19698c5d0bf0029f10d39928d6fa54fc50ffd",
                 "shasum": ""
             },
             "require": {
@@ -509,7 +509,7 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2020-06-16T13:34:29+00:00"
+            "time": "2020-07-16T18:04:50+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",


### PR DESCRIPTION
Bump WooCommerce Blocks version to 2.7.2.

This point release introduces:

- enhancement: Move Draft order logic behind feature flag. https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2874

The fix included in this release will be included in our next major version (3.0.0), so we will not publicly release WC Blocks 2.7.2 in the .org repo. However, WC Blocks 2.7.2 is intended to be included in WC Core 4.3.1.

See 2.7.2 release PR in WC Blocks created by @nerrad here: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2880.

### Prepared Updates

The following documentation, blog posts, and changelog updates are prepared for the release:

**Release announcement:** _There will be no public announcement because this version will not be released in .org repo._

**Developer Notes:** _N/A_

**Relevant developer documentation:** _N/A_

**Happiness Engineer:** pca54o-51-p2

## Quality

**Testing:** Confirm that in this branch the `woocommerce_cleanup_draft_orders` as action is not present in the list of scheduled actions.

* [x] Changes in this release are covered by Automated Tests.
     * [x] Unit tests
     * [x] E2E tests
     * [x] for each supported WordPress and WooCommerce core versions.

* This release has been tested on the following platforms:
     * [x] mobile
     * [x] desktop

* [ ] This release affects public facing REST APIs.
    * [ ] It conforms to REST API versioning policy.

* [ ] This release impacts **other extensions** or **backward compatibility**.
    * [x] The release changes the signature of public methods or functions
        Note: the signatures are changed, but these were callbacks on filters and internal only. They were not promoted as a public api.
        * [ ] This is documented (see: <!-- Enter a link to the documentation here -->)
    * [ ] The release affects filters or action hooks.
        * [ ] This is documented (see: <!-- Enter a link to the documentation here -->)

* [x] Link to **testing instructions** for this release: [Testing Instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/c9419cd39e01d17e00daca792e51b20f95e52b73/docs/testing/releases/272.md#when-distributed-as-a-package-in-woocommerce-core).

* [ ] The release has a negative performance impact on sites.
    * [ ] There are new assets (JavaScript or CSS bundles)
    * [ ] There is an increase to the size of JavaScrip or CSS bundles) <!-- please include rationale for this increase -->
    * [ ] Other negative performance impacts (if yes, include list below)

* [ ] The release has positive performance impact on sites. If checked, please document these improvements here.