### PR TITLE
Fixed: If product is virtual, shipping content dosn't hide

### DIFF
--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -160,7 +160,7 @@ jQuery( function( $ ) {
 
 			var $shipping_tab = $( 'div#shipping_product_data' );
 
-			if ('block' === $( $shipping_tab ).css( 'display' )) {
+			if ( 'block' === $( $shipping_tab ).css( 'display' ) ) {
 				$( 'a[href="#general_product_data"]' ).click();
 			}
 		}

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -154,8 +154,15 @@ jQuery( function( $ ) {
 		if ( is_downloadable ) {
 			$( '.hide_if_downloadable' ).hide();
 		}
+
 		if ( is_virtual ) {
 			$( '.hide_if_virtual' ).hide();
+
+			var $shipping_tab = $( 'div#shipping_product_data' );
+
+			if ('block' === $( $shipping_tab ).css( 'display' )) {
+				$( 'a[href="#general_product_data"]' ).click();
+			}
 		}
 
 		$( '.hide_if_' + product_type ).hide();


### PR DESCRIPTION
Fix the issue when a user makes a product virtual on the "Shipping" tab and still able to edit dimensions and other shipping data.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27574.

### How to test the changes in this Pull Request:

1. Go to the product editing screen, scroll to the "Product data" metabox;
2. Make sure that the product is simple;
3. Click the "Shipping" tab;
4. Click "Virtual:" checkbox.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Hide "Shipping" panel after making a product virtual (#27574).
