### PR TITLE
Remove WooCommerce Blocks source files

### DIFF
--- a/bin/package-update.sh
+++ b/bin/package-update.sh
@@ -25,6 +25,13 @@ output 3 "Updating autoloader classmaps..."
 composer dump-autoload
 output 2 "Done"
 
+# Clean extra files
+output 3 "Removing WooCommerce Blocks source files..."
+rm -rf ./packages/woocommerce-blocks/storybook
+rm -rf ./packages/woocommerce-blocks/assets/css
+rm -rf ./packages/woocommerce-blocks/assets/js
+output 2 "Done"
+
 # Convert textdomains
 output 3 "Updating package PHP textdomains..."
 


### PR DESCRIPTION
We included WooCommerce Blocks source files in the package included with WooCommerce, but we don't need them, this PR adds a step to `bin/package-update.sh`.
We need to delete:
- `packages/woocommerce-blocks/storybook` however this folder won't exist as of Blocks 3.3.0, the next version to be shipped, but I deleted it anyway for the current version.
- `packages/woocommerce-blocks/assets/css`
- `packages/woocommerce-blocks/assets/js`
I left `assets/img` because we use them directly.

### How to test the changes in this Pull Request:

1. Locally, run `composer install` or `composer update`
2. You should see that the folders mentioned above are deleted.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Delete WooCommerce Blocks redundant source files.