### PR TITLE
Added woocommerce_order_item_quantity filter to ReserveStock::reserve_stock_for_order

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -64,8 +64,8 @@ function wc_update_product_stock( $product, $stock_quantity = null, $operation =
 /**
  * Update a product's stock status.
  *
- * @param  int $product_id Product ID.
- * @param  string $status     Status.
+ * @param int    $product_id Product ID.
+ * @param string $status     Status.
  */
 function wc_update_product_stock_status( $product_id, $status ) {
 	$product = wc_get_product( $product_id );
@@ -170,6 +170,13 @@ function wc_reduce_stock_levels( $order_id ) {
 			continue;
 		}
 
+		/**
+		 * Filter order item quantity.
+		 *
+		 * @param int|float             $quantity Quantity.
+		 * @param WC_Order              $order    Order data.
+		 * @param WC_Order_Item_Product $item Order item data.
+		 */
 		$qty       = apply_filters( 'woocommerce_order_item_quantity', $item->get_quantity(), $order, $item );
 		$item_name = $product->get_formatted_name();
 		$new_stock = wc_update_product_stock( $product, $qty, 'decrease' );

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -101,8 +101,18 @@ final class ReserveStock {
 					continue;
 				}
 
-				$managed_by_id          = $product->get_stock_managed_by_id();
-				$rows[ $managed_by_id ] = isset( $rows[ $managed_by_id ] ) ? $rows[ $managed_by_id ] + $item->get_quantity() : $item->get_quantity();
+				$managed_by_id = $product->get_stock_managed_by_id();
+
+				/**
+				 * Filter order item quantity.
+				 *
+				 * @param int|float             $quantity Quantity.
+				 * @param WC_Order              $order    Order data.
+				 * @param WC_Order_Item_Product $item Order item data.
+				 */
+				$item_quantity = apply_filters( 'woocommerce_order_item_quantity', $item->get_quantity(), $order, $item );
+
+				$rows[ $managed_by_id ] = isset( $rows[ $managed_by_id ] ) ? $rows[ $managed_by_id ] + $item_quantity : $item_quantity;
 			}
 
 			if ( ! empty( $rows ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This filter is used by several plugins, like [Measurement Price Calculator](https://woocommerce.com/products/measurement-price-calculator/) from SkyVerge, should be required if you are working with stock levels set in decimals.

Closes #27226.

### How to test the changes in this Pull Request:

1. In admin, create an Measurement Price Calculator product with calculated inventory: [https://cloud.skyver.ge/KourD1We](https://cloud.skyver.ge/KourD1We)
2. Set the stock level to 0.5 kg
3. Go to shop and add 0.25 kg of product to cart: [https://cloud.skyver.ge/Blu50WO0](https://cloud.skyver.ge/Blu50WO0)
4. Attempt to complete checkout
5. See error: [https://cloud.skyver.ge/v1u2RQx5](https://cloud.skyver.ge/v1u2RQx5)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Added `woocommerce_order_item_quantity` filter to `ReserveStock::reserve_stock_for_order()`
