### PR TITLE
Remove duplicate `get_available_variations()` function argument

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -282,12 +282,11 @@ class WC_Product_Variable extends WC_Product {
 	/**
 	 * Get an array of available variations for the current product.
 	 *
-	 * @param bool $render_variations Prepares a data array for each variant for output in the add to cart form. Pass `false` to only return the available variations as objects.
-	 * @param bool $return_array_of_data If true, return an array of data for the variation; if false, return a WC_Product_Variation object.
+	 * @param string $return Optional. The format to return the results in. Can be 'array' to return an array of variation data or 'objects' for the product objects. Default 'array'.
 	 *
-	 * @return array|WC_Product_Variation
+	 * @return array[]|WC_Product_Variation[]
 	 */
-	public function get_available_variations( $render_variations = true, $return_array_of_data = true ) {
+	public function get_available_variations( $return = 'array' ) {
 		$variation_ids        = $this->get_children();
 		$available_variations = array();
 
@@ -309,14 +308,14 @@ class WC_Product_Variable extends WC_Product {
 				continue;
 			}
 
-			if ( $render_variations ) {
-				$available_variations[] = $return_array_of_data ? $this->get_available_variation( $variation ) : $variation;
+			if ( 'array' === $return ) {
+				$available_variations[] = $this->get_available_variation( $variation );
 			} else {
 				$available_variations[] = $variation;
 			}
 		}
 
-		if ( $render_variations ) {
+		if ( 'array' === $return ) {
 			$available_variations = array_values( array_filter( $available_variations ) );
 		}
 
@@ -622,7 +621,7 @@ class WC_Product_Variable extends WC_Product {
 			}
 		);
 
-		$variations = $this->get_available_variations( true, false );
+		$variations = $this->get_available_variations( 'objects' );
 		foreach ( $variations as $variation ) {
 			if ( $this->variation_matches_filters( $variation, $attributes_with_terms ) ) {
 				return true;

--- a/tests/php/includes/class-wc-product-variable-test.php
+++ b/tests/php/includes/class-wc-product-variable-test.php
@@ -1,0 +1,42 @@
+<?php
+
+/**
+ * Tests for WC_Product_Variable.
+ */
+class WC_Product_Variable_Test extends \WC_Unit_Test_Case {
+	/**
+	 * @testdox 'get_available_variations' returns the variations as arrays if no parameters is passed.
+	 */
+	public function test_get_available_variations_returns_array_when_no_parameter_is_passed() {
+		$product = WC_Helper_Product::create_variation_product();
+
+		$variations = $product->get_available_variations();
+
+		$this->assertIsArray( $variations[0] );
+		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
+	}
+
+	/**
+	 * @testdox 'get_available_variations' returns the variations as arrays if the parameter passed is 'array'.
+	 */
+	public function test_get_available_variations_returns_array_when_array_parameter_is_passed() {
+		$product = WC_Helper_Product::create_variation_product();
+
+		$variations = $product->get_available_variations( 'array' );
+
+		$this->assertIsArray( $variations[0] );
+		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]['sku'] );
+	}
+
+	/**
+	 * @testdox 'get_available_variations' returns the variations as objects if the parameter passed is 'objects'.
+	 */
+	public function test_get_available_variations_returns_object_when_objects_parameter_is_passed() {
+		$product = WC_Helper_Product::create_variation_product();
+
+		$variations = $product->get_available_variations( 'objects' );
+
+		$this->assertInstanceOf( WC_Product_Variation::class, $variations[0] );
+		$this->assertEquals( 'DUMMY SKU VARIABLE SMALL', $variations[0]->get_sku() );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

As part of WC 4.4 compatibility testing for WC Subscriptions we have to update our `WC_Product_Variable_Subscription::get_available_variations()` function signature to match the changes made to `WC_Product_Variable::get_available_variations()` in https://github.com/woocommerce/woocommerce/pull/26303 and https://github.com/woocommerce/woocommerce/pull/26260. 

While I was doing that I couldn't quite work out what the difference between `$render_variations` and `$return_array_of_data` was. IMO they behave the exact same and can even lead to misleading results. 

For example, the returned variable type broken down by input arguments:

<table>
<thead>
  <tr>
    <th><code>$render_variations</code></th>
    <th><code>$return_array_of_data</code></th>
    <th>Result</th>
  </tr>
</thead>
<tbody>
  <tr>
    <td><code>true</code></td>
    <td><code>true</code></td>
    <td>array</td>
  </tr>
  <tr>
    <td><code>true</code></td>
    <td><code>false</code></td>
    <td>objects</td>
  </tr>
  <tr>
    <td><code>false</code></td>
    <td><code>false</code></td>
    <td>objects</td>
  </tr>
  <tr>
    <td><code>false</code></td>
    <td><code>true</code></td>
    <td>objects</td>
  </tr>
</tbody>
</table>

You'll notice in the last row, that even though `$return_array_of_data` is `true` it returns objects. Looking at [these lines](https://github.com/woocommerce/woocommerce/blob/4.4.0-beta.1/includes/class-wc-product-variable.php#L312-L316), I'm not sure what the intent is between the two arguments, I think they're both trying to achieve the same result; return objects.

- `$render_variations === false` will always return the objects (`$variation`). 
- `$render_variations === true` will return an array or the object (`$variation`). If it's objects, `$render_variations` could just have been `false` and returned the same result. 

Essentially there's redundancy. 

### How to test the changes in this Pull Request:

There are currently only 2 uses of `WC_Product_Variable::get_available_variations()` in core. One of them uses the default args and won't be affected by this, I've updated the other one which was updated in https://github.com/woocommerce/woocommerce/pull/26260/commits/bc7085b3c45cf1e542e941fbd52fd7ad537efa8f to get the objects. 

I'm not really sure how to test this other than to call the `get_available_variations()` function with different args and notice the results don't change when you change the `$return_array_of_data` argument when `$render_variations` is false. 

cc @Konamiman since you might know how to test this after submitting the original PR. Also let me know if I'm missing something. 🙂

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

