### PR TITLE
Additional protection for fieldlocale

### DIFF
--- a/assets/js/frontend/address-i18n.js
+++ b/assets/js/frontend/address-i18n.js
@@ -103,8 +103,10 @@ jQuery( function( $ ) {
 				}
 
 				// Class changes.
-				field.removeClass( 'form-row-first form-row-last form-row-wide' );
-				field.addClass( fieldLocale.class.join( ' ' ) );
+				if ( Array.isArray( fieldLocale.class ) ) {
+					field.removeClass( 'form-row-first form-row-last form-row-wide' );
+					field.addClass( fieldLocale.class.join( ' ' ) );
+				}
 			});
 
 			var fieldsets = $(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/795.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This adds additional protection around field locale property to prevent a JS error.

### How to test the changes in this Pull Request:

1. Apply the PR, install the PayPal Checkout Plugin
2. There should not be any errors in the console, and PayPal buttons should render correctly in Checkout and cart pages.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Add more protection for field locale property incase it's not defined.
