### PR TITLE
[4.4] Pagination of custom product queries broken

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -45,7 +45,7 @@ class WC_Query {
 			add_action( 'parse_request', array( $this, 'parse_request' ), 0 );
 			add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
 			add_filter( 'the_posts', array( $this, 'remove_product_query_filters' ) );
-			add_filter( 'found_posts', array( $this, 'adjust_posts_count' ) );
+			add_filter( 'found_posts', array( $this, 'adjust_posts_count' ), 10, 2 );
 			add_filter( 'get_pagenum_link', array( $this, 'remove_add_to_cart_pagination' ), 10, 1 );
 		}
 		$this->init_query_vars();
@@ -379,7 +379,12 @@ class WC_Query {
 	 *
 	 * @return int Adjusted posts count.
 	 */
-	public function adjust_posts_count( $count ) {
+	public function adjust_posts_count( $count, $query ) {
+
+		if ( ! $query->get( 'wc_query' ) ) {
+			return $count;
+		}
+
 		$posts = $this->get_current_posts();
 		if ( is_null( $posts ) ) {
 			return $count;

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -376,6 +376,7 @@ class WC_Query {
 	 *
 	 * @since 4.4.0
 	 * @param int $count Original posts count, as supplied by the found_posts filter.
+	 * @param WP_Query $query The current WP_Query object.
 	 *
 	 * @return int Adjusted posts count.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This PR limits the newly created `adjust_posts_count` filter to the main product query. Added a new check to determine if `$query->get( 'wc_query' )` is empty and return the unmodified count.

Closes #27163 

### How to test the changes in this Pull Request:

1. Create a custom, paginated product query
2. The count of `found_posts` will be filtered based on the main query, and the pagination of the custom query will be broken

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?