### PR TITLE
Allow zero as variation attribute option

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1040,7 +1040,6 @@ class WC_Cart extends WC_Legacy_Cart {
 
 				// Gather posted attributes.
 				$posted_attributes = array();
-
 				foreach ( $parent_data->get_attributes() as $attribute ) {
 					if ( ! $attribute['is_variation'] ) {
 						continue;
@@ -1056,7 +1055,7 @@ class WC_Cart extends WC_Legacy_Cart {
 						}
 
 						// Don't include if it's empty.
-						if ( ! empty( $value ) ) {
+						if ( ! empty( $value ) || '0' === $value ) {
 							$posted_attributes[ $attribute_key ] = $value;
 						}
 					}

--- a/tests/legacy/unit-tests/cart/cart.php
+++ b/tests/legacy/unit-tests/cart/cart.php
@@ -2248,7 +2248,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 
 		// Attempt adding variation with add_to_cart_action, without specifying attribute_pa_colour.
 		$_REQUEST['add-to-cart']         = $variation['variation_id'];
-		$_REQUEST['attribute_pa_number'] = '0';
+		$_REQUEST['attribute_pa_number'] = '';
 		WC_Form_Handler::add_to_cart_action( false );
 		$notices = WC()->session->get( 'wc_notices', array() );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When we improved the validation on filtering we made the empty check too aggressive and started filtering out variations with "0" as the attribute value. This PR makes the check a little more permissive so that they are usable again.

Closes #27618.

### How to test the changes in this Pull Request:

1. Create a variable product with an attribute containing options like "0|1|2"
2. Try to add the product to your cart. Without the PR it will tell you that a required attribute is missing. With the PR it will successfully add to the cart.
3. Build a URL to add the product to the cart and make sure it doesn't add those with no value set with the PR. (e.x. http://woocommerce.test/?add-to-cart=34&quantity=1&product_id=34&variation_id=35&attribute_countings= should give an error!)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Adjusted validation to allow for variations with "0" as an attribute value.
