### PR TITLE
Modify the logic for deleting variations

### DIFF
--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -127,7 +127,10 @@ class WC_Post_Data {
 	 * @param string     $to      New type.
 	 */
 	public static function product_type_changed( $product, $from, $to ) {
-		if ( 'variable' === $from && 'variable' !== $to ) {
+		$from_variable_type = ( false !== strpos( $from, 'variable' ) );
+		$to_variable_type   = ( false !== strpos( $to, 'variable' ) );
+
+		if ( $from_variable_type && ! $to_variable_type ) {
 			// If the product is no longer variable, we should ensure all variations are removed.
 			$data_store = WC_Data_Store::load( 'product-variable' );
 			$data_store->delete_variations( $product->get_id(), true );

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -127,10 +127,10 @@ class WC_Post_Data {
 	 * @param string     $to      New type.
 	 */
 	public static function product_type_changed( $product, $from, $to ) {
-		$from_variable_type = ( false !== strpos( $from, 'variable' ) );
-		$to_variable_type   = ( false !== strpos( $to, 'variable' ) );
+		apply_filters( 'woocommerce_from_product_type_changed', $from );
+		apply_filters( 'woocommerce_to_product_type_changed', $to );
 
-		if ( $from_variable_type && ! $to_variable_type ) {
+		if ( 'variable' === $from && 'variable' !== $to ) {
 			// If the product is no longer variable, we should ensure all variations are removed.
 			$data_store = WC_Data_Store::load( 'product-variable' );
 			$data_store->delete_variations( $product->get_id(), true );

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -121,7 +121,7 @@ class WC_Post_Data {
 	/**
 	 * Handle type changes.
 	 *
-	 * @since 4.9.0
+	 * @since 3.0.0
 	 *
 	 * @param WC_Product $product Product data.
 	 * @param string     $from    Origin type.

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -127,10 +127,7 @@ class WC_Post_Data {
 	 * @param string     $to      New type.
 	 */
 	public static function product_type_changed( $product, $from, $to ) {
-		apply_filters( 'woocommerce_from_product_type_changed', $from );
-		apply_filters( 'woocommerce_to_product_type_changed', $to );
-
-		if ( 'variable' === $from && 'variable' !== $to ) {
+		if ( apply_filters( 'woocommerce_delete_variations_on_product_type_change', 'variable' === $from && 'variable' !== $to, $product, $from, $to ) ) {
 			// If the product is no longer variable, we should ensure all variations are removed.
 			$data_store = WC_Data_Store::load( 'product-variable' );
 			$data_store->delete_variations( $product->get_id(), true );

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -121,12 +121,23 @@ class WC_Post_Data {
 	/**
 	 * Handle type changes.
 	 *
-	 * @since 3.0.0
+	 * @since 4.9.0
+	 *
 	 * @param WC_Product $product Product data.
 	 * @param string     $from    Origin type.
 	 * @param string     $to      New type.
 	 */
 	public static function product_type_changed( $product, $from, $to ) {
+		/**
+		 * Filter to prevent variations from being deleted while switching from a variable product type to a variable product type.
+		 *
+		 * @since 4.9.0
+		 *
+		 * @param bool       A boolean value of true will delete the variations.
+		 * @param WC_Product $product Product data.
+		 * @return string    $from    Origin type.
+		 * @param string     $to      New type.
+		 */
 		if ( apply_filters( 'woocommerce_delete_variations_on_product_type_change', 'variable' === $from && 'variable' !== $to, $product, $from, $to ) ) {
 			// If the product is no longer variable, we should ensure all variations are removed.
 			$data_store = WC_Data_Store::load( 'product-variable' );


### PR DESCRIPTION
## Summary 

Implements the following expected behavior which fixes an issue with Subscriptions:
1. Switch from variable subscription to non-variable one will delete variations.
2. Switch from variable subscription to variable product and vice-versa will NOT delete any variations.

This shall have no side-effects in WooCommerce Core.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/26959.
Closes https://github.com/woocommerce/woocommerce-subscriptions/issues/3672

### How to test the changes in this Pull Request:

This was originally pushed to WC Subscriptions but it makes more sense to add it directly to WooCommerce. Testing instructions are therefore available in WC Subscriptions PR: https://github.com/woocommerce/woocommerce-subscriptions/pull/3795.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Improves the logic for deleting variations when a product type is changed
