### PR TITLE
Fix usage of "package" tag in file headers

### DIFF
--- a/i18n/continents.php
+++ b/i18n/continents.php
@@ -4,7 +4,7 @@
  *
  * Returns an array of continents.
  *
- * @package WooCommerce/i18n
+ * @package WooCommerce\i18n
  * @version 2.5.0
  */
 

--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -2,7 +2,7 @@
 /**
  * Locales information
  *
- * @package WooCommerce/i18n
+ * @package WooCommerce\i18n
  * @version 3.5.0
  */
 

--- a/i18n/phone.php
+++ b/i18n/phone.php
@@ -4,7 +4,7 @@
  *
  * Returns an array of calling codes.
  *
- * @package WooCommerce/i18n
+ * @package WooCommerce\i18n
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -7,7 +7,7 @@
  *
  * @class       WC_Data
  * @version     3.0.0
- * @package     WooCommerce/Classes
+ * @package     WooCommerce\Classes
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -20,7 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Implemented by classes using the same CRUD(s) pattern.
  *
  * @version  2.6.0
- * @package  WooCommerce/Abstracts
+ * @package  WooCommerce\Abstracts
  */
 abstract class WC_Data {
 

--- a/includes/abstracts/abstract-wc-integration.php
+++ b/includes/abstracts/abstract-wc-integration.php
@@ -7,7 +7,7 @@
  *
  * @class       WC_Settings_API
  * @version     2.6.0
- * @package     WooCommerce/Abstracts
+ * @package     WooCommerce\Abstracts
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @class    WC_Integration
  * @extends  WC_Settings_API
  * @version  2.6.0
- * @package  WooCommerce/Abstracts
+ * @package  WooCommerce\Abstracts
  */
 abstract class WC_Integration extends WC_Settings_API {
 

--- a/includes/abstracts/abstract-wc-log-handler.php
+++ b/includes/abstracts/abstract-wc-log-handler.php
@@ -3,7 +3,7 @@
  * Log handling functionality.
  *
  * @class WC_Log_Handler
- * @package WooCommerce/Abstracts
+ * @package WooCommerce\Abstracts
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Abstract WC Log Handler Class
  *
  * @version        1.0.0
- * @package        WooCommerce/Abstracts
+ * @package        WooCommerce\Abstracts
  */
 abstract class WC_Log_Handler implements WC_Log_Handler_Interface {
 

--- a/includes/abstracts/abstract-wc-object-query.php
+++ b/includes/abstracts/abstract-wc-object-query.php
@@ -2,7 +2,7 @@
 /**
  * Query abstraction layer functionality.
  *
- * @package  WooCommerce/Abstracts
+ * @package  WooCommerce\Abstracts
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Extended by classes to provide a query abstraction layer for safe object searching.
  *
  * @version  3.1.0
- * @package  WooCommerce/Abstracts
+ * @package  WooCommerce\Abstracts
  */
 abstract class WC_Object_Query {
 

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -7,7 +7,7 @@
  *
  * @class       WC_Abstract_Order
  * @version     3.0.0
- * @package     WooCommerce/Classes
+ * @package     WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -6,7 +6,7 @@
  *
  * @class WC_Payment_Gateway
  * @version 2.1.0
- * @package WooCommerce/Abstracts
+ * @package WooCommerce\Abstracts
  */
 
 use Automattic\Jetpack\Constants;
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @class       WC_Payment_Gateway
  * @extends     WC_Settings_API
  * @version     2.1.0
- * @package     WooCommerce/Abstracts
+ * @package     WooCommerce\Abstracts
  */
 abstract class WC_Payment_Gateway extends WC_Settings_API {
 

--- a/includes/abstracts/abstract-wc-payment-token.php
+++ b/includes/abstracts/abstract-wc-payment-token.php
@@ -5,7 +5,7 @@
  * Generic payment tokens functionality which can be extended by idividual types of payment tokens.
  *
  * @class WC_Payment_Token
- * @package WooCommerce/Abstracts
+ * @package WooCommerce\Abstracts
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -23,7 +23,7 @@ require_once WC_ABSPATH . 'includes/legacy/abstract-wc-legacy-payment-token.php'
  * @class       WC_Payment_Token
  * @version     3.0.0
  * @since       2.6.0
- * @package     WooCommerce/Abstracts
+ * @package     WooCommerce\Abstracts
  */
 abstract class WC_Payment_Token extends WC_Legacy_Payment_Token {
 

--- a/includes/abstracts/abstract-wc-privacy.php
+++ b/includes/abstracts/abstract-wc-privacy.php
@@ -3,7 +3,7 @@
  * WooCommerce abstract privacy class.
  *
  * @since 3.4.0
- * @package WooCommerce/Abstracts
+ * @package WooCommerce\Abstracts
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
  * privacy data to be exported and privacy data to be deleted.
  *
  * @version  3.4.0
- * @package  WooCommerce/Abstracts
+ * @package  WooCommerce\Abstracts
  */
 abstract class WC_Abstract_Privacy {
 	/**

--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce product base class.
  *
- * @package WooCommerce/Abstracts
+ * @package WooCommerce\Abstracts
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -21,7 +21,7 @@ require_once WC_ABSPATH . 'includes/legacy/abstract-wc-legacy-product.php';
  * The WooCommerce product class handles individual product data.
  *
  * @version 3.0.0
- * @package WooCommerce/Abstracts
+ * @package WooCommerce\Abstracts
  */
 class WC_Product extends WC_Abstract_Legacy_Product {
 

--- a/includes/abstracts/abstract-wc-session.php
+++ b/includes/abstracts/abstract-wc-session.php
@@ -4,7 +4,7 @@
  *
  * @class       WC_Session
  * @version     2.0.0
- * @package     WooCommerce/Abstracts
+ * @package     WooCommerce\Abstracts
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -4,7 +4,7 @@
  *
  * Admin Settings API used by Integrations, Shipping Methods, and Payment Gateways.
  *
- * @package  WooCommerce/Abstracts
+ * @package  WooCommerce\Abstracts
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -3,7 +3,7 @@
  * Abstract shipping method
  *
  * @class WC_Shipping_Method
- * @package WooCommerce/Abstracts
+ * @package WooCommerce\Abstracts
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @class       WC_Shipping_Method
  * @version     3.0.0
- * @package     WooCommerce/Abstracts
+ * @package     WooCommerce\Abstracts
  */
 abstract class WC_Shipping_Method extends WC_Settings_API {
 

--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -3,7 +3,7 @@
  * Abstract widget class
  *
  * @class WC_Widget
- * @package  WooCommerce/Abstracts
+ * @package  WooCommerce\Abstracts
  */
 
 use Automattic\Jetpack\Constants;
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * WC_Widget
  *
- * @package  WooCommerce/Abstracts
+ * @package  WooCommerce\Abstracts
  * @version  2.5.0
  * @extends  WP_Widget
  */

--- a/includes/abstracts/class-wc-background-process.php
+++ b/includes/abstracts/class-wc-background-process.php
@@ -5,7 +5,7 @@
  * Uses https://github.com/A5hleyRich/wp-background-processing to handle DB
  * updates in the background.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -2,7 +2,7 @@
 /**
  * Addons Page
  *
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  * @version  2.5.0
  */
 

--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -2,7 +2,7 @@
 /**
  * Load assets
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  * @version 3.7.0
  */
 

--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -4,7 +4,7 @@
  *
  * The attributes section lets users add custom attributes to assign to products - they can also be used in the "Filter Products by Attribute" widget.
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  * @version 2.3.0
  */
 

--- a/includes/admin/class-wc-admin-customize.php
+++ b/includes/admin/class-wc-admin-customize.php
@@ -4,7 +4,7 @@
  *
  * @author   WooCommerce
  * @category Admin
- * @package  WooCommerce/Admin/Customize
+ * @package  WooCommerce\Admin\Customize
  * @version  3.1.0
  */
 

--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -2,7 +2,7 @@
 /**
  * Admin Dashboard
  *
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     2.1.0
  */
 

--- a/includes/admin/class-wc-admin-duplicate-product.php
+++ b/includes/admin/class-wc-admin-duplicate-product.php
@@ -2,7 +2,7 @@
 /**
  * Duplicate product functionality
  *
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     3.0.0
  */
 

--- a/includes/admin/class-wc-admin-exporters.php
+++ b/includes/admin/class-wc-admin-exporters.php
@@ -2,7 +2,7 @@
 /**
  * Init WooCommerce data exporters.
  *
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     3.1.0
  */
 

--- a/includes/admin/class-wc-admin-help.php
+++ b/includes/admin/class-wc-admin-help.php
@@ -2,7 +2,7 @@
 /**
  * Add some content to the help tab
  *
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     2.1.0
  */
 

--- a/includes/admin/class-wc-admin-importers.php
+++ b/includes/admin/class-wc-admin-importers.php
@@ -2,7 +2,7 @@
 /**
  * Init WooCommerce data importers.
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/admin/class-wc-admin-log-table-list.php
+++ b/includes/admin/class-wc-admin-log-table-list.php
@@ -4,7 +4,7 @@
  *
  * @author   WooThemes
  * @category Admin
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  * @version  1.0.0
  */
 

--- a/includes/admin/class-wc-admin-meta-boxes.php
+++ b/includes/admin/class-wc-admin-meta-boxes.php
@@ -4,7 +4,7 @@
  *
  * Sets up the write panels used by products and orders (custom post types).
  *
- * @package WooCommerce/Admin/Meta Boxes
+ * @package WooCommerce\Admin\Meta Boxes
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/admin/class-wc-admin-permalink-settings.php
+++ b/includes/admin/class-wc-admin-permalink-settings.php
@@ -5,7 +5,7 @@
  * @class       WC_Admin_Permalink_Settings
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     2.3.0
  */
 

--- a/includes/admin/class-wc-admin-pointers.php
+++ b/includes/admin/class-wc-admin-pointers.php
@@ -4,7 +4,7 @@
  *
  * @author   WooThemes
  * @category Admin
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  * @version  2.4.0
  */
 

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -2,7 +2,7 @@
 /**
  * Post Types Admin
  *
- * @package  WooCommerce\admin
+ * @package  WooCommerce\Admin
  * @version  3.3.0
  */
 

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -2,7 +2,7 @@
 /**
  * Post Types Admin
  *
- * @package  WooCommerce/admin
+ * @package  WooCommerce\admin
  * @version  3.3.0
  */
 

--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -4,7 +4,7 @@
  *
  * @author   WooThemes
  * @category Admin
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  * @version  2.4.0
  */
 

--- a/includes/admin/class-wc-admin-reports.php
+++ b/includes/admin/class-wc-admin-reports.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     2.0.0
  */
 

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Admin Settings Class
  *
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  * @version  3.4.0
  */
 

--- a/includes/admin/class-wc-admin-setup-wizard.php
+++ b/includes/admin/class-wc-admin-setup-wizard.php
@@ -4,7 +4,7 @@
  *
  * Takes new users through some basic steps to setup their store.
  *
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     2.6.0
  */
 

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -2,7 +2,7 @@
 /**
  * Debug/Status page
  *
- * @package WooCommerce/Admin/System Status
+ * @package WooCommerce\Admin\System Status
  * @version 2.2.0
  */
 

--- a/includes/admin/class-wc-admin-taxonomies.php
+++ b/includes/admin/class-wc-admin-taxonomies.php
@@ -4,7 +4,7 @@
  *
  * @class    WC_Admin_Taxonomies
  * @version  2.3.10
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -3,7 +3,7 @@
  * WooCommerce Admin
  *
  * @class    WC_Admin
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  * @version  2.6.0
  */
 

--- a/includes/admin/helper/class-wc-helper-api.php
+++ b/includes/admin/helper/class-wc-helper-api.php
@@ -3,7 +3,7 @@
  * WooCommerce Admin
  *
  * @class    WC_Helper_API
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -3,7 +3,7 @@
  * The update helper for WooCommerce.com plugins.
  *
  * @class WC_Helper_Updater
- * @package WooCommerce/Admin.
+ * @package WooCommerce\Admin.
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -3,7 +3,7 @@
  * WooCommerce Admin
  *
  * @class    WC_Helper
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/admin/helper/views/html-section-nav.php
+++ b/includes/admin/helper/views/html-section-nav.php
@@ -2,7 +2,7 @@
 /**
  * Helper admin navigation.
  *
- * @package WooCommerce/Helper
+ * @package WooCommerce\Helper
  */
 
 defined( 'ABSPATH' ) || exit(); ?>

--- a/includes/admin/importers/class-wc-product-csv-importer-controller.php
+++ b/includes/admin/importers/class-wc-product-csv-importer-controller.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WP_Importer' ) ) {
 /**
  * Product importer controller - handles file upload and forms in admin.
  *
- * @package     WooCommerce/Admin/Importers
+ * @package     WooCommerce\Admin\Importers
  * @version     3.1.0
  */
 class WC_Product_CSV_Importer_Controller {

--- a/includes/admin/importers/class-wc-tax-rate-importer.php
+++ b/includes/admin/importers/class-wc-tax-rate-importer.php
@@ -3,7 +3,7 @@
  * Tax importer class file
  *
  * @version 2.3.0
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -17,7 +17,7 @@ if ( ! class_exists( 'WP_Importer' ) ) {
 /**
  * Tax Rates importer - import tax rates and local tax rates into WooCommerce.
  *
- * @package     WooCommerce/Admin/Importers
+ * @package     WooCommerce\Admin\Importers
  * @version     2.3.0
  */
 class WC_Tax_Rate_Importer extends WP_Importer {

--- a/includes/admin/importers/views/html-product-csv-import-form.php
+++ b/includes/admin/importers/views/html-product-csv-import-form.php
@@ -2,7 +2,7 @@
 /**
  * Admin View: Product import form
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/list-tables/abstract-class-wc-admin-list-table.php
+++ b/includes/admin/list-tables/abstract-class-wc-admin-list-table.php
@@ -2,7 +2,7 @@
 /**
  * List tables.
  *
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  * @version  3.3.0
  */
 

--- a/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
@@ -2,7 +2,7 @@
 /**
  * List tables: coupons.
  *
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  * @version  3.3.0
  */
 

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -2,7 +2,7 @@
 /**
  * List tables: orders.
  *
- * @package WooCommerce\admin
+ * @package WooCommerce\Admin
  * @version 3.3.0
  */
 

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -2,7 +2,7 @@
 /**
  * List tables: products.
  *
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  * @version  3.3.0
  */
 

--- a/includes/admin/marketplace-suggestions/views/container.php
+++ b/includes/admin/marketplace-suggestions/views/container.php
@@ -2,7 +2,7 @@
 /**
  * Marketplace suggestions container
  *
- * @package  WooCommerce/Templates
+ * @package  WooCommerce\Templates
  * @version  3.6.0
  */
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Meta Boxes
+ * @package     WooCommerce\Admin\Meta Boxes
  * @version     2.1.0
  */
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Meta Boxes
+ * @package     WooCommerce\Admin\Meta Boxes
  * @version     2.1.0
  */
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Meta Boxes
+ * @package     WooCommerce\Admin\Meta Boxes
  * @version     2.2.0
  */
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-downloads.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-downloads.php
@@ -4,7 +4,7 @@
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Meta Boxes
+ * @package     WooCommerce\Admin\Meta Boxes
  * @version     2.1.0
  */
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Meta Boxes
+ * @package     WooCommerce\Admin\Meta Boxes
  * @version     2.1.0
  */
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -2,7 +2,7 @@
 /**
  * Order Notes
  *
- * @package WooCommerce/Admin/Meta Boxes
+ * @package WooCommerce\Admin\Meta Boxes
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -4,7 +4,7 @@
  *
  * Displays the product data box, tabbed, with several panels covering price, stock etc.
  *
- * @package  WooCommerce/Admin/Meta Boxes
+ * @package  WooCommerce\Admin\Meta Boxes
  * @version  3.0.0
  */
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-images.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Meta Boxes
+ * @package     WooCommerce\Admin\Meta Boxes
  * @version     2.1.0
  */
 

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-reviews.php
@@ -4,7 +4,7 @@
  *
  * Functions for displaying product reviews data meta box.
  *
- * @package WooCommerce/Admin/Meta Boxes
+ * @package WooCommerce\Admin\Meta Boxes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-short-description.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-short-description.php
@@ -4,7 +4,7 @@
  *
  * Replaces the standard excerpt box.
  *
- * @package     WooCommerce/Admin/Meta Boxes
+ * @package     WooCommerce\Admin\Meta Boxes
  * @version     2.1.0
  */
 

--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -2,7 +2,7 @@
 /**
  * Shows an order item
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  * @var object $item The item being displayed
  * @var int $item_id The id of the item being displayed
  */

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -2,7 +2,7 @@
 /**
  * Order items HTML for meta box.
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/meta-boxes/views/html-order-notes.php
+++ b/includes/admin/meta-boxes/views/html-order-notes.php
@@ -2,7 +2,7 @@
 /**
  * Order notes HTML for meta box.
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -2,12 +2,12 @@
 /**
  * Shows a shipping line
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  *
  * @var object $item The item being displayed
  * @var int $item_id The id of the item being displayed
  *
- * @package WooCommerce/Admin/Views
+ * @package WooCommerce\Admin\Views
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -2,7 +2,7 @@
 /**
  * Product general data panel.
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/meta-boxes/views/html-product-data-linked-products.php
+++ b/includes/admin/meta-boxes/views/html-product-data-linked-products.php
@@ -2,7 +2,7 @@
 /**
  * Linked product options.
  *
- * @package WooCommerce\admin
+ * @package WooCommerce\Admin
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/meta-boxes/views/html-product-data-linked-products.php
+++ b/includes/admin/meta-boxes/views/html-product-data-linked-products.php
@@ -2,7 +2,7 @@
 /**
  * Linked product options.
  *
- * @package WooCommerce/admin
+ * @package WooCommerce\admin
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/meta-boxes/views/html-product-data-panel.php
+++ b/includes/admin/meta-boxes/views/html-product-data-panel.php
@@ -2,7 +2,7 @@
 /**
  * Product data meta box.
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/plugin-updates/class-wc-plugin-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugin-updates.php
@@ -2,7 +2,7 @@
 /**
  * Class for displaying plugin warning notifications and determining 3rd party plugin compatibility.
  *
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     3.2.0
  */
 

--- a/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
@@ -2,7 +2,7 @@
 /**
  * Manages WooCommerce plugin updating on the Plugins screen.
  *
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     3.2.0
  */
 

--- a/includes/admin/plugin-updates/class-wc-updates-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-updates-screen-updates.php
@@ -2,7 +2,7 @@
 /**
  * Manages WooCommerce plugin updating on the Updates screen.
  *
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     3.2.0
  */
 

--- a/includes/admin/reports/class-wc-admin-report.php
+++ b/includes/admin/reports/class-wc-admin-report.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */
 class WC_Admin_Report {

--- a/includes/admin/reports/class-wc-report-coupon-usage.php
+++ b/includes/admin/reports/class-wc-report-coupon-usage.php
@@ -2,7 +2,7 @@
 /**
  * Coupon usage report functionality
  *
- * @package WooCommerce/Admin/Reports
+ * @package WooCommerce\Admin\Reports
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */
 class WC_Report_Coupon_Usage extends WC_Admin_Report {

--- a/includes/admin/reports/class-wc-report-customer-list.php
+++ b/includes/admin/reports/class-wc-report-customer-list.php
@@ -16,7 +16,7 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
 /**
  * WC_Report_Customer_List.
  *
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */
 class WC_Report_Customer_List extends WP_List_Table {

--- a/includes/admin/reports/class-wc-report-customers.php
+++ b/includes/admin/reports/class-wc-report-customers.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * WC_Report_Customers
  *
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */
 class WC_Report_Customers extends WC_Admin_Report {

--- a/includes/admin/reports/class-wc-report-downloads.php
+++ b/includes/admin/reports/class-wc-report-downloads.php
@@ -4,7 +4,7 @@
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     3.3.0
  */
 

--- a/includes/admin/reports/class-wc-report-low-in-stock.php
+++ b/includes/admin/reports/class-wc-report-low-in-stock.php
@@ -2,7 +2,7 @@
 /**
  * WC_Report_Low_In_Stock.
  *
- * @package WooCommerce/Admin/Reports
+ * @package WooCommerce\Admin\Reports
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/reports/class-wc-report-most-stocked.php
+++ b/includes/admin/reports/class-wc-report-most-stocked.php
@@ -2,7 +2,7 @@
 /**
  * WC_Report_Most_Stocked.
  *
- * @package WooCommerce/Admin/Reports
+ * @package WooCommerce\Admin\Reports
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/reports/class-wc-report-out-of-stock.php
+++ b/includes/admin/reports/class-wc-report-out-of-stock.php
@@ -2,7 +2,7 @@
 /**
  * WC_Report_Out_Of_Stock.
  *
- * @package WooCommerce/Admin/Reports
+ * @package WooCommerce\Admin\Reports
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/reports/class-wc-report-sales-by-category.php
+++ b/includes/admin/reports/class-wc-report-sales-by-category.php
@@ -2,7 +2,7 @@
 /**
  * Sales by category report functionality
  *
- * @package WooCommerce/Admin/Reporting
+ * @package WooCommerce\Admin\Reporting
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */
 class WC_Report_Sales_By_Category extends WC_Admin_Report {

--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -2,7 +2,7 @@
 /**
  * WC_Report_Sales_By_Date
  *
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */
 

--- a/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -2,7 +2,7 @@
 /**
  * Sales By Product Reporting
  *
- * @package WooCommerce/Admin/Reporting
+ * @package WooCommerce\Admin\Reporting
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * WC_Report_Sales_By_Product
  *
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */
 class WC_Report_Sales_By_Product extends WC_Admin_Report {

--- a/includes/admin/reports/class-wc-report-stock.php
+++ b/includes/admin/reports/class-wc-report-stock.php
@@ -13,7 +13,7 @@ if ( ! class_exists( 'WP_List_Table' ) ) {
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */
 class WC_Report_Stock extends WP_List_Table {

--- a/includes/admin/reports/class-wc-report-taxes-by-code.php
+++ b/includes/admin/reports/class-wc-report-taxes-by-code.php
@@ -2,7 +2,7 @@
 /**
  * Taxes by tax code report.
  *
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * WC_Report_Taxes_By_Code
  *
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */
 class WC_Report_Taxes_By_Code extends WC_Admin_Report {

--- a/includes/admin/reports/class-wc-report-taxes-by-date.php
+++ b/includes/admin/reports/class-wc-report-taxes-by-date.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin/Reports
+ * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */
 class WC_Report_Taxes_By_Date extends WC_Admin_Report {

--- a/includes/admin/settings/class-wc-settings-accounts.php
+++ b/includes/admin/settings/class-wc-settings-accounts.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Account Settings.
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/settings/class-wc-settings-advanced.php
+++ b/includes/admin/settings/class-wc-settings-advanced.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce advanced settings
  *
- * @package  WooCommerce/Admin
+ * @package  WooCommerce\Admin
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Email Settings
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  * @version 2.1.0
  */
 

--- a/includes/admin/settings/class-wc-settings-general.php
+++ b/includes/admin/settings/class-wc-settings-general.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce General Settings
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/settings/class-wc-settings-integrations.php
+++ b/includes/admin/settings/class-wc-settings-integrations.php
@@ -4,7 +4,7 @@
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     2.1.0
  */
 

--- a/includes/admin/settings/class-wc-settings-page.php
+++ b/includes/admin/settings/class-wc-settings-page.php
@@ -4,7 +4,7 @@
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     2.1.0
  */
 

--- a/includes/admin/settings/class-wc-settings-payment-gateways.php
+++ b/includes/admin/settings/class-wc-settings-payment-gateways.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Checkout Settings
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Product Settings
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  * @version 2.4.0
  */
 

--- a/includes/admin/settings/class-wc-settings-shipping.php
+++ b/includes/admin/settings/class-wc-settings-shipping.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Shipping Settings
  *
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     2.6.0
  */
 

--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -4,7 +4,7 @@
  *
  * @author      WooThemes
  * @category    Admin
- * @package     WooCommerce/Admin
+ * @package     WooCommerce\Admin
  * @version     2.1.0
  */
 

--- a/includes/admin/settings/views/html-admin-page-shipping-classes.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-classes.php
@@ -2,7 +2,7 @@
 /**
  * Shipping classes admin
  *
- * @package WooCommerce/Admin/Shipping
+ * @package WooCommerce\Admin\Shipping
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -2,7 +2,7 @@
 /**
  * Shipping zone admin
  *
- * @package WooCommerce/Admin/Shipping
+ * @package WooCommerce\Admin\Shipping
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/settings/views/html-keys-edit.php
+++ b/includes/admin/settings/views/html-keys-edit.php
@@ -2,7 +2,7 @@
 /**
  * Admin view: Edit API keys
  *
- * @package WooCommerce/Admin/Settings
+ * @package WooCommerce\Admin\Settings
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/settings/views/html-settings-tax.php
+++ b/includes/admin/settings/views/html-settings-tax.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * Admin view: Settings tax
+ *
+ * @package WooCommerce\Admin\Settings
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/admin/settings/views/html-webhooks-edit.php
+++ b/includes/admin/settings/views/html-webhooks-edit.php
@@ -2,7 +2,7 @@
 /**
  * Admin View: Edit Webhooks
  *
- * @package WooCommerce/Admin/Webhooks/Views
+ * @package WooCommerce\Admin\Webhooks\Views
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/settings/views/settings-tax.php
+++ b/includes/admin/settings/views/settings-tax.php
@@ -2,7 +2,7 @@
 /**
  * Tax settings.
  *
- * @package Settings.
+ * @package WooCommerce\Admin\Settings.
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -2,7 +2,7 @@
 /**
  * Admin View: Page - Addons
  *
- * @package WooCommerce/Admin
+ * @package WooCommerce\Admin
  * @var string $view
  * @var object $addons
  */

--- a/includes/admin/views/html-admin-page-product-export.php
+++ b/includes/admin/views/html-admin-page-product-export.php
@@ -2,7 +2,7 @@
 /**
  * Admin View: Product Export
  *
- * @package WooCommerce/Admin/Export
+ * @package WooCommerce\Admin\Export
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/views/html-admin-page-status-logs-db.php
+++ b/includes/admin/views/html-admin-page-status-logs-db.php
@@ -2,7 +2,7 @@
 /**
  * Admin View: Page - Status Database Logs
  *
- * @package WooCommerce/Admin/Logs
+ * @package WooCommerce\Admin\Logs
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/views/html-admin-page-status-logs.php
+++ b/includes/admin/views/html-admin-page-status-logs.php
@@ -2,7 +2,7 @@
 /**
  * Admin View: Page - Status Logs
  *
- * @package WooCommerce/Admin/Logs
+ * @package WooCommerce\Admin\Logs
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/views/html-notice-regenerating-lookup-table.php
+++ b/includes/admin/views/html-notice-regenerating-lookup-table.php
@@ -2,7 +2,7 @@
 /**
  * Admin View: Notice - Regenerating product lookup table.
  *
- * @package WooCommerce\admin
+ * @package WooCommerce\Admin
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/admin/views/html-notice-regenerating-lookup-table.php
+++ b/includes/admin/views/html-notice-regenerating-lookup-table.php
@@ -2,7 +2,7 @@
 /**
  * Admin View: Notice - Regenerating product lookup table.
  *
- * @package WooCommerce/admin
+ * @package WooCommerce\admin
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/admin/views/html-notice-template-check.php
+++ b/includes/admin/views/html-notice-template-check.php
@@ -2,7 +2,7 @@
 /**
  * Admin View: Notice - Template Check
  *
- * @package WooCommerce/Views
+ * @package WooCommerce\Views
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/views/html-quick-edit-product.php
+++ b/includes/admin/views/html-quick-edit-product.php
@@ -2,7 +2,7 @@
 /**
  * Admin View: Quick Edit Product
  *
- * @package admin.
+ * @package WooCommerce\Admin\Notices
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/admin/views/html-report-by-date.php
+++ b/includes/admin/views/html-report-by-date.php
@@ -2,7 +2,7 @@
 /**
  * Admin View: Report by Date (with date filters)
  *
- * @package WooCommerce/Admin/Reporting
+ * @package WooCommerce\Admin\Reporting
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Admin Functions
  *
- * @package  WooCommerce/Admin/Functions
+ * @package  WooCommerce\Admin\Functions
  * @version  2.4.0
  */
 

--- a/includes/admin/wc-meta-box-functions.php
+++ b/includes/admin/wc-meta-box-functions.php
@@ -4,7 +4,7 @@
  *
  * @author      WooThemes
  * @category    Core
- * @package     WooCommerce/Admin/Functions
+ * @package     WooCommerce\Admin\Functions
  * @version     2.3.0
  */
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -3,7 +3,7 @@
  * WooCommerce WC_AJAX. AJAX Event Handlers.
  *
  * @class   WC_AJAX
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -7,7 +7,7 @@
  * - Legacy REST API - Deprecated in 2.6.0. @see class-wc-legacy-api.php
  * - WP REST API - The main REST API in WooCommerce which is built on top of the WP REST API.
  *
- * @package WooCommerce/API
+ * @package WooCommerce\API
  * @since   2.0.0
  */
 

--- a/includes/class-wc-auth.php
+++ b/includes/class-wc-auth.php
@@ -4,7 +4,7 @@
  *
  * Handles wc-auth endpoint requests.
  *
- * @package WooCommerce/API
+ * @package WooCommerce\API
  * @since   2.4.0
  */
 

--- a/includes/class-wc-autoloader.php
+++ b/includes/class-wc-autoloader.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Autoloader.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 2.3.0
  */
 

--- a/includes/class-wc-background-emailer.php
+++ b/includes/class-wc-background-emailer.php
@@ -3,7 +3,7 @@
  * Background Emailer
  *
  * @version 3.0.1
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/class-wc-background-updater.php
+++ b/includes/class-wc-background-updater.php
@@ -4,7 +4,7 @@
  *
  * @version 2.6.0
  * @deprecated 3.6.0 Replaced with queue.
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -2,7 +2,7 @@
 /**
  * WC_Breadcrumb class.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 2.3.0
  */
 

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -2,7 +2,7 @@
 /**
  * WC_Cache_Helper class.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-cart-fees.php
+++ b/includes/class-wc-cart-fees.php
@@ -6,7 +6,7 @@
  *
  * We suggest using the action woocommerce_cart_calculate_fees hook for adding fees.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.2.0
  */
 

--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -2,7 +2,7 @@
 /**
  * Cart session handling class.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.2.0
  */
 

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -9,7 +9,7 @@
  * - if something is being stored e.g. item total, store unrounded. This is so taxes can be recalculated later accurately.
  * - if calculating a total, round (if settings allow).
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.2.0
  */
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -5,7 +5,7 @@
  * The WooCommerce cart class stores cart data and active coupons as well as handling customer sessions and some cart related urls.
  * The cart class also has a price calculation function which calls upon other classes to calculate totals.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 2.1.0
  */
 

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -4,7 +4,7 @@
  *
  * The WooCommerce checkout class handles the checkout process, collecting user data and processing the payment.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.4.0
  */
 

--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -4,7 +4,7 @@
  *
  * Handle comments (reviews and order notes).
  *
- * @package WooCommerce/Classes/Products
+ * @package WooCommerce\Classes\Products
  * @version 2.3.0
  */
 

--- a/includes/class-wc-coupon.php
+++ b/includes/class-wc-coupon.php
@@ -4,7 +4,7 @@
  *
  * The WooCommerce coupons class gets coupon data from storage and checks coupon validity.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  */
 

--- a/includes/class-wc-customer-download-log.php
+++ b/includes/class-wc-customer-download-log.php
@@ -2,7 +2,7 @@
 /**
  * Class for customer download logs.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.3.0
  * @since   3.3.0
  */

--- a/includes/class-wc-customer-download.php
+++ b/includes/class-wc-customer-download.php
@@ -2,7 +2,7 @@
 /**
  * Class for customer download permissions.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  * @since   3.0.0
  */

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -2,7 +2,7 @@
 /**
  * The WooCommerce customer class handles storage of the current customer's data, such as location.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  */
 

--- a/includes/class-wc-datetime.php
+++ b/includes/class-wc-datetime.php
@@ -4,7 +4,7 @@
  * timezone is absent
  *
  * @since   3.0.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -2,7 +2,7 @@
 /**
  * Discount calculation
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @since   3.2.0
  */
 

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -4,7 +4,7 @@
  *
  * Handle digital downloads.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 2.2.0
  */
 

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -4,7 +4,7 @@
  *
  * WooCommerce Emails Class which handles the sending on transactional emails and email templates. This class loads in available emails.
  *
- * @package WooCommerce/Classes/Emails
+ * @package WooCommerce\Classes\Emails
  * @version 2.3.0
  */
 

--- a/includes/class-wc-embed.php
+++ b/includes/class-wc-embed.php
@@ -3,7 +3,7 @@
  * WooCommerce product embed
  *
  * @version  2.4.11
- * @package  WooCommerce/Classes/Embed
+ * @package  WooCommerce\Classes\Embed
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -2,7 +2,7 @@
 /**
  * Handle frontend forms.
  *
- * @package WooCommerce/Classes/
+ * @package WooCommerce\Classes\
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -2,7 +2,7 @@
 /**
  * Handle frontend scripts
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 2.3.0
  */
 

--- a/includes/class-wc-geo-ip.php
+++ b/includes/class-wc-geo-ip.php
@@ -4,7 +4,7 @@
  *
  * This class is a fork of GeoIP class from MaxMind LLC.
  *
- * @package    WooCommerce/Classes
+ * @package    WooCommerce\Classes
  * @version    2.4.0
  * @deprecated 3.4.0
  */

--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -6,7 +6,7 @@
  *
  * This product includes GeoLite data created by MaxMind, available from http://www.maxmind.com.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.9.0
  */
 

--- a/includes/class-wc-https.php
+++ b/includes/class-wc-https.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @class    WC_HTTPS
  * @version  2.2.0
- * @package  WooCommerce/Classes
+ * @package  WooCommerce\Classes
  * @category Class
  * @author   WooThemes
  */

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -2,7 +2,7 @@
 /**
  * Installation related functions and actions.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  */
 

--- a/includes/class-wc-integrations.php
+++ b/includes/class-wc-integrations.php
@@ -5,7 +5,7 @@
  * Loads Integrations into WooCommerce.
  *
  * @version 3.9.0
- * @package WooCommerce/Classes/Integrations
+ * @package WooCommerce\Classes\Integrations
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-log-levels.php
+++ b/includes/class-wc-log-levels.php
@@ -3,7 +3,7 @@
  * Standard log levels
  *
  * @version 3.2.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -4,7 +4,7 @@
  *
  * @class          WC_Logger
  * @version        2.0.0
- * @package        WooCommerce/Classes
+ * @package        WooCommerce\Classes
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/class-wc-order-factory.php
+++ b/includes/class-wc-order-factory.php
@@ -5,7 +5,7 @@
  * The WooCommerce order factory creating the right order objects.
  *
  * @version 3.0.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-order-item-coupon.php
+++ b/includes/class-wc-order-item-coupon.php
@@ -2,7 +2,7 @@
 /**
  * Order Line Item (coupon)
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  * @since   3.0.0
  */

--- a/includes/class-wc-order-item-fee.php
+++ b/includes/class-wc-order-item-fee.php
@@ -5,7 +5,7 @@
  * Fee is an amount of money charged for a particular piece of work
  * or for a particular right or service, and not supposed to be negative.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  * @since   3.0.0
  */

--- a/includes/class-wc-order-item-meta.php
+++ b/includes/class-wc-order-item-meta.php
@@ -4,7 +4,7 @@
  *
  * A Simple class for managing order item meta so plugins add it in the correct format.
  *
- * @package     WooCommerce/Classes
+ * @package     WooCommerce\Classes
  * @deprecated  3.0.0 wc_display_item_meta function is used instead.
  * @version     2.4
  */

--- a/includes/class-wc-order-item-product.php
+++ b/includes/class-wc-order-item-product.php
@@ -2,7 +2,7 @@
 /**
  * Order Line Item (product)
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  * @since   3.0.0
  */

--- a/includes/class-wc-order-item-shipping.php
+++ b/includes/class-wc-order-item-shipping.php
@@ -2,7 +2,7 @@
 /**
  * Order Line Item (shipping)
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  * @since   3.0.0
  */

--- a/includes/class-wc-order-item-tax.php
+++ b/includes/class-wc-order-item-tax.php
@@ -2,7 +2,7 @@
 /**
  * Order Line Item (tax)
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  * @since   3.0.0
  */

--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -5,7 +5,7 @@
  * A class which represents an item within an order and handles CRUD.
  * Uses ArrayAccess to be BW compatible with WC_Orders::get_items().
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  * @since   3.0.0
  */

--- a/includes/class-wc-order-query.php
+++ b/includes/class-wc-order-query.php
@@ -3,7 +3,7 @@
  * Parameter-based Order querying
  * Args and usage: https://github.com/woocommerce/woocommerce/wiki/wc_get_orders-and-WC_Order_Query
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.1.0
  * @since   3.1.0
  */

--- a/includes/class-wc-order-refund.php
+++ b/includes/class-wc-order-refund.php
@@ -4,7 +4,7 @@
  * contain much of the same data.
  *
  * @version 3.0.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -5,7 +5,7 @@
  * Loads payment gateways via hooks for use in the store.
  *
  * @version 2.2.0
- * @package WooCommerce/Classes/Payment
+ * @package WooCommerce\Classes\Payment
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-payment-tokens.php
+++ b/includes/class-wc-payment-tokens.php
@@ -4,7 +4,7 @@
  *
  * An API for storing and managing tokens for gateways and customers.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  * @since   2.6.0
  */

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -4,7 +4,7 @@
  *
  * Standardises certain post data on save.
  *
- * @package WooCommerce/Classes/Data
+ * @package WooCommerce\Classes\Data
  * @version 2.2.0
  */
 

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -4,7 +4,7 @@
  *
  * Registers post types and taxonomies.
  *
- * @package WooCommerce/Classes/Products
+ * @package WooCommerce\Classes\Products
  * @version 2.5.0
  */
 

--- a/includes/class-wc-privacy-background-process.php
+++ b/includes/class-wc-privacy-background-process.php
@@ -2,7 +2,7 @@
 /**
  * Order cleanup background process.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.4.0
  * @since   3.4.0
  */

--- a/includes/class-wc-product-attribute.php
+++ b/includes/class-wc-product-attribute.php
@@ -5,7 +5,7 @@
  * Attributes can be global (taxonomy based) or local to the product itself.
  * Uses ArrayAccess to be BW compatible with previous ways of reading attributes.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  * @since   3.0.0
  */

--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -2,7 +2,7 @@
 /**
  * Represents a file which can be downloaded.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  * @since   3.0.0
  */

--- a/includes/class-wc-product-external.php
+++ b/includes/class-wc-product-external.php
@@ -4,7 +4,7 @@
  *
  * External products cannot be bought; they link offsite. Extends simple products.
  *
- * @package WooCommerce/Classes/Products
+ * @package WooCommerce\Classes\Products
  * @version 3.0.0
  */
 

--- a/includes/class-wc-product-factory.php
+++ b/includes/class-wc-product-factory.php
@@ -4,7 +4,7 @@
  *
  * The WooCommerce product factory creating the right product object.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  */
 

--- a/includes/class-wc-product-query.php
+++ b/includes/class-wc-product-query.php
@@ -4,7 +4,7 @@
  *
  * Args and usage: https://github.com/woocommerce/woocommerce/wiki/wc_get_products-and-WC_Product_Query
  *
- * @package  WooCommerce/Classes
+ * @package  WooCommerce\Classes
  * @version  3.2.0
  * @since    3.2.0
  */

--- a/includes/class-wc-product-simple.php
+++ b/includes/class-wc-product-simple.php
@@ -4,7 +4,7 @@
  *
  * The default product type kinda product.
  *
- * @package WooCommerce/Classes/Products
+ * @package WooCommerce\Classes\Products
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -5,7 +5,7 @@
  * The WooCommerce product class handles individual product data.
  *
  * @version 3.0.0
- * @package WooCommerce/Classes/Products
+ * @package WooCommerce\Classes\Products
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -4,7 +4,7 @@
  *
  * The WooCommerce product variation class handles product variation data.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.0.0
  */
 

--- a/includes/class-wc-rate-limiter.php
+++ b/includes/class-wc-rate-limiter.php
@@ -19,7 +19,7 @@
  *     add_notice( 'Sorry, too soon!' );
  * }
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.9.0
  * @since   3.9.0
  */

--- a/includes/class-wc-regenerate-images-request.php
+++ b/includes/class-wc-regenerate-images-request.php
@@ -2,7 +2,7 @@
 /**
  * All functionality to regenerate images in the background when settings change.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.3.0
  * @since   3.3.0
  */

--- a/includes/class-wc-regenerate-images.php
+++ b/includes/class-wc-regenerate-images.php
@@ -4,7 +4,7 @@
  *
  * All functionality pertaining to regenerating product images in realtime.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.5.0
  * @since   3.3.0
  */

--- a/includes/class-wc-register-wp-admin-settings.php
+++ b/includes/class-wc-register-wp-admin-settings.php
@@ -2,7 +2,7 @@
 /**
  * Take settings registered for WP-Admin and hooks them up to the REST API
  *
- * @package  WooCommerce/Classes
+ * @package  WooCommerce\Classes
  * @version  3.0.0
  * @since    3.0.0
  */

--- a/includes/class-wc-rest-authentication.php
+++ b/includes/class-wc-rest-authentication.php
@@ -2,7 +2,7 @@
 /**
  * REST API Authentication
  *
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.6.0
  */
 

--- a/includes/class-wc-rest-exception.php
+++ b/includes/class-wc-rest-exception.php
@@ -4,7 +4,7 @@
  *
  * Extends Exception to provide additional data.
  *
- * @package WooCommerce/API
+ * @package WooCommerce\API
  * @since   2.6.0
  */
 

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -7,7 +7,7 @@
  *
  * @class    WC_Session_Handler
  * @version  2.5.0
- * @package  WooCommerce/Classes
+ * @package  WooCommerce\Classes
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/class-wc-shipping-rate.php
+++ b/includes/class-wc-shipping-rate.php
@@ -4,7 +4,7 @@
  *
  * Simple Class for storing rates.
  *
- * @package WooCommerce/Classes/Shipping
+ * @package WooCommerce\Classes\Shipping
  * @since   2.6.0
  */
 

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -4,7 +4,7 @@
  *
  * @since   2.6.0
  * @version 3.0.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-shipping-zones.php
+++ b/includes/class-wc-shipping-zones.php
@@ -2,7 +2,7 @@
 /**
  * Handles storage and retrieval of shipping zones
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.3.0
  * @since   2.6.0
  */

--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -5,7 +5,7 @@
  * Handles shipping and loads shipping methods via hooks.
  *
  * @version 2.6.0
- * @package WooCommerce/Classes/Shipping
+ * @package WooCommerce\Classes\Shipping
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -2,7 +2,7 @@
 /**
  * Shortcodes
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @version 3.2.0
  */
 

--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -2,7 +2,7 @@
 /**
  * Structured data's handler and generator using JSON-LD format.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  * @since   3.0.0
  * @version 3.0.0
  */

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -2,7 +2,7 @@
 /**
  * Tax calculation and rate finding class.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -2,7 +2,7 @@
 /**
  * Template Loader
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -7,7 +7,7 @@
  *
  * @class WC_Tracker
  * @since 2.3.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -7,7 +7,7 @@
  * Webhooks are enqueued to their associated actions, delivered, and logged.
  *
  * @version  3.2.0
- * @package  WooCommerce/Webhooks
+ * @package  WooCommerce\Webhooks
  * @since    2.2.0
  */
 

--- a/includes/cli/class-wc-cli-rest-command.php
+++ b/includes/cli/class-wc-cli-rest-command.php
@@ -2,7 +2,7 @@
 /**
  * WP_CLI_Rest_Command class file.
  *
- * @package WooCommerce\Cli
+ * @package WooCommerce\CLI
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/data-stores/abstract-wc-order-data-store-cpt.php
+++ b/includes/data-stores/abstract-wc-order-data-store-cpt.php
@@ -2,7 +2,7 @@
 /**
  * Abstract_WC_Order_Data_Store_CPT class file.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/data-stores/class-wc-coupon-data-store-cpt.php
+++ b/includes/data-stores/class-wc-coupon-data-store-cpt.php
@@ -2,7 +2,7 @@
 /**
  * Class WC_Coupon_Data_Store_CPT file.
  *
- * @package WooCommerce\DataStore
+ * @package WooCommerce\DataStores
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/data-stores/class-wc-data-store-wp.php
+++ b/includes/data-stores/class-wc-data-store-wp.php
@@ -6,7 +6,7 @@
  * your own meta handling functions.
  *
  * @version 3.0.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -2,7 +2,7 @@
 /**
  * WC_Order_Data_Store_CPT class file.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -2,7 +2,7 @@
 /**
  * WC_Product_Data_Store_CPT class file.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/data-stores/class-wc-product-variable-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variable-data-store-cpt.php
@@ -2,7 +2,7 @@
 /**
  * File for WC Variable Product Data Store class.
  *
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/data-stores/class-wc-webhook-data-store.php
+++ b/includes/data-stores/class-wc-webhook-data-store.php
@@ -3,7 +3,7 @@
  * Webhook Data Store
  *
  * @version  3.3.0
- * @package  WooCommerce/Classes/Data_Store
+ * @package  WooCommerce\Classes\Data_Store
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/emails/class-wc-email-cancelled-order.php
+++ b/includes/emails/class-wc-email-cancelled-order.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_Cancelled_Order', false ) ) :
 	 *
 	 * @class       WC_Email_Cancelled_Order
 	 * @version     2.2.7
-	 * @package     WooCommerce/Classes/Emails
+	 * @package     WooCommerce\Classes\Emails
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Cancelled_Order extends WC_Email {

--- a/includes/emails/class-wc-email-customer-completed-order.php
+++ b/includes/emails/class-wc-email-customer-completed-order.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_Customer_Completed_Order', false ) ) :
 	 *
 	 * @class       WC_Email_Customer_Completed_Order
 	 * @version     2.0.0
-	 * @package     WooCommerce/Classes/Emails
+	 * @package     WooCommerce\Classes\Emails
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_Completed_Order extends WC_Email {

--- a/includes/emails/class-wc-email-customer-invoice.php
+++ b/includes/emails/class-wc-email-customer-invoice.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_Customer_Invoice', false ) ) :
 	 *
 	 * @class       WC_Email_Customer_Invoice
 	 * @version     3.5.0
-	 * @package     WooCommerce/Classes/Emails
+	 * @package     WooCommerce\Classes\Emails
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_Invoice extends WC_Email {

--- a/includes/emails/class-wc-email-customer-new-account.php
+++ b/includes/emails/class-wc-email-customer-new-account.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_Customer_New_Account', false ) ) :
 	 *
 	 * @class       WC_Email_Customer_New_Account
 	 * @version     3.5.0
-	 * @package     WooCommerce/Classes/Emails
+	 * @package     WooCommerce\Classes\Emails
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_New_Account extends WC_Email {

--- a/includes/emails/class-wc-email-customer-note.php
+++ b/includes/emails/class-wc-email-customer-note.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_Customer_Note', false ) ) :
 	 *
 	 * @class       WC_Email_Customer_Note
 	 * @version     3.5.0
-	 * @package     WooCommerce/Classes/Emails
+	 * @package     WooCommerce\Classes\Emails
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_Note extends WC_Email {

--- a/includes/emails/class-wc-email-customer-on-hold-order.php
+++ b/includes/emails/class-wc-email-customer-on-hold-order.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_Customer_On_Hold_Order', false ) ) :
 	 *
 	 * @class       WC_Email_Customer_On_Hold_Order
 	 * @version     2.6.0
-	 * @package     WooCommerce/Classes/Emails
+	 * @package     WooCommerce\Classes\Emails
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_On_Hold_Order extends WC_Email {

--- a/includes/emails/class-wc-email-customer-processing-order.php
+++ b/includes/emails/class-wc-email-customer-processing-order.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_Customer_Processing_Order', false ) ) :
 	 *
 	 * @class       WC_Email_Customer_Processing_Order
 	 * @version     3.5.0
-	 * @package     WooCommerce/Classes/Emails
+	 * @package     WooCommerce\Classes\Emails
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_Processing_Order extends WC_Email {

--- a/includes/emails/class-wc-email-customer-refunded-order.php
+++ b/includes/emails/class-wc-email-customer-refunded-order.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_Customer_Refunded_Order', false ) ) :
 	 *
 	 * @class    WC_Email_Customer_Refunded_Order
 	 * @version  3.5.0
-	 * @package  WooCommerce/Classes/Emails
+	 * @package  WooCommerce\Classes\Emails
 	 * @extends  WC_Email
 	 */
 	class WC_Email_Customer_Refunded_Order extends WC_Email {

--- a/includes/emails/class-wc-email-customer-reset-password.php
+++ b/includes/emails/class-wc-email-customer-reset-password.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_Customer_Reset_Password', false ) ) :
 	 *
 	 * @class       WC_Email_Customer_Reset_Password
 	 * @version     3.5.0
-	 * @package     WooCommerce/Classes/Emails
+	 * @package     WooCommerce\Classes\Emails
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Customer_Reset_Password extends WC_Email {

--- a/includes/emails/class-wc-email-failed-order.php
+++ b/includes/emails/class-wc-email-failed-order.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_Failed_Order', false ) ) :
 	 *
 	 * @class       WC_Email_Failed_Order
 	 * @version     2.5.0
-	 * @package     WooCommerce/Classes/Emails
+	 * @package     WooCommerce\Classes\Emails
 	 * @extends     WC_Email
 	 */
 	class WC_Email_Failed_Order extends WC_Email {

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -18,7 +18,7 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 	 *
 	 * @class       WC_Email_New_Order
 	 * @version     2.0.0
-	 * @package     WooCommerce/Classes/Emails
+	 * @package     WooCommerce\Classes\Emails
 	 * @extends     WC_Email
 	 */
 	class WC_Email_New_Order extends WC_Email {

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -20,7 +20,7 @@ if ( class_exists( 'WC_Email', false ) ) {
  *
  * @class       WC_Email
  * @version     2.5.0
- * @package     WooCommerce/Classes/Emails
+ * @package     WooCommerce\Classes\Emails
  * @extends     WC_Settings_API
  */
 class WC_Email extends WC_Settings_API {

--- a/includes/export/abstract-wc-csv-batch-exporter.php
+++ b/includes/export/abstract-wc-csv-batch-exporter.php
@@ -4,7 +4,7 @@
  *
  * Based on https://pippinsplugins.com/batch-processing-for-big-data/
  *
- * @package  WooCommerce/Export
+ * @package  WooCommerce\Export
  * @version  3.1.0
  */
 

--- a/includes/export/abstract-wc-csv-exporter.php
+++ b/includes/export/abstract-wc-csv-exporter.php
@@ -2,7 +2,7 @@
 /**
  * Handles CSV export.
  *
- * @package  WooCommerce/Export
+ * @package  WooCommerce\Export
  * @version  3.1.0
  */
 

--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -2,7 +2,7 @@
 /**
  * Handles product CSV export.
  *
- * @package WooCommerce/Export
+ * @package WooCommerce\Export
  * @version 3.1.0
  */
 

--- a/includes/gateways/bacs/class-wc-gateway-bacs.php
+++ b/includes/gateways/bacs/class-wc-gateway-bacs.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @class       WC_Gateway_BACS
  * @extends     WC_Payment_Gateway
  * @version     2.1.0
- * @package     WooCommerce/Classes/Payment
+ * @package     WooCommerce\Classes\Payment
  */
 class WC_Gateway_BACS extends WC_Payment_Gateway {
 

--- a/includes/gateways/cheque/class-wc-gateway-cheque.php
+++ b/includes/gateways/cheque/class-wc-gateway-cheque.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @class       WC_Gateway_Cheque
  * @extends     WC_Payment_Gateway
  * @version     2.1.0
- * @package     WooCommerce/Classes/Payment
+ * @package     WooCommerce\Classes\Payment
  */
 class WC_Gateway_Cheque extends WC_Payment_Gateway {
 

--- a/includes/gateways/class-wc-payment-gateway-cc.php
+++ b/includes/gateways/class-wc-payment-gateway-cc.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Credit Card Payment Gateway
  *
  * @since       2.6.0
- * @package     WooCommerce/Classes
+ * @package     WooCommerce\Classes
  */
 class WC_Payment_Gateway_CC extends WC_Payment_Gateway {
 

--- a/includes/gateways/class-wc-payment-gateway-echeck.php
+++ b/includes/gateways/class-wc-payment-gateway-echeck.php
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Class for eCheck Payment Gateway
  *
  * @since       2.6.0
- * @package     WooCommerce/Classes
+ * @package     WooCommerce\Classes
  */
 class WC_Payment_Gateway_ECheck extends WC_Payment_Gateway {
 

--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -19,7 +19,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @class       WC_Gateway_COD
  * @extends     WC_Payment_Gateway
  * @version     2.1.0
- * @package     WooCommerce/Classes/Payment
+ * @package     WooCommerce\Classes\Payment
  */
 class WC_Gateway_COD extends WC_Payment_Gateway {
 

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -7,7 +7,7 @@
  * @class       WC_Gateway_Paypal
  * @extends     WC_Payment_Gateway
  * @version     2.3.0
- * @package     WooCommerce/Classes/Payment
+ * @package     WooCommerce\Classes\Payment
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-ipn-handler.php
@@ -2,7 +2,7 @@
 /**
  * Handles responses from PayPal IPN.
  *
- * @package WooCommerce/PayPal
+ * @package WooCommerce\PayPal
  * @version 3.3.0
  */
 

--- a/includes/gateways/paypal/includes/settings-paypal.php
+++ b/includes/gateways/paypal/includes/settings-paypal.php
@@ -2,7 +2,7 @@
 /**
  * Settings for PayPal Gateway.
  *
- * @package WooCommerce/Classes/Payment
+ * @package WooCommerce\Classes\Payment
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -2,7 +2,7 @@
 /**
  * Abstract Product importer
  *
- * @package  WooCommerce/Import
+ * @package  WooCommerce\Import
  * @version  3.1.0
  */
 

--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Product CSV importer
  *
- * @package WooCommerce/Import
+ * @package WooCommerce\Import
  * @version 3.1.0
  */
 

--- a/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-database-service.php
+++ b/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-database-service.php
@@ -3,7 +3,7 @@
  * The database service class file.
  *
  * @version 3.9.0
- * @package WooCommerce/Integrations
+ * @package WooCommerce\Integrations
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
+++ b/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
@@ -3,7 +3,7 @@
  * MaxMind Geolocation Integration
  *
  * @version 3.9.0
- * @package WooCommerce/Integrations
+ * @package WooCommerce\Integrations
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/interfaces/class-wc-abstract-order-data-store-interface.php
+++ b/includes/interfaces/class-wc-abstract-order-data-store-interface.php
@@ -3,7 +3,7 @@
  * Order Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interfaces
+ * @package WooCommerce\Interfaces
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-coupon-data-store-interface.php
+++ b/includes/interfaces/class-wc-coupon-data-store-interface.php
@@ -3,7 +3,7 @@
  * Coupon Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interfaces
+ * @package WooCommerce\Interfaces
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-customer-data-store-interface.php
+++ b/includes/interfaces/class-wc-customer-data-store-interface.php
@@ -3,7 +3,7 @@
  * Customer Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-customer-download-data-store-interface.php
+++ b/includes/interfaces/class-wc-customer-download-data-store-interface.php
@@ -3,7 +3,7 @@
  * Customer Download Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-customer-download-log-data-store-interface.php
+++ b/includes/interfaces/class-wc-customer-download-log-data-store-interface.php
@@ -3,7 +3,7 @@
  * Customer Download Log Data Store Interface
  *
  * @version 3.3.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-importer-interface.php
+++ b/includes/interfaces/class-wc-importer-interface.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Importer Interface
  *
- * @package  WooCommerce/Interface
+ * @package  WooCommerce\Interface
  * @version  3.1.0
  */
 

--- a/includes/interfaces/class-wc-log-handler-interface.php
+++ b/includes/interfaces/class-wc-log-handler-interface.php
@@ -3,7 +3,7 @@
  * Log Handler Interface
  *
  * @version 3.3.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-logger-interface.php
+++ b/includes/interfaces/class-wc-logger-interface.php
@@ -3,7 +3,7 @@
  * Logger Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-object-data-store-interface.php
+++ b/includes/interfaces/class-wc-object-data-store-interface.php
@@ -3,7 +3,7 @@
  * Object Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-order-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-data-store-interface.php
@@ -3,7 +3,7 @@
  * Order Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-order-item-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-item-data-store-interface.php
@@ -3,7 +3,7 @@
  * Order Item Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-order-item-product-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-item-product-data-store-interface.php
@@ -3,7 +3,7 @@
  * Order Item Product Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-order-item-type-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-item-type-data-store-interface.php
@@ -3,7 +3,7 @@
  * Order Item Type Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-order-refund-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-refund-data-store-interface.php
@@ -3,7 +3,7 @@
  * Order Refund Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-payment-token-data-store-interface.php
+++ b/includes/interfaces/class-wc-payment-token-data-store-interface.php
@@ -3,7 +3,7 @@
  * Payment Token Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-product-data-store-interface.php
+++ b/includes/interfaces/class-wc-product-data-store-interface.php
@@ -3,7 +3,7 @@
  * Product Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-product-variable-data-store-interface.php
+++ b/includes/interfaces/class-wc-product-variable-data-store-interface.php
@@ -3,7 +3,7 @@
  * Product Variable Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-queue-interface.php
+++ b/includes/interfaces/class-wc-queue-interface.php
@@ -3,7 +3,7 @@
  * Queue Interface
  *
  * @version 3.5.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-shipping-zone-data-store-interface.php
+++ b/includes/interfaces/class-wc-shipping-zone-data-store-interface.php
@@ -3,7 +3,7 @@
  * Shipping Zone Data Store Interface
  *
  * @version 3.0.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/interfaces/class-wc-webhooks-data-store-interface.php
+++ b/includes/interfaces/class-wc-webhooks-data-store-interface.php
@@ -3,7 +3,7 @@
  * Webhook Data Store Interface
  *
  * @version  3.2.0
- * @package  WooCommerce/Interface
+ * @package  WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/legacy/abstract-wc-legacy-order.php
+++ b/includes/legacy/abstract-wc-legacy-order.php
@@ -10,7 +10,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This class will be removed in future versions.
  *
  * @version	 3.0.0
- * @package	 WooCommerce/Abstracts
+ * @package	 WooCommerce\Abstracts
  * @category	Abstract Class
  * @author	  WooThemes
  */

--- a/includes/legacy/abstract-wc-legacy-payment-token.php
+++ b/includes/legacy/abstract-wc-legacy-payment-token.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * directly on the object.
  *
  * @version  3.0.0
- * @package  WooCommerce/Classes
+ * @package  WooCommerce\Classes
  * @category Class
  * @author   WooCommerce
  */

--- a/includes/legacy/abstract-wc-legacy-product.php
+++ b/includes/legacy/abstract-wc-legacy-product.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * This class will be removed in future versions.
  *
  * @version  3.0.0
- * @package  WooCommerce/Abstracts
+ * @package  WooCommerce\Abstracts
  * @category Abstract Class
  * @author   WooThemes
  */

--- a/includes/legacy/api/class-wc-rest-legacy-coupons-controller.php
+++ b/includes/legacy/api/class-wc-rest-legacy-coupons-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Legacy Coupons controller class.
  *
- * @package WooCommerce/API
+ * @package WooCommerce\API
  * @extends WC_REST_CRUD_Controller
  */
 class WC_REST_Legacy_Coupons_Controller extends WC_REST_CRUD_Controller {

--- a/includes/legacy/api/class-wc-rest-legacy-orders-controller.php
+++ b/includes/legacy/api/class-wc-rest-legacy-orders-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Legacy Orders controller class.
  *
- * @package WooCommerce/API
+ * @package WooCommerce\API
  * @extends WC_REST_CRUD_Controller
  */
 class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {

--- a/includes/legacy/api/class-wc-rest-legacy-products-controller.php
+++ b/includes/legacy/api/class-wc-rest-legacy-products-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Legacy Products controller class.
  *
- * @package WooCommerce/API
+ * @package WooCommerce\API
  * @extends WC_REST_CRUD_Controller
  */
 class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {

--- a/includes/legacy/api/v1/class-wc-api-authentication.php
+++ b/includes/legacy/api/v1/class-wc-api-authentication.php
@@ -4,7 +4,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.1.0
  * @version  2.4.0
  */

--- a/includes/legacy/api/v1/class-wc-api-coupons.php
+++ b/includes/legacy/api/v1/class-wc-api-coupons.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-customers.php
+++ b/includes/legacy/api/v1/class-wc-api-customers.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-json-handler.php
+++ b/includes/legacy/api/v1/class-wc-api-json-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-orders.php
+++ b/includes/legacy/api/v1/class-wc-api-orders.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-products.php
+++ b/includes/legacy/api/v1/class-wc-api-products.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     3.0
  */

--- a/includes/legacy/api/v1/class-wc-api-reports.php
+++ b/includes/legacy/api/v1/class-wc-api-reports.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-resource.php
+++ b/includes/legacy/api/v1/class-wc-api-resource.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-server.php
+++ b/includes/legacy/api/v1/class-wc-api-server.php
@@ -9,7 +9,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-xml-handler.php
+++ b/includes/legacy/api/v1/class-wc-api-xml-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/interface-wc-api-handler.php
+++ b/includes/legacy/api/v1/interface-wc-api-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v2/class-wc-api-authentication.php
+++ b/includes/legacy/api/v2/class-wc-api-authentication.php
@@ -4,7 +4,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.1.0
  * @version  2.4.0
  */

--- a/includes/legacy/api/v2/class-wc-api-coupons.php
+++ b/includes/legacy/api/v2/class-wc-api-coupons.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-customers.php
+++ b/includes/legacy/api/v2/class-wc-api-customers.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.2
  */
 

--- a/includes/legacy/api/v2/class-wc-api-exception.php
+++ b/includes/legacy/api/v2/class-wc-api-exception.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.2
  */
 

--- a/includes/legacy/api/v2/class-wc-api-json-handler.php
+++ b/includes/legacy/api/v2/class-wc-api-json-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-orders.php
+++ b/includes/legacy/api/v2/class-wc-api-orders.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-products.php
+++ b/includes/legacy/api/v2/class-wc-api-products.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     3.0
  */

--- a/includes/legacy/api/v2/class-wc-api-reports.php
+++ b/includes/legacy/api/v2/class-wc-api-reports.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-resource.php
+++ b/includes/legacy/api/v2/class-wc-api-resource.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-server.php
+++ b/includes/legacy/api/v2/class-wc-api-server.php
@@ -9,7 +9,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-webhooks.php
+++ b/includes/legacy/api/v2/class-wc-api-webhooks.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.2
  */
 

--- a/includes/legacy/api/v2/interface-wc-api-handler.php
+++ b/includes/legacy/api/v2/interface-wc-api-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-authentication.php
+++ b/includes/legacy/api/v3/class-wc-api-authentication.php
@@ -4,7 +4,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.1.0
  * @version  2.4.0
  */

--- a/includes/legacy/api/v3/class-wc-api-coupons.php
+++ b/includes/legacy/api/v3/class-wc-api-coupons.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-customers.php
+++ b/includes/legacy/api/v3/class-wc-api-customers.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.2
  */
 

--- a/includes/legacy/api/v3/class-wc-api-exception.php
+++ b/includes/legacy/api/v3/class-wc-api-exception.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.2
  */
 

--- a/includes/legacy/api/v3/class-wc-api-json-handler.php
+++ b/includes/legacy/api/v3/class-wc-api-json-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-orders.php
+++ b/includes/legacy/api/v3/class-wc-api-orders.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-products.php
+++ b/includes/legacy/api/v3/class-wc-api-products.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  * @version     3.0
  */

--- a/includes/legacy/api/v3/class-wc-api-reports.php
+++ b/includes/legacy/api/v3/class-wc-api-reports.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-resource.php
+++ b/includes/legacy/api/v3/class-wc-api-resource.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-server.php
+++ b/includes/legacy/api/v3/class-wc-api-server.php
@@ -9,7 +9,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-taxes.php
+++ b/includes/legacy/api/v3/class-wc-api-taxes.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.5.0
  */
 

--- a/includes/legacy/api/v3/class-wc-api-webhooks.php
+++ b/includes/legacy/api/v3/class-wc-api-webhooks.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.2
  */
 

--- a/includes/legacy/api/v3/interface-wc-api-handler.php
+++ b/includes/legacy/api/v3/interface-wc-api-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce/API
+ * @package     WooCommerce\API
  * @since       2.1
  */
 

--- a/includes/legacy/class-wc-legacy-api.php
+++ b/includes/legacy/class-wc-legacy-api.php
@@ -4,7 +4,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce/API
+ * @package  WooCommerce\API
  * @since    2.6
  */
 

--- a/includes/legacy/class-wc-legacy-cart.php
+++ b/includes/legacy/class-wc-legacy-cart.php
@@ -6,7 +6,7 @@
  * This class will be removed in future versions.
  *
  * @version  3.2.0
- * @package  WooCommerce/Classes
+ * @package  WooCommerce\Classes
  * @category Class
  * @author   Automattic
  */

--- a/includes/legacy/class-wc-legacy-coupon.php
+++ b/includes/legacy/class-wc-legacy-coupon.php
@@ -11,7 +11,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @class       WC_Legacy_Coupon
  * @version     3.0.0
- * @package     WooCommerce/Classes
+ * @package     WooCommerce\Classes
  * @category    Class
  * @author      WooThemes
  */

--- a/includes/legacy/class-wc-legacy-customer.php
+++ b/includes/legacy/class-wc-legacy-customer.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Legacy Customer.
  *
  * @version  3.0.0
- * @package  WooCommerce/Classes
+ * @package  WooCommerce\Classes
  * @category Class
  * @author   WooThemes
  */

--- a/includes/legacy/class-wc-legacy-shipping-zone.php
+++ b/includes/legacy/class-wc-legacy-shipping-zone.php
@@ -7,7 +7,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Legacy Shipping Zone.
  *
  * @version  3.0.0
- * @package  WooCommerce/Classes
+ * @package  WooCommerce\Classes
  * @category Class
  * @author   WooThemes
  */

--- a/includes/legacy/class-wc-legacy-webhook.php
+++ b/includes/legacy/class-wc-legacy-webhook.php
@@ -6,7 +6,7 @@
  * This class will be removed in future versions.
  *
  * @version  3.2.0
- * @package  WooCommerce/Classes
+ * @package  WooCommerce\Classes
  * @category Class
  * @author   Automattic
  */

--- a/includes/log-handlers/class-wc-log-handler-db.php
+++ b/includes/log-handlers/class-wc-log-handler-db.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @class          WC_Log_Handler_DB
  * @version        1.0.0
- * @package        WooCommerce/Classes/Log_Handlers
+ * @package        WooCommerce\Classes\Log_Handlers
  */
 class WC_Log_Handler_DB extends WC_Log_Handler {
 

--- a/includes/log-handlers/class-wc-log-handler-email.php
+++ b/includes/log-handlers/class-wc-log-handler-email.php
@@ -28,7 +28,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @class          WC_Log_Handler_Email
  * @version        1.0.0
- * @package        WooCommerce/Classes/Log_Handlers
+ * @package        WooCommerce\Classes\Log_Handlers
  */
 class WC_Log_Handler_Email extends WC_Log_Handler {
 

--- a/includes/log-handlers/class-wc-log-handler-file.php
+++ b/includes/log-handlers/class-wc-log-handler-file.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @class          WC_Log_Handler_File
  * @version        1.0.0
- * @package        WooCommerce/Classes/Log_Handlers
+ * @package        WooCommerce\Classes\Log_Handlers
  */
 class WC_Log_Handler_File extends WC_Log_Handler {
 

--- a/includes/payment-tokens/class-wc-payment-token-cc.php
+++ b/includes/payment-tokens/class-wc-payment-token-cc.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @class       WC_Payment_Token_CC
  * @version     3.0.0
  * @since       2.6.0
- * @package     WooCommerce/PaymentTokens
+ * @package     WooCommerce\PaymentTokens
  */
 class WC_Payment_Token_CC extends WC_Payment_Token {
 

--- a/includes/payment-tokens/class-wc-payment-token-echeck.php
+++ b/includes/payment-tokens/class-wc-payment-token-echeck.php
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * @class       WC_Payment_Token_ECheck
  * @version     3.0.0
  * @since       2.6.0
- * @package     WooCommerce/PaymentTokens
+ * @package     WooCommerce\PaymentTokens
  */
 class WC_Payment_Token_ECheck extends WC_Payment_Token {
 

--- a/includes/queue/class-wc-action-queue.php
+++ b/includes/queue/class-wc-action-queue.php
@@ -3,7 +3,7 @@
  * Action Queue
  *
  * @version 3.5.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/queue/class-wc-queue.php
+++ b/includes/queue/class-wc-queue.php
@@ -3,7 +3,7 @@
  * WC Queue
  *
  * @version 3.5.0
- * @package WooCommerce/Interface
+ * @package WooCommerce\Interface
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -3,7 +3,7 @@
  * Flat Rate Shipping Method.
  *
  * @version 2.6.0
- * @package WooCommerce/Classes/Shipping
+ * @package WooCommerce\Classes\Shipping
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/shipping/flat-rate/includes/settings-flat-rate.php
+++ b/includes/shipping/flat-rate/includes/settings-flat-rate.php
@@ -2,7 +2,7 @@
 /**
  * Settings for flat rate shipping.
  *
- * @package WooCommerce/Classes/Shipping
+ * @package WooCommerce\Classes\Shipping
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @class   WC_Shipping_Free_Shipping
  * @version 2.6.0
- * @package WooCommerce/Classes/Shipping
+ * @package WooCommerce\Classes\Shipping
  */
 class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 

--- a/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
+++ b/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @deprecated  2.6.0
  * @version     2.4.0
- * @package     WooCommerce/Classes/Shipping
+ * @package     WooCommerce\Classes\Shipping
  */
 class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 

--- a/includes/shipping/legacy-free-shipping/class-wc-shipping-legacy-free-shipping.php
+++ b/includes/shipping/legacy-free-shipping/class-wc-shipping-legacy-free-shipping.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @deprecated  2.6.0
  * @version 2.4.0
- * @package WooCommerce/Classes/Shipping
+ * @package WooCommerce\Classes\Shipping
  */
 class WC_Shipping_Legacy_Free_Shipping extends WC_Shipping_Method {
 

--- a/includes/shipping/legacy-international-delivery/class-wc-shipping-legacy-international-delivery.php
+++ b/includes/shipping/legacy-international-delivery/class-wc-shipping-legacy-international-delivery.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @deprecated  2.6.0
  * @version     2.4.0
- * @package     WooCommerce/Classes/Shipping
+ * @package     WooCommerce\Classes\Shipping
  */
 class WC_Shipping_Legacy_International_Delivery extends WC_Shipping_Legacy_Flat_Rate {
 

--- a/includes/shipping/legacy-local-delivery/class-wc-shipping-legacy-local-delivery.php
+++ b/includes/shipping/legacy-local-delivery/class-wc-shipping-legacy-local-delivery.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @deprecated  2.6.0
  * @version     2.3.0
- * @package     WooCommerce/Classes/Shipping
+ * @package     WooCommerce\Classes\Shipping
  */
 class WC_Shipping_Legacy_Local_Delivery extends WC_Shipping_Local_Pickup {
 

--- a/includes/shipping/legacy-local-pickup/class-wc-shipping-legacy-local-pickup.php
+++ b/includes/shipping/legacy-local-pickup/class-wc-shipping-legacy-local-pickup.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @deprecated  2.6.0
  * @version     2.3.0
- * @package     WooCommerce/Classes/Shipping
+ * @package     WooCommerce\Classes\Shipping
  */
 class WC_Shipping_Legacy_Local_Pickup extends WC_Shipping_Method {
 

--- a/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
+++ b/includes/shipping/local-pickup/class-wc-shipping-local-pickup.php
@@ -16,7 +16,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  *
  * @class       WC_Shipping_Local_Pickup
  * @version     2.6.0
- * @package     WooCommerce/Classes/Shipping
+ * @package     WooCommerce\Classes\Shipping
  */
 class WC_Shipping_Local_Pickup extends WC_Shipping_Method {
 

--- a/includes/shortcodes/class-wc-shortcode-cart.php
+++ b/includes/shortcodes/class-wc-shortcode-cart.php
@@ -4,7 +4,7 @@
  *
  * Used on the cart page, the cart shortcode displays the cart contents and interface for coupon codes and other cart bits and pieces.
  *
- * @package WooCommerce/Shortcodes/Cart
+ * @package WooCommerce\Shortcodes\Cart
  * @version 2.3.0
  */
 

--- a/includes/shortcodes/class-wc-shortcode-checkout.php
+++ b/includes/shortcodes/class-wc-shortcode-checkout.php
@@ -4,7 +4,7 @@
  *
  * Used on the checkout page, the checkout shortcode displays the checkout process.
  *
- * @package WooCommerce/Shortcodes/Checkout
+ * @package WooCommerce\Shortcodes\Checkout
  * @version 2.0.0
  */
 

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -4,7 +4,7 @@
  *
  * Shows the 'my account' section where the customer can view past orders and update their information.
  *
- * @package WooCommerce/Shortcodes/My_Account
+ * @package WooCommerce\Shortcodes\My_Account
  * @version 2.0.0
  */
 

--- a/includes/shortcodes/class-wc-shortcode-order-tracking.php
+++ b/includes/shortcodes/class-wc-shortcode-order-tracking.php
@@ -4,7 +4,7 @@
  *
  * Lets a user see the status of an order by entering their order details.
  *
- * @package WooCommerce/Shortcodes/Order_Tracking
+ * @package WooCommerce\Shortcodes\Order_Tracking
  * @version 3.0.0
  */
 

--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -2,7 +2,7 @@
 /**
  * Products shortcode
  *
- * @package  WooCommerce/Shortcodes
+ * @package  WooCommerce\Shortcodes
  * @version  3.2.4
  */
 

--- a/includes/theme-support/class-wc-twenty-eleven.php
+++ b/includes/theme-support/class-wc-twenty-eleven.php
@@ -3,7 +3,7 @@
  * Twenty Eleven support.
  *
  * @since   3.3.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/theme-support/class-wc-twenty-fifteen.php
+++ b/includes/theme-support/class-wc-twenty-fifteen.php
@@ -4,7 +4,7 @@
  *
  * @class   WC_Twenty_Fifteen
  * @since   3.3.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/theme-support/class-wc-twenty-fourteen.php
+++ b/includes/theme-support/class-wc-twenty-fourteen.php
@@ -4,7 +4,7 @@
  *
  * @class   WC_Twenty_Fourteen
  * @since   3.3.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/theme-support/class-wc-twenty-nineteen.php
+++ b/includes/theme-support/class-wc-twenty-nineteen.php
@@ -3,7 +3,7 @@
  * Twenty Nineteen support.
  *
  * @since   3.5.X
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/theme-support/class-wc-twenty-seventeen.php
+++ b/includes/theme-support/class-wc-twenty-seventeen.php
@@ -3,7 +3,7 @@
  * Twenty Seventeen support.
  *
  * @since   2.6.9
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/theme-support/class-wc-twenty-sixteen.php
+++ b/includes/theme-support/class-wc-twenty-sixteen.php
@@ -3,7 +3,7 @@
  * Twenty Sixteen support.
  *
  * @since   3.3.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/theme-support/class-wc-twenty-ten.php
+++ b/includes/theme-support/class-wc-twenty-ten.php
@@ -3,7 +3,7 @@
  * Twenty Ten support.
  *
  * @since   3.3.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/theme-support/class-wc-twenty-thirteen.php
+++ b/includes/theme-support/class-wc-twenty-thirteen.php
@@ -4,7 +4,7 @@
  *
  * @class   WC_Twenty_Thirteen
  * @since   3.3.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/theme-support/class-wc-twenty-twelve.php
+++ b/includes/theme-support/class-wc-twenty-twelve.php
@@ -4,7 +4,7 @@
  *
  * @class   WC_Twenty_Twelve
  * @since   3.3.0
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/theme-support/class-wc-twenty-twenty.php
+++ b/includes/theme-support/class-wc-twenty-twenty.php
@@ -3,7 +3,7 @@
  * Twenty Twenty support.
  *
  * @since   3.8.1
- * @package WooCommerce/Classes
+ * @package WooCommerce\Classes
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/traits/trait-wc-item-totals.php
+++ b/includes/traits/trait-wc-item-totals.php
@@ -2,7 +2,7 @@
 /**
  * This ongoing trait will have shared calculation logic between WC_Abstract_Order and WC_Cart_Totals classes.
  *
- * @package WooCommerce/Traits
+ * @package WooCommerce\Traits
  * @version 3.9.0
  */
 

--- a/includes/walkers/class-product-cat-dropdown-walker.php
+++ b/includes/walkers/class-product-cat-dropdown-walker.php
@@ -2,7 +2,7 @@
 /**
  * Legacy WC_Product_Cat_Dropdown_Walker file
  *
- * @package WooCommerce/Classes/Walkers
+ * @package WooCommerce\Classes\Walkers
  * @deprecated 3.4.0
  */
 

--- a/includes/walkers/class-product-cat-list-walker.php
+++ b/includes/walkers/class-product-cat-list-walker.php
@@ -2,7 +2,7 @@
 /**
  * Legacy WC_Product_Cat_List_Walker file
  *
- * @package WooCommerce/Classes/Walkers
+ * @package WooCommerce\Classes\Walkers
  * @deprecated 3.4.0
  */
 

--- a/includes/walkers/class-wc-product-cat-dropdown-walker.php
+++ b/includes/walkers/class-wc-product-cat-dropdown-walker.php
@@ -2,7 +2,7 @@
 /**
  * WC_Product_Cat_Dropdown_Walker class
  *
- * @package WooCommerce/Classes/Walkers
+ * @package WooCommerce\Classes\Walkers
  * @version 3.4.0
  */
 

--- a/includes/walkers/class-wc-product-cat-list-walker.php
+++ b/includes/walkers/class-wc-product-cat-list-walker.php
@@ -2,7 +2,7 @@
 /**
  * WC_Product_Cat_List_Walker class
  *
- * @package WooCommerce/Classes/Walkers
+ * @package WooCommerce\Classes\Walkers
  * @version 3.4.0
  */
 

--- a/includes/wc-account-functions.php
+++ b/includes/wc-account-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for account specific things.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 2.6.0
  */
 

--- a/includes/wc-attribute-functions.php
+++ b/includes/wc-attribute-functions.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Attribute Functions
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 2.1.0
  */
 

--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for cart specific things.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 2.5.0
  */
 

--- a/includes/wc-conditional-functions.php
+++ b/includes/wc-conditional-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for determining the current query/page.
  *
- * @package     WooCommerce/Functions
+ * @package     WooCommerce\Functions
  * @version     2.3.0
  */
 

--- a/includes/wc-coupon-functions.php
+++ b/includes/wc-coupon-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for coupon specific things.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 3.0.0
  */
 

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for formatting data.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 2.1.0
  */
 

--- a/includes/wc-notice-functions.php
+++ b/includes/wc-notice-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for error/message handling and display.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 2.1.0
  */
 

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for order specific things.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 3.4.0
  */
 

--- a/includes/wc-order-item-functions.php
+++ b/includes/wc-order-item-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for order specific things.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 3.4.0
  */
 

--- a/includes/wc-product-functions.php
+++ b/includes/wc-product-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for product specific things.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 3.0.0
  */
 

--- a/includes/wc-rest-functions.php
+++ b/includes/wc-rest-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for REST specific things.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 2.6.0
  */
 

--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions used to manage product stock levels.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 3.4.0
  */
 

--- a/includes/wc-template-hooks.php
+++ b/includes/wc-template-hooks.php
@@ -4,7 +4,7 @@
  *
  * Action/filter hooks used for WooCommerce functions/templates.
  *
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.1.0
  */
 

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for handling terms/term meta.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 2.1.0
  */
 

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for updating data, used by the background updater.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 3.3.0
  */
 

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -4,7 +4,7 @@
  *
  * Functions for customers.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 2.2.0
  */
 

--- a/includes/wc-webhook-functions.php
+++ b/includes/wc-webhook-functions.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce Webhook functions
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 3.3.0
  */
 

--- a/includes/wc-widget-functions.php
+++ b/includes/wc-widget-functions.php
@@ -4,7 +4,7 @@
  *
  * Widget related functions and widget registration.
  *
- * @package WooCommerce/Functions
+ * @package WooCommerce\Functions
  * @version 2.3.0
  */
 

--- a/includes/wccom-site/class-wc-wccom-site-installer-requirements-check.php
+++ b/includes/wccom-site/class-wc-wccom-site-installer-requirements-check.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce.com Product Installation Requirements Check.
  *
- * @package WooCommerce\WooCommerce_Site
+ * @package WooCommerce\WCCom
  * @since   3.8.0
  */
 

--- a/includes/wccom-site/class-wc-wccom-site-installer.php
+++ b/includes/wccom-site/class-wc-wccom-site-installer.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce.com Product Installation.
  *
- * @package WooCommerce\WooCommerce_Site
+ * @package WooCommerce\WCCom
  * @since   3.7.0
  */
 

--- a/includes/wccom-site/class-wc-wccom-site.php
+++ b/includes/wccom-site/class-wc-wccom-site.php
@@ -2,7 +2,7 @@
 /**
  * WooCommerce.com Product Installation.
  *
- * @package WooCommerce\WooCommerce_Site
+ * @package WooCommerce\WCCom
  * @since   3.7.0
  */
 

--- a/includes/wccom-site/rest-api/class-wc-rest-wccom-site-installer-errors.php
+++ b/includes/wccom-site/rest-api/class-wc-rest-wccom-site-installer-errors.php
@@ -2,7 +2,7 @@
 /**
  * WCCOM Site Installer Errors Class
  *
- * @package WooCommerce\WooCommerce_Site\Rest_Api
+ * @package WooCommerce\WCCom\API
  * @since   3.9.0
  */
 

--- a/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
+++ b/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API WCCOM Site Installer Controller Class.
  *
- * @package WooCommerce/WCCOM_Site/REST_API
+ * @package WooCommerce\WCCOM_Site\REST_API
  * @extends WC_REST_Controller
  */
 class WC_REST_WCCOM_Site_Installer_Controller extends WC_REST_Controller {

--- a/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
+++ b/includes/wccom-site/rest-api/endpoints/class-wc-rest-wccom-site-installer-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to /installer.
  *
- * @package WooCommerce\WooCommerce_Site\Rest_Api
+ * @package WooCommerce\WCCom\API
  * @since   3.7.0
  */
 
@@ -13,7 +13,6 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API WCCOM Site Installer Controller Class.
  *
- * @package WooCommerce\WCCOM_Site\REST_API
  * @extends WC_REST_Controller
  */
 class WC_REST_WCCOM_Site_Installer_Controller extends WC_REST_Controller {

--- a/includes/widgets/class-wc-widget-cart.php
+++ b/includes/widgets/class-wc-widget-cart.php
@@ -4,7 +4,7 @@
  *
  * Displays shopping cart widget.
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 2.3.0
  */
 

--- a/includes/widgets/class-wc-widget-layered-nav-filters.php
+++ b/includes/widgets/class-wc-widget-layered-nav-filters.php
@@ -2,7 +2,7 @@
 /**
  * Layered Navigation Filters Widget.
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 2.3.0
  */
 

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -2,7 +2,7 @@
 /**
  * Layered nav widget
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 2.6.0
  */
 

--- a/includes/widgets/class-wc-widget-price-filter.php
+++ b/includes/widgets/class-wc-widget-price-filter.php
@@ -4,7 +4,7 @@
  *
  * Generates a range slider to filter products by price.
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 2.3.0
  */
 

--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -2,7 +2,7 @@
 /**
  * Product Categories Widget
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 2.3.0
  */
 

--- a/includes/widgets/class-wc-widget-product-search.php
+++ b/includes/widgets/class-wc-widget-product-search.php
@@ -2,7 +2,7 @@
 /**
  * Product Search Widget.
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 2.3.0
  */
 

--- a/includes/widgets/class-wc-widget-product-tag-cloud.php
+++ b/includes/widgets/class-wc-widget-product-tag-cloud.php
@@ -2,7 +2,7 @@
 /**
  * Tag Cloud Widget.
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 3.4.0
  */
 

--- a/includes/widgets/class-wc-widget-products.php
+++ b/includes/widgets/class-wc-widget-products.php
@@ -2,7 +2,7 @@
 /**
  * List products. One widget to rule them all.
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 3.3.0
  */
 

--- a/includes/widgets/class-wc-widget-rating-filter.php
+++ b/includes/widgets/class-wc-widget-rating-filter.php
@@ -2,7 +2,7 @@
 /**
  * Rating Filter Widget and related functions.
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 2.6.0
  */
 

--- a/includes/widgets/class-wc-widget-recent-reviews.php
+++ b/includes/widgets/class-wc-widget-recent-reviews.php
@@ -2,7 +2,7 @@
 /**
  * Recent Reviews Widget.
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 2.3.0
  */
 

--- a/includes/widgets/class-wc-widget-recently-viewed.php
+++ b/includes/widgets/class-wc-widget-recently-viewed.php
@@ -2,7 +2,7 @@
 /**
  * Recent Products Widget.
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 3.3.0
  */
 

--- a/includes/widgets/class-wc-widget-top-rated-products.php
+++ b/includes/widgets/class-wc-widget-top-rated-products.php
@@ -3,7 +3,7 @@
  * Top Rated Products Widget.
  * Gets and displays top rated products in an unordered list.
  *
- * @package WooCommerce/Widgets
+ * @package WooCommerce\Widgets
  * @version 3.3.0
  */
 

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -73,6 +73,15 @@
 		<exclude-pattern>tests/Tools/</exclude-pattern>
 	</rule>
 
+	<rule ref="Squiz.Commenting.FileComment.MissingPackageTag">
+		<exclude-pattern>src/</exclude-pattern>
+		<exclude-pattern>tests/php/</exclude-pattern>
+	</rule>
+	<rule ref="Squiz.Commenting.FileComment.Missing">
+		<exclude-pattern>src/</exclude-pattern>
+		<exclude-pattern>tests/php/</exclude-pattern>
+	</rule>
+
 	<rule ref="Squiz.Commenting.FunctionCommentThrowTag.Missing">
 		<exclude-pattern>tests/php/</exclude-pattern>
 	</rule>
@@ -80,7 +89,7 @@
 	<rule ref="Squiz.Commenting.FileComment.Missing">
 		<exclude-pattern>tests/php/</exclude-pattern>
 	</rule>
-	
+
 	<rule ref="WordPress.NamingConventions.ValidFunctionName.MethodNameInvalid">
 		<exclude-pattern>src/</exclude-pattern>
 	</rule>

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -2,7 +2,7 @@
 /**
  * Includes the composer Autoloader used for packages and classes in the src/ directory.
  *
- * @package Automattic/WooCommerce
+ * @package WooCommerce
  */
 
 namespace Automattic\WooCommerce;

--- a/src/Autoloader.php
+++ b/src/Autoloader.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Includes the composer Autoloader used for packages and classes in the src/ directory.
- *
- * @package WooCommerce
  */
 
 namespace Automattic\WooCommerce;

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Handle product stock reservation during checkout.
- *
- * @package WooCommerce
  */
 
 namespace Automattic\WooCommerce\Checkout\Helpers;

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -2,7 +2,7 @@
 /**
  * Handle product stock reservation during checkout.
  *
- * @package Automattic/WooCommerce
+ * @package WooCommerce
  */
 
 namespace Automattic\WooCommerce\Checkout\Helpers;

--- a/src/Checkout/Helpers/ReserveStockException.php
+++ b/src/Checkout/Helpers/ReserveStockException.php
@@ -2,7 +2,7 @@
 /**
  * Exceptions for stock reservation.
  *
- * @package Automattic/WooCommerce
+ * @package WooCommerce
  */
 
 namespace Automattic\WooCommerce\Checkout\Helpers;

--- a/src/Checkout/Helpers/ReserveStockException.php
+++ b/src/Checkout/Helpers/ReserveStockException.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Exceptions for stock reservation.
- *
- * @package WooCommerce
  */
 
 namespace Automattic\WooCommerce\Checkout\Helpers;

--- a/src/Container.php
+++ b/src/Container.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Container class file.
- *
- * @package WooCommerce
  */
 
 namespace Automattic\WooCommerce;

--- a/src/Container.php
+++ b/src/Container.php
@@ -2,7 +2,7 @@
 /**
  * Container class file.
  *
- * @package Automattic\WooCommerce
+ * @package WooCommerce
  */
 
 namespace Automattic\WooCommerce;

--- a/src/Internal/DependencyManagement/AbstractServiceProvider.php
+++ b/src/Internal/DependencyManagement/AbstractServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * AbstractServiceProvider class file.
  *
- * @package Automattic\WooCommerce\Internal\DependencyManagement
+ * @package WooCommerce\Internal\DependencyManagement
  */
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement;

--- a/src/Internal/DependencyManagement/AbstractServiceProvider.php
+++ b/src/Internal/DependencyManagement/AbstractServiceProvider.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * AbstractServiceProvider class file.
- *
- * @package WooCommerce\Internal\DependencyManagement
  */
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement;

--- a/src/Internal/DependencyManagement/ContainerException.php
+++ b/src/Internal/DependencyManagement/ContainerException.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * ExtendedContainer class file.
- *
- * @package WooCommerce\Internal\DependencyManagement
  */
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement;

--- a/src/Internal/DependencyManagement/ContainerException.php
+++ b/src/Internal/DependencyManagement/ContainerException.php
@@ -2,7 +2,7 @@
 /**
  * ExtendedContainer class file.
  *
- * @package Automattic\WooCommerce\Internal\DependencyManagement
+ * @package WooCommerce\Internal\DependencyManagement
  */
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement;

--- a/src/Internal/DependencyManagement/ExtendedContainer.php
+++ b/src/Internal/DependencyManagement/ExtendedContainer.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * ExtendedContainer class file.
- *
- * @package WooCommerce\Internal\DependencyManagement
  */
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement;

--- a/src/Internal/DependencyManagement/ExtendedContainer.php
+++ b/src/Internal/DependencyManagement/ExtendedContainer.php
@@ -2,7 +2,7 @@
 /**
  * ExtendedContainer class file.
  *
- * @package Automattic\WooCommerce\Internal\DependencyManagement
+ * @package WooCommerce\Internal\DependencyManagement
  */
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement;

--- a/src/Internal/DependencyManagement/ServiceProviders/ProxiesServiceProvider.php
+++ b/src/Internal/DependencyManagement/ServiceProviders/ProxiesServiceProvider.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Proxies class file.
- *
- * @package WooCommerce\Internal\DependencyManagement\ServiceProviders
  */
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;

--- a/src/Internal/DependencyManagement/ServiceProviders/ProxiesServiceProvider.php
+++ b/src/Internal/DependencyManagement/ServiceProviders/ProxiesServiceProvider.php
@@ -2,7 +2,7 @@
 /**
  * Proxies class file.
  *
- * @package Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders
+ * @package WooCommerce\Internal\DependencyManagement\ServiceProviders
  */
 
 namespace Automattic\WooCommerce\Internal\DependencyManagement\ServiceProviders;

--- a/src/Internal/WCCom/ConnectionHelper.php
+++ b/src/Internal/WCCom/ConnectionHelper.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Helpers for managing connection to WooCommerce.com.
- *
- * @package WooCommerce\Internals\WCCom
  */
 
 namespace Automattic\WooCommerce\Internal\WCCom;

--- a/src/Internal/WCCom/ConnectionHelper.php
+++ b/src/Internal/WCCom/ConnectionHelper.php
@@ -2,7 +2,7 @@
 /**
  * Helpers for managing connection to WooCommerce.com.
  *
- * @package Automattic\WooCommerce\Internals\WCCom
+ * @package WooCommerce\Internals\WCCom
  */
 
 namespace Automattic\WooCommerce\Internal\WCCom;

--- a/src/Packages.php
+++ b/src/Packages.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * Loads WooCommece packages from the /packages directory. These are packages developed outside of core.
- *
- * @package WooCommerce
  */
 
 namespace Automattic\WooCommerce;

--- a/src/Packages.php
+++ b/src/Packages.php
@@ -2,7 +2,7 @@
 /**
  * Loads WooCommece packages from the /packages directory. These are packages developed outside of core.
  *
- * @package Automattic/WooCommerce
+ * @package WooCommerce
  */
 
 namespace Automattic\WooCommerce;

--- a/src/Proxies/ActionsProxy.php
+++ b/src/Proxies/ActionsProxy.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * ActionsProxy class file.
- *
- * @package WooCommerce\Tools\Proxies
  */
 
 namespace Automattic\WooCommerce\Proxies;

--- a/src/Proxies/ActionsProxy.php
+++ b/src/Proxies/ActionsProxy.php
@@ -2,7 +2,7 @@
 /**
  * ActionsProxy class file.
  *
- * @package Automattic/WooCommerce/Tools/Proxies
+ * @package WooCommerce\Tools\Proxies
  */
 
 namespace Automattic\WooCommerce\Proxies;
@@ -11,8 +11,6 @@ namespace Automattic\WooCommerce\Proxies;
  * Proxy for interacting with WordPress actions and filters.
  *
  * This class should be used instead of directly accessing the WordPress functions, to ease unit testing.
- *
- * @package Automattic\WooCommerce\Tools\Proxies
  */
 class ActionsProxy {
 

--- a/src/Proxies/LegacyProxy.php
+++ b/src/Proxies/LegacyProxy.php
@@ -2,7 +2,7 @@
 /**
  * LegacyProxy class file.
  *
- * @package Automattic/WooCommerce/Tools/Proxies
+ * @package WooCommerce\Tools\Proxies
  */
 
 namespace Automattic\WooCommerce\Proxies;
@@ -15,8 +15,6 @@ use \Psr\Container\ContainerInterface as Container;
  * This class should be used to interact with code outside the `src` directory, especially functions and classes
  * in the `includes` directory, unless a more specific proxy exists for the functionality at hand (e.g. `ActionsProxy`).
  * Idempotent functions can be executed directly.
- *
- * @package Automattic\WooCommerce\Tools\Proxies
  */
 class LegacyProxy {
 

--- a/src/Proxies/LegacyProxy.php
+++ b/src/Proxies/LegacyProxy.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * LegacyProxy class file.
- *
- * @package WooCommerce\Tools\Proxies
  */
 
 namespace Automattic\WooCommerce\Proxies;

--- a/templates/archive-product.php
+++ b/templates/archive-product.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.0
  */
 

--- a/templates/auth/footer.php
+++ b/templates/auth/footer.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Auth
+ * @package WooCommerce\Templates\Auth
  * @version 2.4.0
  */
 

--- a/templates/auth/form-grant-access.php
+++ b/templates/auth/form-grant-access.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Auth
+ * @package WooCommerce\Templates\Auth
  * @version 4.3.0
  */
 

--- a/templates/auth/form-login.php
+++ b/templates/auth/form-login.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Auth
+ * @package WooCommerce\Templates\Auth
  * @version 3.4.0
  */
 

--- a/templates/auth/header.php
+++ b/templates/auth/header.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Auth
+ * @package WooCommerce\Templates\Auth
  * @version 2.4.0
  */
 

--- a/templates/cart/cart-empty.php
+++ b/templates/cart/cart-empty.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.0
  */
 

--- a/templates/cart/cart-item-data.php
+++ b/templates/cart/cart-item-data.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     2.4.0
  */
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/cart/cart-shipping.php
+++ b/templates/cart/cart-shipping.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.6.0
  */
 

--- a/templates/cart/cart-totals.php
+++ b/templates/cart/cart-totals.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.3.6
  */
 

--- a/templates/cart/cross-sells.php
+++ b/templates/cart/cross-sells.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 4.4.0
  */
 

--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.7.0
  */
 

--- a/templates/cart/proceed-to-checkout-button.php
+++ b/templates/cart/proceed-to-checkout-button.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.4.0
  */
 

--- a/templates/cart/shipping-calculator.php
+++ b/templates/cart/shipping-calculator.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 4.0.0
  */
 

--- a/templates/checkout/cart-errors.php
+++ b/templates/checkout/cart-errors.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.0
  */
 

--- a/templates/checkout/form-billing.php
+++ b/templates/checkout/form-billing.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.6.0
  * @global WC_Checkout $checkout
  */

--- a/templates/checkout/form-checkout.php
+++ b/templates/checkout/form-checkout.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.0
  */
 

--- a/templates/checkout/form-coupon.php
+++ b/templates/checkout/form-coupon.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.4
  */
 

--- a/templates/checkout/form-login.php
+++ b/templates/checkout/form-login.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.8.0
  */
 

--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.0
  */
 

--- a/templates/checkout/form-shipping.php
+++ b/templates/checkout/form-shipping.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.6.0
  * @global WC_Checkout $checkout
  */

--- a/templates/checkout/order-receipt.php
+++ b/templates/checkout/order-receipt.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.2.0
  */
 

--- a/templates/checkout/payment-method.php
+++ b/templates/checkout/payment-method.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.5.0
  */
 

--- a/templates/checkout/payment.php
+++ b/templates/checkout/payment.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.3
  */
 

--- a/templates/checkout/review-order.php
+++ b/templates/checkout/review-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.8.0
  */
 

--- a/templates/checkout/terms.php
+++ b/templates/checkout/terms.php
@@ -2,7 +2,7 @@
 /**
  * Checkout terms and conditions area.
  *
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.0
  */
 

--- a/templates/checkout/thankyou.php
+++ b/templates/checkout/thankyou.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.7.0
  */
 

--- a/templates/content-product.php
+++ b/templates/content-product.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.6.0
  */
 

--- a/templates/content-product_cat.php
+++ b/templates/content-product_cat.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.6.1
  */
 

--- a/templates/content-single-product.php
+++ b/templates/content-single-product.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.6.0
  */
 

--- a/templates/content-widget-price-filter.php
+++ b/templates/content-widget-price-filter.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.7.1
  */
 

--- a/templates/content-widget-product.php
+++ b/templates/content-widget-product.php
@@ -10,7 +10,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.5
  */
 

--- a/templates/content-widget-reviews.php
+++ b/templates/content-widget-reviews.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.0
  */
 

--- a/templates/emails/admin-cancelled-order.php
+++ b/templates/emails/admin-cancelled-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 4.1.0
  */
 

--- a/templates/emails/admin-failed-order.php
+++ b/templates/emails/admin-failed-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/admin-new-order.php
+++ b/templates/emails/admin-new-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/HTML
+ * @package WooCommerce\Templates\Emails\HTML
  * @version 3.7.0
  */
 

--- a/templates/emails/customer-completed-order.php
+++ b/templates/emails/customer-completed-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/customer-new-account.php
+++ b/templates/emails/customer-new-account.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/customer-note.php
+++ b/templates/emails/customer-note.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/customer-on-hold-order.php
+++ b/templates/emails/customer-on-hold-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/customer-processing-order.php
+++ b/templates/emails/customer-processing-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/customer-refunded-order.php
+++ b/templates/emails/customer-refunded-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/customer-reset-password.php
+++ b/templates/emails/customer-reset-password.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 4.0.0
  */
 

--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.9.0
  */
 

--- a/templates/emails/email-customer-details.php
+++ b/templates/emails/email-customer-details.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 2.5.0
  */
 

--- a/templates/emails/email-downloads.php
+++ b/templates/emails/email-downloads.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.0
  */
 

--- a/templates/emails/email-footer.php
+++ b/templates/emails/email-footer.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 4.0.0
  */
 

--- a/templates/emails/email-order-details.php
+++ b/templates/emails/email-order-details.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 4.0.0
  */
 

--- a/templates/emails/plain/admin-cancelled-order.php
+++ b/templates/emails/plain/admin-cancelled-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 4.1.0
  */
 

--- a/templates/emails/plain/admin-failed-order.php
+++ b/templates/emails/plain/admin-failed-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.7.0
  */
 

--- a/templates/emails/plain/admin-new-order.php
+++ b/templates/emails/plain/admin-new-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.7.0
  */
 

--- a/templates/emails/plain/customer-completed-order.php
+++ b/templates/emails/plain/customer-completed-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.7.0
  */
 

--- a/templates/emails/plain/customer-invoice.php
+++ b/templates/emails/plain/customer-invoice.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.7.0
  */
 

--- a/templates/emails/plain/customer-new-account.php
+++ b/templates/emails/plain/customer-new-account.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.7.0
  */
 

--- a/templates/emails/plain/customer-note.php
+++ b/templates/emails/plain/customer-note.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.7.0
  */
 

--- a/templates/emails/plain/customer-on-hold-order.php
+++ b/templates/emails/plain/customer-on-hold-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.7.0
  */
 

--- a/templates/emails/plain/customer-processing-order.php
+++ b/templates/emails/plain/customer-processing-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.7.0
  */
 

--- a/templates/emails/plain/customer-refunded-order.php
+++ b/templates/emails/plain/customer-refunded-order.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.7.0
  */
 

--- a/templates/emails/plain/customer-reset-password.php
+++ b/templates/emails/plain/customer-reset-password.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.7.0
  */
 

--- a/templates/emails/plain/email-addresses.php
+++ b/templates/emails/plain/email-addresses.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.4.0
  */
 

--- a/templates/emails/plain/email-customer-details.php
+++ b/templates/emails/plain/email-customer-details.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails/Plain
+ * @package WooCommerce\Templates\Emails\Plain
  * @version 3.4.0
  */
 

--- a/templates/emails/plain/email-downloads.php
+++ b/templates/emails/plain/email-downloads.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.0
  */
 

--- a/templates/emails/plain/email-order-details.php
+++ b/templates/emails/plain/email-order-details.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates/Emails
+ * @package WooCommerce\Templates\Emails
  * @version 3.7.0
  */
 

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates/Emails/Plain
+ * @package     WooCommerce\Templates\Emails\Plain
  * @version     3.7.0
  */
 

--- a/templates/global/breadcrumb.php
+++ b/templates/global/breadcrumb.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     2.3.0
  * @see         woocommerce_breadcrumb()
  */

--- a/templates/global/form-login.php
+++ b/templates/global/form-login.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.6.0
  */
 

--- a/templates/global/quantity-input.php
+++ b/templates/global/quantity-input.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 4.0.0
  */
 

--- a/templates/global/sidebar.php
+++ b/templates/global/sidebar.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     1.6.4
  */
 

--- a/templates/global/wrapper-end.php
+++ b/templates/global/wrapper-end.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.3.0
  */
 

--- a/templates/global/wrapper-start.php
+++ b/templates/global/wrapper-start.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.3.0
  */
 

--- a/templates/loop/add-to-cart.php
+++ b/templates/loop/add-to-cart.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.3.0
  */
 

--- a/templates/loop/loop-end.php
+++ b/templates/loop/loop-end.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     2.0.0
  */
 

--- a/templates/loop/loop-start.php
+++ b/templates/loop/loop-start.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.3.0
  */
 

--- a/templates/loop/no-products-found.php
+++ b/templates/loop/no-products-found.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.0.0
  */
 

--- a/templates/loop/orderby.php
+++ b/templates/loop/orderby.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.6.0
  */
 

--- a/templates/loop/pagination.php
+++ b/templates/loop/pagination.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.3.1
  */
 

--- a/templates/loop/price.php
+++ b/templates/loop/price.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     1.6.4
  */
 

--- a/templates/loop/rating.php
+++ b/templates/loop/rating.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.6.0
  */
 

--- a/templates/loop/result-count.php
+++ b/templates/loop/result-count.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.7.0
  */
 

--- a/templates/loop/sale-flash.php
+++ b/templates/loop/sale-flash.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     1.6.4
  */
 

--- a/templates/myaccount/dashboard.php
+++ b/templates/myaccount/dashboard.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 4.4.0
  */
 

--- a/templates/myaccount/downloads.php
+++ b/templates/myaccount/downloads.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.2.0
  */
 

--- a/templates/myaccount/form-add-payment-method.php
+++ b/templates/myaccount/form-add-payment-method.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 4.3.0
  */
 

--- a/templates/myaccount/form-edit-account.php
+++ b/templates/myaccount/form-edit-account.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.0
  */
 

--- a/templates/myaccount/form-edit-address.php
+++ b/templates/myaccount/form-edit-address.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.6.0
  */
 

--- a/templates/myaccount/form-login.php
+++ b/templates/myaccount/form-login.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 4.1.0
  */
 

--- a/templates/myaccount/form-lost-password.php
+++ b/templates/myaccount/form-lost-password.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.2
  */
 

--- a/templates/myaccount/form-reset-password.php
+++ b/templates/myaccount/form-reset-password.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.5
  */
 

--- a/templates/myaccount/lost-password-confirmation.php
+++ b/templates/myaccount/lost-password-confirmation.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.9.0
  */
 

--- a/templates/myaccount/my-account.php
+++ b/templates/myaccount/my-account.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.0
  */
 

--- a/templates/myaccount/my-address.php
+++ b/templates/myaccount/my-address.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.6.0
  */
 

--- a/templates/myaccount/my-downloads.php
+++ b/templates/myaccount/my-downloads.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     2.0.0
  * @deprecated  2.6.0
  */

--- a/templates/myaccount/my-orders.php
+++ b/templates/myaccount/my-orders.php
@@ -3,7 +3,7 @@
  * My Orders - Deprecated
  *
  * @deprecated 2.6.0 this template file is no longer used. My Account shortcode uses orders.php.
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/myaccount/navigation.php
+++ b/templates/myaccount/navigation.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.6.0
  */
 

--- a/templates/myaccount/orders.php
+++ b/templates/myaccount/orders.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.7.0
  */
 

--- a/templates/myaccount/payment-methods.php
+++ b/templates/myaccount/payment-methods.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.6.0
  */
 

--- a/templates/myaccount/view-order.php
+++ b/templates/myaccount/view-order.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.0.0
  */
 

--- a/templates/notices/error.php
+++ b/templates/notices/error.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.9.0
  */
 

--- a/templates/notices/notice.php
+++ b/templates/notices/notice.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.9.0
  */
 

--- a/templates/notices/success.php
+++ b/templates/notices/success.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.9.0
  */
 

--- a/templates/order/form-tracking.php
+++ b/templates/order/form-tracking.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.6.0
  */
 

--- a/templates/order/order-again.php
+++ b/templates/order/order-again.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.0
  */
 

--- a/templates/order/order-details-customer.php
+++ b/templates/order/order-details-customer.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.4
  */
 

--- a/templates/order/order-details-item.php
+++ b/templates/order/order-details-item.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.7.0
  */
 

--- a/templates/order/order-details.php
+++ b/templates/order/order-details.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.7.0
  */
 

--- a/templates/order/order-downloads.php
+++ b/templates/order/order-downloads.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.3.0
  */
 

--- a/templates/order/tracking.php
+++ b/templates/order/tracking.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.2.0
  */
 

--- a/templates/product-searchform.php
+++ b/templates/product-searchform.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.3.0
  */
 

--- a/templates/single-product-reviews.php
+++ b/templates/single-product-reviews.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 4.3.0
  */
 

--- a/templates/single-product.php
+++ b/templates/single-product.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     1.6.4
  */
 

--- a/templates/single-product/add-to-cart/external.php
+++ b/templates/single-product/add-to-cart/external.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.0
  */
 

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 4.0.0
  */
 

--- a/templates/single-product/add-to-cart/simple.php
+++ b/templates/single-product/add-to-cart/simple.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.0
  */
 

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.5
  */
 

--- a/templates/single-product/add-to-cart/variation-add-to-cart-button.php
+++ b/templates/single-product/add-to-cart/variation-add-to-cart-button.php
@@ -3,7 +3,7 @@
  * Single variation cart button
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.0
  */
 

--- a/templates/single-product/add-to-cart/variation.php
+++ b/templates/single-product/add-to-cart/variation.php
@@ -6,7 +6,7 @@
  * The values will be dynamically replaced after selecting attributes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.5.0
  */
 

--- a/templates/single-product/meta.php
+++ b/templates/single-product/meta.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.0.0
  */
 

--- a/templates/single-product/photoswipe.php
+++ b/templates/single-product/photoswipe.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.0.0
  */
 

--- a/templates/single-product/price.php
+++ b/templates/single-product/price.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.0.0
  */
 

--- a/templates/single-product/product-attributes.php
+++ b/templates/single-product/product-attributes.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.6.0
  */
 

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.1
  */
 

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.5.1
  */
 

--- a/templates/single-product/rating.php
+++ b/templates/single-product/rating.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.6.0
  */
 

--- a/templates/single-product/related.php
+++ b/templates/single-product/related.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.9.0
  */
 

--- a/templates/single-product/review-meta.php
+++ b/templates/single-product/review-meta.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.4.0
  */
 

--- a/templates/single-product/review-rating.php
+++ b/templates/single-product/review-rating.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.6.0
  */
 

--- a/templates/single-product/review.php
+++ b/templates/single-product/review.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.6.0
  */
 

--- a/templates/single-product/sale-flash.php
+++ b/templates/single-product/sale-flash.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     1.6.4
  */
 

--- a/templates/single-product/share.php
+++ b/templates/single-product/share.php
@@ -13,7 +13,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.5.0
  */
 

--- a/templates/single-product/short-description.php
+++ b/templates/single-product/short-description.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.3.0
  */
 

--- a/templates/single-product/stock.php
+++ b/templates/single-product/stock.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.0.0
  */
 

--- a/templates/single-product/tabs/additional-information.php
+++ b/templates/single-product/tabs/additional-information.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.0.0
  */
 

--- a/templates/single-product/tabs/description.php
+++ b/templates/single-product/tabs/description.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 2.0.0
  */
 

--- a/templates/single-product/tabs/tabs.php
+++ b/templates/single-product/tabs/tabs.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.8.0
  */
 

--- a/templates/single-product/up-sells.php
+++ b/templates/single-product/up-sells.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     3.0.0
  */
 

--- a/templates/taxonomy-product_cat.php
+++ b/templates/taxonomy-product_cat.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     1.6.4
  */
 

--- a/templates/taxonomy-product_tag.php
+++ b/templates/taxonomy-product_tag.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
- * @package     WooCommerce/Templates
+ * @package     WooCommerce\Templates
  * @version     1.6.4
  */
 

--- a/tests/Tools/CodeHacking/CodeHacker.php
+++ b/tests/Tools/CodeHacking/CodeHacker.php
@@ -2,7 +2,7 @@
 /**
  * CodeHacker class file.
  *
- * @package WooCommerce/Testing
+ * @package WooCommerce\Testing
  */
 
 //phpcs:disable WordPress.WP.AlternativeFunctions, WordPress.PHP.NoSilencedErrors.Discouraged

--- a/tests/Tools/CodeHacking/CodeHackerTestHook.php
+++ b/tests/Tools/CodeHacking/CodeHackerTestHook.php
@@ -2,7 +2,7 @@
 /**
  * CodeHackerTestHook class file.
  *
- * @package WooCommerce/Testing
+ * @package WooCommerce\Testing
  */
 
 namespace Automattic\WooCommerce\Testing\Tools\CodeHacking;

--- a/tests/Tools/CodeHacking/Hacks/BypassFinalsHack.php
+++ b/tests/Tools/CodeHacking/Hacks/BypassFinalsHack.php
@@ -2,7 +2,7 @@
 /**
  * BypassFinalsHack class file.
  *
- * @package WooCommerce/Testing
+ * @package WooCommerce\Testing
  */
 
 namespace Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks;

--- a/tests/Tools/CodeHacking/Hacks/CodeHack.php
+++ b/tests/Tools/CodeHacking/Hacks/CodeHack.php
@@ -2,7 +2,7 @@
 /**
  * CodeHack class file.
  *
- * @package WooCommerce/Testing
+ * @package WooCommerce\Testing
  */
 
 namespace Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks;

--- a/tests/Tools/CodeHacking/Hacks/FunctionsMockerHack.php
+++ b/tests/Tools/CodeHacking/Hacks/FunctionsMockerHack.php
@@ -2,7 +2,7 @@
 /**
  * FunctionsMockerHack class file.
  *
- * @package WooCommerce/Testing
+ * @package WooCommerce\Testing
  */
 
 namespace Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks;

--- a/tests/Tools/CodeHacking/Hacks/StaticMockerHack.php
+++ b/tests/Tools/CodeHacking/Hacks/StaticMockerHack.php
@@ -2,7 +2,7 @@
 /**
  * StaticMockerHack class file.
  *
- * @package WooCommerce/Testing
+ * @package WooCommerce\Testing
  */
 
 namespace Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks;

--- a/tests/legacy/framework/helpers/class-wc-helper-order.php
+++ b/tests/legacy/framework/helpers/class-wc-helper-order.php
@@ -2,7 +2,7 @@
 /**
  * Order helpers.
  *
- * @package WooCommerce/Tests
+ * @package WooCommerce\Tests
  */
 
 /**

--- a/tests/legacy/framework/helpers/class-wc-helper-product.php
+++ b/tests/legacy/framework/helpers/class-wc-helper-product.php
@@ -2,7 +2,7 @@
 /**
  * Product helpers.
  *
- * @package woocommerce/tests
+ * @package WooCommerce\Tests
  */
 
 /**

--- a/tests/legacy/framework/helpers/class-wc-helper-shipping.php
+++ b/tests/legacy/framework/helpers/class-wc-helper-shipping.php
@@ -2,7 +2,7 @@
 /**
  * Helper class for shipping related unit tests.
  *
- * @package WooCommerce\Tests|Helper
+ * @package WooCommerce\Tests\Helper
  */
 
 /**

--- a/tests/legacy/unit-tests/checkout/checkout.php
+++ b/tests/legacy/unit-tests/checkout/checkout.php
@@ -2,7 +2,7 @@
 /**
  * Checkout tests.
  *
- * @package WooCommerce|Tests|Checkout
+ * @package WooCommerce\Tests\Checkout
  */
 
 /**

--- a/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
+++ b/tests/legacy/unit-tests/order/class-wc-tests-order-functions.php
@@ -2,7 +2,7 @@
 /**
  * Class WC_Tests_Order_Functions file.
  *
- * @package WooCommerce/Tests
+ * @package WooCommerce\Tests
  */
 
 use Automattic\Jetpack\Constants;

--- a/tests/legacy/unit-tests/order/class-wc-tests-orders.php
+++ b/tests/legacy/unit-tests/order/class-wc-tests-orders.php
@@ -2,7 +2,7 @@
 /**
  * Class WC_Tests_Order file.
  *
- * @package WooCommerce|Tests|Order
+ * @package WooCommerce\Tests\Order
  */
 
 /**

--- a/tests/legacy/unit-tests/payment-gateways/cod.php
+++ b/tests/legacy/unit-tests/payment-gateways/cod.php
@@ -2,7 +2,7 @@
 /**
  * Contains tests for the COD Payment Gateway.
  *
- * @package WooCommerce/Tests/PaymentGateways
+ * @package WooCommerce\Tests\PaymentGateways
  */
 
 use Automattic\Jetpack\Constants;

--- a/tests/legacy/unit-tests/payment-gateways/payment-gateways.php
+++ b/tests/legacy/unit-tests/payment-gateways/payment-gateways.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * @package WooCommerce/Tests/PaymentGateways
+ * @package WooCommerce\Tests\PaymentGateways
  */
 
 /**

--- a/tests/legacy/unit-tests/templates/functions.php
+++ b/tests/legacy/unit-tests/templates/functions.php
@@ -2,7 +2,7 @@
 /**
  * Test template funcitons.
  *
- * @package WooCommerce/Tests/Templates
+ * @package WooCommerce\Tests\Templates
  * @since   3.4.0
  */
 

--- a/tests/legacy/unit-tests/widgets/class-wc-tests-widget.php
+++ b/tests/legacy/unit-tests/widgets/class-wc-tests-widget.php
@@ -2,7 +2,7 @@
 /**
  * Testing WC_Widget functionality.
  *
- * @package WooCommerce/Tests/Widgets
+ * @package WooCommerce\Tests\Widgets
  */
 
 /**

--- a/tests/php/includes/class-wc-ajax-test.php
+++ b/tests/php/includes/class-wc-ajax-test.php
@@ -2,7 +2,7 @@
 /**
  * Class WC_AJAX_Test file.
  *
- * @package WooCommerce|Tests|WC_AJAX.
+ * @package WooCommerce\Tests\WC_AJAX.
  */
 
 /**

--- a/tests/php/src/Internal/DependencyManagement/AbstractServiceProviderTest.php
+++ b/tests/php/src/Internal/DependencyManagement/AbstractServiceProviderTest.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * AbstractServiceProviderTests class file.
- *
- * @package WooCommerce\Tests\Internal\DependencyManagement
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement;

--- a/tests/php/src/Internal/DependencyManagement/AbstractServiceProviderTest.php
+++ b/tests/php/src/Internal/DependencyManagement/AbstractServiceProviderTest.php
@@ -2,7 +2,7 @@
 /**
  * AbstractServiceProviderTests class file.
  *
- * @package Automattic\WooCommerce\Tests\Internal\DependencyManagement
+ * @package WooCommerce\Tests\Internal\DependencyManagement
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement;

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithConstructorArgumentWithoutTypeHint.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithConstructorArgumentWithoutTypeHint.php
@@ -2,7 +2,7 @@
 /**
  * ClassWithConstructorArgumentWithoutTypeHint class file.
  *
- * @package Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
+ * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses;

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithConstructorArgumentWithoutTypeHint.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithConstructorArgumentWithoutTypeHint.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * ClassWithConstructorArgumentWithoutTypeHint class file.
- *
- * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses;

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithDependencies.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithDependencies.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * ClassWithDependencies class file.
- *
- * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses;

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithDependencies.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithDependencies.php
@@ -2,7 +2,7 @@
 /**
  * ClassWithDependencies class file.
  *
- * @package Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
+ * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses;

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithPrivateConstructor.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithPrivateConstructor.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * ClassWithPrivateConstructor class file.
- *
- * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses;

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithPrivateConstructor.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithPrivateConstructor.php
@@ -2,7 +2,7 @@
 /**
  * ClassWithPrivateConstructor class file.
  *
- * @package Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
+ * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses;

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithScalarConstructorArgument.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithScalarConstructorArgument.php
@@ -2,7 +2,7 @@
 /**
  * ClassWithConstructorArgumentWithoutTypeHint class file.
  *
- * @package Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
+ * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses;

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithScalarConstructorArgument.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithScalarConstructorArgument.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * ClassWithConstructorArgumentWithoutTypeHint class file.
- *
- * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses;

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithSingleton.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithSingleton.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * ClassWithSingleton class file.
- *
- * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 // This class is in the root namespace on purpose, since it simulates being a legacy class in the 'includes' directory.

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithSingleton.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithSingleton.php
@@ -2,7 +2,7 @@
 /**
  * ClassWithSingleton class file.
  *
- * @package Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
+ * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 // This class is in the root namespace on purpose, since it simulates being a legacy class in the 'includes' directory.

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/DependencyClass.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/DependencyClass.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * DependencyClass class file.
- *
- * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses;

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/DependencyClass.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/DependencyClass.php
@@ -2,7 +2,7 @@
 /**
  * DependencyClass class file.
  *
- * @package Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
+ * @package WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClasses;

--- a/tests/php/src/Internal/DependencyManagement/ExtendedContainerTest.php
+++ b/tests/php/src/Internal/DependencyManagement/ExtendedContainerTest.php
@@ -2,7 +2,7 @@
 /**
  * ExtendedContainerTests class file.
  *
- * @package Automattic\WooCommerce\Tests\Internal\DependencyManagement
+ * @package WooCommerce\Tests\Internal\DependencyManagement
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement;

--- a/tests/php/src/Internal/DependencyManagement/ExtendedContainerTest.php
+++ b/tests/php/src/Internal/DependencyManagement/ExtendedContainerTest.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * ExtendedContainerTests class file.
- *
- * @package WooCommerce\Tests\Internal\DependencyManagement
  */
 
 namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement;

--- a/tests/php/src/Proxies/ClassThatDependsOnLegacyCodeTest.php
+++ b/tests/php/src/Proxies/ClassThatDependsOnLegacyCodeTest.php
@@ -2,7 +2,7 @@
 /**
  * ClassThatDependsOnLegacyCodeTest class file
  *
- * @package Automattic\WooCommerce\Tests\Proxies
+ * @package WooCommerce\Tests\Proxies
  */
 
 namespace Automattic\WooCommerce\Tests\Proxies;

--- a/tests/php/src/Proxies/ClassThatDependsOnLegacyCodeTest.php
+++ b/tests/php/src/Proxies/ClassThatDependsOnLegacyCodeTest.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * ClassThatDependsOnLegacyCodeTest class file
- *
- * @package WooCommerce\Tests\Proxies
  */
 
 namespace Automattic\WooCommerce\Tests\Proxies;

--- a/tests/php/src/Proxies/ExampleClasses/ClassThatDependsOnLegacyCode.php
+++ b/tests/php/src/Proxies/ExampleClasses/ClassThatDependsOnLegacyCode.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * ClassThatDependsOnLegacyCode class file
- *
- * @package WooCommerce\Tests\Proxies\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Proxies\ExampleClasses;

--- a/tests/php/src/Proxies/ExampleClasses/ClassThatDependsOnLegacyCode.php
+++ b/tests/php/src/Proxies/ExampleClasses/ClassThatDependsOnLegacyCode.php
@@ -2,7 +2,7 @@
 /**
  * ClassThatDependsOnLegacyCode class file
  *
- * @package Automattic\WooCommerce\Tests\Proxies\ExampleClasses
+ * @package WooCommerce\Tests\Proxies\ExampleClasses
  */
 
 namespace Automattic\WooCommerce\Tests\Proxies\ExampleClasses;

--- a/tests/php/src/Proxies/LegacyProxyTest.php
+++ b/tests/php/src/Proxies/LegacyProxyTest.php
@@ -2,7 +2,7 @@
 /**
  * LegacyProxyTests class file
  *
- * @package Automattic\WooCommerce\Tests\Proxies
+ * @package WooCommerce\Tests\Proxies
  */
 
 namespace Automattic\WooCommerce\Tests\Proxies;

--- a/tests/php/src/Proxies/LegacyProxyTest.php
+++ b/tests/php/src/Proxies/LegacyProxyTest.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * LegacyProxyTests class file
- *
- * @package WooCommerce\Tests\Proxies
  */
 
 namespace Automattic\WooCommerce\Tests\Proxies;

--- a/tests/php/src/Proxies/MockableLegacyProxyTest.php
+++ b/tests/php/src/Proxies/MockableLegacyProxyTest.php
@@ -2,7 +2,7 @@
 /**
  * MockableLegacyProxyTests class file
  *
- * @package Automattic\WooCommerce\Tests\Proxies
+ * @package WooCommerce\Tests\Proxies
  */
 
 namespace Automattic\WooCommerce\Tests\Proxies;

--- a/tests/php/src/Proxies/MockableLegacyProxyTest.php
+++ b/tests/php/src/Proxies/MockableLegacyProxyTest.php
@@ -1,8 +1,6 @@
 <?php
 /**
  * MockableLegacyProxyTests class file
- *
- * @package WooCommerce\Tests\Proxies
  */
 
 namespace Automattic\WooCommerce\Tests\Proxies;

--- a/tests/unit-tests/widgets/class-wc-tests-widget-layered-nav.php
+++ b/tests/unit-tests/widgets/class-wc-tests-widget-layered-nav.php
@@ -2,7 +2,7 @@
 /**
  * Testing WC_Widget_Layered_Nav functionality.
  *
- * @package WooCommerce/Tests/Widgets
+ * @package WooCommerce\Tests\Widgets
  */
 
 /**


### PR DESCRIPTION
This PR fixes the usage of `@package` tag, it will improve the code reference generated from our code base.

Note that now inside `src/` isn't required a file comment or `@package` since those classes use namespaces.