### PR TITLE
Fix - Remove "There are no notes yet" after adding the first one by AJAX

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1315,6 +1315,7 @@ jQuery( function ( $ ) {
 			};
 
 			$.post( woocommerce_admin_meta_boxes.ajax_url, data, function( response ) {
+				$( 'ul.order_notes .no-items' ).remove();
 				$( 'ul.order_notes' ).prepend( response );
 				$( '#woocommerce-order-notes' ).unblock();
 				$( '#add_order_note' ).val( '' );

--- a/includes/admin/meta-boxes/views/html-order-notes.php
+++ b/includes/admin/meta-boxes/views/html-order-notes.php
@@ -41,7 +41,7 @@ defined( 'ABSPATH' ) || exit;
 		}
 	} else {
 		?>
-		<li><?php esc_html_e( 'There are no notes yet.', 'woocommerce' ); ?></li>
+		<li class="no-items"><?php esc_html_e( 'There are no notes yet.', 'woocommerce' ); ?></li>
 		<?php
 	}
 	?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix bug when adding the first note to an order whereby the `There are no notes yet` message is not removed.

Closes #27413 

### How to test the changes in this Pull Request:

1. Create an order
2. Add a note to the order
3. Observe that the `There are no notes yet` message is removed after adding the first note

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Remove "There are no notes yet" after adding the first one by AJAX.
