### PR TITLE
prep e2e-utils package for publish

### DIFF
--- a/tests/e2e/utils/package.json
+++ b/tests/e2e/utils/package.json
@@ -1,16 +1,26 @@
 {
-    "name": "@woocommerce/e2e-utils",
-    "version": "0.1.0",
-    "description": "End-To-End (E2E) test utils for WooCommerce",
-    "homepage": "https://github.com/woocommerce/woocommerce/tree/master/tests/e2e-utils/README.md",
-    "repository": {
-      "type": "git",
-      "url": "https://github.com/woocommerce/woocommerce.git"
-    },
-    "license": "GPL-3.0+",
-    "main": "build/index.js",
-    "module": "build-module/index.js",
-    "dependencies": {
-      "@wordpress/e2e-test-utils": "4.6.0"
-    }
+  "name": "@woocommerce/e2e-utils",
+  "version": "0.1.0",
+  "description": "End-To-End (E2E) test utils for WooCommerce",
+  "homepage": "https://github.com/woocommerce/woocommerce/tree/master/tests/e2e-utils/README.md",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/woocommerce/woocommerce.git"
+  },
+  "license": "GPL-3.0+",
+  "main": "build/index.js",
+  "module": "build-module/index.js",
+  "dependencies": {
+    "@wordpress/e2e-test-utils": "4.6.0",
+    "@woocommerce/model-factories": "file:../factories"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "clean": "rm -rf ./build ./build-module",
+    "compile": "node ./../bin/build.js",
+    "build": "npm run clean && npm run compile",
+    "prepare": "npm run build"
   }
+}

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -6,7 +6,7 @@
  * Internal dependencies
  */
 import { StoreOwnerFlow } from './flows';
-import modelRegistry from '../../utils/factories';
+import modelRegistry from './factories';
 import { SimpleProduct } from '@woocommerce/model-factories';
 import { clickTab, uiUnblocked, verifyCheckboxIsUnset } from './page-utils';
 

--- a/tests/e2e/utils/src/factories.js
+++ b/tests/e2e/utils/src/factories.js
@@ -2,7 +2,7 @@ import {
 	AdapterTypes,
 	initializeUsingBasicAuth,
 	ModelRegistry,
-	registerSimpleProduct
+	registerSimpleProduct,
 } from '@woocommerce/model-factories';
 
 const config = require( 'config' );

--- a/tests/e2e/utils/src/index.js
+++ b/tests/e2e/utils/src/index.js
@@ -1,4 +1,4 @@
-import { CustomerFlow, StoreOwnerFlow } from './src/flows';
+import { CustomerFlow, StoreOwnerFlow } from './flows';
 
 import {
 	completeOnboardingWizard,
@@ -6,7 +6,7 @@ import {
 	createSimpleProduct,
 	createVariableProduct,
 	verifyAndPublish,
-} from './src/components';
+} from './components';
 
 import {
 	clearAndFillInput,
@@ -20,7 +20,7 @@ import {
 	verifyCheckboxIsSet,
 	verifyCheckboxIsUnset,
 	verifyValueOfInputField,
-} from './src/page-utils';
+} from './page-utils';
 
 module.exports = {
 	CustomerFlow,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates `tests/e2e/utils` to add it to the `npm run build:packages` command.

Closes #26431 .

### How to test the changes in this Pull Request:

1. `npm install`
2. `npm run build:packages`
  - This should build 3 packages: `env`, `factories`, `utils`
3. `npm run docker:up`
4. `npm run test:e2e`
  - E2E tests should run successfully
5. `npm run docker:down`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev: Add `@woocommerce/e2e-utils` to packages build.
