### PR TITLE
Fixed style of reviews under the Activity section of Dashboard. Issue #27532

### DIFF
--- a/assets/css/dashboard.scss
+++ b/assets/css/dashboard.scss
@@ -255,3 +255,11 @@ ul.woocommerce_stats {
 	font-family: "WooCommerce";
 	content: "\e01d";
 }
+
+#activity-widget #the-comment-list .review .dashboard-comment-wrap {
+    padding-left: 63px;
+}
+
+#activity-widget #the-comment-list .review .comment-author {
+	margin:0;
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Wordpress doesn't give the "has-avatar" CSS class to comments with a custom type like "reviews", which messed up the style of the reviews under the Activity section of the Wordpress Dashboard. I couldn't find a way to add the "has-avatar" CSS class to the review's HTML tag. So I added some additional CSS, which would apply the same style as the "has-avatar" CSS class to the reviews. Additionally, I fixed some unnecessary margins.  Closes #27532 .

### How to test the changes in this Pull Request:

1. Compile the SCSS file
2. Add a review to any product.
3. Visit the Wordpress Dashboard and see the fixed styling of the review under "Activity".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed style of the product reviews shown under the Activity section of the Dashboard.
