### PR TITLE
add args to wc_create_new_customer to autogenerate password/username

### DIFF
--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -39,8 +39,10 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 	 * @return int|WP_Error Returns WP_Error on failure, Int (user ID) on success.
 	 */
 	function wc_create_new_customer( $email, $username = '', $password = '', $args = array() ) {
-		$autogenerate_username = ( 'yes' === get_option( 'woocommerce_registration_generate_username', 'yes' ) || $args['generate_username'] );
-		$autogenerate_password = ( 'yes' === get_option( 'woocommerce_registration_generate_password', 'yes' ) || $args['generate_password'] );
+		$autogenerate_username = 'yes' === get_option( 'woocommerce_registration_generate_username', 'yes' );
+		$autogenerate_password = 'yes' === get_option( 'woocommerce_registration_generate_password', 'yes' );
+		$autogenerate_username = array_key_exists( 'generate_username', $args ) ? $args['generate_username'] : $autogenerate_username;
+		$autogenerate_password = array_key_exists( 'generate_password', $args ) ? $args['generate_password'] : $autogenerate_password;
 
 		if ( empty( $email ) || ! is_email( $email ) ) {
 			return new WP_Error( 'registration-error-invalid-email', __( 'Please provide a valid email address.', 'woocommerce' ) );

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -39,6 +39,9 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 	 * @return int|WP_Error Returns WP_Error on failure, Int (user ID) on success.
 	 */
 	function wc_create_new_customer( $email, $username = '', $password = '', $args = array() ) {
+		$autogenerate_username = ( 'yes' === get_option( 'woocommerce_registration_generate_username', 'yes' ) || $args['generate_username'] );
+		$autogenerate_password = ( 'yes' === get_option( 'woocommerce_registration_generate_password', 'yes' ) || $args['generate_password'] );
+
 		if ( empty( $email ) || ! is_email( $email ) ) {
 			return new WP_Error( 'registration-error-invalid-email', __( 'Please provide a valid email address.', 'woocommerce' ) );
 		}
@@ -47,7 +50,7 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 			return new WP_Error( 'registration-error-email-exists', apply_filters( 'woocommerce_registration_error_email_exists', __( 'An account is already registered with your email address. <a href="#" class="showlogin">Please log in.</a>', 'woocommerce' ), $email ) );
 		}
 
-		if ( 'yes' === get_option( 'woocommerce_registration_generate_username', 'yes' ) && empty( $username ) ) {
+		if ( $autogenerate_username && empty( $username ) ) {
 			$username = wc_create_new_customer_username( $email, $args );
 		}
 
@@ -63,7 +66,7 @@ if ( ! function_exists( 'wc_create_new_customer' ) ) {
 
 		// Handle password creation.
 		$password_generated = false;
-		if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && empty( $password ) ) {
+		if ( $autogenerate_password && empty( $password ) ) {
 			$password           = wp_generate_password();
 			$password_generated = true;
 		}
@@ -897,7 +900,7 @@ function wc_update_user_last_active( $user_id ) {
 	if ( ! $user_id ) {
 		return;
 	}
-	update_user_meta( $user_id, 'wc_last_active', (string) strtotime( date( 'Y-m-d', time() ) ) );
+	update_user_meta( $user_id, 'wc_last_active', (string) strtotime( gmdate( 'Y-m-d', time() ) ) );
 }
 
 /**

--- a/templates/emails/customer-new-account.php
+++ b/templates/emails/customer-new-account.php
@@ -23,7 +23,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ); ?></p>
 <?php /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */ ?>
 <p><?php printf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), '<strong>' . esc_html( $user_login ) . '</strong>', make_clickable( esc_url( wc_get_page_permalink( 'myaccount' ) ) ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?></p>
-<?php if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && $password_generated ) : ?>
+<?php if ( $password_generated ) : ?>
 	<?php /* translators: %s: Auto generated password */ ?>
 	<p><?php printf( esc_html__( 'Your password has been automatically generated: %s', 'woocommerce' ), '<strong>' . esc_html( $user_pass ) . '</strong>' ); ?></p>
 <?php endif; ?>

--- a/templates/emails/plain/customer-new-account.php
+++ b/templates/emails/plain/customer-new-account.php
@@ -26,7 +26,7 @@ echo sprintf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $user_login ) ) .
 /* translators: %1$s: Site title, %2$s: Username, %3$s: My account link */
 echo sprintf( esc_html__( 'Thanks for creating an account on %1$s. Your username is %2$s. You can access your account area to view orders, change your password, and more at: %3$s', 'woocommerce' ), esc_html( $blogname ), esc_html( $user_login ), esc_html( wc_get_page_permalink( 'myaccount' ) ) ) . "\n\n";
 
-if ( 'yes' === get_option( 'woocommerce_registration_generate_password' ) && $password_generated ) {
+if ( $password_generated ) {
 	/* translators: %s: Auto generated password */
 	echo sprintf( esc_html__( 'Your password has been automatically generated: %s', 'woocommerce' ), esc_html( $user_pass ) ) . "\n\n";
 }


### PR DESCRIPTION
Related: https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2377 https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2851#issuecomment-664092646

When an account is created, a username and password can be automatically generated. This is a really helpful feature, as it makes signing up that much easier. This is especially relevant when shoppers are signing up as part of a checkout flow. If we can keep this simple it's easier for shoppers and better for merchants :)

In WooCommerce, there are two store options in `WooCommerce > Settings > Accounts & Privacy` that control this behaviour:

- `When creating an account, automatically generate an account username for the customer based on their name, surname or email`
- `When creating an account, automatically generate an account password`

<img width="881" alt="Screen Shot 2020-07-27 at 3 20 56 PM" src="https://user-images.githubusercontent.com/4167300/88500402-c7532c80-d01c-11ea-91b5-621f6e245067.png">

In the new checkout block, we're keen to always generate the username and password when creating accounts, to reduce the number of fields/text boxes between a shopper and completing checkout. (At least, for the initial version of the block.)

Currently there's no way to programmatically create a user account with an autogenerated username and password - the core routine `wc_create_new_customer()` always refers to the options. This PR is a proposal that the routine should _also_ allow autogenerate behaviour based on arguments to the function. 

Note that the option values may also be consulted elsewhere in Woo core code. From my research it looks like the password option is consulted in the template for the new account email; I don't think this is necessary, as the template has an explicit parameter indicating a generated password.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### How to test the changes in this Pull Request:
The goal of this PR is that existing behaviour is unaffected, and the API routine is more flexible for use by blocks. So the testing steps here are regression testing.

1. Test creating an account via various flows (signup form, create account via checkout, invite user from admin, etc).
2. Repeat tests with different combinations of autogenerate options.
3. Ensure that new accounts are created correctly with appropriate username and password (user or automatically provided), and that the new account email content is relevant, useful and correct in all cases.

To test the more flexible interface to `wc_create_new_customer()`, you could try calling the routine in `wp shell` or a custom plugin, or via an open PR in blocks plugin (TBC!).

e.g. 

```php
wc_create_new_customer(
  'shopper@shopaholic.org',
  '',
  '', 
  [
    'autogenerate_password' => true,
    'autogenerate_username' => true,
  ]
);
```
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

Haven't considered tests yet, but if we do proceed with this I think it's a good opportunity to tighten up this area with some test coverage and isolate some of the code responsible for creating accounts. cc @ObliviousHarmony  🧪 

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
