### PR TITLE
Bump woocommerce admin version to 1.5.0-rc.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "^1.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.5.0-rc.4",
+    "woocommerce/woocommerce-admin": "1.5.0-rc.5",
     "woocommerce/woocommerce-blocks": "3.1.0"
   },
   "require-dev": {


### PR DESCRIPTION
This just bumps the included version of woocommerce admin to the latest - 1.5.0-rc.5