### PR TITLE
Fix "Hide shipping costs until an address is entered"

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1396,10 +1396,8 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 
 		if ( 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ) ) {
-			if ( ! $this->get_customer()->has_calculated_shipping() ) {
-				if ( ! $this->get_customer()->get_shipping_country() || ( ! $this->get_customer()->get_shipping_state() && ! $this->get_customer()->get_shipping_postcode() ) ) {
-					return false;
-				}
+			if ( ! $this->get_customer()->get_shipping_country() || ! $this->get_customer()->get_shipping_state() || ! $this->get_customer()->get_shipping_postcode() ) {
+				return false;
 			}
 		}
 

--- a/tests/php/includes/class-wc-cart-test.php
+++ b/tests/php/includes/class-wc-cart-test.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ * Unit tests for the WC_Cart_Test class.
+ *
+ * @package WooCommerce\Tests\Cart.
+ */
+
+/**
+ * Class WC_Cart_Test
+ */
+class WC_Cart_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * tearDown.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		WC()->cart->empty_cart();
+		WC()->customer->set_is_vat_exempt( false );
+		WC()->session->set( 'wc_notices', null );
+	}
+
+	/**
+	 * Test show shipping.
+	 */
+	public function test_show_shipping() {
+		// Test with an empty cart.
+		$this->assertFalse( WC()->cart->show_shipping() );
+
+		// Add a product to the cart.
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		// Test with "woocommerce_ship_to_countries" disabled.
+		$default_ship_to_countries = get_option( 'woocommerce_ship_to_countries', '' );
+		update_option( 'woocommerce_ship_to_countries', 'disabled' );
+		$this->assertFalse( WC()->cart->show_shipping() );
+
+		// Test with default "woocommerce_ship_to_countries" and "woocommerce_shipping_cost_requires_address".
+		update_option( 'woocommerce_ship_to_countries', $default_ship_to_countries );
+		$this->assertTrue( WC()->cart->show_shipping() );
+
+		// Test with "woocommerce_shipping_cost_requires_address" enabled.
+		$default_shipping_cost_requires_address = get_option( 'woocommerce_shipping_cost_requires_address', 'no' );
+		update_option( 'woocommerce_shipping_cost_requires_address', 'yes' );
+		$this->assertFalse( WC()->cart->show_shipping() );
+
+		// Set address for shipping calculation required for "woocommerce_shipping_cost_requires_address".
+		WC()->cart->get_customer()->set_shipping_country( 'US' );
+		WC()->cart->get_customer()->set_shipping_state( 'NY' );
+		WC()->cart->get_customer()->set_shipping_postcode( '12345' );
+		$this->assertTrue( WC()->cart->show_shipping() );
+
+		// Reset.
+		update_option( 'woocommerce_shipping_cost_requires_address', $default_shipping_cost_requires_address );
+		$product->delete( true );
+	}
+}

--- a/tests/php/includes/class-wc-cart-test.php
+++ b/tests/php/includes/class-wc-cart-test.php
@@ -55,5 +55,8 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		// Reset.
 		update_option( 'woocommerce_shipping_cost_requires_address', $default_shipping_cost_requires_address );
 		$product->delete( true );
+		WC()->cart->get_customer()->set_shipping_country( 'GB' );
+		WC()->cart->get_customer()->set_shipping_state( '' );
+		WC()->cart->get_customer()->set_shipping_postcode( '' );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently by enabling `woocommerce_shipping_cost_requires_address` will display shipping costs if finds a country or if a state + postcode, what doesn't really reflects what the settings says.

This PR makes `woocommerce_shipping_cost_requires_address` a little more strict by displaying shipping costs only when a customer enters a country, state and postcode, those are all required information to proper calculate shipping zones and costs.

Closes #26876.

### How to test the changes in this Pull Request:


1. Navigate to `WooCommerce/Settings/Shipping/Shipping options` and select the following checkboxes:

- Hide shipping costs until an address is entered
- Default to customer billing address
- Enable debug mode

![Screen Shot 2020-06-25 at 5 33 24 PM](https://user-images.githubusercontent.com/19143190/85798042-c6239c80-b70a-11ea-8412-78615d725c2a.png)

2. From a private browser window start a guest cart by placing an item to the cart and observe that the shipping rate is being displayed regardless of the fact that `Hide shipping costs until an address is entered` is selected. Note that the address may get partially entered by the geolocation option or from the store location:

![ship](https://user-images.githubusercontent.com/19143190/85798207-13077300-b70b-11ea-948b-d40e0a27244e.jpg)

3. Now apply this patch and update your cart.
4. Not that now shipping costs only get displayed if you have entered country, state and postcode, like for a recurring customer.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed the logic behind "Hide shipping costs until an address is entered".