### PR TITLE
Enhanced ajax checkout coupon issue

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -578,7 +578,7 @@ jQuery( function( $ ) {
 		init: function() {
 			$( document.body ).on( 'click', 'a.showcoupon', this.show_coupon_form );
 			$( document.body ).on( 'click', '.woocommerce-remove-coupon', this.remove_coupon );
-			$( 'form.checkout_coupon' ).hide().submit( this.submit );
+			$( document.body ).on( 'submit', 'form.checkout_coupon', this.submit );
 		},
 		show_coupon_form: function() {
 			$( '.checkout_coupon' ).slideToggle( 400, function() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### How to test the changes in this Pull Request:

1. Load the Checkout coupon form by ajax or hook it where the content loaded by ajax in the checkout page
2. The checkout coupon form is not applying by ajax because of this code: `$( 'form.checkout_coupon' ).hide().submit( this.submit );`
3. If you change the code to this:  `$( document.body ).on( 'submit', 'form.checkout_coupon', this.submit );` the ajax checkout coupon form will work fine. otherwise, the checkout page is getting reload.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhanced checkout coupon javascript event