### PR TITLE
Fixed usage of package tag in REST API and templates

### DIFF
--- a/includes/admin/helper/class-wc-helper-api.php
+++ b/includes/admin/helper/class-wc-helper-api.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * WooCommerce Admin
+ * WooCommerce Admin Helper API
  *
- * @class    WC_Helper_API
- * @package  WooCommerce\Admin
+ * @package WooCommerce\Admin\Helper
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/helper/class-wc-helper-compat.php
+++ b/includes/admin/helper/class-wc-helper-compat.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * WooCommerce Admin Helper Compat
+ *
+ * @package WooCommerce\Admin\Helper
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/admin/helper/class-wc-helper-options.php
+++ b/includes/admin/helper/class-wc-helper-options.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * WooCommerce Admin Helper Options
+ *
+ * @package WooCommerce\Admin\Helper
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/admin/helper/class-wc-helper-plugin-info.php
+++ b/includes/admin/helper/class-wc-helper-plugin-info.php
@@ -1,4 +1,10 @@
 <?php
+/**
+ * WooCommerce Admin Helper Plugin Info
+ *
+ * @package WooCommerce\Admin\Helper
+ */
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }

--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -3,7 +3,7 @@
  * The update helper for WooCommerce.com plugins.
  *
  * @class WC_Helper_Updater
- * @package WooCommerce\Admin.
+ * @package WooCommerce\Admin\Helper
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/includes/admin/helper/class-wc-helper.php
+++ b/includes/admin/helper/class-wc-helper.php
@@ -1,9 +1,8 @@
 <?php
 /**
- * WooCommerce Admin
+ * WooCommerce Admin Helper
  *
- * @class    WC_Helper
- * @package  WooCommerce\Admin
+ * @package WooCommerce\Admin\Helper
  */
 
 use Automattic\Jetpack\Constants;

--- a/includes/class-wc-api.php
+++ b/includes/class-wc-api.php
@@ -7,7 +7,7 @@
  * - Legacy REST API - Deprecated in 2.6.0. @see class-wc-legacy-api.php
  * - WP REST API - The main REST API in WooCommerce which is built on top of the WP REST API.
  *
- * @package WooCommerce\API
+ * @package WooCommerce\RestApi
  * @since   2.0.0
  */
 

--- a/includes/class-wc-auth.php
+++ b/includes/class-wc-auth.php
@@ -4,7 +4,7 @@
  *
  * Handles wc-auth endpoint requests.
  *
- * @package WooCommerce\API
+ * @package WooCommerce\RestApi
  * @since   2.4.0
  */
 

--- a/includes/class-wc-rest-authentication.php
+++ b/includes/class-wc-rest-authentication.php
@@ -2,7 +2,7 @@
 /**
  * REST API Authentication
  *
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.6.0
  */
 

--- a/includes/class-wc-rest-exception.php
+++ b/includes/class-wc-rest-exception.php
@@ -4,7 +4,7 @@
  *
  * Extends Exception to provide additional data.
  *
- * @package WooCommerce\API
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 

--- a/includes/legacy/api/class-wc-rest-legacy-coupons-controller.php
+++ b/includes/legacy/api/class-wc-rest-legacy-coupons-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Legacy Coupons controller class.
  *
- * @package WooCommerce\API
+ * @package WooCommerce\RestApi
  * @extends WC_REST_CRUD_Controller
  */
 class WC_REST_Legacy_Coupons_Controller extends WC_REST_CRUD_Controller {

--- a/includes/legacy/api/class-wc-rest-legacy-orders-controller.php
+++ b/includes/legacy/api/class-wc-rest-legacy-orders-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Legacy Orders controller class.
  *
- * @package WooCommerce\API
+ * @package WooCommerce\RestApi
  * @extends WC_REST_CRUD_Controller
  */
 class WC_REST_Legacy_Orders_Controller extends WC_REST_CRUD_Controller {

--- a/includes/legacy/api/class-wc-rest-legacy-products-controller.php
+++ b/includes/legacy/api/class-wc-rest-legacy-products-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Legacy Products controller class.
  *
- * @package WooCommerce\API
+ * @package WooCommerce\RestApi
  * @extends WC_REST_CRUD_Controller
  */
 class WC_REST_Legacy_Products_Controller extends WC_REST_CRUD_Controller {

--- a/includes/legacy/api/v1/class-wc-api-authentication.php
+++ b/includes/legacy/api/v1/class-wc-api-authentication.php
@@ -4,7 +4,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.1.0
  * @version  2.4.0
  */

--- a/includes/legacy/api/v1/class-wc-api-coupons.php
+++ b/includes/legacy/api/v1/class-wc-api-coupons.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-customers.php
+++ b/includes/legacy/api/v1/class-wc-api-customers.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-json-handler.php
+++ b/includes/legacy/api/v1/class-wc-api-json-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-orders.php
+++ b/includes/legacy/api/v1/class-wc-api-orders.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-products.php
+++ b/includes/legacy/api/v1/class-wc-api-products.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     3.0
  */

--- a/includes/legacy/api/v1/class-wc-api-reports.php
+++ b/includes/legacy/api/v1/class-wc-api-reports.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-resource.php
+++ b/includes/legacy/api/v1/class-wc-api-resource.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-server.php
+++ b/includes/legacy/api/v1/class-wc-api-server.php
@@ -9,7 +9,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/class-wc-api-xml-handler.php
+++ b/includes/legacy/api/v1/class-wc-api-xml-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v1/interface-wc-api-handler.php
+++ b/includes/legacy/api/v1/interface-wc-api-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     2.1
  */

--- a/includes/legacy/api/v2/class-wc-api-authentication.php
+++ b/includes/legacy/api/v2/class-wc-api-authentication.php
@@ -4,7 +4,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.1.0
  * @version  2.4.0
  */

--- a/includes/legacy/api/v2/class-wc-api-coupons.php
+++ b/includes/legacy/api/v2/class-wc-api-coupons.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-customers.php
+++ b/includes/legacy/api/v2/class-wc-api-customers.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.2
  */
 

--- a/includes/legacy/api/v2/class-wc-api-exception.php
+++ b/includes/legacy/api/v2/class-wc-api-exception.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.2
  */
 

--- a/includes/legacy/api/v2/class-wc-api-json-handler.php
+++ b/includes/legacy/api/v2/class-wc-api-json-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-orders.php
+++ b/includes/legacy/api/v2/class-wc-api-orders.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-products.php
+++ b/includes/legacy/api/v2/class-wc-api-products.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     3.0
  */

--- a/includes/legacy/api/v2/class-wc-api-reports.php
+++ b/includes/legacy/api/v2/class-wc-api-reports.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-resource.php
+++ b/includes/legacy/api/v2/class-wc-api-resource.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-server.php
+++ b/includes/legacy/api/v2/class-wc-api-server.php
@@ -9,7 +9,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.1
  */
 

--- a/includes/legacy/api/v2/class-wc-api-webhooks.php
+++ b/includes/legacy/api/v2/class-wc-api-webhooks.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.2
  */
 

--- a/includes/legacy/api/v2/interface-wc-api-handler.php
+++ b/includes/legacy/api/v2/interface-wc-api-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-authentication.php
+++ b/includes/legacy/api/v3/class-wc-api-authentication.php
@@ -4,7 +4,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.1.0
  * @version  2.4.0
  */

--- a/includes/legacy/api/v3/class-wc-api-coupons.php
+++ b/includes/legacy/api/v3/class-wc-api-coupons.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-customers.php
+++ b/includes/legacy/api/v3/class-wc-api-customers.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.2
  */
 

--- a/includes/legacy/api/v3/class-wc-api-exception.php
+++ b/includes/legacy/api/v3/class-wc-api-exception.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.2
  */
 

--- a/includes/legacy/api/v3/class-wc-api-json-handler.php
+++ b/includes/legacy/api/v3/class-wc-api-json-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-orders.php
+++ b/includes/legacy/api/v3/class-wc-api-orders.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-products.php
+++ b/includes/legacy/api/v3/class-wc-api-products.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  * @version     3.0
  */

--- a/includes/legacy/api/v3/class-wc-api-reports.php
+++ b/includes/legacy/api/v3/class-wc-api-reports.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-resource.php
+++ b/includes/legacy/api/v3/class-wc-api-resource.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-server.php
+++ b/includes/legacy/api/v3/class-wc-api-server.php
@@ -9,7 +9,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.1
  */
 

--- a/includes/legacy/api/v3/class-wc-api-taxes.php
+++ b/includes/legacy/api/v3/class-wc-api-taxes.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.5.0
  */
 

--- a/includes/legacy/api/v3/class-wc-api-webhooks.php
+++ b/includes/legacy/api/v3/class-wc-api-webhooks.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.2
  */
 

--- a/includes/legacy/api/v3/interface-wc-api-handler.php
+++ b/includes/legacy/api/v3/interface-wc-api-handler.php
@@ -6,7 +6,7 @@
  *
  * @author      WooThemes
  * @category    API
- * @package     WooCommerce\API
+ * @package     WooCommerce\RestApi
  * @since       2.1
  */
 

--- a/includes/legacy/class-wc-legacy-api.php
+++ b/includes/legacy/class-wc-legacy-api.php
@@ -4,7 +4,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package  WooCommerce\API
+ * @package  WooCommerce\RestApi
  * @since    2.6
  */
 

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-coupons-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Coupons controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Posts_Controller
  */
 class WC_REST_Coupons_V1_Controller extends WC_REST_Posts_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-customer-downloads-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-customer-downloads-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Customers controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Customer_Downloads_V1_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-customers-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-customers-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Customers controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Customers_V1_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-order-notes-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-order-notes-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Order Notes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Order_Notes_V1_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-order-refunds-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-order-refunds-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    2.6.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Order Refunds controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Orders_V1_Controller
  */
 class WC_REST_Order_Refunds_V1_Controller extends WC_REST_Orders_V1_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Orders controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Posts_Controller
  */
 class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-product-attribute-terms-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-product-attribute-terms-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Product Attribute Terms controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Terms_Controller
  */
 class WC_REST_Product_Attribute_Terms_V1_Controller extends WC_REST_Terms_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Product Attributes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-product-categories-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-product-categories-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Product Categories controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Terms_Controller
  */
 class WC_REST_Product_Categories_V1_Controller extends WC_REST_Terms_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-product-reviews-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-product-reviews-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Product Reviews Controller Class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Product_Reviews_V1_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-product-shipping-classes-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-product-shipping-classes-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Product Shipping Classes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Terms_Controller
  */
 class WC_REST_Product_Shipping_Classes_V1_Controller extends WC_REST_Terms_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-product-tags-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-product-tags-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Product Tags controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Terms_Controller
  */
 class WC_REST_Product_Tags_V1_Controller extends WC_REST_Terms_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-products-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Products controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Posts_Controller
  */
 class WC_REST_Products_V1_Controller extends WC_REST_Posts_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-report-sales-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-report-sales-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Report Sales controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Report_Sales_V1_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-report-top-sellers-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-report-top-sellers-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Report Top Sellers controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Report_Sales_V1_Controller
  */
 class WC_REST_Report_Top_Sellers_V1_Controller extends WC_REST_Report_Sales_V1_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-reports-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-reports-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Reports controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Reports_V1_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-tax-classes-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-tax-classes-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Tax Classes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Tax_Classes_V1_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-taxes-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-taxes-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -17,7 +17,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Taxes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Taxes_V1_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-webhook-deliveries-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-webhook-deliveries-v1-controller.php
@@ -6,7 +6,7 @@
  *
  * @author   WooThemes
  * @category API
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -18,7 +18,7 @@ if ( ! defined( 'ABSPATH' ) ) {
  * REST API Webhook Deliveries controller class.
  *
  * @deprecated 3.3.0 Webhooks deliveries logs now uses logging system.
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Webhook_Deliveries_V1_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-webhooks-v1-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /webhooks endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Webhooks controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Webhooks_V1_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-coupons-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /coupons endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Coupons controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_CRUD_Controller
  */
 class WC_REST_Coupons_V2_Controller extends WC_REST_CRUD_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-customer-downloads-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-customer-downloads-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /customers/<customer_id>/downloads endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Customers controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Customer_Downloads_V1_Controller
  */
 class WC_REST_Customer_Downloads_V2_Controller extends WC_REST_Customer_Downloads_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-customers-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-customers-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /customers endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Customers controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Customers_V1_Controller
  */
 class WC_REST_Customers_V2_Controller extends WC_REST_Customers_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-network-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-network-orders-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /orders/network endpoint
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.4.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Network Orders controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Orders_V2_Controller
  */
 class WC_REST_Network_Orders_V2_Controller extends WC_REST_Orders_V2_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-order-notes-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-order-notes-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /orders/<order_id>/notes endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Order Notes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Order_Notes_V1_Controller
  */
 class WC_REST_Order_Notes_V2_Controller extends WC_REST_Order_Notes_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /orders/<order_id>/refunds endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Order Refunds controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Orders_V2_Controller
  */
 class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /orders endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Orders controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_CRUD_Controller
  */
 class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-payment-gateways-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-payment-gateways-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /payment_gateways endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Paymenga gateways controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Payment_Gateways_V2_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-product-attribute-terms-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-product-attribute-terms-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the products/attributes/<attribute_id>/terms endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Attribute Terms controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Attribute_Terms_V1_Controller
  */
 class WC_REST_Product_Attribute_Terms_V2_Controller extends WC_REST_Product_Attribute_Terms_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-product-attributes-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-product-attributes-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the products/attributes endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Attributes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Attributes_V1_Controller
  */
 class WC_REST_Product_Attributes_V2_Controller extends WC_REST_Product_Attributes_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-product-categories-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-product-categories-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the products/categories endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Categories controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Categories_V1_Controller
  */
 class WC_REST_Product_Categories_V2_Controller extends WC_REST_Product_Categories_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-product-reviews-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-product-reviews-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to /products/<product_id>/reviews.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Reviews Controller Class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Reviews_V1_Controller
  */
 class WC_REST_Product_Reviews_V2_Controller extends WC_REST_Product_Reviews_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-product-shipping-classes-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-product-shipping-classes-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the products/shipping_classes endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Shipping Classes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Shipping_Classes_V1_Controller
  */
 class WC_REST_Product_Shipping_Classes_V2_Controller extends WC_REST_Product_Shipping_Classes_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-product-tags-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-product-tags-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the products/tags endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Tags controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Tags_V1_Controller
  */
 class WC_REST_Product_Tags_V2_Controller extends WC_REST_Product_Tags_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-product-variations-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /products/<product_id>/variations endpoints.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API variations controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Products_V2_Controller
  */
 class WC_REST_Product_Variations_V2_Controller extends WC_REST_Products_V2_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /products endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Products controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_CRUD_Controller
  */
 class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-report-sales-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-report-sales-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the reports/sales endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Report Sales controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Report_Sales_V1_Controller
  */
 class WC_REST_Report_Sales_V2_Controller extends WC_REST_Report_Sales_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-report-top-sellers-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-report-top-sellers-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the reports/top_sellers endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Report Top Sellers controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Report_Top_Sellers_V1_Controller
  */
 class WC_REST_Report_Top_Sellers_V2_Controller extends WC_REST_Report_Top_Sellers_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-reports-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-reports-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the reports endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Reports controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Reports_V1_Controller
  */
 class WC_REST_Reports_V2_Controller extends WC_REST_Reports_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-setting-options-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /settings/$group/$setting endpoints.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Setting Options controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Setting_Options_V2_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-settings-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-settings-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /settings endpoints.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Settings controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Settings_V2_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-shipping-methods-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-shipping-methods-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /shipping_methods endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Shipping methods controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Shipping_Methods_V2_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-shipping-zone-locations-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-shipping-zone-locations-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /shipping/zones/<id>/locations endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Shipping Zone Locations class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Shipping_Zones_Controller_Base
  */
 class WC_REST_Shipping_Zone_Locations_V2_Controller extends WC_REST_Shipping_Zones_Controller_Base {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-shipping-zone-methods-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-shipping-zone-methods-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /shipping/zones/<id>/methods endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Shipping Zone Methods class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Shipping_Zones_Controller_Base
  */
 class WC_REST_Shipping_Zone_Methods_V2_Controller extends WC_REST_Shipping_Zones_Controller_Base {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-shipping-zones-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-shipping-zones-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /shipping/zones endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Shipping Zones class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Shipping_Zones_Controller_Base
  */
 class WC_REST_Shipping_Zones_V2_Controller extends WC_REST_Shipping_Zones_Controller_Base {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /system_status/tools/* endpoints.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * System status tools controller.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /system_status endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * System status controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-tax-classes-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-tax-classes-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /taxes/classes endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Tax Classes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Tax_Classes_V1_Controller
  */
 class WC_REST_Tax_Classes_V2_Controller extends WC_REST_Tax_Classes_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-taxes-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-taxes-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /taxes endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Taxes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Taxes_V1_Controller
  */
 class WC_REST_Taxes_V2_Controller extends WC_REST_Taxes_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-webhook-deliveries-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-webhook-deliveries-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /webhooks/<webhook_id>/deliveries endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -14,7 +14,7 @@ defined( 'ABSPATH' ) || exit;
  * REST API Webhook Deliveries controller class.
  *
  * @deprecated 3.3.0 Webhooks deliveries logs now uses logging system.
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Webhook_Deliveries_V1_Controller
  */
 class WC_REST_Webhook_Deliveries_V2_Controller extends WC_REST_Webhook_Deliveries_V1_Controller {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-webhooks-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-webhooks-v2-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /webhooks endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Webhooks controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Webhooks_V1_Controller
  */
 class WC_REST_Webhooks_V2_Controller extends WC_REST_Webhooks_V1_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -12,7 +12,7 @@
  * If necessary extend this class and create new abstract classes like `WC_REST_CRUD_Controller` or `WC_REST_Terms_Controller`.
  *
  * @class   WC_REST_Controller
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @see     https://developer.wordpress.org/rest-api/extending-the-rest-api/controller-classes/
  */
 
@@ -23,7 +23,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Abstract Rest Controller Class
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends  WP_REST_Controller
  * @version  2.6.0
  */

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-coupons-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /coupons endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Coupons controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Coupons_V2_Controller
  */
 class WC_REST_Coupons_Controller extends WC_REST_Coupons_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -3,7 +3,7 @@
  * Abstract Rest CRUD Controller Class
  *
  * @class    WC_REST_CRUD_Controller
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @version  3.0.0
  */
 

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-customer-downloads-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-customer-downloads-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /customers/<customer_id>/downloads endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Customers controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Customer_Downloads_V2_Controller
  */
 class WC_REST_Customer_Downloads_Controller extends WC_REST_Customer_Downloads_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-customers-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-customers-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /customers endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Customers controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Customers_V2_Controller
  */
 class WC_REST_Customers_Controller extends WC_REST_Customers_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-data-continents-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-data-continents-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /data/continents endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.5.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Data continents controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Data_Continents_Controller extends WC_REST_Data_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-data-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-data-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /data endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.5.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Data controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Data_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-data-countries-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-data-countries-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /data/countries endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.5.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Data countries controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Data_Countries_Controller extends WC_REST_Data_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-data-currencies-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-data-currencies-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /data/currencies endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.5.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Data Currencies controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  */
 class WC_REST_Data_Currencies_Controller extends WC_REST_Data_Controller {
 

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-network-orders-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-network-orders-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /orders/network endpoint
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.4.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Network Orders controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Network_Orders_V2_Controller
  */
 class WC_REST_Network_Orders_Controller extends WC_REST_Network_Orders_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-order-notes-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-order-notes-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /orders/<order_id>/notes endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Order Notes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Order_Notes_V2_Controller
  */
 class WC_REST_Order_Notes_Controller extends WC_REST_Order_Notes_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /orders/<order_id>/refunds endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Order Refunds controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Order_Refunds_V2_Controller
  */
 class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /orders endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Orders controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Orders_V2_Controller
  */
 class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-payment-gateways-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-payment-gateways-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /payment_gateways endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Paymenga gateways controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Payment_Gateways_V2_Controller
  */
 class WC_REST_Payment_Gateways_Controller extends WC_REST_Payment_Gateways_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-posts-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-posts-controller.php
@@ -3,7 +3,7 @@
  * Abstract Rest Posts Controller Class
  *
  * @class WC_REST_Posts_Controller
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -13,7 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * WC_REST_Posts_Controller
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @version  2.6.0
  */
 abstract class WC_REST_Posts_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-product-attribute-terms-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-product-attribute-terms-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the products/attributes/<attribute_id>/terms endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Attribute Terms controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Attribute_Terms_V2_Controller
  */
 class WC_REST_Product_Attribute_Terms_Controller extends WC_REST_Product_Attribute_Terms_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-product-attributes-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-product-attributes-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the products/attributes endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Attributes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Attributes_V2_Controller
  */
 class WC_REST_Product_Attributes_Controller extends WC_REST_Product_Attributes_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-product-categories-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-product-categories-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the products/categories endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Categories controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Categories_V2_Controller
  */
 class WC_REST_Product_Categories_Controller extends WC_REST_Product_Categories_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-product-reviews-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to /products/reviews.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.5.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Reviews Controller Class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 class WC_REST_Product_Reviews_Controller extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-product-shipping-classes-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-product-shipping-classes-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the products/shipping_classes endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Shipping Classes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Shipping_Classes_V2_Controller
  */
 class WC_REST_Product_Shipping_Classes_Controller extends WC_REST_Product_Shipping_Classes_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-product-tags-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-product-tags-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the products/tags endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Product Tags controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Tags_V2_Controller
  */
 class WC_REST_Product_Tags_Controller extends WC_REST_Product_Tags_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /products/<product_id>/variations endpoints.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API variations controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Product_Variations_V2_Controller
  */
 class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /products endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Products controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Products_V2_Controller
  */
 class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-report-coupons-totals-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-report-coupons-totals-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /reports/coupons/count endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.5.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Reports Coupons Totals controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Reports_Controller
  */
 class WC_REST_Report_Coupons_Totals_Controller extends WC_REST_Reports_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-report-customers-totals-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-report-customers-totals-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /reports/customers/count endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.5.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Reports Customers Totals controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Reports_Controller
  */
 class WC_REST_Report_Customers_Totals_Controller extends WC_REST_Reports_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-report-orders-totals-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-report-orders-totals-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /reports/orders/count endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.5.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Reports Orders Totals controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Reports_Controller
  */
 class WC_REST_Report_Orders_Totals_Controller extends WC_REST_Reports_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-report-products-totals-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-report-products-totals-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /reports/products/count endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.5.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Reports Products Totals controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Reports_Controller
  */
 class WC_REST_Report_Products_Totals_Controller extends WC_REST_Reports_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-report-reviews-totals-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-report-reviews-totals-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /reports/reviews/count endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.5.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Reports Reviews Totals controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Reports_Controller
  */
 class WC_REST_Report_Reviews_Totals_Controller extends WC_REST_Reports_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-report-sales-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-report-sales-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the reports/sales endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Report Sales controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Report_Sales_V2_Controller
  */
 class WC_REST_Report_Sales_Controller extends WC_REST_Report_Sales_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-report-top-sellers-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-report-top-sellers-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the reports/top_sellers endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Report Top Sellers controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Report_Top_Sellers_V2_Controller
  */
 class WC_REST_Report_Top_Sellers_Controller extends WC_REST_Report_Top_Sellers_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-reports-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-reports-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the reports endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Reports controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Reports_V2_Controller
  */
 class WC_REST_Reports_Controller extends WC_REST_Reports_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-setting-options-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-setting-options-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /settings/$group/$setting endpoints.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Setting Options controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Setting_Options_V2_Controller
  */
 class WC_REST_Setting_Options_Controller extends WC_REST_Setting_Options_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-settings-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-settings-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /settings endpoints.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Settings controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Settings_V2_Controller
  */
 class WC_REST_Settings_Controller extends WC_REST_Settings_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-methods-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-methods-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /shipping_methods endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * Shipping methods controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Shipping_Methods_V2_Controller
  */
 class WC_REST_Shipping_Methods_Controller extends WC_REST_Shipping_Methods_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zone-locations-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zone-locations-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /shipping/zones/<id>/locations endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Shipping Zone Locations class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Shipping_Zone_Locations_V2_Controller
  */
 class WC_REST_Shipping_Zone_Locations_Controller extends WC_REST_Shipping_Zone_Locations_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zone-methods-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zone-methods-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /shipping/zones/<id>/methods endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Shipping Zone Methods class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Shipping_Zone_Methods_V2_Controller
  */
 class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zone_Methods_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zones-controller-base.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zones-controller-base.php
@@ -4,7 +4,7 @@
  *
  * Houses common functionality between Shipping Zones and Locations.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since    3.0.0
  */
 
@@ -15,7 +15,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * REST API Shipping Zones base class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Controller
  */
 abstract class WC_REST_Shipping_Zones_Controller_Base extends WC_REST_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zones-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zones-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /shipping/zones endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Shipping Zones class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Shipping_Zones_V2_Controller
  */
 class WC_REST_Shipping_Zones_Controller extends WC_REST_Shipping_Zones_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-system-status-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-system-status-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /system_status endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * System status controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_System_Status_V2_Controller
  */
 class WC_REST_System_Status_Controller extends WC_REST_System_Status_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-system-status-tools-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-system-status-tools-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /system_status/tools/* endpoints.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   3.0.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * System status tools controller.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_System_Status_Tools_V2_Controller
  */
 class WC_REST_System_Status_Tools_Controller extends WC_REST_System_Status_Tools_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-tax-classes-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-tax-classes-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /taxes/classes endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Tax Classes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Tax_Classes_V2_Controller
  */
 class WC_REST_Tax_Classes_Controller extends WC_REST_Tax_Classes_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /taxes endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Taxes controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Taxes_V2_Controller
  */
 class WC_REST_Taxes_Controller extends WC_REST_Taxes_V2_Controller {

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
@@ -2,7 +2,7 @@
 /**
  * Abstract Rest Terms Controller
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @version  3.3.0
  */
 

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-webhooks-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-webhooks-controller.php
@@ -4,7 +4,7 @@
  *
  * Handles requests to the /webhooks endpoint.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @since   2.6.0
  */
 
@@ -13,7 +13,7 @@ defined( 'ABSPATH' ) || exit;
 /**
  * REST API Webhooks controller class.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  * @extends WC_REST_Webhooks_V2_Controller
  */
 class WC_REST_Webhooks_Controller extends WC_REST_Webhooks_V2_Controller {

--- a/includes/rest-api/Package.php
+++ b/includes/rest-api/Package.php
@@ -4,7 +4,7 @@
  *
  * Returns information about the package and handles init.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  */
 
 namespace Automattic\WooCommerce\RestApi;

--- a/includes/rest-api/Server.php
+++ b/includes/rest-api/Server.php
@@ -2,7 +2,7 @@
 /**
  * Initialize this version of the REST API.
  *
- * @package Automattic/WooCommerce/RestApi
+ * @package WooCommerce\RestApi
  */
 
 namespace Automattic\WooCommerce\RestApi;

--- a/includes/rest-api/Utilities/ImageAttachment.php
+++ b/includes/rest-api/Utilities/ImageAttachment.php
@@ -2,7 +2,7 @@
 /**
  * Helper to upload files via the REST API.
  *
- * @package Automattic/WooCommerce/Utilities
+ * @package WooCommerce\Utilities
  */
 
 namespace Automattic\WooCommerce\RestApi\Utilities;

--- a/includes/rest-api/Utilities/SingletonTrait.php
+++ b/includes/rest-api/Utilities/SingletonTrait.php
@@ -2,7 +2,7 @@
 /**
  * Singleton class trait.
  *
- * @package Automattic/WooCommerce/Utilities
+ * @package WooCommerce\Utilities
  */
 
 namespace Automattic\WooCommerce\RestApi\Utilities;

--- a/templates/cart/cart.php
+++ b/templates/cart/cart.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
- * @package WooCommerce/Templates
+ * @package WooCommerce\Templates
  * @version 3.8.0
  */
 

--- a/templates/single-product/title.php
+++ b/templates/single-product/title.php
@@ -11,7 +11,7 @@
  * the readme will list any important changes.
  *
  * @see        https://docs.woocommerce.com/document/template-structure/
- * @package    WooCommerce/Templates
+ * @package    WooCommerce\Templates
  * @version    1.6.4
  */
 

--- a/tests/legacy/unit-tests/rest-api/AbstractRestApiTest.php
+++ b/tests/legacy/unit-tests/rest-api/AbstractRestApiTest.php
@@ -14,7 +14,7 @@
  * - Routes
  * - Collection params/queries
  *
- * @package Automattic/WooCommerce/RestApi/Tests
+ * @package WooCommerce\RestApi/Tests
  */
 
 namespace Automattic\WooCommerce\RestApi\UnitTests;

--- a/tests/legacy/unit-tests/rest-api/AbstractRestApiTest.php
+++ b/tests/legacy/unit-tests/rest-api/AbstractRestApiTest.php
@@ -14,7 +14,7 @@
  * - Routes
  * - Collection params/queries
  *
- * @package WooCommerce\RestApi/Tests
+ * @package WooCommerce\RestApi\Tests
  */
 
 namespace Automattic\WooCommerce\RestApi\UnitTests;


### PR DESCRIPTION
Fixed incorrect use of the `@package` tag, note that `/` is invalid as a package delimiter, we should always use `\`.
Also update all `@package` tags from REST API related classes, so makes easy to find in our code reference.
And included missing `@package` in the helper classes.

This is an example of our code reference including those incorrect package names:

![Screenshot_2020-09-17 WooCommerce Code Reference](https://user-images.githubusercontent.com/1264099/93506458-ac9d8580-f8f2-11ea-87f8-6825caab6139.png)
