### PR TITLE
Add new alias & title for `lost-password` endpoint, so can be used for setting new account password

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -49,9 +49,11 @@ class WC_Form_Handler {
 				$user_id = absint( $_GET['id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			}
 
+			$set_password_url = wc_get_account_endpoint_url( 'set-password' );
+
 			$value = sprintf( '%d:%s', $user_id, wp_unslash( $_GET['key'] ) ); // phpcs:ignore
 			WC_Shortcode_My_Account::set_reset_password_cookie( $value );
-			wp_safe_redirect( add_query_arg( 'show-reset-form', 'true', wc_lostpassword_url() ) );
+			wp_safe_redirect( add_query_arg( 'show-reset-form', 'true', $set_password_url ) );
 			exit;
 		}
 	}

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -78,6 +78,7 @@ class WC_Query {
 			'edit-address'               => get_option( 'woocommerce_myaccount_edit_address_endpoint', 'edit-address' ),
 			'payment-methods'            => get_option( 'woocommerce_myaccount_payment_methods_endpoint', 'payment-methods' ),
 			'lost-password'              => get_option( 'woocommerce_myaccount_lost_password_endpoint', 'lost-password' ),
+			'set-password'               => get_option( 'woocommerce_myaccount_set_password_endpoint', 'set-password' ),
 			'customer-logout'            => get_option( 'woocommerce_logout_endpoint', 'customer-logout' ),
 			'add-payment-method'         => get_option( 'woocommerce_myaccount_add_payment_method_endpoint', 'add-payment-method' ),
 			'delete-payment-method'      => get_option( 'woocommerce_myaccount_delete_payment_method_endpoint', 'delete-payment-method' ),
@@ -131,6 +132,9 @@ class WC_Query {
 				break;
 			case 'lost-password':
 				$title = __( 'Lost password', 'woocommerce' );
+				break;
+			case 'set-password':
+				$title = __( 'Set password', 'woocommerce' );
 				break;
 			default:
 				$title = '';

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -51,7 +51,7 @@ class WC_Shortcode_My_Account {
 				wc_add_notice( __( 'Your password has been reset successfully.', 'woocommerce' ) );
 			}
 
-			if ( isset( $wp->query_vars['lost-password'] ) ) {
+			if ( isset( $wp->query_vars['lost-password'] ) || isset( $wp->query_vars['set-password'] ) ) {
 				self::lost_password();
 			} else {
 				wc_get_template( 'myaccount/form-login.php' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a new query var and page title for the `lost-password` endpoint in `my-account`. 

This allows the lost-password form to be used for setting a password for a new account. See https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3236 for an example – this PR uses the new endpoint when a shopper requests an account as part of purchase (using the checkout block).

There aren't any major functionality changes here - the same template and form and backend logic are used for the set password screen. This PR simply adds a new query var, and a page title using the same conventions as the others (so this can be hooked by stores if needed). Then in the my account shortcode class, the lost password 

Since this adds a new query var, you'll need to regenerate permalinks to test it (`Settings > Permalinks > Save Changes`). Should this PR include a call to [`flush_rewrite_rules()`](https://developer.wordpress.org/reference/functions/flush_rewrite_rules/) in a plugin update hook, so this is automatic when stores update woocommerce plugin?

### New hooks
- `woocommerce_myaccount_set_password_endpoint` - allows changing the slug/path for the endpoint
- `woocommerce_endpoint_set_password_title` - allows changing the title shown on the page

### Limitations / FYI
- As noted above, this won't work until permalinks are refreshed.
- The code / functions have not been renamed/refactored. The method could be renamed so it's more general, e.g. `lost_password()` => `new_password_form` (and the template etc). 
  - The template for the form is now being used for two slightly different use cases, so if stores override or customise it they may be affected.
- This PR doesn't include admin UI for editing/disabling the endpoint, is this needed? I.e. add to this UI here:

<img width="1436" alt="Screen Shot 2020-10-05 at 12 10 16 PM" src="https://user-images.githubusercontent.com/4167300/95029300-bc470780-0703-11eb-8d9b-c6a66f1ba991.png">


Closes #27754 .

### How to test the changes in this Pull Request:
- Flush permalinks - `Settings > Permalinks > Save Changes`.
- Test reset password flows - ensure existing flow is not broken/changed.

To test the new feature, you'll need to generate an appropriate url with a valid password reset key. The url will look something like this:

`http://your.dev.test.store/my-account/set-password/?action=rp&key=jbee9auNaqktsa1oq1hf&login=mary`

This uses the same url params as the WordPress core set password flow. So you can use the regular lost password flow, then change the url to `my-account/set-password` and add the `action=rp` param, or test with the accompanying PR in WooCommerce Blocks: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3236 (see PR for full test instructions).

Bonus points: 

- Test hooking to customise the path and/or page title and confirm everything works correctly.


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add new `my-account/set-password` endpoint alias for setting new account password.
