### PR TITLE
Change data-type from mixed to composite and date-time to string on the fly for REST API

### DIFF
--- a/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -511,7 +511,7 @@ class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-customers-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-customers-v2-controller.php
@@ -350,7 +350,7 @@ class WC_REST_Customers_V2_Controller extends WC_REST_Customers_V1_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -410,7 +410,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 						),
@@ -432,13 +432,13 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 							),
 							'name'         => array(
 								'description' => __( 'Product name.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
 							'product_id'   => array(
 								'description' => __( 'Product ID.', 'woocommerce' ),
-								'type'        => array( 'integer', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
@@ -535,7 +535,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce' ),
-											'type'        => array( 'string', 'null' ),
+											'type'        => 'mixed',
 											'context'     => array( 'view', 'edit' ),
 											'readonly'    => true,
 										),

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1170,7 +1170,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 						),
@@ -1191,12 +1191,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'name'         => array(
 								'description' => __( 'Product name.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 							'product_id'   => array(
 								'description' => __( 'Product ID.', 'woocommerce' ),
-								'type'        => array( 'integer' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 							'variation_id' => array(
@@ -1282,7 +1282,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce' ),
-											'type'        => array( 'string', 'null' ),
+											'type'        => 'mixed',
 											'context'     => array( 'view', 'edit' ),
 										),
 									),
@@ -1373,7 +1373,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce' ),
-											'type'        => array( 'string', 'null' ),
+											'type'        => 'mixed',
 											'context'     => array( 'view', 'edit' ),
 										),
 									),
@@ -1397,12 +1397,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'method_title' => array(
 								'description' => __( 'Shipping method name.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 							'method_id'    => array(
 								'description' => __( 'Shipping method ID.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 							'instance_id'  => array(
@@ -1464,7 +1464,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce' ),
-											'type'        => array( 'string', 'null' ),
+											'type'        => 'mixed',
 											'context'     => array( 'view', 'edit' ),
 										),
 									),
@@ -1488,7 +1488,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'name'       => array(
 								'description' => __( 'Fee name.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 							'tax_class'  => array(
@@ -1562,7 +1562,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce' ),
-											'type'        => array( 'string', 'null' ),
+											'type'        => 'mixed',
 											'context'     => array( 'view', 'edit' ),
 										),
 									),
@@ -1586,7 +1586,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'code'         => array(
 								'description' => __( 'Coupon code.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 							'discount'     => array(
@@ -1620,7 +1620,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 										),
 										'value' => array(
 											'description' => __( 'Meta value.', 'woocommerce' ),
-											'type'        => array( 'string', 'null' ),
+											'type'        => 'mixed',
 											'context'     => array( 'view', 'edit' ),
 										),
 									),

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
@@ -981,7 +981,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 								'context'     => array( 'view', 'edit' ),
 							),
 							'value' => array(
-								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
+								'description' => __( 'Meta value.', 'woocommerce' ),
 								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
@@ -799,7 +799,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 				),
 				'manage_stock'          => array(
 					'description' => __( 'Stock management at variation level.', 'woocommerce' ),
-					'type'        => array( 'boolean', 'null' ),
+					'type'        => 'mixed',
 					'default'     => false,
 					'context'     => array( 'view', 'edit' ),
 				),
@@ -981,7 +981,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 								'context'     => array( 'view', 'edit' ),
 							),
 							'value' => array(
-								'description' => __( 'Meta value.', 'woocommerce' ),
+								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
 								'type'        => array( 'string', 'null' ),
 								'context'     => array( 'view', 'edit' ),
 							),

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
@@ -982,7 +982,7 @@ class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Contr
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce-rest-api' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -2084,7 +2084,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
@@ -530,18 +530,12 @@ class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {
 				),
 				'value'       => array(
 					'description' => __( 'Setting value.', 'woocommerce' ),
-					'type'        => array( 'string', 'array', 'null' ),
-					'items'       => array(
-						'type' => array( 'string', 'null' ),
-					),
+					'type'        => 'mixed',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'default'     => array(
 					'description' => __( 'Default value for the setting.', 'woocommerce' ),
-					'type'        => array( 'string', 'array', 'null' ),
-					'items'       => array(
-						'type' => array( 'string', 'null' ),
-					),
+					'type'        => 'mixed',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -99,7 +99,11 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 	}
 
 	/**
-	 * Change datatypes `date-time` to string, and `mixed` to composite of all built in types.
+	 * Change datatypes `date-time` to string, and `mixed` to composite of all built in types. This is required for maintaining forward compatibility with WP 5.5 since custom post types are not supported anymore.
+	 *
+	 * See @link https://core.trac.wordpress.org/changeset/48306
+	 *
+	 * We still use the 'mixed' type, since if we convert to composite type everywhere, it won't work in 5.4 anymore because they require to define the full schema.
 	 *
 	 * @param array $endpoint_args Schema with datatypes to convert.
 

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -127,7 +127,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 			 * WARNING: Order of fields here is important, types of fields are ordered from most specific to least specific as perceived by core's built-in type validation methods.
 			 */
 			if ( 'mixed' === $params['type'] ) {
-				$params['type'] = array( 'object', 'string', 'number', 'boolean', 'integer', 'array', 'null' );
+				$params['type'] = array( 'null', 'object', 'string', 'number', 'boolean', 'integer', 'array' );
 			}
 
 			if ( isset( $params['properties'] ) ) {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -93,16 +93,53 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 			return $endpoint_args;
 		}
 
-		foreach ( $endpoint_args as $field_id => $params ) {
-			/**
-			 * Custom types are not supported as of WP 5.5, this translates type => 'date-time' to type => 'string' with format date-time.
-			 */
-			if ( 'date-time' === $params['type'] ) {
-				$endpoint_args[ $field_id ]['type']   = 'string';
-				$endpoint_args[ $field_id ]['format'] = 'date-time';
-			}
+		$endpoint_args = $this->adjust_wp_5_5_datatype_compatibility( $endpoint_args );
+
+		return $endpoint_args;
+	}
+
+	/**
+	 * Change datatypes `date-time` to string, and `mixed` to composite of all built in types.
+	 *
+	 * @param array $endpoint_args Schema with datatypes to convert.
+
+	 * @return mixed Schema with converted datatype.
+	 */
+	protected function adjust_wp_5_5_datatype_compatibility( $endpoint_args ) {
+		if ( version_compare( get_bloginfo( 'version' ), '5.5', '<' ) ) {
+			return $endpoint_args;
 		}
 
+		foreach ( $endpoint_args as $field_id => $params ) {
+
+			if ( ! isset( $params['type'] ) ) {
+				continue;
+			}
+
+			/**
+			 * Custom types are not supported as of WP 5.5, this translates type => 'date-time' to type => 'string'.
+			 */
+			if ( 'date-time' === $params['type'] ) {
+				$params['type'] = 'string';
+			}
+
+			/**
+			 * WARNING: Order of fields here is important, types of fields are ordered from most specific to least specific as perceived by core's built-in type validation methods.
+			 */
+			if ( 'mixed' === $params['type'] ) {
+				$params['type'] = array( 'object', 'string', 'number', 'boolean', 'integer', 'array', 'null' );
+			}
+
+			if ( isset( $params['properties'] ) ) {
+				$params['properties'] = $this->adjust_wp_5_5_datatype_compatibility( $params['properties'] );
+			}
+
+			if ( isset( $params['items'] ) && isset( $params['items']['properties'] ) ) {
+				$params['items']['properties'] = $this->adjust_wp_5_5_datatype_compatibility( $params['items']['properties'] );
+			}
+
+			$endpoint_args[ $field_id ] = $params;
+		}
 		return $endpoint_args;
 	}
 

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -124,7 +124,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 			 * Custom types are not supported as of WP 5.5, this translates type => 'date-time' to type => 'string'.
 			 */
 			if ( 'date-time' === $params['type'] ) {
-				$params['type'] = 'string';
+				$params['type'] = array( 'null', 'string' );
 			}
 
 			/**

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -91,8 +91,6 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 		return true;
 	}
 
-
-
 	/**
 	 * Get object permalink.
 	 *

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-customers-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-customers-controller.php
@@ -293,7 +293,7 @@ class WC_REST_Customers_Controller extends WC_REST_Customers_V2_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -736,7 +736,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1288,7 +1288,7 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 							),
 							'value' => array(
 								'description' => __( 'Meta value.', 'woocommerce' ),
-								'type'        => array( 'string', 'null' ),
+								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
 						),

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-setting-options-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-setting-options-controller.php
@@ -199,18 +199,12 @@ class WC_REST_Setting_Options_Controller extends WC_REST_Setting_Options_V2_Cont
 				),
 				'value'       => array(
 					'description' => __( 'Setting value.', 'woocommerce' ),
-					'type'        => array( 'string', 'array', 'null' ),
-					'items'       => array(
-						'type' => array( 'string', 'null' ),
-					),
+					'type'        => 'mixed',
 					'context'     => array( 'view', 'edit' ),
 				),
 				'default'     => array(
 					'description' => __( 'Default value for the setting.', 'woocommerce' ),
-					'type'        => array( 'string', 'array', 'null' ),
-					'items'       => array(
-						'type' => array( 'string', 'null' ),
-					),
+					'type'        => 'mixed',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),

--- a/tests/legacy/bootstrap.php
+++ b/tests/legacy/bootstrap.php
@@ -222,6 +222,9 @@ class WC_Unit_Tests_Bootstrap {
 		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-shipping-zones.php';
 		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-payment-token.php';
 		require_once $this->tests_dir . '/framework/helpers/class-wc-helper-settings.php';
+
+		// Traits.
+		require_once $this->tests_dir . '/framework/traits/trait-wc-rest-api-complex-meta.php';
 	}
 
 	/**

--- a/tests/legacy/framework/traits/trait-wc-rest-api-complex-meta.php
+++ b/tests/legacy/framework/traits/trait-wc-rest-api-complex-meta.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Trait for easier testing of objects that have `mixed` data type somewhere.
+ *
+ * @package Automattic/WooCommerce/Tests/WC_REST_API_Complex_Meta.
+ */
+
+/**
+ * Trait WC_REST_API_Complex_Meta
+ */
+trait WC_REST_API_Complex_Meta {
+
+	/**
+	 * Sample data of different built in data types.
+	 *
+	 * @var array
+	 */
+	public static $sample_meta = array(
+		array(
+			'key' => 'string_meta',
+			'value' => 'string_value',
+		),
+		array(
+			'key' => 'int_meta',
+			'value' => 1,
+		),
+		array(
+			'key' => 'bool_meta',
+			'value' => true,
+		),
+		array(
+			'key' => 'array_meta',
+			'value' => array( 1, 2, 'string' ),
+		),
+		array(
+			'key' => 'object_meta',
+			'value' => array(
+				'nested_key1' => 'nested_value1',
+				'nested_key2' => 0,
+				'nested_key3' => true,
+				'nested_key4' => array( 2, 3, 4 ),
+				'nested_key5' => array( 2, 3, array( 'deep' => 'nesting' ) ),
+			),
+		),
+	);
+
+	/**
+	 * Test to update `meta_data` field with a complex data type.
+	 *
+	 * @param string $url     URL to send request against.
+	 * @param array  $options Options for customizations.
+	 */
+	public function assert_update_complex_meta( $url, $options = array() ) {
+		$meta = $options['meta'] ?? self::$sample_meta;
+		$request = new WP_REST_Request( 'PUT', $url );
+		$request->set_body_params( array( 'meta_data' => $meta ) );
+
+		$response = $this->server->dispatch( $request );
+
+		$data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$response_meta = $data['meta_data'];
+
+		foreach ( $meta as $meta_object ) {
+			$found = false;
+			foreach ( $response_meta as $response_meta_object ) {
+				if ( $response_meta_object->key === $meta_object['key'] ) {
+					$response_value = $response_meta_object->value;
+					$this->assertEquals( $meta_object['value'], $response_value );
+					$found = true;
+					break;
+				}
+			}
+			$this->assertEquals( true, $found, sprintf( 'Meta key %s was not found in response.', $meta_object['key'] ) );
+		}
+	}
+}

--- a/tests/legacy/framework/traits/trait-wc-rest-api-complex-meta.php
+++ b/tests/legacy/framework/traits/trait-wc-rest-api-complex-meta.php
@@ -33,6 +33,10 @@ trait WC_REST_API_Complex_Meta {
 			'value' => array( 1, 2, 'string' ),
 		),
 		array(
+			'key' => 'null_meta',
+			'value' => 'null',
+		),
+		array(
 			'key' => 'object_meta',
 			'value' => array(
 				'nested_key1' => 'nested_value1',

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/product-variations.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/product-variations.php
@@ -7,6 +7,7 @@
  */
 
 class Product_Variations_API_V2 extends WC_REST_Unit_Test_Case {
+	use WC_REST_API_Complex_Meta;
 
 	/**
 	 * Setup our test server, endpoints, and user info.
@@ -297,6 +298,19 @@ class Product_Variations_API_V2 extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/products/' . $product->get_id() . '/variations' ) );
 		$variations = $response->get_data();
 		$this->assertEquals( 3, count( $variations ) );
+	}
+
+	/**
+	 * Test updating complex meta object.
+	 */
+	public function test_update_complex_meta_27282() {
+		wp_set_current_user( $this->user );
+		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
+		$product->save();
+		$variations = $product->get_available_variations( 'objects' );
+		$first_variation_id = $variations[0]->get_id();
+		$url = '/wc/v2/products/' . $product->get_id() . '/variations/' . $first_variation_id;
+		$this->assert_update_complex_meta( $url );
 	}
 
 	/**

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -10,6 +10,7 @@
  * Class WC_Tests_API_Orders
  */
 class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
+	use WC_REST_API_Complex_Meta;
 
 	/**
 	 * Array of order to track
@@ -76,12 +77,22 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$order2->save();
 
 		$request = new WP_REST_Request( 'GET', '/wc/v3/orders' );
-		$request->set_query_params( array( 'orderby' => 'modified', 'order' => 'asc' ) );
+		$request->set_query_params(
+			array(
+				'orderby' => 'modified',
+				'order' => 'asc',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$orders   = $response->get_data();
 		$this->assertEquals( $order1->get_id(), $orders[0]['id'] );
 
-		$request->set_query_params( array( 'orderby' => 'modified', 'order' => 'desc' ) );
+		$request->set_query_params(
+			array(
+				'orderby' => 'modified',
+				'order' => 'desc',
+			)
+		);
 		$response = $this->server->dispatch( $request );
 		$orders   = $response->get_data();
 		$this->assertEquals( $order2->get_id(), $orders[0]['id'] );
@@ -208,6 +219,20 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 						'method_title' => 'Flat rate',
 						'total'        => '10.00',
 						'instance_id'  => '1',
+						'meta_data'    => array(
+							array(
+								'key'   => 'string',
+								'value' => 'string_val',
+							),
+							array(
+								'key'   => 'integer',
+								'value' => 1,
+							),
+							array(
+								'key'   => 'array',
+								'value' => array( 1, 2 ),
+							),
+						),
 					),
 				),
 			)

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
@@ -10,6 +10,7 @@
   * WC_Tests_API_Product class.
   */
 class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
+	use WC_REST_API_Complex_Meta;
 
 	/**
 	 * Setup our test server, endpoints, and user info.
@@ -218,7 +219,7 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 		$product      = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
 		$response     = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products/' . $product->get_id() ) );
 		$data         = $response->get_data();
-		$date_created = date( 'Y-m-d\TH:i:s', current_time( 'timestamp' ) );
+		$date_created = gmdate( 'Y-m-d\TH:i:s', current_time( 'timestamp' ) );
 
 		$this->assertEquals( 'DUMMY SKU', $data['sku'] );
 		$this->assertEquals( 10, $data['regular_price'] );
@@ -453,6 +454,17 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/products' ) );
 		$products = $response->get_data();
 		$this->assertEquals( 3, count( $products ) );
+	}
+
+	/**
+	 * Test to update complex metadata.
+	 */
+	public function test_update_complex_meta_27282() {
+		wp_set_current_user( $this->user );
+		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$product->save();
+		$url = '/wc/v3/products/' . $product->get_id();
+		$this->assert_update_complex_meta( $url );
 	}
 
 	/**

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
@@ -490,6 +490,19 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$data = $response->get_data();
 		$this->assertEquals( null, $data['date_on_sale_from'] );
+
+		$request->set_body_params( array( 'date_on_sale_from' => $date_from_sale ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( $date_from_sale, $data['date_on_sale_from'] );
+
+		// Null does not delete.
+		$request->set_body_params( array( 'date_on_sale_from' => null ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( $date_from_sale, $data['date_on_sale_from'] );
 	}
 
 	/**

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
@@ -468,6 +468,31 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Test to update datetime property.
+	 */
+	public function test_update_date_time() {
+		wp_set_current_user( $this->user );
+		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
+		$product->save();
+		$date_from_sale = '2020-01-01T01:01:01';
+
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/products/' . $product->get_id() );
+
+		$request->set_body_params( array( 'date_on_sale_from' => $date_from_sale ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( $date_from_sale, $data['date_on_sale_from'] );
+
+		// Empty string should delete.
+		$request->set_body_params( array( 'date_on_sale_from' => '' ) );
+		$response = $this->server->dispatch( $request );
+		$this->assertEquals( 200, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertEquals( null, $data['date_on_sale_from'] );
+	}
+
+	/**
 	 * Test creating a single product without permission.
 	 *
 	 * @since 3.5.0


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There are few changes in this PR:

1. Reverted change where we converted from mixed to built-in data types: https://github.com/woocommerce/woocommerce/commit/083e529668d5d8b8a72d829253ca3ff82430c647
2. Added on the fly conversions for date-time to string
3. Added on the fly conversions for mixed to composite data types.

### Important
When converting from mixed type, new types have to be converted into `array( 'null', 'object', 'string', 'number', 'boolean', 'integer', 'array' );` in **this order**. Otherwise, WP Core will probably cast them differently, for example, string can be cast as an array, boolean can be cast as int, and so on. This is the only order I could find which does seem to be working as expected  and is from most specific to least specific as per implementation of core's sanitization functions.

Closes #27282.

### How to test the changes in this Pull Request:

For any product, run an API request like so:
```
PUT https://w.test/wp-json/wc/v3/products/{product_id}?consumer_key=ck_xxxxx&consumer_secret=csxxxxx
Content-Type: application/json

{
  "date_on_sale_from_gmt":  "",
  "meta_data": [
    {
      "key": "test_key",
      "value": { "type":  "complex" }
    }
  ]
}
```
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Restore backward compatibility with WC 4.x and forward compatibility with WC 5.5
