### PR TITLE
Fix Japan zip code format issue #27108

### DIFF
--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -74,7 +74,7 @@ class WC_Validation {
 				$valid = (bool) preg_match( '/([AC-FHKNPRTV-Y]\d{2}|D6W)[0-9AC-FHKNPRTV-Y]{4}/', wc_normalize_postcode( $postcode ) );
 				break;
 			case 'JP':
-				$valid = (bool) preg_match( '/^([0-9]{3})([-])([0-9]{4})$/', $postcode );
+				$valid = (bool) preg_match( '/^([0-9]{3})([-]?)([0-9]{4})$/', $postcode );
 				break;
 			case 'PT':
 				$valid = (bool) preg_match( '/^([0-9]{4})([-])([0-9]{3})$/', $postcode );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fixes #27108 

### How to test the changes in this Pull Request:

1. Make sure you have shipping zones and rates set with dummy data
2. Add simple product to cart
3. Go to cart
4. Click calculate shipping link
5. Change Country to Japan, change prefecture to Tokyo, change city to Tokyo, Change Postcode/ZIP to 1340088

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Fixes Japan zip code format issue (dash is now optional)