### PR TITLE
Don't request empty locales list for plugin translations.

### DIFF
--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -191,7 +191,7 @@ class WC_Helper_Updater {
 		$locales = apply_filters( 'plugins_update_check_locales', $locales );
 		$locales = array_unique( $locales );
 
-		// No locales, means that the respone will be empty.
+		// No locales, the respone will be empty, we can return now.
 		if ( empty( $locales ) ) {
 			return array();
 		}

--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -191,6 +191,11 @@ class WC_Helper_Updater {
 		$locales = apply_filters( 'plugins_update_check_locales', $locales );
 		$locales = array_unique( $locales );
 
+		// No locales, means that the respone will be empty.
+		if ( empty( $locales ) ) {
+			return array();
+		}
+
 		// Scan local plugins which may or may not have a subscription.
 		$plugins                 = WC_Helper::get_local_woo_plugins();
 		$active_woo_plugins      = array_intersect( array_keys( $plugins ), get_option( 'active_plugins', array() ) );


### PR DESCRIPTION
This is a supplement to #26750. If there are no locales we should not do any requests since the response will be empty. This is not strictly a bug fix but a performance improvement. Sites that have English as the UI language and have never been set to a different language do not need language packs.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Set interface to English
2. Clean wp-content/languages from all the files in all the folders
3. Check that the code short circuits at the added code.

As an additional check one can change the interface language. Now after the WP core downloads the new language pack the code should go further.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>  Enhancement - Don't request language packs for empty locales list.
