### PR TITLE
Fix non-static method invocation

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -489,7 +489,7 @@ class WC_Post_Types {
 	 * @since 4.4.0
 	 * @return bool
 	 */
-	public function updated_term_messages( $messages ) {
+	public static function updated_term_messages( $messages ) {
 		$messages['product_cat'] = array(
 			0 => '',
 			1 => __( 'Category added.', 'woocommerce' ),


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Updating a product term (e.g. product category) on **4.4.0-rc1** results in the following warning being thrown:

`PHP Deprecated:  Non-static method WC_Post_Types::updated_term_messages() should not be called statically in wp-includes/class-wp-hook.php on line 287`

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This pull requests correctly marks the invoked method as a static method. 

### How to test the changes in this Pull Request:

1. Update taxonomy term of a product category
2. Observe that change completed successfully, and no warnings thrown

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
