### PR TITLE
Bump WC version to 4.7.0

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -22,7 +22,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '4.6.0';
+	public $version = '4.7.0';
 
 	/**
 	 * WooCommerce Schema version.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce",
   "title": "WooCommerce",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "homepage": "https://woocommerce.com/",
   "repository": {
     "type": "git",

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 4.6.0-dev
+ * Version: 4.7.0-dev
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
This PR updates WooCommerce version in the master branch (files `woocommerce.php` and `includes/class-woocommerce.php`) to `4.7.0`. It should be merged once WooCommerce 4.6.0-beta is released this Tuesday.

I'm opting to update the changelog in a separate PR that will be merged directly to the release branch once that is created. This is to avoid including changes to a version that is yet to be released in changelog.txt in master as we point to that file from WP.org.