### PR TITLE
Fix pre-push hook used by husky

### DIFF
--- a/bin/pre-push.sh
+++ b/bin/pre-push.sh
@@ -4,8 +4,8 @@ PROTECTED_BRANCH="master"
 REMOTE_REF=$(echo "$HUSKY_GIT_STDIN" | cut -d " " -f 3)
 
 if [ -n "$REMOTE_REF" ]; then
-	if [ "refs/heads/${PROTECTED_BRANCH}" == "$REMOTE_REF" ]; then
-		if [ "$TERM" == "dumb" ]; then
+	if [ "refs/heads/${PROTECTED_BRANCH}" = "$REMOTE_REF" ]; then
+		if [ "$TERM" = "dumb" ]; then
 			>&2 echo "Sorry, you are unable to push to master using a GUI client! Please use git CLI."
 			exit 1
 		fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The pre-push hook uses sh but contained syntax that is only supported by bash. In sh `=` should be used instead of `==` to check for string equality. Before this change, we were getting the following error when pushing to any branch:

```
git push
husky > pre-push (node v10.22.1)
./bin/pre-push.sh: 7: [: refs/heads/master: unexpected operator
```

This error didn't block the push, but meant that the message asking developers to confirm if they wanted to push to master was never displayed. This problem was introduced in commit 8c25557bf58be31d2136611bf9916a1d3e9f13f7 added in PR #27028.

### How to test the changes in this Pull Request:

1. On a fork of this repository, test that pushing to any branch produces the error above.
2. Switch to master, merge this branch, and test that the error is gone and instead you see a message asking to confirm that you want to push to master. Test that if you type `n` the push ir aborted and that if you type `y` the push is completed.