### PR TITLE
switch to site locale before translating refund reason

### DIFF
--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -778,6 +778,7 @@ function wc_order_fully_refunded( $order_id ) {
 	}
 
 	// Create the refund object.
+	wc_switch_to_site_locale();
 	wc_create_refund(
 		array(
 			'amount'     => $max_refund,
@@ -786,6 +787,7 @@ function wc_order_fully_refunded( $order_id ) {
 			'line_items' => array(),
 		)
 	);
+	wc_restore_locale();
 
 	$order->add_order_note( __( 'Order status set to refunded. To return funds to the customer you will need to issue a refund through your payment gateway.', 'woocommerce' ) );
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR switches to the site locale before translating the refund reason.

Closes #27288 .

### How to test the changes in this Pull Request:

1. Go to the Settings > General and change the site language to other than English that has a language pack
2. Set your profile language to English
3. Place an order through the shop
4. Go to the dashboard and refund the order using the status dropdown
5. Check the refund order meta `_refund_reason` is translated to the selected site language
6. Check the email sent to the customer for the same translation

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: Switch to site locale before translating refund reason.
