### PR TITLE
Fix incorrect adjustment of post count in WC_Query

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -368,8 +368,9 @@ class WC_Query {
 	}
 
 	/**
-	 * When the request is filtering by attributes via layered nav plugin we need to adjust the total posts count
-	 * to account for variable products having stock in some variations but not in others.
+	 * When we are listing products and the request is filtering by attributes via layered nav plugin
+	 * we need to adjust the total posts count to account for variable products having stock
+	 * in some variations but not in others.
 	 * We do that by just checking if each product is visible.
 	 *
 	 * We also cache the post visibility so that it isn't checked again when displaying the posts list.
@@ -385,18 +386,22 @@ class WC_Query {
 			return $count;
 		}
 
-		$count = 0;
 		foreach ( $posts as $post ) {
-			$id      = is_object( $post ) ? $post->ID : $post;
-			$product = wc_get_product( $id );
+			if ( is_object( $post ) && 'product' !== $post->post_type ) {
+				continue;
+			}
+
+			$product_id = is_object( $post ) ? $post->ID : $post;
+			$product    = wc_get_product( $product_id );
 			if ( ! is_object( $product ) ) {
 				continue;
 			}
+
 			if ( $product->is_visible() ) {
-				wc_set_loop_product_visibility( $id, true );
-				$count++;
+				wc_set_loop_product_visibility( $product_id, true );
 			} else {
-				wc_set_loop_product_visibility( $id, false );
+				wc_set_loop_product_visibility( $product_id, false );
+				$count--;
 			}
 		}
 

--- a/tests/legacy/unit-tests/util/class-wc-tests-wc-query.php
+++ b/tests/legacy/unit-tests/util/class-wc-tests-wc-query.php
@@ -526,7 +526,7 @@ class WC_Tests_WC_Query extends WC_Unit_Test_Case {
 	 * @testdox adjust_posts should return the input unmodified if the posts do not represent products.
 	 */
 	public function test_adjust_posts_count_when_the_posts_are_not_products() {
-		list($sut, $products) = $this->setup_adjust_posts_test( true, true, 'page' );
+		list( $sut, $products ) = $this->setup_adjust_posts_test( true, true, 'page' );
 
 		$products[0]->set_stock_status( 'outofstock' );
 		$products[0]->save();

--- a/tests/legacy/unit-tests/util/class-wc-tests-wc-query.php
+++ b/tests/legacy/unit-tests/util/class-wc-tests-wc-query.php
@@ -441,12 +441,13 @@ class WC_Tests_WC_Query extends WC_Unit_Test_Case {
 	/**
 	 * Setup for a test for adjust_posts.
 	 *
-	 * @param bool $with_nav_filtering_data Should WC_Query::get_layered_nav_chosen_attributes return filtering data?.
-	 * @param bool $use_objects If true, get_current_posts will return objects with an ID property; if false, it will returns the ids.
+	 * @param bool   $with_nav_filtering_data Should WC_Query::get_layered_nav_chosen_attributes return filtering data?.
+	 * @param bool   $use_objects If true, get_current_posts will return objects with an ID property; if false, it will returns the ids.
+	 * @param string $post_type The value of the 'post_type' property for the objects generated when $use_objects is true.
 	 *
 	 * @return array An array where the first element is the instance of WC_Query, and the second is an array of sample products created.
 	 */
-	private function setup_adjust_posts_test( $with_nav_filtering_data, $use_objects ) {
+	private function setup_adjust_posts_test( $with_nav_filtering_data, $use_objects, $post_type = 'product' ) {
 		update_option( 'woocommerce_hide_out_of_stock_items', 'yes' );
 
 		if ( $with_nav_filtering_data ) {
@@ -460,7 +461,10 @@ class WC_Tests_WC_Query extends WC_Unit_Test_Case {
 		for ( $i = 0; $i < 5; $i++ ) {
 			$product = WC_Helper_Product::create_simple_product();
 			array_push( $products, $product );
-			$post = $use_objects ? (object) array( 'ID' => $product->get_id() ) : $product->get_id();
+			$post = $use_objects ? (object) array(
+				'ID'        => $product->get_id(),
+				'post_type' => $post_type,
+			) : $product->get_id();
 			array_push( $posts, $post );
 		}
 
@@ -495,8 +499,8 @@ class WC_Tests_WC_Query extends WC_Unit_Test_Case {
 		$products[1]->set_stock_status( 'outofstock' );
 		$products[1]->save();
 
-		$this->assertEquals( 3, $sut->adjust_posts_count( 34 ) );
-		$this->assertEquals( 3, wc_get_loop_prop( 'total' ) );
+		$this->assertEquals( 32, $sut->adjust_posts_count( 34 ) );
+		$this->assertEquals( 32, wc_get_loop_prop( 'total' ) );
 		$this->assertEquals( false, wc_get_loop_product_visibility( $products[0]->get_id() ) );
 		$this->assertEquals( false, wc_get_loop_product_visibility( $products[1]->get_id() ) );
 		foreach ( array_slice( $products, 2 ) as $product ) {
@@ -514,6 +518,18 @@ class WC_Tests_WC_Query extends WC_Unit_Test_Case {
 			->getMock();
 
 		$sut->method( 'get_current_posts' )->willReturn( null );
+
+		$this->assertEquals( 34, $sut->adjust_posts_count( 34 ) );
+	}
+
+	/**
+	 * @testdox adjust_posts should return the input unmodified if the posts do not represent products.
+	 */
+	public function test_adjust_posts_count_when_the_posts_are_not_products() {
+		list($sut, $products) = $this->setup_adjust_posts_test( true, true, 'page' );
+
+		$products[0]->set_stock_status( 'outofstock' );
+		$products[0]->save();
 
 		$this->assertEquals( 34, $sut->adjust_posts_count( 34 ) );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/26260 introduced a handler for the `found_posts` filter in the `WC_Query` class in order to adjust the count depending on the visibility of variation products. However the handler incorrectly assumed that the filter was triggered only when listing products, when actually it's also triggered for any post type e.g. pages. In these cases the post count was set to zero, which caused bugs (e.g. orders list appeared empty in customer profiles).

Now the handler starts with the originally supplied posts count, and only decrements it when a post is a product AND is not visible.

Closes #27162.

### How to test the changes in this Pull Request:

1. Login as a customer, go to the orders page in your account and verify that all your orders are listed (place a new order if you didn't have any).
2. Verify that the functionality introduced in https://github.com/woocommerce/woocommerce/pull/26260 still works.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Not needed since the bug was introduced in 4.4 beta 1 and the fix will be included in the final release.
