### PR TITLE
Change relative include paths to absolute include paths

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -28,11 +28,10 @@ class WC_Admin_Post_Types {
 	 * Constructor.
 	 */
 	public function __construct() {
-		$dir = __DIR__ . DIRECTORY_SEPARATOR;
-		include_once $dir . 'class-wc-admin-meta-boxes.php';
+		include_once __DIR__ . '/class-wc-admin-meta-boxes.php';
 
 		if ( ! function_exists( 'duplicate_post_plugin_activation' ) ) {
-			include_once $dir . 'class-wc-admin-duplicate-product.php';
+			include_once __DIR__ . '/class-wc-admin-duplicate-product.php';
 		}
 
 		// Load correct list table classes for current screen.
@@ -95,15 +94,15 @@ class WC_Admin_Post_Types {
 
 		switch ( $screen_id ) {
 			case 'edit-shop_order':
-				include_once $dir . 'list-tables/class-wc-admin-list-table-orders.php';
+				include_once __DIR__ . '/list-tables/class-wc-admin-list-table-orders.php';
 				$wc_list_table = new WC_Admin_List_Table_Orders();
 				break;
 			case 'edit-shop_coupon':
-				include_once $dir . 'list-tables/class-wc-admin-list-table-coupons.php';
+				include_once __DIR__ . '/list-tables/class-wc-admin-list-table-coupons.php';
 				$wc_list_table = new WC_Admin_List_Table_Coupons();
 				break;
 			case 'edit-product':
-				include_once $dir . 'list-tables/class-wc-admin-list-table-products.php';
+				include_once __DIR__ . '/list-tables/class-wc-admin-list-table-products.php';
 				$wc_list_table = new WC_Admin_List_Table_Products();
 				break;
 		}

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -28,10 +28,11 @@ class WC_Admin_Post_Types {
 	 * Constructor.
 	 */
 	public function __construct() {
-		include_once dirname( __FILE__ ) . '/class-wc-admin-meta-boxes.php';
+		$dir = __DIR__ . DIRECTORY_SEPARATOR;
+		include_once $dir . 'class-wc-admin-meta-boxes.php';
 
 		if ( ! function_exists( 'duplicate_post_plugin_activation' ) ) {
-			include_once dirname( __FILE__ ) . 'class-wc-admin-duplicate-product.php';
+			include_once $dir . 'class-wc-admin-duplicate-product.php';
 		}
 
 		// Load correct list table classes for current screen.
@@ -94,15 +95,15 @@ class WC_Admin_Post_Types {
 
 		switch ( $screen_id ) {
 			case 'edit-shop_order':
-				include_once dirname( __FILE__ ) . 'list-tables/class-wc-admin-list-table-orders.php';
+				include_once $dir . 'list-tables/class-wc-admin-list-table-orders.php';
 				$wc_list_table = new WC_Admin_List_Table_Orders();
 				break;
 			case 'edit-shop_coupon':
-				include_once dirname( __FILE__ ) . 'list-tables/class-wc-admin-list-table-coupons.php';
+				include_once $dir . 'list-tables/class-wc-admin-list-table-coupons.php';
 				$wc_list_table = new WC_Admin_List_Table_Coupons();
 				break;
 			case 'edit-product':
-				include_once dirname( __FILE__ ) . 'list-tables/class-wc-admin-list-table-products.php';
+				include_once $dir . 'list-tables/class-wc-admin-list-table-products.php';
 				$wc_list_table = new WC_Admin_List_Table_Products();
 				break;
 		}

--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -31,7 +31,7 @@ class WC_Admin_Post_Types {
 		include_once dirname( __FILE__ ) . '/class-wc-admin-meta-boxes.php';
 
 		if ( ! function_exists( 'duplicate_post_plugin_activation' ) ) {
-			include_once 'class-wc-admin-duplicate-product.php';
+			include_once dirname( __FILE__ ) . 'class-wc-admin-duplicate-product.php';
 		}
 
 		// Load correct list table classes for current screen.
@@ -94,15 +94,15 @@ class WC_Admin_Post_Types {
 
 		switch ( $screen_id ) {
 			case 'edit-shop_order':
-				include_once 'list-tables/class-wc-admin-list-table-orders.php';
+				include_once dirname( __FILE__ ) . 'list-tables/class-wc-admin-list-table-orders.php';
 				$wc_list_table = new WC_Admin_List_Table_Orders();
 				break;
 			case 'edit-shop_coupon':
-				include_once 'list-tables/class-wc-admin-list-table-coupons.php';
+				include_once dirname( __FILE__ ) . 'list-tables/class-wc-admin-list-table-coupons.php';
 				$wc_list_table = new WC_Admin_List_Table_Coupons();
 				break;
 			case 'edit-product':
-				include_once 'list-tables/class-wc-admin-list-table-products.php';
+				include_once dirname( __FILE__ ) . 'list-tables/class-wc-admin-list-table-products.php';
 				$wc_list_table = new WC_Admin_List_Table_Products();
 				break;
 		}

--- a/includes/admin/class-wc-admin-settings.php
+++ b/includes/admin/class-wc-admin-settings.php
@@ -49,15 +49,15 @@ if ( ! class_exists( 'WC_Admin_Settings', false ) ) :
 
 				include_once dirname( __FILE__ ) . '/settings/class-wc-settings-page.php';
 
-				$settings[] = include 'settings/class-wc-settings-general.php';
-				$settings[] = include 'settings/class-wc-settings-products.php';
-				$settings[] = include 'settings/class-wc-settings-tax.php';
-				$settings[] = include 'settings/class-wc-settings-shipping.php';
-				$settings[] = include 'settings/class-wc-settings-payment-gateways.php';
-				$settings[] = include 'settings/class-wc-settings-accounts.php';
-				$settings[] = include 'settings/class-wc-settings-emails.php';
-				$settings[] = include 'settings/class-wc-settings-integrations.php';
-				$settings[] = include 'settings/class-wc-settings-advanced.php';
+				$settings[] = include __DIR__ . '/settings/class-wc-settings-general.php';
+				$settings[] = include __DIR__ . '/settings/class-wc-settings-products.php';
+				$settings[] = include __DIR__ . '/settings/class-wc-settings-tax.php';
+				$settings[] = include __DIR__ . '/settings/class-wc-settings-shipping.php';
+				$settings[] = include __DIR__ . '/settings/class-wc-settings-payment-gateways.php';
+				$settings[] = include __DIR__ . '/settings/class-wc-settings-accounts.php';
+				$settings[] = include __DIR__ . '/settings/class-wc-settings-emails.php';
+				$settings[] = include __DIR__ . '/settings/class-wc-settings-integrations.php';
+				$settings[] = include __DIR__ . '/settings/class-wc-settings-advanced.php';
 
 				self::$settings = apply_filters( 'woocommerce_get_settings_pages', $settings );
 			}

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -19,14 +19,14 @@ class WC_Admin_Status {
 	 * Handles output of the reports page in admin.
 	 */
 	public static function output() {
-		include_once dirname( __FILE__ ) . '/views/html-admin-page-status.php';
+		include_once __DIR__ . DIRECTORY_SEPARATOR . 'views/html-admin-page-status.php';
 	}
 
 	/**
 	 * Handles output of report.
 	 */
 	public static function status_report() {
-		include_once dirname( __FILE__ ) . '/views/html-admin-page-status-report.php';
+		include_once __DIR__ . DIRECTORY_SEPARATOR  . 'views/html-admin-page-status-report.php';
 	}
 
 	/**
@@ -80,7 +80,7 @@ class WC_Admin_Status {
 			echo '<div class="updated inline"><p>' . esc_html__( 'Your changes have been saved.', 'woocommerce' ) . '</p></div>';
 		}
 
-		include_once dirname( __FILE__ ) . '/views/html-admin-page-status-tools.php';
+		include_once __DIR__ . DIRECTORY_SEPARATOR . 'views/html-admin-page-status-tools.php';
 	}
 
 	/**
@@ -124,7 +124,7 @@ class WC_Admin_Status {
 			self::remove_log();
 		}
 
-		include_once dirname( __FILE__ ) . 'views/html-admin-page-status-logs.php';
+		include_once __DIR__ . DIRECTORY_SEPARATOR . 'views/html-admin-page-status-logs.php';
 	}
 
 	/**
@@ -142,7 +142,7 @@ class WC_Admin_Status {
 		$log_table_list = new WC_Admin_Log_Table_List();
 		$log_table_list->prepare_items();
 
-		include_once dirname( __FILE__ ) . 'views/html-admin-page-status-logs-db.php';
+		include_once __DIR__ . DIRECTORY_SEPARATOR . 'views/html-admin-page-status-logs-db.php';
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -19,14 +19,14 @@ class WC_Admin_Status {
 	 * Handles output of the reports page in admin.
 	 */
 	public static function output() {
-		include_once __DIR__ . DIRECTORY_SEPARATOR . 'views/html-admin-page-status.php';
+		include_once __DIR__ . '/views/html-admin-page-status.php';
 	}
 
 	/**
 	 * Handles output of report.
 	 */
 	public static function status_report() {
-		include_once __DIR__ . DIRECTORY_SEPARATOR  . 'views/html-admin-page-status-report.php';
+		include_once __DIR__ . '/views/html-admin-page-status-report.php';
 	}
 
 	/**
@@ -80,7 +80,7 @@ class WC_Admin_Status {
 			echo '<div class="updated inline"><p>' . esc_html__( 'Your changes have been saved.', 'woocommerce' ) . '</p></div>';
 		}
 
-		include_once __DIR__ . DIRECTORY_SEPARATOR . 'views/html-admin-page-status-tools.php';
+		include_once __DIR__ . '/views/html-admin-page-status-tools.php';
 	}
 
 	/**
@@ -124,7 +124,7 @@ class WC_Admin_Status {
 			self::remove_log();
 		}
 
-		include_once __DIR__ . DIRECTORY_SEPARATOR . 'views/html-admin-page-status-logs.php';
+		include_once __DIR__ . '/views/html-admin-page-status-logs.php';
 	}
 
 	/**
@@ -142,7 +142,7 @@ class WC_Admin_Status {
 		$log_table_list = new WC_Admin_Log_Table_List();
 		$log_table_list->prepare_items();
 
-		include_once __DIR__ . DIRECTORY_SEPARATOR . 'views/html-admin-page-status-logs-db.php';
+		include_once __DIR__ . '/views/html-admin-page-status-logs-db.php';
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -124,7 +124,7 @@ class WC_Admin_Status {
 			self::remove_log();
 		}
 
-		include_once 'views/html-admin-page-status-logs.php';
+		include_once dirname( __FILE__ ) . 'views/html-admin-page-status-logs.php';
 	}
 
 	/**
@@ -142,7 +142,7 @@ class WC_Admin_Status {
 		$log_table_list = new WC_Admin_Log_Table_List();
 		$log_table_list->prepare_items();
 
-		include_once 'views/html-admin-page-status-logs-db.php';
+		include_once dirname( __FILE__ ) . 'views/html-admin-page-status-logs-db.php';
 	}
 
 	/**

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -208,7 +208,7 @@ class WC_Admin_Webhooks {
 			$webhook_id = absint( $_GET['edit-webhook'] ); // WPCS: input var okay, CSRF ok.
 			$webhook    = new WC_Webhook( $webhook_id );
 
-			include dirname( __FILE__ ) . 'settings/views/html-webhooks-edit.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'settings/views/html-webhooks-edit.php';
 			return;
 		}
 

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -208,7 +208,7 @@ class WC_Admin_Webhooks {
 			$webhook_id = absint( $_GET['edit-webhook'] ); // WPCS: input var okay, CSRF ok.
 			$webhook    = new WC_Webhook( $webhook_id );
 
-			include 'settings/views/html-webhooks-edit.php';
+			include dirname( __FILE__ ) . 'settings/views/html-webhooks-edit.php';
 			return;
 		}
 

--- a/includes/admin/class-wc-admin-webhooks.php
+++ b/includes/admin/class-wc-admin-webhooks.php
@@ -208,7 +208,7 @@ class WC_Admin_Webhooks {
 			$webhook_id = absint( $_GET['edit-webhook'] ); // WPCS: input var okay, CSRF ok.
 			$webhook    = new WC_Webhook( $webhook_id );
 
-			include __DIR__ . DIRECTORY_SEPARATOR . 'settings/views/html-webhooks-edit.php';
+			include __DIR__ .  '/settings/views/html-webhooks-edit.php';
 			return;
 		}
 

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -49,21 +49,19 @@ class WC_Admin {
 	 * Include any classes we need within admin.
 	 */
 	public function includes() {
-		$dir = __DIR__ . DIRECTORY_SEPARATOR;
-
-		include_once $dir . 'wc-admin-functions.php';
-		include_once $dir . 'wc-meta-box-functions.php';
-		include_once $dir . 'class-wc-admin-post-types.php';
-		include_once $dir . 'class-wc-admin-taxonomies.php';
-		include_once $dir . 'class-wc-admin-menus.php';
-		include_once $dir . 'class-wc-admin-customize.php';
-		include_once $dir . 'class-wc-admin-notices.php';
-		include_once $dir . 'class-wc-admin-assets.php';
-		include_once $dir . 'class-wc-admin-api-keys.php';
-		include_once $dir . 'class-wc-admin-webhooks.php';
-		include_once $dir . 'class-wc-admin-pointers.php';
-		include_once $dir . 'class-wc-admin-importers.php';
-		include_once $dir . 'class-wc-admin-exporters.php';
+		include_once __DIR__ . '/wc-admin-functions.php';
+		include_once __DIR__ . '/wc-meta-box-functions.php';
+		include_once __DIR__ . '/class-wc-admin-post-types.php';
+		include_once __DIR__ . '/class-wc-admin-taxonomies.php';
+		include_once __DIR__ . '/class-wc-admin-menus.php';
+		include_once __DIR__ . '/class-wc-admin-customize.php';
+		include_once __DIR__ . '/class-wc-admin-notices.php';
+		include_once __DIR__ . '/class-wc-admin-assets.php';
+		include_once __DIR__ . '/class-wc-admin-api-keys.php';
+		include_once __DIR__ . '/class-wc-admin-webhooks.php';
+		include_once __DIR__ . '/class-wc-admin-pointers.php';
+		include_once __DIR__ . '/class-wc-admin-importers.php';
+		include_once __DIR__ . '/class-wc-admin-exporters.php';
 
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
@@ -73,24 +71,24 @@ class WC_Admin {
 
 		// Help Tabs.
 		if ( apply_filters( 'woocommerce_enable_admin_help_tab', true ) ) {
-			include_once $dir . 'class-wc-admin-help.php';
+			include_once __DIR__ . '/class-wc-admin-help.php';
 		}
 
 		// Setup/welcome.
 		if ( ! empty( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			switch ( $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				case 'wc-setup':
-					include_once $dir . 'class-wc-admin-setup-wizard.php';
+					include_once __DIR__ . '/class-wc-admin-setup-wizard.php';
 					break;
 			}
 		}
 
 		// Helper.
-		include_once $dir . 'helper/class-wc-helper.php';
+		include_once __DIR__ . '/helper/class-wc-helper.php';
 
 		// Marketplace suggestions & related REST API.
-		include_once $dir . 'marketplace-suggestions/class-wc-marketplace-suggestions.php';
-		include_once $dir . 'marketplace-suggestions/class-wc-marketplace-updater.php';
+		include_once __DIR__ . '/marketplace-suggestions/class-wc-marketplace-suggestions.php';
+		include_once __DIR__ . '/marketplace-suggestions/class-wc-marketplace-updater.php';
 	}
 
 	/**
@@ -98,7 +96,6 @@ class WC_Admin {
 	 */
 	public function conditional_includes() {
 		$screen = get_current_screen();
-		$dir = __DIR__ . DIRECTORY_SEPARATOR;
 
 		if ( ! $screen ) {
 			return;
@@ -107,22 +104,22 @@ class WC_Admin {
 		switch ( $screen->id ) {
 			case 'dashboard':
 			case 'dashboard-network':
-				include $dir . 'class-wc-admin-dashboard.php';
+				include __DIR__ . '/class-wc-admin-dashboard.php';
 				break;
 			case 'options-permalink':
-				include $dir . 'class-wc-admin-permalink-settings.php';
+				include __DIR__ . '/class-wc-admin-permalink-settings.php';
 				break;
 			case 'plugins':
-				include $dir . 'plugin-updates/class-wc-plugins-screen-updates.php';
+				include __DIR__ . '/plugin-updates/class-wc-plugins-screen-updates.php';
 				break;
 			case 'update-core':
-				include $dir . 'plugin-updates/class-wc-updates-screen-updates.php';
+				include __DIR__ . '/plugin-updates/class-wc-updates-screen-updates.php';
 				break;
 			case 'users':
 			case 'user':
 			case 'profile':
 			case 'user-edit':
-				include $dir . 'class-wc-admin-profile.php';
+				include __DIR__ . '/class-wc-admin-profile.php';
 				break;
 		}
 	}
@@ -226,7 +223,7 @@ class WC_Admin {
 
 			// get the preview email content.
 			ob_start();
-			include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-email-template-preview.php';
+			include __DIR__ . '/views/html-email-template-preview.php';
 			$message = ob_get_clean();
 
 			// create a new email.

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -104,22 +104,22 @@ class WC_Admin {
 		switch ( $screen->id ) {
 			case 'dashboard':
 			case 'dashboard-network':
-				include 'class-wc-admin-dashboard.php';
+				include dirname( __FILE__ ) . 'class-wc-admin-dashboard.php';
 				break;
 			case 'options-permalink':
-				include 'class-wc-admin-permalink-settings.php';
+				include dirname( __FILE__ ) . 'class-wc-admin-permalink-settings.php';
 				break;
 			case 'plugins':
-				include 'plugin-updates/class-wc-plugins-screen-updates.php';
+				include dirname( __FILE__ ) . 'plugin-updates/class-wc-plugins-screen-updates.php';
 				break;
 			case 'update-core':
-				include 'plugin-updates/class-wc-updates-screen-updates.php';
+				include dirname( __FILE__ ) . 'plugin-updates/class-wc-updates-screen-updates.php';
 				break;
 			case 'users':
 			case 'user':
 			case 'profile':
 			case 'user-edit':
-				include 'class-wc-admin-profile.php';
+				include dirname( __FILE__ ) . 'class-wc-admin-profile.php';
 				break;
 		}
 	}
@@ -223,7 +223,7 @@ class WC_Admin {
 
 			// get the preview email content.
 			ob_start();
-			include 'views/html-email-template-preview.php';
+			include dirname( __FILE__ ) . 'views/html-email-template-preview.php';
 			$message = ob_get_clean();
 
 			// create a new email.

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -86,7 +86,7 @@ class WC_Admin {
 		}
 
 		// Helper.
-		include_once $dir. 'helper/class-wc-helper.php';
+		include_once $dir . 'helper/class-wc-helper.php';
 
 		// Marketplace suggestions & related REST API.
 		include_once $dir . 'marketplace-suggestions/class-wc-marketplace-suggestions.php';

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -49,19 +49,21 @@ class WC_Admin {
 	 * Include any classes we need within admin.
 	 */
 	public function includes() {
-		include_once dirname( __FILE__ ) . '/wc-admin-functions.php';
-		include_once dirname( __FILE__ ) . '/wc-meta-box-functions.php';
-		include_once dirname( __FILE__ ) . '/class-wc-admin-post-types.php';
-		include_once dirname( __FILE__ ) . '/class-wc-admin-taxonomies.php';
-		include_once dirname( __FILE__ ) . '/class-wc-admin-menus.php';
-		include_once dirname( __FILE__ ) . '/class-wc-admin-customize.php';
-		include_once dirname( __FILE__ ) . '/class-wc-admin-notices.php';
-		include_once dirname( __FILE__ ) . '/class-wc-admin-assets.php';
-		include_once dirname( __FILE__ ) . '/class-wc-admin-api-keys.php';
-		include_once dirname( __FILE__ ) . '/class-wc-admin-webhooks.php';
-		include_once dirname( __FILE__ ) . '/class-wc-admin-pointers.php';
-		include_once dirname( __FILE__ ) . '/class-wc-admin-importers.php';
-		include_once dirname( __FILE__ ) . '/class-wc-admin-exporters.php';
+		$dir = __DIR__ . DIRECTORY_SEPARATOR;
+
+		include_once $dir . 'wc-admin-functions.php';
+		include_once $dir . 'wc-meta-box-functions.php';
+		include_once $dir . 'class-wc-admin-post-types.php';
+		include_once $dir . 'class-wc-admin-taxonomies.php';
+		include_once $dir . 'class-wc-admin-menus.php';
+		include_once $dir . 'class-wc-admin-customize.php';
+		include_once $dir . 'class-wc-admin-notices.php';
+		include_once $dir . 'class-wc-admin-assets.php';
+		include_once $dir . 'class-wc-admin-api-keys.php';
+		include_once $dir . 'class-wc-admin-webhooks.php';
+		include_once $dir . 'class-wc-admin-pointers.php';
+		include_once $dir . 'class-wc-admin-importers.php';
+		include_once $dir . 'class-wc-admin-exporters.php';
 
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks.php';
 		include_once WC_ABSPATH . 'includes/tracks/class-wc-tracks-event.php';
@@ -71,24 +73,24 @@ class WC_Admin {
 
 		// Help Tabs.
 		if ( apply_filters( 'woocommerce_enable_admin_help_tab', true ) ) {
-			include_once dirname( __FILE__ ) . '/class-wc-admin-help.php';
+			include_once $dir . 'class-wc-admin-help.php';
 		}
 
 		// Setup/welcome.
 		if ( ! empty( $_GET['page'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			switch ( $_GET['page'] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				case 'wc-setup':
-					include_once dirname( __FILE__ ) . '/class-wc-admin-setup-wizard.php';
+					include_once $dir . 'class-wc-admin-setup-wizard.php';
 					break;
 			}
 		}
 
 		// Helper.
-		include_once dirname( __FILE__ ) . '/helper/class-wc-helper.php';
+		include_once $dir. 'helper/class-wc-helper.php';
 
 		// Marketplace suggestions & related REST API.
-		include_once dirname( __FILE__ ) . '/marketplace-suggestions/class-wc-marketplace-suggestions.php';
-		include_once dirname( __FILE__ ) . '/marketplace-suggestions/class-wc-marketplace-updater.php';
+		include_once $dir . 'marketplace-suggestions/class-wc-marketplace-suggestions.php';
+		include_once $dir . 'marketplace-suggestions/class-wc-marketplace-updater.php';
 	}
 
 	/**
@@ -96,6 +98,7 @@ class WC_Admin {
 	 */
 	public function conditional_includes() {
 		$screen = get_current_screen();
+		$dir = __DIR__ . DIRECTORY_SEPARATOR;
 
 		if ( ! $screen ) {
 			return;
@@ -104,22 +107,22 @@ class WC_Admin {
 		switch ( $screen->id ) {
 			case 'dashboard':
 			case 'dashboard-network':
-				include dirname( __FILE__ ) . 'class-wc-admin-dashboard.php';
+				include $dir . 'class-wc-admin-dashboard.php';
 				break;
 			case 'options-permalink':
-				include dirname( __FILE__ ) . 'class-wc-admin-permalink-settings.php';
+				include $dir . 'class-wc-admin-permalink-settings.php';
 				break;
 			case 'plugins':
-				include dirname( __FILE__ ) . 'plugin-updates/class-wc-plugins-screen-updates.php';
+				include $dir . 'plugin-updates/class-wc-plugins-screen-updates.php';
 				break;
 			case 'update-core':
-				include dirname( __FILE__ ) . 'plugin-updates/class-wc-updates-screen-updates.php';
+				include $dir . 'plugin-updates/class-wc-updates-screen-updates.php';
 				break;
 			case 'users':
 			case 'user':
 			case 'profile':
 			case 'user-edit':
-				include dirname( __FILE__ ) . 'class-wc-admin-profile.php';
+				include $dir . 'class-wc-admin-profile.php';
 				break;
 		}
 	}
@@ -223,7 +226,7 @@ class WC_Admin {
 
 			// get the preview email content.
 			ob_start();
-			include dirname( __FILE__ ) . 'views/html-email-template-preview.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-email-template-preview.php';
 			$message = ob_get_clean();
 
 			// create a new email.

--- a/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
@@ -15,7 +15,7 @@ if ( class_exists( 'WC_Admin_List_Table_Coupons', false ) ) {
 }
 
 if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once 'abstract-class-wc-admin-list-table.php';
+	include_once dirname( __FILE__ ) . 'abstract-class-wc-admin-list-table.php';
 }
 
 /**

--- a/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
@@ -15,7 +15,7 @@ if ( class_exists( 'WC_Admin_List_Table_Coupons', false ) ) {
 }
 
 if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once __DIR__ . DIRECTORY_SEPARATOR . 'abstract-class-wc-admin-list-table.php';
+	include_once __DIR__ . '/abstract-class-wc-admin-list-table.php';
 }
 
 /**

--- a/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-coupons.php
@@ -15,7 +15,7 @@ if ( class_exists( 'WC_Admin_List_Table_Coupons', false ) ) {
 }
 
 if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once dirname( __FILE__ ) . 'abstract-class-wc-admin-list-table.php';
+	include_once __DIR__ . DIRECTORY_SEPARATOR . 'abstract-class-wc-admin-list-table.php';
 }
 
 /**

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -15,7 +15,7 @@ if ( class_exists( 'WC_Admin_List_Table_Orders', false ) ) {
 }
 
 if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once 'abstract-class-wc-admin-list-table.php';
+	include_once dirname( __FILE__ ) . 'abstract-class-wc-admin-list-table.php';
 }
 
 /**

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -15,7 +15,7 @@ if ( class_exists( 'WC_Admin_List_Table_Orders', false ) ) {
 }
 
 if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once __DIR__ . DIRECTORY_SEPARATOR . 'abstract-class-wc-admin-list-table.php';
+	include_once __DIR__  . '/abstract-class-wc-admin-list-table.php';
 }
 
 /**

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -15,7 +15,7 @@ if ( class_exists( 'WC_Admin_List_Table_Orders', false ) ) {
 }
 
 if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once dirname( __FILE__ ) . 'abstract-class-wc-admin-list-table.php';
+	include_once __DIR__ . DIRECTORY_SEPARATOR . 'abstract-class-wc-admin-list-table.php';
 }
 
 /**

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -15,7 +15,7 @@ if ( class_exists( 'WC_Admin_List_Table_Products', false ) ) {
 }
 
 if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once dirname( __FILE__ ) . 'abstract-class-wc-admin-list-table.php';
+	include_once __DIR__ . DIRECTORY_SEPARATOR . 'abstract-class-wc-admin-list-table.php';
 }
 
 /**

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -15,7 +15,7 @@ if ( class_exists( 'WC_Admin_List_Table_Products', false ) ) {
 }
 
 if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once __DIR__ . DIRECTORY_SEPARATOR . 'abstract-class-wc-admin-list-table.php';
+	include_once __DIR__ . '/abstract-class-wc-admin-list-table.php';
 }
 
 /**

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -15,7 +15,7 @@ if ( class_exists( 'WC_Admin_List_Table_Products', false ) ) {
 }
 
 if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once 'abstract-class-wc-admin-list-table.php';
+	include_once dirname( __FILE__ ) . 'abstract-class-wc-admin-list-table.php';
 }
 
 /**

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-downloads.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-downloads.php
@@ -56,7 +56,7 @@ class WC_Meta_Box_Order_Downloads {
 						$file       = $product->get_file( $download->get_download_id() );
 						$file_count = isset( $file['name'] ) ? $file['name'] : sprintf( __( 'File %d', 'woocommerce' ), $file_counter );
 
-						include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-order-download-permission.php';
+						include __DIR__ . '/views/html-order-download-permission.php';
 
 						$loop++;
 						$file_counter++;

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-downloads.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-downloads.php
@@ -56,7 +56,7 @@ class WC_Meta_Box_Order_Downloads {
 						$file       = $product->get_file( $download->get_download_id() );
 						$file_count = isset( $file['name'] ) ? $file['name'] : sprintf( __( 'File %d', 'woocommerce' ), $file_counter );
 
-						include dirname( __FILE__ ) . 'views/html-order-download-permission.php';
+						include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-order-download-permission.php';
 
 						$loop++;
 						$file_counter++;

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-downloads.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-downloads.php
@@ -56,7 +56,7 @@ class WC_Meta_Box_Order_Downloads {
 						$file       = $product->get_file( $download->get_download_id() );
 						$file_count = isset( $file['name'] ) ? $file['name'] : sprintf( __( 'File %d', 'woocommerce' ), $file_counter );
 
-						include 'views/html-order-download-permission.php';
+						include dirname( __FILE__ ) . 'views/html-order-download-permission.php';
 
 						$loop++;
 						$file_counter++;

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
@@ -38,7 +38,7 @@ class WC_Meta_Box_Order_Items {
 		$order = $theorder;
 		$data  = get_post_meta( $post->ID );
 
-		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-order-items.php';
+		include __DIR__ . '/views/html-order-items.php';
 	}
 
 	/**

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
@@ -38,7 +38,7 @@ class WC_Meta_Box_Order_Items {
 		$order = $theorder;
 		$data  = get_post_meta( $post->ID );
 
-		include dirname( __FILE__ ) . 'views/html-order-items.php';
+		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-order-items.php';
 	}
 
 	/**

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-items.php
@@ -38,7 +38,7 @@ class WC_Meta_Box_Order_Items {
 		$order = $theorder;
 		$data  = get_post_meta( $post->ID );
 
-		include 'views/html-order-items.php';
+		include dirname( __FILE__ ) . 'views/html-order-items.php';
 	}
 
 	/**

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -28,7 +28,7 @@ class WC_Meta_Box_Order_Notes {
 
 		$notes = wc_get_order_notes( $args );
 
-		include 'views/html-order-notes.php';
+		include dirname( __FILE__ ) . 'views/html-order-notes.php';
 		?>
 		<div class="add_note">
 			<p>

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -28,7 +28,7 @@ class WC_Meta_Box_Order_Notes {
 
 		$notes = wc_get_order_notes( $args );
 
-		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-order-notes.php';
+		include __DIR__ . '/views/html-order-notes.php';
 		?>
 		<div class="add_note">
 			<p>

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-notes.php
@@ -28,7 +28,7 @@ class WC_Meta_Box_Order_Notes {
 
 		$notes = wc_get_order_notes( $args );
 
-		include dirname( __FILE__ ) . 'views/html-order-notes.php';
+		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-order-notes.php';
 		?>
 		<div class="add_note">
 			<p>

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -30,22 +30,21 @@ class WC_Meta_Box_Product_Data {
 
 		wp_nonce_field( 'woocommerce_save_data', 'woocommerce_meta_nonce' );
 
-		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-product-data-panel.php';
+		include __DIR__ . '/views/html-product-data-panel.php';
 	}
 
 	/**
 	 * Show tab content/settings.
 	 */
 	private static function output_tabs() {
-		$dir = __DIR__ . DIRECTORY_SEPARATOR;
 		global $post, $thepostid, $product_object;
 
-		include $dir . 'views/html-product-data-general.php';
-		include $dir . 'views/html-product-data-inventory.php';
-		include $dir . 'views/html-product-data-shipping.php';
-		include $dir . 'views/html-product-data-linked-products.php';
-		include $dir . 'views/html-product-data-attributes.php';
-		include $dir . 'views/html-product-data-advanced.php';
+		include __DIR__ . '/views/html-product-data-general.php';
+		include __DIR__ . '/views/html-product-data-inventory.php';
+		include __DIR__ . '/views/html-product-data-shipping.php';
+		include __DIR__ . '/views/html-product-data-linked-products.php';
+		include __DIR__ . '/views/html-product-data-attributes.php';
+		include __DIR__ . '/views/html-product-data-advanced.php';
 	}
 
 	/**
@@ -178,7 +177,7 @@ class WC_Meta_Box_Product_Data {
 		$variations_per_page    = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) );
 		$variations_total_pages = ceil( $variations_count / $variations_per_page );
 
-		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-product-data-variations.php';
+		include __DIR__  . '/views/html-product-data-variations.php';
 	}
 
 	/**

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -30,7 +30,7 @@ class WC_Meta_Box_Product_Data {
 
 		wp_nonce_field( 'woocommerce_save_data', 'woocommerce_meta_nonce' );
 
-		include 'views/html-product-data-panel.php';
+		include dirname( __FILE__ ) . 'views/html-product-data-panel.php';
 	}
 
 	/**
@@ -39,12 +39,12 @@ class WC_Meta_Box_Product_Data {
 	private static function output_tabs() {
 		global $post, $thepostid, $product_object;
 
-		include 'views/html-product-data-general.php';
-		include 'views/html-product-data-inventory.php';
-		include 'views/html-product-data-shipping.php';
-		include 'views/html-product-data-linked-products.php';
-		include 'views/html-product-data-attributes.php';
-		include 'views/html-product-data-advanced.php';
+		include dirname( __FILE__ ) . 'views/html-product-data-general.php';
+		include dirname( __FILE__ ) . 'views/html-product-data-inventory.php';
+		include dirname( __FILE__ ) . 'views/html-product-data-shipping.php';
+		include dirname( __FILE__ ) . 'views/html-product-data-linked-products.php';
+		include dirname( __FILE__ ) . 'views/html-product-data-attributes.php';
+		include dirname( __FILE__ ) . 'views/html-product-data-advanced.php';
 	}
 
 	/**
@@ -177,7 +177,7 @@ class WC_Meta_Box_Product_Data {
 		$variations_per_page    = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) );
 		$variations_total_pages = ceil( $variations_count / $variations_per_page );
 
-		include 'views/html-product-data-variations.php';
+		include dirname( __FILE__ ) . 'views/html-product-data-variations.php';
 	}
 
 	/**

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -30,21 +30,22 @@ class WC_Meta_Box_Product_Data {
 
 		wp_nonce_field( 'woocommerce_save_data', 'woocommerce_meta_nonce' );
 
-		include dirname( __FILE__ ) . 'views/html-product-data-panel.php';
+		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-product-data-panel.php';
 	}
 
 	/**
 	 * Show tab content/settings.
 	 */
 	private static function output_tabs() {
+		$dir = __DIR__ . DIRECTORY_SEPARATOR;
 		global $post, $thepostid, $product_object;
 
-		include dirname( __FILE__ ) . 'views/html-product-data-general.php';
-		include dirname( __FILE__ ) . 'views/html-product-data-inventory.php';
-		include dirname( __FILE__ ) . 'views/html-product-data-shipping.php';
-		include dirname( __FILE__ ) . 'views/html-product-data-linked-products.php';
-		include dirname( __FILE__ ) . 'views/html-product-data-attributes.php';
-		include dirname( __FILE__ ) . 'views/html-product-data-advanced.php';
+		include $dir . 'views/html-product-data-general.php';
+		include $dir . 'views/html-product-data-inventory.php';
+		include $dir . 'views/html-product-data-shipping.php';
+		include $dir . 'views/html-product-data-linked-products.php';
+		include $dir . 'views/html-product-data-attributes.php';
+		include $dir . 'views/html-product-data-advanced.php';
 	}
 
 	/**
@@ -177,7 +178,7 @@ class WC_Meta_Box_Product_Data {
 		$variations_per_page    = absint( apply_filters( 'woocommerce_admin_meta_boxes_variations_per_page', 15 ) );
 		$variations_total_pages = ceil( $variations_count / $variations_per_page );
 
-		include dirname( __FILE__ ) . 'views/html-product-data-variations.php';
+		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-product-data-variations.php';
 	}
 
 	/**

--- a/includes/admin/meta-boxes/views/html-order-item.php
+++ b/includes/admin/meta-boxes/views/html-order-item.php
@@ -41,7 +41,7 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 		<input type="hidden" name="order_item_tax_class[<?php echo absint( $item_id ); ?>]" value="<?php echo esc_attr( $item->get_tax_class() ); ?>" />
 
 		<?php do_action( 'woocommerce_before_order_itemmeta', $item_id, $item, $product ); ?>
-		<?php require 'html-order-item-meta.php'; ?>
+		<?php require __DIR__ . '/html-order-item-meta.php'; ?>
 		<?php do_action( 'woocommerce_after_order_itemmeta', $item_id, $item, $product ); ?>
 	</td>
 

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -59,7 +59,7 @@ if ( wc_tax_enabled() ) {
 			foreach ( $line_items as $item_id => $item ) {
 				do_action( 'woocommerce_before_order_item_' . $item->get_type() . '_html', $item_id, $item, $order );
 
-				include dirname( __FILE__ ) . 'html-order-item.php';
+				include __DIR__ . DIRECTORY_SEPARATOR . 'html-order-item.php';
 
 				do_action( 'woocommerce_order_item_' . $item->get_type() . '_html', $item_id, $item, $order );
 			}
@@ -69,7 +69,7 @@ if ( wc_tax_enabled() ) {
 		<tbody id="order_fee_line_items">
 			<?php
 			foreach ( $line_items_fee as $item_id => $item ) {
-				include dirname( __FILE__ ) . 'html-order-fee.php';
+				include __DIR__ . DIRECTORY_SEPARATOR . 'html-order-fee.php';
 			}
 			do_action( 'woocommerce_admin_order_items_after_fees', $order->get_id() );
 			?>
@@ -78,7 +78,7 @@ if ( wc_tax_enabled() ) {
 			<?php
 			$shipping_methods = WC()->shipping() ? WC()->shipping()->load_shipping_methods() : array();
 			foreach ( $line_items_shipping as $item_id => $item ) {
-				include dirname( __FILE__ ) . 'html-order-shipping.php';
+				include __DIR__ . DIRECTORY_SEPARATOR . 'html-order-shipping.php';
 			}
 			do_action( 'woocommerce_admin_order_items_after_shipping', $order->get_id() );
 			?>
@@ -89,7 +89,7 @@ if ( wc_tax_enabled() ) {
 
 			if ( $refunds ) {
 				foreach ( $refunds as $refund ) {
-					include dirname( __FILE__ ) . 'html-order-refund.php';
+					include __DIR__ . DIRECTORY_SEPARATOR . 'html-order-refund.php';
 				}
 				do_action( 'woocommerce_admin_order_items_after_refunds', $order->get_id() );
 			}

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -59,7 +59,7 @@ if ( wc_tax_enabled() ) {
 			foreach ( $line_items as $item_id => $item ) {
 				do_action( 'woocommerce_before_order_item_' . $item->get_type() . '_html', $item_id, $item, $order );
 
-				include __DIR__ . DIRECTORY_SEPARATOR . 'html-order-item.php';
+				include __DIR__ . '/html-order-item.php';
 
 				do_action( 'woocommerce_order_item_' . $item->get_type() . '_html', $item_id, $item, $order );
 			}
@@ -69,7 +69,7 @@ if ( wc_tax_enabled() ) {
 		<tbody id="order_fee_line_items">
 			<?php
 			foreach ( $line_items_fee as $item_id => $item ) {
-				include __DIR__ . DIRECTORY_SEPARATOR . 'html-order-fee.php';
+				include __DIR__ . '/html-order-fee.php';
 			}
 			do_action( 'woocommerce_admin_order_items_after_fees', $order->get_id() );
 			?>
@@ -78,7 +78,7 @@ if ( wc_tax_enabled() ) {
 			<?php
 			$shipping_methods = WC()->shipping() ? WC()->shipping()->load_shipping_methods() : array();
 			foreach ( $line_items_shipping as $item_id => $item ) {
-				include __DIR__ . DIRECTORY_SEPARATOR . 'html-order-shipping.php';
+				include __DIR__ . '/html-order-shipping.php';
 			}
 			do_action( 'woocommerce_admin_order_items_after_shipping', $order->get_id() );
 			?>
@@ -89,7 +89,7 @@ if ( wc_tax_enabled() ) {
 
 			if ( $refunds ) {
 				foreach ( $refunds as $refund ) {
-					include __DIR__ . DIRECTORY_SEPARATOR . 'html-order-refund.php';
+					include __DIR__ . '/html-order-refund.php';
 				}
 				do_action( 'woocommerce_admin_order_items_after_refunds', $order->get_id() );
 			}

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -59,7 +59,7 @@ if ( wc_tax_enabled() ) {
 			foreach ( $line_items as $item_id => $item ) {
 				do_action( 'woocommerce_before_order_item_' . $item->get_type() . '_html', $item_id, $item, $order );
 
-				include 'html-order-item.php';
+				include dirname( __FILE__ ) . 'html-order-item.php';
 
 				do_action( 'woocommerce_order_item_' . $item->get_type() . '_html', $item_id, $item, $order );
 			}
@@ -69,7 +69,7 @@ if ( wc_tax_enabled() ) {
 		<tbody id="order_fee_line_items">
 			<?php
 			foreach ( $line_items_fee as $item_id => $item ) {
-				include 'html-order-fee.php';
+				include dirname( __FILE__ ) . 'html-order-fee.php';
 			}
 			do_action( 'woocommerce_admin_order_items_after_fees', $order->get_id() );
 			?>
@@ -78,7 +78,7 @@ if ( wc_tax_enabled() ) {
 			<?php
 			$shipping_methods = WC()->shipping() ? WC()->shipping()->load_shipping_methods() : array();
 			foreach ( $line_items_shipping as $item_id => $item ) {
-				include 'html-order-shipping.php';
+				include dirname( __FILE__ ) . 'html-order-shipping.php';
 			}
 			do_action( 'woocommerce_admin_order_items_after_shipping', $order->get_id() );
 			?>
@@ -89,7 +89,7 @@ if ( wc_tax_enabled() ) {
 
 			if ( $refunds ) {
 				foreach ( $refunds as $refund ) {
-					include 'html-order-refund.php';
+					include dirname( __FILE__ ) . 'html-order-refund.php';
 				}
 				do_action( 'woocommerce_admin_order_items_after_refunds', $order->get_id() );
 			}

--- a/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -51,7 +51,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		</div>
 
 		<?php do_action( 'woocommerce_before_order_itemmeta', $item_id, $item, null ); ?>
-		<?php require 'html-order-item-meta.php'; ?>
+		<?php require __DIR__ . '/html-order-item-meta.php'; ?>
 		<?php do_action( 'woocommerce_after_order_itemmeta', $item_id, $item, null ); ?>
 	</td>
 

--- a/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -42,7 +42,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				$metabox_class[] = $attribute->get_name();
 			}
 
-			include __DIR__ . DIRECTORY_SEPARATOR . 'html-product-attribute.php';
+			include __DIR__ . '/html-product-attribute.php';
 		}
 		?>
 	</div>

--- a/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -42,7 +42,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				$metabox_class[] = $attribute->get_name();
 			}
 
-			include 'html-product-attribute.php';
+			include dirname( __FILE__ ) . 'html-product-attribute.php';
 		}
 		?>
 	</div>

--- a/includes/admin/meta-boxes/views/html-product-data-attributes.php
+++ b/includes/admin/meta-boxes/views/html-product-data-attributes.php
@@ -42,7 +42,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 				$metabox_class[] = $attribute->get_name();
 			}
 
-			include dirname( __FILE__ ) . 'html-product-attribute.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'html-product-attribute.php';
 		}
 		?>
 	</div>

--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -89,7 +89,7 @@ defined( 'ABSPATH' ) || exit;
 					$downloadable_files = $product_object->get_downloads( 'edit' );
 					if ( $downloadable_files ) {
 						foreach ( $downloadable_files as $key => $file ) {
-							include 'html-product-download.php';
+							include dirname( __FILE__ ) . 'html-product-download.php';
 						}
 					}
 					?>
@@ -105,7 +105,7 @@ defined( 'ABSPATH' ) || exit;
 									'name' => '',
 								);
 								ob_start();
-								require 'html-product-download.php';
+								require dirname( __FILE__ ) . 'html-product-download.php';
 								echo esc_attr( ob_get_clean() );
 								?>
 							"><?php esc_html_e( 'Add File', 'woocommerce' ); ?></a>

--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -89,7 +89,7 @@ defined( 'ABSPATH' ) || exit;
 					$downloadable_files = $product_object->get_downloads( 'edit' );
 					if ( $downloadable_files ) {
 						foreach ( $downloadable_files as $key => $file ) {
-							include dirname( __FILE__ ) . 'html-product-download.php';
+							include __DIR__ . DIRECTORY_SEPARATOR . 'html-product-download.php';
 						}
 					}
 					?>
@@ -105,7 +105,7 @@ defined( 'ABSPATH' ) || exit;
 									'name' => '',
 								);
 								ob_start();
-								require dirname( __FILE__ ) . 'html-product-download.php';
+								require __DIR__ . DIRECTORY_SEPARATOR . 'html-product-download.php';
 								echo esc_attr( ob_get_clean() );
 								?>
 							"><?php esc_html_e( 'Add File', 'woocommerce' ); ?></a>

--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -89,7 +89,7 @@ defined( 'ABSPATH' ) || exit;
 					$downloadable_files = $product_object->get_downloads( 'edit' );
 					if ( $downloadable_files ) {
 						foreach ( $downloadable_files as $key => $file ) {
-							include __DIR__ . DIRECTORY_SEPARATOR . 'html-product-download.php';
+							include __DIR__ . '/html-product-download.php';
 						}
 					}
 					?>
@@ -105,7 +105,7 @@ defined( 'ABSPATH' ) || exit;
 									'name' => '',
 								);
 								ob_start();
-								require __DIR__ . DIRECTORY_SEPARATOR . 'html-product-download.php';
+								require __DIR__ . '/html-product-download.php';
 								echo esc_attr( ob_get_clean() );
 								?>
 							"><?php esc_html_e( 'Add File', 'woocommerce' ); ?></a>

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -378,7 +378,7 @@ defined( 'ABSPATH' ) || exit;
 
 							if ( $downloads ) {
 								foreach ( $downloads as $key => $file ) {
-									include dirname( __FILE__ ) . 'html-product-variation-download.php';
+									include __DIR__ . DIRECTORY_SEPARATOR . 'html-product-variation-download.php';
 								}
 							}
 							?>
@@ -394,7 +394,7 @@ defined( 'ABSPATH' ) || exit;
 										'name' => '',
 									);
 									ob_start();
-									require dirname( __FILE__ ) . 'html-product-variation-download.php';
+									require __DIR__ . DIRECTORY_SEPARATOR . 'html-product-variation-download.php';
 									echo esc_attr( ob_get_clean() );
 									?>
 									"><?php esc_html_e( 'Add file', 'woocommerce' ); ?></a>

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -378,7 +378,7 @@ defined( 'ABSPATH' ) || exit;
 
 							if ( $downloads ) {
 								foreach ( $downloads as $key => $file ) {
-									include 'html-product-variation-download.php';
+									include dirname( __FILE__ ) . 'html-product-variation-download.php';
 								}
 							}
 							?>
@@ -394,7 +394,7 @@ defined( 'ABSPATH' ) || exit;
 										'name' => '',
 									);
 									ob_start();
-									require 'html-product-variation-download.php';
+									require dirname( __FILE__ ) . 'html-product-variation-download.php';
 									echo esc_attr( ob_get_clean() );
 									?>
 									"><?php esc_html_e( 'Add file', 'woocommerce' ); ?></a>

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -378,7 +378,7 @@ defined( 'ABSPATH' ) || exit;
 
 							if ( $downloads ) {
 								foreach ( $downloads as $key => $file ) {
-									include __DIR__ . DIRECTORY_SEPARATOR . 'html-product-variation-download.php';
+									include __DIR__ . '/html-product-variation-download.php';
 								}
 							}
 							?>
@@ -394,7 +394,7 @@ defined( 'ABSPATH' ) || exit;
 										'name' => '',
 									);
 									ob_start();
-									require __DIR__ . DIRECTORY_SEPARATOR . 'html-product-variation-download.php';
+									require __DIR__ . '/html-product-variation-download.php';
 									echo esc_attr( ob_get_clean() );
 									?>
 									"><?php esc_html_e( 'Add file', 'woocommerce' ); ?></a>

--- a/includes/admin/plugin-updates/class-wc-plugin-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugin-updates.php
@@ -115,7 +115,7 @@ class WC_Plugin_Updates {
 		$message = sprintf( __( "<strong>Heads up!</strong> The versions of the following plugins you're running haven't been tested with WooCommerce %s. Please update them or confirm compatibility before updating WooCommerce, or you may experience issues:", 'woocommerce' ), $new_version );
 
 		ob_start();
-		include 'views/html-notice-untested-extensions-inline.php';
+		include dirname( __FILE__ ) . 'views/html-notice-untested-extensions-inline.php';
 		return ob_get_clean();
 	}
 
@@ -130,7 +130,7 @@ class WC_Plugin_Updates {
 		$plugins       = $this->major_untested_plugins;
 
 		ob_start();
-		include 'views/html-notice-untested-extensions-modal.php';
+		include dirname( __FILE__ ) . 'views/html-notice-untested-extensions-modal.php';
 		return ob_get_clean();
 	}
 

--- a/includes/admin/plugin-updates/class-wc-plugin-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugin-updates.php
@@ -115,7 +115,7 @@ class WC_Plugin_Updates {
 		$message = sprintf( __( "<strong>Heads up!</strong> The versions of the following plugins you're running haven't been tested with WooCommerce %s. Please update them or confirm compatibility before updating WooCommerce, or you may experience issues:", 'woocommerce' ), $new_version );
 
 		ob_start();
-		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-notice-untested-extensions-inline.php';
+		include __DIR__ . '/views/html-notice-untested-extensions-inline.php';
 		return ob_get_clean();
 	}
 
@@ -130,7 +130,7 @@ class WC_Plugin_Updates {
 		$plugins       = $this->major_untested_plugins;
 
 		ob_start();
-		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-notice-untested-extensions-modal.php';
+		include __DIR__ . '/views/html-notice-untested-extensions-modal.php';
 		return ob_get_clean();
 	}
 

--- a/includes/admin/plugin-updates/class-wc-plugin-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugin-updates.php
@@ -115,7 +115,7 @@ class WC_Plugin_Updates {
 		$message = sprintf( __( "<strong>Heads up!</strong> The versions of the following plugins you're running haven't been tested with WooCommerce %s. Please update them or confirm compatibility before updating WooCommerce, or you may experience issues:", 'woocommerce' ), $new_version );
 
 		ob_start();
-		include dirname( __FILE__ ) . 'views/html-notice-untested-extensions-inline.php';
+		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-notice-untested-extensions-inline.php';
 		return ob_get_clean();
 	}
 
@@ -130,7 +130,7 @@ class WC_Plugin_Updates {
 		$plugins       = $this->major_untested_plugins;
 
 		ob_start();
-		include dirname( __FILE__ ) . 'views/html-notice-untested-extensions-modal.php';
+		include __DIR__ . DIRECTORY_SEPARATOR . 'views/html-notice-untested-extensions-modal.php';
 		return ob_get_clean();
 	}
 

--- a/includes/admin/settings/class-wc-settings-checkout.php
+++ b/includes/admin/settings/class-wc-settings-checkout.php
@@ -8,4 +8,4 @@
 
 defined( 'ABSPATH' ) || exit;
 
-return include 'class-wc-settings-payment-gateways.php';
+return include __DIR__ . '/class-wc-settings-payment-gateways.php';

--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -82,7 +82,7 @@ class WC_Settings_Tax extends WC_Settings_Page {
 		$settings = array();
 
 		if ( '' === $current_section ) {
-			$settings = __DIR__ . '/views/settings-tax.php';
+			$settings = include __DIR__ . '/views/settings-tax.php';
 		}
 		return apply_filters( 'woocommerce_get_settings_' . $this->id, $settings, $current_section );
 	}

--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -82,7 +82,7 @@ class WC_Settings_Tax extends WC_Settings_Page {
 		$settings = array();
 
 		if ( '' === $current_section ) {
-			$settings = include 'views/settings-tax.php';
+			$settings = include dirname( __FILE__ ) . 'views/settings-tax.php';
 		}
 		return apply_filters( 'woocommerce_get_settings_' . $this->id, $settings, $current_section );
 	}
@@ -237,7 +237,7 @@ class WC_Settings_Tax extends WC_Settings_Page {
 		);
 		wp_enqueue_script( 'wc-settings-tax' );
 
-		include 'views/html-settings-tax.php';
+		include dirname( __FILE__ ) . 'views/html-settings-tax.php';
 	}
 
 	/**

--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -237,7 +237,7 @@ class WC_Settings_Tax extends WC_Settings_Page {
 		);
 		wp_enqueue_script( 'wc-settings-tax' );
 
-		include dirname( __FILE__ ) . 'views/html-settings-tax.php';
+		include __DIR__ . '/views/html-settings-tax.php';
 	}
 
 	/**

--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -82,7 +82,7 @@ class WC_Settings_Tax extends WC_Settings_Page {
 		$settings = array();
 
 		if ( '' === $current_section ) {
-			$settings = include dirname( __FILE__ ) . 'views/settings-tax.php';
+			$settings = __DIR__ . DIRECTORY_SEPARATOR . 'views/settings-tax.php';
 		}
 		return apply_filters( 'woocommerce_get_settings_' . $this->id, $settings, $current_section );
 	}

--- a/includes/admin/settings/class-wc-settings-tax.php
+++ b/includes/admin/settings/class-wc-settings-tax.php
@@ -82,7 +82,7 @@ class WC_Settings_Tax extends WC_Settings_Page {
 		$settings = array();
 
 		if ( '' === $current_section ) {
-			$settings = __DIR__ . DIRECTORY_SEPARATOR . 'views/settings-tax.php';
+			$settings = __DIR__ . '/views/settings-tax.php';
 		}
 		return apply_filters( 'woocommerce_get_settings_' . $this->id, $settings, $current_section );
 	}

--- a/includes/admin/settings/views/class-wc-settings-rest-api.php
+++ b/includes/admin/settings/views/class-wc-settings-rest-api.php
@@ -8,4 +8,4 @@
 
 defined( 'ABSPATH' ) || exit;
 
-return include 'class-wc-settings-advanced.php';
+return include __DIR__ . '/class-wc-settings-advanced.php';

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -548,7 +548,7 @@ class WC_AJAX {
 		$order = wc_get_order( absint( $_GET['order_id'] ) ); // WPCS: sanitization ok.
 
 		if ( $order ) {
-			include_once dirname( __FILE__ ) . 'admin/list-tables/class-wc-admin-list-table-orders.php';
+			include_once __DIR__ . DIRECTORY_SEPARATOR . 'admin/list-tables/class-wc-admin-list-table-orders.php';
 
 			wp_send_json_success( WC_Admin_List_Table_Orders::order_preview_get_order_details( $order ) );
 		}
@@ -581,7 +581,7 @@ class WC_AJAX {
 			$metabox_class[] = $attribute->get_name();
 		}
 
-		include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-product-attribute.php';
+		include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-product-attribute.php';
 		wp_die();
 	}
 
@@ -681,7 +681,7 @@ class WC_AJAX {
 						$metabox_class[] = $attribute->get_name();
 					}
 
-					include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-product-attribute.php';
+					include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-product-attribute.php';
 				}
 			}
 
@@ -716,7 +716,7 @@ class WC_AJAX {
 		$variation_id   = $variation_object->save();
 		$variation      = get_post( $variation_id );
 		$variation_data = array_merge( get_post_custom( $variation_id ), wc_get_product_variation_attributes( $variation_id ) ); // kept for BW compatibility.
-		include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-variation-admin.php';
+		include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-variation-admin.php';
 		wp_die();
 	}
 
@@ -816,7 +816,7 @@ class WC_AJAX {
 							/* translators: %d file count */
 							$file_count = sprintf( __( 'File %d', 'woocommerce' ), $file_counter );
 						}
-						include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-download-permission.php';
+						include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-download-permission.php';
 					}
 				}
 			}
@@ -946,12 +946,12 @@ class WC_AJAX {
 
 			// Get HTML to return.
 			ob_start();
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
 			$items_html = ob_get_clean();
 
 			ob_start();
 			$notes = wc_get_order_notes( array( 'order_id' => $order_id ) );
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-notes.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-notes.php';
 			$notes_html = ob_get_clean();
 
 			return array(
@@ -1015,7 +1015,7 @@ class WC_AJAX {
 			$order->save();
 
 			ob_start();
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1057,7 +1057,7 @@ class WC_AJAX {
 			$item_id = $item->save();
 
 			ob_start();
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-shipping.php';
+			include __DIR__ . DIRECTORY_SEPARATOR. 'admin/meta-boxes/views/html-order-shipping.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1104,7 +1104,7 @@ class WC_AJAX {
 			$item->save();
 
 			ob_start();
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1167,7 +1167,7 @@ class WC_AJAX {
 			$order->calculate_totals( false );
 
 			ob_start();
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1214,7 +1214,7 @@ class WC_AJAX {
 			$order->calculate_totals( false );
 
 			ob_start();
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1300,12 +1300,12 @@ class WC_AJAX {
 
 			// Get HTML to return.
 			ob_start();
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
 			$items_html = ob_get_clean();
 
 			ob_start();
 			$notes = wc_get_order_notes( array( 'order_id' => $order_id ) );
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-notes.php';
+			include __DIR__ . DIRECTORY_SEPARATOR. 'admin/meta-boxes/views/html-order-notes.php';
 			$notes_html = ob_get_clean();
 
 			wp_send_json_success(
@@ -1352,7 +1352,7 @@ class WC_AJAX {
 			$order->calculate_totals( false );
 
 			ob_start();
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1391,7 +1391,7 @@ class WC_AJAX {
 		$order = wc_get_order( $order_id );
 		$order->calculate_taxes( $calculate_tax_args );
 		$order->calculate_totals( false );
-		include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
+		include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
 		wp_die();
 	}
 
@@ -1420,12 +1420,12 @@ class WC_AJAX {
 
 			// Get HTML to return.
 			ob_start();
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
 			$items_html = ob_get_clean();
 
 			ob_start();
 			$notes = wc_get_order_notes( array( 'order_id' => $order_id ) );
-			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-notes.php';
+			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-notes.php';
 			$notes_html = ob_get_clean();
 
 			wp_send_json_success(
@@ -1451,7 +1451,7 @@ class WC_AJAX {
 		// Return HTML items.
 		$order_id = absint( $_POST['order_id'] );
 		$order    = wc_get_order( $order_id );
-		include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
+		include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
 		wp_die();
 	}
 
@@ -2101,7 +2101,7 @@ class WC_AJAX {
 				$variation_id   = $variation_object->get_id();
 				$variation      = get_post( $variation_id );
 				$variation_data = array_merge( get_post_custom( $variation_id ), wc_get_product_variation_attributes( $variation_id ) ); // kept for BW compatibility.
-				include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-variation-admin.php';
+				include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-variation-admin.php';
 				$loop++;
 			}
 		}

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -548,7 +548,7 @@ class WC_AJAX {
 		$order = wc_get_order( absint( $_GET['order_id'] ) ); // WPCS: sanitization ok.
 
 		if ( $order ) {
-			include_once 'admin/list-tables/class-wc-admin-list-table-orders.php';
+			include_once dirname( __FILE__ ) . 'admin/list-tables/class-wc-admin-list-table-orders.php';
 
 			wp_send_json_success( WC_Admin_List_Table_Orders::order_preview_get_order_details( $order ) );
 		}
@@ -581,7 +581,7 @@ class WC_AJAX {
 			$metabox_class[] = $attribute->get_name();
 		}
 
-		include 'admin/meta-boxes/views/html-product-attribute.php';
+		include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-product-attribute.php';
 		wp_die();
 	}
 
@@ -681,7 +681,7 @@ class WC_AJAX {
 						$metabox_class[] = $attribute->get_name();
 					}
 
-					include 'admin/meta-boxes/views/html-product-attribute.php';
+					include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-product-attribute.php';
 				}
 			}
 
@@ -716,7 +716,7 @@ class WC_AJAX {
 		$variation_id   = $variation_object->save();
 		$variation      = get_post( $variation_id );
 		$variation_data = array_merge( get_post_custom( $variation_id ), wc_get_product_variation_attributes( $variation_id ) ); // kept for BW compatibility.
-		include 'admin/meta-boxes/views/html-variation-admin.php';
+		include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-variation-admin.php';
 		wp_die();
 	}
 
@@ -816,7 +816,7 @@ class WC_AJAX {
 							/* translators: %d file count */
 							$file_count = sprintf( __( 'File %d', 'woocommerce' ), $file_counter );
 						}
-						include 'admin/meta-boxes/views/html-order-download-permission.php';
+						include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-download-permission.php';
 					}
 				}
 			}
@@ -946,12 +946,12 @@ class WC_AJAX {
 
 			// Get HTML to return.
 			ob_start();
-			include 'admin/meta-boxes/views/html-order-items.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
 			$items_html = ob_get_clean();
 
 			ob_start();
 			$notes = wc_get_order_notes( array( 'order_id' => $order_id ) );
-			include 'admin/meta-boxes/views/html-order-notes.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-notes.php';
 			$notes_html = ob_get_clean();
 
 			return array(
@@ -1015,7 +1015,7 @@ class WC_AJAX {
 			$order->save();
 
 			ob_start();
-			include 'admin/meta-boxes/views/html-order-items.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1057,7 +1057,7 @@ class WC_AJAX {
 			$item_id = $item->save();
 
 			ob_start();
-			include 'admin/meta-boxes/views/html-order-shipping.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-shipping.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1104,7 +1104,7 @@ class WC_AJAX {
 			$item->save();
 
 			ob_start();
-			include 'admin/meta-boxes/views/html-order-items.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1167,7 +1167,7 @@ class WC_AJAX {
 			$order->calculate_totals( false );
 
 			ob_start();
-			include 'admin/meta-boxes/views/html-order-items.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1214,7 +1214,7 @@ class WC_AJAX {
 			$order->calculate_totals( false );
 
 			ob_start();
-			include 'admin/meta-boxes/views/html-order-items.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1300,12 +1300,12 @@ class WC_AJAX {
 
 			// Get HTML to return.
 			ob_start();
-			include 'admin/meta-boxes/views/html-order-items.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
 			$items_html = ob_get_clean();
 
 			ob_start();
 			$notes = wc_get_order_notes( array( 'order_id' => $order_id ) );
-			include 'admin/meta-boxes/views/html-order-notes.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-notes.php';
 			$notes_html = ob_get_clean();
 
 			wp_send_json_success(
@@ -1352,7 +1352,7 @@ class WC_AJAX {
 			$order->calculate_totals( false );
 
 			ob_start();
-			include 'admin/meta-boxes/views/html-order-items.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1391,7 +1391,7 @@ class WC_AJAX {
 		$order = wc_get_order( $order_id );
 		$order->calculate_taxes( $calculate_tax_args );
 		$order->calculate_totals( false );
-		include 'admin/meta-boxes/views/html-order-items.php';
+		include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
 		wp_die();
 	}
 
@@ -1420,12 +1420,12 @@ class WC_AJAX {
 
 			// Get HTML to return.
 			ob_start();
-			include 'admin/meta-boxes/views/html-order-items.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
 			$items_html = ob_get_clean();
 
 			ob_start();
 			$notes = wc_get_order_notes( array( 'order_id' => $order_id ) );
-			include 'admin/meta-boxes/views/html-order-notes.php';
+			include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-notes.php';
 			$notes_html = ob_get_clean();
 
 			wp_send_json_success(
@@ -1451,7 +1451,7 @@ class WC_AJAX {
 		// Return HTML items.
 		$order_id = absint( $_POST['order_id'] );
 		$order    = wc_get_order( $order_id );
-		include 'admin/meta-boxes/views/html-order-items.php';
+		include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-order-items.php';
 		wp_die();
 	}
 
@@ -2101,7 +2101,7 @@ class WC_AJAX {
 				$variation_id   = $variation_object->get_id();
 				$variation      = get_post( $variation_id );
 				$variation_data = array_merge( get_post_custom( $variation_id ), wc_get_product_variation_attributes( $variation_id ) ); // kept for BW compatibility.
-				include 'admin/meta-boxes/views/html-variation-admin.php';
+				include dirname( __FILE__ ) . 'admin/meta-boxes/views/html-variation-admin.php';
 				$loop++;
 			}
 		}

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1057,7 +1057,7 @@ class WC_AJAX {
 			$item_id = $item->save();
 
 			ob_start();
-			include __DIR__ . DIRECTORY_SEPARATOR. 'admin/meta-boxes/views/html-order-shipping.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-shipping.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1104,7 +1104,7 @@ class WC_AJAX {
 			$item->save();
 
 			ob_start();
-			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -548,7 +548,7 @@ class WC_AJAX {
 		$order = wc_get_order( absint( $_GET['order_id'] ) ); // WPCS: sanitization ok.
 
 		if ( $order ) {
-			include_once __DIR__ . DIRECTORY_SEPARATOR . 'admin/list-tables/class-wc-admin-list-table-orders.php';
+			include_once __DIR__ . '/admin/list-tables/class-wc-admin-list-table-orders.php';
 
 			wp_send_json_success( WC_Admin_List_Table_Orders::order_preview_get_order_details( $order ) );
 		}
@@ -581,7 +581,7 @@ class WC_AJAX {
 			$metabox_class[] = $attribute->get_name();
 		}
 
-		include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-product-attribute.php';
+		include __DIR__ . '/admin/meta-boxes/views/html-product-attribute.php';
 		wp_die();
 	}
 
@@ -681,7 +681,7 @@ class WC_AJAX {
 						$metabox_class[] = $attribute->get_name();
 					}
 
-					include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-product-attribute.php';
+					include __DIR__ . '/admin/meta-boxes/views/html-product-attribute.php';
 				}
 			}
 
@@ -716,7 +716,7 @@ class WC_AJAX {
 		$variation_id   = $variation_object->save();
 		$variation      = get_post( $variation_id );
 		$variation_data = array_merge( get_post_custom( $variation_id ), wc_get_product_variation_attributes( $variation_id ) ); // kept for BW compatibility.
-		include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-variation-admin.php';
+		include __DIR__ . '/admin/meta-boxes/views/html-variation-admin.php';
 		wp_die();
 	}
 
@@ -816,7 +816,7 @@ class WC_AJAX {
 							/* translators: %d file count */
 							$file_count = sprintf( __( 'File %d', 'woocommerce' ), $file_counter );
 						}
-						include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-download-permission.php';
+						include __DIR__ . '/admin/meta-boxes/views/html-order-download-permission.php';
 					}
 				}
 			}
@@ -946,12 +946,12 @@ class WC_AJAX {
 
 			// Get HTML to return.
 			ob_start();
-			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
 			$items_html = ob_get_clean();
 
 			ob_start();
 			$notes = wc_get_order_notes( array( 'order_id' => $order_id ) );
-			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-notes.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-notes.php';
 			$notes_html = ob_get_clean();
 
 			return array(
@@ -1015,7 +1015,7 @@ class WC_AJAX {
 			$order->save();
 
 			ob_start();
-			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1167,7 +1167,7 @@ class WC_AJAX {
 			$order->calculate_totals( false );
 
 			ob_start();
-			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1214,7 +1214,7 @@ class WC_AJAX {
 			$order->calculate_totals( false );
 
 			ob_start();
-			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1300,12 +1300,12 @@ class WC_AJAX {
 
 			// Get HTML to return.
 			ob_start();
-			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
 			$items_html = ob_get_clean();
 
 			ob_start();
 			$notes = wc_get_order_notes( array( 'order_id' => $order_id ) );
-			include __DIR__ . DIRECTORY_SEPARATOR. 'admin/meta-boxes/views/html-order-notes.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-notes.php';
 			$notes_html = ob_get_clean();
 
 			wp_send_json_success(
@@ -1352,7 +1352,7 @@ class WC_AJAX {
 			$order->calculate_totals( false );
 
 			ob_start();
-			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
 			$response['html'] = ob_get_clean();
 		} catch ( Exception $e ) {
 			wp_send_json_error( array( 'error' => $e->getMessage() ) );
@@ -1391,7 +1391,7 @@ class WC_AJAX {
 		$order = wc_get_order( $order_id );
 		$order->calculate_taxes( $calculate_tax_args );
 		$order->calculate_totals( false );
-		include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
+		include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
 		wp_die();
 	}
 
@@ -1420,12 +1420,12 @@ class WC_AJAX {
 
 			// Get HTML to return.
 			ob_start();
-			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
 			$items_html = ob_get_clean();
 
 			ob_start();
 			$notes = wc_get_order_notes( array( 'order_id' => $order_id ) );
-			include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-notes.php';
+			include __DIR__ . '/admin/meta-boxes/views/html-order-notes.php';
 			$notes_html = ob_get_clean();
 
 			wp_send_json_success(
@@ -1451,7 +1451,7 @@ class WC_AJAX {
 		// Return HTML items.
 		$order_id = absint( $_POST['order_id'] );
 		$order    = wc_get_order( $order_id );
-		include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-order-items.php';
+		include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';
 		wp_die();
 	}
 
@@ -2101,7 +2101,7 @@ class WC_AJAX {
 				$variation_id   = $variation_object->get_id();
 				$variation      = get_post( $variation_id );
 				$variation_data = array_merge( get_post_custom( $variation_id ), wc_get_product_variation_attributes( $variation_id ) ); // kept for BW compatibility.
-				include __DIR__ . DIRECTORY_SEPARATOR . 'admin/meta-boxes/views/html-variation-admin.php';
+				include __DIR__ . '/admin/meta-boxes/views/html-variation-admin.php';
 				$loop++;
 			}
 		}

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -218,17 +218,17 @@ class WC_Emails {
 		// Include email classes.
 		include_once dirname( __FILE__ ) . '/emails/class-wc-email.php';
 
-		$this->emails['WC_Email_New_Order']                 = include 'emails/class-wc-email-new-order.php';
-		$this->emails['WC_Email_Cancelled_Order']           = include 'emails/class-wc-email-cancelled-order.php';
-		$this->emails['WC_Email_Failed_Order']              = include 'emails/class-wc-email-failed-order.php';
-		$this->emails['WC_Email_Customer_On_Hold_Order']    = include 'emails/class-wc-email-customer-on-hold-order.php';
-		$this->emails['WC_Email_Customer_Processing_Order'] = include 'emails/class-wc-email-customer-processing-order.php';
-		$this->emails['WC_Email_Customer_Completed_Order']  = include 'emails/class-wc-email-customer-completed-order.php';
-		$this->emails['WC_Email_Customer_Refunded_Order']   = include 'emails/class-wc-email-customer-refunded-order.php';
-		$this->emails['WC_Email_Customer_Invoice']          = include 'emails/class-wc-email-customer-invoice.php';
-		$this->emails['WC_Email_Customer_Note']             = include 'emails/class-wc-email-customer-note.php';
-		$this->emails['WC_Email_Customer_Reset_Password']   = include 'emails/class-wc-email-customer-reset-password.php';
-		$this->emails['WC_Email_Customer_New_Account']      = include 'emails/class-wc-email-customer-new-account.php';
+		$this->emails['WC_Email_New_Order']                 = include __DIR__ . '/emails/class-wc-email-new-order.php';
+		$this->emails['WC_Email_Cancelled_Order']           = include __DIR__ . '/emails/class-wc-email-cancelled-order.php';
+		$this->emails['WC_Email_Failed_Order']              = include __DIR__ . '/emails/class-wc-email-failed-order.php';
+		$this->emails['WC_Email_Customer_On_Hold_Order']    = include __DIR__ . '/emails/class-wc-email-customer-on-hold-order.php';
+		$this->emails['WC_Email_Customer_Processing_Order'] = include __DIR__ . '/emails/class-wc-email-customer-processing-order.php';
+		$this->emails['WC_Email_Customer_Completed_Order']  = include __DIR__ . '/emails/class-wc-email-customer-completed-order.php';
+		$this->emails['WC_Email_Customer_Refunded_Order']   = include __DIR__ . '/emails/class-wc-email-customer-refunded-order.php';
+		$this->emails['WC_Email_Customer_Invoice']          = include __DIR__ . '/emails/class-wc-email-customer-invoice.php';
+		$this->emails['WC_Email_Customer_Note']             = include __DIR__ . '/emails/class-wc-email-customer-note.php';
+		$this->emails['WC_Email_Customer_Reset_Password']   = include __DIR__ . '/emails/class-wc-email-customer-reset-password.php';
+		$this->emails['WC_Email_Customer_New_Account']      = include __DIR__ . '/emails/class-wc-email-customer-new-account.php';
 
 		$this->emails = apply_filters( 'woocommerce_email_classes', $this->emails );
 	}

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -35,8 +35,8 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		}
 
 		// Include supporting classes.
-		include_once 'class-wc-privacy-erasers.php';
-		include_once 'class-wc-privacy-exporters.php';
+		include_once dirname( __FILE__ ) . 'class-wc-privacy-erasers.php';
+		include_once dirname( __FILE__ ) . 'class-wc-privacy-exporters.php';
 
 		// This hook registers WooCommerce data exporters.
 		$this->add_exporter( 'woocommerce-customer-data', __( 'WooCommerce Customer Data', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'customer_data_exporter' ) );

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -9,7 +9,7 @@
 defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'WC_Privacy_Background_Process', false ) ) {
-	include_once __DIR__ . DIRECTORY_SEPARATOR . 'class-wc-privacy-background-process.php';
+	include_once __DIR__ . '/class-wc-privacy-background-process.php';
 }
 
 /**
@@ -35,8 +35,8 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		}
 
 		// Include supporting classes.
-		include_once __DIR__ . DIRECTORY_SEPARATOR . 'class-wc-privacy-erasers.php';
-		include_once __DIR__ . DIRECTORY_SEPARATOR . 'class-wc-privacy-exporters.php';
+		include_once __DIR__ . '/class-wc-privacy-erasers.php';
+		include_once __DIR__ . '/class-wc-privacy-exporters.php';
 
 		// This hook registers WooCommerce data exporters.
 		$this->add_exporter( 'woocommerce-customer-data', __( 'WooCommerce Customer Data', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'customer_data_exporter' ) );

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -9,7 +9,7 @@
 defined( 'ABSPATH' ) || exit;
 
 if ( ! class_exists( 'WC_Privacy_Background_Process', false ) ) {
-	include_once dirname( __FILE__ ) . '/class-wc-privacy-background-process.php';
+	include_once __DIR__ . DIRECTORY_SEPARATOR . 'class-wc-privacy-background-process.php';
 }
 
 /**
@@ -35,8 +35,8 @@ class WC_Privacy extends WC_Abstract_Privacy {
 		}
 
 		// Include supporting classes.
-		include_once dirname( __FILE__ ) . 'class-wc-privacy-erasers.php';
-		include_once dirname( __FILE__ ) . 'class-wc-privacy-exporters.php';
+		include_once __DIR__ . DIRECTORY_SEPARATOR . 'class-wc-privacy-erasers.php';
+		include_once __DIR__ . DIRECTORY_SEPARATOR . 'class-wc-privacy-exporters.php';
 
 		// This hook registers WooCommerce data exporters.
 		$this->add_exporter( 'woocommerce-customer-data', __( 'WooCommerce Customer Data', 'woocommerce' ), array( 'WC_Privacy_Exporters', 'customer_data_exporter' ) );

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -9,7 +9,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-require_once __DIR__ . DIRECTORY_SEPARATOR . 'legacy/class-wc-legacy-shipping-zone.php';
+require_once __DIR__ . '/legacy/class-wc-legacy-shipping-zone.php';
 
 /**
  * WC_Shipping_Zone class.

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -9,7 +9,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-require_once dirname( __FILE__ ) . 'legacy/class-wc-legacy-shipping-zone.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'legacy/class-wc-legacy-shipping-zone.php';
 
 /**
  * WC_Shipping_Zone class.

--- a/includes/class-wc-shipping-zone.php
+++ b/includes/class-wc-shipping-zone.php
@@ -9,7 +9,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-require_once 'legacy/class-wc-legacy-shipping-zone.php';
+require_once dirname( __FILE__ ) . 'legacy/class-wc-legacy-shipping-zone.php';
 
 /**
  * WC_Shipping_Zone class.

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Constants;
 
 defined( 'ABSPATH' ) || exit;
 
-require_once 'legacy/class-wc-legacy-webhook.php';
+require_once dirname( __FILE__ ) . 'legacy/class-wc-legacy-webhook.php';
 
 /**
  * Webhook class.

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Constants;
 
 defined( 'ABSPATH' ) || exit;
 
-require_once __DIR__ . DIRECTORY_SEPARATOR . 'legacy/class-wc-legacy-webhook.php';
+require_once __DIR__ . '/legacy/class-wc-legacy-webhook.php';
 
 /**
  * Webhook class.

--- a/includes/class-wc-webhook.php
+++ b/includes/class-wc-webhook.php
@@ -15,7 +15,7 @@ use Automattic\Jetpack\Constants;
 
 defined( 'ABSPATH' ) || exit;
 
-require_once dirname( __FILE__ ) . 'legacy/class-wc-legacy-webhook.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'legacy/class-wc-legacy-webhook.php';
 
 /**
  * Webhook class.

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -294,7 +294,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 	 * Initialise Gateway Settings Form Fields.
 	 */
 	public function init_form_fields() {
-		$this->form_fields = include 'includes/settings-paypal.php';
+		$this->form_fields = include __DIR__ . '/includes/settings-paypal.php';
 	}
 
 	/**

--- a/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
+++ b/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
@@ -8,7 +8,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-require_once dirname( __FILE__ ) . 'class-wc-integration-maxmind-database-service.php';
+require_once __DIR__ . DIRECTORY_SEPARATOR . 'class-wc-integration-maxmind-database-service.php';
 
 /**
  * WC Integration MaxMind Geolocation

--- a/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
+++ b/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
@@ -8,7 +8,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-require_once 'class-wc-integration-maxmind-database-service.php';
+require_once dirname( __FILE__ ) . 'class-wc-integration-maxmind-database-service.php';
 
 /**
  * WC Integration MaxMind Geolocation

--- a/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
+++ b/includes/integrations/maxmind-geolocation/class-wc-integration-maxmind-geolocation.php
@@ -8,7 +8,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-require_once __DIR__ . DIRECTORY_SEPARATOR . 'class-wc-integration-maxmind-database-service.php';
+require_once __DIR__ . '/class-wc-integration-maxmind-database-service.php';
 
 /**
  * WC Integration MaxMind Geolocation

--- a/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
+++ b/includes/shipping/flat-rate/class-wc-shipping-flat-rate.php
@@ -44,7 +44,7 @@ class WC_Shipping_Flat_Rate extends WC_Shipping_Method {
 	 * Init user set variables.
 	 */
 	public function init() {
-		$this->instance_form_fields = include 'includes/settings-flat-rate.php';
+		$this->instance_form_fields = include __DIR__ . '/includes/settings-flat-rate.php';
 		$this->title                = $this->get_option( 'title' );
 		$this->tax_status           = $this->get_option( 'tax_status' );
 		$this->cost                 = $this->get_option( 'cost' );

--- a/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
+++ b/includes/shipping/legacy-flat-rate/class-wc-shipping-legacy-flat-rate.php
@@ -85,7 +85,7 @@ class WC_Shipping_Legacy_Flat_Rate extends WC_Shipping_Method {
 	 * Initialise Settings Form Fields.
 	 */
 	public function init_form_fields() {
-		$this->form_fields = include 'includes/settings-flat-rate.php';
+		$this->form_fields = include __DIR__ . '/includes/settings-flat-rate.php';
 	}
 
 	/**

--- a/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
+++ b/tests/legacy/unit-tests/util/class-wc-tests-core-functions.php
@@ -324,7 +324,7 @@ class WC_Tests_Core_Functions extends WC_Unit_Test_Case {
 	 */
 	public function return_valid_logger_instance() {
 		if ( ! class_exists( 'Dummy_WC_Logger' ) ) {
-			include_once 'dummy-wc-logger.php';
+			include_once __DIR__ . '/dummy-wc-logger.php';
 		}
 		return new Dummy_WC_Logger();
 	}

--- a/tests/legacy/unit-tests/widgets/class-wc-tests-widget.php
+++ b/tests/legacy/unit-tests/widgets/class-wc-tests-widget.php
@@ -15,7 +15,7 @@ class WC_Tests_Widget extends WC_Unit_Test_Case {
 	 * @return void
 	 */
 	public function test_instance() {
-		require_once 'class-dummy-widget.php';
+		require_once __DIR__ . '/class-dummy-widget.php';
 		$dummy_widget = new Dummy_Widget();
 		$this->assertTrue( property_exists( $dummy_widget, 'widget_id' ) );
 	}
@@ -27,7 +27,7 @@ class WC_Tests_Widget extends WC_Unit_Test_Case {
 	 */
 	public function test_caching() {
 		global $wp_widget_factory;
-		require_once 'class-dummy-widget.php';
+		require_once __DIR__ . '/class-dummy-widget.php';
 		register_widget( 'Dummy_Widget' );
 
 		$dummy_widget = $wp_widget_factory->widgets['Dummy_Widget'];
@@ -59,7 +59,7 @@ class WC_Tests_Widget extends WC_Unit_Test_Case {
 	 */
 	public function test_form() {
 		global $wp_widget_factory;
-		require_once 'class-dummy-widget.php';
+		require_once __DIR__ . '/class-dummy-widget.php';
 		register_widget( 'Dummy_Widget' );
 		$dummy_widget = $wp_widget_factory->widgets['Dummy_Widget'];
 		$this->assertEmpty( $dummy_widget->form( array( 'widget_id' => $dummy_widget->widget_id ) ) );


### PR DESCRIPTION
## Overview
Relative include paths in PHP can break, when server is running `opcache`. See [here about vulnerability details](https://stackoverflow.com/a/30913177).

WordPress.com deploy system refuses to include WooCommerce, because of that issue - for more context, see here - [internal a8c discussion](p3topS-MV-p2)

This PR changes the relative include paths to absolute include paths.

Editing to add: There is a [similar PR for Action Scheduler](https://github.com/woocommerce/action-scheduler/blob/fix/remove-relative-include-paths/action-scheduler.php) that will need to be included with this PR.


### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Relates to #27269 and https://github.com/woocommerce/action-scheduler/pull/604

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Changed relative `include` paths to absolute `include` paths using `__DIR__`.