### PR TITLE
Fixed update term message. Issue: #27831

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -497,7 +497,7 @@ class WC_Post_Types {
 			3 => __( 'Category updated.', 'woocommerce' ),
 			4 => __( 'Category not added.', 'woocommerce' ),
 			5 => __( 'Category not updated.', 'woocommerce' ),
-			6 => __( 'Category not deleted.', 'woocommerce' ),
+			6 => __( 'Categories deleted.', 'woocommerce' ),
 		);
 
 		$messages['product_tag'] = array(
@@ -507,7 +507,7 @@ class WC_Post_Types {
 			3 => __( 'Tag updated.', 'woocommerce' ),
 			4 => __( 'Tag not added.', 'woocommerce' ),
 			5 => __( 'Tag not updated.', 'woocommerce' ),
-			6 => __( 'Tag not deleted.', 'woocommerce' ),
+			6 => __( 'Tags deleted.', 'woocommerce' ),
 		);
 
 		$wc_product_attributes = array();

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -533,7 +533,7 @@ class WC_Post_Types {
 						/* translators: %s: taxonomy label */
 						5 => sprintf( _x( '%s not updated', 'taxonomy term messages', 'woocommerce' ), $label ),
 						/* translators: %s: taxonomy label */
-						6 => sprintf( _x( '%s not deleted', 'taxonomy term messages', 'woocommerce' ), $label ),
+						6 => sprintf( _x( '%s deleted', 'taxonomy term messages', 'woocommerce' ), $label ),
 					);
 				}
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

An update term message defined for product categories and tags was incorrect which led to wrong notice upon bulk deletion of product categories or terms. This fixes that. Closes #27831 .

### How to test the changes in this Pull Request:

1. Go to product categories / tags page.
2. Select multiple tags / categories.
3. Select 'Delete' in the Bulk actions drop down and click Apply.
4. The tags / categories get deleted along with the correct notice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed an update term message to give the correct notice.
