### PR TITLE
Prepare 4.6.0 changelog

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,46 @@
 == Changelog ==
 
+= 4.6.0-beta - 2020-09-22 =
+
+**WooCommerce**
+
+* Tweak - Removed the "Features" settings page now that the WooCommerce Admin dashboard is enabled by default. #27047
+* Tweak - Deprecate old setup wizard. #26853
+* Tweak - Add WC pages when the plugin is activated now that the old setup wizard was deprecated. #26853
+* Fix - When adding a grouped product to the cart, quantity is passed through the `woocommerce_stock_amount` filter like it's done for simple and variable products. #27219
+* Fix - Several style improvements to notices in theme Twenty Twenty. #27387
+* Fix - Fixed countries list sorting and added support to PHP internationalization functions. #27416
+* Fix - Remove "There are no notes yet" after adding the first one by AJAX. #27449
+* Fix - Fix PHP docblock summary to properly reflect the role of `wc_get_coupon_id_by_code` function. #27453
+* Fix - Fix white space character in add-to-cart script. #27459
+* Fix - Adding missing css property to email templates to ensure header background color is less likely to be overridden by email client. #27525
+* Fix - Encapsulate scope of `c` variable to avoid polluting the global scope and potentially causing problems if other plugins use the same variable name. #27610
+* Fix - Fix bug when using tax classes with some non-ASCII characters. #27615
+* Fix - Paypal gateway: protect code against a fatal error if WooCommerce is unable to communicate with PayPal. #27616
+* Fix - Added WP environment type to tracker. #27685
+* Fix - Prevent fatal errors when trying to determine what is the product type taxonomy term. #27441
+* Fix - Typo in the error message shown in the customizer. #27008
+* Dev - Introduced `woocommerce_return_to_shop_text` filter. #25419
+* Dev - Introduced `woocommerce_cart_item_required_stock_is_not_enough` filter. #26196
+* Dev - Changed relative `include` paths to absolute `include` paths using `__DIR__`. #27433
+* Dev - Fixed duplicated use of `woocommerce_add_$notice_type`. #27437
+* Dev - Allow public access to core capabilities for other plugins. #26976
+* Dev - Add `woocommerce_should_send_no_stock_notification` filter. #27634
+* Dev - New action 'woocommerce_after_order_details' added in a order-details.php template. #26327
+* Localization - Remove duplicated entry for Cyprus when listing countries by continent. #27636
+* Localization - Add Egypt regions. #27495
+* Localization - Updated name for the Hungarian county called Csongrád-Csanád. #27075
+* Localization - Adding states for Benin country. #27217
+* Localization - Add KR locale info. #27496
+* Localization - Fixed the name of the Spain state of `Biscay`. #27548
+
+**WooCommerce Admin - 1.6.0**
+
+Pending an update from Isotope
+
+**WooCommerce Blocks - 3.2.0, 3.3.0 and 3.4.0**
+
+
 = 4.5.2 - 2020-09-14 =
 * Fix - Revert the changes in filtering by attribute that were introduced in WooCommerce 4.4. #27625
 * Fix - Adjusted validation to allow for variations with "0" as an attribute value. #27633

--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,17 @@ Pending an update from Isotope
 
 **WooCommerce Blocks - 3.2.0, 3.3.0 and 3.4.0**
 
+- Fix an undefined variable PHP notice related to Product REST API. [#2962](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2962)
+- Fixed an issue that was making some blocks not to render correctly in the Empty cart template. [#2904](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2904)
+- Fixes a styling issue in the Product Search block in the editor. [#3014](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3014)
+- Improved focus styles of error states on form elements. [#2974](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2974)
+- Deprecate wc.wcSettings.setSetting function. [#3010](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3010)
+- Improve behaviour of draft order cleanup to account for clobbered custom shop order status. [#2912](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/2912)
+- Fixed styling options of the Product Title block (in All Products). [3095](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3095)
+- Fix product reviews schema date fields to use new (WP 5.5) `date-time` format. ([3109](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3109))
+- Use wp_login_url instead of hardcoding login path. ([3090](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3090))
+- Create DebouncedValidatedTextInput component. ([3108](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3108))
+- Merge ProductPrice atomic block and component. ([3065](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3065))
 
 = 4.5.2 - 2020-09-14 =
 * Fix - Revert the changes in filtering by attribute that were introduced in WooCommerce 4.4. #27625

--- a/readme.txt
+++ b/readme.txt
@@ -160,57 +160,6 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 == Changelog ==
 
-= 4.5.2 - 2020-09-14 =
-* Fix - Revert the changes in filtering by attribute that were introduced in WooCommerce 4.4. #27625
-* Fix - Adjusted validation to allow for variations with "0" as an attribute value. #27633
-
-= 4.5.1 - 2020-09-09 =
-
-**WooCommerce**
-* Fix - Check for state and postcode fields only if required in `show_shipping`. #27628
-
-= 4.5.0 - 2020-09-08 =
-
-**WooCommerce**
-* Localization - Added postcode validation for Bosnia and Herzegovina. #27048
-* Localization - Added the postcode validation for Liechtenstein. #27059
-* Localization - Add i18n locale information for Liechtenstein, Switzerland and Austria. #27193
-* Tweak - Increase priority of `admin_body_class` filter to avoid comflict with plugins that incorrectly remove all body classes from WP. #27426
-* Tweak - Rename built-in PayPal payment method to PayPal Standard. #27468
-* Fix - Remove whitespace within a link. #26897
-* Fix - `get_review_count_for_product` return all comments count not only 'review' types #26928
-* Fix - Hidden field type is now supported by `woocommerce_form_field`. #27023
-* Fix - Remove state for country liechtenstein. #27057
-* Fix - Fixed validation of variation attributes while adding products to the cart. #27115
-* Fix - Coupon code inconsistent between admins and shop owners. #27140
-* Fix - Fixed the logic behind "Hide shipping costs until an address is entered". #27143
-* Fix - Searches for variations now will fallback to parent SKU if one is not entered. #27171
-* Fix - Release coupon holds for cancelled orders previously in pending status. #27179
-* Fix - Fixes Japan zip code format issue (dash is now optional). #27244
-* Fix - Restore backward compatibility with WC 4.x and forward compatibility with WC 5.5. #27318
-* Fix - Switch to site locale before translating refund reason. #27323
-* Fix - Declare `WC_Post_Types::updated_term_messages` as a static method to remove PHP deprecation warning. #27436
-* Fix - Allow HTML to be entered in product title for formatting purposes. #27465
-* Fix - Filter by attribute widget not working properly for variations having attribute values of "Any...". #27508
-* Fix - Fixed the layout of the variations and attributes sections in the product page in the admin when running WP >= 5.5. #27590
-* Dev - Added additional stock-based cart filters including `woocommerce_cart_product_cannot_add_another_message`, `woocommerce_cart_product_out_of_stock_message`, and `woocommerce_cart_product_not_enough_stock_message`. #26439
-* Dev - Changed text domain to `woocommerce` for REST API files. #27248
-* Dev - Added file path to the `woocommerce_file_download_method` filter. #27152
-* Dev - Merge API Package into core. #27100
-
-**WooCommerce Admin 1.5.0**
-* Enhancement - Add eWAY to Payment Setup for AU/NZ Stores. #4947
-* Fix - Use clipRule and fillRule props. #4889, part of #4864
-* Fix - Admin order page shipping label prompt compatibility with WCS 1.24. #5025
-* Dev - New notification: Don't forget to test your checkout. #4805
-* Dev - Enable tax calculation before redirecting to standard tax rates page. #4878
-* Dev - Added event recording to Orders, Stock, and Reviews panels. #4861
-* Dev - Added personalization to purchase extension task. #4849
-* Dev - Display modal with more info about the new homescreen. #4890
-* Dev - Task list - add a shortcut back to store setup. #4853
-* Dev - Update the colors of the illustrations in the welcome modal. #4945
-[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce/master/changelog.txt).
-
 == Upgrade Notice ==
 
 = 4.0 =

--- a/readme.txt
+++ b/readme.txt
@@ -160,11 +160,11 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 == Changelog ==
 
-== Upgrade Notice ==
-
 = 4.7.0 - 2020-11-xx =
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce/master/changelog.txt).
+
+== Upgrade Notice ==
 
 = 4.0 =
 4.0 is a major update. Make a full site backup, update your theme and extensions, and [review update best practices](https://docs.woocommerce.com/document/how-to-update-your-site) before upgrading.

--- a/readme.txt
+++ b/readme.txt
@@ -162,5 +162,9 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 == Upgrade Notice ==
 
+= 4.7.0 - 2020-11-xx =
+
+[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce/master/changelog.txt).
+
 = 4.0 =
 4.0 is a major update. Make a full site backup, update your theme and extensions, and [review update best practices](https://docs.woocommerce.com/document/how-to-update-your-site) before upgrading.


### PR DESCRIPTION
This PR adds the WooCommerce 4.6.0 changelog to changelog.txt. We are still waiting for the changelog for WooCommerce Admin 1.6.0 which is included in this version. It should be finished by Monday. I also removed WooCommerce 4.5.0 changelog from readme.txt to help us remember to copy the WC 4.6.0 changelog from changelog.txt to readme.txt once the changes from WooCommerce Admin are included.

For now I'm using `master` as the base branch of this PR, but my plan is to change the base branch to `release/4.6` once that branch is created before merging this PR.