### PR TITLE
Fix e2e OBW test to not untick physical products in product type list

### DIFF
--- a/tests/e2e/utils/components.js
+++ b/tests/e2e/utils/components.js
@@ -116,7 +116,7 @@ const completeOnboardingWizard = async () => {
 	expect( productTypesCheckboxes ).toHaveLength( 8 );
 
 	// Select Physical and Downloadable products
-	for ( let i = 0; i < 2; i++ ) {
+	for ( let i = 1; i < 2; i++ ) {
 		await productTypesCheckboxes[i].click();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Removes click on `Physical products` checkbox as it is already ticked by default since https://github.com/woocommerce/woocommerce-admin/pull/4900 (via https://github.com/woocommerce/woocommerce/pull/27214)

This fixes the test failure on the setup task list where `Set up shipping` task was missing because we had unticked `Physical products`

### How to test the changes in this Pull Request:

1. Make sure e2e tests pass locally and on Travis. Run tests as per [our docs](https://github.com/woocommerce/woocommerce/tree/master/tests/e2e#running-tests). 

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

N/A since we don't include changes made to e2e tests into changelog or releases. 