### PR TITLE
Update woocommerce-admin to 1.6.0-rc.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.6.0-beta.1",
+    "woocommerce/woocommerce-admin": "1.6.0-rc.2",
     "woocommerce/woocommerce-blocks": "3.4.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ddfcf89afffda07ac78adfff8b311224",
+    "content-hash": "09f903e011afa87780182f1d20f5b1b9",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -380,7 +380,7 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.4.44",
+            "version": "v3.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
@@ -468,16 +468,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "1.6.0-beta.1",
+            "version": "1.6.0-rc.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "a03cafd0a218451d83c42285b02f797555a7450e"
+                "reference": "22f1d5f9c0a7e536d395f87d01591eed7c910f14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/a03cafd0a218451d83c42285b02f797555a7450e",
-                "reference": "a03cafd0a218451d83c42285b02f797555a7450e",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/22f1d5f9c0a7e536d395f87d01591eed7c910f14",
+                "reference": "22f1d5f9c0a7e536d395f87d01591eed7c910f14",
                 "shasum": ""
             },
             "require": {
@@ -511,7 +511,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-09-18T15:24:50+00:00"
+            "time": "2020-09-30T16:42:38+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -2424,16 +2424,16 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v3.4.44",
+            "version": "v3.4.45",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "5ec813ccafa8164ef21757e8c725d3a57da59200"
+                "reference": "52140652ed31cee3dabd0c481b5577201fa769b4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/5ec813ccafa8164ef21757e8c725d3a57da59200",
-                "reference": "5ec813ccafa8164ef21757e8c725d3a57da59200",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/52140652ed31cee3dabd0c481b5577201fa769b4",
+                "reference": "52140652ed31cee3dabd0c481b5577201fa769b4",
                 "shasum": ""
             },
             "require": {
@@ -2469,7 +2469,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2020-02-14T07:34:21+00:00"
+            "time": "2020-09-02T16:06:40+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",


### PR DESCRIPTION
Supersedes #27808

This branch pulls in the latest wc-admin package for inclusion in 4.6 RC1

The changelog can be seen at pbIJXs-gV-p2