### PR TITLE
disable automatic Chromium download by default

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -158,6 +158,14 @@ For example:
 - `PUPPETEER_SLOWMO=10` - will run tests faster
 - `PUPPETEER_SLOWMO=70` - will run tests slower
 
+By default, the automatic fresh download of Chromium is disabled. To enable this
+
+```
+PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true npm run test:e2e-dev
+```
+
+**Note** This won't prevent Puppeteer downloading Chromium if Chromium isn't installed.
+
 ### How to run an individual test
 
 To run an individual test, use the direct path to the spec. For example:

--- a/tests/e2e/env/bin/e2e-test-integration.js
+++ b/tests/e2e/env/bin/e2e-test-integration.js
@@ -5,7 +5,7 @@ const program = require( 'commander' );
 const path = require( 'path' );
 const fs = require( 'fs' );
 const { getAppRoot } = require( '../utils' );
-const { JEST_PUPPETEER_CONFIG } = process.env;
+const { JEST_PUPPETEER_CONFIG, PUPPETEER_SKIP_CHROMIUM_DOWNLOAD } = process.env;
 
 program
 	.usage( '<file ...> [options]' )
@@ -29,6 +29,7 @@ let testEnvVars = {
 	NODE_CONFIG_DIR: nodeConfigDirs.join( ':' ),
 	node_config_dev: program.dev ? 'yes' : 'no',
 	jest_test_timeout: program.dev ? 120000 : 30000,
+	PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: typeof PUPPETEER_SKIP_CHROMIUM_DOWNLOAD == 'undefined' ? true : PUPPETEER_SKIP_CHROMIUM_DOWNLOAD,
 };
 
 if ( ! JEST_PUPPETEER_CONFIG ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds the default disable `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` on running E2E tests.

Closes #27493 .

### How to test the changes in this Pull Request:

1. Follow the E2E readme instructions for setting up the E2E environment
2. Run `npm run test:e2e-dev`
3. Chromium should not be automatically downloaded
4. Run `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=false npm run test:e2e-dev`
5. Chromium should download


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

