### PR TITLE
Fix #27401

### DIFF
--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 4.0.0
+ * @version 4.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -26,6 +26,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 		<tbody>
 			<?php
 			$quantites_required      = false;
+			$has_items_in_stock      = false;
 			$previous_post           = $post;
 			$grouped_product_columns = apply_filters(
 				'woocommerce_grouped_product_columns',
@@ -42,6 +43,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 			foreach ( $grouped_products as $grouped_product_child ) {
 				$post_object        = get_post( $grouped_product_child->get_id() );
 				$quantites_required = $quantites_required || ( $grouped_product_child->is_purchasable() && ! $grouped_product_child->has_options() );
+				$has_items_in_stock = $has_items_in_stock || $grouped_product_child->is_in_stock();
 				$post               = $post_object; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				setup_postdata( $post );
 
@@ -107,7 +109,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 	<input type="hidden" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>" />
 
-	<?php if ( $quantites_required ) : ?>
+	<?php if ( $quantites_required && $has_items_in_stock ) : ?>
 
 		<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Hide the Add to Cart button when all products that are part of a Grouped product are out of stock.

Closes #27401 

### How to test the changes in this Pull Request:

1. Create a Grouped product
2. Set the stock status to `Out of stock` for each of the products that are part of it
3. Observe that the Add to Cart button is now hidden as the product cannot be added to the cart
