### PR TITLE
issue #24631 - Updated needs payment check to use order

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -1155,7 +1155,7 @@ class WC_Checkout {
 
 				do_action( 'woocommerce_checkout_order_processed', $order_id, $posted_data, $order );
 
-				if ( WC()->cart->needs_payment() ) {
+				if ( $order->needs_payment() ) {
 					$this->process_order_payment( $order_id, $posted_data['payment_method'] );
 				} else {
 					$this->process_order_without_payment( $order_id );


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

After an order is processed at checkout, there is a check to determine whether payment is required for the order. This was previously based on whether the current cart requires payment and so if for any reason the cart is no longer valid or does not contain items, e.g. as described here:

- https://github.com/woocommerce/woocommerce/issues/24631

then the order will be marked complete as no payment is required. Instead this is now changed to check the order if payment is required. 

This change updates the check to see if the order requires payment which resolves this issue, and probably makes more sense anyway.

### How to test the changes in this Pull Request:

1. Add a product to the cart and checkout using a _"Payment on _delivery"_ type payment gateway. You will see the order confirmation page and the order will have a status of _"Awaiting payment"_.
2. Add this code to functions.php of your theme - `add_action( 'woocommerce_new_order', 'clear_my_cart', 1, 1 ); function clear_my_cart($order_id){ global $woocommerce; $woocommerce->cart->empty_cart(); }` (repro steps from here - https://github.com/woocommerce/woocommerce/issues/24631") and repeat step 1. The order will have a status of _"Awaiting payment"_.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Update logic to determine if an order requires payment to check the order instead of the cart.
