### PR TITLE
WooCommerce 4.3.3 Prep

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -1,5 +1,10 @@
 == Changelog ==
 
+= 4.3.3 - 2020-08-14 =
+
+**WooCommerce REST API 1.0.10-pl-2**
+* Fix - Fix regression and restore backward compatibility for date-time and mixed datatypes. #239
+
 = 4.3.2 - 2020-08-10 =
 
 **WooCommerce**

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "1.3.1",
     "woocommerce/woocommerce-blocks": "2.7.3",
-    "woocommerce/woocommerce-rest-api": "1.0.10-pl-1"
+    "woocommerce/woocommerce-rest-api": "1.0.10-pl-2"
   },
   "require-dev": {
     "phpunit/phpunit": "7.5.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d26bcde4bb058571783f17357510614c",
+    "content-hash": "3a1c990fe6c75ee1a50b4ed59e87b374",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -527,16 +527,16 @@
         },
         {
             "name": "woocommerce/woocommerce-rest-api",
-            "version": "1.0.10-pl-1",
+            "version": "1.0.10-pl-2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-rest-api.git",
-                "reference": "3da37902921fd90a010a8d2277fc56425c3b1f02"
+                "reference": "7a46674fe6ba4981e0d21795ddc70aa5b8dbbf6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/3da37902921fd90a010a8d2277fc56425c3b1f02",
-                "reference": "3da37902921fd90a010a8d2277fc56425c3b1f02",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-rest-api/zipball/7a46674fe6ba4981e0d21795ddc70aa5b8dbbf6b",
+                "reference": "7a46674fe6ba4981e0d21795ddc70aa5b8dbbf6b",
                 "shasum": ""
             },
             "require": {
@@ -563,7 +563,8 @@
             ],
             "description": "The WooCommerce core REST API.",
             "homepage": "https://github.com/woocommerce/woocommerce-rest-api",
-            "time": "2020-08-07T12:26:08+00:00"
+            "abandoned": true,
+            "time": "2020-08-13T14:58:06+00:00"
         }
     ],
     "packages-dev": [

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -20,7 +20,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '4.3.2';
+	public $version = '4.3.3';
 
 	/**
 	 * WooCommerce Schema version.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce",
   "title": "WooCommerce",
-  "version": "4.3.2",
+  "version": "4.3.3",
   "homepage": "https://woocommerce.com/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.2
 Tested up to: 5.4
 Requires PHP: 7.0
-Stable tag: 4.3.2
+Stable tag: 4.3.3
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -179,17 +179,10 @@ INTERESTED IN DEVELOPMENT?
 
 == Changelog ==
 
-= 4.3.2 - 2020-08-10 =
+= 4.3.3 - 2020-08-14 =
 
-**WooCommerce**
-* Fix - Remove new WP 5.5 meta box arrows from "Order data" and "Order items" meta boxes. #27173
-* Fix - "Product type" dropdown missing from Product's data meta box on WP 5.5. #27170
-
-**WooCommerce Blocks 2.7.3**
-* Fix - Fix missing permissions_callback arg in StoreApi route definitions. #2926
-
-**WooCommerce REST API 1.0.10-pl-1**
-* Enhancement - Compatibility fixes for WordPress 5.5 #232
+**WooCommerce REST API 1.0.10-pl-2**
+* Fix - Fix regression and restore backward compatibility for date-time and mixed datatypes. #239
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce/master/CHANGELOG.txt).
 

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 4.3.2
+ * Version: 4.3.3
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
This PR contains following changes:

1. Update WC REST API to 1.0.10-pl-2
2. Version bump WC to 4.3.3