### PR TITLE
[PHP 8] Remove a useless test assertion that fails in PHP 8

### DIFF
--- a/tests/legacy/unit-tests/core/main-class.php
+++ b/tests/legacy/unit-tests/core/main-class.php
@@ -1,9 +1,14 @@
 <?php
+/**
+ * Tests for the WooCommerce instance and general constants.
+ *
+ * @package WooCommerce\Tests\Util
+ */
 
 use Automattic\Jetpack\Constants;
 
 /**
- * WooCommerce class.
+ * WC_Test_WooCommerce class.
  *
  * @package WooCommerce\Tests\Util
  */
@@ -51,7 +56,6 @@ class WC_Test_WooCommerce extends WC_Unit_Test_Case {
 		$this->assertEquals( '|', WC_DELIMITER );
 		$this->assertNotEquals( WC_LOG_DIR, '' );
 		$this->assertEquals( false, WC_TEMPLATE_DEBUG_MODE );
-		$this->assertLessThanOrEqual( 2, WC_TAX_ROUNDING_MODE );
 		$this->assertEquals( $this->wc->template_path(), WC_TEMPLATE_PATH );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The assertion is useless (the `WC_TAX_ROUNDING_MODE` constant is already tested a few lines above anyway), and it was failing in PHP 8 because `'auto' < 2` is evaluated as false, while it's evaluated to true in PHP 7.

### How to test the changes in this Pull Request:

Switch to PHP 8 and run the tests in that file.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Dev - Remove a useless test assertion that was failing in PHP 8
