### PR TITLE
Fixed: Calling 'WC_Coupon::save()' multiple times causes some fields not being updated when trying to delete coupon restrictions. Issue #24570

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -387,7 +387,9 @@ class WC_Meta_Box_Coupon_Data {
 				'email_restrictions'          => array_filter( array_map( 'trim', explode( ',', wc_clean( $_POST['customer_email'] ) ) ) ),
 			)
 		);
-		$coupon->save();
+
 		do_action( 'woocommerce_coupon_options_save', $post_id, $coupon );
+
+		$coupon->save();
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Putting the hook `woocommerce_coupon_options_save` before `$coupon->save()` Helps prevent External plugins or 
addons from calling `$coupon->save()` again when they edit a `prop`. So when hooking a function to `woocommerce_coupon_options_save`, `$coupon->save()` doesn't need to be called in that custom function.
e.g
```
add_action( 'woocommerce_coupon_options_save', function( $post_id, $coupon ) { 
    $coupon->set_product_ids( $data );
    $coupon->save();
}, 10, 2 );
```

This in turn, solves the issue @zaglov found in #24570 : "If you try to remove coupon restrictions like for instance products or categories the changes will not be saved. This error occurs only if the coupon is saved twice during the process - for instance inside of the woocommerce_coupon_options_save action."

Closes #24570

### How to test the changes in this Pull Request:
1. `$coupon->save()` won't need to be called again by custom functions hooked to this.
```
add_action( 'woocommerce_coupon_options_save', function( $post_id, $coupon ) { 
    $coupon->set_product_ids( $data );
 
}, 10, 2 );
```
2. That prevents the issue in #24570 😅

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix: no need to call WC_Coupon::save() when hooked to woocommerce_coupon_options_save when editing props