### PR TITLE
Encapsulate scope of `c` variable

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -348,9 +348,11 @@ function wc_body_class( $classes ) {
 function wc_no_js() {
 	?>
 	<script type="text/javascript">
-		var c = document.body.className;
-		c = c.replace(/woocommerce-no-js/, 'woocommerce-js');
-		document.body.className = c;
+		(function () {
+			var c = document.body.className;
+			c = c.replace(/woocommerce-no-js/, 'woocommerce-js');
+			document.body.className = c;
+		})()
 	</script>
 	<?php
 }


### PR DESCRIPTION
By changing to auto invoking call the `c` variable will be encapsulated in its scope therefore not polluting the global scope and will continue to function as previously.

Fixes conflict and reassigning of already used variables when using other minified scripts. In my case the problem occurred with the Speed Booster Pack plugin.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. `<body>` tag should have `woocommerce-js` class present if javascript is active.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [-] Have you written new tests for your changes, as applicable?
New test were not necessary since changes do not change current behaviour.
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Encapsulate scope of `c` variable to avoid polluting the global scope and potentially causing problems if other plugins use the same variable name.
