### PR TITLE
Fix bug when using tax classes with some non-ASCII characters

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -371,7 +371,7 @@ class WC_Meta_Box_Product_Data {
 				'featured'           => isset( $_POST['_featured'] ),
 				'catalog_visibility' => isset( $_POST['_visibility'] ) ? wc_clean( wp_unslash( $_POST['_visibility'] ) ) : null,
 				'tax_status'         => isset( $_POST['_tax_status'] ) ? wc_clean( wp_unslash( $_POST['_tax_status'] ) ) : null,
-				'tax_class'          => isset( $_POST['_tax_class'] ) ? wc_clean( wp_unslash( $_POST['_tax_class'] ) ) : null,
+				'tax_class'          => isset( $_POST['_tax_class'] ) ? sanitize_title( wp_unslash( $_POST['_tax_class'] ) ) : null,
 				'weight'             => isset( $_POST['_weight'] ) ? wc_clean( wp_unslash( $_POST['_weight'] ) ) : null,
 				'length'             => isset( $_POST['_length'] ) ? wc_clean( wp_unslash( $_POST['_length'] ) ) : null,
 				'width'              => isset( $_POST['_width'] ) ? wc_clean( wp_unslash( $_POST['_width'] ) ) : null,


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a bug that made it impossible to assign to a product a tax class that contained non-ASCII characters that are URL encoded by sanitize_title().

WooCommerce uses sanitize_title() to generate a slug when creating a tax class ([/includes/class-wc-tax.php#L808](https://github.com/woocommerce/woocommerce/blob/d48f1d4e2efcfab8206799df2085f021ec273722/includes/class-wc-tax.php#L808)). sanitize_title() converts some non-ASCII to ASCII equivalents (those handled by remove_accents()) and URL encodes others (like some Greek characters, for example).

The code was using wc_clean() to sanitize the tax class when the user edited a product. The problem is that wc_clean() removes URL encoded characters, changing the slug of some tax class, causing WooCommerce to use the standard tax class instead without any errors. To fix this issue, this commit replaces wc_clean() with sanitize_title(). This should be enough for security purposes and should not cause any issues with non-ASCII characters.

I didn't fix the PHPCS violations in the modified file as I'm not sure of the consequences of using gmdate() instead of date() for the sales dates. I suspect this modification might change the behavior of WooCommerce during a sale depending on the server configuration.

Closes #26590.

### How to test the changes in this Pull Request:

1. See #26590 for testing instructions.

### Changelog entry

> Fix bug when using tax classes with some non-ASCII characters
