### PR TITLE
Fix composer install errors

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,6 +24,9 @@
     "wp-cli/i18n-command": "2.2.5"
   },
   "config": {
+    "platform": {
+      "php": "7.1"
+    },
     "preferred-install": {
         "woocommerce/action-scheduler": "dist",
         "woocommerce/woocommerce-rest-api": "dist",

--- a/composer.json
+++ b/composer.json
@@ -24,9 +24,6 @@
     "wp-cli/i18n-command": "2.2.5"
   },
   "config": {
-    "platform": {
-      "php": "7.1"
-    },
     "preferred-install": {
         "woocommerce/action-scheduler": "dist",
         "woocommerce/woocommerce-rest-api": "dist",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e69d0979fe4d3a65a022a8ad90dfafa3",
+    "content-hash": "96f2da050b30dcd3e6dfee4df6ec2849",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -482,16 +482,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "1.5.0-rc.4",
+            "version": "1.5.0-rc.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "386ccd8c3fbe99fc0d6c8ae5016eefbf98e63fd4"
+                "reference": "baef859e2c4fc7e06bd7880b157348e422b97655"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/386ccd8c3fbe99fc0d6c8ae5016eefbf98e63fd4",
-                "reference": "386ccd8c3fbe99fc0d6c8ae5016eefbf98e63fd4",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/baef859e2c4fc7e06bd7880b157348e422b97655",
+                "reference": "baef859e2c4fc7e06bd7880b157348e422b97655",
                 "shasum": ""
             },
             "require": {
@@ -525,7 +525,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-09-02T04:26:29+00:00"
+            "time": "2020-09-03T03:28:02+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2458,25 +2458,25 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v5.1.5",
+            "version": "v3.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "2b765f0cf6612b3636e738c0689b29aa63088d5d"
+                "reference": "5ec813ccafa8164ef21757e8c725d3a57da59200"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/2b765f0cf6612b3636e738c0689b29aa63088d5d",
-                "reference": "2b765f0cf6612b3636e738c0689b29aa63088d5d",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/5ec813ccafa8164ef21757e8c725d3a57da59200",
+                "reference": "5ec813ccafa8164ef21757e8c725d3a57da59200",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.2.5"
+                "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "5.1-dev"
+                    "dev-master": "3.4-dev"
                 }
             },
             "autoload": {
@@ -2517,7 +2517,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2020-08-17T10:01:29+00:00"
+            "time": "2020-02-14T07:34:21+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",


### PR DESCRIPTION
Currently there's some issues with our `composer-lock.json`, making impossible to install some dependencies:

```
  Problem 1
    - Installation request for symfony/finder v5.1.5 -> satisfiable by symfony/finder[v5.1.5].
    - symfony/finder v5.1.5 requires php >=7.2.5 -> your PHP version (7.4.9) overridden by "config.platform.php" version (7.1) does not satisfy that requirement.
  Problem 2
    - wp-cli/wp-cli v2.4.1 requires symfony/finder >2.7 -> satisfiable by symfony/finder[v5.1.5].
    - wp-cli/wp-cli v2.4.1 requires symfony/finder >2.7 -> satisfiable by symfony/finder[v5.1.5].
    - symfony/finder v5.1.5 requires php >=7.2.5 -> your PHP version (7.4.9) overridden by "config.platform.php" version (7.1) does not satisfy that requirement.
    - Installation request for wp-cli/wp-cli v2.4.1 -> satisfiable by wp-cli/wp-cli[v2.4.1].

husky > post-merge hook failed (cannot be bypassed with --no-verify due to Git specs)
```

I managed to fix it by excluding this file and creating it again. It also makes our nightly builds fail.