### PR TITLE
Fix post-merge.sh exit status

### DIFF
--- a/bin/post-merge.sh
+++ b/bin/post-merge.sh
@@ -3,7 +3,10 @@
 changedFiles="$(git diff-tree -r --name-only --no-commit-id ORIG_HEAD HEAD)"
 
 runOnChange() {
-	echo "$changedFiles" | grep -q "$1" && eval "$2"
+	if echo "$changedFiles" | grep -q "$1"
+	then
+		eval "$2"
+	fi
 }
 
 runOnChange "package-lock.json" "npm install"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR tweaks the function runOnChange() to make sure it always returns the correct exit status. Before this change, this function would return 1 instead of 0 when there was no change to composer.lock and package-lock.json in the commits that were merged. This resulted in husky mistakenly reporting a failure when actually the post-merge script succeeded.

Example (see the last line):

```
$ git merge fix/26972
Auto-merging includes/class-wc-install.php
Auto-merging includes/admin/settings/class-wc-settings-advanced.php
Merge made by the 'recursive' strategy.
 includes/admin/settings/class-wc-settings-advanced.php | 23 -----------------------
 includes/class-wc-install.php                          | 12 ------------
 2 files changed, 35 deletions(-)
husky > post-merge (node v10.22.1)
husky > post-merge hook failed (cannot be bypassed with --no-verify due to Git specs)
```

Instead the output should be:

```
git merge fix/26972  
Auto-merging includes/class-wc-install.php
Auto-merging includes/admin/settings/class-wc-settings-advanced.php
Merge made by the 'recursive' strategy.
 includes/admin/settings/class-wc-settings-advanced.php | 23 -----------------------
 includes/class-wc-install.php                          | 12 ------------
 2 files changed, 35 deletions(-)
husky > post-merge (node v10.22.1)
```

### How to test the changes in this Pull Request:

1. While using this branch, merge another branch that doesn't contain changes to `composer.lock` and `package-lock.json`. Check that the merge succeeds and doesn't report an error.
2. Still using this branch, merge another branch that does contain changes to  `composer.lock` and/or `package-lock.json`. Check that Husky correctly runs `composer install` and/or `npm install`.
