### PR TITLE
Fixing force jQuery code wrap in wc_print_js() and adding defer to inline script tag

### DIFF
--- a/includes/tracks/events/class-wc-coupons-tracking.php
+++ b/includes/tracks/events/class-wc-coupons-tracking.php
@@ -26,7 +26,7 @@ class WC_Coupons_Tracking {
 			"
 			function onApplyBulkActions( event ) {
 				var id = event.data.id;
-				var action = $( '#' + id ).val();
+				var action = jQuery( '#' + id ).val();
 				
 				if ( action && '-1' !== action ) {
 					window.wcTracks.recordEvent( 'coupons_view_bulk_action', {
@@ -34,8 +34,8 @@ class WC_Coupons_Tracking {
 					} );
 				}
 			}
-			$( '#doaction' ).on( 'click', { id: 'bulk-action-selector-top' }, onApplyBulkActions );
-			$( '#doaction2' ).on( 'click', { id: 'bulk-action-selector-bottom' }, onApplyBulkActions );
+			jQuery( '#doaction' ).on( 'click', { id: 'bulk-action-selector-top' }, onApplyBulkActions );
+			jQuery( '#doaction2' ).on( 'click', { id: 'bulk-action-selector-bottom' }, onApplyBulkActions );
 		"
 		);
 	}

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -127,21 +127,21 @@ class WC_Products_Tracking {
 	public function track_product_updated_client_side( $post ) {
 		wc_enqueue_js(
 			"
-			if ( $( 'h1.wp-heading-inline' ).text().trim() === '" . __( 'Edit product', 'woocommerce' ) . "') {
-				var initialStockValue = $( '#_stock' ).val();
+			if ( jQuery( 'h1.wp-heading-inline' ).text().trim() === '" . __( 'Edit product', 'woocommerce' ) . "') {
+				var initialStockValue = jQuery( '#_stock' ).val();
 				var hasRecordedEvent = false;
 
-				$( '#publish' ).click( function() {
+				jQuery( '#publish' ).click( function() {
 					if ( hasRecordedEvent ) {
 						return;
 					}
 
-					var currentStockValue = $( '#_stock' ).val();
+					var currentStockValue = jQuery( '#_stock' ).val();
 					var properties = {
-						product_type:			$( '#product-type' ).val(),
-						is_virtual:				$( '#_virtual' ).is( ':checked' ) ? 'Y' : 'N',
-						is_downloadable:		$( '#_downloadable' ).is( ':checked' ) ? 'Y' : 'N',
-						manage_stock:			$( '#_manage_stock' ).is( ':checked' ) ? 'Y' : 'N',
+						product_type:			jQuery( '#product-type' ).val(),
+						is_virtual:				jQuery( '#_virtual' ).is( ':checked' ) ? 'Y' : 'N',
+						is_downloadable:		jQuery( '#_downloadable' ).is( ':checked' ) ? 'Y' : 'N',
+						manage_stock:			jQuery( '#_manage_stock' ).is( ':checked' ) ? 'Y' : 'N',
 						stock_quantity_update:	( initialStockValue != currentStockValue ) ? 'Y' : 'N',
 					};
 

--- a/includes/tracks/events/class-wc-status-tracking.php
+++ b/includes/tracks/events/class-wc-status-tracking.php
@@ -37,7 +37,7 @@ class WC_Status_Tracking {
 			if ( 'status' === $tab ) {
 				wc_enqueue_js(
 					"
-					$( 'a.debug-report' ).click( function() {
+					jQuery( 'a.debug-report' ).click( function() {
 						window.wcTracks.recordEvent( 'status_view_reports' );
 					} );
 				"

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1007,7 +1007,7 @@ function wc_print_js() {
 		$wc_queued_js = preg_replace( '/&#(x)?0*(?(1)27|39);?/i', "'", $wc_queued_js );
 		$wc_queued_js = str_replace( "\r", '', $wc_queued_js );
 
-		$js = "<!-- WooCommerce JavaScript -->\n<script type=\"text/javascript\">\njQuery(function($) { $wc_queued_js });\n</script>\n";
+		$js = "<!-- WooCommerce JavaScript -->\n<script type=\"text/javascript\">\n$wc_queued_js\n</script>\n";
 
 		/**
 		 * Queued jsfilter.

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1007,7 +1007,7 @@ function wc_print_js() {
 		$wc_queued_js = preg_replace( '/&#(x)?0*(?(1)27|39);?/i', "'", $wc_queued_js );
 		$wc_queued_js = str_replace( "\r", '', $wc_queued_js );
 
-		$js = "<!-- WooCommerce JavaScript -->\n<script type=\"text/javascript\">\n$wc_queued_js\n</script>\n";
+		$js = "<!-- WooCommerce JavaScript -->\n<script type=\"text/javascript\" defer>\n$wc_queued_js\n</script>\n";
 
 		/**
 		 * Queued jsfilter.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

A lot of themes and WooCommerce Plugins/Extensions uses `wc_enqueue_js()` to add their scripts that they would like to be added as inline scripts. Then `wc_print_js()` sanitize the scripts inside the queue and then add then as inline JS.

Currently, the problem is `wc_print_js()` forcefully wraps the `$wc_queued_js` queue variable inside `jQuery(function($) { ... });` unnecessarily. Also, the inline script tag doesn't have `defer` attribute in it. This leads to two problems:

1. Many extensions or themes that are trying to make the web `jQuery` free and write their code in pure vanilla JS, even their code gets wrapped with that `jQuery` call. So, if a site developer/owner things to get rid of `jQuery` on his/her website as none of the themes or plugins they use need `jQuery`, they still have to load `jQuery` as their vanilla JS codes are wrapped within a `jQuery` function for no reason. Removing this unnecessary jQuery wrap solves that major issue. So, if anyone wants to use jQuery they still can write their jQuery code however they line, but if someone chooses to go with vanilla JS, they are not forced to load jQuery.
2. Ad there is no `defer` tag in the inline script tag if any site owner loads their JS codes with `defer` to ensure they are not render-blocking, the script inside the inline script tag will simply fail. I really see no harm in adding the `defer` tag in the inline script. As unlike `async`, `defer` maintain the same order that they are called, it will not lead to major issues like `async` which doesn't follow the order of the scripts.
3. Due to the above two mentioned changes, I saw inside the WooCommerce core in some places `$` has been used to refer to `jQuery`, so instead of wrapping those scripts to `jQuery(function($) { ... });` so that they can use `$` to refer to `jQuery`, I've replaced the `$()` with `jQuery()` so that they don't need that extra two lines of code.

Closes: #27512

### How to test the changes in this Pull Request:

1. Install the plugin
2. Use it normally as this pull request doesn't add any major breaking changes. It is just improvements in terms of web performance.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

- Fixed forcefully wrapping codes added via `wc_enqueue_js()` with a jQuery function wrapper. Now inline scripts that are added via `wc_enqueue_js()` will no longer have a jQuery wrapper function around it. So, if anyone writes vanilla JS code, it will truly be jQuery dependency-free.
- Added `defer` attribute to the inline script tag added by `wc_print_js()` to ensure if anyone is loading the `jQuery` scripts in defer mode to better web performance, these inline scripts will no longer throw any errors. Also due to using defer the scripts will follow the proper script order whether you load your jQuery in defer mode or not.
- Some WooCommerce core inline JS file used `$()` to call `jQuery()` , now they have been changed to `jQuery()` so that it works perfectly with the new `wc_print_js()`.