### PR TITLE
Removed the define for the `JETPACK_AUTOLOAD_DEV` constant

### DIFF
--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -36,20 +36,6 @@ class Autoloader {
 			return false;
 		}
 
-		/**
-		 * In order to support local development for feature plugins the autoloader must support dev versions.
-		 *
-		 * - If the checked out branch cannot supply Composer with version information then it
-		 *   assigns it a dev version string for the Jetpack Autoloader to use.
-		 * - By default the Jetpack Autoloader will ignore these dev versions in favor of tagged versions.
-		 *
-		 * Due to this interaction, feature plugin files from the included packages will always be loaded instead
-		 * of the versions in the feature plugin when checked out from a repository as a dev version. By setting
-		 * this constant we change the behavior of the autoloader so that dev versions are prioritized over the
-		 * tagged versions included in WooCommerce Core.
-		 */
-		define( 'JETPACK_AUTOLOAD_DEV', true );
-
 		$autoloader_result = require $autoloader;
 		if ( ! $autoloader_result ) {
 			return false;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Originally this define was set to avoid the potential confusion that could be created when it is not set. After a chat with @nerrad we decided that it should be set in the developer's `wp-config.php` so that WooCommerce Core doesn't have any unintended side-effects for other plugins that use the autoloader.

We can address the confusion in our feature plugins by giving a notice when using a developer build without the constant defined as `true`.

### Special Notes

Once this PR is merged the `woocommerce-admin` and `woo-gutenberg-products-block` plugins will experience some strange behavior. Developers working on the `woo-gutenberg-products-block` plugin will be fine but those working on `woocommerce-admin` will need to add the `JETPACK_AUTOLOAD_DEV` constant to their `wp-config.php`.

### How to test the changes in this Pull Request:

1. Clone `woocommerce-admin` into your plugins and make sure the resources are built and the plugin activated.
2. Add a logging statement to the package's `Package.php` file's `init()` method.
3. Go to the WooCommerce Dashboard and then check your log. Without the PR you'll see the log message but with it you will not.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Removed the `JETPACK_AUTOLOAD_DEV` define
