### PR TITLE
Remove the second occurrence of woocommerce_add_{$notice_type} filter

### DIFF
--- a/includes/wc-notice-functions.php
+++ b/includes/wc-notice-functions.php
@@ -88,7 +88,7 @@ function wc_add_notice( $message, $notice_type = 'success', $data = array() ) {
 
 	if ( ! empty( $message ) ) {
 		$notices[ $notice_type ][] = array(
-			'notice' => apply_filters( 'woocommerce_add_' . $notice_type, $message ),
+			'notice' => $message,
 			'data'   => $data,
 		);
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removes the second occurrence of `woocommerce_add_{$notice_type}` filter from `wc_add_notice` function.

### Changelog entry

> Dev - Fixed duplicated use of `woocommerce_add_$notice_type`.
