### PR TITLE
Added missing changelog for 4.3.1 to default branch

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,13 @@
 == Changelog ==
 
+= 4.3.1 - 2020-07-21 =
+
+**WooCommerce Admin 1.3.1**
+* Fix - PHP Fatal errors when columns are missing from the Notes table. #4831
+
+**WooCommerce Blocks 2.7.2**
+* Enhancement - Move Draft order logic behind feature flag. #2874
+
 = 4.3.0 - 2020-07-08 =
 
 **WooCommerce**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.2
 Tested up to: 5.4
 Requires PHP: 7.0
-Stable tag: 4.3.0
+Stable tag: 4.3.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added missing changelog entries for 4.3.1 release to default branch.
Also, bumped stable tag to 4.3.1 in default branch.

### How to test the changes in this Pull Request:

Not a code change.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Not needed.
