### PR TITLE
Bump wc-admin to 1.5.0-rc.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "^1.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.5.0-rc.1",
+    "woocommerce/woocommerce-admin": "1.5.0-rc.2",
     "woocommerce/woocommerce-blocks": "3.1.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "7f82f8a4f08f7f4f966dc2ef68081293",
+    "content-hash": "6f5bef4c75b0d62b2f3d9bc2458eff03",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -468,16 +468,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "1.5.0-rc.1",
+            "version": "1.5.0-rc.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "97a540e2e114b8c7566dc97109ba04536f905de0"
+                "reference": "bb2fbb0e105e419478b09a15dc4b43c8f1426381"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/97a540e2e114b8c7566dc97109ba04536f905de0",
-                "reference": "97a540e2e114b8c7566dc97109ba04536f905de0",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/bb2fbb0e105e419478b09a15dc4b43c8f1426381",
+                "reference": "bb2fbb0e105e419478b09a15dc4b43c8f1426381",
                 "shasum": ""
             },
             "require": {
@@ -511,7 +511,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-08-18T03:05:31+00:00"
+            "time": "2020-08-20T23:35:02+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2937,6 +2937,5 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }


### PR DESCRIPTION
This bumps the bundled version of wc-admin to 1.5.0-rc.2