### PR TITLE
#26764 secure cookie filter hook

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1032,7 +1032,15 @@ function wc_print_js() {
  */
 function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = false ) {
 	if ( ! headers_sent() ) {
-		setcookie( $name, $value, $expire, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, $secure, apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) );
+		setcookie(
+			$name,
+			$value,
+			$expire,
+			COOKIEPATH ? COOKIEPATH : '/',
+			COOKIE_DOMAIN,
+			apply_filters( 'woocommerce_cookie_secure', $secure, $name, $value, $expire, $httponly ),
+			apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure )
+		);
 	} elseif ( Constants::is_true( 'WP_DEBUG' ) ) {
 		headers_sent( $file, $line );
 		trigger_error( "{$name} cookie cannot be set - headers already sent by {$file} on line {$line}", E_USER_NOTICE ); // @codingStandardsIgnoreLine


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds the filter `woocommerce_cookie_secure` to set the secure flag for all cookies like `woocommerce_cookie_httponly`. The use case is broader than for `wc_session_use_secure_cookie` because this applies only to the session cookie.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #26764.

### How to test the changes in this Pull Request:

1. Add a hook for `woocommerce_cookie_secure`
2. Inspect the cookies set by woocommerce

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

add a filter hook `woocommerce_cookie_secure` to modify the cookie secure flag
