### PR TITLE
Fix OBW e2e test to reflect changes in WooCommerce 4.5 release

### DIFF
--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -149,9 +149,14 @@ const completeOnboardingWizard = async () => {
 	await page.waitForSelector( '.woocommerce-select-control__control' );
 	await expect( page ).toClick( '.woocommerce-select-control__option', { text: config.get( 'onboardingwizard.sellingelsewhere' ) } );
 
-	// Disable business extension downloads
-	const pluginToggle = await page.$( '#woocommerce-business-extensions__checkbox' );
-	pluginToggle.click();
+	// Query for the extensions toggles
+	const extensionsToggles = await page.$$( '.components-form-toggle__input' );
+	expect( extensionsToggles ).toHaveLength( 3 );
+
+	// Disable download of the 3 extensions
+	for ( let i = 0; i < 3; i++ ) {
+		await extensionsToggles[i].click();
+	}
 
 	// Wait for "Continue" button to become active
 	await page.waitForSelector( 'button.is-primary:not(:disabled)' );

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -93,7 +93,7 @@ const completeOnboardingWizard = async () => {
 	expect( industryCheckboxes ).toHaveLength( 9 );
 
 	// Select all industries including "Other"
-	for ( let i = 0; i < 10; i++ ) {
+	for ( let i = 0; i < 9; i++ ) {
 		await industryCheckboxes[i].click();
 	}
 

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -150,7 +150,7 @@ const completeOnboardingWizard = async () => {
 	await expect( page ).toClick( '.woocommerce-select-control__option', { text: config.get( 'onboardingwizard.sellingelsewhere' ) } );
 
 	// Disable business extension downloads
-	const pluginToggle = await page.$( '.woocommerce-business-extensions .components-checkbox-control__input-container' );
+	const pluginToggle = await page.$( '#woocommerce-business-extensions__checkbox' );
 	pluginToggle.click();
 
 	// Wait for "Continue" button to become active


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes the OBW e2e test to reflect changes introduced in WooCommerce Admin in WooCommere 4.5 release:

- The number of industries changed from 10 to 9 in the Industries onboarding section. `Travel and Tourism` industry was removed: https://github.com/woocommerce/woocommerce-admin/pull/5065

### How to test the changes in this Pull Request:

1. Make sure tests are passing on Travis. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A
