### PR TITLE
Add back in activation transient to redirect on install

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -308,6 +308,7 @@ class WC_Install {
 		self::maybe_update_db_version();
 
 		delete_transient( 'wc_installing' );
+		set_transient( '_wc_activation_redirect', 1, 30 );
 
 		do_action( 'woocommerce_flush_rewrite_rules' );
 		do_action( 'woocommerce_installed' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds back in the activation transient that previously existed in WC core.  Allows WooCommerce Admin to control the redirection after install.

Closes #27755

### How to test the changes in this Pull Request:

1. Follow instructions in WCA branch - https://github.com/woocommerce/woocommerce-admin/pull/5214