### PR TITLE
prevent regenerate image filter loop

### DIFF
--- a/includes/class-wc-regenerate-images-request.php
+++ b/includes/class-wc-regenerate-images-request.php
@@ -241,7 +241,16 @@ class WC_Regenerate_Images_Request extends WC_Background_Process {
 	 * @return array
 	 */
 	public function adjust_intermediate_image_sizes( $sizes ) {
-		return apply_filters( 'woocommerce_regenerate_images_intermediate_image_sizes', array( 'woocommerce_thumbnail', 'woocommerce_gallery_thumbnail', 'woocommerce_single' ) );
+		// Prevent a filter loop.
+		$unfiltered_sizes = array( 'woocommerce_thumbnail', 'woocommerce_gallery_thumbnail', 'woocommerce_single' );
+		static $in_filter = false;
+		if ( $in_filter ) {
+			return $unfiltered_sizes;
+		}
+		$in_filter      = true;
+		$filtered_sizes = apply_filters( 'woocommerce_regenerate_images_intermediate_image_sizes', $unfiltered_sizes );
+		$in_filter      = false;
+		return $filtered_sizes;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a check to prevent a loop between the `intermediate_image_sizes` and `woocommerce_regenerate_images_intermediate_image_sizes` filters.

Closes #27475 .

### How to test the changes in this Pull Request:

1. Install the Smart Image Resize and Regenerate Thumbnails plugins
2. Go to Tools -> Regenerate Thumbnails
3. Uncheck Skip regenerating ..
4. Regenerate thumbnails 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Prevent regenerate image filter loop.
