### PR TITLE
Fixed: Draft post set as shop page causes trouble

### DIFF
--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -286,15 +286,6 @@ class WC_Settings_Products extends WC_Settings_Page {
 			);
 
 		} else {
-			$draft_pages = get_posts(
-				array(
-					'post_type'       => 'page',
-					'post_status'     => 'draft',
-					'fields'          => 'ids',
-					'posts_per_page'  => -1,
-				)
-			);
-
 			$settings = apply_filters(
 				'woocommerce_product_settings',
 				apply_filters(
@@ -313,7 +304,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 							'id'       => 'woocommerce_shop_page_id',
 							'type'     => 'single_select_page',
 							'default'  => '',
-							'args'     => array( 'exclude' => $draft_pages ),
+							'args'     => array( 'post_status' => 'publish,private' ),
 							'class'    => 'wc-enhanced-select-nostd',
 							'css'      => 'min-width:300px;',
 							'desc_tip' => __( 'This sets the base page of your shop - this is where your product archive will be.', 'woocommerce' ),

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -286,6 +286,15 @@ class WC_Settings_Products extends WC_Settings_Page {
 			);
 
 		} else {
+			$draft_pages = get_posts(
+				array(
+					'post_type'       => 'page',
+					'post_status'     => 'draft',
+					'fields'          => 'ids',
+					'posts_per_page'  => -1,
+				)
+			);
+
 			$settings = apply_filters(
 				'woocommerce_product_settings',
 				apply_filters(
@@ -304,6 +313,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 							'id'       => 'woocommerce_shop_page_id',
 							'type'     => 'single_select_page',
 							'default'  => '',
+							'args'     => array( 'exclude' => $draft_pages ),
 							'class'    => 'wc-enhanced-select-nostd',
 							'css'      => 'min-width:300px;',
 							'desc_tip' => __( 'This sets the base page of your shop - this is where your product archive will be.', 'woocommerce' ),


### PR DESCRIPTION
Disallow a user to use draft pages as a Shop page to avoid weird behaviour it causes.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #24136.

### How to test the changes in this Pull Request:

1. You should have at least one page with status "Draft";
2. Go to Woocommerce -> Settings -> Products;
3. Expand the "Shop page" select. You shouldn't see any drafts.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Exclude draft pages from the "Shop page" setting.
