### PR TITLE
Refreshed woocommerce/woocommerce-admin for 1.4.0-beta.2 re-release

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -558,12 +558,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "8c1818854b0188ae636d2a4d065865196e26e002"
+                "reference": "d56ac35bbb62bda2c981443932e7f90b0f6dbe99"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/8c1818854b0188ae636d2a4d065865196e26e002",
-                "reference": "8c1818854b0188ae636d2a4d065865196e26e002",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/d56ac35bbb62bda2c981443932e7f90b0f6dbe99",
+                "reference": "d56ac35bbb62bda2c981443932e7f90b0f6dbe99",
                 "shasum": ""
             },
             "require": {


### PR DESCRIPTION
# All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR just refreshes the `composer.lock` file with the re-release of 1.4.0-beta.2.

### How to test the changes in this Pull Request:

1. Delete your `packages/woocommerce-admin` folder so that Composer will download it again
2. Run `composer clearcache` for good measure
3. Run `composer install`
4. Check the `packages/woocommerce-admin/src/FeaturePlugin.php` file and make sure the `check_build()` method calls the `should_use_minified_js_file()` method. If this is present you've successfully downloaded the latest release.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->