### PR TITLE
Fix PHP docblock summary for wc_get_coupon_id_by_code

### DIFF
--- a/includes/wc-coupon-functions.php
+++ b/includes/wc-coupon-functions.php
@@ -82,7 +82,7 @@ function wc_get_coupon_code_by_id( $id ) {
 }
 
 /**
- * Get coupon code by ID.
+ * Get coupon ID by code.
  *
  * @since 3.0.0
  * @param string $code    Coupon code.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Entering a coupon code name to `wc_get_coupon_id_by_code` returns the coupon ID. We can test the expected behavior by running a unit test:
```sh
vendor/bin/phpunit --filter test_wc_get_coupon_id_by_code tests/legacy/unit-tests/coupon/functions.php
```

<!-- Mark completed items with an [x] -->

### Changelog entry
Fix PHP docblock summary to properly reflect the role of `wc_get_coupon_id_by_code` function.
