### PR TITLE
Fixed negative rate cost

### DIFF
--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -266,7 +266,7 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 		$args = apply_filters(
 			'woocommerce_shipping_method_add_rate_args',
 			wp_parse_args(
-				$args,
+				$this->set_zero_cost_if_negative( $args ),
 				array(
 					'id'             => $this->get_rate_id(), // ID for the rate. If not passed, this id:instance default will be used.
 					'label'          => '', // Label for the rate.
@@ -324,6 +324,22 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 		}
 
 		$this->rates[ $args['id'] ] = apply_filters( 'woocommerce_shipping_method_add_rate', $rate, $args, $this );
+	}
+
+	/**
+	 * Set zero cost if negative.
+	 *
+	 * @param array $args Arguments (default: array()).
+	 *
+	 * @return array
+	 */
+	private function set_zero_cost_if_negative( $args = array() ) {
+		if ( isset( $args['cost'] ) && 0.0 > (float) $args['cost'] ) {
+			$args['cost'] = 0.0;
+			$args['taxes'] = '';
+		}
+
+		return $args;
 	}
 
 	/**

--- a/includes/abstracts/abstract-wc-shipping-method.php
+++ b/includes/abstracts/abstract-wc-shipping-method.php
@@ -281,6 +281,8 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 			$this
 		);
 
+		$args = $this->set_zero_cost_if_negative( $args );
+
 		// ID and label are required.
 		if ( ! $args['id'] || ! $args['label'] ) {
 			return;
@@ -325,6 +327,23 @@ abstract class WC_Shipping_Method extends WC_Settings_API {
 
 		$this->rates[ $args['id'] ] = apply_filters( 'woocommerce_shipping_method_add_rate', $rate, $args, $this );
 	}
+
+	/**
+	 * Set zero cost if negative.
+	 *
+	 * @param array $args Arguments (default: array()).
+	 *
+	 * @return array
+	 */
+	private function set_zero_cost_if_negative( $args = array() ) {
+		if ( isset( $args['cost'] ) && 0.0 > (float) $args['cost'] ) {
+			$args['cost'] = 0.0;
+			$args['taxes'] = '';
+		}
+
+		return $args;
+	}
+
 
 	/**
 	 * Calc taxes per item being shipping in costs array.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When there is nagative cost for rate, cart and checkout shows free shipping but order contains negative values.

Flat rate used as an example.

Shipping method settings:
![image](https://user-images.githubusercontent.com/8124521/92243862-6c85de00-eec2-11ea-83c3-b0585d18c775.png)

Checkout:
![image](https://user-images.githubusercontent.com/8124521/92246931-bb357700-eec6-11ea-9f4d-a84b19e0af69.png)

Order:
![image](https://user-images.githubusercontent.com/8124521/92244369-15ccd400-eec3-11ea-813f-765ce8802d10.png)

After fix:
----------
Checkout:
![image](https://user-images.githubusercontent.com/8124521/92246858-a5c04d00-eec6-11ea-956e-171c04d742f4.png)

Order:
![image](https://user-images.githubusercontent.com/8124521/92244751-9a1f5700-eec3-11ea-95a8-53f1c030821e.png)


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
