### PR TITLE
Fix OBW e2e test in WC 4.3: Scroll Home Screen tasks list into view for the `Set up shipping` click to work

### DIFF
--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -51,6 +51,9 @@ describe( 'Store owner can go through store Setup Wizard', () => {
 
 describe( 'Store owner can go through setup Task List', () => {
 	it( 'can setup shipping', async () => {
+		await page.evaluate( () => {
+			document.querySelector( '.woocommerce-list__item-title' ).scrollIntoView();
+		} );
 		// Query for all tasks on the list
 		const taskListItems = await page.$$( '.woocommerce-list__item-title' );
 		expect( taskListItems ).toHaveLength( 6 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added scroll Home Screen tasks list into view for the `Set up shipping` click to work. 

### How to test the changes in this Pull Request:

1. Make sure e2e tests pass locally and on Travis. Run tests as per [our docs](https://github.com/woocommerce/woocommerce/tree/master/tests/e2e#running-tests). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A since we don't include changes made to e2e tests into changelog or releases. 
