### PR TITLE
Update woocommerce-admin package to 1.4.0-beta.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.4.0-beta.1",
+    "woocommerce/woocommerce-admin": "1.4.0-beta.2",
     "woocommerce/woocommerce-blocks": "3.0.0",
     "woocommerce/woocommerce-rest-api": "1.0.11"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8c1f82c00b53093f703e7cecd4e9895c",
+    "content-hash": "877625af18978cccd2d02780fbd11842",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -554,16 +554,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "v1.4.0-beta.1",
+            "version": "v1.4.0-beta.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "9fb6f4167020e1b45c57040b782797a7055a0e95"
+                "reference": "8c1818854b0188ae636d2a4d065865196e26e002"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/9fb6f4167020e1b45c57040b782797a7055a0e95",
-                "reference": "9fb6f4167020e1b45c57040b782797a7055a0e95",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/8c1818854b0188ae636d2a4d065865196e26e002",
+                "reference": "8c1818854b0188ae636d2a4d065865196e26e002",
                 "shasum": ""
             },
             "require": {
@@ -597,7 +597,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-07-22T01:44:35+00:00"
+            "time": "2020-07-28T00:28:40+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
For consideration in WooCommerce 4.4 Beta - here is the latest release of woocommerce-admin.

### Changelog

* Add the experimental resolver to WCA data package (https://github.com/woocommerce/woocommerce-admin/pull/4862)
* Fix for theme upload error in onboarding wizard (https://github.com/woocommerce/woocommerce-admin/pull/4852)
* CSS fix to center skip link on theme selection step in onboarding wizard (https://github.com/woocommerce/woocommerce-admin/pull/4847)
* Remove "profiler" menu item (https://github.com/woocommerce/woocommerce-admin/pull/4851)
* Fix for PHP warnings on WPEngine (https://github.com/woocommerce/woocommerce-admin/pull/4856)

### Changelog entry

> Dev - Update WooCommerce Admin version to v1.4.0-beta.2