### PR TITLE
Rename built-in PayPal payment method to PayPal Standard

### DIFF
--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -42,7 +42,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 		$this->id                = 'paypal';
 		$this->has_fields        = false;
 		$this->order_button_text = __( 'Proceed to PayPal', 'woocommerce' );
-		$this->method_title      = __( 'PayPal', 'woocommerce' );
+		$this->method_title      = __( 'PayPal Standard', 'woocommerce' );
 		/* translators: %s: Link to WC system status page */
 		$this->method_description = __( 'PayPal Standard redirects customers to PayPal to enter their payment information.', 'woocommerce' );
 		$this->supports           = array(
@@ -283,7 +283,7 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 			?>
 			<div class="inline error">
 				<p>
-					<strong><?php esc_html_e( 'Gateway disabled', 'woocommerce' ); ?></strong>: <?php esc_html_e( 'PayPal does not support your store currency.', 'woocommerce' ); ?>
+					<strong><?php esc_html_e( 'Gateway disabled', 'woocommerce' ); ?></strong>: <?php esc_html_e( 'PayPal Standard does not support your store currency.', 'woocommerce' ); ?>
 				</p>
 			</div>
 			<?php

--- a/includes/gateways/paypal/includes/settings-paypal.php
+++ b/includes/gateways/paypal/includes/settings-paypal.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Settings for PayPal Gateway.
+ * Settings for PayPal Standard Gateway.
  *
  * @package WooCommerce\Classes\Payment
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Rename built-in PayPal payment method to PayPal Standard. Renames the method only in the admin area, not the front-end of the site to avoid confusing shoppers.

Closes #27467.

### How to test the changes in this Pull Request:

1. Go to `/admin.php?page=wc-settings&tab=checkout`
2. Confirm the Method title is now **PayPal Standard** instead of only **PayPal**

Settings screenshot before this patch:

<img width="1406" alt="Screen Shot 2020-08-25 at 12 26 25" src="https://user-images.githubusercontent.com/235523/91115966-af7bd080-e6ce-11ea-8f4d-88863544af66.png">

Settings screenshot after this patch:

<img width="1405" alt="Screen Shot 2020-08-25 at 12 24 40" src="https://user-images.githubusercontent.com/235523/91115987-b99dcf00-e6ce-11ea-9f24-617704332530.png">

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Tweak - Rename built-in PayPal payment method to PayPal Standard.

/cc @bmccotter 