### PR TITLE
Add woocommerce_product_has_options filter to has_options() method

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1738,7 +1738,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	 * @return boolean
 	 */
 	public function has_options() {
-		return false;
+		return apply_filters( 'woocommerce_product_has_options', false, $this );
 	}
 
 	/*

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -590,7 +590,7 @@ class WC_Product_Variable extends WC_Product {
 	 * @return boolean
 	 */
 	public function has_options() {
-		return true;
+		return apply_filters( 'woocommerce_product_has_options', true, $this );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:
Add woocommerce_product_has_options filter to has_options() method in both product abstract class and variable product class. The value of `has_options()` is used by the product blocks to tell if the product can be added to the cart via ajax or needs to be linked to the single product page.

Without this filter there is no way for Name Your Price (or Product Add-ons with a required addon) to prevent their products from firing the ajax add to cart script when the add to cart button is clicked. both plugins have validation that prevents the product from actually being added, but you get an error notice that doesn't really make sense since there's no place to make the customization (enter a price, or fill in required addon) in the All Products block itself.

Closes #27555

Closes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3070

### How to test the changes in this Pull Request:

1. Create Name Your Price product
2. Add All Products block to a page
3. Add the following snippet:

```
/**
 * Tell Woo product has options when NYP is enabled.
 * 
 * @param bool $is_nyp
 * @param  WC_Product $product
 *
 * @return bool
 */
function kia_nyp_modify_has_options( $has_options, $product ) {
    if ( class_exists( 'WC_Name_Your_Price_Helpers' ) && WC_Name_Your_Price_Helpers::is_nyp( $product ) ) {
    	$has_options = true;
    }

    return $has_options;
}
add_filter( 'woocommerce_product_has_options', 'kia_nyp_modify_has_options', 10, 2 );
```

What should happen now is that a Name Your Price product cannot be added to the cart and will instead be redirected to the single product page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add woocommerce_product_has_options filter for compatibility for custom products in the All Products block
