### PR TITLE
Fix changelog link in readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -321,7 +321,7 @@ INTERESTED IN DEVELOPMENT?
 * Fix - 'Product Summary' in All Products block is not pulling in the short description of the product. #2913
 * Dev - Add query filter when searching for a table. #2886
 
-[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce/master/CHANGELOG.txt).
+[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce/master/changelog.txt).
 
 == Upgrade Notice ==
 


### PR DESCRIPTION
Just a small fix, since we renaming the changelog.txt file name in master.
No need for changelog or to cherry pick this issue, once merged on `release/4.4` will be all fixed, since we have fixed master in #27312