### PR TITLE
Added cache and filter for wc-customer get operations.

### DIFF
--- a/includes/admin/reports/class-wc-report-customer-list.php
+++ b/includes/admin/reports/class-wc-report-customer-list.php
@@ -62,6 +62,7 @@ class WC_Report_Customer_List extends WP_List_Table {
 
 			delete_user_meta( $user_id, '_money_spent' );
 			delete_user_meta( $user_id, '_order_count' );
+			delete_user_meta( $user_id, '_last_order' );
 			/* translators: User display name */
 			echo '<div class="updated"><p>' . sprintf( esc_html__( 'Refreshed stats for %s', 'woocommerce' ), esc_html( $user->display_name ) ) . '</p></div>';
 		}

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -406,8 +406,9 @@ class WC_Post_Data {
 					$customer->save();
 				}
 
-				// Delete order count meta.
+				// Delete order count and last order meta.
 				delete_user_meta( $customer_id, '_order_count' );
+				delete_user_meta( $customer_id, '_last_order' );
 			}
 
 			// Clean up items.

--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -64,6 +64,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 		'syntax_highlighting',
 		'_order_count',
 		'_money_spent',
+		'_last_order',
 		'_woocommerce_tracks_anon_id',
 	);
 

--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -349,7 +349,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 			update_user_meta( $customer->get_id(), '_last_order', $last_order );
 		}
 
-		if ( ! $last_order || '' === $last_order ) {
+		if ( ! $last_order ) {
 			return false;
 		}
 

--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -324,22 +324,31 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 	 * @return WC_Order|false
 	 */
 	public function get_last_order( &$customer ) {
-		global $wpdb;
-
-		$last_order = $wpdb->get_var(
-			// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-			"SELECT posts.ID
-			FROM $wpdb->posts AS posts
-			LEFT JOIN {$wpdb->postmeta} AS meta on posts.ID = meta.post_id
-			WHERE meta.meta_key = '_customer_user'
-			AND   meta.meta_value = '" . esc_sql( $customer->get_id() ) . "'
-			AND   posts.post_type = 'shop_order'
-			AND   posts.post_status IN ( '" . implode( "','", array_map( 'esc_sql', array_keys( wc_get_order_statuses() ) ) ) . "' )
-			ORDER BY posts.ID DESC"
-			// phpcs:enable
+		$last_order = apply_filters(
+			'woocommerce_customer_get_last_order',
+			get_user_meta( $customer->get_id(), '_last_order', true ),
+			$customer
 		);
 
-		if ( ! $last_order ) {
+		if ( '' === $last_order ) {
+			global $wpdb;
+
+			$last_order = $wpdb->get_var(
+				// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+				"SELECT posts.ID
+				FROM $wpdb->posts AS posts
+				LEFT JOIN {$wpdb->postmeta} AS meta on posts.ID = meta.post_id
+				WHERE meta.meta_key = '_customer_user'
+				AND   meta.meta_value = '" . esc_sql( $customer->get_id() ) . "'
+				AND   posts.post_type = 'shop_order'
+				AND   posts.post_status IN ( '" . implode( "','", array_map( 'esc_sql', array_keys( wc_get_order_statuses() ) ) ) . "' )
+				ORDER BY posts.ID DESC"
+				// phpcs:enable
+			);
+			update_user_meta( $customer->get_id(), '_last_order', $last_order );
+		}
+
+		if ( ! $last_order || '' === $last_order ) {
 			return false;
 		}
 
@@ -354,7 +363,11 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 	 * @return integer
 	 */
 	public function get_order_count( &$customer ) {
-		$count = get_user_meta( $customer->get_id(), '_order_count', true );
+		$count = apply_filters(
+			'woocommerce_customer_get_order_count',
+			get_user_meta( $customer->get_id(), '_order_count', true ),
+			$customer
+		);
 
 		if ( '' === $count ) {
 			global $wpdb;

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -456,7 +456,7 @@ function wc_delete_shop_order_transients( $order = 0 ) {
 		delete_transient( $transient );
 	}
 
-	// Clear money spent for user associated with order.
+	// Clear customer's order related caches.
 	if ( is_a( $order, 'WC_Order' ) ) {
 		$order_id = $order->get_id();
 		delete_user_meta( $order->get_customer_id(), '_money_spent' );

--- a/includes/wc-order-functions.php
+++ b/includes/wc-order-functions.php
@@ -461,6 +461,7 @@ function wc_delete_shop_order_transients( $order = 0 ) {
 		$order_id = $order->get_id();
 		delete_user_meta( $order->get_customer_id(), '_money_spent' );
 		delete_user_meta( $order->get_customer_id(), '_order_count' );
+		delete_user_meta( $order->get_customer_id(), '_last_order' );
 	} else {
 		$order_id = 0;
 	}

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -701,6 +701,7 @@ function wc_update_230_options() {
 	// _money_spent and _order_count may be out of sync - clear them
 	delete_metadata( 'user', 0, '_money_spent', '', true );
 	delete_metadata( 'user', 0, '_order_count', '', true );
+	delete_metadata( 'user', 0, '_last_order', '', true );
 
 	// To prevent taxes being hidden when using a default 'no address' in a store with tax inc prices, set the woocommerce_default_customer_address to use the store base address by default.
 	if ( '' === get_option( 'woocommerce_default_customer_address', false ) && wc_prices_include_tax() ) {

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -898,7 +898,7 @@ function wc_update_user_last_active( $user_id ) {
 	if ( ! $user_id ) {
 		return;
 	}
-	update_user_meta( $user_id, 'wc_last_active', (string) strtotime( date( 'Y-m-d', time() ) ) );
+	update_user_meta( $user_id, 'wc_last_active', (string) strtotime( gmdate( 'Y-m-d', time() ) ) );
 }
 
 /**

--- a/includes/wc-user-functions.php
+++ b/includes/wc-user-functions.php
@@ -272,6 +272,7 @@ function wc_update_new_customer_past_orders( $customer_id ) {
 		update_user_meta( $customer_id, 'paying_customer', 1 );
 		update_user_meta( $customer_id, '_order_count', '' );
 		update_user_meta( $customer_id, '_money_spent', '' );
+		delete_user_meta( $customer_id, '_last_order' );
 	}
 
 	return $linked;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR improves the performance of some slow operations on WC-Customer: `get_last_order` and `get_order_count`.

`get_last_order`:
 - Stores value into a new user_meta field as already did for many other calculations in the class.
 - Added filter to allow hook into before the (potentially slow) DB query.

`get_order_count`:
 - Added filter to allow hook into before the (potentially slow) DB query.

Hooks can be used to prevent the query go into the DB in case other solution (like solr backend) is available to get the data.


Closes #26925 .

### How to test the changes in this Pull Request:

1. With the unit tests over `WC_Customer_Data_Store` class as long the changes are technical details and no functionality is changed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added filters to hook into WC_Customer get_last order and get_order_count before the DB intensive query.
> Added cache for customers last_order value.