### PR TITLE
Generalize photoswipe button event target

### DIFF
--- a/plugins/woocommerce/changelog/photoswipe-event-target
+++ b/plugins/woocommerce/changelog/photoswipe-event-target
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Trigger Photoswipe modal when clicking child elements of the trigger element

--- a/plugins/woocommerce/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/legacy/js/frontend/single-product.js
@@ -300,7 +300,7 @@ jQuery( function( $ ) {
 			eventTarget = $( e.target ),
 			clicked;
 
-		if ( eventTarget.is( '.woocommerce-product-gallery__trigger' ) || eventTarget.is( '.woocommerce-product-gallery__trigger img' ) ) {
+		if ( eventTarget.closest( '.woocommerce-product-gallery__trigger' ) !== null ) {
 			clicked = this.$target.find( '.flex-active-slide' );
 		} else {
 			clicked = eventTarget.closest( '.woocommerce-product-gallery__image' );

--- a/plugins/woocommerce/legacy/js/frontend/single-product.js
+++ b/plugins/woocommerce/legacy/js/frontend/single-product.js
@@ -300,7 +300,7 @@ jQuery( function( $ ) {
 			eventTarget = $( e.target ),
 			clicked;
 
-		if ( eventTarget.closest( '.woocommerce-product-gallery__trigger' ) !== null ) {
+		if ( 0 < eventTarget.closest( '.woocommerce-product-gallery__trigger' ).length ) {
 			clicked = this.$target.find( '.flex-active-slide' );
 		} else {
 			clicked = eventTarget.closest( '.woocommerce-product-gallery__image' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This solves a custom theme interoperability issue. I have a theme were the `<a href="#" class="woocommerce-product-gallery__trigger"></a>` button has an SVG child element.

This causes an issue where clicking the SVG element causes the event target to be the `<svg>` not the `<a>`. Since the event target can only be `.woocommerce-product-gallery__trigger` or `.woocommerce-product-gallery__trigger img` the `if` statement on line 303 fails and the valued of `clicked` becomes the first image in the slider.

By ensuring the the event target is (or is a child of) `.woocommerce-product-gallery__trigger` we can let the event propagate up the DOM and still capture it at the `.woocommerce-product-gallery__trigger` element and test to ensure the clicked element is a child.

### How to test the changes in this Pull Request:

1. Create a product with multiple images in the gallery.
2. Click the image open photoswipe modal button.
3. Ensure the image in the modal is the currently active image.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? **N/A**
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Allow custom open photoswipe button inner HTML by generalizing the photoswipe button event target
