### PR TITLE
Update the activation transient to only get added on new installs

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -308,7 +308,7 @@ class WC_Install {
 		self::maybe_update_db_version();
 
 		delete_transient( 'wc_installing' );
-		set_transient( '_wc_activation_redirect', 1, 30 );
+		self::maybe_enable_setup_wizard();
 
 		do_action( 'woocommerce_flush_rewrite_rules' );
 		do_action( 'woocommerce_installed' );
@@ -402,6 +402,17 @@ class WC_Install {
 		usort( $update_versions, 'version_compare' );
 
 		return ! is_null( $current_db_version ) && version_compare( $current_db_version, end( $update_versions ), '<' );
+	}
+
+	/**
+	 * See if we need the setup wizard or not.
+	 *
+	 * @since 4.6.0
+	 */
+	private static function maybe_enable_setup_wizard() {
+		if ( self::is_new_install() ) {
+			set_transient( '_wc_activation_redirect', 1, 30 );
+		}
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -304,11 +304,11 @@ class WC_Install {
 		self::create_cron_jobs();
 		self::create_files();
 		self::maybe_create_pages();
+		self::maybe_enable_setup_wizard();
 		self::update_wc_version();
 		self::maybe_update_db_version();
 
 		delete_transient( 'wc_installing' );
-		self::maybe_enable_setup_wizard();
 
 		do_action( 'woocommerce_flush_rewrite_rules' );
 		do_action( 'woocommerce_installed' );

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -304,7 +304,7 @@ class WC_Install {
 		self::create_cron_jobs();
 		self::create_files();
 		self::maybe_create_pages();
-		self::maybe_enable_setup_wizard();
+		self::maybe_set_activation_transients();
 		self::update_wc_version();
 		self::maybe_update_db_version();
 
@@ -405,11 +405,11 @@ class WC_Install {
 	}
 
 	/**
-	 * See if we need the setup wizard or not.
+	 * See if we need to set redirect transients for activation or not.
 	 *
 	 * @since 4.6.0
 	 */
-	private static function maybe_enable_setup_wizard() {
+	private static function maybe_set_activation_transients() {
 		if ( self::is_new_install() ) {
 			set_transient( '_wc_activation_redirect', 1, 30 );
 		}


### PR DESCRIPTION
Follow up to #27806

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This updates the transient introduced in #27806 so that it is only added on new installs.


### How to test the changes in this Pull Request:

1. Install and activate WooCommerce on a new site with this PR applied. Verify that the `_wc_activation_redirect` transient is added at installation.
2. On a site that isn't new, activate WC with this PR applied. Verify that `_wc_activation_redirect` isn't added.

Note: You can test in coordination with https://github.com/woocommerce/woocommerce-admin/pull/5230 to make it easier to verify the transient's existence.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

No changelog needed for this change.
