### PR TITLE
Update WooCommerce Blocks package to 3.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "1.5.0",
-    "woocommerce/woocommerce-blocks": "3.1.0"
+    "woocommerce/woocommerce-blocks": "3.4.0"
   },
   "require-dev": {
     "phpunit/phpunit": "7.5.20",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11ae24e5fa6a835a12e6e4f853825392",
+    "content-hash": "7aa2bbdd451be96ace6c9d6d0068ceda",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -515,16 +515,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v3.1.0",
+            "version": "v3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "d8fdcb4fc90c392e672b0e75bb0b7fd81dac7436"
+                "reference": "d64a2616932f312ec4fd8f4e46195c3f9aca0000"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/d8fdcb4fc90c392e672b0e75bb0b7fd81dac7436",
-                "reference": "d8fdcb4fc90c392e672b0e75bb0b7fd81dac7436",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/d64a2616932f312ec4fd8f4e46195c3f9aca0000",
+                "reference": "d64a2616932f312ec4fd8f4e46195c3f9aca0000",
                 "shasum": ""
             },
             "require": {
@@ -558,7 +558,7 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2020-07-29T15:45:19+00:00"
+            "time": "2020-09-15T12:10:40+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 3.4.0. It includes changes from WooCommerce Blocks 3.2.0-3.4.0 and intended to target WooCommerce 4.6.0 for release.

Details from all the different releases included in this pull:

## Blocks 3.2.0

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3016)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/docs/testing/releases/320.md)
* [Release post](https://developer.woocommerce.com/2020/08/18/woocommerce-blocks-3-2-release-notes/)

## Blocks 3.3.0

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3077)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/docs/testing/releases/330.md)
* [Release post](https://developer.woocommerce.com/2020/09/02/woocommerce-blocks-3-3-0-release-notes/)

## Blocks 3.4.0

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3144)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/main/docs/testing/releases/340.md)
* [Release post](https://developer.woocommerce.com/2020/09/15/woocommerce-blocks-3-4-0-release-notes/)


### Changelog entry

> Dev - Update WooCommerce Blocks version to 3.4.0