### PR TITLE
Add product object as parameter for add to cart handler

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -769,7 +769,7 @@ class WC_Form_Handler {
 		$add_to_cart_handler = apply_filters( 'woocommerce_add_to_cart_handler', $adding_to_cart->get_type(), $adding_to_cart );
 
 		if ( 'variable' === $add_to_cart_handler || 'variation' === $add_to_cart_handler ) {
-			$was_added_to_cart = self::add_to_cart_handler_variable( $product_id );
+			$was_added_to_cart = self::add_to_cart_handler_variable( $product_id, $adding_to_cart );
 		} elseif ( 'grouped' === $add_to_cart_handler ) {
 			$was_added_to_cart = self::add_to_cart_handler_grouped( $product_id );
 		} elseif ( has_action( 'woocommerce_add_to_cart_handler_' . $add_to_cart_handler ) ) {
@@ -865,16 +865,20 @@ class WC_Form_Handler {
 	 * @since 2.4.6 Split from add_to_cart_action.
 	 * @throws Exception If add to cart fails.
 	 * @param int $product_id Product ID to add to the cart.
+	 * @param obj WC_Product $product Product object to add to cart.
 	 * @return bool success or not
 	 */
-	private static function add_to_cart_handler_variable( $product_id ) {
+	private static function add_to_cart_handler_variable( $product_id, $adding_to_cart = false ) {
 		try {
 			$variation_id         = empty( $_REQUEST['variation_id'] ) ? '' : absint( wp_unslash( $_REQUEST['variation_id'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$quantity             = empty( $_REQUEST['quantity'] ) ? 1 : wc_stock_amount( wp_unslash( $_REQUEST['quantity'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			$missing_attributes   = array();
 			$variations           = array();
 			$variation_attributes = array();
-			$adding_to_cart       = wc_get_product( $product_id );
+
+			if ( ! $adding_to_cart instanceof WC_Product ) {
+				$adding_to_cart = wc_get_product( $product_id );
+			}
 
 			if ( ! $adding_to_cart ) {
 				return false;

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -773,7 +773,7 @@ class WC_Form_Handler {
 		} elseif ( 'grouped' === $add_to_cart_handler ) {
 			$was_added_to_cart = self::add_to_cart_handler_grouped( $product_id );
 		} elseif ( has_action( 'woocommerce_add_to_cart_handler_' . $add_to_cart_handler ) ) {
-			do_action( 'woocommerce_add_to_cart_handler_' . $add_to_cart_handler, $url ); // Custom handler.
+			do_action( 'woocommerce_add_to_cart_handler_' . $add_to_cart_handler, $url, $adding_to_cart ); // Custom handler.
 		} else {
 			$was_added_to_cart = self::add_to_cart_handler_simple( $product_id );
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The product object is fetched once when determining which add to cart handler to use and then again in the variable handler. The product would need to be fetched a second time in any custom handler as well. 

Closes # .



### Changelog entry

> Add product object to `woocommerce_add_to_cart_handler_$add_to_cart_handler` hook.
