### PR TITLE
Add Email Dark Theme admin options, styles, and markup.

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -126,6 +126,18 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				),
 
 				array(
+					'title'       => __( 'Header image - Dark Theme', 'woocommerce' ),
+					'desc'        => __( 'URL to an image you want to show in the email header when the email client is using the dark theme/dark mode. Upload images using the media uploader (Admin > Media).', 'woocommerce' ),
+					'id'          => 'woocommerce_email_header_image_dk',
+					'type'        => 'text',
+					'css'         => 'min-width:400px;',
+					'placeholder' => __( 'N/A', 'woocommerce' ),
+					'default'     => '',
+					'autoload'    => false,
+					'desc_tip'    => true,
+				),
+
+				array(
 					'title'       => __( 'Footer text', 'woocommerce' ),
 					/* translators: %s: Available placeholders for use */
 					'desc'        => __( 'The text to appear in the footer of all WooCommerce emails.', 'woocommerce' ) . ' ' . sprintf( __( 'Available placeholders: %s', 'woocommerce' ), '{site_title} {site_url}' ),
@@ -182,6 +194,54 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'type'     => 'color',
 					'css'      => 'width:6em;',
 					'default'  => '#3c3c3c',
+					'autoload' => false,
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'    => __( 'Base color - Dark Theme', 'woocommerce' ),
+					/* translators: %s: default color */
+					'desc'     => sprintf( __( 'The base color for WooCommerce email templates when the email client is using the dark theme/dark mode. Default %s.', 'woocommerce' ), '<code>#96588a</code>' ),
+					'id'       => 'woocommerce_email_base_color_dk',
+					'type'     => 'color',
+					'css'      => 'width:6em;',
+					'default'  => '#96588a',
+					'autoload' => false,
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'    => __( 'Background color - Dark Theme', 'woocommerce' ),
+					/* translators: %s: default color */
+					'desc'     => sprintf( __( 'The background color for WooCommerce email templates when the email client is using the dark theme/dark mode. Default %s.', 'woocommerce' ), '<code>#2c2c2c</code>' ),
+					'id'       => 'woocommerce_email_background_color_dk',
+					'type'     => 'color',
+					'css'      => 'width:6em;',
+					'default'  => '#2c2c2c',
+					'autoload' => false,
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'    => __( 'Body background color - Dark Theme', 'woocommerce' ),
+					/* translators: %s: default color */
+					'desc'     => sprintf( __( 'The main body background color when the email client is using the dark theme/dark mode. Default %s.', 'woocommerce' ), '<code>#1c1c1c</code>' ),
+					'id'       => 'woocommerce_email_body_background_color_dk',
+					'type'     => 'color',
+					'css'      => 'width:6em;',
+					'default'  => '#1c1c1c',
+					'autoload' => false,
+					'desc_tip' => true,
+				),
+
+				array(
+					'title'    => __( 'Body text color - Dark Theme', 'woocommerce' ),
+					/* translators: %s: default color */
+					'desc'     => sprintf( __( 'The main body text color when the email client is using the dark theme/dark mode. Default %s.', 'woocommerce' ), '<code>#DFDFDF</code>' ),
+					'id'       => 'woocommerce_email_text_color_dk',
+					'type'     => 'color',
+					'css'      => 'width:6em;',
+					'default'  => '#DFDFDF',
 					'autoload' => false,
 					'desc_tip' => true,
 				),

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -24,6 +24,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 <html <?php language_attributes(); ?>>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=<?php bloginfo( 'charset' ); ?>" />
+		<meta name="color-scheme" content="light dark">
+		<meta name="supported-color-schemes" content="light dark">
 		<title><?php echo get_bloginfo( 'name', 'display' ); ?></title>
 	</head>
 	<body <?php echo is_rtl() ? 'rightmargin' : 'leftmargin'; ?>="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -20,11 +20,17 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Load colors.
-$bg        = get_option( 'woocommerce_email_background_color' );
-$body      = get_option( 'woocommerce_email_body_background_color' );
-$base      = get_option( 'woocommerce_email_base_color' );
-$base_text = wc_light_or_dark( $base, '#202020', '#ffffff' );
-$text      = get_option( 'woocommerce_email_text_color' );
+$bg           = get_option( 'woocommerce_email_background_color' );
+$body         = get_option( 'woocommerce_email_body_background_color' );
+$base         = get_option( 'woocommerce_email_base_color' );
+$base_text    = wc_light_or_dark( $base, '#202020', '#ffffff' );
+$text         = get_option( 'woocommerce_email_text_color' );
+$bg_dk        = get_option( 'woocommerce_email_background_color_dk' );
+$body_dk      = get_option( 'woocommerce_email_body_background_color_dk' );
+$base_dk      = get_option( 'woocommerce_email_base_color_dk' );
+$base_text_dk = wc_light_or_dark( $base_dk, '#202020', '#ffffff' );
+$text_dk      = get_option( 'woocommerce_email_text_color_dk' );
+$image_dk_src = get_option( 'woocommerce_email_header_image_dk' );
 
 // Pick a contrasting color for links.
 $link_color = wc_hex_is_light( $base ) ? $base : $base_text;
@@ -39,6 +45,13 @@ $base_lighter_20 = wc_hex_lighter( $base, 20 );
 $base_lighter_40 = wc_hex_lighter( $base, 40 );
 $text_lighter_20 = wc_hex_lighter( $text, 20 );
 $text_lighter_40 = wc_hex_lighter( $text, 40 );
+
+$bg_dk_lighter_10   = wc_hex_lighter( $bg_dk, 10 );
+$body_dk_lighter_10 = wc_hex_lighter( $body_dk, 10 );
+$base_dk_darker_20  = wc_hex_darker( $base_dk, 20 );
+$base_dk_darker_40  = wc_hex_darker( $base_dk, 40 );
+$text_dk_darker_20  = wc_hex_darker( $text_dk, 20 );
+$text_dk_darker_40  = wc_hex_darker( $text_dk, 40 );
 
 // !important; is a gmail hack to prevent styles being stripped if it doesn't like something.
 // body{padding: 0;} ensures proper scale/positioning of the email in the iOS native email app.
@@ -164,7 +177,7 @@ body {
 }
 
 .link {
-	color: <?php echo esc_attr( $link_color ); ?>;
+	color: <?php echo esc_attr( $base ); ?>;
 }
 
 #header_wrapper {
@@ -224,5 +237,103 @@ img {
 	margin-<?php echo is_rtl() ? 'left' : 'right'; ?>: 10px;
 	max-width: 100%;
 	height: auto;
+}
+
+// important flag is necessary as long as styles are inlined on each element as these styles are written to the style tag in the document head.
+:root {
+	color-scheme: light dark;
+	supported-color-schemes: light dark;
+}
+@media (prefers-color-scheme: dark) {
+	#wrapper,
+	[data-ogsc] #wrapper,
+	[data-ogsb] #wrapper {
+		background-color: <?php echo esc_attr( $bg_dk ); ?> !important;
+	}
+
+	#template_container,
+	[data-ogsb] #template_container,
+	[data-ogsc] #template_container {
+		background-color: <?php echo esc_attr( $body_dk ); ?> !important;
+		border: 1px solid <?php echo esc_attr( $bg_dk_lighter_10 ); ?> !important;
+	}
+
+	#template_header,
+	[data-ogsc] #template_header,
+	[data-ogsb] #template_header {
+		background-color: <?php echo esc_attr( $base_dk ); ?> !important;
+		color: <?php echo esc_attr( $base_text_dk ); ?> !important;
+	}
+
+	#template_header_image p img,
+	[data-ogsc] #template_header_image p img {
+		content:url('<?php echo esc_attr( $image_dk_src ); ?>') !important;
+	}
+
+	#template_header h1,
+	[data-ogsc] #template_header h1,
+	#template_header h1 a,
+	[data-ogsc] #template_header h1 a {
+		color: <?php echo esc_attr( $base_text ); ?> !important;
+	}
+
+	#template_footer #credit,
+	[data-ogsc] #template_footer #credit {
+		color: <?php echo esc_attr( $text_dk_darker_40 ); ?> !important;
+	}
+
+	#body_content,
+	[data-ogsb] #body_content,
+	[data-ogsc] #body_content {
+		background-color: <?php echo esc_attr( $body_dk ); ?> !important;
+	}
+
+	#body_content_inner,
+	[data-ogsc] #body_content_inner {
+		color: <?php echo esc_attr( $text_dk_darker_20 ); ?> !important;
+	}
+
+	.td,
+	[data-ogsc] .td {
+		color: <?php echo esc_attr( $text_dk_darker_20 ); ?> !important;
+		border: 1px solid <?php echo esc_attr( $body_dk_lighter_10 ); ?> !important;
+	}
+
+	.address,
+	[data-ogsc] .address {
+		color: <?php echo esc_attr( $text_dk_darker_20 ); ?> !important;
+		border: 1px solid <?php echo esc_attr( $body_dk_lighter_10 ); ?> !important;
+	}
+
+	.text,
+	[data-ogsc] .text {
+		color: <?php echo esc_attr( $text_dk ); ?> !important;
+	}
+
+	.link,
+	[data-ogsc] .link {
+		color: <?php echo esc_attr( $base_dk ); ?> !important;
+	}
+
+	h1,
+	[data-ogsc] h1 {
+		color: <?php echo esc_attr( $base_dk ); ?> !important;
+		text-shadow: 0 1px 0 <?php echo esc_attr( $base_dk_darker_20 ); ?> !important;
+	}
+
+	h2,
+	[data-ogsc] h2 {
+		color: <?php echo esc_attr( $base_dk ); ?> !important;
+	}
+
+	h3,
+	[data-ogsc] h3 {
+		color: <?php echo esc_attr( $base_dk ); ?> !important;
+	}
+
+	a,
+	[data-ogsc] a {
+		color: <?php echo esc_attr( $link_color_dk ); ?> !important;
+	}
 }
 <?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds optional dark theme settings for emails, and adds styles and markup to enable them.

This PR replaces #26744 which I previously submitted, and have now closed, as this PR more closely follows contributing guidelines.

per file changes:
Adds styles for dark theme / Dark Mode to all emails - email-styles.php
Adds fields in WC / Settings / Email for discrete dark theme styles, and dark theme alternate image - class-wc-settings-emails.php
Adds meta tags to WC Email Header for supporting light and dark themes - email-header.php

### How to test the changes in this Pull Request:

1. Email template preview via WC / Settings / Email honors adherence to system light/dark mode.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Enhancement - Adds settings and styles for dark theme support when sending WC Emails where supported by the user's email client.
