### PR TITLE
Fixed $columns type in WC_Shortcode_Products->get_wrapper_classes() docblock

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -521,7 +521,7 @@ class WC_Shortcode_Products {
 	 * Get wrapper classes.
 	 *
 	 * @since  3.2.0
-	 * @param  array $columns Number of columns.
+	 * @param  int $columns Number of columns.
 	 * @return array
 	 */
 	protected function get_wrapper_classes( $columns ) {


### PR DESCRIPTION
### All Submissions:

* [ x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ x ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR simply corrects the argument type in the `WC_Shortcode_Products->get_wrapper_classes()` docblock. They type is currently `array`. This is incorrect and does not conform to the usage in the `WC_Shortcode_Products` class.

https://github.com/woocommerce/woocommerce/blob/9b9ebc396a13bf1cd2a0e2b44743809cb884beac/includes/shortcodes/class-wc-shortcode-products.php#L612-L615

As you can see we are passing in an `int`. The usage inside the `get_wrapper_classes()` method also would indicate that the type should be `int`.

https://github.com/woocommerce/woocommerce/blob/9b9ebc396a13bf1cd2a0e2b44743809cb884beac/includes/shortcodes/class-wc-shortcode-products.php#L527-L537

As the above code shows it is concatenated with a string. I imagine the desired string would be `columns-1` or `columns-2` not `columns-Array`.

### Changelog entry

Probably not worth the space in the changelog.
