### PR TITLE
Add filters to ignore reduce/increase/reserve stock for specific items

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -155,10 +155,16 @@ function wc_reduce_stock_levels( $order_id ) {
 	}
 
 	$changes = array();
+	$order_item_keys_to_ignore = apply_filters( 'woocommerce_reduce_stock_levels_ignore_order_item_keys', array() );
 
 	// Loop over all items.
-	foreach ( $order->get_items() as $item ) {
+	foreach ( $order->get_items() as $item_key => $item ) {
 		if ( ! $item->is_type( 'line_item' ) ) {
+			continue;
+		}
+
+		// Ignore order item keys if ignores set
+		if ( in_array( $item_key, $order_item_keys_to_ignore ) ) {
 			continue;
 		}
 
@@ -254,10 +260,16 @@ function wc_increase_stock_levels( $order_id ) {
 	}
 
 	$changes = array();
+	$order_item_keys_to_ignore = apply_filters( 'woocommerce_increase_stock_levels_ignore_order_item_keys', array() );
 
 	// Loop over all items.
-	foreach ( $order->get_items() as $item ) {
+	foreach ( $order->get_items() as $item_key => $item ) {
 		if ( ! $item->is_type( 'line_item' ) ) {
+			continue;
+		}
+
+		// Ignore order item keys if ignores set
+		if ( in_array( $item_key, $order_item_keys_to_ignore ) ) {
 			continue;
 		}
 

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -80,8 +80,14 @@ final class ReserveStock {
 				}
 			);
 			$rows  = array();
+			$order_item_keys_to_ignore = apply_filters( 'woocommerce_reserve_stock_for_order_ignore_order_item_keys', array() );
 
-			foreach ( $items as $item ) {
+			foreach ( $items as $item_key => $item ) {
+				// Ignore order item keys if ignores set
+				if ( in_array( $item_key, $order_item_keys_to_ignore ) ) {
+					continue;
+				}
+
 				$product = $item->get_product();
 
 				if ( ! $product->is_in_stock() ) {


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

These changes add filters to the reduce/increase/reserve stock functions to allow specific order items to be excluded, this functionality allows these functions to be bypassed for specific items which require it (deemed through use of specific meta set against the order item). In some custom development scenarios in the present code this would require the use of a backtrace to find out which functions are being called and the order items removed in some other way.

Closes https://github.com/woocommerce/woocommerce/issues/26943.

### How to test the changes in this Pull Request:

1. Create some custom functionality which adds some order item meta which should be used to ignore the checks
2. Add the filters in a plugin/theme, return that the order item id should be ignored if the above meta is set
3. Purchase the products, check the stock hasn't been reduced/reserved
4. Refund the order, check the stock haven't been increased.

### Changelog entry

> Add filters to ignore reduce/increase/reserve stock for specific items

I do feel it might be wise instead to add some overall filter for this which these 3 functions (and potentially others I may not be aware of to hook into instead of 3 separate filters).