### PR TITLE
Bump woocommerce-admin version to 1.5.0-beta.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "3.1.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.4.0-beta.3",
+    "woocommerce/woocommerce-admin": "1.5.0-beta.3",
     "woocommerce/woocommerce-blocks": "3.1.0"
   },
   "require-dev": {


### PR DESCRIPTION
This just increases the `woocommerce-admin` version to 1.5.0-beta.1