### PR TITLE
Fixed - Fixed "Product type" dropdown from Product's data meta box on WP 5.5

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -4347,14 +4347,13 @@ img.help_tip {
 
 		span {
 			display: block;
-			vertical-align: middle;
 			line-height: 24px;
+		}
 
-			span {
-				display: inline;
-				line-height: inherit;
-				vertical-align: baseline;
-			}
+		.type_box {
+			display: inline;
+			line-height: inherit;
+			vertical-align: baseline;
 		}
 
 		select {
@@ -6815,6 +6814,23 @@ table.bar_chart {
 
 		@media only screen and (max-width: 782px) {
 			min-width: 100% !important;
+		}
+	}
+}
+
+.wc-wp-version-gte-55 {
+
+	#woocommerce-product-data {
+
+		.hndle {
+			display: block;
+			line-height: 24px;
+
+			.type_box {
+				display: inline;
+				line-height: inherit;
+				vertical-align: baseline;
+			}
 		}
 	}
 }

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -27,7 +27,11 @@ jQuery( function( $ ) {
 	});
 
 	// Type box.
-	$( '.type_box' ).appendTo( '#woocommerce-product-data .hndle span' );
+	if ( $( 'body' ).hasClass( 'wc-wp-version-gte-55' ) ) {
+		$( '.type_box' ).appendTo( ' #woocommerce-product-data .hndle' );
+	} else {
+		$( '.type_box' ).appendTo( ' #woocommerce-product-data .hndle span' );
+	}
 
 	$( function() {
 		// Prevent inputs in meta box headings opening/closing contents.

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -28,9 +28,9 @@ jQuery( function( $ ) {
 
 	// Type box.
 	if ( $( 'body' ).hasClass( 'wc-wp-version-gte-55' ) ) {
-		$( '.type_box' ).appendTo( ' #woocommerce-product-data .hndle' );
+		$( '.type_box' ).appendTo( '#woocommerce-product-data .hndle' );
 	} else {
-		$( '.type_box' ).appendTo( ' #woocommerce-product-data .hndle span' );
+		$( '.type_box' ).appendTo( '#woocommerce-product-data .hndle span' );
 	}
 
 	$( function() {

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -331,6 +331,11 @@ class WC_Admin {
 			$classes .= ' wc-wp-version-gte-53';
 		}
 
+		// Add WP 5.5+ compatibility class.
+		if ( $raw_version && version_compare( $version, '5.5', '>=' ) ) {
+			$classes .= ' wc-wp-version-gte-55';
+		}
+
 		return $classes;
 	}
 }


### PR DESCRIPTION
WP 5.5 doesn't introduce a <span> tag inside metaboxes headings

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There's no "Product type" dropdown using on WordPress 5.5-RC1-48681:

![product](https://user-images.githubusercontent.com/19143190/88849942-9dcf0800-d1b8-11ea-90f0-d93f7ff1dd75.jpg)

This happens because WP Core changed the heading of meta boxes, before used to be something like `<h2><span>Product Data</span></h2>`, but on WP 5.5 it changed to `<h2>Product Data</h2>`

Closes #27167.

### How to test the changes in this Pull Request:

1. Install WP 5.5, you can install using WP-CLI: `wp core update --version=nightly --force`
2. Go to `wp-admin/post-new.php?post_type=product`
3. Check that there's no "Product type" dropdown or the "Virtual" and "Downlodable" checkboxes.
4. Checkout to this branch and run `grunt assets`
5. Go back to `wp-admin/post-new.php?post_type=product` and check if it's all fixed now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - "Product type" dropdown missing from Product's data meta box on WP 5.5
