### PR TITLE
Retrieve/update product stock threshold via REST API #27291

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -517,6 +517,11 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 				$product->set_manage_stock( $request['manage_stock'] );
 			}
 
+			// Low stock threshold.
+			if ( isset( $request['low_stock_amount'] ) ) {
+				$product->set_low_stock_amount( $request['low_stock_amount'] );
+			}
+
 			// Backorders.
 			if ( isset( $request['backorders'] ) ) {
 				$product->set_backorders( $request['backorders'] );
@@ -934,6 +939,11 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 					'enum'        => array_keys( wc_get_product_stock_status_options() ),
 					'context'     => array( 'view', 'edit' ),
 				),
+				'low_stock_amount'        => array(
+					'description' => __( 'Low stock threshold.', 'woocommerce' ),
+					'type'        => 'integer',
+					'context'     => array( 'view', 'edit' ),
+				),
 				'backorders'            => array(
 					'description' => __( 'If managing stock, this controls if backorders are allowed.', 'woocommerce' ),
 					'type'        => 'string',
@@ -1331,11 +1341,15 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	protected function get_product_data( $product, $context = 'view' ) {
 		$data = parent::get_product_data( $product, $context );
 
-		// Replace in_stock with stock_status.
+		// Replace in_stock with stock_status and add low_stock_amount data.
 		$pos             = array_search( 'in_stock', array_keys( $data ), true );
 		$array_section_1 = array_slice( $data, 0, $pos, true );
 		$array_section_2 = array_slice( $data, $pos + 1, null, true );
+		$new_data        = array(
+			'stock_status'     => $product->get_stock_status( $context ),
+			'low_stock_amount' => $product->get_low_stock_amount( $context ),
+		);
 
-		return $array_section_1 + array( 'stock_status' => $product->get_stock_status( $context ) ) + $array_section_2;
+		return $array_section_1 + $new_data + $array_section_2;
 	}
 }

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
@@ -642,7 +642,7 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
 		$properties = $data['schema']['properties'];
-		$this->assertEquals( 65, count( $properties ) );
+		$this->assertEquals( 66, count( $properties ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #27291.

### How to test the changes in this Pull Request:

1. Create a product, check "Manage Stock" and set a value in product stock threshold field.
2. Retrieve the product with v3 REST API, response should include low_stock_amount with your value.
3. PUT {"low_stock_amount":5}, response should include low_stock_amount with your new value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Retrieve/update product stock threshold via REST API.