### PR TITLE
Check for state and postcode fields only if required

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1528,7 +1528,15 @@ class WC_Cart extends WC_Legacy_Cart {
 		}
 
 		if ( 'yes' === get_option( 'woocommerce_shipping_cost_requires_address' ) ) {
-			if ( ! $this->get_customer()->get_shipping_country() || ! $this->get_customer()->get_shipping_state() || ! $this->get_customer()->get_shipping_postcode() ) {
+			$country = $this->get_customer()->get_shipping_country();
+			if ( ! $country ) {
+				return false;
+			}
+			$country_fields = WC()->countries->get_address_fields( $country, 'shipping_' );
+			if ( isset( $country_fields['shipping_state'] ) && $country_fields['shipping_state']['required'] && ! $this->get_customer()->get_shipping_state() ) {
+				return false;
+			}
+			if ( isset( $country_fields['shipping_postcode'] ) && $country_fields['shipping_postcode']['required'] && ! $this->get_customer()->get_shipping_postcode() ) {
 				return false;
 			}
 		}

--- a/tests/php/includes/class-wc-cart-test.php
+++ b/tests/php/includes/class-wc-cart-test.php
@@ -99,4 +99,37 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		WC()->cart->get_customer()->set_shipping_state( '' );
 		WC()->cart->get_customer()->set_shipping_postcode( '' );
 	}
+
+	/**
+	 * Test show_shipping for countries with various state/postcode requirement.
+	 */
+	public function test_show_shipping_for_countries_different_shipping_requirements() {
+		$default_shipping_cost_requires_address = get_option( 'woocommerce_shipping_cost_requires_address', 'no' );
+		update_option( 'woocommerce_shipping_cost_requires_address', 'yes' );
+
+		WC()->cart->empty_cart();
+		$this->assertFalse( WC()->cart->show_shipping() );
+
+		$product = WC_Helper_Product::create_simple_product();
+		WC()->cart->add_to_cart( $product->get_id(), 1 );
+
+		// Country that does not require state.
+		WC()->cart->get_customer()->set_shipping_country( 'LB' );
+		WC()->cart->get_customer()->set_shipping_state( '' );
+		WC()->cart->get_customer()->set_shipping_postcode( '12345' );
+		$this->assertTrue( WC()->cart->show_shipping() );
+
+		// Country that does not require postcode.
+		WC()->cart->get_customer()->set_shipping_country( 'NG' );
+		WC()->cart->get_customer()->set_shipping_state( 'AB' );
+		WC()->cart->get_customer()->set_shipping_postcode( '' );
+		$this->assertTrue( WC()->cart->show_shipping() );
+
+		// Reset.
+		update_option( 'woocommerce_shipping_cost_requires_address', $default_shipping_cost_requires_address );
+		$product->delete( true );
+		WC()->cart->get_customer()->set_shipping_country( 'GB' );
+		WC()->cart->get_customer()->set_shipping_state( '' );
+		WC()->cart->get_customer()->set_shipping_postcode( '' );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

We were doing state and postcode even for countries where its not required, but unfortunately as an unintended effect we were ending up deducing that shippping is not required if this check was not met.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27624 .

### How to test the changes in this Pull Request:

1. Check the option `WP Admin > WooCommerce > Settings > Shipping > Shipping Options > Calculations > Check - Hide shipping costs until an address is entered` and save settings
1. Go to the checkout page after adding any physical product in the cart.
2. Set your country to something that does not require state (for example Denmark). Also, make sure you have a shipping set up for this country.
3. Without this PR you would be able to checkout without paying for shipping. With this patch you won;t be able to.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Check for state and postcode fields only if required in show_shipping.
