### PR TITLE
Update the changelog, readme, and woocommerce.php to prepare for 4.5 release

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@
 * Fix - Declare `WC_Post_Types::updated_term_messages` as a static method to remove PHP deprecation warning. #27436
 * Fix - Allow HTML to be entered in product title for formatting purposes. #27465
 * Fix - Filter by attribute widget not working properly for variations having attribute values of "Any...". #27508
+* Fix - Fixed the layout of the variations and attributes sections in the product page in the admin when running WP >= 5.5. #27590
 * Dev - Added additional stock-based cart filters including `woocommerce_cart_product_cannot_add_another_message`, `woocommerce_cart_product_out_of_stock_message`, and `woocommerce_cart_product_not_enough_stock_message`. #26439
 * Dev - Changed text domain to `woocommerce` for REST API files. #27248
 * Dev - Added file path to the `woocommerce_file_download_method` filter. #27152

--- a/readme.txt
+++ b/readme.txt
@@ -160,8 +160,6 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 == Changelog ==
 
-
-
 = 4.5.0 - 2020-09-08 =
 
 **WooCommerce**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 7.0
-Stable tag: 4.4.1
+Stable tag: 4.5.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -185,6 +185,7 @@ WooCommerce comes with some sample data you can use to see how products look; im
 * Fix - Declare `WC_Post_Types::updated_term_messages` as a static method to remove PHP deprecation warning. #27436
 * Fix - Allow HTML to be entered in product title for formatting purposes. #27465
 * Fix - Filter by attribute widget not working properly for variations having attribute values of "Any...". #27508
+* Fix - Fixed the layout of the variations and attributes sections in the product page in the admin when running WP >= 5.5. #27590
 * Dev - Added additional stock-based cart filters including `woocommerce_cart_product_cannot_add_another_message`, `woocommerce_cart_product_out_of_stock_message`, and `woocommerce_cart_product_not_enough_stock_message`. #26439
 * Dev - Changed text domain to `woocommerce` for REST API files. #27248
 * Dev - Added file path to the `woocommerce_file_download_method` filter. #27152

--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -7,7 +7,7 @@ if [[ ${RUN_PHPCS} == 1 ]]; then
 	if [ "$CHANGED_FILES" != "" ]; then
 		if [ ! -f "./vendor/bin/phpcs" ]; then
 			# Install wpcs globally
-			composer require woocommerce/woocommerce-sniffs
+			composer global require woocommerce/woocommerce-sniffs --update-with-all-dependencies
 		fi
 
 		echo "Running Code Sniffer."

--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -11,6 +11,6 @@ if [[ ${RUN_PHPCS} == 1 ]]; then
 		fi
 
 		echo "Running Code Sniffer."
-		./vendor/bin/phpcs --ignore=$IGNORE --encoding=utf-8 -s -n -p $CHANGED_FILES
+		phpcs --ignore=$IGNORE --encoding=utf-8 -s -n -p $CHANGED_FILES
 	fi
 fi

--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -7,7 +7,7 @@ if [[ ${RUN_PHPCS} == 1 ]]; then
 	if [ "$CHANGED_FILES" != "" ]; then
 		if [ ! -f "./vendor/bin/phpcs" ]; then
 			# Install wpcs globally
-			composer require woocommerce/woocommerce-sniffs --update-with-all-dependencies
+			composer require woocommerce/woocommerce-sniffs
 		fi
 
 		echo "Running Code Sniffer."

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -3,12 +3,12 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 4.5.0-rc.3
+ * Version: 4.5.0
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce
  * Domain Path: /i18n/languages/
- * Requires at least: 5.2
+ * Requires at least: 5.3
  * Requires PHP: 7.0
  *
  * @package WooCommerce


### PR DESCRIPTION
This PR updates the `changelog.txt`, `readme.txt`, and `woocommerce.php` for the 4.5 release of WooCommerce.