### PR TITLE
Fixes to notice styles in Twenty Twenty

### DIFF
--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -202,6 +202,10 @@ a.button {
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
+
+	.button {
+		order: 2;
+	}
 }
 
 .woocommerce-message {

--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -188,12 +188,17 @@ a.button {
 .woocommerce-info {
 	margin-bottom: 5rem;
 	margin-left: 0;
-	padding: 1.5rem 3rem;
 	background: #eee;
 	font-size: 0.88889em;
 	font-family: $headings;
 	list-style: none;
 	overflow: hidden;
+}
+
+.woocommerce-message,
+.woocommerce-error li,
+.woocommerce-info {
+	padding: 1.5rem 3rem;
 	display: flex;
 	justify-content: space-between;
 	align-items: center;
@@ -218,6 +223,10 @@ a.button {
 		&.button {
 			background: #111;
 		}
+	}
+
+	> li {
+		margin: 0;
 	}
 }
 

--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -1641,7 +1641,6 @@ a.reset_variations {
 .woocommerce-checkout {
 
 	ul.woocommerce-error {
-		margin-left: 0;
 		flex-direction: column;
 		align-items: flex-start;
 


### PR DESCRIPTION
Fixes #27385.
Fixes #27386.

### How to test the changes in this Pull Request:

#27386:

1. Switch your theme to Twenty Twenty.
2. Go to `https://one.wordpress.test/cart/?add-to-cart=19` (replacing `one.wordpress.test` with your test site URL and `19` with the ID of a product).
3. Look at the notice that appears and verify the button is aligned to the right:

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/90544303-41438500-e187-11ea-9f39-4c95eb4a5066.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/90545310-c0858880-e188-11ea-840c-8af5ddf05999.png)

#27385:

1. Switch your theme to Twenty Twenty.
2. Create a page with some lorem ipsum text but without any WC block or shortcode (ie: `my-page`).
3. Edit a product so it can only be added once to the Cart.
![imatge](https://user-images.githubusercontent.com/3616980/87408703-27c97f00-c5c4-11ea-9ebb-c2dfdcc5472e.png)
4. Go to `https://one.wordpress.test/my-page/?add-to-cart=19` (replacing `one.wordpress.test` with your test site URL and `19` with the ID of the product you modified).
5. Reload the page several times.
6. Now go to `https://one.wordpress.test/cart/` and notice errors are displayed horizontally one on top of the other instead of horizontally.

_Before:_
![imatge](https://user-images.githubusercontent.com/3616980/90545784-73ee7d00-e189-11ea-9178-fe216bcd0a6c.png)

_After:_
![imatge](https://user-images.githubusercontent.com/3616980/90545713-5a4d3580-e189-11ea-81eb-60d5229c53ef.png)

### Changelog entry

> Fix - Several style improvements to notices in theme Twenty Twenty.