### PR TITLE
Add missing headless flag for running e2e tests in dev mode + README updates

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -5,7 +5,7 @@ Automated end-to-end tests for WooCommerce.
 ## Table of contents
 
 - [Pre-requisites](#pre-requisites)
-  - [Install NodeJS](#install-nodejs)
+  - [Install Node.js](#install-node.js)
   - [Install Docker](#install-docker)
 - [Configuration](#configuration)
   - [Test Environment](#test-environment)
@@ -19,19 +19,16 @@ Automated end-to-end tests for WooCommerce.
   - [How to skip tests](#how-to-skip-tests)
 - [Writing tests](#writing-tests) 
 - [Debugging tests](#debugging-tests)
-- [Docker basics](#docker-basics)
-  - [How to stop and restart Docker](#how-to-stop-and-restart-docker)
-  - [How to stop Docker and do a clean restart](#how-to-stop-docker-and-do-a-clean-restart)
 
 ## Pre-requisites
 
-### Install NodeJS
+### Install Node.js
 
-Install NodeJS on Mac:
+Follow [instructions on the node.js site](https://nodejs.org/en/download/) to install Node.js. 
 
-```bash
-brew install node 
-```
+### Install NVM
+
+Follow instructions in the [NVM repository](https://github.com/nvm-sh/nvm) to install NVM. 
 
 ### Install Docker
 
@@ -88,6 +85,8 @@ Setup Wizard e2e test (located in `activate-and-setup` directory) will run befor
 
 - `git checkout master` or checkout the branch where you need to run tests 
 
+- Run `nvm use`
+
 - Run `npm install`
 
 - Run `npm install jest --global`
@@ -96,27 +95,29 @@ Setup Wizard e2e test (located in `activate-and-setup` directory) will run befor
 
 - Run `npm run build:core`
 
-- Run the following command to build the test site using Docker: `npm run docker:up` and watch the site being built. Note that it may take a few minutes the first time you do that. The process is considered completed when the messages letting you know that WordPress was installed, WooCommerce was activated and users created will be displayed:
+- Run `npm run docker:up` - it will build the test site using Docker.  
+
+- Run `docker ps` - to confirm that the Docker containers were built and running. You should see the log that looks similar to below indicating that everything had been built as expected:
 
 ```
-wordpress-cli_1             | Success: WordPress installed successfully.
-wordpress-cli_1             | Plugin 'woocommerce' activated.
-wordpress-cli_1             | Success: Activated 1 of 1 plugins.
-wordpress-cli_1             | Success: Created user 2.
-woocommerce_wordpress-cli_1 exited with code 0
-woocommerce_wordpress-cli_1 exited with code 0
+CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                  NAMES
+c380e1964506        env_wordpress-cli   "entrypoint.sh"          7 seconds ago       Up 5 seconds                               woocommerce_wordpress-cli
+2ab8e8439e9f        wordpress:5.5.1     "docker-entrypoint.s…"   8 seconds ago       Up 7 seconds        0.0.0.0:8084->80/tcp   woocommerce_wordpress-www
+4c1e3f2a49db        mariadb:10.5.5      "docker-entrypoint.s…"   10 seconds ago      Up 8 seconds        3306/tcp               woocommerce_db
 ```
 
-For more Docker commands, scroll down to [Docker basics](#docker-basics).
+- Navigate to `http://localhost:8084/`
 
-- Open new terminal window and `cd` to the current branch again.
+If everything went well, you should be able to access the site. If you changed the port to something other than `8084`, use the appropriate port to access your site. 
 
-- Run the following command to make sure the containers were built and running: `docker ps`. You should see the 2 following containers: 
+As noted in [Test Variables](#test-variables) section, use the following Admin user details to login:
 
-- `woocommerce_wordpress-woocommerce-dev`
-- `mariadb:10.4`
+```
+Username: admin
+PW: password
+```
 
-- Navigate to `http://localhost:8084/`. If everything went well, you should be able to access the site.  
+- Run `npm run docker:down` when you are done with running e2e tests or when making any changes to test suite.
 
 ### How to run tests in headless mode
 
@@ -208,11 +209,3 @@ The following packages are used to write tests:
 ## Debugging tests 
 
 For Puppeteer debugging, follow [Google's documentation](https://developers.google.com/web/tools/puppeteer/debugging).   
-
-## Docker basics
-
-### How to stop and restart Docker
-
-- Press `Ctrl+C` in the terminal window where the containers are running 
-- Stop the container(s) using the following command: `npm run docker:down`
-- Restart the containers using the following command: `npm run docker:up`

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -17,6 +17,7 @@ Automated end-to-end tests for WooCommerce.
   - [How to run tests in non-headless mode](#how-to-run-tests-in-non-headless-mode)
   - [How to run an individual test](#how-to-run-an-individual-test)
   - [How to skip tests](#how-to-skip-tests)
+  - [How to run tests using custom WordPress, PHP and MariaDV versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadv-versions)
 - [Writing tests](#writing-tests) 
 - [Debugging tests](#debugging-tests)
 
@@ -106,6 +107,10 @@ c380e1964506        env_wordpress-cli   "entrypoint.sh"          7 seconds ago  
 4c1e3f2a49db        mariadb:10.5.5      "docker-entrypoint.s…"   10 seconds ago      Up 8 seconds        3306/tcp               woocommerce_db
 ```
 
+Note that by default, Docker will download the latest images available for WordPress, PHP and MariaDB. In the example above, you can see that WordPress 5.5.1 and MariaDB 10.5.5 were used. 
+
+See [How to run tests using custom WordPress, PHP and MariaDV versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadv-versions) if you'd like to use different versions.  
+
 - Navigate to `http://localhost:8084/`
 
 If everything went well, you should be able to access the site. If you changed the port to something other than `8084`, use the appropriate port to access your site. 
@@ -189,6 +194,20 @@ Finally, you can apply both `.only` and `.skip` to `describe` part of the test:
 
 ```
 describe.skip( 'Store owner can go through store Setup Wizard', () => {}
+```
+
+### How to run tests using custom WordPress, PHP and MariaDV versions
+
+The following variables can be used to specify the versions of WordPress, PHP and Maria DB that you'd like to use to built your test site with Docker:
+
+- `WP_VERSION`
+- `TRAVIS_PHP_VERSION`
+- `TRAVIS_MARIADB_VERSION`  
+
+The full command to build the site will look as follows:
+
+```
+TRAVIS_MARIADB_VERSION=10.5.3 TRAVIS_PHP_VERSION=7.4.5 WP_VERSION=5.4.1 npm run docker:up
 ```
 
 ## Writing tests

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -143,7 +143,20 @@ Tests are being run headless by default. However, sometimes it's useful to obser
 npm run test:e2e-dev
 ```
 
-The dev mode also enables SlowMo mode. SlowMo slows down Puppeteer’s operations so we can better see what is happening in the browser. You can adjust the SlowMo value by copying `/tests/e2e/env/config/jest.puppetee.config.js` to `/tests/e2e/config` and editing the value in that file. The default `PUPPETEER_SLOWMO=50` means test actions will be slowed down by 50 milliseconds.
+The dev mode also enables SlowMo mode. SlowMo slows down Puppeteer’s operations so we can better see what is happening in the browser. 
+
+By default, SlowMo mode is set to slow down running of tests by 50 milliseconds. If you'd like to override it and have the tests run faster or slower in the `-dev` mode, pass `PUPPETEER_SLOWMO` variable when running tests as shown below: 
+
+```
+PUPPETEER_SLOWMO=10 npm run test:e2e-dev
+```
+
+The faster you want the tests to run, the lower the value should be of `PUPPETEER_SLOWMO` should be. 
+
+For example:
+
+- `PUPPETEER_SLOWMO=10` - will run tests faster
+- `PUPPETEER_SLOWMO=70` - will run tests slower
 
 ### How to run an individual test
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -6,6 +6,7 @@ Automated end-to-end tests for WooCommerce.
 
 - [Pre-requisites](#pre-requisites)
   - [Install Node.js](#install-node.js)
+  - [Install NVM](#install-nvm)
   - [Install Docker](#install-docker)
 - [Configuration](#configuration)
   - [Test Environment](#test-environment)

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -125,6 +125,8 @@ PW: password
 
 - Run `npm run docker:down` when you are done with running e2e tests or when making any changes to test suite.
 
+Note that running `npm run docker:down` and then `npm run docker:up` re-initializes the test container.
+
 ### How to run tests in headless mode
 
 To run e2e tests in headless mode use the following command:

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -91,11 +91,11 @@ Setup Wizard e2e test (located in `activate-and-setup` directory) will run befor
 
 - Run `npm install`
 
-- Run `npm install jest --global`
-
 - Run `composer install --no-dev`
 
-- Run `npm run build:core`
+- Run `npm run build:assets`
+
+- Run `npm install jest --global`
 
 - Run `npm run docker:up` - it will build the test site using Docker.  
 

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -18,7 +18,7 @@ Automated end-to-end tests for WooCommerce.
   - [How to run tests in non-headless mode](#how-to-run-tests-in-non-headless-mode)
   - [How to run an individual test](#how-to-run-an-individual-test)
   - [How to skip tests](#how-to-skip-tests)
-  - [How to run tests using custom WordPress, PHP and MariaDV versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadv-versions)
+  - [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions)
 - [Writing tests](#writing-tests) 
 - [Debugging tests](#debugging-tests)
 
@@ -110,7 +110,7 @@ c380e1964506        env_wordpress-cli   "entrypoint.sh"          7 seconds ago  
 
 Note that by default, Docker will download the latest images available for WordPress, PHP and MariaDB. In the example above, you can see that WordPress 5.5.1 and MariaDB 10.5.5 were used. 
 
-See [How to run tests using custom WordPress, PHP and MariaDV versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadv-versions) if you'd like to use different versions.  
+See [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions) if you'd like to use different versions.  
 
 - Navigate to `http://localhost:8084/`
 
@@ -197,9 +197,9 @@ Finally, you can apply both `.only` and `.skip` to `describe` part of the test:
 describe.skip( 'Store owner can go through store Setup Wizard', () => {}
 ```
 
-### How to run tests using custom WordPress, PHP and MariaDV versions
+### How to run tests using custom WordPress, PHP and MariaDB versions
 
-The following variables can be used to specify the versions of WordPress, PHP and Maria DB that you'd like to use to built your test site with Docker:
+The following variables can be used to specify the versions of WordPress, PHP and MariaDB that you'd like to use to built your test site with Docker:
 
 - `WP_VERSION`
 - `TRAVIS_PHP_VERSION`

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -114,7 +114,7 @@ See [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-
 
 - Navigate to `http://localhost:8084/`
 
-If everything went well, you should be able to access the site. If you changed the port to something other than `8084`, use the appropriate port to access your site. 
+If everything went well, you should be able to access the site. If you changed the port to something other than `8084` as per [Test Variables](#test-variables) section, use the appropriate port to access your site. 
 
 As noted in [Test Variables](#test-variables) section, use the following Admin user details to login:
 

--- a/tests/e2e/env/config/env.setup.js
+++ b/tests/e2e/env/config/env.setup.js
@@ -5,4 +5,5 @@ global.process.env = {
 	...global.process.env,
 	// Remove the trailing slash from jest sequencer WORDPRESS_URL.
 	WP_BASE_URL: testConfig.baseUrl,
+	PUPPETEER_SLOWMO: true,
 };

--- a/tests/e2e/env/config/jest-puppeteer.config.js
+++ b/tests/e2e/env/config/jest-puppeteer.config.js
@@ -17,6 +17,7 @@ if ( 'no' == global.process.env.node_config_dev ) {
 			ignoreHTTPSErrors: true,
 			args: [ '--window-size=1920,1080', '--user-agent=chrome' ],
 			devtools: true,
+			headless: false,
 			defaultViewport: {
 				width: 1280,
 				height: 800,

--- a/tests/e2e/env/config/jest-puppeteer.config.js
+++ b/tests/e2e/env/config/jest-puppeteer.config.js
@@ -14,8 +14,8 @@ if ( 'no' == global.process.env.node_config_dev ) {
 	puppeteerConfig = {
 		launch: {
 			...jestPuppeteerConfig.launch,
-			slowMo: process.env.PUPPETEER_SLOWMO ? false : 50,
-			headless: process.env.PUPPETEER_HEADLESS || false,
+			slowMo: process.env.PUPPETEER_SLOWMO ? process.env.PUPPETEER_SLOWMO : 50,
+			headless: false,
 			ignoreHTTPSErrors: true,
 			args: [ '--window-size=1920,1080', '--user-agent=chrome' ],
 			devtools: true,

--- a/tests/e2e/env/config/jest-puppeteer.config.js
+++ b/tests/e2e/env/config/jest-puppeteer.config.js
@@ -14,10 +14,11 @@ if ( 'no' == global.process.env.node_config_dev ) {
 	puppeteerConfig = {
 		launch: {
 			...jestPuppeteerConfig.launch,
+			slowMo: process.env.PUPPETEER_SLOWMO ? false : 50,
+			headless: process.env.PUPPETEER_HEADLESS || false,
 			ignoreHTTPSErrors: true,
 			args: [ '--window-size=1920,1080', '--user-agent=chrome' ],
 			devtools: true,
-			headless: false,
 			defaultViewport: {
 				width: 1280,
 				height: 800,

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -52,6 +52,9 @@ describe( 'Store owner can go through store Setup Wizard', () => {
 
 describe( 'Store owner can go through setup Task List', () => {
 	it( 'can setup shipping', async () => {
+		await page.evaluate( () => {
+			document.querySelector( '.woocommerce-list__item-title' ).scrollIntoView();
+		} );
 		// Query for all tasks on the list
 		const taskListItems = await page.$$( '.woocommerce-list__item-title' );
 		expect( taskListItems ).toHaveLength( 6 );

--- a/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/setup-wizard.test.js
@@ -52,9 +52,6 @@ describe( 'Store owner can go through store Setup Wizard', () => {
 
 describe( 'Store owner can go through setup Task List', () => {
 	it( 'can setup shipping', async () => {
-		await page.evaluate( () => {
-			document.querySelector( '.woocommerce-list__item-title' ).scrollIntoView();
-		} );
 		// Query for all tasks on the list
 		const taskListItems = await page.$$( '.woocommerce-list__item-title' );
 		expect( taskListItems ).toHaveLength( 6 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds the following changes:

1) Adds missing `headless: false` flag back for running e2e tests in `-dev` mode. Without this flag, when running e2e tests in `-dev` mode via `npm run test:e2e-dev` command, the tests would run but without a browser being visible (headless). With the `headless: false` flag added, the e2e tests are being run in a non-headless mode as expected when running the `npm run test:e2e-dev` command. 

2) Added `slowMo` flag back to our Puppeteer config so that e2e tests run in the `-dev` mode could be slowed down by 50 milliseconds by default in order to better understand what is happening in the browser when the tests are running. The speed can be overridden by passing `PUPPETEER_SLOWMO` when running the tests like so: `PUPPETEER_SLOWMO=10 npm run test:e2e-dev`. The slower the value of `PUPPETEER_SLOWMO`, the faster tests will run. Added note to README as well documenting how to use `PUPPETEER_SLOWMO` variable. 

2) Added instructions in the pre-requisites for running the e2e tests section with the requirement of having `nvm` installed and with the appropriate command to be run before running `npm install`. Now need to also run `nvm use`. 

3) Updated the list of commands that need to be run in order to build e2e test env using Docker. 

4) Removed unnecessary instructions from setting up the testing environment section which were related to the older Docker setup that we had. 

5) Added instructions to README on how to run tests using custom WordPress, PHP, and MariaDB versions. 

### How to test the changes in this Pull Request:

1. Make sure you have [NVM installed](https://github.com/nvm-sh/nvm) if you don't have yet. 
2. Once you confirm that NVM is installed, run the following commands to build e2e test environment (the README was updated with the same list of commands as a part of this PR - no more `makepot` file error): 

```
- Run `nvm use`
- Run `npm install`
- Run `composer install --no-dev`
- Run `npm run build:assets`
- Run `npm install jest --global`
- Run `npm run docker:up`
```

3. Run `npm run test:e2e` and confirm that tests are being run in **headless** mode.
4. Run `npm run test:e2e-dev` and confirm that tests are being run in **non-headless** mode.
5. Run `PUPPETEER_SLOWMO=10 npm run test:e2e-dev` and confirm that tests now run faster than in step 4. 
6. Run `PUPPETEER_SLOWMO=300 npm run test:e2e-dev` and confirm that tests now run slower than in step 4.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A because we don't include e2e test PRs into releases therefore no changelog is needed. 
