### PR TITLE
Renamed Postcode / ZIP to Pin code & renamed State / County to State for India

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1052,6 +1052,14 @@ class WC_Countries {
 							'required' => false,
 						),
 					),
+					'IN' => array(
+						'postcode' => array(
+							'label' => __( 'Pin code', 'woocommerce' ),
+						),
+						'state'    => array(
+							'label' => __( 'State', 'woocommerce' ),
+						),
+					),
 					'IT' => array(
 						'postcode' => array(
 							'priority' => 65,


### PR DESCRIPTION
Renamed Postcode / ZIP to Pin code & renamed State / County to State for India

Reference: https://en.m.wikipedia.org/wiki/Address#India

P.S. Please review as I am not very clear about PR process. 
Thanks

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Renamed "Postcode / ZIP" to "Pin code", and renamed "State / County" to "State" for India.
