### PR TITLE
Added new hook woocommerce_before_product_type_changed

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -824,6 +824,18 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		$old_type = WC_Product_Factory::get_product_type( $product->get_id() );
 		$new_type = $product->get_type();
 
+		$old_product = WC_Data_Store::load($old_type);
+
+		/**
+		 * Make the old product way more easier accessible
+		 *
+		 * @var WC_Product $old_product The old product before type change
+		 * @var WC_Product $product		The type changed Product
+		 * @var string $old_type		The old type of the product
+		 * @var string $new_type		The new changed type of the product
+		 */
+		do_action('woocommerce_before_product_type_changed', $old_product, $product, $old_type, $new_type);
+
 		wp_set_object_terms( $product->get_id(), $new_type, 'product_type' );
 		update_post_meta( $product->get_id(), '_product_version', Constants::get_constant( 'WC_VERSION' ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Described at the created Issue Ticket [#27256](https://github.com/woocommerce/woocommerce/issues/27256)

### How to test the changes in this Pull Request:

1. Create a new product at the WooCommerce backoffice
2. Publish a new product
3. Change the type of the product and update the product
4. Check if you got the old product and the product, also for the string values of the old and new product type from the implemented hook `woocommerce_before_prodcut_type_changed` 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added new hook `woocommerce_before_product_type_changed`
