### PR TITLE
PHP8 Warning: Change __wakeup() to a public method

### DIFF
--- a/includes/rest-api/Utilities/SingletonTrait.php
+++ b/includes/rest-api/Utilities/SingletonTrait.php
@@ -45,5 +45,8 @@ trait SingletonTrait {
 	/**
 	 * Prevent unserializing.
 	 */
-	private function __wakeup() {}
+	final public function __wakeup() {
+		wc_doing_it_wrong( __FUNCTION__, __( 'Unserializing instances of this class is forbidden.', 'woocommerce' ), '4.6' );
+		die();
+	}
 }


### PR DESCRIPTION
PHP requires that all magic methods be public. As of PHP8, `__wakeup()` being declared as non-public causes a warning.

```
php -l woocommerce/includes/rest-api/Utilities/SingletonTrait.php

PHP Warning:  The magic method Automattic\WooCommerce\RestApi\Utilities\SingletonTrait::__wakeup() must have public visibility in woocommerce/includes/rest-api/Utilities/SingletonTrait.php on line 48
```

Attached **untested** patch simply moves it to public, calls `wc_doing_it_wrong()` and `die()` for safety.

See also: https://github.com/Automattic/jetpack/pull/17200

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
 * PHP8 warnings

### How to test the changes in this Pull Request:

1. Install PHP8
2. Run a lint check

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Improved PHP 8 support
