### PR TITLE
Added environment type var to WC tracker.

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -202,11 +202,19 @@ class WC_Tracker {
 			$memory        = max( $memory, $system_memory );
 		}
 
+		// WordPress 5.5+ environment type specification.
+		// 'production' is the default in WP, thus using it as a default here, too.
+		$environment_type = 	'production';
+		if ( function_exists( 'wp_get_environment_type' ) ) {
+			$environment_type = wp_get_environment_type();
+		}
+
 		$wp_data['memory_limit'] = size_format( $memory );
 		$wp_data['debug_mode']   = ( defined( 'WP_DEBUG' ) && WP_DEBUG ) ? 'Yes' : 'No';
 		$wp_data['locale']       = get_locale();
 		$wp_data['version']      = get_bloginfo( 'version' );
 		$wp_data['multisite']    = is_multisite() ? 'Yes' : 'No';
+		$wp_data['env_type']     = $environment_type;
 
 		return $wp_data;
 	}

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -204,7 +204,7 @@ class WC_Tracker {
 
 		// WordPress 5.5+ environment type specification.
 		// 'production' is the default in WP, thus using it as a default here, too.
-		$environment_type = 	'production';
+		$environment_type = 'production';
 		if ( function_exists( 'wp_get_environment_type' ) ) {
 			$environment_type = wp_get_environment_type();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This change adds WP's new environment type to WC tracker to give us an option to better tell prod vs staging and dev sites.

I didn't add unit tests as this class doesn't have any yet and the methods that call this are mostly private, the public one sends the data to the tracker. Feel free to require them via a comment if you think it would be better.

### How to test the changes in this Pull Request:

1. Enable tracking in your testing environment.
2. Add the following override to activate the code: `add_filter( 'woocommerce_tracker_send_override', '__return_true' );`
3. Make sure you turn off _1 submission per hour_ limit, e.g. by commenting out https://github.com/woocommerce/woocommerce/blob/master/includes/class-wc-tracker.php#L57
4. Running WP 5.5(.1), add `define( 'WP_ENVIRONMENT_TYPE', 'staging' );` to your wp-config.php
5. Check that the output sent to tracker includes `env_type` set to `staging` in the `wp` section.
6. Running WP 5.5(.1), remove `define( 'WP_ENVIRONMENT_TYPE', 'staging' );` from your wp-config.php.
7. Check that the output sent to tracker includes `env_type` set to `production` in the `wp` section.
8. Downgrade to WP before 5.5, e.g. 5.4 or 5.0.
9. Check that the output sent to tracker includes `env_type` set to `production` in the `wp` section (the default for `wp_get_environment_type`, as per [the post](https://make.wordpress.org/core/2020/07/24/new-wp_get_environment_type-function-in-wordpress-5-5/))

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added WP environment type to tracker.
