### PR TITLE
Update minimum WordPress version for WooCommerce 4.5

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, kloon, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski
 Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, downloads, payments, paypal, storefront, stripe, woo commerce
-Requires at least: 5.2
+Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 7.0
 Stable tag: 4.4.1


### PR DESCRIPTION
This PR updates the minimum WordPress version in `readme.txt` to follow the [`L-2`](https://developer.woocommerce.com/2020/05/08/wordpress-core-support-policy/) policy ahead of the release of WooCommerce 4.5.