### PR TITLE
Fix product_variation going to draft on importing #27308

### DIFF
--- a/includes/import/class-wc-product-csv-importer.php
+++ b/includes/import/class-wc-product-csv-importer.php
@@ -823,12 +823,15 @@ class WC_Product_CSV_Importer extends WC_Product_Importer {
 				-1 => 'draft',
 				0  => 'private',
 				1  => 'publish',
+				2  => 'pending' //add pending status to products
 			);
 			$data['status'] = isset( $statuses[ $data['published'] ] ) ? $statuses[ $data['published'] ] : 'draft';
 
-			// Fix draft status of variations.
-			if ( isset( $data['type'] ) && 'variation' === $data['type'] && -1 === $data['published'] ) {
-				$data['status'] = 'publish';
+			// Fix draft status of variations. It should be like this.
+			if ( isset( $data['type'] ) && 'variation' === $data['type'] ) {
+				if ( isset( $data['status'] ) && 'draft' == $data['status'] ) {
+					$data['status'] = "publish";                                                                                                    
+				}
 			}
 
 			unset( $data['published'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Made the **product_variations** marked as publish even if they are marked draft(-1) in CSV.

### How to test the changes in this Pull Request:

1. Create a CSV  file for products with variable products and it's variations ( can use sample csv as well)
2. Set **published** field to **-1**
3. Import CSV file using default importer in woo-commerce products page 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
- Fix issue to product_variations not visible on edit product page after importing them as draft.
