### PR TITLE
Fix coding standards test on Travis

### DIFF
--- a/includes/admin/class-wc-admin-customize.php
+++ b/includes/admin/class-wc-admin-customize.php
@@ -2,10 +2,8 @@
 /**
  * Setup customize items.
  *
- * @author   WooCommerce
- * @category Admin
- * @package  WooCommerce\Admin\Customize
- * @version  3.1.0
+ * @package WooCommerce\Admin\Customize
+ * @version 3.1.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -5,6 +5,11 @@ if [[ ${RUN_PHPCS} == 1 ]]; then
 	IGNORE="tests/cli/,includes/libraries/,includes/api/legacy/"
 
 	if [ "$CHANGED_FILES" != "" ]; then
+		if [ ! -f "./vendor/bin/phpcs" ]; then
+			# Install wpcs globally
+			composer require woocommerce/woocommerce-sniffs
+		fi
+
 		echo "Running Code Sniffer."
 		./vendor/bin/phpcs --ignore=$IGNORE --encoding=utf-8 -s -n -p $CHANGED_FILES
 	fi

--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -7,7 +7,7 @@ if [[ ${RUN_PHPCS} == 1 ]]; then
 	if [ "$CHANGED_FILES" != "" ]; then
 		if [ ! -f "./vendor/bin/phpcs" ]; then
 			# Install wpcs globally
-			composer require woocommerce/woocommerce-sniffs
+			composer require woocommerce/woocommerce-sniffs --update-with-all-dependencies
 		fi
 
 		echo "Running Code Sniffer."


### PR DESCRIPTION
It will force to install WooCommerce Sniffs without getting any error like:

```
Your requirements could not be resolved to an installable set of packages.

  Problem 1

    - Can only install one of: dealerdirect/phpcodesniffer-composer-installer[v0.7.0, v0.6.2].

    - Can only install one of: dealerdirect/phpcodesniffer-composer-installer[v0.7.0, v0.6.2].

    - woocommerce/woocommerce-sniffs 0.1.0 requires dealerdirect/phpcodesniffer-composer-installer 0.7.0 -> satisfiable by dealerdirect/phpcodesniffer-composer-installer[v0.7.0].

    - Installation request for woocommerce/woocommerce-sniffs ^0.1.0 -> satisfiable by woocommerce/woocommerce-sniffs[0.1.0].

    - Installation request for dealerdirect/phpcodesniffer-composer-installer (locked at v0.6.2) -> satisfiable by dealerdirect/phpcodesniffer-composer-installer[v0.6.2].

Installation failed, reverting ./composer.json to its original content.
```