### PR TITLE
Fix #27339

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -1189,8 +1189,10 @@ class WC_Tax {
 	public static function get_rates_for_tax_class( $tax_class ) {
 		global $wpdb;
 
+		$tax_class = self::format_tax_rate_class( $tax_class );
+
 		// Get all the rates and locations. Snagging all at once should significantly cut down on the number of queries.
-		$rates     = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `{$wpdb->prefix}woocommerce_tax_rates` WHERE `tax_rate_class` = %s;", sanitize_title( $tax_class ) ) );
+		$rates     = $wpdb->get_results( $wpdb->prepare( "SELECT * FROM `{$wpdb->prefix}woocommerce_tax_rates` WHERE `tax_rate_class` = %s;", $tax_class ) );
 		$locations = $wpdb->get_results( "SELECT * FROM `{$wpdb->prefix}woocommerce_tax_rate_locations`" );
 
 		if ( ! empty( $rates ) ) {

--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -403,7 +403,7 @@ class WC_Tax {
 
 		$criteria_string = implode( ' AND ', $criteria );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		$found_rates = $wpdb->get_results(
 			"
 			SELECT tax_rates.*, COUNT( locations.location_id ) as postcode_count, COUNT( locations2.location_id ) as city_count


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Correctly format the tax rate class the same way as it formatted for DB insertion when requesting tax rates lists. This ensures that `Standard` rates are retrieved correctly when `Standard` is entered as an additional tax rate under `Tax` -> `Tax options` -> `Additional tax classes`.

Closes #27339 

### How to test the changes in this Pull Request:

1. Add `Standard` as an additional tax rate
2. Add a new tax rate under `Standard rates` and click `Save changes`
3. Refresh the page and observe the new rate shows

### Changelog entry

* Fix - When additional tax class is added named 'Standard', it conflicts with the default Standard class.
