### PR TITLE
Release coupon holds when status it updated to cancelled regardless of recorded coupons

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -861,6 +861,9 @@ function wc_update_coupon_usage_counts( $order_id ) {
 	} elseif ( ! $order->has_status( 'cancelled' ) && ! $has_recorded ) {
 		$action = 'increase';
 		$order->get_data_store()->set_recorded_coupon_usage_counts( $order, true );
+	} elseif ( $order->has_status( 'cancelled' ) ) {
+		$order->get_data_store()->release_held_coupons( $order, true );
+		return;
 	} else {
 		return;
 	}

--- a/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -1477,6 +1477,45 @@ class WC_Tests_Order_Functions extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Checks if coupons are released when switching from pending to cancelled state.
+	 *
+	 * Tests the fix for issue #26741
+	 */
+	public function test_wc_cancelled_order_releases_coupon_hold_from_pending_state() {
+		$coupon_code       = 'coupon1';
+		$coupon_data_store = WC_Data_Store::load( 'coupon' );
+
+		$coupon = WC_Helper_Coupon::create_coupon(
+			$coupon_code,
+			array(
+				'usage_limit' => 1,
+				'usage_limit_per_user' => 1,
+			)
+		);
+
+		$product = WC_Helper_Product::create_simple_product( true );
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+		WC()->cart->add_discount( $coupon_code );
+
+		$order_id = WC_Checkout::instance()->create_order(
+			array(
+				'billing_email'  => 'a@b.com',
+				'payment_method' => 'dummy',
+			)
+		);
+
+		$this->assertEquals( 1, $coupon_data_store->get_tentative_usage_count( $coupon->get_id() ) );
+		$this->assertEquals( 1, $coupon_data_store->get_tentative_usages_for_user( $coupon->get_id(), array( 'a@b.com' ) ) );
+		$this->assertEquals( 1, $coupon_data_store->get_usage_by_email( $coupon, 'a@b.com' ) );
+
+		$order = new WC_Order( $order_id );
+		$order->update_status( 'cancelled' );
+		$this->assertEquals( 0, $coupon_data_store->get_tentative_usage_count( $coupon->get_id() ) );
+		$this->assertEquals( 0, $coupon_data_store->get_tentative_usages_for_user( $coupon->get_id(), array( 'a@b.com' ) ) );
+		$this->assertEquals( 0, $coupon_data_store->get_usage_by_email( $coupon, 'a@b.com' ) );
+	}
+
+	/**
 	 * Test if everything works as expected when coupon hold is disabled using filter.
 	 */
 	public function test_wc_update_usage_count_without_coupon_hold() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
This PR updates the method to update coupon usage counts such that it releases coupon holds on an order changed to cancelled status, regardless of whether or not coupon usage has been recorded. This releases coupon holds for cancelled orders that were previously in pending state so that they can be used by a new cart.

Closes #26741.

### How to test the changes in this Pull Request:

1. Apply this PR.
2. Create a new coupon with usage limits. Set both the usage limit per coupon and the usage limit per user to 1. 
![image](https://user-images.githubusercontent.com/363749/88943299-edf9a900-d250-11ea-8941-9d948a860de9.png)
3. From WooCommerce -> Settings -> Payments, make sure the PayPal payment method is enabled.
4. Manage the settings for the PayPal payment method, and select "Enable PayPal sandbox".
5. Create (or use an existing) sandbox application [from the PayPal Developer Dashboard](https://developer.paypal.com/developer/applications). Enter your sandbox credentials into WooCommerce and save the changes.
6. Add an item to your cart, and apply the coupon code you previously created.
7. Proceed to checkout. Your coupon should be applied to your order.
8. Select PayPal as your payment method, and select "Proceed to PayPal". 
![image](https://user-images.githubusercontent.com/363749/88943489-2a2d0980-d251-11ea-845c-133492706440.png)
9. When shown the login screen for PayPal, select "Cancel and return to Merchant". 
![image](https://user-images.githubusercontent.com/363749/88943541-3a44e900-d251-11ea-92f1-5a879c42a8c5.png)
10. Verify that the coupon still exists in your cart, and that if you checkout successfully (either with PayPal, or another payment method), the coupon is still applied.
11. Verify that after using the coupon successfully, the usage restrictions are still enforced. You should not be able to use the coupon a second time.



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: Release coupon holds for cancelled orders previously in pending status.
