### PR TITLE
Upgraded Jetpack Autoloader to 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
   "minimum-stability": "dev",
   "require": {
     "php": ">=7.0",
-    "automattic/jetpack-autoloader": "^1.7.0",
+    "automattic/jetpack-autoloader": "^2.0.2",
     "automattic/jetpack-constants": "^1.1",
     "composer/installers": "1.7.0",
     "league/container": "^3.3",

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "1.4.0-beta.1",
     "woocommerce/woocommerce-blocks": "3.0.0",
-    "woocommerce/woocommerce-rest-api": "1.0.10"
+    "woocommerce/woocommerce-rest-api": "1.0.11"
   },
   "require-dev": {
     "phpunit/phpunit": "7.5.20",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.3.1",
+    "woocommerce/woocommerce-admin": "1.4.0-beta.1",
     "woocommerce/woocommerce-blocks": "3.0.0",
     "woocommerce/woocommerce-rest-api": "1.0.10"
   },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "1.3.1",
-    "woocommerce/woocommerce-blocks": "2.7.1",
+    "woocommerce/woocommerce-blocks": "3.0.0",
     "woocommerce/woocommerce-rest-api": "1.0.10"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,24 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c0a0cf15845787f05ec6bc30f06084c4",
+    "content-hash": "8c1f82c00b53093f703e7cecd4e9895c",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v1.7.0",
+            "version": "v2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "7c6736eeee0f9fc49fa691fe3e958725efb27ca0"
+                "reference": "4502da4b2443fc1b61389cacc94c34876aca2b3d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/7c6736eeee0f9fc49fa691fe3e958725efb27ca0",
-                "reference": "7c6736eeee0f9fc49fa691fe3e958725efb27ca0",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/4502da4b2443fc1b61389cacc94c34876aca2b3d",
+                "reference": "4502da4b2443fc1b61389cacc94c34876aca2b3d",
                 "shasum": ""
             },
             "require": {
-                "composer-plugin-api": "^1.1"
+                "composer-plugin-api": "^1.1 || ^2.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5"
@@ -40,7 +40,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2020-04-23T02:28:37+00:00"
+            "time": "2020-07-09T13:18:38+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
@@ -554,20 +554,20 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "v1.3.1",
+            "version": "v1.4.0-beta.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "337036202a29078aed827f8e5dec566a9c57929a"
+                "reference": "9fb6f4167020e1b45c57040b782797a7055a0e95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/337036202a29078aed827f8e5dec566a9c57929a",
-                "reference": "337036202a29078aed827f8e5dec566a9c57929a",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/9fb6f4167020e1b45c57040b782797a7055a0e95",
+                "reference": "9fb6f4167020e1b45c57040b782797a7055a0e95",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "^1.6.0",
+                "automattic/jetpack-autoloader": "^2.0.0",
                 "composer/installers": "1.7.0",
                 "php": ">=5.6|>=7.0"
             },
@@ -597,24 +597,24 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-07-20T22:33:15+00:00"
+            "time": "2020-07-22T01:44:35+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v2.7.1",
+            "version": "v3.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "0025c5cda83892c6f566fffd05197006f230d16c"
+                "reference": "cc00da60f21a7219e7e5ef5599996c68fee7b2be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/0025c5cda83892c6f566fffd05197006f230d16c",
-                "reference": "0025c5cda83892c6f566fffd05197006f230d16c",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/cc00da60f21a7219e7e5ef5599996c68fee7b2be",
+                "reference": "cc00da60f21a7219e7e5ef5599996c68fee7b2be",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "^1.6.0",
+                "automattic/jetpack-autoloader": "^2.0.0",
                 "composer/installers": "1.7.0"
             },
             "require-dev": {
@@ -644,24 +644,24 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2020-06-16T13:34:29+00:00"
+            "time": "2020-07-22T13:34:19+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",
-            "version": "1.0.10",
+            "version": "1.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-rest-api.git",
-                "reference": "fdcb116b4f5b699b942c01b46fd863c7da8b4b7c"
+                "reference": "304bb95cb4b95f182f09d56153d5ac254d5fe60a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/fdcb116b4f5b699b942c01b46fd863c7da8b4b7c",
-                "reference": "fdcb116b4f5b699b942c01b46fd863c7da8b4b7c",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/304bb95cb4b95f182f09d56153d5ac254d5fe60a",
+                "reference": "304bb95cb4b95f182f09d56153d5ac254d5fe60a",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "^1.2.0"
+                "automattic/jetpack-autoloader": "^2.0.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "6.5.14",
@@ -684,7 +684,7 @@
             ],
             "description": "The WooCommerce core REST API.",
             "homepage": "https://github.com/woocommerce/woocommerce-rest-api",
-            "time": "2020-06-16T09:51:51+00:00"
+            "time": "2020-07-24T13:38:16+00:00"
         }
     ],
     "packages-dev": [

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -22,33 +22,6 @@ class Autoloader {
 	private function __construct() {}
 
 	/**
-	 * These namespaces are autoloaded by our temporary PSR-4 autoloader. This enables us to bypass the limitations
-	 * imposed by the 1.x branch of the Jetpack Autoloader until the 2.x branch is in-use.
-	 *
-	 * Note: Due to the way we load the files you must place more specific namespaces first or they won't be used!
-	 *
-	 * @var string[]
-	 */
-	private static $autoloaded_namespaces = array(
-		'Psr\\Container\\'                        => __DIR__ . '/../vendor/psr/container/src/',
-		'League\\Container\\'                     => __DIR__ . '/../vendor/league/container/src/',
-		'Automattic\\WooCommerce\\Tests\\'        => __DIR__ . '/../tests/php/src/',
-		'Automattic\\WooCommerce\\Testing\\Tools' => __DIR__ . '/../tests/Tools/',
-		'Automattic\\WooCommerce\\'               => __DIR__ . '/',
-	);
-
-	/**
-	 * These namespaces are excluded from being autoloaded by our temporary PSR-4 autoloader.
-	 *
-	 * @var string[]
-	 */
-	private static $excluded_namespaces = array(
-		'Automattic\\WooCommerce\\Admin\\',
-		'Automattic\\WooCommerce\\Blocks\\',
-		'Automattic\\WooCommerce\\RestApi\\',
-	);
-
-	/**
 	 * Require the autoloader and return the result.
 	 *
 	 * If the autoloader is not present, let's log the failure and display a nice admin notice.
@@ -63,45 +36,12 @@ class Autoloader {
 			return false;
 		}
 
-		self::register_psr4_autoloader();
-
 		$autoloader_result = require $autoloader;
 		if ( ! $autoloader_result ) {
 			return false;
 		}
 
 		return $autoloader_result;
-	}
-
-	/**
-	 * Define a PSR-4 autoloader to load any desired classes before the Jetpack Autoloader to avoid triggering its
-	 * error messages.
-	 *
-	 * TODO: Remove after the JetPack Autoloader dependency has been updated to v2.
-	 */
-	protected static function register_psr4_autoloader() {
-		spl_autoload_register(
-			function ( $class ) {
-				foreach ( self::$excluded_namespaces as $namespace ) {
-					if ( substr( $class, 0, strlen( $namespace ) ) === $namespace ) {
-						return;
-					}
-				}
-
-				foreach ( self::$autoloaded_namespaces as $namespace => $directory ) {
-					$len = strlen( $namespace );
-					if ( substr( $class, 0, $len ) === $namespace ) {
-						$filename = $directory . str_replace( '\\', '/', substr( $class, $len ) ) . '.php';
-						if ( file_exists( $filename ) ) {
-							require $filename;
-						}
-						return;
-					}
-				}
-			},
-			true,
-			true
-		);
 	}
 
 	/**

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -36,6 +36,20 @@ class Autoloader {
 			return false;
 		}
 
+		/**
+		 * In order to support local development for feature plugins the autoloader must support dev versions.
+		 *
+		 * - If the checked out branch cannot supply Composer with version information then it
+		 *   assigns it a dev version string for the Jetpack Autoloader to use.
+		 * - By default the Jetpack Autoloader will ignore these dev versions in favor of tagged versions.
+		 *
+		 * Due to this interaction, feature plugin files from the included packages will always be loaded instead
+		 * of the versions in the feature plugin when checked out from a repository as a dev version. By setting
+		 * this constant we change the behavior of the autoloader so that dev versions are prioritized over the
+		 * tagged versions included in WooCommerce Core.
+		 */
+		define( 'JETPACK_AUTOLOAD_DEV', true );
+
 		$autoloader_result = require $autoloader;
 		if ( ! $autoloader_result ) {
 			return false;

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -60,7 +60,7 @@ describe( 'Store owner can go through setup Task List', () => {
 
 		await Promise.all( [
 			// Click on "Set up shipping" task to move to the next step
-			taskListItems[3].click(),
+			taskListItems[4].click(),
 
 			// Wait for shipping setup section to load
 			page.waitForNavigation( { waitUntil: 'networkidle0' } ),

--- a/tests/e2e/utils/components.js
+++ b/tests/e2e/utils/components.js
@@ -139,22 +139,17 @@ const completeOnboardingWizard = async () => {
 
 	// Fill the number of products you plan to sell
 	await selectControls[0].click();
-	await page.waitForSelector( '.woocommerce-select-control__listbox' );
+	await page.waitForSelector( '.woocommerce-select-control__control' );
 	await expect( page ).toClick( '.woocommerce-select-control__option', { text: config.get( 'onboardingwizard.numberofproducts' ) } );
 
 	// Fill currently selling elsewhere
 	await selectControls[1].click();
-	await page.waitForSelector( '.woocommerce-select-control__listbox' );
+	await page.waitForSelector( '.woocommerce-select-control__control' );
 	await expect( page ).toClick( '.woocommerce-select-control__option', { text: config.get( 'onboardingwizard.sellingelsewhere' ) } );
 
-	// Query for the plugin upload toggles
-	const pluginToggles = await page.$$( '.components-form-toggle__input' );
-	expect( pluginToggles ).toHaveLength( 3 );
-
-	// Disable Market on Facebook, Mailchimp and Google Shopping download
-	for ( let i = 0; i < 3; i++ ) {
-		await pluginToggles[i].click();
-	}
+	// Disable business extension downloads
+	const pluginToggle = await page.$( '.woocommerce-business-extensions .components-checkbox-control__input-container' );
+	pluginToggle.click();
 
 	// Wait for "Continue" button to become active
 	await page.waitForSelector( 'button.is-primary:not(:disabled)' );

--- a/tests/e2e/utils/components.js
+++ b/tests/e2e/utils/components.js
@@ -113,7 +113,7 @@ const completeOnboardingWizard = async () => {
 
 	// Query for the product types checkboxes
 	const productTypesCheckboxes = await page.$$( '.components-checkbox-control__input' );
-	expect( productTypesCheckboxes ).toHaveLength( 6 );
+	expect( productTypesCheckboxes ).toHaveLength( 8 );
 
 	// Select Physical and Downloadable products
 	for ( let i = 0; i < 2; i++ ) {

--- a/tests/e2e/utils/components.js
+++ b/tests/e2e/utils/components.js
@@ -88,10 +88,10 @@ const completeOnboardingWizard = async () => {
 
 	// Query for the industries checkboxes
 	const industryCheckboxes = await page.$$( '.components-checkbox-control__input' );
-	expect( industryCheckboxes ).toHaveLength( 8 );
+	expect( industryCheckboxes ).toHaveLength( 10 );
 
 	// Select all industries including "Other"
-	for ( let i = 0; i < 8; i++ ) {
+	for ( let i = 0; i < 10; i++ ) {
 		await industryCheckboxes[i].click();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

With the release of Jetpack 8.7 the [2.0 version of the Jetpack Autoloader](https://github.com/Automattic/jetpack/pull/15106) seems stable enough that we can adopt it in WooCommerce Core. One of the greatest benefits of this autoloader is that packages may now use dependencies before `plugins_loaded` has been executed. This is an important requirement for our dependency container so that we are able to resolve classes out of it when bootstrapping the plugin.

Since all of the component packages had to be updated at the same time in order to update any of them, this PR is an aggregate with an update to the `composer.lock` file. I've also set the `JETPACK_AUTOLOAD_DEV` constant in order to support local development for our feature plugins.

## Contained PRs

- Core: #26904
- REST API: #27121
- WooCommerce Blocks: #27099
- WooCommerce Admin: I've manually included the `1.4.0-beta.1` release in this PR. We should be receiving an official PR next week containing all of the information about the release. This was necessary in order to update the dependency.

### Testing Instructions

One of the caveats of this PR is that we had to enable a constant in order for anyone to develop feature plugins. Please make sure that the code from feature plugins (when checked out from their respective repository) are still being loaded from the plugin and not from WooCommerce Core. I verified that this works using logging in the `Package.php` file for respective plugins to see where the code was coming from.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Dev - Upgraded to the 2.x Jetpack Autoloader.
