### PR TITLE
Remove protection as we already diff and update only if needed.

### DIFF
--- a/includes/admin/wc-admin-functions.php
+++ b/includes/admin/wc-admin-functions.php
@@ -210,7 +210,7 @@ function wc_maybe_adjust_line_item_product_stock( $item, $item_quantity = -1 ) {
 	$item_quantity         = wc_stock_amount( $item_quantity >= 0 ? $item_quantity : $item->get_quantity() );
 	$already_reduced_stock = wc_stock_amount( $item->get_meta( '_reduced_stock', true ) );
 
-	if ( ! $product || ! $product->managing_stock() || ! $already_reduced_stock || $item_quantity === $already_reduced_stock ) {
+	if ( ! $product || ! $product->managing_stock() ) {
 		return false;
 	}
 

--- a/tests/php/includes/class-wc-ajax-test.php
+++ b/tests/php/includes/class-wc-ajax-test.php
@@ -84,5 +84,4 @@ class WC_AJAX_Test extends \WC_Unit_Test_Case {
 			}
 		}
 	}
-
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR restores the earlier behavior from #26642, while also keeping the fix targeted for #26607.

In #26642 we removed adding reduced_stock meta when adding new order item to prevent ghost entries, but in inadvertently exposed an underlying bug where _reduced_stock meta was getting set to 0 if it's empty.

We were then checking the presence of this meta, but also not reducing the stock in case it was not set.

This check is not needed since, in later lines, we check if there is a difference between expected values of _reduced_stock vs what should actually have been reduced. So basically we won't reduce stock for items unless a `_reduced_stock` value is already set. We stopped setting this value in #26642 for items added in the admin view.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27445.

### How to test the changes in this Pull Request:

1. Create a product with a managed inventory.
1. Start creating a new manual order and add the product from step 1.
2. Click on create, stock should be adjusted based on items in the order.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Adjust stock even if `reduce_stock` meta is not set in `wc_maybe_reduce_stock_levels`
