### PR TITLE
Package Update: Update WooCommerce Blocks to 3.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "1.4.0-beta.2",
-    "woocommerce/woocommerce-blocks": "3.0.0",
+    "woocommerce/woocommerce-blocks": "3.1.0",
     "woocommerce/woocommerce-rest-api": "1.0.11"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -597,20 +597,20 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-07-28T00:28:40+00:00"
+            "time": "2020-07-28T15:18:55+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v3.0.0",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "cc00da60f21a7219e7e5ef5599996c68fee7b2be"
+                "reference": "d8fdcb4fc90c392e672b0e75bb0b7fd81dac7436"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/cc00da60f21a7219e7e5ef5599996c68fee7b2be",
-                "reference": "cc00da60f21a7219e7e5ef5599996c68fee7b2be",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/d8fdcb4fc90c392e672b0e75bb0b7fd81dac7436",
+                "reference": "d8fdcb4fc90c392e672b0e75bb0b7fd81dac7436",
                 "shasum": ""
             },
             "require": {
@@ -644,7 +644,7 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2020-07-22T13:34:19+00:00"
+            "time": "2020-07-29T15:45:19+00:00"
         },
         {
             "name": "woocommerce/woocommerce-rest-api",


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 3.1.0. It includes a fix to a regression with the All Products block, so ideally it should be merged into WC 4.4.

Some more details:
* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2938)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/docs/testing/releases/310.md)
* [Release post](https://woocommerce.wordpress.com/2020/07/29/woocommerce-blocks-3-1-release-notes/)
* [Changelog](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/release/3.1/readme.txt#L88)

### Changelog entry

> Dev - Update WooCommerce Blocks version to 3.1.0