### PR TITLE
Added filters for stock quantity - for different unit stock

### DIFF
--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -208,6 +208,9 @@ function wc_maybe_adjust_line_item_product_stock( $item, $item_quantity = -1 ) {
 
 	$product               = $item->get_product();
 	$item_quantity         = wc_stock_amount( $item_quantity >= 0 ? $item_quantity : $item->get_quantity() );
+
+	// Possibility to change item quantity - for the sake of different unit based stock.
+	$item_quantity         = apply_filters( 'woocommerce_maybe_adjust_line_item_product_stock_item_quantity', $item_quantity, $item );
 	$already_reduced_stock = wc_stock_amount( $item->get_meta( '_reduced_stock', true ) );
 
 	if ( ! $product || ! $product->managing_stock() || ! $already_reduced_stock || $item_quantity === $already_reduced_stock ) {
@@ -216,6 +219,9 @@ function wc_maybe_adjust_line_item_product_stock( $item, $item_quantity = -1 ) {
 
 	$order                  = $item->get_order();
 	$refunded_item_quantity = $order->get_qty_refunded_for_item( $item->get_id() );
+
+	// Possibility to change refunded item quantity - for the sake of different unit based stock.
+	$refunded_item_quantity = apply_filters( 'woocommerce_maybe_adjust_line_item_product_stock_refunded_item_quantity', $refunded_item_quantity, $item );
 	$diff                   = $item_quantity + $refunded_item_quantity - $already_reduced_stock;
 
 	if ( $diff < 0 ) {

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -702,6 +702,9 @@ function wc_restock_refunded_items( $order, $refunded_line_items ) {
 		$item_stock_reduced = $item->get_meta( '_reduced_stock', true );
 		$qty_to_refund      = $refunded_line_items[ $item_id ]['qty'];
 
+		// Possibility to change refunded quantity - for the sake of different unit based stock.
+		$qty_to_refund = apply_filters( 'woocommerce_restock_refunded_items_qty_to_refund', $qty_to_refund, $item );
+
 		if ( ! $item_stock_reduced || ! $qty_to_refund || ! $product || ! $product->managing_stock() ) {
 			continue;
 		}


### PR DESCRIPTION


### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I have added new filters so it is possible to alter the requested stock. This was made so it will be possible to use different unit based stock. For example Weight based stock. All other filters necessary to do that are already in place.



### How to test the changes in this Pull Request:

1. Hook onto any of the above filters
2. Change the desired quantity - and stock will be working against new quantities

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
