### PR TITLE
allow variation image to be removed via REST API

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -354,16 +354,21 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	protected function set_variation_image( $variation, $image ) {
 		$attachment_id = isset( $image['id'] ) ? absint( $image['id'] ) : 0;
 
-		if ( 0 === $attachment_id && isset( $image['src'] ) ) {
-			$upload = wc_rest_upload_image_from_url( esc_url_raw( $image['src'] ) );
+		if ( 0 === $attachment_id ) {
+			if ( isset( $image['src'] ) ) {
+				$upload = wc_rest_upload_image_from_url( esc_url_raw( $image['src'] ) );
 
-			if ( is_wp_error( $upload ) ) {
-				if ( ! apply_filters( 'woocommerce_rest_suppress_image_upload_error', false, $upload, $variation->get_id(), array( $image ) ) ) {
-					throw new WC_REST_Exception( 'woocommerce_variation_image_upload_error', $upload->get_error_message(), 400 );
+				if ( is_wp_error( $upload ) ) {
+					if ( ! apply_filters( 'woocommerce_rest_suppress_image_upload_error', false, $upload, $variation->get_id(), array($image))) {
+						throw new WC_REST_Exception( 'woocommerce_variation_image_upload_error', $upload->get_error_message(), 400);
+					}
 				}
-			}
 
-			$attachment_id = wc_rest_set_uploaded_image_as_attachment( $upload, $variation->get_id() );
+				$attachment_id = wc_rest_set_uploaded_image_as_attachment( $upload, $variation->get_id() );
+			} else {
+				$variation->set_image_id( '' );
+				return $variation;
+			}
 		}
 
 		if ( ! wp_attachment_is_image( $attachment_id ) ) {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -234,9 +234,9 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			if ( ! $parent ) {
 				return new WP_Error(
 					// Translators: %d parent ID.
-					"woocommerce_rest_{$this->post_type}_invalid_parent", sprintf( __( 'Cannot set attributes due to invalid parent product.', 'woocommerce' ), $variation->get_parent_id() ), array(
-						'status' => 404,
-					)
+					"woocommerce_rest_{$this->post_type}_invalid_parent",
+					__( 'Cannot set attributes due to invalid parent product.', 'woocommerce' ),
+					array( 'status' => 404 )
 				);
 			}
 
@@ -359,8 +359,8 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 				$upload = wc_rest_upload_image_from_url( esc_url_raw( $image['src'] ) );
 
 				if ( is_wp_error( $upload ) ) {
-					if ( ! apply_filters( 'woocommerce_rest_suppress_image_upload_error', false, $upload, $variation->get_id(), array($image))) {
-						throw new WC_REST_Exception( 'woocommerce_variation_image_upload_error', $upload->get_error_message(), 400);
+					if ( ! apply_filters( 'woocommerce_rest_suppress_image_upload_error', false, $upload, $variation->get_id(), array( $image ) ) ) {
+						throw new WC_REST_Exception( 'woocommerce_variation_image_upload_error', $upload->get_error_message(), 400 );
 					}
 				}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27116 .

### How to test the changes in this Pull Request:

1. Create a variable product with no images
2. Add two variations and set product images for both
3. Retrieve the product then one of the variations with `v3` REST API
4. `PUT` `{"id":1234,"image":{"id":0}}` where 1234 is the variation ID
5. Response should include no image
6. Check dashboard that image was removed from variation

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Allow variation image to be removed via REST API.
