### PR TITLE
Make next webhook not return a date when the webhook is already running.

### DIFF
--- a/includes/queue/class-wc-action-queue.php
+++ b/includes/queue/class-wc-action-queue.php
@@ -126,7 +126,7 @@ class WC_Action_Queue implements WC_Queue_Interface {
 
 		$next_timestamp = as_next_scheduled_action( $hook, $args, $group );
 
-		if ( $next_timestamp ) {
+		if ( is_numeric( $next_timestamp ) ) {
 			return new WC_DateTime( "@{$next_timestamp}", new DateTimeZone( 'UTC' ) );
 		}
 


### PR DESCRIPTION


### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This should fix webhooks being missed on state changes.

It makes the next webhook not return a date when the webhook is already running.

This does change the `get_next` functionality slightly so a running action will now not give the time of running. There might be some side effects of this, but I haven't noticed any yet in testing, and I think in most cases this would be the desired behavior.

This should be okay for webhooks because if the webhook is running then it already has the data from the state it started running. If a new webhook is asked to trigger then it should queue so it gets the new data state.

A potential fix for #26851.

### How to test the changes in this Pull Request:

1. Follow the bug report steps in #26851 before and after this PR.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Change webhooks to allow triggering a new one if one is currently running.