### PR TITLE
Update woocommerce-admin to 1.4.0-beta.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "^3.1",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.4.0-beta.2",
+    "woocommerce/woocommerce-admin": "1.4.0-beta.3",
     "woocommerce/woocommerce-blocks": "3.1.0",
     "woocommerce/woocommerce-rest-api": "1.0.11"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "877625af18978cccd2d02780fbd11842",
+    "content-hash": "d7df64252352cb3445d827cf204f24b4",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
-            "version": "v2.0.2",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-autoloader.git",
-                "reference": "4502da4b2443fc1b61389cacc94c34876aca2b3d"
+                "reference": "802517b3ff3010de89141d9f7c4d56aec1d21527"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/4502da4b2443fc1b61389cacc94c34876aca2b3d",
-                "reference": "4502da4b2443fc1b61389cacc94c34876aca2b3d",
+                "url": "https://api.github.com/repos/Automattic/jetpack-autoloader/zipball/802517b3ff3010de89141d9f7c4d56aec1d21527",
+                "reference": "802517b3ff3010de89141d9f7c4d56aec1d21527",
                 "shasum": ""
             },
             "require": {
@@ -40,20 +40,20 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "time": "2020-07-09T13:18:38+00:00"
+            "time": "2020-07-27T20:37:00+00:00"
         },
         {
             "name": "automattic/jetpack-constants",
-            "version": "v1.3.0",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Automattic/jetpack-constants.git",
-                "reference": "77e4a85601c63dc98b3dd282090eb8558a61685c"
+                "reference": "b4210d56948529b43785ce31e0055f435eac1f9f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/77e4a85601c63dc98b3dd282090eb8558a61685c",
-                "reference": "77e4a85601c63dc98b3dd282090eb8558a61685c",
+                "url": "https://api.github.com/repos/Automattic/jetpack-constants/zipball/b4210d56948529b43785ce31e0055f435eac1f9f",
+                "reference": "b4210d56948529b43785ce31e0055f435eac1f9f",
                 "shasum": ""
             },
             "require-dev": {
@@ -71,7 +71,7 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for defining constants in a more testable way.",
-            "time": "2020-06-22T11:37:41+00:00"
+            "time": "2020-07-01T15:55:35+00:00"
         },
         {
             "name": "composer/installers",
@@ -258,12 +258,6 @@
                 "league",
                 "provider",
                 "service"
-            ],
-            "funding": [
-                {
-                    "url": "https://github.com/philipobenito",
-                    "type": "github"
-                }
             ],
             "time": "2020-05-18T08:20:23+00:00"
         },
@@ -501,20 +495,6 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-16T08:31:04+00:00"
         },
         {
@@ -554,16 +534,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "v1.4.0-beta.2",
+            "version": "v1.4.0-beta.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "d56ac35bbb62bda2c981443932e7f90b0f6dbe99"
+                "reference": "df2af46a8552cdee15df0030fccbe4cd5a6d270d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/d56ac35bbb62bda2c981443932e7f90b0f6dbe99",
-                "reference": "d56ac35bbb62bda2c981443932e7f90b0f6dbe99",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/df2af46a8552cdee15df0030fccbe4cd5a6d270d",
+                "reference": "df2af46a8552cdee15df0030fccbe4cd5a6d270d",
                 "shasum": ""
             },
             "require": {
@@ -597,7 +577,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-07-28T15:18:55+00:00"
+            "time": "2020-08-04T02:21:47+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2594,25 +2574,11 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-02-14T07:34:21+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.18.0",
+            "version": "v1.18.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
@@ -3075,6 +3041,5 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }


### PR DESCRIPTION
Greetings - here is a branch to update the woocommerce-admin package to version 1.4.0-beta.3 for inclusion in RC of 4.4

Details on the changes included since the last beta are:

- Remove new WP 5.5 meta box arrows in the shipping banner [#4914](https://github.com/woocommerce/woocommerce-admin/pull/4914)
- Allow revisiting of the payments task [#4918](https://github.com/woocommerce/woocommerce-admin/pull/4918)
- Fix use of Jetpack autoloader. [#4920](https://github.com/woocommerce/woocommerce-admin/pull/4920)
- Only show WCPay task in US based stores [#4899](https://github.com/woocommerce/woocommerce-admin/pull/4899)
- Polyfill core-data saveUser() on WP 5.3.x. [#4869](https://github.com/woocommerce/woocommerce-admin/pull/4869)
- OBW: fix product types step bugs [#4900](https://github.com/woocommerce/woocommerce-admin/pull/4900)
- Center all descriptive text on OBW steps. [#4902](https://github.com/woocommerce/woocommerce-admin/pull/4902)
- fix linter errors [#4904](https://github.com/woocommerce/woocommerce-admin/pull/4904)
- Onboarding: Change account required text on biz step. [#4909](https://github.com/woocommerce/woocommerce-admin/pull/4909)