### PR TITLE
Fixed country list sorting

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -50,7 +50,7 @@ class WC_Countries {
 		if ( empty( $this->countries ) ) {
 			$this->countries = apply_filters( 'woocommerce_countries', include WC()->plugin_path() . '/i18n/countries.php' );
 			if ( apply_filters( 'woocommerce_sort_countries', true ) ) {
-				$this->countries = wc_asort_by_locale( $this->countries );
+				wc_asort_by_locale( $this->countries );
 			}
 		}
 

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -48,17 +48,10 @@ class WC_Countries {
 	 */
 	public function get_countries() {
 		if ( empty( $this->countries ) ) {
-			$countries = apply_filters( 'woocommerce_countries', include WC()->plugin_path() . '/i18n/countries.php' );
+			$this->countries = apply_filters( 'woocommerce_countries', include WC()->plugin_path() . '/i18n/countries.php' );
 			if ( apply_filters( 'woocommerce_sort_countries', true ) ) {
-				if ( class_exists( 'Collator' ) ) {
-					$collator = new Collator( get_locale() );
-					$collator->asort( $countries, Collator::SORT_STRING );
-				} else {
-					uasort( $countries, 'wc_ascii_uasort_comparison' );
-				}
+				$this->countries = wc_asort_by_locale( $this->countries );
 			}
-
-			$this->countries = $countries;
 		}
 
 		return $this->countries;

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -48,10 +48,17 @@ class WC_Countries {
 	 */
 	public function get_countries() {
 		if ( empty( $this->countries ) ) {
-			$this->countries = apply_filters( 'woocommerce_countries', include WC()->plugin_path() . '/i18n/countries.php' );
+			$countries = apply_filters( 'woocommerce_countries', include WC()->plugin_path() . '/i18n/countries.php' );
 			if ( apply_filters( 'woocommerce_sort_countries', true ) ) {
-				uasort( $this->countries, 'wc_ascii_uasort_comparison' );
+				if ( class_exists( 'Collator' ) ) {
+					$collator = new Collator( get_locale() );
+					$collator->asort( $countries, Collator::SORT_STRING );
+				} else {
+					uasort( $countries, 'wc_ascii_uasort_comparison' );
+				}
 			}
+
+			$this->countries = $countries;
 		}
 
 		return $this->countries;

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1773,7 +1773,7 @@ function wc_ascii_uasort_comparison( $a, $b ) {
  * @param string $locale Locale.
  * @return array
  */
-function wc_asort_by_locale( $data, $locale = '' ) {
+function wc_asort_by_locale( &$data, $locale = '' ) {
 	// Use Collator if PHP Internationalization Functions (php-intl) is available.
 	if ( class_exists( 'Collator' ) ) {
 		$locale   = $locale ? $locale : get_locale();

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1752,12 +1752,9 @@ function wc_uasort_comparison( $a, $b ) {
  * @return int
  */
 function wc_ascii_uasort_comparison( $a, $b ) {
-	// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
-	if ( function_exists( 'iconv' ) && defined( 'ICONV_IMPL' ) && @strcasecmp( ICONV_IMPL, 'unknown' ) !== 0 ) {
-		$a = @iconv( 'UTF-8', 'ASCII//TRANSLIT//IGNORE', $a );
-		$b = @iconv( 'UTF-8', 'ASCII//TRANSLIT//IGNORE', $b );
-	}
-	// phpcs:enable WordPress.PHP.NoSilencedErrors.Discouraged
+	$a = remove_accents( html_entity_decode( $a ) );
+	$b = remove_accents( html_entity_decode( $b ) );
+
 	return strcmp( $a, $b );
 }
 

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1763,6 +1763,44 @@ function wc_ascii_uasort_comparison( $a, $b ) {
 }
 
 /**
+ * Sort array according to current locale rules and maintaining index association.
+ * By default tries to use Collator from PHP Internationalization Functions if available.
+ * If PHP Collator class doesn't exists it fallback to removing accepts from a array
+ * and by sorting with `uasort( $data, 'strcmp' )` giving support for ASCII values.
+ *
+ * @since 4.6.0
+ * @param array  $data   List of values to sort.
+ * @param string $locale Locale.
+ * @return array
+ */
+function wc_asort_by_locale( $data, $locale = '' ) {
+	// Use Collator if PHP Internationalization Functions (php-intl) is available.
+	if ( class_exists( 'Collator' ) ) {
+		$locale   = $locale ? $locale : get_locale();
+		$collator = new Collator( $locale );
+		$collator->asort( $data, Collator::SORT_STRING );
+		return $data;
+	}
+
+	$raw_data = $data;
+
+	array_walk(
+		$data,
+		function ( &$value ) {
+			$value = remove_accents( html_entity_decode( $value ) );
+		}
+	);
+
+	uasort( $data, 'strcmp' );
+
+	foreach ( $data as $key => $val ) {
+		$data[ $key ] = $raw_data[ $key ];
+	}
+
+	return $data;
+}
+
+/**
  * Get rounding mode for internal tax calculations.
  *
  * @since 3.2.4

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1752,8 +1752,12 @@ function wc_uasort_comparison( $a, $b ) {
  * @return int
  */
 function wc_ascii_uasort_comparison( $a, $b ) {
-	$a = remove_accents( html_entity_decode( $a ) );
-	$b = remove_accents( html_entity_decode( $b ) );
+	// phpcs:disable WordPress.PHP.NoSilencedErrors.Discouraged
+	if ( function_exists( 'iconv' ) && defined( 'ICONV_IMPL' ) && @strcasecmp( ICONV_IMPL, 'unknown' ) !== 0 ) {
+		$a = @iconv( 'UTF-8', 'ASCII//TRANSLIT//IGNORE', $a );
+		$b = @iconv( 'UTF-8', 'ASCII//TRANSLIT//IGNORE', $b );
+	}
+	// phpcs:enable WordPress.PHP.NoSilencedErrors.Discouraged
 
 	return strcmp( $a, $b );
 }

--- a/tests/php/includes/wc-core-functions-test.php
+++ b/tests/php/includes/wc-core-functions-test.php
@@ -38,7 +38,8 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 			'AX' => 'Åland Islands',
 		);
 
-		$sorted_values = wc_asort_by_locale( $unsorted_values );
+		$sorted_values = $unsorted_values;
+		wc_asort_by_locale( $sorted_values );
 
 		$this->assertSame( array( 'Afghanistan', 'Åland Islands', 'Espagne', 'Éthiopie' ), array_values( $sorted_values ) );
 	}

--- a/tests/php/includes/wc-core-functions-test.php
+++ b/tests/php/includes/wc-core-functions-test.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Core functions tests
+ *
+ * @package WooCommerce\Tests\Functions.
+ */
+
+/**
+ * Class WC_Core_Functions_Test
+ */
+class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * Test wc_ascii_uasort_comparison() function.
+	 */
+	public function test_wc_ascii_uasort_comparison() {
+		$unsorted_values = array(
+			'ET' => 'Éthiopie',
+			'ES' => 'Espagne',
+			'AF' => 'Afghanistan',
+			'AX' => 'Åland Islands',
+		);
+
+		$sorted_values = $unsorted_values;
+		uasort( $sorted_values, 'wc_ascii_uasort_comparison' );
+
+		$this->assertSame( array( 'Afghanistan', 'Åland Islands', 'Espagne', 'Éthiopie' ), array_values( $sorted_values ) );
+	}
+}

--- a/tests/php/includes/wc-core-functions-test.php
+++ b/tests/php/includes/wc-core-functions-test.php
@@ -26,4 +26,20 @@ class WC_Core_Functions_Test extends \WC_Unit_Test_Case {
 
 		$this->assertSame( array( 'Afghanistan', 'Åland Islands', 'Espagne', 'Éthiopie' ), array_values( $sorted_values ) );
 	}
+
+	/**
+	 * Test wc_asort_by_locale() function.
+	 */
+	public function test_wc_asort_by_locale() {
+		$unsorted_values = array(
+			'ET' => 'Éthiopie',
+			'ES' => 'Espagne',
+			'AF' => 'Afghanistan',
+			'AX' => 'Åland Islands',
+		);
+
+		$sorted_values = wc_asort_by_locale( $unsorted_values );
+
+		$this->assertSame( array( 'Afghanistan', 'Åland Islands', 'Espagne', 'Éthiopie' ), array_values( $sorted_values ) );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

For a long time we have issues with this sorting, since it need to consider accents, if we don't consider accents the result will be:

```
Égypte
Åland Islands
Îles Turques et Caïques
Émirats Arabes Unis
Équateur
Éthiopie
Afghanistan
Afrique du Sud
```

We attempted to solve this issue using `iconv`, as you can see with those PRs:

- #22417
- #23363

Yet it doesn't solve problems in all installations, even in my localhost environment I could find some inconsistencies comparing results from what is rendered in the browser and what `iconv` returns for my in the PHP CLI interface.

To solve this issue I introduced the `wc_asort_by_locale()` function, where it first tries to use the PHP's `Collator` class (available since PHP 5.3, but not installed by default in all installations), if `Collator` class isn't available, we remove all accepts from the string using WP's `remove_accepts()` function, and making the comparison at once for all values (this last one is a performance improvement compared to the previous solution).

Closes #27415.

### How to test the changes in this Pull Request:

1. Change your WordPress installation language to `fr_FR`. With WP-CLI it can be done using the follow commands:
```bash
wp language core install fr_FR --activate
wp language plugin install woocommerce fr_FR
```
2. Make sure your store is selling to all countries in `/wp-admin/admin.php?page=wc-settings`.
3. Add some product to the cart and to go the checkout page.
4. Check that the list of countries display incorrect values, or maybe not because `iconv`, so no one knows if you'll manage to see this bug or not :man_shrugging:, it will depend on your environment, and while I'm able to reproduce this issue, I'm not sure what is wrong in my environment, and why it works when I try with PHP CLI/PHPUnit.
5. Apply this patch, and check the list of countries again the checkout page.
6. Now check that everything got sorted correctly.
7. If in your installation there's no `php-intl` (PHP - Internationalization Functions) installed, make sure to install, so you'll also be able to test with `Collator` fallback. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed countries list sorting and added support to PHP Internationalization Functions.
