### PR TITLE
Removed dot "." from the generated password string

### DIFF
--- a/templates/emails/plain/customer-new-account.php
+++ b/templates/emails/plain/customer-new-account.php
@@ -28,7 +28,7 @@ echo sprintf( esc_html__( 'Thanks for creating an account on %1$s. Your username
 
 if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && $password_generated ) {
 	/* translators: %s: Auto generated password */
-	echo sprintf( esc_html__( 'Your password has been automatically generated: %s.', 'woocommerce' ), esc_html( $user_pass ) ) . "\n\n";
+	echo sprintf( esc_html__( 'Your password has been automatically generated: %s', 'woocommerce' ), esc_html( $user_pass ) ) . "\n\n";
 }
 
 echo "\n\n----------------------------------------\n\n";


### PR DESCRIPTION
There is an extra dot "." right after the generated password string which is not part of the actual password and creates confusion for the users who want to login. It would be great if we can remove it.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<img width="949" alt="Screen Shot 2020-07-19 at 1 47 30 PM" src="https://user-images.githubusercontent.com/8451635/87873058-d1df4780-c9c6-11ea-861d-b9e6a7059920.png">

### Changelog entry

> Fix - Remove the dot after the generated password in new account emails.