### PR TITLE
Fix taxes endpoint not returning multiple postcodes/cities

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-taxes-controller.php
@@ -24,4 +24,73 @@ class WC_REST_Taxes_Controller extends WC_REST_Taxes_V2_Controller {
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Add tax rate locales to the response array.
+	 *
+	 * @param array    $data Response data.
+	 * @param stdClass $tax  Tax object.
+	 *
+	 * @return array
+	 */
+	protected function add_tax_rate_locales( $data, $tax ) {
+		global $wpdb;
+
+		$data              = parent::add_tax_rate_locales( $data, $tax );
+		$data['postcodes'] = array();
+		$data['cities']    = array();
+
+		// Get locales from a tax rate.
+		$locales = $wpdb->get_results(
+			$wpdb->prepare(
+				"
+				SELECT location_code, location_type
+				FROM {$wpdb->prefix}woocommerce_tax_rate_locations
+				WHERE tax_rate_id = %d
+				",
+				$tax->tax_rate_id
+			)
+		);
+
+		if ( ! is_wp_error( $tax ) && ! is_null( $tax ) ) {
+			foreach ( $locales as $locale ) {
+				if ( 'postcode' === $locale->location_type ) {
+					$data['postcodes'][] = $locale->location_code;
+				} elseif ( 'city' === $locale->location_type ) {
+					$data['cities'][] = $locale->location_code;
+				}
+			}
+		}
+
+		return $data;
+	}
+
+	/**
+	 * Get the taxes schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		$schema = parent::get_item_schema();
+
+		$schema['properties']['postcodes'] = array(
+			'description' => __( 'List of postcodes / ZIPs.', 'woocommerce' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'string',
+			),
+			'context'     => array( 'view', 'edit' ),
+		);
+
+		$schema['properties']['cities'] = array(
+			'description' => __( 'List of city names.', 'woocommerce' ),
+			'type'        => 'array',
+			'items'       => array(
+				'type' => 'string',
+			),
+			'context'     => array( 'view', 'edit' ),
+		);
+
+		return $schema;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The proposed changes allow the `taxes` endpoint to return an array of postcodes/cities for tax rates with multiple (semi-colon separated) postcodes and/or cities in two new keys, `cities` and `postcodes`; the old existing `city` and `postcode` keys are kept for compatibility and will return only one of the available values.

Closes #27750 .

### How to test the changes in this Pull Request:

1. In WooCommerce admin go to Settings - Tax - Standard Rates and create 3 rates: one with no cities or postcodes specified, another one with one city and one postcode, and one with two cities and two postcodes (separate them with a semicolon, `;`).

2. Temporarily add this at the ned of your woocommerce.php file, this way you won't have to bother about REST API authentication: `add_filter('woocommerce_rest_check_permissions', function() {return true;}, 10, 0 );` (note that this will cause a bunch of unit tests to fail)

3. Retrieve the taxes via the `/wp-json/wc/v3/taxes` endpoint and verity that the results are consistent:

For no city and no postcode:

```json
 {
    "postcode": "",
    "city": "",
    "postcodes": [],
    "cities": []
}
```

For one city and postcode:

```json
 {
    "postcode": "1111",
    "city": "OSAKA",
    "postcodes": [
      "1111"
    ],
    "cities": [
      "OSAKA"
    ],
}
```

For two cities and postcodes:

```json
{
    "postcode": "2222",
    "city": "KOBE",
    "postcodes": [
      "1111",
      "2222"
    ],
    "cities": [
      "OSAKA",
      "KOBE"
    ],
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Add array-typed "cities" and "postcodes" to the response of the "tax" endpoint in the REST API to overcome the limitation of "city" and "postcode" returning always one single value.