### PR TITLE
Fix variations and attributes layout when running WP >= 5.5

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -5067,6 +5067,7 @@ img.help_tip {
 
 		.handlediv {
 			width: 27px;
+			float: right;
 
 			&::before {
 				content: "\f142" !important;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes the layout of the sections of the product page in the admin that display variations and attributes. It was broken since WP 5.5 was releases. This version of WP removed a CSS rule that WooCommerce uses (see https://github.com/WordPress/WordPress/commit/22d0cd6c963d4ac0e203f7423294c15fb2e5d45a#diff-fc8970b78a0739bd367f17c3a8e552e6L1993). So this commit simply adds this rule back.

Fixes #27326

### How to test the changes in this Pull Request:

1. Check #27326 for testing instructions.
2. Make sure that the layout is fixed when running both WP 5.5 and WP 5.4

### Changelog entry

> Fix - Fixed the layout of the variations and attributes sections in the product page in the admin when running WP >= 5.5
