### PR TITLE
Paypal gateway: protect code against a fatal error if WooCommerce is unable to communicate with PayPal

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-api-handler.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-api-handler.php
@@ -115,10 +115,10 @@ class WC_Gateway_Paypal_API_Handler {
 
 		WC_Gateway_Paypal::log( 'DoCapture Response: ' . wc_print_r( $raw_response, true ) );
 
-		if ( empty( $raw_response['body'] ) ) {
-			return new WP_Error( 'paypal-api', 'Empty Response' );
-		} elseif ( is_wp_error( $raw_response ) ) {
+		if ( is_wp_error( $raw_response ) ) {
 			return $raw_response;
+		} elseif ( empty( $raw_response['body'] ) ) {
+			return new WP_Error( 'paypal-api', 'Empty Response' );
 		}
 
 		parse_str( $raw_response['body'], $response );
@@ -148,10 +148,10 @@ class WC_Gateway_Paypal_API_Handler {
 
 		WC_Gateway_Paypal::log( 'Refund Response: ' . wc_print_r( $raw_response, true ) );
 
-		if ( empty( $raw_response['body'] ) ) {
-			return new WP_Error( 'paypal-api', 'Empty Response' );
-		} elseif ( is_wp_error( $raw_response ) ) {
+		if ( is_wp_error( $raw_response ) ) {
 			return $raw_response;
+		} elseif ( empty( $raw_response['body'] ) ) {
+			return new WP_Error( 'paypal-api', 'Empty Response' );
 		}
 
 		parse_str( $raw_response['body'], $response );

--- a/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-test.php
+++ b/tests/php/includes/gateways/paypal/class-wc-gateway-paypal-test.php
@@ -1,0 +1,98 @@
+<?php
+/**
+ * Unit tests for WC_Gateway_Paypal class.
+ *
+ * @package WooCommerce\Tests\Paypal.
+ */
+
+/**
+ * Class WC_Gateway_Paypal_Test.
+ */
+class WC_Gateway_Paypal_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * @var string Dummy identifiable transaction ID.
+	 */
+	private $transaction_id_26960 = 'dummy_id_26960';
+
+	/**
+	 * @var string Dummy indentifiable error message.
+	 */
+	private $error_message_26960 = 'Paypal error for GH issue 26960';
+
+	/**
+	 * Test do_capture when API returns error.
+	 *
+	 * see @link https://github.com/woocommerce/woocommerce/issues/26960
+	 */
+	public function test_do_capture_when_api_return_error() {
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		update_post_meta( $order->get_id(), '_paypal_status', 'pending' );
+		update_post_meta( $order->get_id(), '_transaction_id', $this->transaction_id_26960 );
+		$order->set_payment_method( 'paypal' );
+		$order->save();
+
+		// Force HTTP error.
+		add_filter( 'pre_http_request', array( $this, '__return_paypal_error' ), 10, 2 );
+
+		( new WC_Gateway_Paypal() )->capture_payment( $order->get_id() );
+
+		// reset error.
+		remove_filter( 'pre_http_request', array( $this, '__return_paypal_error' ) );
+
+		$order_notes = wc_get_order_notes( array( 'order_id' => $order->get_id() ) );
+		$latest_note = current( $order_notes );
+		$this->assertContains( $this->error_message_26960, $latest_note->content );
+	}
+
+	/**
+	 * Test do_capture when API returns error.
+	 *
+	 * see @link https://github.com/woocommerce/woocommerce/issues/26960
+	 */
+	public function test_refund_transaction_when_api_return_error() {
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+
+		update_post_meta( $order->get_id(), '_paypal_status', 'pending' );
+		update_post_meta( $order->get_id(), '_transaction_id', $this->transaction_id_26960 );
+		$order->set_payment_method( 'paypal' );
+		$order->save();
+
+		// Force HTTP error.
+		add_filter( 'pre_http_request', array( $this, '__return_paypal_error' ), 10, 2 );
+
+		// Force refunds check to true.
+		$paypal_gateway = $this->getMockBuilder( WC_Gateway_Paypal::class )->setMethods( array( 'can_refund_order' ) )->getMock();
+		$paypal_gateway->method( 'can_refund_order' )->willReturn( 'true' );
+
+		$response = $paypal_gateway->process_refund( $order );
+
+		// reset error.
+		remove_filter( 'pre_http_request', array( $this, '__return_paypal_error' ) );
+
+		$this->assertWPError( $response );
+		$this->assertContains( $this->error_message_26960, $response->get_error_message() );
+	}
+
+	/**
+	 * Utility function for raising error when this is a PayPal request using transaction_id_26960.
+	 *
+	 * @param bool  $value      Original pre-value, likely to be false.
+	 * @param array $parsed_url Parsed URL object.
+	 *
+	 * @return bool|WP_Error Raise error or return original value.
+	 */
+	public function __return_paypal_error( $value, $parsed_url ) {
+		if ( isset( $parsed_url['body'] ) && isset( $parsed_url['body']['AUTHORIZATIONID'] ) && $this->transaction_id_26960 === $parsed_url['body']['AUTHORIZATIONID'] ) {
+			return new WP_Error( 'error', $this->error_message_26960 );
+		}
+		if ( isset( $parsed_url['body'] ) && isset( $parsed_url['body']['TRANSACTIONID'] ) && $this->transaction_id_26960 === $parsed_url['body']['TRANSACTIONID'] ) {
+			return new WP_Error( 'error', $this->error_message_26960 );
+		}
+		return $value;
+	}
+
+}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the order of the error handling check to protect the code against a possible fatal error if wp_safe_remote_post() returns an instance of WP_Error. This problem only occurs in sites that for some reason are unable to communicate with PayPal. This problem was reported in #26960 for WC_Gateway_Paypal_API_Handler::do_capture(), but I'm also fixing it for WC_Gateway_Paypal_API_Handler::refund_transaction() as the latter could also suffer from the same issue.

Closes #26960.

### How to test the changes in this Pull Request:

1. Check that the code changes make sense.
2. I couldn't find a way to test this, but there is a bit more information about the problem in #26960.

### Changelog entry

> Paypal gateway: protect code against a fatal error if WooCommerce is unable to communicate with PayPal
