### PR TITLE
Update WooCommerce Admin to 1.4.0 for 4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "3.1.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.4.0-beta.3",
+    "woocommerce/woocommerce-admin": "1.4.0",
     "woocommerce/woocommerce-blocks": "3.1.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5b0c8903ebb5c38675bdc50029a51db8",
+    "content-hash": "01256f8ff122a1d16a9f6182238bf92a",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -259,12 +259,6 @@
                 "provider",
                 "service"
             ],
-            "funding": [
-                {
-                    "url": "https://github.com/philipobenito",
-                    "type": "github"
-                }
-            ],
             "time": "2020-05-18T08:20:23+00:00"
         },
         {
@@ -501,20 +495,6 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-16T08:31:04+00:00"
         },
         {
@@ -554,20 +534,20 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "v1.4.0-beta.3",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "df2af46a8552cdee15df0030fccbe4cd5a6d270d"
+                "reference": "f63648e12a29f596a28b926ed86cf3b8603dda6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/df2af46a8552cdee15df0030fccbe4cd5a6d270d",
-                "reference": "df2af46a8552cdee15df0030fccbe4cd5a6d270d",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/f63648e12a29f596a28b926ed86cf3b8603dda6c",
+                "reference": "f63648e12a29f596a28b926ed86cf3b8603dda6c",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "^2.0.0",
+                "automattic/jetpack-autoloader": "^2.2.0",
                 "composer/installers": "1.7.0",
                 "php": ">=5.6|>=7.0"
             },
@@ -597,7 +577,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-08-04T02:21:47+00:00"
+            "time": "2020-08-17T22:44:32+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -767,20 +747,6 @@
             "keywords": [
                 "constructor",
                 "instantiate"
-            ],
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-05-29T17:27:14+00:00"
         },
@@ -1043,12 +1009,6 @@
                 "duplicate",
                 "object",
                 "object graph"
-            ],
-            "funding": [
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-06-29T13:22:24+00:00"
         },
@@ -2478,16 +2438,16 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "3.5.5",
+            "version": "3.5.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6"
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
-                "reference": "73e2e7f57d958e7228fce50dc0c61f58f017f9f6",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/e97627871a7eab2f70e59166072a6b767d5834e0",
+                "reference": "e97627871a7eab2f70e59166072a6b767d5834e0",
                 "shasum": ""
             },
             "require": {
@@ -2525,7 +2485,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2020-04-17T01:09:41+00:00"
+            "time": "2020-08-10T04:50:15+00:00"
         },
         {
             "name": "symfony/finder",
@@ -2574,20 +2534,6 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-02-14T07:34:21+00:00"
         },
         {
@@ -2649,20 +2595,6 @@
                 "ctype",
                 "polyfill",
                 "portable"
-            ],
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
             ],
             "time": "2020-07-14T12:35:20+00:00"
         },
@@ -3070,6 +3002,5 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }


### PR DESCRIPTION
This PR includes the final release of WooCommerce Admin 1.4.0. The new changes included in this final release that are new since RC are:

[#4956](https://github.com/woocommerce/woocommerce-admin/pull/4956)  Match the requires version to the exact Wordpress version number in readme.txt.
[#4940](https://github.com/woocommerce/woocommerce-admin/pull/4940) Fix usage of "package" tag in file headers
[#4974](https://github.com/woocommerce/woocommerce-admin/pull/4974) Fix industry args type in REST API
[#4948](https://github.com/woocommerce/woocommerce-admin/pull/4948) Update style on shipping banner
[#4994](https://github.com/woocommerce/woocommerce-admin/pull/4994) CSS Fixes for Business Features Popover ( parts 1&2 )
[#4993](https://github.com/woocommerce/woocommerce-admin/pull/4993) Update Jetpack Autoloader to match Woo Core