### PR TITLE
Filter quantity in add_to_cart_handler_grouped

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -826,6 +826,7 @@ class WC_Form_Handler {
 			$quantity_set = false;
 
 			foreach ( $items as $item => $quantity ) {
+				$quantity = wc_stock_amount( $quantity );
 				if ( $quantity <= 0 ) {
 					continue;
 				}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

When adding a grouped product to the cart, pass the `quantity` value through the `wc_stock_amount()` function. This ensures the value is an integer and applies the `woocommerce_stock_amount` filter. This makes grouped products behavior consistent with simple and variable products.

Closes #27218.

### How to test the changes in this Pull Request:

1. Go to a grouped product page, e.g. `Logo Collection` from sample product data.
2. Pick a quantity for the `Hoodie with Logo` and add it to the cart.
3. Go to a single product page, e.g. `Album` from sample product data.
4. Pick a quantity and add it to the cart.
5. Now, go to the `woocommerce_sessions` table in the database and check the product quantities of that cart session. Verify `Album`'s quantity as well as `Hoodie with Logo`'s quantity are integers.

### Changelog entry

> When adding a grouped product to the cart, quantity is passed through the `woocommerce_stock_amount` filter like it's done for simple and variable products.