### PR TITLE
Add protection for Order queries using a status that is not a registered post status.

### DIFF
--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -785,20 +785,20 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				$query_vars['post_status'] = wc_is_order_status( 'wc-' . $query_vars['post_status'] ) ? 'wc-' . $query_vars['post_status'] : $query_vars['post_status'];
 			}
 
-			// verify post_status is actually registered.
+			// Verify post_status is actually registered.
 			$post_stati = is_array( $query_vars['post_status'] ) ? $query_vars['post_status'] : array( $query_vars['post_status'] );
 			foreach ( $post_stati as $post_status ) {
 				$post_status_exists = get_post_stati( array( 'name' => $post_status ) );
 				if ( empty( $post_status_exists ) ) {
 					$message = sprintf(
-						/* translators: 1: Status name */
+						/* translators: %s: status name */
 						__(
-							'The provided order query contains an order status that is not registered as a custom post status (status provided is %1$s). It is possible there is something removing any expected registered custom post status before the query is made.',
+							'The provided order query contains an order status that is not registered as a custom post status (status provided is %s). It is possible there is something removing any expected registered custom post status before the query is made.',
 							'woocommerce'
 						),
 						$post_status
 					);
-					// bail.
+					// Bail.
 					throw new \Exception( $message );
 				}
 			}

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -746,6 +746,9 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 *
 	 * @since 3.1.0
 	 * @param array $query_vars query vars from a WC_Order_Query.
+	 *
+	 * @throws \Exception When status arg exists with a status that is not
+	 *                    registered as a custom post status.
 	 * @return array
 	 */
 	protected function get_wp_query_args( $query_vars ) {
@@ -782,20 +785,20 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				$query_vars['post_status'] = wc_is_order_status( 'wc-' . $query_vars['post_status'] ) ? 'wc-' . $query_vars['post_status'] : $query_vars['post_status'];
 			}
 
-			// verify post_status is actually registered
-			$post_stati = is_array( $query_vars['post_status'] ) ? $query_vars['post_status'] : [ $query_vars['post_status'] ];
-			foreach( $post_stati as $post_status )  {
-				$post_status_exists = get_post_stati( [ 'name' => $post_status ] );
+			// verify post_status is actually registered.
+			$post_stati = is_array( $query_vars['post_status'] ) ? $query_vars['post_status'] : array( $query_vars['post_status'] );
+			foreach ( $post_stati as $post_status ) {
+				$post_status_exists = get_post_stati( array( 'name' => $post_status ) );
 				if ( empty( $post_status_exists ) ) {
-					/* translators: 1: Status name */
 					$message = sprintf(
+						/* translators: 1: Status name */
 						__(
 							'The provided order query contains an order status that is not registered as a custom post status (status provided is %1$s). It is possible there is something removing any expected registered custom post status before the query is made.',
 							'woocommerce'
 						),
 						$post_status
 					);
-					// bail
+					// bail.
 					throw new \Exception( $message );
 				}
 			}
@@ -871,7 +874,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 	 * @return array|object
 	 */
 	public function query( $query_vars ) {
-		$orders = [];
+		$orders = array();
 		try {
 			$args = $this->get_wp_query_args( $query_vars );
 

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -793,7 +793,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 					$message = sprintf(
 						/* translators: %s: status name */
 						__(
-							'The provided order query contains an order status that is not registered as a custom post status (status provided is %s). It is possible there is something removing any expected registered custom post status before the query is made.',
+							'The provided order query contains an order status that is not registered as a custom post status (status provided is %s). It is possible there is something removing an expected registered custom post status before the query is made.',
 							'woocommerce'
 						),
 						$post_status

--- a/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -15,16 +15,29 @@ use Automattic\Jetpack\Constants;
  */
 class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 
+	/**
+	 * Property for holding caught exceptions during tests.
+	 * @var \Exception
+	 */
 	private $caught_exception;
 
+	/**
+	 * Setup before tests
+	 */
 	public function setUp() {
-		// set listening for exceptions
-		add_action( 'woocommerce_caught_exception', function($exception_object){
-			$this->caught_exception = $exception_object;
-		});
+		// set listening for exceptions.
+		add_action(
+			'woocommerce_caught_exception',
+			function( $exception_object ) {
+				$this->caught_exception = $exception_object;
+			}
+		);
 		parent::setUp();
 	}
 
+	/**
+	 * Teardown after tests
+	 */
 	public function tearDown() {
 		remove_all_actions( 'woocommerce_caught_exception' );
 		parent::tearDown();
@@ -1460,7 +1473,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$coupon = WC_Helper_Coupon::create_coupon(
 			$coupon_code,
 			array(
-				'usage_limit' => 2,
+				'usage_limit'          => 2,
 				'usage_limit_per_user' => 2,
 			)
 		);
@@ -1501,7 +1514,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 		$coupon = WC_Helper_Coupon::create_coupon(
 			$coupon_code,
 			array(
-				'usage_limit' => 2,
+				'usage_limit'          => 2,
 				'usage_limit_per_user' => 2,
 			)
 		);
@@ -1560,13 +1573,13 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	 * post status
 	 */
 	public function test_wc_get_order_non_registered_status_param() {
-		// temporarily hide error logging we don't care about (and keeps from polluting stdout)
-		$original_logging_destination = ini_get('error_log');
-		ini_set('error_log', '/dev/null');
-		$orders = wc_get_orders( [ 'status' => 'i-do-not-exist' ] );
+		// temporarily hide error logging we don't care about (and keeps from polluting stdout).
+		$original_logging_destination = ini_get( 'error_log' );
+		ini_set( 'error_log', '/dev/null' );
+		$orders = wc_get_orders( array( 'status' => 'i-do-not-exist' ) );
 		$this->assertEmpty( $orders );
 		$this->assertContains( 'provided order query contains an order status that is not registered', $this->caught_exception->getMessage() );
-		//restore original logging destination
-		ini_set('error_log', $this->original_logging_destination);
+		// restore original logging destination.
+		ini_set( 'error_log', $this->original_logging_destination );
 	}
 }

--- a/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -25,7 +25,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	 * Setup before tests
 	 */
 	public function setUp() {
-		// set listening for exceptions.
+		// Set listening for exceptions.
 		add_action(
 			'woocommerce_caught_exception',
 			function( $exception_object ) {
@@ -36,7 +36,7 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Teardown after tests
+	 * Teardown after tests.
 	 */
 	public function tearDown() {
 		remove_all_actions( 'woocommerce_caught_exception' );
@@ -1573,13 +1573,13 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	 * post status
 	 */
 	public function test_wc_get_order_non_registered_status_param() {
-		// temporarily hide error logging we don't care about (and keeps from polluting stdout).
+		// Temporarily hide error logging we don't care about (and keeps from polluting stdout).
 		$original_logging_destination = ini_get( 'error_log' );
 		ini_set( 'error_log', '/dev/null' );
 		$orders = wc_get_orders( array( 'status' => 'i-do-not-exist' ) );
 		$this->assertEmpty( $orders );
 		$this->assertContains( 'provided order query contains an order status that is not registered', $this->caught_exception->getMessage() );
-		// restore original logging destination.
-		ini_set( 'error_log', $this->original_logging_destination );
+		// Restore original logging destination.
+		ini_set( 'error_log', $original_logging_destination );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

For background, you can see this pull made in the WC Blocks repo: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2912

Currently it is possible for filtered order statuses (via the `woocommerce_register_shop_order_post_statuses`) to be implemented incorrectly and thus resulting in unexpected results when doing a order query that is filtered by a status. The caller may _expect_ the status to be registered as a custom post status, when in fact it might not be because code executing later on that hook clobbers the order statuses actually registered. In turn, this means when the query makes its way to `WP_Query`, the non registered `post_status` will be removed from the query leading to potentially unexpected results.

This is potentially destructive if (as the case with logic in the WC Blocks plugin) the results from the query are used to delete orders.

The proposed protection in this pull does the following:

- If the query has a value on `post_status` query argument, then verify all statuses in that argument are a registered WP post status.
- If any of those are _not_ registered, then an exception is thrown. Otherwise processing continues.
- `WC_Order_Data_Store_CPT::query` catches any thrown exception and returns an empty array along with feeding the exception to `wc_caught_exception` which should surface in any error logs configured for the site.

### Some things to consider while reviewing

- The exception is being thrown from `WC_Order_Data_Store_CPT::get_wp_query_args` which is a protected method. I don't see this being used by any other code in Woo Core, but because this could feasibly be used in extension extending this class, if they aren't catching potential exceptions, and there is flawed code on sites, the thrown exception could be potentially breaking. If this is a concern, then before merging you may want to consider an alternative way of aborting the query.
- There's multiple other places an incoming query could be mangled (filters etc). Long term, it might be good to consider a similar feature to WP core for it's queries where query related filters can be explicitly suppressed via query_args. Having something like that is not a solution for the post_status option, but would be potentially good additional protection for queries needing to protect against filtering happening in WC data stores when making a query.

### How to test the changes in this Pull Request:

The changes seem to be covered well by existing tests (including new phpunit tests added). However, this does have impact on any code doing an Order query with order statuses. So smoke testing of UI/UX related to that, and also scanning extensions that might be doing that would probably be prudent.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added protection for Order queries filtering by status which might not be a registered WP post status at the time of the query.
