### PR TITLE
Improve API performance by only fetching required fields.

### DIFF
--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -930,7 +930,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			$cache_keys_mapping[ $order_id ] = WC_Cache_Helper::get_cache_prefix( 'orders' ) . 'refunds' . $order_id;
 		}
 		$non_cached_ids = array();
-		$cache_values = wp_cache_get_multiple( array_values( $cache_keys_mapping ), 'orders' );
+		$cache_values = wc_cache_get_multiple( array_values( $cache_keys_mapping ), 'orders' );
 		foreach ( $order_ids as $order_id ) {
 			if ( false === $cache_values[ $cache_keys_mapping[ $order_id ] ] ) {
 				$non_cached_ids[] = $order_id;
@@ -996,7 +996,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 			},
 			$order_ids
 		);
-		$cache_values = wp_cache_get_multiple( $cache_keys, 'orders' );
+		$cache_values = wc_cache_get_multiple( $cache_keys, 'orders' );
 		$non_cached_ids = array();
 		foreach ( $order_ids as $order_id ) {
 			if ( false === $cache_values[ 'order-items-' . $order_id ] ) {
@@ -1049,7 +1049,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		foreach ( $order_ids as $order_id ) {
 			$cache_keys_mapping[ $order_id ] = WC_Order::generate_meta_cache_key( $order_id, 'orders' );
 		}
-		$cache_values = wp_cache_get_multiple( array_values( $cache_keys_mapping ), 'orders' );
+		$cache_values = wc_cache_get_multiple( array_values( $cache_keys_mapping ), 'orders' );
 		$non_cached_ids = array();
 		foreach ( $order_ids as $order_id ) {
 			if ( false === $cache_values[ $cache_keys_mapping[ $order_id ] ] ) {

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -637,74 +637,202 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 		if ( $request instanceof WP_REST_Request ) {
 			$fields = $this->get_fields_for_response( $request );
 		}
-		$base_data = array(
-			'id'                    => $product->get_id(),
-			'name'                  => $product->get_name( $context ),
-			'slug'                  => $product->get_slug( $context ),
-			'permalink'             => $product->get_permalink(),
-			'date_created'          => wc_rest_prepare_date_response( $product->get_date_created( $context ), false ),
-			'date_created_gmt'      => wc_rest_prepare_date_response( $product->get_date_created( $context ) ),
-			'date_modified'         => wc_rest_prepare_date_response( $product->get_date_modified( $context ), false ),
-			'date_modified_gmt'     => wc_rest_prepare_date_response( $product->get_date_modified( $context ) ),
-			'type'                  => $product->get_type(),
-			'status'                => $product->get_status( $context ),
-			'featured'              => $product->is_featured(),
-			'catalog_visibility'    => $product->get_catalog_visibility( $context ),
-			'description'           => 'view' === $context ? wpautop( do_shortcode( $product->get_description() ) ) : $product->get_description( $context ),
-			'short_description'     => 'view' === $context ? apply_filters( 'woocommerce_short_description', $product->get_short_description() ) : $product->get_short_description( $context ),
-			'sku'                   => $product->get_sku( $context ),
-			'price'                 => $product->get_price( $context ),
-			'regular_price'         => $product->get_regular_price( $context ),
-			'sale_price'            => $product->get_sale_price( $context ) ? $product->get_sale_price( $context ) : '',
-			'date_on_sale_from'     => wc_rest_prepare_date_response( $product->get_date_on_sale_from( $context ), false ),
-			'date_on_sale_from_gmt' => wc_rest_prepare_date_response( $product->get_date_on_sale_from( $context ) ),
-			'date_on_sale_to'       => wc_rest_prepare_date_response( $product->get_date_on_sale_to( $context ), false ),
-			'date_on_sale_to_gmt'   => wc_rest_prepare_date_response( $product->get_date_on_sale_to( $context ) ),
-			'on_sale'               => $product->is_on_sale( $context ),
-			'purchasable'           => $product->is_purchasable(),
-			'total_sales'           => $product->get_total_sales( $context ),
-			'virtual'               => $product->is_virtual(),
-			'downloadable'          => $product->is_downloadable(),
-			'downloads'             => $this->get_downloads( $product ),
-			'download_limit'        => $product->get_download_limit( $context ),
-			'download_expiry'       => $product->get_download_expiry( $context ),
-			'external_url'          => $product->is_type( 'external' ) ? $product->get_product_url( $context ) : '',
-			'button_text'           => $product->is_type( 'external' ) ? $product->get_button_text( $context ) : '',
-			'tax_status'            => $product->get_tax_status( $context ),
-			'tax_class'             => $product->get_tax_class( $context ),
-			'manage_stock'          => $product->managing_stock(),
-			'stock_quantity'        => $product->get_stock_quantity( $context ),
-			'in_stock'              => $product->is_in_stock(),
-			'backorders'            => $product->get_backorders( $context ),
-			'backorders_allowed'    => $product->backorders_allowed(),
-			'backordered'           => $product->is_on_backorder(),
-			'sold_individually'     => $product->is_sold_individually(),
-			'weight'                => $product->get_weight( $context ),
-			'dimensions'            => array(
-				'length' => $product->get_length( $context ),
-				'width'  => $product->get_width( $context ),
-				'height' => $product->get_height( $context ),
-			),
-			'shipping_required'     => $product->needs_shipping(),
-			'shipping_taxable'      => $product->is_shipping_taxable(),
-			'shipping_class'        => $product->get_shipping_class(),
-			'shipping_class_id'     => $product->get_shipping_class_id( $context ),
-			'reviews_allowed'       => $product->get_reviews_allowed( $context ),
-			'average_rating'        => 'view' === $context ? wc_format_decimal( $product->get_average_rating(), 2 ) : $product->get_average_rating( $context ),
-			'rating_count'          => $product->get_rating_count(),
-			'upsell_ids'            => array_map( 'absint', $product->get_upsell_ids( $context ) ),
-			'cross_sell_ids'        => array_map( 'absint', $product->get_cross_sell_ids( $context ) ),
-			'parent_id'             => $product->get_parent_id( $context ),
-			'purchase_note'         => 'view' === $context ? wpautop( do_shortcode( wp_kses_post( $product->get_purchase_note() ) ) ) : $product->get_purchase_note( $context ),
-			'categories'            => $this->get_taxonomy_terms( $product ),
-			'tags'                  => $this->get_taxonomy_terms( $product, 'tag' ),
-			'images'                => $this->get_images( $product ),
-			'attributes'            => $this->get_attributes( $product ),
-			'default_attributes'    => $this->get_default_attributes( $product ),
-			'variations'            => array(),
-			'grouped_products'      => array(),
-			'menu_order'            => $product->get_menu_order( $context ),
-		);
+		$base_data = array();
+		foreach ( $fields as $field ) {
+			switch ( $field ) {
+				case 'id':
+					$base_data['id'] = $product->get_id();
+					break;
+				case 'name':
+					$base_data['name'] = $product->get_name( $context );
+					break;
+				case 'slug':
+					$base_data['slug'] = $product->get_slug( $context );
+					break;
+
+				case 'permalink':
+					$base_data['permalink'] = $product->get_permalink();
+					break;
+				case 'date_created':
+					$base_data['date_created'] = wc_rest_prepare_date_response( $product->get_date_created( $context ), false );
+					break;
+				case 'date_created_gmt':
+					$base_data['date_created_gmt'] = wc_rest_prepare_date_response( $product->get_date_created( $context ) );
+					break;
+				case 'date_modified':
+					$base_data['date_modified'] = wc_rest_prepare_date_response( $product->get_date_modified( $context ), false );
+					break;
+				case 'date_modified_gmt':
+					$base_data['date_modified_gmt'] = wc_rest_prepare_date_response( $product->get_date_modified( $context ) );
+					break;
+				case 'type':
+					$base_data['type'] = $product->get_type();
+					break;
+				case 'status':
+					$base_data['status'] = $product->get_status( $context );
+					break;
+				case 'featured':
+					$base_data['featured'] = $product->is_featured();
+					break;
+				case 'catalog_visibility':
+					$base_data['catalog_visibility'] = $product->get_catalog_visibility( $context );
+					break;
+				case 'description':
+					$base_data['description'] = 'view' === $context ? wpautop( do_shortcode( $product->get_description() ) ) : $product->get_description( $context );
+					break;
+				case 'short_description':
+					$base_data['short_description'] = 'view' === $context ? apply_filters( 'woocommerce_short_description', $product->get_short_description() ) : $product->get_short_description( $context );
+					break;
+				case 'sku':
+					$base_data['sku'] = $product->get_sku( $context );
+					break;
+				case 'price':
+					$base_data['price'] = $product->get_price( $context );
+					break;
+				case 'regular_price':
+					$base_data['regular_price'] = $product->get_regular_price( $context );
+					break;
+				case 'sale_price':
+					$base_data['sale_price'] = $product->get_sale_price( $context ) ? $product->get_sale_price( $context ) : '';
+					break;
+				case 'date_on_sale_from':
+					$base_data['date_on_sale_from'] = wc_rest_prepare_date_response( $product->get_date_on_sale_from( $context ), false );
+					break;
+				case 'date_on_sale_from_gmt':
+					$base_data['date_on_sale_from_gmt'] = wc_rest_prepare_date_response( $product->get_date_on_sale_from( $context ) );
+					break;
+				case 'date_on_sale_to':
+					$base_data['date_on_sale_to'] = wc_rest_prepare_date_response( $product->get_date_on_sale_to( $context ), false );
+					break;
+				case 'date_on_sale_to_gmt':
+					$base_data['date_on_sale_to_gmt'] = wc_rest_prepare_date_response( $product->get_date_on_sale_to( $context ) );
+					break;
+				case 'on_sale':
+					$base_data['on_sale'] = $product->is_on_sale( $context );
+					break;
+				case 'purchasable':
+					$base_data['purchasable'] = $product->is_purchasable();
+					break;
+				case 'total_sales':
+					$base_data['total_sales'] = $product->get_total_sales( $context );
+					break;
+				case 'virtual':
+					$base_data['virtual'] = $product->is_virtual();
+					break;
+				case 'downloadable':
+					$base_data['downloadable'] = $product->is_downloadable();
+					break;
+				case 'downloads':
+					$base_data['downloads'] = $this->get_downloads( $product );
+					break;
+				case 'download_limit':
+					$base_data['download_limit'] = $product->get_download_limit( $context );
+					break;
+				case 'download_expiry':
+					$base_data['download_expiry'] = $product->get_download_expiry( $context );
+					break;
+				case 'external_url':
+					$base_data['external_url'] = $product->is_type( 'external' ) ? $product->get_product_url( $context ) : '';
+					break;
+				case 'button_text':
+					$base_data['button_text'] = $product->is_type( 'external' ) ? $product->get_button_text( $context ) : '';
+					break;
+				case 'tax_status':
+					$base_data['tax_status'] = $product->get_tax_status( $context );
+					break;
+				case 'tax_class':
+					$base_data['tax_class'] = $product->get_tax_class( $context );
+					break;
+				case 'manage_stock':
+					$base_data['manage_stock'] = $product->managing_stock();
+					break;
+				case 'stock_quantity':
+					$base_data['stock_quantity'] = $product->get_stock_quantity( $context );
+					break;
+				case 'in_stock':
+					$base_data['in_stock'] = $product->is_in_stock();
+					break;
+				case 'backorders':
+					$base_data['backorders'] = $product->get_backorders( $context );
+					break;
+				case 'backorders_allowed':
+					$base_data['backorders_allowed'] = $product->backorders_allowed();
+					break;
+				case 'backordered':
+					$base_data['backordered'] = $product->is_on_backorder();
+					break;
+				case 'sold_individually':
+					$base_data['sold_individually'] = $product->is_sold_individually();
+					break;
+				case 'weight':
+					$base_data['weight'] = $product->get_weight( $context );
+					break;
+				case 'dimensions':
+					$base_data['dimensions'] = array(
+						'length' => $product->get_length( $context ),
+						'width'  => $product->get_width( $context ),
+						'height' => $product->get_height( $context ),
+					);
+					break;
+				case 'shipping_required':
+					$base_data['shipping_required'] = $product->needs_shipping();
+					break;
+				case 'shipping_taxable':
+					$base_data['shipping_taxable'] = $product->is_shipping_taxable();
+					break;
+				case 'shipping_class':
+					$base_data['shipping_class'] = $product->get_shipping_class();
+					break;
+				case 'shipping_class_id':
+					$base_data['shipping_class_id'] = $product->get_shipping_class_id( $context );
+					break;
+				case 'reviews_allowed':
+					$base_data['reviews_allowed'] = $product->get_reviews_allowed( $context );
+					break;
+				case 'average_rating':
+					$base_data['average_rating'] = 'view' === $context ? wc_format_decimal( $product->get_average_rating(), 2 ) : $product->get_average_rating( $context );
+					break;
+				case 'rating_count':
+					$base_data['rating_count'] = $product->get_rating_count();
+					break;
+				case 'upsell_ids':
+					$base_data['upsell_ids'] = array_map( 'absint', $product->get_upsell_ids( $context ) );
+					break;
+				case 'cross_sell_ids':
+					$base_data['cross_sell_ids'] = array_map( 'absint', $product->get_cross_sell_ids( $context ) );
+					break;
+				case 'parent_id':
+					$base_data['parent_id'] = $product->get_parent_id( $context );
+					break;
+				case 'purchase_note':
+					$base_data['purchase_note'] = 'view' === $context ? wpautop( do_shortcode( wp_kses_post( $product->get_purchase_note() ) ) ) : $product->get_purchase_note( $context );
+					break;
+				case 'categories':
+					$base_data['categories'] = $this->get_taxonomy_terms( $product );
+					break;
+				case 'tags':
+					$base_data['tags'] = $this->get_taxonomy_terms( $product, 'tag' );
+					break;
+				case 'images':
+					$base_data['images'] = $this->get_images( $product );
+					break;
+				case 'attributes':
+					$base_data['attributes'] = $this->get_attributes( $product );
+					break;
+				case 'default_attributes':
+					$base_data['default_attributes'] = $this->get_default_attributes( $product );
+					break;
+				case 'variations':
+					$base_data['variations'] = array();
+					break;
+				case 'grouped_products':
+					$base_data['grouped_products'] = array();
+					break;
+				case 'menu_order':
+					$base_data['menu_order'] = $product->get_menu_order( $context );
+					break;
+			}
+		}
 
 		$data = array_merge(
 			$base_data,

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -159,8 +159,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	 */
 	public function prepare_object_for_response( $object, $request ) {
 		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$fields  = $this->get_fields_for_response( $request );
-		$data    = $this->get_product_data( $object, $context, $fields );
+		$data    = $this->get_product_data( $object, $context, $request );
 
 		// Add variations to variable products.
 		if ( $object->is_type( 'variable' ) && $object->has_child() ) {
@@ -626,14 +625,18 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Get product data.
 	 *
-	 * @param WC_Product $product Product instance.
-	 * @param string     $context Request context.
-	 *                            Options: 'view' and 'edit'.
-	 * @param array      $fields  List of fields to fetch. If empty, then all fields will be returned.
+	 * @param WC_Product      $product Product instance.
+	 * @param string          $context Request context. Options: 'view' and 'edit'.
+	 * @param WP_REST_Request $request Current request object. For backward compatibility, we pass this argument silently.
 	 *
 	 * @return array
 	 */
-	protected function get_product_data( $product, $context = 'view', $fields = array() ) {
+	protected function get_product_data( $product, $context = 'view' ) {
+		$fields = array();
+		$request = func_get_arg( 2 );
+		if ( $request instanceof WP_REST_Request ) {
+			$fields = $this->get_fields_for_response( $request );
+		}
 		$base_data = array(
 			'id'                    => $product->get_id(),
 			'name'                  => $product->get_name( $context ),

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -517,6 +517,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 		$properties = isset( $schema['properties'] ) ? $schema['properties'] : array();
 
 		$additional_fields = $this->get_additional_fields();
+
 		foreach ( $additional_fields as $field_name => $field_options ) {
 			// For back-compat, include any field with an empty schema
 			// because it won't be present in $this->get_item_schema().
@@ -560,8 +561,8 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 				}
 				// Check for nested fields if $field is not a direct match.
 				$nested_fields = explode( '.', $field );
-				// A nested field is included so long as its top-level property is
-				// present in the schema.
+				// A nested field is included so long as its top-level property
+				// is present in the schema.
 				if ( in_array( $nested_fields[0], $fields, true ) ) {
 					$response_fields[] = $field;
 				}

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-controller.php
@@ -533,6 +533,7 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 		if ( isset( $this->_fields ) && is_array( $this->_fields ) && $request === $this->_request ) {
 			return $this->_fields;
 		}
+		$this->_request = $request;
 
 		$schema     = $this->get_item_schema();
 		$properties = isset( $schema['properties'] ) ? $schema['properties'] : array();
@@ -560,10 +561,12 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 		$fields = array_keys( $properties );
 
 		if ( ! isset( $request['_fields'] ) ) {
+			$this->_fields = $fields;
 			return $fields;
 		}
 		$requested_fields = wp_parse_list( $request['_fields'] );
 		if ( 0 === count( $requested_fields ) ) {
+			$this->_fields = $fields;
 			return $fields;
 		}
 		// Trim off outside whitespace from the comma delimited list.
@@ -591,7 +594,6 @@ abstract class WC_REST_Controller extends WP_REST_Controller {
 			},
 			array()
 		);
-		$this->_request = $request;
 		return $this->_fields;
 	}
 }

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -480,6 +480,24 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	}
 
 	/**
+	 * Get fields for an object if getter is defined.
+	 *
+	 * @param object $object  Object we are fetching response for.
+	 * @param string $context Context of the request. Can be `view` or `edit`.
+	 * @param array  $fields  List of fields to fetch.
+	 * @return array Data fetched from getters.
+	 */
+	public function fetch_fields_using_getters( $object, $context, $fields ) {
+		$data = array();
+		foreach ( $fields as $field ) {
+			if ( method_exists( $this, "api_get_$field" ) ) {
+				$data[ $field ] = $this->{"api_get_$field"}( $object, $context );
+			}
+		}
+		return $data;
+	}
+
+	/**
 	 * Prepare links for the request.
 	 *
 	 * @param WC_Data         $object  Object data.

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -25,6 +25,25 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	 */
 	protected $namespace = 'wc/v3';
 
+
+	/**
+	 * Get Orders.
+	 *
+	 * @param  array $query_args Query args.
+	 *
+	 * @return array Products.
+	 */
+	protected function get_objects( $query_args ) {
+		$query_args['paginate'] = true;
+		$results                = wc_get_orders( $query_args );
+
+		return array(
+			'objects' => $results->orders,
+			'total'   => $results->total,
+			'pages'   => $results->max_num_pages,
+		);
+	}
+
 	/**
 	 * Calculate coupons.
 	 *

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1327,10 +1327,12 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @param string     $context Request context.
 	 *                            Options: 'view' and 'edit'.
 	 * @param array      $fields  List of fields to fetch. If empty, then all fields will be returned.
+	 *                            For backward compatibility, we pass this argument silently.
 	 * @return array
 	 */
-	protected function get_product_data( $product, $context = 'view', $fields = array() ) {
-		$data = parent::get_product_data( $product, $context, $fields );
+	protected function get_product_data( $product, $context = 'view' ) {
+		$request = func_get_arg( 2 );
+		$data = parent::get_product_data( $product, $context, $request );
 
 		// Replace in_stock with stock_status.
 		$pos             = array_search( 'in_stock', array_keys( $data ), true );

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1326,10 +1326,11 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * @param WC_Product $product Product instance.
 	 * @param string     $context Request context.
 	 *                            Options: 'view' and 'edit'.
+	 * @param array      $fields  List of fields to fetch. If empty, then all fields will be returned.
 	 * @return array
 	 */
-	protected function get_product_data( $product, $context = 'view' ) {
-		$data = parent::get_product_data( $product, $context );
+	protected function get_product_data( $product, $context = 'view', $fields = array() ) {
+		$data = parent::get_product_data( $product, $context, $fields );
 
 		// Replace in_stock with stock_status.
 		$pos             = array_search( 'in_stock', array_keys( $data ), true );

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -218,6 +218,25 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	}
 
 	/**
+	 * Get products.
+	 *
+	 * @param  array $query_args Query args.
+	 *
+	 * @return array Products.
+	 */
+	protected function get_objects( $query_args ) {
+		$query_args['paginate'] = true;
+		$query_args['return']   = 'objects';
+		$results                = wc_get_products( $query_args );
+
+		return array(
+			'objects' => $results->products,
+			'total'   => $results->total,
+			'pages'   => $results->max_num_pages,
+		);
+	}
+
+	/**
 	 * Set product images.
 	 *
 	 * @throws WC_REST_Exception REST API exceptions.
@@ -1336,9 +1355,12 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 		// Replace in_stock with stock_status.
 		$pos             = array_search( 'in_stock', array_keys( $data ), true );
-		$array_section_1 = array_slice( $data, 0, $pos, true );
-		$array_section_2 = array_slice( $data, $pos + 1, null, true );
+		if ( false !== $pos ) {
+			$array_section_1 = array_slice( $data, 0, $pos, true );
+			$array_section_2 = array_slice( $data, $pos + 1, null, true );
+			$data =  $array_section_1 + array( 'stock_status' => $product->get_stock_status( $context ) ) + $array_section_2;
+		}
 
-		return $array_section_1 + array( 'stock_status' => $product->get_stock_status( $context ) ) + $array_section_2;
+		return $data;
 	}
 }

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2484,3 +2484,23 @@ function wc_is_running_from_async_action_scheduler() {
 	// phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	return isset( $_REQUEST['action'] ) && 'as_async_request_queue_runner' === $_REQUEST['action'];
 }
+
+/**
+ * Polyfill for wp_cache_get_multiple for WP versions before 5.5.
+ *
+ * @param array  $keys   Array of keys to get from group.
+ * @param string $group  Optional. Where the cache contents are grouped. Default empty.
+ * @param bool   $force  Optional. Whether to force an update of the local cache from the persistent
+ *                            cache. Default false.
+ * @return array|bool Array of values.
+ */
+function wc_cache_get_multiple( $keys, $group = '', $force = false ) {
+	if ( function_exists( 'wp_cache_get_multiple' ) ) {
+		return wp_cache_get_multiple( $keys, $group, $force );
+	}
+	$values = array();
+	foreach ( $keys as $key ) {
+		$values[ $key ] = wp_cache_get( $key, $group, $force );
+	}
+	return $values;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This needs #27734 as a pre-requisite.

This PR aims to improve the performance of API not fetching fields that are not needed when possible. This is implemented only for orders and product endpoints for now, but if beneficial can be extended to other endpoints as well. 

Benchmark results:
(Note that all these tests are for 100 entries per page, across diffferent pages).

On my local setup (w/o optmized DB, caching etc):
![Screenshot 2020-10-05 at 10 50 03 PM](https://user-images.githubusercontent.com/7571618/95111488-30fa6000-075d-11eb-9bfb-dc0cb5a3de59.png)

On a production site (with heavily optimized DB, caching etc):
![Screenshot 2020-10-05 at 10 49 40 PM](https://user-images.githubusercontent.com/7571618/95111520-3c4d8b80-075d-11eb-85a1-db1c3b6ef6e8.png)

To benchmark I wrote some [K6 benchmarking tests](https://github.com/Automattic/wc-api-performance).

### How to test the changes in this Pull Request:

1. Make sure that the existing Products and Orders API test passes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancements - Fetch only required data from DB when possible in API calls.