### PR TITLE
Add User-friendly Attribute Names and Values to Order Line Items Metadata

### DIFF
--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -199,7 +199,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 
 		// Expand meta_data to include user-friendly values.
 		$formatted_meta_data = $item->get_formatted_meta_data( null, true );
-		$data['meta_data'] = array_map(
+		$data['meta_data']   = array_map(
 			array( $this, 'clean_formatted_order_item_meta_data' ),
 			$formatted_meta_data,
 			array_keys( $formatted_meta_data )
@@ -219,10 +219,10 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 */
 	private function clean_formatted_order_item_meta_data( $meta_data, $meta_data_id ) {
 		return array(
-			'id' => $meta_data_id,
-			'key' => $meta_data->key,
-			'value' => $meta_data->value,
-			'display_key' => wc_clean( $meta_data->display_key ),
+			'id'            => $meta_data_id,
+			'key'           => $meta_data->key,
+			'value'         => $meta_data->value,
+			'display_key'   => wc_clean( $meta_data->display_key ),
 			'display_value' => wc_clean( $meta_data->display_value ),
 		);
 	}
@@ -1296,31 +1296,31 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 								'items'       => array(
 									'type'       => 'object',
 									'properties' => array(
-										'id'    => array(
+										'id'            => array(
 											'description' => __( 'Meta ID.', 'woocommerce' ),
 											'type'        => 'integer',
 											'context'     => array( 'view', 'edit' ),
 											'readonly'    => true,
 										),
-										'key'   => array(
+										'key'           => array(
 											'description' => __( 'Meta key.', 'woocommerce' ),
 											'type'        => 'string',
 											'context'     => array( 'view', 'edit' ),
 										),
-										'value' => array(
+										'value'         => array(
 											'description' => __( 'Meta value.', 'woocommerce' ),
 											'type'        => 'mixed',
 											'context'     => array( 'view', 'edit' ),
 										),
-										'display_key' => array(
-											'description' => __( 'Meta key for UI display.', 'woocommerce-rest-api' ),
-											'type' => 'string',
-											'context' => array( 'view', 'edit' ),
+										'display_key'   => array(
+											'description' => __( 'Meta key for UI display.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
 										),
 										'display_value' => array(
-											'description' => __( 'Meta value for UI display.', 'woocommerce-rest-api' ),
-											'type' => 'string',
-											'context' => array( 'view', 'edit' ),
+											'description' => __( 'Meta value for UI display.', 'woocommerce' ),
+											'type'        => 'string',
+											'context'     => array( 'view', 'edit' ),
 										),
 									),
 								),

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1285,6 +1285,16 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 											'type'        => 'mixed',
 											'context'     => array( 'view', 'edit' ),
 										),
+										'display_key' => array(
+											'description' => __( 'Meta key for UI display.', 'woocommerce-rest-api' ),
+											'type' => 'string',
+											'context' => array( 'view', 'edit' ),
+										),
+										'display_value' => array(
+											'description' => __( 'Meta value for UI display.', 'woocommerce-rest-api' ),
+											'type' => 'string',
+											'context' => array( 'view', 'edit' ),
+										),
 									),
 								),
 							),

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -197,7 +197,34 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		unset( $data['order_id'] );
 		unset( $data['type'] );
 
+		// Expand meta_data to include user-friendly values.
+		$formatted_meta_data = $item->get_formatted_meta_data( null, true );
+		$data['meta_data'] = array_map(
+			array( $this, 'clean_formatted_order_item_meta_data' ),
+			$formatted_meta_data,
+			array_keys( $formatted_meta_data )
+		);
+
 		return $data;
+	}
+
+	/**
+	 * Sanitizes an object from the array returned by {@link WC_Order_Item::get_formatted_meta_data} and includes
+	 * the {@link WC_Meta_Data} `id` in the resulting array.
+	 *
+	 * @param Object  $meta_data An object result from {@link WC_Order_Item::get_formatted_meta_data}.
+	 *        This is expected to have the properties `key`, `value`, `display_key`, and `display_value`.
+	 * @param integer $meta_data_id The id of the {@link WC_Meta_Data}.
+	 * @return array
+	 */
+	private function clean_formatted_order_item_meta_data( $meta_data, $meta_data_id ) {
+		return array(
+			'id' => $meta_data_id,
+			'key' => $meta_data->key,
+			'value' => $meta_data->value,
+			'display_key' => wc_clean( $meta_data->display_key ),
+			'display_value' => wc_clean( $meta_data->display_value ),
+		);
 	}
 
 	/**

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -590,8 +590,8 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 * Gets the product ID from the SKU or posted ID.
 	 *
 	 * @throws WC_REST_Exception When SKU or ID is not valid.
-	 * @param array           $posted Request data.
-	 * @param string          $action 'create' to add line item or 'update' to update it.
+	 * @param array  $posted Request data.
+	 * @param string $action 'create' to add line item or 'update' to update it.
 	 * @return int
 	 */
 	protected function get_product_id( $posted, $action = 'create' ) {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -212,19 +212,19 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	 * Merge the `$formatted_meta_data` `display_key` and `display_value` attribute values into the corresponding
 	 * {@link WC_Meta_Data}. Returns the merged array.
 	 *
-	 * @param WC_Meta_Data $meta_item An object from {@link WC_Order_Item::get_meta_data()}.
-	 * @param Object[]     $formatted_meta_data An object result from {@link WC_Order_Item::get_formatted_meta_data}.
+	 * @param WC_Meta_Data $meta_item           An object from {@link WC_Order_Item::get_meta_data()}.
+	 * @param array        $formatted_meta_data An object result from {@link WC_Order_Item::get_formatted_meta_data}.
 	 * The keys are the IDs of {@link WC_Meta_Data}.
 	 *
 	 * @return array
 	 */
 	private function merge_meta_item_with_formatted_meta_display_attributes( $meta_item, $formatted_meta_data ) {
 		$result = array(
-			'id' => $meta_item->id,
-			'key' => $meta_item->key,
-			'value' => $meta_item->value,
-			'display_key' => null,
-			'display_value' => null,
+			'id'            => $meta_item->id,
+			'key'           => $meta_item->key,
+			'value'         => $meta_item->value,
+			'display_key'   => $meta_item->key,   // Default to original key, in case a formatted key is not available.
+			'display_value' => $meta_item->value, // Default to original value, in case a formatted value is not available.
 		);
 
 		if ( array_key_exists( $meta_item->id, $formatted_meta_data ) ) {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1313,12 +1313,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 											'context'     => array( 'view', 'edit' ),
 										),
 										'display_key' => array(
-											'description' => __( 'Meta key for UI display.', 'woocommerce-rest-api' ),
+											'description' => __( 'Meta key for UI display.', 'woocommerce' ),
 											'type' => 'string',
 											'context' => array( 'view', 'edit' ),
 										),
 										'display_value' => array(
-											'description' => __( 'Meta value for UI display.', 'woocommerce-rest-api' ),
+											'description' => __( 'Meta value for UI display.', 'woocommerce' ),
 											'type' => 'string',
 											'context' => array( 'view', 'edit' ),
 										),

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -268,44 +268,4 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 		return $params;
 	}
-
-	/**
-	 * Expands an order item to get its data.
-	 *
-	 * @param WC_Order_item $item Order item data.
-	 * @return array
-	 */
-	protected function get_order_item_data( $item ) {
-		$data = parent::get_order_item_data( $item );
-
-		$product = is_callable( array( $item, 'get_product' ) ) ? $item->get_product() : false;
-
-		$formatted_meta_data = $item->get_formatted_meta_data( null, true );
-		$data['meta_data'] = array_map(
-			array( $this, 'clean_formatted_meta_data' ),
-			$formatted_meta_data,
-			array_keys( $formatted_meta_data )
-		);
-
-		return $data;
-	}
-
-	/**
-	 * Sanitizes an object from the array returned by {@link WC_Order_Item::get_formatted_meta_data} and includes
-	 * the {@link WC_Meta_Data} `id` in the resulting array.
-	 *
-	 * @param Object  $meta_data An object result from {@link WC_Order_Item::get_formatted_meta_data}.
-	 *        This is expected to have the properties `key`, `value`, `display_key`, and `display_value`.
-	 * @param integer $meta_data_id The id of the {@link WC_Meta_Data}.
-	 * @return array
-	 */
-	private function clean_formatted_meta_data( $meta_data, $meta_data_id ) {
-		return array(
-			'id' => $meta_data_id,
-			'key' => $meta_data->key,
-			'value' => $meta_data->value,
-			'display_key' => wc_clean( $meta_data->display_key ),
-			'display_value' => wc_clean( $meta_data->display_value ),
-		);
-	}
 }

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -244,18 +244,6 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 		$schema['properties']['coupon_lines']['items']['properties']['discount']['readonly'] = true;
 
-		$meta_data_item_properties_ref = &$schema['properties']['line_items']['items']['properties']['meta_data']['items']['properties'];
-		$meta_data_item_properties_ref['display_key'] = array(
-			'description' => __( 'Meta key for UI display.', 'woocommerce-rest-api' ),
-			'type' => 'string',
-			'context' => array( 'view', 'edit' ),
-		);
-		$meta_data_item_properties_ref['display_value'] = array(
-			'description' => __( 'Meta value for UI display.', 'woocommerce-rest-api' ),
-			'type' => 'string',
-			'context' => array( 'view', 'edit' ),
-		);
-
 		return $schema;
 	}
 

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -244,6 +244,18 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 		$schema['properties']['coupon_lines']['items']['properties']['discount']['readonly'] = true;
 
+		$meta_data_item_properties_ref = &$schema['properties']['line_items']['items']['properties']['meta_data']['items']['properties'];
+		$meta_data_item_properties_ref['display_key'] = array(
+			'description' => __( 'Meta key for UI display.', 'woocommerce-rest-api' ),
+			'type' => 'string',
+			'context' => array( 'view', 'edit' ),
+		);
+		$meta_data_item_properties_ref['display_value'] = array(
+			'description' => __( 'Meta value for UI display.', 'woocommerce-rest-api' ),
+			'type' => 'string',
+			'context' => array( 'view', 'edit' ),
+		);
+
 		return $schema;
 	}
 

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -718,4 +718,25 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 42, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 	}
+
+	/**
+	 * Test the order line items schema.
+	 */
+	public function test_order_line_items_schema() {
+		wp_set_current_user( $this->user );
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$request = new WP_REST_Request( 'OPTIONS', '/wc/v2/orders/' . $order->get_id() );
+		$response = $this->server->dispatch( $request );
+
+		$data = $response->get_data();
+
+		$line_item_properties = $data['schema']['properties']['line_items']['items']['properties'];
+		$this->assertEquals( 14, count( $line_item_properties ) );
+		$this->assertArrayHasKey( 'id', $line_item_properties );
+		$this->assertArrayHasKey( 'meta_data', $line_item_properties );
+
+		$meta_data_item_properties = $line_item_properties['meta_data']['items']['properties'];
+		$this->assertEquals( 5, count( $meta_data_item_properties ) );
+		$this->assertEquals( [ 'id', 'key', 'value', 'display_key', 'display_value' ], array_keys( $meta_data_item_properties ) );
+	}
 }

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -69,6 +69,57 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Tests line items have the expected meta_data properties when getting a single order.
+	 */
+	public function test_get_item_with_line_items_meta_data() {
+		wp_set_current_user( $this->user );
+
+		$site_level_attribute_id = wc_create_attribute( array( 'name' => 'Site Level Color' ) );
+		$site_level_attribute_slug = wc_attribute_taxonomy_name_by_id( $site_level_attribute_id );
+
+		// Register the attribute so that wp_insert_term will be successful
+		register_taxonomy( $site_level_attribute_slug, array( 'product' ), array() );
+
+		$site_level_term_insertion_result = wp_insert_term( 'Site Level Value - Blue', $site_level_attribute_slug );
+		$site_level_term = get_term( $site_level_term_insertion_result['term_id'] );
+
+		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
+		$variation = wc_get_product( $product->get_children()[0] );
+
+		$line_item = new WC_Order_Item_Product();
+		$line_item->set_product( $variation );
+		$line_item->set_props( array(
+			'variation' => array( "attribute_{$site_level_attribute_slug}" => $site_level_term->slug )
+		) );
+
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order->add_item( $line_item );
+		$order->save();
+
+		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v2/orders/' . $order->get_id() ) );
+		$data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $order->get_id(), $data['id'] );
+
+		$last_line_item = array_slice( $data['line_items'], -1 )[0];
+
+		$size_meta_data = $last_line_item['meta_data'][0];
+		$this->assertEquals( $line_item->get_meta_data()[0]->id, $size_meta_data['id'] );
+		$this->assertEquals( 'pa_size', $size_meta_data['key'] );
+		$this->assertEquals( 'size', $size_meta_data['display_key'] );
+		$this->assertEquals( 'small', $size_meta_data['value'] );
+		$this->assertEquals( 'small', $size_meta_data['display_value'] );
+
+		$color_meta_data = $last_line_item['meta_data'][1];
+		$this->assertEquals( $line_item->get_meta_data()[1]->id, $color_meta_data['id'] );
+		$this->assertEquals( $site_level_attribute_slug, $color_meta_data['key'] );
+		$this->assertEquals( 'Site Level Color', $color_meta_data['display_key'] );
+		$this->assertEquals( $site_level_term->slug, $color_meta_data['value'] );
+		$this->assertEquals( 'Site Level Value - Blue', $color_meta_data['display_value'] );
+	}
+
+	/**
 	 * Tests getting a single order.
 	 * @since 3.0.0
 	 */

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -155,7 +155,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$site_level_attribute_id = wc_create_attribute( array( 'name' => 'Site Level Type' ) );
 		$site_level_attribute_slug = wc_attribute_taxonomy_name_by_id( $site_level_attribute_id );
 
-		// Register the attribute so that wp_insert_term will be successful
+		// Register the attribute so that wp_insert_term will be successful.
 		register_taxonomy( $site_level_attribute_slug, array( 'product' ), array() );
 
 		$site_level_term_insertion_result = wp_insert_term( 'Site Level Value - Wood', $site_level_attribute_slug );
@@ -166,9 +166,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 		$line_item = new WC_Order_Item_Product();
 		$line_item->set_product( $variation );
-		$line_item->set_props( array(
-			'variation' => array( "attribute_{$site_level_attribute_slug}" => $site_level_term->slug )
-		) );
+		$line_item->set_props(
+			array( 'variation' => array( "attribute_{$site_level_attribute_slug}" => $site_level_term->slug ) )
+		);
 
 		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
 		$order->add_item( $line_item );
@@ -870,6 +870,6 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 		$meta_data_item_properties = $line_item_properties['meta_data']['items']['properties'];
 		$this->assertEquals( 5, count( $meta_data_item_properties ) );
-		$this->assertEquals( [ 'id', 'key', 'value', 'display_key', 'display_value' ], array_keys( $meta_data_item_properties ) );
+		$this->assertEquals( array( 'id', 'key', 'value', 'display_key', 'display_value' ), array_keys( $meta_data_item_properties ) );
 	}
 }

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -168,12 +168,13 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $order->get_id(), $data['id'] );
 
 		$last_line_item = array_slice( $data['line_items'], -1 )[0];
-		$first_meta_data = $last_line_item['meta_data'][0];
-		$this->assertEquals( $line_item->get_meta_data()[0]->id, $first_meta_data['id'] );
-		$this->assertEquals( 'pa_size', $first_meta_data['key'] );
-		$this->assertEquals( 'size', $first_meta_data['display_key'] );
-		$this->assertEquals( 'small', $first_meta_data['value'] );
-		$this->assertEquals( 'small', $first_meta_data['display_value'] );
+
+		$size_meta_data = $last_line_item['meta_data'][0];
+		$this->assertEquals( $line_item->get_meta_data()[0]->id, $size_meta_data['id'] );
+		$this->assertEquals( 'pa_size', $size_meta_data['key'] );
+		$this->assertEquals( 'size', $size_meta_data['display_key'] );
+		$this->assertEquals( 'small', $size_meta_data['value'] );
+		$this->assertEquals( 'small', $size_meta_data['display_value'] );
 	}
 
 	/**

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -316,8 +316,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $order->get_shipping_country(), $data['shipping']['country'] );
 		$this->assertEquals( 1, count( $data['line_items'] ) );
 		$this->assertEquals( 1, count( $data['shipping_lines'] ) );
+
 		$shipping = current( $order->get_items( 'shipping' ) );
-		$expected = array(
+		$expected_shipping_line = array(
 			'id'           => $shipping->get_id(),
 			'method_title' => $shipping->get_method_title(),
 			'method_id'    => $shipping->get_method_id(),
@@ -325,9 +326,10 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 			'total'        => wc_format_decimal( $shipping->get_total(), '' ),
 			'total_tax'    => wc_format_decimal( $shipping->get_total_tax(), '' ),
 			'taxes'        => array(),
-			'meta_data'    => $shipping->get_meta_data(),
 		);
-		$this->assertEquals( $expected, $data['shipping_lines'][0] );
+		foreach ( $expected_shipping_line as $key => $value ) {
+			$this->assertEquals( $value, $data['shipping_lines'][0][ $key ] );
+		}
 	}
 
 	/**

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -330,6 +330,14 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		foreach ( $expected_shipping_line as $key => $value ) {
 			$this->assertEquals( $value, $data['shipping_lines'][0][ $key ] );
 		}
+
+		$actual_shipping_line_meta_data = $data['shipping_lines'][0]['meta_data'];
+		$this->assertCount( 3, $actual_shipping_line_meta_data );
+		foreach ( $shipping->get_meta_data() as $index => $expected_meta_item ) {
+			$this->assertEquals( $expected_meta_item->id, $actual_shipping_line_meta_data[ $index ]['id'] );
+			$this->assertEquals( $expected_meta_item->key, $actual_shipping_line_meta_data[ $index ]['key'] );
+			$this->assertEquals( $expected_meta_item->value, $actual_shipping_line_meta_data[ $index ]['value'] );
+		}
 	}
 
 	/**

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -155,9 +155,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
 		$variation = wc_get_product( $product->get_children()[0] );
 
-		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
 		$line_item = new WC_Order_Item_Product();
 		$line_item->set_product( $variation );
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
 		$order->add_item( $line_item );
 		$order->save();
 

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -152,13 +152,13 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_get_item_with_line_items_meta_data() {
 		wp_set_current_user( $this->user );
 
-		$site_level_attribute_id = wc_create_attribute( array( 'name' => 'Site Level Color' ) );
+		$site_level_attribute_id = wc_create_attribute( array( 'name' => 'Site Level Type' ) );
 		$site_level_attribute_slug = wc_attribute_taxonomy_name_by_id( $site_level_attribute_id );
 
 		// Register the attribute so that wp_insert_term will be successful
 		register_taxonomy( $site_level_attribute_slug, array( 'product' ), array() );
 
-		$site_level_term_insertion_result = wp_insert_term( 'Site Level Value - Blue', $site_level_attribute_slug );
+		$site_level_term_insertion_result = wp_insert_term( 'Site Level Value - Wood', $site_level_attribute_slug );
 		$site_level_term = get_term( $site_level_term_insertion_result['term_id'] );
 
 		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
@@ -192,9 +192,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$color_meta_data = $last_line_item['meta_data'][1];
 		$this->assertEquals( $line_item->get_meta_data()[1]->id, $color_meta_data['id'] );
 		$this->assertEquals( $site_level_attribute_slug, $color_meta_data['key'] );
-		$this->assertEquals( 'Site Level Color', $color_meta_data['display_key'] );
+		$this->assertEquals( 'Site Level Type', $color_meta_data['display_key'] );
 		$this->assertEquals( $site_level_term->slug, $color_meta_data['value'] );
-		$this->assertEquals( 'Site Level Value - Blue', $color_meta_data['display_value'] );
+		$this->assertEquals( 'Site Level Value - Wood', $color_meta_data['display_value'] );
 	}
 
 	/**

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -337,6 +337,8 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 			$this->assertEquals( $expected_meta_item->id, $actual_shipping_line_meta_data[ $index ]['id'] );
 			$this->assertEquals( $expected_meta_item->key, $actual_shipping_line_meta_data[ $index ]['key'] );
 			$this->assertEquals( $expected_meta_item->value, $actual_shipping_line_meta_data[ $index ]['value'] );
+			$this->assertEquals( $expected_meta_item->key, $actual_shipping_line_meta_data[ $index ]['display_key'] );
+			$this->assertEquals( $expected_meta_item->value, $actual_shipping_line_meta_data[ $index ]['display_value'] );
 		}
 	}
 

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -152,11 +152,24 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_get_item_with_line_items_meta_data() {
 		wp_set_current_user( $this->user );
 
+		$site_level_attribute_id = wc_create_attribute( array( 'name' => 'Site Level Color' ) );
+		$site_level_attribute_slug = wc_attribute_taxonomy_name_by_id( $site_level_attribute_id );
+
+		// Register the attribute so that wp_insert_term will be successful
+		register_taxonomy( $site_level_attribute_slug, array( 'product' ), array() );
+
+		$site_level_term_insertion_result = wp_insert_term( 'Site Level Value - Blue', $site_level_attribute_slug );
+		$site_level_term = get_term( $site_level_term_insertion_result['term_id'] );
+
 		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
 		$variation = wc_get_product( $product->get_children()[0] );
 
 		$line_item = new WC_Order_Item_Product();
 		$line_item->set_product( $variation );
+		$line_item->set_props( array(
+			'variation' => array( "attribute_{$site_level_attribute_slug}" => $site_level_term->slug )
+		) );
+
 		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
 		$order->add_item( $line_item );
 		$order->save();
@@ -175,6 +188,13 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 'size', $size_meta_data['display_key'] );
 		$this->assertEquals( 'small', $size_meta_data['value'] );
 		$this->assertEquals( 'small', $size_meta_data['display_value'] );
+
+		$color_meta_data = $last_line_item['meta_data'][1];
+		$this->assertEquals( $line_item->get_meta_data()[1]->id, $color_meta_data['id'] );
+		$this->assertEquals( $site_level_attribute_slug, $color_meta_data['key'] );
+		$this->assertEquals( 'Site Level Color', $color_meta_data['display_key'] );
+		$this->assertEquals( $site_level_term->slug, $color_meta_data['value'] );
+		$this->assertEquals( 'Site Level Value - Blue', $color_meta_data['display_value'] );
 	}
 
 	/**

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -851,4 +851,25 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 42, count( $properties ) );
 		$this->assertArrayHasKey( 'id', $properties );
 	}
+
+	/**
+	 * Test the order line items schema.
+	 */
+	public function test_order_line_items_schema() {
+		wp_set_current_user( $this->user );
+		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$request = new WP_REST_Request( 'OPTIONS', '/wc/v3/orders/' . $order->get_id() );
+		$response = $this->server->dispatch( $request );
+
+		$data = $response->get_data();
+
+		$line_item_properties = $data['schema']['properties']['line_items']['items']['properties'];
+		$this->assertEquals( 14, count( $line_item_properties ) );
+		$this->assertArrayHasKey( 'id', $line_item_properties );
+		$this->assertArrayHasKey( 'meta_data', $line_item_properties );
+
+		$meta_data_item_properties = $line_item_properties['meta_data']['items']['properties'];
+		$this->assertEquals( 5, count( $meta_data_item_properties ) );
+		$this->assertEquals( [ 'id', 'key', 'value', 'display_key', 'display_value' ], array_keys( $meta_data_item_properties ) );
+	}
 }

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -152,13 +152,15 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_get_item_with_line_items_meta_data() {
 		wp_set_current_user( $this->user );
 
-		$site_level_attribute_id = wc_create_attribute( array( 'name' => 'Site Level Type' ) );
+		$attribute_name = 'Site Level Type';
+		$site_level_attribute_id = wc_create_attribute( array( 'name' => $attribute_name ) );
 		$site_level_attribute_slug = wc_attribute_taxonomy_name_by_id( $site_level_attribute_id );
 
 		// Register the attribute so that wp_insert_term will be successful.
 		register_taxonomy( $site_level_attribute_slug, array( 'product' ), array() );
 
-		$site_level_term_insertion_result = wp_insert_term( 'Site Level Value - Wood', $site_level_attribute_slug );
+		$term_name = 'Site Level Value - Wood';
+		$site_level_term_insertion_result = wp_insert_term( $term_name, $site_level_attribute_slug );
 		$site_level_term = get_term( $site_level_term_insertion_result['term_id'] );
 
 		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
@@ -192,9 +194,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$color_meta_data = $last_line_item['meta_data'][1];
 		$this->assertEquals( $line_item->get_meta_data()[1]->id, $color_meta_data['id'] );
 		$this->assertEquals( $site_level_attribute_slug, $color_meta_data['key'] );
-		$this->assertEquals( 'Site Level Type', $color_meta_data['display_key'] );
+		$this->assertEquals( $attribute_name, $color_meta_data['display_key'] );
 		$this->assertEquals( $site_level_term->slug, $color_meta_data['value'] );
-		$this->assertEquals( 'Site Level Value - Wood', $color_meta_data['display_value'] );
+		$this->assertEquals( $term_name, $color_meta_data['display_value'] );
 	}
 
 	/**


### PR DESCRIPTION
From https://github.com/woocommerce/woocommerce-rest-api/pull/229

> 
> Fixes #9.
> 
> Ref: p91TBi-2Lt-p2
> 
> This will also allow us to fix these issues for the WooCommerce iOS and Android apps:
> 
>     woocommerce/woocommerce-android#1286
>     woocommerce/woocommerce-ios#1127
>     woocommerce/woocommerce-ios#2280
> 
> Background
> 
> For both the iOS and Android apps, we regularly receive feedback from users that they could not view the details of the variable products in the orders. Example: C013AAPA4G0-p1596070344020400-slack. To find a solution, @AmandaRiu investigated what the iOS and Android apps can do using the REST API and posted her findings at p91TBi-2Lt-p2.
> 
> The apps use the line_items name in the GET /v3/orders response. However, the name does not include all the selected variations. Consider an order for a variable product with color "Blue" and size "Medium". The API endpoint would return something like this (simplified result):
> 
>     "line_items": [
>         {
>             "id": 5,
>             "name": "Variable Hoodie - Blue",
> 
>             "meta_data": [
>                 {
>                     "id": 51,
>                     "key": "pa_store-level-size",
>                     "value": "medium",
>                 },
>                 {
>                     "id": 52,
>                     "key": "product-level-color",
>                     "value": "Blue",
>                 },
>             ],
>     
>         }
> 
> As shown above, the size was not included in the name. This is how it would look like in the iOS app:
> 
> WCAdmin shows the attribute that was omitted:
> 
> Why Not Use Metadata?
> 
> We could use the meta_data array to find the missing attributes. However, this may be unreliable because:
> 
>     We have to analyze name to figure out which attribute is already filled in. This can include finding the dash separator, which I think can be customized too.
>     The value in meta_data is the sanitized value. In the example above, "medium" should be "Medium" (capital M).
> 
> Solution
> 
> The name not showing all the attributes is probably attributed to the generate_product_title function in WooCommerce. It's probably possible to solve the issue by making sure that all attributes are included. However, this won't solve one of our other design requirements (woocommerce/woocommerce-ios#2280) which is to present the attributes separately:
> 
> We would still have to do a string operation to split out the attribute values.
> 
> In this PR, I'm proposing adding the displayable attribute name and values in the meta_data instead:
> 
>     "line_items": [
>         {
>             "id": 5,
>             "name": "Variable Hoodie - Blue",
> 
>             "meta_data": [
>                 {
>                     "id": 51,
>                     "key": "pa_store-level-size",
>                     "value": "medium",
>                     "display_key": "Store Level Size",
>                     "display_value": "Medium"
>                 },
>                 {
>                     "id": 52,
>                     "key": "product-level-color",
>                     "value": "Blue",
>                     "display_key": "Product Level Color",
>                     "display_value": "Blue"
>                 },
>             ],
>     
>         }
> 
> With these available properties, the API clients (e.g. iOS and Android apps) would be able to easily decide how to present the attributes.
> 
> There is still the problem with the name possibly showing one of the attributes. I'm planning to submit another PR to fix that after this one.
> Schema
> 
> I added the new properties above in the schema.
> 
>                             "meta_data": {
>                                 "description": "Meta data.",
>                                 "type": "array",
>                                 "context": [
>                                     "view",
>                                     "edit"
>                                 ],
>                                 "items": {
>                                     "type": "object",
>                                     "properties": {
>                                         "id": {
>                                             "description": "Meta ID.",
>                                             "type": "integer",
>                                             "context": [
>                                                 "view",
>                                                 "edit"
>                                             ],
>                                             "readonly": true
>                                         },
>                                         "key": {
>                                             "description": "Meta key.",
>                                             "type": "string",
>                                             "context": [
>                                                 "view",
>                                                 "edit"
>                                             ]
>                                         },
>                                         "value": {
>                                             "description": "Meta value.",
>                                             "type": "mixed",
>                                             "context": [
>                                                 "view",
>                                                 "edit"
>                                             ]
>                                         },
>                                         "display_key": {
>                                             "description": "Meta key for UI display.",
>                                             "type": "string",
>                                             "context": [
>                                                 "view",
>                                                 "edit"
>                                             ]
>                                         },
>                                         "display_value": {
>                                             "description": "Meta value for UI display.",
>                                             "type": "string",
>                                             "context": [
>                                                 "view",
>                                                 "edit"
>                                             ]
>                                         }
>                                     }
>                                 }
>                             },
> 
> Changes
> 
> These new properties are only applied to Orders API V3 since we are hoping to get fixed in the mobile apps soon. I did this by overriding the get_order_item_data in Controllers\Version3\ WC_REST_Orders_Controller.
> 
> Please let me know if I should include this in V4 as well.
> Testing
> 
> This is just a suggestion but please feel free to test other scenarios. 🙂
> 
>     In wp-admin → Products → Attributes, add a new attribute and add terms to that attribute.
>     Add a new Variable product in wp-admin → Products → Add New.
>     Set this product as Variable.
>     In the product's Attributes section, add the attribute created in Step 1. Set this as "Used for variations". Add values.
>     Add a Custom product attribute. Set this as "Used for variations". Add values.
>     Save the attributes.
>     In the product's Variations section, create variations for all the options. Or create a few variations only.
>     Set prices for all the variations.
>     Publish the product.
>     As a customer, place an order of the created Variable product. Make note of the Order ID.
>     In the API, run GET /wp-json/wc/v3/orders/{OrderID}.
>     Confirm that the line_items meta_data has the display_key and display_value properties and they are correct.
> 
> Unit Test
> 
> I have also added a unit test that I think covers the manual testing scenario above.
> 