### PR TITLE
Expose automattic/puppeteer-utils in e2e-environment

### DIFF
--- a/tests/e2e/core-tests/specs/activate-and-setup/setup.test.js
+++ b/tests/e2e/core-tests/specs/activate-and-setup/setup.test.js
@@ -11,6 +11,10 @@ const {
 	verifyValueOfInputField
 } = require( '@woocommerce/e2e-utils' );
 
+const {
+	waitAndClick
+} = require( '@woocommerce/e2e-environment' );
+
 /**
  * External dependencies
  */
@@ -50,7 +54,7 @@ const runInitialStoreSettingsTest = () => {
 			await page.click('input[value="/%postname%/"]', {text: ' Post name'});
 
 			// Select "Custom base" in product permalinks section
-			await page.click('#woocommerce_custom_selection');
+			await waitAndClick( page, '#woocommerce_custom_selection' );
 
 			// Fill custom base slug to use
 			await expect(page).toFill('#woocommerce_permalink_structure', '/product/');

--- a/tests/e2e/env/index.js
+++ b/tests/e2e/env/index.js
@@ -14,6 +14,20 @@ const {
 const { getAppRoot, getTestConfig } = require( './utils' );
 const webpackAlias = require( './webpack-alias' );
 
+const {
+	clickAndWaitForNewPage,
+	getAccountCredentials,
+	isEventuallyPresent,
+	isEventuallyVisible,
+	logDebugLog,
+	logHTML,
+	waitAndClick,
+	waitAndType,
+	waitForSelector,
+	scrollIntoView,
+	Page
+} = require( '@automattic/puppeteer-utils' );
+
 module.exports = {
 	babelConfig,
 	esLintConfig,
@@ -26,4 +40,15 @@ module.exports = {
 	getAppRoot,
 	getTestConfig,
 	webpackAlias,
+	clickAndWaitForNewPage,
+	getAccountCredentials,
+	isEventuallyPresent,
+	isEventuallyVisible,
+	logDebugLog,
+	logHTML,
+	waitAndClick,
+	waitAndType,
+	waitForSelector,
+	scrollIntoView,
+	Page,
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27787 .

This PR integrates `@automattic/puppeteer-utils` fully so that its page utilities such as `await waitAndClick( page, titleSelector );` could be used in WooCommerce Core e2e tests: https://github.com/Automattic/puppeteer-utils#page-utilities

The purpose of this PR is to try using `await waitAndClick( page, titleSelector );` only in one of the tests to ensure that functions can be used at all. We will refactor existing tests to use more of these functions throughout in separate PRs. 

In this PR, we are adding the example function in the `setup.test.js` test. 

### How to test the changes in this Pull Request:

1. Make sure `setup.test.js` test runs and passes. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A
