### PR TITLE
Queue all webhooks on shutdown.

### DIFF
--- a/includes/wc-webhook-functions.php
+++ b/includes/wc-webhook-functions.php
@@ -9,21 +9,40 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Process the synchronous web hooks at the end of the request.
+ * Process the web hooks at the end of the request.
  *
  * @since 4.4.0
  */
-function wc_webhook_execute_synchronous_queue() {
-	global $wc_queued_sync_webhooks;
-	if ( empty( $wc_queued_sync_webhooks ) ) {
+function wc_webhook_execute_queue() {
+	global $wc_queued_webhooks;
+	if ( empty( $wc_queued_webhooks ) ) {
 		return;
 	}
 
-	foreach ( $wc_queued_sync_webhooks as $data ) {
-		$data['webhook']->deliver( $data['arg'] );
+	foreach ( $wc_queued_webhooks as $data ) {
+		// Webhooks are processed in the background by default
+		// so as to avoid delays or failures in delivery from affecting the
+		// user who triggered it.
+		if ( apply_filters( 'woocommerce_webhook_deliver_async', true, $data['webhook'], $data['arg'] ) ) {
+
+			$queue_args = array(
+				'webhook_id' => $data['webhook']->get_id(),
+				'arg'        => $data['arg'],
+			);
+
+			$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_deliver_webhook_async', $queue_args, 'woocommerce-webhooks' );
+
+			// Make webhooks unique - only schedule one webhook every 10 minutes to maintain backward compatibility with WP Cron behaviour seen in WC < 3.5.0.
+			if ( is_null( $next_scheduled_date ) || $next_scheduled_date->getTimestamp() >= ( 600 + gmdate( 'U' ) ) ) {
+				WC()->queue()->add( 'woocommerce_deliver_webhook_async', $queue_args, 'woocommerce-webhooks' );
+			}
+		} else {
+			// Deliver immediately.
+			$data['webhook']->deliver( $data['arg'] );
+		}
 	}
 }
-register_shutdown_function( 'wc_webhook_execute_synchronous_queue' );
+register_shutdown_function( 'wc_webhook_execute_queue' );
 
 /**
  * Process webhook delivery.
@@ -33,34 +52,15 @@ register_shutdown_function( 'wc_webhook_execute_synchronous_queue' );
  * @param array      $arg     Delivery arguments.
  */
 function wc_webhook_process_delivery( $webhook, $arg ) {
-	// Webhooks are processed in the background by default
-	// so as to avoid delays or failures in delivery from affecting the
-	// user who triggered it.
-	if ( apply_filters( 'woocommerce_webhook_deliver_async', true, $webhook, $arg ) ) {
-
-		$queue_args = array(
-			'webhook_id' => $webhook->get_id(),
-			'arg'        => $arg,
-		);
-
-		$next_scheduled_date = WC()->queue()->get_next( 'woocommerce_deliver_webhook_async', $queue_args, 'woocommerce-webhooks' );
-
-		// Make webhooks unique - only schedule one webhook every 10 minutes to maintain backward compatibility with WP Cron behaviour seen in WC < 3.5.0.
-		if ( is_null( $next_scheduled_date ) || $next_scheduled_date->getTimestamp() >= ( 600 + gmdate( 'U' ) ) ) {
-			WC()->queue()->add( 'woocommerce_deliver_webhook_async', $queue_args, 'woocommerce-webhooks' );
-		}
-	} else {
-		// We need to queue the webhook so that it can be ran after the request has finished processing.
-		// This must be done in order to keep parity with how they are executed asynchronously.
-		global $wc_queued_sync_webhooks;
-		if ( ! isset( $wc_queued_sync_webhooks ) ) {
-			$wc_queued_sync_webhooks = array();
-		}
-		$wc_queued_sync_webhooks[] = array(
-			'webhook' => $webhook,
-			'arg'     => $arg,
-		);
+	// We need to queue the webhook so that it can be ran after the request has finished processing.
+	global $wc_queued_webhooks;
+	if ( ! isset( $wc_queued_webhooks ) ) {
+		$wc_queued_webhooks = array();
 	}
+	$wc_queued_webhooks[] = array(
+		'webhook' => $webhook,
+		'arg'     => $arg,
+	);
 }
 add_action( 'woocommerce_webhook_process_delivery', 'wc_webhook_process_delivery', 10, 2 );
 

--- a/includes/wc-webhook-functions.php
+++ b/includes/wc-webhook-functions.php
@@ -42,7 +42,7 @@ function wc_webhook_execute_queue() {
 		}
 	}
 }
-register_shutdown_function( 'wc_webhook_execute_queue' );
+add_action( 'shutdown', 'wc_webhook_execute_queue' );
 
 /**
  * Process webhook delivery.


### PR DESCRIPTION
This is a potential fix for https://github.com/woocommerce/woocommerce/issues/27066

It is possible for a later duplicate webhook to be fired too early if the same webhook triggers in one request more than once with the updated changes from the second one missing if it happens too quickly. (See https://github.com/woocommerce/woocommerce/issues/27066 for more details)

This queues all webhook to be register on shutdown instead of just synchronous ones to make sure all data from the request is updated first before the webhook gets queued. This is based on the change here: https://github.com/woocommerce/woocommerce/pull/26878

I'm not sure if this is the best way to fix this, but with this change in place I am no longer able to reproduce the bug with my tests here: https://github.com/matt-h/woocommerce-webhook-race

Open to any suggestions. I made changes to the tests which removes the specific test that added this to sync webhooks and included them in the test that tests all. Not sure if this should be broken out more?

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27066

### How to test the changes in this Pull Request:

1. Load this change into the WooCommerce install running through this: https://github.com/matt-h/woocommerce-webhook-race
2. Run the tests, it should never trigger the issue and just keep generating orders successfully.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Delayed the execution of all webhooks until after the request has completed.
