### PR TITLE
Revert string capitalization to the original version

### DIFF
--- a/templates/cart/cart-empty.php
+++ b/templates/cart/cart-empty.php
@@ -32,7 +32,7 @@ if ( wc_get_page_id( 'shop' ) > 0 ) : ?>
 				 * @since 4.6.0
 				 * @param string $default_text Default text.
 				 */
-				echo esc_html( apply_filters( 'woocommerce_return_to_shop_text', __( 'Return To Shop', 'woocommerce' ) ) );
+				echo esc_html( apply_filters( 'woocommerce_return_to_shop_text', __( 'Return to shop', 'woocommerce' ) ) );
 			?>
 		</a>
 	</p>


### PR DESCRIPTION
### Changes proposed in this Pull Request:

PR #25419 added a filter to change the value of the text in a button in the cart-empty.php template. But it mistakenly changed the
capitalization of the string from 'Return to shop' to 'Return To Shop'. This commit simply restores the string to its original version. Kudos to @JimmyAppelt for noticing this change (https://github.com/woocommerce/woocommerce/pull/25419#issuecomment-702662023).

Adding this PR to the 4.6 milestone as the new filter introduced in #25419 will ship with this version as well.

### How to test the changes in this Pull Request:

1. Just check that the code changes make sense.