### PR TITLE
Fixed packages required to run code sniffer on unit tests

### DIFF
--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -5,9 +5,6 @@ if [[ ${RUN_PHPCS} == 1 ]]; then
 	IGNORE="tests/cli/,includes/libraries/,includes/api/legacy/"
 
 	if [ "$CHANGED_FILES" != "" ]; then
-		# Install wpcs globally:
-    	composer require woocommerce/woocommerce-sniffs
-
 		echo "Running Code Sniffer."
 		./vendor/bin/phpcs --ignore=$IGNORE --encoding=utf-8 -s -n -p $CHANGED_FILES
 	fi


### PR DESCRIPTION
Everything already gets installed by the `composer.lock` file.