### PR TITLE
Fix paypal unit tests

### DIFF
--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/payment-gateways.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/payment-gateways.php
@@ -5,7 +5,6 @@
  * @package WooCommerce\Tests\API
  * @since 3.0.0
  */
-
 class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 
 	/**
@@ -151,7 +150,7 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 	public function test_update_payment_gateway() {
 		wp_set_current_user( $this->user );
 
-		// Test defaults
+		// Test defaults.
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/payment_gateways/paypal' ) );
 		$paypal   = $response->get_data();
 
@@ -159,7 +158,7 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'admin@example.org', $paypal['settings']['email']['value'] );
 		$this->assertEquals( 'no', $paypal['settings']['testmode']['value'] );
 
-		// test updating single setting
+		// Test updating single setting.
 		$request = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/paypal' );
 		$request->set_body_params(
 			array(
@@ -176,7 +175,7 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'woo@woo.local', $paypal['settings']['email']['value'] );
 		$this->assertEquals( 'no', $paypal['settings']['testmode']['value'] );
 
-		// test updating multiple settings
+		// Test updating multiple settings.
 		$request = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/paypal' );
 		$request->set_body_params(
 			array(
@@ -194,7 +193,7 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'woo@woo.local', $paypal['settings']['email']['value'] );
 		$this->assertEquals( 'yes', $paypal['settings']['testmode']['value'] );
 
-		// Test other parameters, and recheck settings
+		// Test other parameters, and recheck settings.
 		$request = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/paypal' );
 		$request->set_body_params(
 			array(
@@ -211,7 +210,7 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'woo@woo.local', $paypal['settings']['email']['value'] );
 		$this->assertEquals( 'yes', $paypal['settings']['testmode']['value'] );
 
-		// test bogus
+		// Test bogus parameter.
 		$request = new WP_REST_Request( 'POST', '/wc/v2/payment_gateways/paypal' );
 		$request->set_body_params(
 			array(
@@ -308,11 +307,11 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 		$settings = array();
 		$gateway->init_form_fields();
 		foreach ( $gateway->form_fields as $id => $field ) {
-			// Make sure we at least have a title and type
+			// Make sure we at least have a title and type.
 			if ( empty( $field['title'] ) || empty( $field['type'] ) ) {
 				continue;
 			}
-			// Ignore 'title' settings/fields -- they are UI only
+			// Ignore 'title' settings/fields -- they are UI only.
 			if ( 'title' === $field['type'] ) {
 				continue;
 			}

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/payment-gateways.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/payment-gateways.php
@@ -106,7 +106,7 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 				'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
 				'order'              => '',
 				'enabled'            => false,
-				'method_title'       => 'PayPal',
+				'method_title'       => 'PayPal Standard',
 				'method_description' => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
 				'settings'           => array_diff_key(
 					$this->get_settings( 'WC_Gateway_Paypal' ),

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/payment-gateways.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/payment-gateways.php
@@ -5,6 +5,10 @@
  * @package WooCommerce\Tests\API
  * @since 3.0.0
  */
+
+/**
+ * Payment gateway test class.
+ */
 class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 
 	/**
@@ -102,11 +106,11 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals(
 			array(
 				'id'                 => 'paypal',
-				'title'              => 'PayPal Standard',
+				'title'              => 'PayPal',
 				'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
 				'order'              => '',
 				'enabled'            => false,
-				'method_title'       => 'PayPal',
+				'method_title'       => 'PayPal Standard',
 				'method_description' => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
 				'settings'           => array_diff_key(
 					$this->get_settings( 'WC_Gateway_Paypal' ),

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/payment-gateways.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/payment-gateways.php
@@ -103,7 +103,7 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals(
 			array(
 				'id'                 => 'paypal',
-				'title'              => 'PayPal',
+				'title'              => 'PayPal Standard',
 				'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
 				'order'              => '',
 				'enabled'            => false,

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/payment-gateways.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/payment-gateways.php
@@ -106,7 +106,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$this->assertEquals(
 			array(
 				'id'                 => 'paypal',
-				'title'              => 'PayPal',
+				'title'              => 'PayPal Standard',
 				'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
 				'order'              => '',
 				'enabled'            => false,

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/payment-gateways.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/payment-gateways.php
@@ -5,7 +5,6 @@
  * @package WooCommerce\Tests\API
  * @since 3.5.0
  */
-
 class Payment_Gateways extends WC_REST_Unit_Test_Case {
 
 	/**
@@ -158,7 +157,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 	public function test_update_payment_gateway() {
 		wp_set_current_user( $this->user );
 
-		// Test defaults
+		// Test defaults.
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/payment_gateways/paypal' ) );
 		$paypal   = $response->get_data();
 
@@ -166,7 +165,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'admin@example.org', $paypal['settings']['email']['value'] );
 		$this->assertEquals( 'no', $paypal['settings']['testmode']['value'] );
 
-		// test updating single setting
+		// Test updating single setting.
 		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/paypal' );
 		$request->set_body_params(
 			array(
@@ -183,7 +182,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'woo@woo.local', $paypal['settings']['email']['value'] );
 		$this->assertEquals( 'no', $paypal['settings']['testmode']['value'] );
 
-		// test updating multiple settings
+		// Test updating multiple settings.
 		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/paypal' );
 		$request->set_body_params(
 			array(
@@ -201,7 +200,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'woo@woo.local', $paypal['settings']['email']['value'] );
 		$this->assertEquals( 'yes', $paypal['settings']['testmode']['value'] );
 
-		// Test other parameters, and recheck settings
+		// Test other parameters, and recheck settings.
 		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/paypal' );
 		$request->set_body_params(
 			array(
@@ -218,7 +217,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'woo@woo.local', $paypal['settings']['email']['value'] );
 		$this->assertEquals( 'yes', $paypal['settings']['testmode']['value'] );
 
-		// test bogus
+		// Test bogus paramter.
 		$request = new WP_REST_Request( 'POST', '/wc/v3/payment_gateways/paypal' );
 		$request->set_body_params(
 			array(
@@ -316,7 +315,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$settings = array();
 		$gateway->init_form_fields();
 		foreach ( $gateway->form_fields as $id => $field ) {
-			// Make sure we at least have a title and type
+			// Make sure we at least have a title and type.
 			if ( empty( $field['title'] ) || empty( $field['type'] ) ) {
 				continue;
 			}

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/payment-gateways.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/payment-gateways.php
@@ -109,7 +109,7 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 				'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
 				'order'              => '',
 				'enabled'            => false,
-				'method_title'       => 'PayPal',
+				'method_title'       => 'PayPal Standard',
 				'method_description' => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
 				'method_supports'    => array(
 					'products',

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/payment-gateways.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/payment-gateways.php
@@ -5,6 +5,10 @@
  * @package WooCommerce\Tests\API
  * @since 3.5.0
  */
+
+/**
+ * Payment gateway test class.
+ */
 class Payment_Gateways extends WC_REST_Unit_Test_Case {
 
 	/**
@@ -105,11 +109,11 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$this->assertEquals(
 			array(
 				'id'                 => 'paypal',
-				'title'              => 'PayPal Standard',
+				'title'              => 'PayPal',
 				'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
 				'order'              => '',
 				'enabled'            => false,
-				'method_title'       => 'PayPal',
+				'method_title'       => 'PayPal Standard',
 				'method_description' => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
 				'method_supports'    => array(
 					'products',


### PR DESCRIPTION
This PR fixes the unit tests broken by the Paypal gate name change in #27468.