### PR TITLE
Remove duplicated entry for Cyprus

### DIFF
--- a/i18n/continents.php
+++ b/i18n/continents.php
@@ -154,7 +154,6 @@ return array(
 			'BG',
 			'BY',
 			'CH',
-			'CY',
 			'CZ',
 			'DE',
 			'DK',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Cyprus was listed both in Europe and Asia in the list of continents. This meant that when users search for it, for example when creating a new shipping zone, it would be displayed twice.

This commit fixes this problem by removing Cyprus from Europe and leaving it in Asia. CLDR puts Cyprus in Western Asia (https://github.com/unicode-org/cldr/blob/2dd06669d833823e26872f249aa304bc9d9d2a90/tools/java/org/unicode/cldr/util/data/UnMacroRegions.txt#L229).

I checked and there are no other cases of countries added to more than one continent in i18n/continents.php.

Closes #27220.

### How to test the changes in this Pull Request:

1. Go to `/wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new`
2. Search for `Cyprus` in the `Zone regions` and check the country is displayed only once.

### Changelog entry

> Localization - Remove duplicated entry for Cyprus when listing countries by continent
