### PR TITLE
Version bump wc-admin 1.5.0-rc.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "maxmind-db/reader": "1.6.0",
     "pelago/emogrifier": "3.1.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.4.0",
+    "woocommerce/woocommerce-admin": "1.5.0-rc.1",
     "woocommerce/woocommerce-blocks": "3.1.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f6765e0d7fd6969b3f92bf71807a97c",
+    "content-hash": "42e4de440843075e3074f98fa1ef5b61",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -534,20 +534,20 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "1.4.0",
+            "version": "1.5.0-rc.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "f63648e12a29f596a28b926ed86cf3b8603dda6c"
+                "reference": "97a540e2e114b8c7566dc97109ba04536f905de0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/f63648e12a29f596a28b926ed86cf3b8603dda6c",
-                "reference": "f63648e12a29f596a28b926ed86cf3b8603dda6c",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/97a540e2e114b8c7566dc97109ba04536f905de0",
+                "reference": "97a540e2e114b8c7566dc97109ba04536f905de0",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "^2.2.0",
+                "automattic/jetpack-autoloader": "^2.0.0",
                 "composer/installers": "1.7.0",
                 "php": ">=5.6|>=7.0"
             },
@@ -577,7 +577,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-08-17T22:44:32+00:00"
+            "time": "2020-08-18T03:05:31+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -1735,7 +1735,6 @@
             "keywords": [
                 "tokenizer"
             ],
-            "abandoned": true,
             "time": "2019-09-17T06:23:10+00:00"
         },
         {


### PR DESCRIPTION
This bumps the required version of WC Admin to 1.5.0-rc.1 - the latest release of the 1.5.0 branch.

See https://github.com/woocommerce/woocommerce-admin/releases/tag/v1.5.0-rc.1