### PR TITLE
Add protection to run adjust methods only if product query.

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -44,8 +44,6 @@ class WC_Query {
 			add_filter( 'query_vars', array( $this, 'add_query_vars' ), 0 );
 			add_action( 'parse_request', array( $this, 'parse_request' ), 0 );
 			add_action( 'pre_get_posts', array( $this, 'pre_get_posts' ) );
-			add_filter( 'the_posts', array( $this, 'handle_get_posts' ) );
-			add_filter( 'found_posts', array( $this, 'adjust_posts_count' ), 10, 2 );
 			add_filter( 'get_pagenum_link', array( $this, 'remove_add_to_cart_pagination' ), 10, 1 );
 		}
 		$this->init_query_vars();
@@ -355,11 +353,15 @@ class WC_Query {
 	/**
 	 * Handler for the 'the_posts' WP filter.
 	 *
-	 * @param array $posts Posts from WP Query.
+	 * @param array    $posts Posts from WP Query.
+	 * @param WP_Query $query Current query.
 	 *
 	 * @return array
 	 */
-	public function handle_get_posts( $posts ) {
+	public function handle_get_posts( $posts, $query ) {
+		if ( 'product_query' !== $query->get( 'wc_query' ) ) {
+			return $posts;
+		}
 		$this->adjust_total_pages();
 		$this->remove_product_query_filters( $posts );
 		return $posts;
@@ -511,7 +513,8 @@ class WC_Query {
 
 		// Additonal hooks to change WP Query.
 		add_filter( 'posts_clauses', array( $this, 'price_filter_post_clauses' ), 10, 2 );
-
+		add_filter( 'the_posts', array( $this, 'handle_get_posts' ), 10, 2 );
+		add_filter( 'found_posts', array( $this, 'adjust_posts_count' ), 10, 2 );
 		do_action( 'woocommerce_product_query', $q, $this );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This has two changes:

1. Hook the filter for adjusting product visibility in `product_query` instead of in init, so we only call those functions when necessary.
2. Add protections in case query is not the main query. Although change 1 should be enough, but adding this protection for brevity.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fixes the wc_get_loop_prop fatal in 4.4.0
Closes #27394.

### How to test the changes in this Pull Request:

Follow from #26260

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Add protection to run adjust methods only if product query.