### PR TITLE
use first gallery image on single product when image not assigned

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1473,7 +1473,16 @@ if ( ! function_exists( 'woocommerce_show_product_images' ) ) {
 	 * Output the product image before the single product summary.
 	 */
 	function woocommerce_show_product_images() {
-		wc_get_template( 'single-product/product-image.php' );
+		global $product;
+		$post_thumbnail_id = $product->get_image_id();
+		if ( ! $post_thumbnail_id ) {
+			$gallery_image_ids = $product->get_gallery_image_ids();
+			if ( ! empty( $gallery_image_ids ) ) {
+				$post_thumbnail_id = array_shift( $gallery_image_ids );
+			}
+		}
+		$args = compact( 'post_thumbnail_id', 'gallery_image_ids' );
+		wc_get_template( 'single-product/product-image.php', $args );
 	}
 }
 if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
@@ -1482,7 +1491,13 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
 	 * Output the product thumbnails.
 	 */
 	function woocommerce_show_product_thumbnails() {
-		wc_get_template( 'single-product/product-thumbnails.php' );
+		global $product;
+		$attachment_ids = $product->get_gallery_image_ids();
+
+		if ( $attachment_ids && ! $product->get_image_id() ) {
+				array_shift( $attachment_ids );
+		}
+		wc_get_template( 'single-product/product-thumbnails.php', array( 'attachment_ids' => $attachment_ids ) );
 	}
 }
 

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1481,8 +1481,7 @@ if ( ! function_exists( 'woocommerce_show_product_images' ) ) {
 				$post_thumbnail_id = array_shift( $gallery_image_ids );
 			}
 		}
-		$args = compact( 'post_thumbnail_id', 'gallery_image_ids' );
-		wc_get_template( 'single-product/product-image.php', $args );
+		wc_get_template( 'single-product/product-thumbnails.php', array( 'post_thumbnail_id' => $post_thumbnail_id ) );
 	}
 }
 if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
@@ -1495,7 +1494,7 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
 		$attachment_ids = $product->get_gallery_image_ids();
 
 		if ( $attachment_ids && ! $product->get_image_id() ) {
-				array_shift( $attachment_ids );
+			array_shift( $attachment_ids );
 		}
 		wc_get_template( 'single-product/product-thumbnails.php', array( 'attachment_ids' => $attachment_ids ) );
 	}

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 4.5.0
+ * @version 4.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.5.1
+ * @version 4.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -26,11 +26,17 @@ global $product;
 
 $columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 );
 $post_thumbnail_id = $product->get_image_id();
+if ( ! $post_thumbnail_id ) {
+	$gallery_image_ids = $product->get_gallery_image_ids();
+	if ( ! empty( $gallery_image_ids ) ) {
+		$post_thumbnail_id = array_shift( $gallery_image_ids );
+	}
+}
 $wrapper_classes   = apply_filters(
 	'woocommerce_single_product_image_gallery_classes',
 	array(
 		'woocommerce-product-gallery',
-		'woocommerce-product-gallery--' . ( $product->get_image_id() ? 'with-images' : 'without-images' ),
+		'woocommerce-product-gallery--' . ( $post_thumbnail_id ? 'with-images' : 'without-images' ),
 		'woocommerce-product-gallery--columns-' . absint( $columns ),
 		'images',
 	)
@@ -39,7 +45,7 @@ $wrapper_classes   = apply_filters(
 <div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>" style="opacity: 0; transition: opacity .25s ease-in-out;">
 	<figure class="woocommerce-product-gallery__wrapper">
 		<?php
-		if ( $product->get_image_id() ) {
+		if ( $post_thumbnail_id ) {
 			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
 		} else {
 			$html  = '<div class="woocommerce-product-gallery__image--placeholder">';

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -25,13 +25,6 @@ if ( ! function_exists( 'wc_get_gallery_image_html' ) ) {
 global $product;
 
 $columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 );
-$post_thumbnail_id = $product->get_image_id();
-if ( ! $post_thumbnail_id ) {
-	$gallery_image_ids = $product->get_gallery_image_ids();
-	if ( ! empty( $gallery_image_ids ) ) {
-		$post_thumbnail_id = array_shift( $gallery_image_ids );
-	}
-}
 $wrapper_classes   = apply_filters(
 	'woocommerce_single_product_image_gallery_classes',
 	array(

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     3.5.1
+ * @version     4.5.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -26,7 +26,10 @@ global $product;
 
 $attachment_ids = $product->get_gallery_image_ids();
 
-if ( $attachment_ids && $product->get_image_id() ) {
+if ( $attachment_ids ) {
+	if ( ! $product->get_image_id() ) {
+		array_shift( $attachment_ids );
+	}
 	foreach ( $attachment_ids as $attachment_id ) {
 		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id ), $attachment_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 	}

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -24,12 +24,7 @@ if ( ! function_exists( 'wc_get_gallery_image_html' ) ) {
 
 global $product;
 
-$attachment_ids = $product->get_gallery_image_ids();
-
 if ( $attachment_ids ) {
-	if ( ! $product->get_image_id() ) {
-		array_shift( $attachment_ids );
-	}
 	foreach ( $attachment_ids as $attachment_id ) {
 		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id ), $attachment_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 	}

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     4.5.0
+ * @version     4.6.0
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the single product image and gallery templates to use the first gallery image as the product image when not product image is set.

Closes #27222 .
Closes #27247 .

### How to test the changes in this Pull Request:

1. Create a product and assign multiple gallery images
2. View the single product
3. First gallery image should be used as product image and not be duplicated in the list of gallery images
4. Assign a product image
5. Product image & gallery should be displayed the same as in master
6. Image zoom should work in all testing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Use first gallery image on single product when image not assigned.
