### PR TITLE
Updating e2e tests for OBW changes

### DIFF
--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -115,7 +115,7 @@ const completeOnboardingWizard = async () => {
 
 	// Query for the product types checkboxes
 	const productTypesCheckboxes = await page.$$( '.components-checkbox-control__input' );
-	expect( productTypesCheckboxes ).toHaveLength( 8 );
+	expect( productTypesCheckboxes ).toHaveLength( 7 );
 
 	// Select Physical and Downloadable products
 	for ( let i = 1; i < 2; i++ ) {
@@ -189,16 +189,26 @@ const completeOnboardingWizard = async () => {
 
 	// End of onboarding wizard
 
-	// Wait for "Woo-hoo almost there" window to appear
-	await page.waitForSelector( '.components-modal__header-heading' );
+	// Wait for homescreen welcome modal to appear
+	await page.waitForSelector( '.woocommerce__welcome-modal__page-content__header' );
 	await expect( page ).toMatchElement(
-		'.components-modal__header-heading', { text: 'Woo hoo - you\'re almost there!' }
+		'.woocommerce__welcome-modal__page-content__header', { text: 'Welcome to your WooCommerce store\’s online HQ!' }
 	);
 
-	// Wait for "Continue" button to become active
-	await page.waitForSelector( 'button.is-primary:not(:disabled)' );
-	// Click on "Continue" button to move to the next step
-	await page.click( 'button.is-primary:not(:disabled)' );
+	// Wait for "Next" button to become active
+	await page.waitForSelector( 'button.components-guide__forward-button' );
+	// Click on "Next" button to move to the next step
+	await page.click( 'button.components-guide__forward-button' );
+
+	// Wait for "Next" button to become active
+	await page.waitForSelector( 'button.components-guide__forward-button' );
+	// Click on "Next" button to move to the next step
+	await page.click( 'button.components-guide__forward-button' );
+
+	// Wait for "Let's go" button to become active
+	await page.waitForSelector( 'button.components-guide__finish-button' );
+	// Click on "Let's go" button to move to the next step
+	await page.click( 'button.components-guide__finish-button' );
 };
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates check on OBW Product selection to account for removal of composite products 
https://github.com/woocommerce/woocommerce-admin/pull/4996 (via https://github.com/woocommerce/woocommerce/pull/27379)
This fixes the test failure in the OBW when we expected more items in the product selection list

Updated to complete the new Welcome modal after the OBW
https://github.com/woocommerce/woocommerce-admin/pull/4890 (via https://github.com/woocommerce/woocommerce/pull/27379)
This fixes the test failure on the setup task list where `Set up shipping` task was blocked because we hadn't dismissed the new welcome modal

### How to test the changes in this Pull Request:

1. Make sure e2e tests pass locally and on Travis. Run tests as per [our docs](https://github.com/woocommerce/woocommerce/tree/master/tests/e2e#running-tests). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

N/A since we don't include changes made to e2e tests into changelog or releases. 