### PR TITLE
Update E2E env jest preset default version.

### DIFF
--- a/tests/e2e/env/package.json
+++ b/tests/e2e/env/package.json
@@ -22,7 +22,7 @@
   "module": "build-module/index.js",
   "dependencies": {
     "@wordpress/e2e-test-utils": "^4.6.0",
-    "@wordpress/jest-preset-default": "^5.4.0",
+    "@wordpress/jest-preset-default": "^6.2.0",
     "app-root-path": "^3.0.0",
     "jest": "^25.1.0",
     "jest-puppeteer": "^4.4.0",


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-admin/pull/4343#issuecomment-658984615.

6.x.x will update Jest to `>=25`, and therefore the weak ref detection dependencies.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Install node modules
2. Link @wooocommerce/e2e-environment for local testing
3. Test https://github.com/woocommerce/woocommerce-admin/pull/4343

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Update jest-preset-default version to ^6.2.0
