### PR TITLE
Updated woocommerce/action-build to v2

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -11,9 +11,9 @@ jobs:
         uses: actions/checkout@v2
       - name: Build
         id: build
-        uses: woocommerce/action-build@master
+        uses: woocommerce/action-build@v2
         with:
-          generate-zip: true
+          generate_zip: true
       - name: Upload release asset
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -17,9 +17,9 @@ jobs:
           ref: ${{ matrix.build }}
       - name: Build
         id: build
-        uses: woocommerce/action-build@master
+        uses: woocommerce/action-build@v2
         with:
-          generate-zip: true
+          generate_zip: true
       - name: Deploy nightly build
         uses: WebFreak001/deploy-nightly@v1.0.3
         env:


### PR DESCRIPTION
`woocommerce/action-build` uses GitHub default `INPUT_` feature, so updating to v2 where things are a little more optimized, and also uses the new `npm run build:core` command introduced in WooCommerce 4.5.