### PR TITLE
Update href of premium support link

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1378,7 +1378,7 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 		);
 
 		if ( WCConnectionHelper::is_connected() ) {
-			$row_meta['premium_support'] = '<a href="' . esc_url( apply_filters( 'woocommerce_support_url', 'https://woocommerce.com/my-account/tickets/' ) ) . '" aria-label="' . esc_attr__( 'Visit premium customer support', 'woocommerce' ) . '">' . esc_html__( 'Premium support', 'woocommerce' ) . '</a>';
+			$row_meta['premium_support'] = '<a href="' . esc_url( apply_filters( 'woocommerce_support_url', 'https://woocommerce.com/my-account/create-a-ticket/' ) ) . '" aria-label="' . esc_attr__( 'Visit premium customer support', 'woocommerce' ) . '">' . esc_html__( 'Premium support', 'woocommerce' ) . '</a>';
 		}
 
 		return array_merge( $links, $row_meta );


### PR DESCRIPTION
#25981 # All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

* Updates the `href` of the premium support link we show in the WooCommerce plugins list item when a store is connected to WooCommerce.com. The URL `https://woocommerce.com/my-account/tickets/` is now deprecated. (See 1596565121.435300-slack-24FN1V2/C.) This change points the link instead to the "create ticket" page.

### How to test the changes in this Pull Request:

1. Check the branch out on a local WordPress instance. If you haven't already, follow the steps for [setting up a WooCommerce dev environment](https://github.com/woocommerce/woocommerce/wiki/How-to-set-up-WooCommerce-development-environment).
2. Connect your store to WooCommerce.com.
3. Check that the `Premium Support` link goes to https://woocommerce.com/create-ticket.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update - Change href of premium support link