### PR TITLE
Make WC_Tax::get_tax_rate_classes() public

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -745,7 +745,7 @@ class WC_Tax {
 	 * @since 3.7.0
 	 * @return array Array of tax class objects consisting of tax_rate_class_id, name, and slug.
 	 */
-	protected static function get_tax_rate_classes() {
+	public static function get_tax_rate_classes() {
 		global $wpdb;
 
 		$cache_key        = 'tax-rate-classes';

--- a/tests/legacy/unit-tests/tax/tax.php
+++ b/tests/legacy/unit-tests/tax/tax.php
@@ -466,8 +466,25 @@ class WC_Tests_Tax extends WC_Unit_Test_Case {
 		$tax_classes = WC_Tax::get_tax_classes();
 		$this->assertEquals( $tax_classes, array( 'Reduced rate', 'Zero rate' ) );
 
-		$tax_classes = WC_Tax::get_tax_class_slugs();
-		$this->assertEquals( $tax_classes, array( 'reduced-rate', 'zero-rate' ) );
+		$tax_class_slugs = WC_Tax::get_tax_class_slugs();
+		$this->assertEquals( $tax_class_slugs, array( 'reduced-rate', 'zero-rate' ) );
+
+		$tax_rate_classes = WC_Tax::get_tax_rate_classes();
+		$this->assertEquals(
+			$tax_rate_classes,
+			array(
+				(object) array(
+					'tax_rate_class_id' => '1',
+					'name'              => 'Reduced rate',
+					'slug'              => 'reduced-rate',
+				),
+				(object) array(
+					'tax_rate_class_id' => '2',
+					'name'              => 'Zero rate',
+					'slug'              => 'zero-rate',
+				),
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I believe that the visibility of `WC_Tax::get_tax_rate_classes()` should be `public` just like all the other static helper methods in the class that can be used by third parties.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - `WC_Tax::get_tax_rate_classes()` is now public.
