### PR TITLE
LF line endings on checkout for PHP files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,13 +1,20 @@
-/.* export-ignore
-bin export-ignore
+# Set the default behavior, in case people don't have `core.autocrlf` set.
+* text=auto
+
+# Declare files that will always have LF line endings on checkout.
+*.php text eol=lf
+
+# Remove files for archives generated using `git archive`.
+/.*                export-ignore
+bin                export-ignore
 CODE_OF_CONDUCT.md export-ignore
-changelog.txt export-ignore
-composer.* export-ignore
-Gruntfile.js export-ignore
-package.json export-ignore
-package-lock.json export-ignore
-phpcs.xml export-ignore
-phpunit.* export-ignore
-README.md export-ignore
-tests export-ignore
-renovate.json export-ignore
+changelog.txt      export-ignore
+composer.*         export-ignore
+Gruntfile.js       export-ignore
+package.json       export-ignore
+package-lock.json  export-ignore
+phpcs.xml          export-ignore
+phpunit.*          export-ignore
+README.md          export-ignore
+renovate.json      export-ignore
+tests              export-ignore


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Declares PHP files to always have LF line endings on checkout. Useful for users on Windows OS.

