### PR TITLE
Remove new WP 5.5 meta box arrows

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1062,6 +1062,7 @@ ul.wc_coupon_list_block {
 
 #woocommerce-order-data {
 
+	.postbox-header,
 	.hndle,
 	.handlediv {
 		display: none;
@@ -1466,6 +1467,7 @@ ul.wc_coupon_list_block {
 		display: block !important;
 	}
 
+	.postbox-header,
 	.hndle,
 	.handlediv {
 		display: none;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

WP 5.5 introduce new arrows to move meta boxes, and those are not hidden like the old ones, see:

![arrows](https://user-images.githubusercontent.com/19143190/88855505-f99d8f00-d1c0-11ea-9ba9-52f53f3fe23c.jpg)

Note that the first meta box is part of WooCommerce Admin and need to be fixed there too.

Closes #27169.

### How to test the changes in this Pull Request:

1. Install WP 5.5 RC, you can install using `wp core update --version=nightly --force`
2. Go to any order page and check the Order data and Order items meta boxes to see the new arrows.
3. Checkout this branch and run `grunt css`.
4. Go back to any order details and check the meta boxes again, now should be all hidden again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Remove new WP 5.5 meta box arrows from "Order data" and "Order items" meta boxes.
