### PR TITLE
Added the parent's SKU to product searches for variations

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1559,9 +1559,16 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		}
 
 		$post_types   = $include_variations ? array( 'product', 'product_variation' ) : array( 'product' );
+		$join_query   = '';
 		$type_where   = '';
 		$status_where = '';
 		$limit_query  = '';
+
+		// When searching variations we should include the parent's meta table for use in searches.
+		if ( $include_variations ) {
+			$join_query = " LEFT JOIN {$wpdb->wc_product_meta_lookup} parent_wc_product_meta_lookup
+			 ON posts.post_type = 'product_variation' AND parent_wc_product_meta_lookup.product_id = posts.post_parent ";
+		}
 
 		/**
 		 * Hook woocommerce_search_products_post_statuses.
@@ -1602,8 +1609,16 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$searchand        = '';
 
 			foreach ( $search_terms as $search_term ) {
-				$like              = '%' . $wpdb->esc_like( $search_term ) . '%';
-				$term_group_query .= $wpdb->prepare( " {$searchand} ( ( posts.post_title LIKE %s) OR ( posts.post_excerpt LIKE %s) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s ) )", $like, $like, $like, $like ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$like = '%' . $wpdb->esc_like( $search_term ) . '%';
+
+				// Variations should also search the parent's meta table for fallback fields.
+				if ( $include_variations ) {
+					$variation_query = $wpdb->prepare( ' OR ( wc_product_meta_lookup.sku = "" AND parent_wc_product_meta_lookup.sku LIKE %s ) ', $like );
+				} else {
+					$variation_query = '';
+				}
+
+				$term_group_query .= $wpdb->prepare( " {$searchand} ( ( posts.post_title LIKE %s) OR ( posts.post_excerpt LIKE %s) OR ( posts.post_content LIKE %s ) OR ( wc_product_meta_lookup.sku LIKE %s ) $variation_query)", $like, $like, $like, $like ); // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 				$searchand         = ' AND ';
 			}
 
@@ -1643,6 +1658,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			// phpcs:disable
 			"SELECT DISTINCT posts.ID as product_id, posts.post_parent as parent_id FROM {$wpdb->posts} posts
 			 LEFT JOIN {$wpdb->wc_product_meta_lookup} wc_product_meta_lookup ON posts.ID = wc_product_meta_lookup.product_id
+			 $join_query
 			WHERE posts.post_type IN ('" . implode( "','", $post_types ) . "')
 			$search_where
 			$status_where

--- a/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
+++ b/tests/php/includes/data-stores/class-wc-product-data-store-cpt-test.php
@@ -1,0 +1,41 @@
+<?php
+
+/**
+ * Class WC_Product_Data_Store_CPT_Test
+ */
+class WC_Product_Data_Store_CPT_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox Variations should appear when searching for parent product's SKU.
+	 */
+	public function test_variation_searches_parent_sku() {
+		$parent = new WC_Product_Variable();
+		$parent->set_name( 'Blue widget' );
+		$parent->set_sku( 'blue-widget-1' );
+		$parent->save();
+
+		$variation = new WC_Product_Variation();
+		$variation->set_parent_id( $parent->get_id() );
+		$variation->set_sku( '' );
+		$variation->save();
+
+		$data_store = WC_Data_Store::load( 'product' );
+
+		// No variations should be found searching for just the parent.
+		$results = $data_store->search_products( 'blue-widget-1', '', false, true );
+		$this->assertContains( $parent->get_id(), $results );
+		$this->assertNotContains( $variation->get_id(), $results );
+
+		// Variation should be found when searching for it.
+		$results = $data_store->search_products( 'blue-widget-1', '', true, true );
+		$this->assertContains( $parent->get_id(), $results );
+		$this->assertContains( $variation->get_id(), $results );
+
+		$variation->set_sku( 'test-widget' );
+		$variation->save();
+
+		// Variations should be found when searching for their specific SKU.
+		$results = $data_store->search_products( 'test-widget', '', true, true );
+		$this->assertContains( $variation->get_id(), $results );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a variation has no SKU filled out it will default to the parent's in most cases. A caveat here however is that searching does not take this behavior into consideration. This PR adds a join to the product search for the parent's lookup table for variations and checks the SKU of the parent when the child does not have one entered.

I also considered making this change in `get_data_for_lookup_table()` but it seemed like invalidating the entire table would be problematic and the `product_id` is already indexed on the lookup table.

Closes #25543.

### How to test the changes in this Pull Request:

1. Create a variable product with two variations.
2. Set a SKU on the parent of `parent-sku` and `child-sku` on ONE of the children.
3. Create an order and add a product.
4. Search for `parent-sku`. Without the PR no variations will be visible, with the PR, the variation that has no SKU will show up.
5. Search for `child-sku` and note both with and without the PR the variation with the SKU will show up.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Searches for variations now will fallback to parent SKU if one is not entered.
