### PR TITLE
Fix: pagination controls not displaying in products list

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -44,7 +44,7 @@ class WC_Query {
 			add_filter( 'query_vars', array( $this, 'add_query_vars' ), 0 );
 			add_action( 'parse_request', array( $this, 'parse_request' ), 0 );
 			add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
-			add_filter( 'the_posts', array( $this, 'remove_product_query_filters' ) );
+			add_filter( 'the_posts', array( $this, 'handle_get_posts' ) );
 			add_filter( 'found_posts', array( $this, 'adjust_posts_count' ), 10, 2 );
 			add_filter( 'get_pagenum_link', array( $this, 'remove_add_to_cart_pagination' ), 10, 1 );
 		}
@@ -353,6 +353,32 @@ class WC_Query {
 	}
 
 	/**
+	 * Handler for the 'the_posts' WP filter.
+	 *
+	 * @param array $posts Posts from WP Query.
+	 *
+	 * @return array
+	 */
+	public function handle_get_posts( $posts ) {
+		$this->adjust_total_pages();
+		$this->remove_product_query_filters( $posts );
+		return $posts;
+	}
+
+	/**
+	 * The 'adjust_posts_count' method that handles the 'found_posts' filter indirectly initializes
+	 * the loop properties with a call to 'wc_setup_loop'. This includes setting 'total_pages' to
+	 * '$GLOBALS['wp_query']->max_num_pages', which at that point has a value of zero.
+	 * Thus we need to set the real value from the 'the_posts' filter, where $GLOBALS['wp_query']->max_num_pages'
+	 * will aready have been initialized.
+	 */
+	private function adjust_total_pages() {
+		if ( 0 === wc_get_loop_prop( 'total_pages' ) ) {
+			wc_set_loop_prop( 'total_pages', $GLOBALS['wp_query']->max_num_pages );
+		}
+	}
+
+	/**
 	 * Pre_get_posts above may adjust the main query to add WooCommerce logic. When this query is done, we need to ensure
 	 * all custom filters are removed.
 	 *
@@ -376,13 +402,12 @@ class WC_Query {
 	 * We also cache the post visibility so that it isn't checked again when displaying the posts list.
 	 *
 	 * @since 4.4.0
-	 * @param int $count Original posts count, as supplied by the found_posts filter.
+	 * @param int      $count Original posts count, as supplied by the found_posts filter.
 	 * @param WP_Query $query The current WP_Query object.
 	 *
 	 * @return int Adjusted posts count.
 	 */
 	public function adjust_posts_count( $count, $query ) {
-
 		if ( ! $query->get( 'wc_query' ) ) {
 			return $count;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

This bug was introduced in #26260. The sequence is:

1. `WC_Query::adjust_posts_count` runs to handle `found_posts filter`, this indirectly executes `wc_setup_loop`.
2. At this point `$GLOBALS['wp_query']->max_num_pages` hasn't been set yet, and has a value of 0. Thus the loop variable `total_pages` is set to 0.
3. Later `wc_setup_loop` runs again and this time `$GLOBALS['wp_query']->max_num_pages` is already set, but since the loop variable `total_pages` already exists, it keeps its value of 0.
4. The pagination controls never show if `total_pages` is less than 2.

### Changes proposed in this Pull Request:

The fix consists of hooking into `the_posts` to set the value of `total_pages` again, at that point `$GLOBALS['wp_query']->max_num_pages` is already set.

### How to test the changes in this Pull Request:

1. Make sure that you have enough visible products to fill more than one page (default page size is 12).
2. Go to the shop and list products. The counter says "Showing 1-12 of X results", with X>12; but there are no pagination controls.
3. Checkout this branch and try again, now the pagination controls are there and work as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Not needed since it's a fix for a bug that was introduced in 4.4 beta 1.
