### PR TITLE
Added filter for no stock notification emails

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -637,6 +637,18 @@ class WC_Emails {
 		if ( 'no' === get_option( 'woocommerce_notify_no_stock', 'yes' ) ) {
 			return;
 		}
+		
+		/**
+		 * Determine if the current product should trigger a no stock notification
+		 *
+		 * @param WC_Product $product - The out of stock product object
+		 *
+		 * @since 4.4.0
+		 */
+		$should_notify = apply_filters( 'woocommerce_should_send_no_stock_notification', true, $product );
+		if ( false === $should_notify ) {
+			return;
+		}
 
 		$subject = sprintf( '[%s] %s', $this->get_blogname(), __( 'Product out of stock', 'woocommerce' ) );
 		/* translators: %s: product name */

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -641,12 +641,11 @@ class WC_Emails {
 		/**
 		 * Determine if the current product should trigger a no stock notification
 		 *
-		 * @param WC_Product $product - The out of stock product object
+		 * @param int $product_id - The out of stock product id
 		 *
 		 * @since 4.4.0
 		 */
-		$should_notify = apply_filters( 'woocommerce_should_send_no_stock_notification', true, $product );
-		if ( false === $should_notify ) {
+		if ( false === apply_filters( 'woocommerce_should_send_no_stock_notification', true, $product->get_id() ) ) {
 			return;
 		}
 

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -637,7 +637,7 @@ class WC_Emails {
 		if ( 'no' === get_option( 'woocommerce_notify_no_stock', 'yes' ) ) {
 			return;
 		}
-		
+
 		/**
 		 * Determine if the current product should trigger a no stock notification
 		 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added one new filter so we can do a check before sending the no stock notification. We have some subscription products that are out of stock and we want renewals to work properly but to not have email notifications happening every time the orders go through. This is a kinda related to (and based on): https://github.com/woocommerce/woocommerce/pull/26908


### How to test the changes in this Pull Request:

1. Use the filter to stop the no stock notification emails from happening

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [] Have you successfully run tests with your changes locally?

### Changelog entry
> New - Add `woocommerce_should_send_no_stock_notification` filter 