### PR TITLE
Refactor/reserve stock class

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1005,12 +1005,12 @@ CREATE TABLE {$wpdb->prefix}wc_tax_rate_classes (
   UNIQUE KEY slug (slug($max_index_length))
 ) $collate;
 CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
-	`order_id` bigint(20) NOT NULL,
+	`customer_id` varchar(100) NOT NULL,
 	`product_id` bigint(20) NOT NULL,
 	`stock_quantity` double NOT NULL DEFAULT 0,
 	`timestamp` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
 	`expires` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
-	PRIMARY KEY  (`order_id`, `product_id`)
+	PRIMARY KEY  (`customer_id`, `product_id`)
 ) $collate;
 		";
 

--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -344,7 +344,7 @@ function wc_reserve_stock_for_order( $order ) {
 	$order = $order instanceof WC_Order ? $order : wc_get_order( $order );
 
 	if ( $order ) {
-		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->reserve_stock_for_order( $order );
+		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->release_stock_for_customer( $order->get_customer_id() );
 	}
 }
 add_action( 'woocommerce_checkout_order_created', 'wc_reserve_stock_for_order' );
@@ -370,7 +370,7 @@ function wc_release_stock_for_order( $order ) {
 	$order = $order instanceof WC_Order ? $order : wc_get_order( $order );
 
 	if ( $order ) {
-		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->release_stock_for_order( $order );
+		( new \Automattic\WooCommerce\Checkout\Helpers\ReserveStock() )->release_stock_for_customer( $order->get_customer_id() );
 	}
 }
 add_action( 'woocommerce_checkout_order_exception', 'wc_release_stock_for_order' );

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -250,10 +250,11 @@ final class ReserveStock {
 	 * Returns query statement for getting reserved stock of a product.
 	 *
 	 * @param  int     $product_id Product ID.
-	 * @param  integer $exclude_customer_id Optional customer_id to exclude from the results.
+	 * @param  integer $exclude_order_id Optional order_id to exclude from the results.
+	 * @param  string  $exclude_customer_id Optional customer_id to exclude from the results.
 	 * @return string|void Query statement.
 	 */
-	private function get_query_for_reserved_stock( $product_id, $exclude_customer_id = 0 ) {
+	private function get_query_for_reserved_stock( $product_id, $exclude_order_id = 0, $exclude_customer_id = 0 ) {
 		global $wpdb;
 
 		$query = $wpdb->prepare(
@@ -261,9 +262,11 @@ final class ReserveStock {
 			SELECT COALESCE( SUM( stock_table.`stock_quantity` ), 0 ) FROM $wpdb->wc_reserved_stock stock_table
 			WHERE stock_table.`product_id` = %d
 			AND stock_table.`expires` > NOW()
+			AND stock_table.`order_id` != %s
 			AND stock_table.`customer_id` != %s
 			",
 			$product_id,
+			$exclude_order_id,
 			$exclude_customer_id
 		);
 
@@ -274,8 +277,9 @@ final class ReserveStock {
 		 * @since 4.5.0
 		 * @param string $query            The query for getting reserved stock of a product.
 		 * @param int    $product_id       Product ID.
-		 * @param int    $exclude_customer_id customer_id to exclude from the results.
+		 * @param int    $exclude_order_id order_id to exclude from the results.
+		 * @param string $exclude_customer_id customer_id to exclude from the results.
 		 */
-		return apply_filters( 'woocommerce_query_for_reserved_stock', $query, $product_id, $exclude_customer_id );
+		return apply_filters( 'woocommerce_query_for_reserved_stock', $query, $product_id, $exclude_order_id, $exclude_customer_id );
 	}
 }

--- a/src/Checkout/Helpers/ReserveStock.php
+++ b/src/Checkout/Helpers/ReserveStock.php
@@ -108,7 +108,7 @@ final class ReserveStock {
 	 * Put a temporary hold on stock for a customer using their ID.
 	 *
 	 * @throws ReserveStockException If stock cannot be reserved.
-
+	 *
 	 * @param string $customer_id can be set on the manually, fallback to current customer session.
 	 * @param int    $minutes How long to reserve stock in minutes. Defaults to woocommerce_hold_stock_minutes.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is WIP (work in progress) pull request with suggested change for the current ReservedStock Class.

**Needs more work and discussion**

Conversations about the changes:
https://github.com/woocommerce/woocommerce/issues/27034#issuecomment-673576015
https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/2882#issuecomment-659814643

#### Switch to customer ID from draft order ID
Instead of relying on draft orders, this pull request changes the `ReservedStock` class to reserve stock using the customer ID. The customer id is either the user ID of a logged-in user or a uniquely generated ID for the WC session. It uses the `WC()->session->get_customer_id();`.

**Why?** I believe this method adds more flexibility and performance compared to using draft orders as a reference. We can now use the class easier and use it when draft orders haven't been created yet. E.g I plan to use it when adding products to the cart. 

**Problem with change**: The customer ID on the session is great, though we need to be able to maintain a reference between guest customers who login. E.g on the checkout. There has to be a way to attribute the same reservation to them. I also tried to add backwards compatibility in this example, but it doesn't work as draft-orders also don't store the guest customer_id. ` $order->get_customer_id()` will either be a registered user id or false.

#### New filter for the reservation minutes

I've added a new filter that will allow users to change the amount of minutes stock is reserved for. The filter will allow further flexibility to the reservation system and even bypass it if need be.

#### Breaking changes - this does change the database!

This pull request does change the database schema by replacing the `order_id` column with `customer_id` from in `wc_reserved_stock` table. Let's discuss if there is a reason to keep order IDs a reference. 

WooCommerce Blocks will need to update the referenced functions to be fully compatible with the changes.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

@ObliviousHarmony What do you think of this as a starting point? 