### PR TITLE
Introduced fine-grained cultural adaptation for Jamaican-based WooCommerce stores

### DIFF
--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -159,7 +159,7 @@ return array(
 		'thousand_sep'   => ',',
 		'decimal_sep'    => '.',
 		'num_decimals'   => 2,
-		'weight_unit'    => 'lb',
+		'weight_unit'    => 'lbs',
 		'dimension_unit' => 'in',
 	),
 	'JP' => array(

--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -153,6 +153,15 @@ return array(
 		'weight_unit'    => 'kg',
 		'dimension_unit' => 'cm',
 	),
+	'JM' => array(
+		'currency_code'  => 'JMD',
+		'currency_pos'   => 'left',
+		'thousand_sep'   => ',',
+		'decimal_sep'    => '.',
+		'num_decimals'   => 2,
+		'weight_unit'    => 'lb',
+		'dimension_unit' => 'in',
+	),
 	'JP' => array(
 		'currency_code'  => 'JPY',
 		'currency_pos'   => 'left',

--- a/i18n/states.php
+++ b/i18n/states.php
@@ -752,6 +752,22 @@ return array(
 	),
 	'IL' => array(),
 	'IM' => array(),
+	'JM' => array( // Jamaica's Parishes. Ref: https://en.wikipedia.org/wiki/ISO_3166-2:JM
+        'JM-01' => __( 'Kingston', 'woocommerce' ),
+        'JM-02' => __( 'Saint Andrew', 'woocommerce' ),
+        'JM-03' => __( 'Saint Thomas', 'woocommerce' ),
+        'JM-04' => __( 'Portland', 'woocommerce' ),
+        'JM-05' => __( 'Saint Mary', 'woocommerce' ),
+        'JM-06' => __( 'Saint Ann', 'woocommerce' ),
+        'JM-07' => __( 'Trelawny', 'woocommerce' ),
+        'JM-08' => __( 'Saint James', 'woocommerce' ),
+        'JM-09' => __( 'Hanover', 'woocommerce' ),
+        'JM-10' => __( 'Westmoreland', 'woocommerce' ),
+        'JM-11' => __( 'Saint Elizabeth', 'woocommerce' ),
+        'JM-12' => __( 'Manchester', 'woocommerce' ),
+        'JM-13' => __( 'Clarendon', 'woocommerce' ),
+        'JM-14' => __( 'Saint Catherine', 'woocommerce' )
+    ),
 
 	/**
 	 * Japan States.

--- a/i18n/states.php
+++ b/i18n/states.php
@@ -753,21 +753,21 @@ return array(
 	'IL' => array(),
 	'IM' => array(),
 	'JM' => array( // Jamaica's Parishes. Ref: https://en.wikipedia.org/wiki/ISO_3166-2:JM
-        'JM-01' => __( 'Kingston', 'woocommerce' ),
-        'JM-02' => __( 'Saint Andrew', 'woocommerce' ),
-        'JM-03' => __( 'Saint Thomas', 'woocommerce' ),
-        'JM-04' => __( 'Portland', 'woocommerce' ),
-        'JM-05' => __( 'Saint Mary', 'woocommerce' ),
-        'JM-06' => __( 'Saint Ann', 'woocommerce' ),
-        'JM-07' => __( 'Trelawny', 'woocommerce' ),
-        'JM-08' => __( 'Saint James', 'woocommerce' ),
-        'JM-09' => __( 'Hanover', 'woocommerce' ),
-        'JM-10' => __( 'Westmoreland', 'woocommerce' ),
-        'JM-11' => __( 'Saint Elizabeth', 'woocommerce' ),
-        'JM-12' => __( 'Manchester', 'woocommerce' ),
-        'JM-13' => __( 'Clarendon', 'woocommerce' ),
-        'JM-14' => __( 'Saint Catherine', 'woocommerce' )
-    ),
+		'JM-01' => __( 'Kingston', 'woocommerce' ),
+		'JM-02' => __( 'Saint Andrew', 'woocommerce' ),
+		'JM-03' => __( 'Saint Thomas', 'woocommerce' ),
+		'JM-04' => __( 'Portland', 'woocommerce' ),
+		'JM-05' => __( 'Saint Mary', 'woocommerce' ),
+		'JM-06' => __( 'Saint Ann', 'woocommerce' ),
+		'JM-07' => __( 'Trelawny', 'woocommerce' ),
+		'JM-08' => __( 'Saint James', 'woocommerce' ),
+		'JM-09' => __( 'Hanover', 'woocommerce' ),
+		'JM-10' => __( 'Westmoreland', 'woocommerce' ),
+		'JM-11' => __( 'Saint Elizabeth', 'woocommerce' ),
+		'JM-12' => __( 'Manchester', 'woocommerce' ),
+		'JM-13' => __( 'Clarendon', 'woocommerce' ),
+		'JM-14' => __( 'Saint Catherine', 'woocommerce' )
+	),
 
 	/**
 	 * Japan States.

--- a/i18n/states.php
+++ b/i18n/states.php
@@ -752,7 +752,7 @@ return array(
 	),
 	'IL' => array(),
 	'IM' => array(),
-	'JM' => array( // Jamaica's Parishes. Ref: https://en.wikipedia.org/wiki/ISO_3166-2:JM
+	'JM' => array( // Jamaica's Parishes. Ref: https://en.wikipedia.org/wiki/ISO_3166-2:JM.
 		'JM-01' => __( 'Kingston', 'woocommerce' ),
 		'JM-02' => __( 'Saint Andrew', 'woocommerce' ),
 		'JM-03' => __( 'Saint Thomas', 'woocommerce' ),
@@ -766,7 +766,7 @@ return array(
 		'JM-11' => __( 'Saint Elizabeth', 'woocommerce' ),
 		'JM-12' => __( 'Manchester', 'woocommerce' ),
 		'JM-13' => __( 'Clarendon', 'woocommerce' ),
-		'JM-14' => __( 'Saint Catherine', 'woocommerce' )
+		'JM-14' => __( 'Saint Catherine', 'woocommerce' ),
 	),
 
 	/**

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -520,6 +520,7 @@ class WC_Countries {
 					'IN'      => "{company}\n{name}\n{address_1}\n{address_2}\n{city} {postcode}\n{state}, {country}",
 					'IS'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'IT'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode}\n{city}\n{state_upper}\n{country}",
+					'JM'      => "{name}\n{company}\n{address_1}\n{address_2}\n{city}\n{state}\n{postcode_upper}\n{country}",
 					'JP'      => "{postcode}\n{state} {city} {address_1}\n{address_2}\n{company}\n{last_name} {first_name}\n{country}",
 					'TW'      => "{company}\n{last_name} {first_name}\n{address_1}\n{address_2}\n{state}, {city} {postcode}\n{country}",
 					'LI'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
@@ -1059,6 +1060,19 @@ class WC_Countries {
 						'state'    => array(
 							'required' => true,
 							'label'    => __( 'Province', 'woocommerce' ),
+						),
+					),
+					'JM' => array(
+						'city'     => array(
+							'label' => __( 'Town / City / Post Office', 'woocommerce' ),
+						),
+						'postcode' => array(
+							'required' => false,
+							'label'    => __( 'Postal Code', 'woocommerce' ),
+						),
+						'state'    => array(
+							'required' => true,
+							'label'    => __( 'Parish', 'woocommerce' ),
 						),
 					),
 					'JP' => array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Updated locale information to reflect Jamaica's primary use of Pounds (lbs) and Inch (in) for measurements.
- Updated states array to reflect Jamaica's 14 parishes.
- Updated country specific address naming/formatting rules and the non-requirement of a Postal Code.

### How to test the changes in this Pull Request:

1. Set Jamaica as your store's country in the WooCommerce onboarding wizard to see the appropriate default measurement units.
2. Add a product to your cart and proceed to checkout. Select Jamaica as your billing/shipping country to see address naming scheme reflected and states/parishes listed.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Improved support for stores located in Jamaica.
