### PR TITLE
Rename Csongrád state to Csongrád-Csanád

### DIFF
--- a/i18n/states.php
+++ b/i18n/states.php
@@ -396,7 +396,7 @@ return array(
 		'BA' => __( 'Baranya', 'woocommerce' ),
 		'BZ' => __( 'Borsod-Abaúj-Zemplén', 'woocommerce' ),
 		'BU' => __( 'Budapest', 'woocommerce' ),
-		'CS' => __( 'Csongrád', 'woocommerce' ),
+		'CS' => __( 'Csongrád-Csanád', 'woocommerce' ),
 		'FE' => __( 'Fejér', 'woocommerce' ),
 		'GS' => __( 'Győr-Moson-Sopron', 'woocommerce' ),
 		'HB' => __( 'Hajdú-Bihar', 'woocommerce' ),


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On June 4th, Csongrád was renamed to Csongrád-Csanád. Source: https://en.wikipedia.org/wiki/Csongrád-Csanád_County#History

### Changelog entry

> Updated name for the Hungarian county called Csongrád-Csanád
