### PR TITLE
Prepare 4.5 Beta 1 Release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -6,7 +6,6 @@
 * Localization - Added postcode validation for Bosnia and Herzegovina. #27048
 * Localization - Added the postcode validation for Liechtenstein. #27059
 * Localization - Add i18n locale information for Liechtenstein, Switzerland and Austria. #27193
-* Fix - Added additional stock-based cart filters including woocommerce_cart_product_cannot_add_another_message, woocommerce_cart_product_out_of_stock_message and woocommerce_cart_product_not_enough_stock_message. #26439
 * Fix - Remove whitespace within a link. #26897
 * Fix - `get_review_count_for_product` return all comments count not only 'review' types #26928
 * Fix - Hidden field type is now supported by `woocommerce_form_field`. #27023
@@ -19,6 +18,7 @@
 * Fix - Fixes Japan zip code format issue (dash is now optional). #27244
 * Fix - Restore backward compatibility with WC 4.x and forward compatibility with WC 5.5. #27318
 * Fix - Switch to site locale before translating refund reason. #27323
+* Dev - Added additional stock-based cart filters including woocommerce_cart_product_cannot_add_another_message, woocommerce_cart_product_out_of_stock_message and woocommerce_cart_product_not_enough_stock_message. #26439
 * Dev - Changed text domain to `woocommerce` for REST API files. #27248
 * Dev - Added file path to the `woocommerce_file_download_method` filter. #27152
 * Dev - Merge API Package into core. #27100

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,7 +18,7 @@
 * Fix - Fixes Japan zip code format issue (dash is now optional). #27244
 * Fix - Restore backward compatibility with WC 4.x and forward compatibility with WC 5.5. #27318
 * Fix - Switch to site locale before translating refund reason. #27323
-* Dev - Added additional stock-based cart filters including woocommerce_cart_product_cannot_add_another_message, woocommerce_cart_product_out_of_stock_message and woocommerce_cart_product_not_enough_stock_message. #26439
+* Dev - Added additional stock-based cart filters including `woocommerce_cart_product_cannot_add_another_message`, `woocommerce_cart_product_out_of_stock_message`, and `woocommerce_cart_product_not_enough_stock_message`. #26439
 * Dev - Changed text domain to `woocommerce` for REST API files. #27248
 * Dev - Added file path to the `woocommerce_file_download_method` filter. #27152
 * Dev - Merge API Package into core. #27100

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,40 @@
 == Changelog ==
 
+= 4.5.0 - 2020-09-08 =
+
+**WooCommerce**
+* Localization - Added postcode validation for Bosnia and Herzegovina. #27048
+* Localization - Added the postcode validation for Liechtenstein. #27059
+* Localization - Add i18n locale information for Liechtenstein, Switzerland and Austria. #27193
+* Fix - Added additional stock-based cart filters including woocommerce_cart_product_cannot_add_another_message, woocommerce_cart_product_out_of_stock_message and woocommerce_cart_product_not_enough_stock_message. #26439
+* Fix - Remove whitespace within a link. #26897
+* Fix - `get_review_count_for_product` return all comments count not only 'review' types #26928
+* Fix - Hidden field type is now supported by `woocommerce_form_field`. #27023
+* Fix - Remove state for country liechtenstein. #27057
+* Fix - Fixed validation of variation attributes while adding products to the cart. #27115
+* Fix - Coupon code inconsistent between admins and shop owners. #27140
+* Fix - Fixed the logic behind "Hide shipping costs until an address is entered". #27143
+* Fix - Searches for variations now will fallback to parent SKU if one is not entered. #27171
+* Fix - Release coupon holds for cancelled orders previously in pending status. #27179
+* Fix - Fixes Japan zip code format issue (dash is now optional). #27244
+* Fix - Restore backward compatibility with WC 4.x and forward compatibility with WC 5.5. #27318
+* Fix - Switch to site locale before translating refund reason. #27323
+* Dev - Changed text domain to `woocommerce` for REST API files. #27248
+* Dev - Added file path to the `woocommerce_file_download_method` filter. #27152
+* Dev - Merge API Package into core. #27100
+
+**WooCommerce Admin 1.5.0**
+* Enhancement - Add eWAY to Payment Setup for AU/NZ Stores. #4947
+* Fix - Use clipRule and fillRule props. #4889, part of #4864
+* Tweak: Remove the Composite products option from the onboarding wizard #4703
+* Dev - New notification: Don't forget to test your checkout. #4805
+* Dev - Enable tax calculation before redirecting to standard tax rates page. #4878
+* Dev - Added event recording to Orders, Stock, and Reviews panels. #4861
+* Dev - Added personalization to purchase extension task. #4849
+* Dev - Display modal with more info about the new homescreen. #4890
+* Dev - Task list - add a shortcut back to store setup. #4853
+* Dev - Update the colors of the illustrations in the welcome modal. #4945
+
 = 4.4.1 - 2020-08-19 =
 
 **WooCommerce**

--- a/readme.txt
+++ b/readme.txt
@@ -179,12 +179,42 @@ INTERESTED IN DEVELOPMENT?
 
 == Changelog ==
 
-= 4.4.1 - 2020-08-19 =
+
+
+= 4.5.0 - 2020-09-08 =
 
 **WooCommerce**
-* Fix - Add protection to run adjust methods only if product query. #27396
-* Dev - Stripped the internals of the DI Container to address plugin dependency conflicts it caused. #27395
+* Localization - Added postcode validation for Bosnia and Herzegovina. #27048
+* Localization - Added the postcode validation for Liechtenstein. #27059
+* Localization - Add i18n locale information for Liechtenstein, Switzerland and Austria. #27193
+* Fix - Added additional stock-based cart filters including woocommerce_cart_product_cannot_add_another_message, woocommerce_cart_product_out_of_stock_message and woocommerce_cart_product_not_enough_stock_messag$
+* Fix - Remove whitespace within a link. #26897
+* Fix - `get_review_count_for_product` return all comments count not only 'review' types #26928
+* Fix - Hidden field type is now supported by `woocommerce_form_field`. #27023
+* Fix - Remove state for country liechtenstein. #27057
+* Fix - Fixed validation of variation attributes while adding products to the cart. #27115
+* Fix - Coupon code inconsistent between admins and shop owners. #27140
+* Fix - Fixed the logic behind "Hide shipping costs until an address is entered". #27143
+* Fix - Searches for variations now will fallback to parent SKU if one is not entered. #27171
+* Fix - Release coupon holds for cancelled orders previously in pending status. #27179
+* Fix - Fixes Japan zip code format issue (dash is now optional). #27244
+* Fix - Restore backward compatibility with WC 4.x and forward compatibility with WC 5.5. #27318
+* Fix - Switch to site locale before translating refund reason. #27323
+* Dev - Changed text domain to `woocommerce` for REST API files. #27248
+* Dev - Added file path to the `woocommerce_file_download_method` filter. #27152
+* Dev - Merge API Package into core. #27100
 
+**WooCommerce Admin 1.5.0**
+* Enhancement - Add eWAY to Payment Setup for AU/NZ Stores. #4947
+* Fix - Use clipRule and fillRule props. #4889, part of #4864
+* Tweak: Remove the Composite products option from the onboarding wizard #4703
+* Dev - New notification: Don't forget to test your checkout. #4805
+* Dev - Enable tax calculation before redirecting to standard tax rates page. #4878
+* Dev - Added event recording to Orders, Stock, and Reviews panels. #4861
+* Dev - Added personalization to purchase extension task. #4849
+* Dev - Display modal with more info about the new homescreen. #4890
+* Dev - Task list - add a shortcut back to store setup. #4853
+* Dev - Update the colors of the illustrations in the welcome modal. #4945
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce/master/changelog.txt).
 
 == Upgrade Notice ==

--- a/readme.txt
+++ b/readme.txt
@@ -199,7 +199,7 @@ INTERESTED IN DEVELOPMENT?
 * Fix - Fixes Japan zip code format issue (dash is now optional). #27244
 * Fix - Restore backward compatibility with WC 4.x and forward compatibility with WC 5.5. #27318
 * Fix - Switch to site locale before translating refund reason. #27323
-* Dev - Added additional stock-based cart filters including woocommerce_cart_product_cannot_add_another_message, woocommerce_cart_product_out_of_stock_message and woocommerce_cart_product_not_enough_stock_messag$
+* Dev - Added additional stock-based cart filters including `woocommerce_cart_product_cannot_add_another_message`, `woocommerce_cart_product_out_of_stock_message`, and `woocommerce_cart_product_not_enough_stock_message`. #26439
 * Dev - Changed text domain to `woocommerce` for REST API files. #27248
 * Dev - Added file path to the `woocommerce_file_download_method` filter. #27152
 * Dev - Merge API Package into core. #27100

--- a/readme.txt
+++ b/readme.txt
@@ -187,7 +187,6 @@ INTERESTED IN DEVELOPMENT?
 * Localization - Added postcode validation for Bosnia and Herzegovina. #27048
 * Localization - Added the postcode validation for Liechtenstein. #27059
 * Localization - Add i18n locale information for Liechtenstein, Switzerland and Austria. #27193
-* Fix - Added additional stock-based cart filters including woocommerce_cart_product_cannot_add_another_message, woocommerce_cart_product_out_of_stock_message and woocommerce_cart_product_not_enough_stock_messag$
 * Fix - Remove whitespace within a link. #26897
 * Fix - `get_review_count_for_product` return all comments count not only 'review' types #26928
 * Fix - Hidden field type is now supported by `woocommerce_form_field`. #27023
@@ -200,6 +199,7 @@ INTERESTED IN DEVELOPMENT?
 * Fix - Fixes Japan zip code format issue (dash is now optional). #27244
 * Fix - Restore backward compatibility with WC 4.x and forward compatibility with WC 5.5. #27318
 * Fix - Switch to site locale before translating refund reason. #27323
+* Dev - Added additional stock-based cart filters including woocommerce_cart_product_cannot_add_another_message, woocommerce_cart_product_out_of_stock_message and woocommerce_cart_product_not_enough_stock_messag$
 * Dev - Changed text domain to `woocommerce` for REST API files. #27248
 * Dev - Added file path to the `woocommerce_file_download_method` filter. #27152
 * Dev - Merge API Package into core. #27100

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 4.5.0-dev
+ * Version: 4.5.0-beta.1
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
### Changes proposed in this Pull Request:

* Update version in `woocommerce.php`.
* Add new entries for 4.5.0 to `changelog.txt`.
* Remove 4.4.1 entries from `readme.txt` and add 4.5.0 entries.

