### PR TITLE
Let user stay in the same page after clicking to update WooCommerce

### DIFF
--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -111,7 +111,7 @@ class WC_Notes_Run_Db_Update {
 	private static function update_needed_notice( $note_id = null ) {
 		$update_url = html_entity_decode(
 			wp_nonce_url(
-				add_query_arg( 'do_update_woocommerce', 'true', admin_url( 'admin.php?page=wc-settings' ) ),
+				add_query_arg( 'do_update_woocommerce', 'true', wc_get_current_admin_page() ),
 				'wc_db_update',
 				'wc_db_update_nonce'
 			)
@@ -210,7 +210,7 @@ class WC_Notes_Run_Db_Update {
 				add_query_arg(
 					'wc-hide-notice',
 					'update',
-					admin_url( 'admin.php?page=wc-settings' )
+					wc_get_current_admin_page()
 				),
 				'woocommerce_hide_notices_nonce',
 				'_wc_notice_nonce'

--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -111,7 +111,7 @@ class WC_Notes_Run_Db_Update {
 	private static function update_needed_notice( $note_id = null ) {
 		$update_url = html_entity_decode(
 			wp_nonce_url(
-				add_query_arg( 'do_update_woocommerce', 'true', wc_get_current_admin_page() ),
+				add_query_arg( 'do_update_woocommerce', 'true', wc_get_current_admin_url() ? wc_get_current_admin_url() : admin_url( 'admin.php?page=wc-settings' ) ),
 				'wc_db_update',
 				'wc_db_update_nonce'
 			)
@@ -210,7 +210,7 @@ class WC_Notes_Run_Db_Update {
 				add_query_arg(
 					'wc-hide-notice',
 					'update',
-					wc_get_current_admin_page()
+					wc_get_current_admin_url() ? wc_get_current_admin_url() : admin_url( 'admin.php?page=wc-settings' )
 				),
 				'woocommerce_hide_notices_nonce',
 				'_wc_notice_nonce'

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -486,11 +486,11 @@ function wc_render_invalid_variation_notice( $product_object ) {
  */
 function wc_get_current_admin_url() {
 	$uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
-	$uri = str_replace( '/wp-admin', '', $uri );
+	$uri = preg_replace( '|^.*/wp-admin/|i', '', $uri );
 
 	if ( ! $uri ) {
 		return '';
 	}
 
-	return remove_query_arg( array( '_wpnonce', '_wc_notice_nonce', 'wc_db_update', 'wc_db_update_nonce' ), admin_url( $uri ) );
+	return remove_query_arg( array( '_wpnonce', '_wc_notice_nonce', 'wc_db_update', 'wc_db_update_nonce', 'wc-hide-notice' ), admin_url( $uri ) );
 }

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -474,3 +474,21 @@ function wc_render_invalid_variation_notice( $product_object ) {
 		<?php
 	}
 }
+
+/**
+ * Get current admin page or WooCommerce settings page.
+ *
+ * @internal
+ * @since 4.4.0
+ * @return string
+ */
+function wc_get_current_admin_page() {
+	$uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
+	$uri = str_replace( '/wp-admin', '', $uri );
+
+	if ( ! $uri ) {
+		return admin_url( 'admin.php?page=wc-settings' );
+	}
+
+	return remove_query_arg( array( '_wpnonce', '_wc_notice_nonce', 'wc_db_update', 'wc_db_update_nonce' ), admin_url( $uri ) );
+}

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -476,18 +476,20 @@ function wc_render_invalid_variation_notice( $product_object ) {
 }
 
 /**
- * Get current admin page or WooCommerce settings page.
+ * Get current admin page URL.
+ *
+ * Returns an empty string if it cannot generate a URL.
  *
  * @internal
  * @since 4.4.0
  * @return string
  */
-function wc_get_current_admin_page() {
+function wc_get_current_admin_url() {
 	$uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
 	$uri = str_replace( '/wp-admin', '', $uri );
 
 	if ( ! $uri ) {
-		return admin_url( 'admin.php?page=wc-settings' );
+		return '';
 	}
 
 	return remove_query_arg( array( '_wpnonce', '_wc_notice_nonce', 'wc_db_update', 'wc_db_update_nonce' ), admin_url( $uri ) );

--- a/tests/php/includes/admin/wc-admin-functions-test.php
+++ b/tests/php/includes/admin/wc-admin-functions-test.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Unit tests for the WC_Admin_Functions_Test class
+ *
+ * @package WooCommerce\Tests\Admin
+ */
+
+/**
+ * Class WC_Admin_Functions_Test_Test
+ */
+class WC_Admin_Functions_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Load up the importer classes since they aren't loaded by default.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$bootstrap = \WC_Unit_Tests_Bootstrap::instance();
+		require_once $bootstrap->plugin_dir . '/includes/admin/wc-admin-functions.php';
+	}
+
+	/**
+	 * Test wc_get_current_admin_url() function.
+	 */
+	public function test_wc_get_current_admin_url() {
+		// Since REQUEST_URI is empty on unit tests it should return an empty string.
+		if ( empty( $_SERVER['REQUEST_URI'] ) ) {
+			$this->assertEquals( '', wc_get_current_admin_url() );
+		}
+
+		// Test with REQUEST_URI.
+		$default_uri            = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		$_SERVER['REQUEST_URI'] = '/wp-admin/admin.php?page=wc-admin&foo=bar';
+		$this->assertEquals( admin_url( 'admin.php?page=wc-admin&foo=bar' ), wc_get_current_admin_url() );
+
+		// Test if nonce gets removed.
+		$_SERVER['REQUEST_URI'] = '/wp-admin/admin.php?page=wc-admin&_wpnonce=xxxxxxxxxxxx';
+		$this->assertEquals( admin_url( 'admin.php?page=wc-admin' ), wc_get_current_admin_url() );
+
+		// Restore REQUEST_URI.
+		$_SERVER['REQUEST_URI'] = $default_uri;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27168.

### How to test the changes in this Pull Request:

Steps from: #27168

Apply this patch and try the follow:

1. Complete OBW.
2. When done with OBW, you should be redirected to Home page. 
3. You should see a notification letting you know that the WC DB update is needed. 
4. Click on the `Update WooCommerce Database` button.
5. Check if you stay on the same page instead of being redirected to the "Settings" page instead 
6. After the update is complete move to some page and try the "Thanks!" button.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - After clicking to update WooCommerce, the user will stay in the same page instead of being redirected to the "Settings" page.
