### PR TITLE
Add file path to woocommerce_file_download_method filter

### DIFF
--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -214,6 +214,13 @@ class WC_Download_Handler {
 		}
 
 		$filename             = apply_filters( 'woocommerce_file_download_filename', $filename, $product_id );
+		/**
+		 * Filter download method.
+		 * 
+		 * @param string $method     Download method.
+		 * @param int    $product_id Product ID.
+		 * @param string $file_path  URL to file.
+		 */
 		$file_download_method = apply_filters( 'woocommerce_file_download_method', get_option( 'woocommerce_file_download_method', 'force' ), $product_id, $file_path );
 
 		// Add action to prevent issues in IE.

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -214,7 +214,7 @@ class WC_Download_Handler {
 		}
 
 		$filename             = apply_filters( 'woocommerce_file_download_filename', $filename, $product_id );
-		$file_download_method = apply_filters( 'woocommerce_file_download_method', get_option( 'woocommerce_file_download_method', 'force' ), $product_id );
+		$file_download_method = apply_filters( 'woocommerce_file_download_method', get_option( 'woocommerce_file_download_method', 'force' ), $product_id, $file_path );
 
 		// Add action to prevent issues in IE.
 		add_action( 'nocache_headers', array( __CLASS__, 'ie_nocache_headers_fix' ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add the download file path as a 3rd parameter to the `woocommerce_file_download_method` filter. This allows for dynamically changing the download method depending on the location of the file. For instance, if it's cloud hosted on Amazon S3, we may want to make sure we do a redirect download instead of a PHP force download.

### How to test the changes in this Pull Request:

1. Update environment to include the change.
2. Add the following to functions.php

```php
add_filter( 'woocommerce_file_download_method', function ( $redirect_method, $product_id, $file_path ) {
  $parsed_path = WC_Download_Handler::parse_file_path( $file_path );

  if ( isset( $parsed_path['remote_file'] ) && true === $parsed_path['remote_file'] ) {
    $redirect_method = 'redirect';
  }

  return $redirect_method;
}, 10, 3 );
```

3. If the file is a remote file, use the redirect method.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Added file path to the `woocommerce_file_download_method` filter
