### PR TITLE
Package Update: Update WooCommerce Blocks to 3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "1.3.1",
-    "woocommerce/woocommerce-blocks": "2.7.1",
+    "woocommerce/woocommerce-blocks": "3.0.0",
     "woocommerce/woocommerce-rest-api": "1.0.10"
   },
   "require-dev": {


### PR DESCRIPTION
This pull updates the WooCommerce blocks plugin to 3.0.0. Note, it supersedes the previous 2.9.0 update pull (that had not been merged yet - #26967).

Notes related to this _specific_ version can be found in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2887.  In particular, [testing instructions can be found here](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/bc93ed1b8fbe1caf51fff5d203c4d1ec4a5ecc08/docs/testing/releases/300.md)

However since no other package updates were merged in from previous pulls, this update includes everything from 2.7.1 to this version. You can look at your pull history of closed pulls to get update notes (starting with following the link to #26967).

## Important things:

- This version of the package includes a bump to jetpack/autoloaderv2+ in `composer.json` but the `composer.lock` cannot be updated until there is coordination with updates from other packages. So this likely will need to be merged in as is to master along with other package updates, and then the `composer.lock` file fixed after.

### Changelog entry

> Dev - Update WooCommerce blocks version to 3.0.0