### PR TITLE
Fix some race conditions in WC_Install

### DIFF
--- a/includes/admin/class-wc-admin-notices.php
+++ b/includes/admin/class-wc-admin-notices.php
@@ -253,7 +253,6 @@ class WC_Admin_Notices {
 				include dirname( __FILE__ ) . '/views/html-notice-update.php';
 			}
 		} else {
-			WC_Install::update_db_version();
 			include dirname( __FILE__ ) . '/views/html-notice-updated.php';
 		}
 	}

--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -272,7 +272,6 @@ class WC_Notes_Run_Db_Update {
 				return;
 			} else {
 				// Db update not needed && notice is unactioned -> Thank you note.
-				\WC_Install::update_db_version();
 				self::update_done_notice( $note_id );
 				return;
 			}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -448,8 +448,7 @@ class WC_Install {
 	 * Update WC version to current.
 	 */
 	private static function update_wc_version() {
-		delete_option( 'woocommerce_version' );
-		add_option( 'woocommerce_version', WC()->version );
+		update_option( 'woocommerce_version', WC()->version );
 	}
 
 	/**
@@ -492,8 +491,7 @@ class WC_Install {
 	 * @param string|null $version New WooCommerce DB version or null.
 	 */
 	public static function update_db_version( $version = null ) {
-		delete_option( 'woocommerce_db_version' );
-		add_option( 'woocommerce_db_version', is_null( $version ) ? WC()->version : $version );
+		update_option( 'woocommerce_db_version', is_null( $version ) ? WC()->version : $version );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

In an environment with persistent object caching, concurrent calls to `delete_option()` + `add_option()` can result in the option value leaking out of the `alloptions` cache key, and into its own cache item under the `options` group, while deleting the value from the database.

This causes future function calls to `add_option()` to fail, since the value already exists in cache (under the wrong key). It also causes calls to `delete_option()` to fail, since the value is not in the database.

This commit forces `update_option()` instead of the delete + add combination, as well as removes multiple unnecessary calls to update the `woocommerce_db_version` from admin notes and notices.

### How to test the changes in this Pull Request:

As with most issues surrounding race conditions, this is a bit tricky to test. First you'll need an environment with persistent object caching, [Memcached](https://memcached.org/) for example, with the [wp-memcached drop-in](https://github.com/Automattic/wp-memcached).

You can confirm the problem with `delete_option()` + `add_option()` using a simple mu-plugin:

```
add_action( 'init', function() {
    if ( defined( 'WP_CLI' ) && WP_CLI )
        return;

    delete_option( 'foo' );
    add_option( 'foo', 'bar' );
    die();
} );
```

Run a single request to your site, and confirm the following:

```
wp option get foo # says bar
wp cache get foo options # error, because foo is autoloaded and stored in alloptions
wp cache get alloptions options # big array with foo => bar at the end
```

Confirm that the value exists in the database using a MySQL shell:

```
SELECT * FROM wp_options WHERE option_name = 'foo';
+-----------+-------------+--------------+----------+
| option_id | option_name | option_value | autoload |
+-----------+-------------+--------------+----------+
|      2403 | foo         | bar          | yes      |
+-----------+-------------+--------------+----------+
```

Now run some concurrent requests to your site using [ab](https://httpd.apache.org/docs/2.4/programs/ab.html) for example:

```
ab -c 100 -n 1000 http://localhost/ # 1000 requests with 100 concurrent
```

Then repeat the steps above:

```
wp option get foo # says bar
wp cache get foo options # says bar, because the value leaked from alloptions into its own item
wp cache get alloptions options # big array, but NO foo => bar
```

And finally, in MySQL shell:

```
SELECT * FROM wp_options WHERE option_name = 'foo';
Empty set (0.00 sec)
```

At this point the value is gone, and only remains as a stale item in Memcached under the wrong key. Deleting, adding, or updating the item will not work:

```
$ wp option delete foo
Warning: Could not delete 'foo' option. Does it exist?
$ wp option add foo bar
Error: Could not add option 'foo'. Does it already exist?
$ wp option update foo baz
Error: Could not update option 'foo'.
```

Imagine if this happens to `woocommerce_version` or `woocommerce_db_version`...

Oh hey, guess what! It did happen to us in production earlier this week :) The outcome was not pretty -- as you can guess, this resulted in Woo core trying to run upgrade routines over and over again, because it could never store the final version number.

It's hard to tell exactly how this happened with `woocommerce_version` and `woocommerce_db_version`, but from what I could find, the admin notes and notices are running `update_db_version` on the "thanks for updating" print every single time, until you dismiss the note/notice.

So to reproduce this on a local setup, you'll need to get into a state after an update has been completed, for example by installing a fresh 4.4.1 and upgrading to the latest version, but never dismissing any of the notes or notices. Then run some concurrent requests to wp-admin. The `update_notice()` for example, is triggered on the Dashboard and the Plugins screen.

You should end up with a stale `woocommerce_db_version` in Memcached, and an empty value in the database. Then next time Woo core will want to run some database updates, things are going to break. If the cache item is evicted from Memcached (not very likely because it's quite frequent), things are going to break sooner, and probably harder, because Woo will assume it's db version 0.

With regards to `woocommerce_version` it seems less likely to happen, even though it runs on `init 5`. I guess the transient in `install()` there is somewhat protecting us from the race condition, but transients are prone to race conditions themselves, so two or more concurrent calls to `get_transient()` before `set_transient()` can "easily" fail. So it can still happen, you just need to be unlucky twice. The `yes === ...` stuff is too naive there, I think we need an actual lock.

### Other information:

Note how `update_option()` also fails with the stale cache item. This means that if a site is already stuck with a stale item like that, the only way to recover from that state is to delete it, hopefully without causing many upgrade routines to run, so maybe something like:

```
$stuck_at_version = wp_cache_get( 'woocommerce_db_version', 'options' );
if ( $stuck_at_version ) {
    wp_cache_delete( 'woocommerce_db_version', 'options' );
    update_option( 'woocommerce_db_version', $stuck_at_version );
}
```

Not sure if we'd want to run something like this as part of a db upgrade routine. Maybe check for `wp_using_ext_object_cache()` too, because environments without external object caching will not suffer from this problem.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed some race conditions in `WC_Install`.