### PR TITLE
Review link: add a way to remove the parentheses

### DIFF
--- a/assets/css/woocommerce-layout.scss
+++ b/assets/css/woocommerce-layout.scss
@@ -113,6 +113,14 @@
 			float: right;
 			width: 48%;
 			clear: none;
+
+			.woocommerce-review-link::before {
+				content: "(";
+			}
+
+			.woocommerce-review-link::after {
+				content: ")";
+			}
 		}
 
 		.woocommerce-tabs {

--- a/templates/single-product/rating.php
+++ b/templates/single-product/rating.php
@@ -35,7 +35,7 @@ if ( $rating_count > 0 ) : ?>
 		<?php echo wc_get_rating_html( $average, $rating_count ); // WPCS: XSS ok. ?>
 		<?php if ( comments_open() ) : ?>
 			<?php //phpcs:disable ?>
-			<a href="#reviews" class="woocommerce-review-link" rel="nofollow">(<?php printf( _n( '%s customer review', '%s customer reviews', $review_count, 'woocommerce' ), '<span class="count">' . esc_html( $review_count ) . '</span>' ); ?>)</a>
+			<a href="#reviews" class="woocommerce-review-link" rel="nofollow"><?php printf( _n( '%s customer review', '%s customer reviews', $review_count, 'woocommerce' ), '<span class="count">' . esc_html( $review_count ) . '</span>' ); ?></a>
 			<?php // phpcs:enable ?>
 		<?php endif ?>
 	</div>


### PR DESCRIPTION
Hardcoded parenthesis from the review link has been removed and rendered using CSS pseudo-elements, so now users can simply hide then if needed.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25735.

### How to test the changes in this Pull Request:

1. Open any product;
2. If there are no reviews, leave a review;
3. Check the link "x customer review". It should look like it was before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add a way to remove the parentheses from the product's review link (#25735).
