### PR TITLE
Fixes load of selectWoo and script in customizer to align the dropdow…

### DIFF
--- a/plugins/woocommerce/includes/class-wc-frontend-scripts.php
+++ b/plugins/woocommerce/includes/class-wc-frontend-scripts.php
@@ -363,6 +363,10 @@ class WC_Frontend_Scripts {
 		if ( is_cart() ) {
 			self::enqueue_script( 'wc-cart' );
 		}
+		if ( is_customize_preview() ) {
+			self::enqueue_script( 'selectWoo' );
+			self::enqueue_style( 'select2' );
+		}
 		if ( is_cart() || is_checkout() || is_account_page() ) {
 			self::enqueue_script( 'selectWoo' );
 			self::enqueue_style( 'select2' );
@@ -372,6 +376,12 @@ class WC_Frontend_Scripts {
 				self::enqueue_script( 'wc-password-strength-meter' );
 			}
 		}
+		$js_to_add_to_selectWoo = "
+				var event = document.createEvent('Event');
+				event.initEvent('SelectWooLoaded', true, true);
+				document.documentElement.dispatchEvent(event);
+			";
+		wp_add_inline_script('selectWoo', $js_to_add_to_selectWoo);
 		if ( is_checkout() ) {
 			self::enqueue_script( 'wc-checkout' );
 		}

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-layered-nav.php
@@ -296,8 +296,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			echo wc_query_string_form_fields( null, array( 'filter_' . $taxonomy_filter_name, 'query_type_' . $taxonomy_filter_name ), '', true ); // @codingStandardsIgnoreLine
 			echo '</form>';
 
-			wc_enqueue_js(
-				"
+			$js = "
 				// Update value on change.
 				jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).on( 'change', function() {
 					var slug = jQuery( this ).val();
@@ -309,25 +308,36 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 					}
 				});
 
+				var wc_layered_nav_select = function() {
+					jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).selectWoo( {
+						placeholder: decodeURIComponent('" . rawurlencode( (string) wp_specialchars_decode( $any_label ) ) . "'),
+						minimumResultsForSearch: 5,
+						width: '100%',
+						allowClear: " . ( $multiple ? 'false' : 'true' ) . ",
+						language: {
+							noResults: function() {
+								return '" . esc_js( _x( 'No matches found', 'enhanced select', 'woocommerce' ) ) . "';
+							}
+						}
+					} );
+				};
+
 				// Use Select2 enhancement if possible
 				if ( jQuery().selectWoo ) {
-					var wc_layered_nav_select = function() {
-						jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).selectWoo( {
-							placeholder: decodeURIComponent('" . rawurlencode( (string) wp_specialchars_decode( $any_label ) ) . "'),
-							minimumResultsForSearch: 5,
-							width: '100%',
-							allowClear: " . ( $multiple ? 'false' : 'true' ) . ",
-							language: {
-								noResults: function() {
-									return '" . esc_js( _x( 'No matches found', 'enhanced select', 'woocommerce' ) ) . "';
-								}
-							}
-						} );
-					};
 					wc_layered_nav_select();
+				} else {
+					document.documentElement.addEventListener('SelectWooLoaded', function() {
+						wc_layered_nav_select();
+					} );
 				}
-			"
-			);
+			";
+			if ( is_customize_preview() ) {
+				?>
+				<script><?php echo $js; ?></script>
+				<?php
+			} else {
+				wc_enqueue_js($js);
+			}
 		}
 
 		return $found;

--- a/plugins/woocommerce/includes/widgets/class-wc-widget-product-categories.php
+++ b/plugins/woocommerce/includes/widgets/class-wc-widget-product-categories.php
@@ -240,44 +240,60 @@ class WC_Widget_Product_Categories extends WC_Widget {
 				)
 			);
 
-			wp_enqueue_script( 'selectWoo' );
-			wp_enqueue_style( 'select2' );
-
-			wc_enqueue_js(
-				"
-				jQuery( '.dropdown_product_cat' ).on( 'change', function() {
-					if ( jQuery(this).val() != '' ) {
-						var this_page = '';
-						var home_url  = '" . esc_js( home_url( '/' ) ) . "';
-						if ( home_url.indexOf( '?' ) > 0 ) {
-							this_page = home_url + '&product_cat=' + jQuery(this).val();
+			$js = "
+				var wc_add_change_listener_cat_select = function() {
+					jQuery( '.dropdown_product_cat' ).change( function() {
+						if ( jQuery(this).val() != '' ) {
+							var this_page = '';
+							var home_url  = '" . esc_js( home_url( '/' ) ) . "';
+							if ( home_url.indexOf( '?' ) > 0 ) {
+								this_page = home_url + '&product_cat=' + jQuery(this).val();
+							} else {
+								this_page = home_url + '?product_cat=' + jQuery(this).val();
+							}
+							location.href = this_page;
 						} else {
-							this_page = home_url + '?product_cat=' + jQuery(this).val();
+							location.href = '" . esc_js( wc_get_page_permalink( 'shop' ) ) . "';
 						}
-						location.href = this_page;
-					} else {
-						location.href = '" . esc_js( wc_get_page_permalink( 'shop' ) ) . "';
-					}
-				});
+					});
+				};
+
+
+				var wc_product_cat_select = function() {
+					jQuery( '.dropdown_product_cat' ).selectWoo( {
+						placeholder: '" . esc_js( __( 'Select a category', 'woocommerce' ) ) . "',
+						minimumResultsForSearch: 5,
+						width: '100%',
+						allowClear: true,
+						language: {
+							noResults: function() {
+								return '" . esc_js( _x( 'No matches found', 'enhanced select', 'woocommerce' ) ) . "';
+							}
+						}
+					} );
+				};
+
+				wc_add_change_listener_cat_select();
 
 				if ( jQuery().selectWoo ) {
-					var wc_product_cat_select = function() {
-						jQuery( '.dropdown_product_cat' ).selectWoo( {
-							placeholder: '" . esc_js( __( 'Select a category', 'woocommerce' ) ) . "',
-							minimumResultsForSearch: 5,
-							width: '100%',
-							allowClear: true,
-							language: {
-								noResults: function() {
-									return '" . esc_js( _x( 'No matches found', 'enhanced select', 'woocommerce' ) ) . "';
-								}
-							}
-						} );
-					};
 					wc_product_cat_select();
+				} else {
+					document.documentElement.addEventListener('SelectWooLoaded', function() {
+						wc_product_cat_select();
+					} );
 				}
-			"
-			);
+			";
+
+			if ( is_customize_preview() ) {
+				?>
+				<script><?php echo $js ?></script>
+				<?php
+			} else {
+				wp_enqueue_script('selectWoo');
+				wp_enqueue_style('select2');
+				wc_enqueue_js($js);
+			}
+
 		} else {
 			include_once WC()->plugin_path() . '/includes/walkers/class-wc-product-cat-list-walker.php';
 


### PR DESCRIPTION
…ns with the styles

### Describe the bug

tl;dr; Dropdowns from widgets inconsistent in Customizer and front-end

When using a standard "Filter by" widget in the sidebar and choosing to display that as a dropdown, the way it looks in the Customizer is different than the way it looks on the site.

## To Reproduce
Steps to reproduce the behavior:
1. Go to the Customizer → Widgets → Sidebar
2. Add a widget that can show dropdowns (e.g. "Filter products by Attribute" or "Product Categories")
3. Make sure "Show as dropdown" is checked
4. Publish
5. Observe the way the dropdown looks in the Customizer
6. Compare to the way it looks on the site

## Screenshots
Customizer:
![dropdown-customizer](https://user-images.githubusercontent.com/1710669/87187649-82f52c00-c2bb-11ea-998c-9e604356f7b2.png)

Front end:
<img width="968" alt="site-dropdown" src="https://user-images.githubusercontent.com/1710669/87187712-a029fa80-c2bb-11ea-9005-e670d41401b7.png">

## Expected behavior
Looks should be consistent in Customizer and front end.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/galleria/issues/99 .

### How to test the changes in this Pull Request:

1. Create a page and open customizer
2. Add a Product_cat Widget
3. in the widget select the option show as dropdown.

To test the filter product by attributes
1. Create a shop page
2. Open the customizer uin the shop page
3. Add the widget  filter product by attributes

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Loaded selectWoo in document inside customizer
> Throw an event when the lib is available
> Listen to the event on the widgets to properly initialize them
