### PR TITLE
Fixes spelling country's region Biscay #27538

### DIFF
--- a/i18n/states.php
+++ b/i18n/states.php
@@ -393,7 +393,7 @@ return array(
 		'TO' => __( 'Toledo', 'woocommerce' ),
 		'V'  => __( 'Valencia', 'woocommerce' ),
 		'VA' => __( 'Valladolid', 'woocommerce' ),
-		'BI' => __( 'Bizkaia', 'woocommerce' ),
+		'BI' => __( 'Biscay', 'woocommerce' ),
 		'ZA' => __( 'Zamora', 'woocommerce' ),
 		'Z'  => __( 'Zaragoza', 'woocommerce' ),
 	),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #27538.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Fixed Spain state of `Biscay` name.