### PR TITLE
Adds structure for Twenty Twenty One default theme support. Issue #27766

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -1,0 +1,2 @@
+@import "mixins";
+

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -530,6 +530,9 @@ final class WooCommerce {
 				case 'twentytwenty':
 					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-twenty.php';
 					break;
+				case 'twentytwentyone':
+					include_once WC_ABSPATH . 'includes/theme-support/class-wc-twenty-twenty-one.php';
+					break;
 			}
 		}
 	}

--- a/includes/theme-support/class-wc-twenty-twenty-one.php
+++ b/includes/theme-support/class-wc-twenty-twenty-one.php
@@ -1,0 +1,88 @@
+<?php
+/**
+ * Twenty Twenty One support.
+ *
+ * @since   4.7.0
+ * @package WooCommerce\Classes
+ */
+
+use Automattic\Jetpack\Constants;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * WC_Twenty_Twenty_One class.
+ */
+class WC_Twenty_Twenty_One {
+
+	/**
+	 * Theme init.
+	 */
+	public static function init() {
+
+		// Change WooCommerce wrappers.
+		remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );
+		remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10 );
+
+		add_action( 'woocommerce_before_main_content', array( __CLASS__, 'output_content_wrapper' ), 10 );
+		add_action( 'woocommerce_after_main_content', array( __CLASS__, 'output_content_wrapper_end' ), 10 );
+
+		// This theme doesn't have a traditional sidebar.
+		remove_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10 );
+
+		// Enqueue theme compatibility styles.
+		add_filter( 'woocommerce_enqueue_styles', array( __CLASS__, 'enqueue_styles' ) );
+
+		// Register theme features.
+		add_theme_support( 'wc-product-gallery-zoom' );
+		add_theme_support( 'wc-product-gallery-lightbox' );
+		add_theme_support( 'wc-product-gallery-slider' );
+		add_theme_support(
+			'woocommerce',
+			array(
+				'thumbnail_image_width' => 450,
+				'single_image_width'    => 600,
+			)
+		);
+
+	}
+
+	/**
+	 * Open the Twenty Twenty One wrapper.
+	 */
+	public static function output_content_wrapper() {
+		echo '<section id="primary" class="content-area">';
+		echo '<main id="main" class="site-main">';
+	}
+
+	/**
+	 * Close the Twenty Twenty One wrapper.
+	 */
+	public static function output_content_wrapper_end() {
+		echo '</main>';
+		echo '</section>';
+	}
+
+	/**
+	 * Enqueue CSS for this theme.
+	 *
+	 * @param  array $styles Array of registered styles.
+	 * @return array
+	 */
+	public static function enqueue_styles( $styles ) {
+		unset( $styles['woocommerce-general'] );
+
+		$styles['woocommerce-general'] = array(
+			'src'     => str_replace( array( 'http:', 'https:' ), '', WC()->plugin_url() ) . '/assets/css/twenty-twenty-one.css',
+			'deps'    => '',
+			'version' => Constants::get_constant( 'WC_VERSION' ),
+			'media'   => 'all',
+			'has_rtl' => true,
+		);
+
+		return apply_filters( 'woocommerce_twenty_twenty_one_styles', $styles );
+	}
+
+}
+
+WC_Twenty_Twenty_One::init();

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2319,6 +2319,7 @@ function wc_is_active_theme( $theme ) {
 function wc_is_wp_default_theme_active() {
 	return wc_is_active_theme(
 		array(
+			'twentytwentyone',
 			'twentytwenty',
 			'twentynineteen',
 			'twentyseventeen',


### PR DESCRIPTION
- New class class-wc-twenty-twenty-one.php
- New stylesheet twenty-twenty-one.scss
- Updates checks for default themes in theme_support_includes() and wc_is_wp_default_theme_active()
TODO: Add CSS styles to twenty-twenty-one.scss

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

Part of Issue #27766

### Changes proposed in this Pull Request:

Add base structure for compatibility with Twenty Twenty One default theme. Still needs styles to be added.

### How to test the changes in this Pull Request:

1. Active Twenty Twenty One theme on a site with a WooCommerce store that has products.
2. Navigate to the shop page.
3. Default WooCommerce styles should not be loaded, rather the specific Twenty Twenty Styles should be loaded.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Adds support for Twenty Twenty One default theme.
