### PR TITLE
Allow line-breaks in messages of WC_Log_Handler_DB/WC_Admin_Log_Table_List 

### DIFF
--- a/includes/admin/class-wc-admin-log-table-list.php
+++ b/includes/admin/class-wc-admin-log-table-list.php
@@ -167,7 +167,7 @@ class WC_Admin_Log_Table_List extends WP_List_Table {
 	 * @return string
 	 */
 	public function column_message( $log ) {
-		return esc_html( $log['message'] );
+		return nl2br( esc_html( $log['message'] ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

[Wraps the `esc_html( $log['message'] )` call with `nl2br`](https://github.com/Biont/woocommerce/blob/e384670cc2d0d0286ec0b9c0ab2efee7b89f6209/includes/admin/class-wc-admin-log-table-list.php#L170 )  so newlines are transformed into `<br>` tags despite the whole content being escaped.
This allows at least rudimentary formatting of more complex log entries, for example when rendering an exception trace.

### How to test the changes in this Pull Request:

1. `define('WC_LOG_HANDLER', 'WC_Log_Handler_DB');`
2. Log a string that contains a newline `\n` char
3. Observe how the log messages now have newlines as well

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Allow newlines in log messages of `WC_Admin_Log_Table_List`
