### PR TITLE
Fixed class package tag

### DIFF
--- a/includes/data-stores/class-wc-order-item-shipping-data-store.php
+++ b/includes/data-stores/class-wc-order-item-shipping-data-store.php
@@ -3,7 +3,7 @@
  * WC Order Item Shipping Data Store
  *
  * @version 3.0.0
- * @package data-stores
+ * @package WooCommerce\DataStores
  */
 
 if ( ! defined( 'ABSPATH' ) ) {


### PR DESCRIPTION
This is the only class using an incorrect `@package`, it also generates an incorrect result on:

https://docs.woocommerce.com/wc-apidocs/classes/WC-Order-Item-Shipping-Data-Store.html

And also sub pages like: https://docs.woocommerce.com/wc-apidocs/packages/data.html