### PR TITLE
Update taxonomy template file names to `-`

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -83,7 +83,12 @@ class WC_Template_Loader {
 			$template     = locate_template( $search_files );
 
 			if ( ! $template || WC_TEMPLATE_DEBUG_MODE ) {
-				$template = WC()->plugin_path() . '/templates/' . $default_file;
+				if ( false !== strpos( $default_file, 'product_cat' ) || false !== strpos( $default_file, 'product_tag' ) ) {
+					$cs_template = str_replace('_', '-', $default_file );
+					$template    = WC()->plugin_path() . '/templates/' . $cs_template;
+				} else {
+					$template = WC()->plugin_path() . '/templates/' . $default_file;
+				}
 			}
 		}
 
@@ -149,15 +154,31 @@ class WC_Template_Loader {
 		}
 
 		if ( is_product_taxonomy() ) {
-			$object      = get_queried_object();
-			$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
-			$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
-			$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
-			$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '.php';
+			$object = get_queried_object();
+			if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
+				$cs_taxonomy = str_replace('_', '-', $object->taxonomy );
+				$cs_default  = str_replace('_', '-', $default_file );
+				$templates[] = 'taxonomy-' . $cs_taxonomy . '-' . $object->slug . '.php';
+				$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
+				$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '-' . $object->slug . '.php';
+				$templates[] = 'taxonomy-' . $cs_taxonomy . '.php';
+				$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
+				$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '.php';
+				$templates[] = $cs_default;
+			} else {
+				$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
+				$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
+				$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
+				$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '.php';
+			}
 		}
 
 		$templates[] = $default_file;
-		$templates[] = WC()->template_path() . $default_file;
+		if ( isset( $cs_default ) ) {
+			$templates[] = WC()->template_path() . $cs_default;
+		} else {
+			$templates[] = WC()->template_path() . $default_file;
+		}
 
 		return array_unique( $templates );
 	}

--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -84,7 +84,7 @@ class WC_Template_Loader {
 
 			if ( ! $template || WC_TEMPLATE_DEBUG_MODE ) {
 				if ( false !== strpos( $default_file, 'product_cat' ) || false !== strpos( $default_file, 'product_tag' ) ) {
-					$cs_template = str_replace('_', '-', $default_file );
+					$cs_template = str_replace( '_', '-', $default_file );
 					$template    = WC()->plugin_path() . '/templates/' . $cs_template;
 				} else {
 					$template = WC()->plugin_path() . '/templates/' . $default_file;
@@ -156,8 +156,8 @@ class WC_Template_Loader {
 		if ( is_product_taxonomy() ) {
 			$object = get_queried_object();
 			if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
-				$cs_taxonomy = str_replace('_', '-', $object->taxonomy );
-				$cs_default  = str_replace('_', '-', $default_file );
+				$cs_taxonomy = str_replace( '_', '-', $object->taxonomy );
+				$cs_default  = str_replace( '_', '-', $default_file );
 				$templates[] = 'taxonomy-' . $cs_taxonomy . '-' . $object->slug . '.php';
 				$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
 				$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '-' . $object->slug . '.php';

--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -158,10 +158,8 @@ class WC_Template_Loader {
 			if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
 				$cs_taxonomy = str_replace( '_', '-', $object->taxonomy );
 				$cs_default  = str_replace( '_', '-', $default_file );
-				$templates[] = 'taxonomy-' . $cs_taxonomy . '-' . $object->slug . '.php';
 				$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
 				$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '-' . $object->slug . '.php';
-				$templates[] = 'taxonomy-' . $cs_taxonomy . '.php';
 				$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
 				$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '.php';
 				$templates[] = $cs_default;
@@ -176,9 +174,8 @@ class WC_Template_Loader {
 		$templates[] = $default_file;
 		if ( isset( $cs_default ) ) {
 			$templates[] = WC()->template_path() . $cs_default;
-		} else {
-			$templates[] = WC()->template_path() . $default_file;
 		}
+		$templates[] = WC()->template_path() . $default_file;
 
 		return array_unique( $templates );
 	}

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -400,7 +400,7 @@ function wc_locate_template( $template_name, $template_path = '', $default_path 
 	if ( empty( $template ) ) {
 		$template = locate_template(
 			array(
-				trailingslashit($template_path) . $template_name,
+				trailingslashit( $template_path ) . $template_name,
 				$template_name,
 			)
 		);

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -387,16 +387,32 @@ function wc_locate_template( $template_name, $template_path = '', $default_path 
 	}
 
 	// Look within passed path within the theme - this is priority.
-	$template = locate_template(
-		array(
-			trailingslashit( $template_path ) . $template_name,
-			$template_name,
-		)
-	);
+	if ( false !== strpos( $template_name, 'product_cat' ) || false !== strpos( $template_name, 'product_tag' ) ) {
+		$cs_template = str_replace( '_', '-', $template_name );
+		$template = locate_template(
+			array(
+				trailingslashit( $template_path ) . $cs_template,
+				$cs_template,
+			)
+		);
+	}
+
+	if ( empty( $template ) ) {
+		$template = locate_template(
+			array(
+				trailingslashit($template_path) . $template_name,
+				$template_name,
+			)
+		);
+	}
 
 	// Get default template/.
 	if ( ! $template || WC_TEMPLATE_DEBUG_MODE ) {
-		$template = $default_path . $template_name;
+		if ( empty( $cs_template ) ) {
+			$template = $default_path . $template_name;
+		} else {
+			$template = $default_path . $cs_template;
+		}
 	}
 
 	// Return what we found.

--- a/templates/content-product-cat.php
+++ b/templates/content-product-cat.php
@@ -2,7 +2,7 @@
 /**
  * The template for displaying product category thumbnails within loops
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/content-product_cat.php.
+ * This template can be overridden by copying it to yourtheme/woocommerce/content-product-cat.php.
  *
  * HOWEVER, on occasion WooCommerce will need to update template files and you
  * (the theme developer) will need to copy the new files to your theme to
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 2.6.1
+ * @version 4.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {

--- a/templates/content-product-cat.php
+++ b/templates/content-product-cat.php
@@ -22,33 +22,33 @@ if ( ! defined( 'ABSPATH' ) ) {
 <li <?php wc_product_cat_class( '', $category ); ?>>
 	<?php
 	/**
-	 * woocommerce_before_subcategory hook.
+	 * The woocommerce_before_subcategory hook.
 	 *
 	 * @hooked woocommerce_template_loop_category_link_open - 10
 	 */
 	do_action( 'woocommerce_before_subcategory', $category );
 
 	/**
-	 * woocommerce_before_subcategory_title hook.
+	 * The woocommerce_before_subcategory_title hook.
 	 *
 	 * @hooked woocommerce_subcategory_thumbnail - 10
 	 */
 	do_action( 'woocommerce_before_subcategory_title', $category );
 
 	/**
-	 * woocommerce_shop_loop_subcategory_title hook.
+	 * The woocommerce_shop_loop_subcategory_title hook.
 	 *
 	 * @hooked woocommerce_template_loop_category_title - 10
 	 */
 	do_action( 'woocommerce_shop_loop_subcategory_title', $category );
 
 	/**
-	 * woocommerce_after_subcategory_title hook.
+	 * The woocommerce_after_subcategory_title hook.
 	 */
 	do_action( 'woocommerce_after_subcategory_title', $category );
 
 	/**
-	 * woocommerce_after_subcategory hook.
+	 * The woocommerce_after_subcategory hook.
 	 *
 	 * @hooked woocommerce_template_loop_category_link_close - 10
 	 */

--- a/templates/taxonomy-product-cat.php
+++ b/templates/taxonomy-product-cat.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * The Template for displaying products in a product tag. Simply includes the archive template
+ * The Template for displaying products in a product category. Simply includes the archive template
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/taxonomy-product_tag.php.
+ * This template can be overridden by copying it to yourtheme/woocommerce/taxonomy-product-cat.php.
  *
  * HOWEVER, on occasion WooCommerce will need to update template files and you
  * (the theme developer) will need to copy the new files to your theme to
@@ -12,11 +12,11 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     1.6.4
+ * @version     4.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 wc_get_template( 'archive-product.php' );

--- a/templates/taxonomy-product-tag.php
+++ b/templates/taxonomy-product-tag.php
@@ -1,8 +1,8 @@
 <?php
 /**
- * The Template for displaying products in a product category. Simply includes the archive template
+ * The Template for displaying products in a product tag. Simply includes the archive template
  *
- * This template can be overridden by copying it to yourtheme/woocommerce/taxonomy-product_cat.php.
+ * This template can be overridden by copying it to yourtheme/woocommerce/taxonomy-product-tag.php.
  *
  * HOWEVER, on occasion WooCommerce will need to update template files and you
  * (the theme developer) will need to copy the new files to your theme to
@@ -12,11 +12,11 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     1.6.4
+ * @version     4.7.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 wc_get_template( 'archive-product.php' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the `product_tag` & `product_cat` template names to `product-tag` & `product-cat`. It is backward compatible with the `_` template names. Templates with the `-` name are expected to be in the `woocommerce` folder.

Closes #27681 .

### How to test the changes in this Pull Request:

1. Checkout `master`
2. Switch to the Storefront theme
3. Copy the `product_cat` & `product_tag` templates to the Storefront theme
4. Add an `echo __FILE__;` to each copied template
5. Switch to this branch
6. Change your shop page to show categories 
7. Load the shop page, a product category archive, and a product tag archive
8. The full path of the filename(s) should be output into the page
9. Create `storefront/woocommerce` move the copied templates to that folder
10. Reload each of the pages to check for filename
11. Copy the templates from `product_(cat|tag)` to `product-(cat|tag)`
12. Reload each of the pages to check for filename. The `-` files should be loaded

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Update product_cat/tag taxonomy template file names to product-cat/tag. 
