### PR TITLE
Fix invalid refund amount error when no decimals

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1864,7 +1864,7 @@ class WC_AJAX {
 			$order       = wc_get_order( $order_id );
 			$max_refund  = wc_format_decimal( $order->get_total() - $order->get_total_refunded(), wc_get_price_decimals() );
 
-			if ( ( ! $refund_amount && $refund_amount !== wc_format_decimal(0, wc_get_price_decimals() ) ) || $max_refund < $refund_amount || 0 > $refund_amount ) {
+			if ( ( ! $refund_amount && $refund_amount !== wc_format_decimal( 0, wc_get_price_decimals() ) ) || $max_refund < $refund_amount || 0 > $refund_amount ) {
 				throw new Exception( __( 'Invalid refund amount', 'woocommerce' ) );
 			}
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1864,7 +1864,7 @@ class WC_AJAX {
 			$order       = wc_get_order( $order_id );
 			$max_refund  = wc_format_decimal( $order->get_total() - $order->get_total_refunded(), wc_get_price_decimals() );
 
-			if ( ( ! $refund_amount && ( $refund_amount !== wc_format_decimal( 0, wc_get_price_decimals() ) ) ) || $max_refund < $refund_amount || 0 > $refund_amount ) {
+			if ( ( ! $refund_amount && ( wc_format_decimal( 0, wc_get_price_decimals() ) !== $refund_amount ) ) || $max_refund < $refund_amount || 0 > $refund_amount ) {
 				throw new Exception( __( 'Invalid refund amount', 'woocommerce' ) );
 			}
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -925,6 +925,7 @@ class WC_AJAX {
 				$validation_error = apply_filters( 'woocommerce_ajax_add_order_item_validation', $validation_error, $product, $order, $qty );
 
 				if ( $validation_error->get_error_code() ) {
+					/* translators: %s: error message */
 					throw new Exception( sprintf( __( 'Error: %s', 'woocommerce' ), $validation_error->get_error_message() ) );
 				}
 				$item_id                 = $order->add_product( $product, $qty );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1864,7 +1864,7 @@ class WC_AJAX {
 			$order       = wc_get_order( $order_id );
 			$max_refund  = wc_format_decimal( $order->get_total() - $order->get_total_refunded(), wc_get_price_decimals() );
 
-			if ( ( ! $refund_amount && $refund_amount !== wc_format_decimal( 0, wc_get_price_decimals() ) ) || $max_refund < $refund_amount || 0 > $refund_amount ) {
+			if ( ( ! $refund_amount && ( $refund_amount !== wc_format_decimal( 0, wc_get_price_decimals() ) ) ) || $max_refund < $refund_amount || 0 > $refund_amount ) {
 				throw new Exception( __( 'Invalid refund amount', 'woocommerce' ) );
 			}
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1864,7 +1864,7 @@ class WC_AJAX {
 			$order       = wc_get_order( $order_id );
 			$max_refund  = wc_format_decimal( $order->get_total() - $order->get_total_refunded(), wc_get_price_decimals() );
 
-			if ( ! $refund_amount || $max_refund < $refund_amount || 0 > $refund_amount ) {
+			if ( ( ! $refund_amount && $refund_amount !== wc_format_decimal(0, wc_get_price_decimals() ) ) || $max_refund < $refund_amount || 0 > $refund_amount ) {
 				throw new Exception( __( 'Invalid refund amount', 'woocommerce' ) );
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #26686 .

### How to test the changes in this Pull Request:

1. Go to WooCommerce Settings, set Number of Decimals to 0;
1. Refund an order by setting the quantity to a number > 0 and the refund amount to 0;
1. Shouldn't see a browser alert message "Invalid refund amount".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Invalid refund amount error on $0 refund when number of decimals is equal to 0.