### PR TITLE
#27103 fix, Introduced a parameter to control rate limit option autoload

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -485,7 +485,7 @@ class WC_Form_Handler {
 				return;
 			}
 
-			WC_Rate_Limiter::set_rate_limit( $rate_limit_id, $delay );
+			WC_Rate_Limiter::set_rate_limit( $rate_limit_id, $delay, false );
 
 			ob_start();
 

--- a/includes/class-wc-rate-limiter.php
+++ b/includes/class-wc-rate-limiter.php
@@ -69,11 +69,12 @@ class WC_Rate_Limiter {
 	 *
 	 * @param string $action_id Identifier of the action.
 	 * @param int    $delay Delay in seconds.
+	 * @param bool   $autoload Autoload option, default is true.
 	 * @return bool True if the option setting was successful, false otherwise.
 	 */
-	public static function set_rate_limit( $action_id, $delay ) {
+	public static function set_rate_limit( $action_id, $delay, $autoload = true ) {
 		$option_name         = self::storage_id( $action_id );
 		$next_try_allowed_at = time() + $delay;
-		return update_option( $option_name, $next_try_allowed_at );
+		return update_option( $option_name, $next_try_allowed_at, $autoload );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I think we should set the value of `$autoload` parameter `true` to make it backward compatible. Otherwise it can break other plugin, though the change of error due to option autoload fairly low!

### Another proposal
Can we introduce a hook to this? So it'll give user the power to change the autoload preference without touching the core. :thinking: 

Closes #27103

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
