### PR TITLE
Always sanitize coupon code to prevent inconsistent between admins and shop owners

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1691,7 +1691,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 */
 	public function remove_coupon( $coupon_code ) {
 		$coupon_code = wc_format_coupon_code( $coupon_code );
-		$position    = array_search( $coupon_code, $this->get_applied_coupons(), true );
+		$position    = array_search( $coupon_code, array_map( 'wc_format_coupon_code', $this->get_applied_coupons() ), true );
 
 		if ( false !== $position ) {
 			unset( $this->applied_coupons[ $position ] );

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -154,7 +154,6 @@ class WC_Install {
 			'wc_update_440_db_version',
 		),
 		'4.5.0' => array(
-			'wc_update_450_get_coupons',
 			'wc_update_450_sanitize_coupons_code',
 			'wc_update_450_db_version',
 		),

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -149,6 +149,10 @@ class WC_Install {
 			'wc_update_400_reset_action_scheduler_migration_status',
 			'wc_update_400_db_version',
 		),
+		'4.5.0' => array(
+			'wc_update_450_sanitize_coupons_code',
+			'wc_update_450_db_version',
+		),
 	);
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -154,6 +154,7 @@ class WC_Install {
 			'wc_update_440_db_version',
 		),
 		'4.5.0' => array(
+			'wc_update_450_get_coupons',
 			'wc_update_450_sanitize_coupons_code',
 			'wc_update_450_db_version',
 		),

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -255,6 +255,9 @@ class WC_Post_Data {
 			}
 		} elseif ( 'product' === $data['post_type'] && 'auto-draft' === $data['post_status'] ) {
 			$data['post_title'] = 'AUTO-DRAFT';
+		} elseif ( 'shop_coupon' === $data['post_type'] ) {
+			// Coupons should never allow unfiltered HTML.
+			$data['post_title'] = wp_filter_kses( $data['post_title'] );
 		}
 
 		return $data;

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -22,7 +22,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '4.4.0';
+	public $version = '4.5.0';
 
 	/**
 	 * WooCommerce Schema version.

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -22,7 +22,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '4.5.0';
+	public $version = '4.4.0';
 
 	/**
 	 * WooCommerce Schema version.

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -721,7 +721,7 @@ class WC_Coupon_Data_Store_CPT extends WC_Data_Store_WP implements WC_Coupon_Dat
 		return $wpdb->get_col(
 			$wpdb->prepare(
 				"SELECT ID FROM $wpdb->posts WHERE post_title = %s AND post_type = 'shop_coupon' AND post_status = 'publish' ORDER BY post_date DESC",
-				$code
+				wc_sanitize_coupon_code( $code )
 			)
 		);
 	}

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -375,7 +375,7 @@ function wc_format_coupon_code( $value ) {
  * @return string
  */
 function wc_sanitize_coupon_code( $value ) {
-	return sanitize_post_field( 'post_title', $value, 0, 'db' );
+	return wp_filter_kses( sanitize_post_field( 'post_title', $value, 0, 'db' ) );
 }
 
 /**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2197,7 +2197,7 @@ function wc_update_450_sanitize_coupons_code() {
 	$coupons = $wpdb->get_results(
 		$wpdb->prepare(
 			"SELECT ID, post_title FROM $wpdb->posts WHERE ID > %d AND post_type = 'shop_coupon' LIMIT 10",
-			$data['ID']
+			$last_coupon_id
 		),
 		ARRAY_A
 	);
@@ -2235,7 +2235,7 @@ function wc_update_450_sanitize_coupons_code() {
 	}
 
 	// Start the run again.
-	if ( ! $coupon_id ) {
+	if ( $coupon_id ) {
 		return update_option( 'woocommerce_update_350_last_coupon_id', $coupon_id );
 	}
 

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2110,3 +2110,35 @@ function wc_update_400_reset_action_scheduler_migration_status() {
 function wc_update_400_db_version() {
 	WC_Install::update_db_version( '4.0.0' );
 }
+
+/**
+ * Update DB version to 4.5.0.
+ */
+function wc_update_450_db_version() {
+	WC_Install::update_db_version( '4.5.0' );
+}
+
+/**
+ * Sanitize all coupons code.
+ */
+function wc_update_450_sanitize_coupons_code() {
+	global $wpdb;
+
+	$coupons = $wpdb->get_results( "SELECT ID, post_title FROM {$wpdb->posts} WHERE post_type = 'shop_coupon';" );
+
+	if ( $coupons ) {
+		foreach ( $coupons as $data ) {
+			$code = trim( wp_filter_kses( $data->post_title ) );
+
+			if ( ! empty( $code ) ) {
+				$wpdb->query(
+					$wpdb->prepare(
+						"UPDATE {$wpdb->posts} SET post_title = %s WHERE ID = %d",
+						$code,
+						$data->ID
+					)
+				);
+			}
+		}
+	}
+}

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2224,6 +2224,10 @@ function wc_update_450_sanitize_coupons_code() {
 				)
 			);
 
+			// Clean cache.
+			clean_post_cache( intval( $data['ID'] ) );
+			wp_cache_delete( WC_Cache_Helper::get_cache_prefix( 'coupons' ) . 'coupon_id_from_code_' . $data['post_title'], 'coupons' );
+
 			// Remove items from the list.
 			unset( $coupons[ $key ] );
 		}

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2211,7 +2211,7 @@ function wc_update_450_sanitize_coupons_code() {
 		$coupon_id = intval( $data['ID'] );
 		$code      = trim( wp_filter_kses( $data['post_title'] ) );
 
-		if ( ! empty( $code ) ) {
+		if ( ! empty( $code ) && $data['post_title'] !== $code ) {
 			$wpdb->update(
 				$wpdb->posts,
 				array(

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2192,7 +2192,7 @@ function wc_update_450_sanitize_coupons_code() {
 	global $wpdb;
 
 	$coupon_id      = 0;
-	$last_coupon_id = get_option( 'woocommerce_update_350_last_coupon_id', '0' );
+	$last_coupon_id = get_option( 'woocommerce_update_450_last_coupon_id', '0' );
 
 	$coupons = $wpdb->get_results(
 		$wpdb->prepare(
@@ -2203,7 +2203,7 @@ function wc_update_450_sanitize_coupons_code() {
 	);
 
 	if ( empty( $coupons ) ) {
-		delete_option( 'woocommerce_update_350_last_coupon_id' );
+		delete_option( 'woocommerce_update_450_last_coupon_id' );
 		return false;
 	}
 
@@ -2236,9 +2236,9 @@ function wc_update_450_sanitize_coupons_code() {
 
 	// Start the run again.
 	if ( $coupon_id ) {
-		return update_option( 'woocommerce_update_350_last_coupon_id', $coupon_id );
+		return update_option( 'woocommerce_update_450_last_coupon_id', $coupon_id );
 	}
 
-	delete_option( 'woocommerce_update_350_last_coupon_id' );
+	delete_option( 'woocommerce_update_450_last_coupon_id' );
 	return false;
 }

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2194,7 +2194,13 @@ function wc_update_450_sanitize_coupons_code() {
 	$coupon_id      = 0;
 	$last_coupon_id = get_option( 'woocommerce_update_350_last_coupon_id', '0' );
 
-	$coupons = $wpdb->get_results( $wpdb->prepare( "SELECT ID, post_title FROM $wpdb->posts WHERE ID > %d AND post_type = 'shop_coupon' LIMIT 10", $data['ID'] ), ARRAY_A );
+	$coupons = $wpdb->get_results(
+		$wpdb->prepare(
+			"SELECT ID, post_title FROM $wpdb->posts WHERE ID > %d AND post_type = 'shop_coupon' LIMIT 10",
+			$data['ID']
+		),
+		ARRAY_A
+	);
 
 	if ( empty( $coupons ) ) {
 		delete_option( 'woocommerce_update_350_last_coupon_id' );
@@ -2206,11 +2212,19 @@ function wc_update_450_sanitize_coupons_code() {
 		$code      = trim( wp_filter_kses( $data['post_title'] ) );
 
 		if ( ! empty( $code ) ) {
-			$wpdb->query(
-				$wpdb->prepare(
-					"UPDATE {$wpdb->posts} SET post_title = %s WHERE ID = %d",
-					$code,
-					$coupon_id
+			$wpdb->update(
+				$wpdb->posts,
+				array(
+					'post_title' => $code,
+				),
+				array(
+					'ID' => $coupon_id,
+				),
+				array(
+					'%s',
+				),
+				array(
+					'%d',
 				)
 			);
 

--- a/tests/legacy/framework/class-wc-unit-test-case.php
+++ b/tests/legacy/framework/class-wc-unit-test-case.php
@@ -171,9 +171,9 @@ class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 	 */
 	public function login_as_administrator() {
 		return $this->login_as_role( 'administrator' );
-  }
+	}
 
-  /**
+	/**
 	 * Get an instance of a class that has been registered in the dependency injection container.
 	 * To get an instance of a legacy class (such as the ones in the 'íncludes' directory) use
 	 * 'get_legacy_instance_of' instead.

--- a/tests/php/includes/class-wc-post-data-test.php
+++ b/tests/php/includes/class-wc-post-data-test.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * Post data tests
+ *
+ * @package WooCommerce\Tests\Post_Data.
+ */
+
+/**
+ * Class WC_Post_Data_Test
+ */
+class WC_Post_Data_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * @testdox coupon code should be always sanitized.
+	 */
+	public function test_coupon_code_sanitization() {
+		$this->login_as_role( 'shop_manager' );
+		$coupon    = WC_Helper_Coupon::create_coupon( 'a&a' );
+		$post_data = get_post( $coupon->get_id() );
+		$this->assertEquals( 'a&amp;a', $post_data->post_title );
+		$coupon->delete( true );
+
+		$this->login_as_administrator();
+		$coupon    = WC_Helper_Coupon::create_coupon( 'b&b' );
+		$post_data = get_post( $coupon->get_id() );
+		$this->assertEquals( 'b&amp;b', $post_data->post_title );
+		$coupon->delete( true );
+
+		wp_set_current_user( 0 );
+		$coupon    = WC_Helper_Coupon::create_coupon( 'c&c' );
+		$post_data = get_post( $coupon->get_id() );
+		$this->assertEquals( 'c&amp;c', $post_data->post_title );
+		$coupon->delete( true );
+	}
+}

--- a/tests/php/includes/wc-formatting-functions-test.php
+++ b/tests/php/includes/wc-formatting-functions-test.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Formatting functions tests
+ *
+ * @package WooCommerce\Tests\Formatting.
+ */
+
+/**
+ * Class WC_Formatting_Functions_Test
+ */
+class WC_Formatting_Functions_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Test wc_sanitize_coupon_code() function.
+	 */
+	public function test_wc_sanitize_coupon_code() {
+		$this->assertEquals( 'DUMMYCOUPON', wc_sanitize_coupon_code( 'DUMMYCOUPON' ) );
+		$this->assertEquals( 'a&amp;a', wc_sanitize_coupon_code( 'a&a' ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

By default WordPress will run `kses_init_filters()` if the current user can't use unfiltered HTML, applying the `wp_filter_kses()` function to the `title_save_pre`.
That's why admins can save a coupon code like `a&a` without getting converted into `a&amp;a`.

To fix the inconsistent I'm changing to always apply the same sanitation for all users on WooCommerce, also should be safer to always sanitize.
And it also includes a upgrade routine to fix all codes at once.

Closes #23655.

### How to test the changes in this Pull Request:

1. Create two coupons with the following codes using an admin:
- `a&a`
- `b&amp;b`
2. Now create more two coupons using a shop manager:
- `c&c`
- `d&amp;d`
3. Check that with the shop manager ampersand gets encoded.
4. With the shop manager edit the coupon with code `a&a` and note that the ampersand got encoded making impossible to restore.
5. Apply this patch, edit or create coupons with any user and see that ampersands always get encoded.
6. Added some products to the cart and try use your coupons created in the previous steps.
7. Also try apply coupons with both formats: `a&a` and `a&amp;a`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Coupon code inconsistent between admins and shop owners.