### PR TITLE
Revert "Fixed HTML entities in product name not showing correctly in cart page"

### DIFF
--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -11,8 +11,8 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce\Templates
- * @version 4.4.0
+ * @package WooCommerce/Templates
+ * @version 3.8.0
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -77,9 +77,9 @@ do_action( 'woocommerce_before_cart' ); ?>
 						<td class="product-name" data-title="<?php esc_attr_e( 'Product', 'woocommerce' ); ?>">
 						<?php
 						if ( ! $product_permalink ) {
-							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', esc_html( $_product->get_name() ), $cart_item, $cart_item_key ) . '&nbsp;' );
+							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key ) . '&nbsp;' );
 						} else {
-							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s</a>', esc_url( $product_permalink ), esc_html( $_product->get_name() ) ), $cart_item, $cart_item_key ) );
+							echo wp_kses_post( apply_filters( 'woocommerce_cart_item_name', sprintf( '<a href="%s">%s</a>', esc_url( $product_permalink ), $_product->get_name() ), $cart_item, $cart_item_key ) );
 						}
 
 						do_action( 'woocommerce_after_cart_item_name', $cart_item, $cart_item_key );

--- a/templates/single-product/title.php
+++ b/templates/single-product/title.php
@@ -10,16 +10,13 @@
  * happen. When this occurs the version of the template file will be bumped and
  * the readme will list any important changes.
  *
- * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce\Templates
- * @version 4.4.0
+ * @see        https://docs.woocommerce.com/document/template-structure/
+ * @package    WooCommerce/Templates
+ * @version    1.6.4
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 
-?>
-<h1 class="product_title entry-title">
-	<?php echo esc_html( get_the_title() ); ?>
-</h1>
+the_title( '<h1 class="product_title entry-title">', '</h1>' );


### PR DESCRIPTION
Reverts #26885.

### Changes proposed in this Pull Request:

Because there is a desire to include HTML entities in titles for formatting, escaping them breaks some workflows. Also see #8197, a previous attempt at escaping entities that was also reverted.

Closes #27305.

### How to test the changes in this Pull Request:

1. Create a product with a title such-as: `This is a <<strong>product</strong>> <br /><br />Yes it is!!!`
2. Visit the product page. Verify that the formatting still applies.
![image](https://user-images.githubusercontent.com/363749/91093285-d8448d00-e61e-11ea-8385-2dd5b1e97849.png)
3. Add the product to your cart. Verify that within the cart, the formatting still applies.
![image](https://user-images.githubusercontent.com/363749/91093344-e98d9980-e61e-11ea-8b3d-20ca754869c4.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: Allow HTML to be entered in product title for formatting purposes.
