### PR TITLE
Fix "Create variations from all attributes" for numeric attribute values

### DIFF
--- a/includes/data-stores/class-wc-product-variation-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-variation-data-store-cpt.php
@@ -499,6 +499,7 @@ class WC_Product_Variation_Data_Store_CPT extends WC_Product_Data_Store_CPT impl
 			// Set the attributes as regular taxonomy terms too...
 			$variation_attributes = array_keys( $product->get_variation_attributes( false ) );
 			foreach ( $attributes as $name => $value ) {
+				$value = strval( $value );
 				if ( '' !== $value && in_array( $name, $variation_attributes, true ) && term_exists( $value, $name ) ) {
 					wp_set_post_terms( $product_id, array( $value ), $name );
 				} elseif ( taxonomy_exists( $name ) ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When "Create variations from all attributes" is used to create variations it generates term relationship entries for all the generated variations, however that doesn't happen when the term can be interpreted as a numeric value. This is because in that case `product->get_attributes` returns the attribute values as numbers, but the code that generates the term relationships expect those to always be strings. When manually adding a given variation this doesn't happen.

The fix is to simply `strval`-ize the value before using it, but it might be worth investigating why this is happening.

### How to test the changes in this Pull Request:

1. Create a taxonomy whose terms are all numeric, e.g. "size" with "100", "200", "300"
2. Add a widget to filter by that attribute
3. Create a variable product that uses this taxonomy for variations **but** only with the "100" and "200" values
4. Generate variations from all the attribute values
5. Now add "300" as an additional value for variations, and create a new variation using it
6. Load the shop and verify that the widget displays all possible values (if you repeat all the steps without the fix it will display only "300").

**Note:** I haven't added unit tests because the change is small, it's a case that's difficult to reproduce (when creating products programmatically the bug doesn't appear) and the existing tests already cover the generic case of creating variations. If we decide to investigate and fix the root bug, that's when we'll add tests.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix: term relationship entries not created for variations when using the "Create variations from all attributes" wizard and the attributes can be parsed as numbers.
