### PR TITLE
Escaping output for field label

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2857,7 +2857,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 			$field_html = '';
 
 			if ( $args['label'] && 'checkbox' !== $args['type'] ) {
-				$field_html .= '<label for="' . esc_attr( $label_id ) . '" class="' . esc_attr( implode( ' ', $args['label_class'] ) ) . '">' . $args['label'] . $required . '</label>';
+				$field_html .= '<label for="' . esc_attr( $label_id ) . '" class="' . esc_attr( implode( ' ', $args['label_class'] ) ) . '">' . wp_kses_post( $args['label'] ) . $required . '</label>';
 			}
 
 			$field_html .= '<span class="woocommerce-input-wrapper">' . $field;


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Many plugins modify the field list for Checkout, e.g. by changing their order or labels. In the event of an SQL Injection attack, there is a possibility of unauthorized saving of the label of the field, which is an infected code. When displaying the label on the page, this data is not filtered in any way.

### How to test the changes in this Pull Request:

1. Use the `woocommerce_checkout_fields` filter to change the field label.
2. Set the HTML code as label: `<script>console.log('Hello World');</script>`.
3. JS code will be executed.

Example:

    add_action( 'woocommerce_checkout_fields', function( $fields ) {  
      $fields['billing']['billing_first_name']['label'] = "<script>console.log('Hello World');</script>";
      return $fields;  
    }, 99999 );

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Escaped labels in `woocommerce_form_field()`.