### PR TITLE
Use "Set Password" page title for lost-password endpoint when setting a password

### DIFF
--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -349,8 +349,9 @@ class WC_Breadcrumb {
 	 * Endpoints.
 	 */
 	protected function endpoint_trail() {
+		$action         = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : '';
 		$endpoint       = is_wc_endpoint_url() ? WC()->query->get_current_endpoint() : '';
-		$endpoint_title = $endpoint ? WC()->query->get_endpoint_title( $endpoint ) : '';
+		$endpoint_title = $endpoint ? WC()->query->get_endpoint_title( $endpoint, $action ) : '';
 
 		if ( $endpoint_title ) {
 			$this->add_crumb( $endpoint_title );

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -49,9 +49,18 @@ class WC_Form_Handler {
 				$user_id = absint( $_GET['id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			}
 
-			$value = sprintf( '%d:%s', $user_id, wp_unslash( $_GET['key'] ) ); // phpcs:ignore
+			$action = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : '';
+			$value   = sprintf( '%d:%s', $user_id, wp_unslash( $_GET['key'] ) ); // phpcs:ignore
 			WC_Shortcode_My_Account::set_reset_password_cookie( $value );
-			wp_safe_redirect( add_query_arg( 'show-reset-form', 'true', wc_lostpassword_url() ) );
+			wp_safe_redirect(
+				add_query_arg(
+					array(
+						'show-reset-form' => 'true',
+						'action'          => $action,
+					),
+					wc_lostpassword_url()
+				)
+			);
 			exit;
 		}
 	}

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -49,6 +49,13 @@ class WC_Form_Handler {
 				$user_id = absint( $_GET['id'] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			}
 
+			// If the reset token is not for the current user, ignore the reset request (don't redirect).
+			$logged_in_user_id = get_current_user_id();
+			if ( $logged_in_user_id && $logged_in_user_id !== $user_id ) {
+				wc_add_notice( __( 'This password reset key is for a different user account. Please log out and try again.', 'woocommerce' ), 'error' );
+				return;
+			}
+
 			$action = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : '';
 			$value   = sprintf( '%d:%s', $user_id, wp_unslash( $_GET['key'] ) ); // phpcs:ignore
 			WC_Shortcode_My_Account::set_reset_password_cookie( $value );

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -131,7 +131,7 @@ class WC_Query {
 				$title = __( 'Add payment method', 'woocommerce' );
 				break;
 			case 'lost-password':
-				if ( 'rp' === $action ) {
+				if ( in_array( $action, array( 'rp', 'resetpass', 'newaccount' ) ) ) {
 					$title = __( 'Set password', 'woocommerce' );
 				} else {
 					$title = __( 'Lost password', 'woocommerce' );

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -89,9 +89,10 @@ class WC_Query {
 	 * Get page title for an endpoint.
 	 *
 	 * @param  string $endpoint Endpoint key.
+	 * @param  string $action Action or variation within the endpoint @since 4.6.0.
 	 * @return string
 	 */
-	public function get_endpoint_title( $endpoint ) {
+	public function get_endpoint_title( $endpoint, $action = '' ) {
 		global $wp;
 
 		switch ( $endpoint ) {
@@ -130,14 +131,19 @@ class WC_Query {
 				$title = __( 'Add payment method', 'woocommerce' );
 				break;
 			case 'lost-password':
-				$title = __( 'Lost password', 'woocommerce' );
+				if ( 'rp' === $action ) {
+					$title = __( 'Set password', 'woocommerce' );
+				} else {
+					$title = __( 'Lost password', 'woocommerce' );
+				}
 				break;
 			default:
 				$title = '';
 				break;
 		}
 
-		return apply_filters( 'woocommerce_endpoint_' . $endpoint . '_title', $title, $endpoint );
+		// TBD - docs for filter.
+		return apply_filters( 'woocommerce_endpoint_' . $endpoint . '_title', $title, $endpoint, $action );
 	}
 
 	/**

--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -88,9 +88,12 @@ class WC_Query {
 	/**
 	 * Get page title for an endpoint.
 	 *
-	 * @param  string $endpoint Endpoint key.
-	 * @param  string $action Action or variation within the endpoint @since 4.6.0.
-	 * @return string
+	 * @param string $endpoint Endpoint key.
+	 * @param string $action Optional action or variation within the endpoint.
+	 *
+	 * @since 2.3.0
+	 * @since 4.6.0 Added $action parameter.
+	 * @return string The page title.
 	 */
 	public function get_endpoint_title( $endpoint, $action = '' ) {
 		global $wp;
@@ -142,7 +145,18 @@ class WC_Query {
 				break;
 		}
 
-		// TBD - docs for filter.
+		/**
+		 * Filters the page title used for my-account endpoints.
+		 *
+		 * @since 2.6.0
+		 * @since 4.6.0 Added $action parameter.
+		 *
+		 * @see get_endpoint_title()
+		 *
+		 * @param string $title Default title.
+		 * @param string $endpoint Endpoint key.
+		 * @param string $action Optional action or variation within the endpoint.
+		 */
 		return apply_filters( 'woocommerce_endpoint_' . $endpoint . '_title', $title, $endpoint, $action );
 	}
 

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -39,7 +39,7 @@ class WC_Shortcode_My_Account {
 			return;
 		}
 
-		if ( ! is_user_logged_in() ) {
+		if ( ! is_user_logged_in() || isset( $wp->query_vars['lost-password'] ) ) {
 			$message = apply_filters( 'woocommerce_my_account_message', '' );
 
 			if ( ! empty( $message ) ) {

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -238,12 +238,15 @@ class WC_Shortcode_My_Account {
 		} elseif ( ! empty( $_GET['show-reset-form'] ) ) { // WPCS: input var ok, CSRF ok.
 			if ( isset( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ) && 0 < strpos( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ], ':' ) ) {  // @codingStandardsIgnoreLine
 				list( $rp_id, $rp_key ) = array_map( 'wc_clean', explode( ':', wp_unslash( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ), 2 ) ); // @codingStandardsIgnoreLine
-				$userdata               = get_userdata( absint( $rp_id ) );
+				$rp_id                  = absint( $rp_id );
+				$userdata               = get_userdata( $rp_id );
 				$rp_login               = $userdata ? $userdata->user_login : '';
 				$user                   = self::check_password_reset_key( $rp_key, $rp_login );
+				$logged_in_user_id      = get_current_user_id();
 
 				// Reset key / login is correct, display reset password form with hidden key / login values.
-				if ( is_object( $user ) ) {
+				// Only show reset form if logged-in user matches reset token or no user is logged in.
+				if ( is_object( $user ) && ( ! $logged_in_user_id || $logged_in_user_id === $rp_id ) ) {
 					return wc_get_template(
 						'myaccount/form-reset-password.php',
 						array(

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -238,15 +238,12 @@ class WC_Shortcode_My_Account {
 		} elseif ( ! empty( $_GET['show-reset-form'] ) ) { // WPCS: input var ok, CSRF ok.
 			if ( isset( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ) && 0 < strpos( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ], ':' ) ) {  // @codingStandardsIgnoreLine
 				list( $rp_id, $rp_key ) = array_map( 'wc_clean', explode( ':', wp_unslash( $_COOKIE[ 'wp-resetpass-' . COOKIEHASH ] ), 2 ) ); // @codingStandardsIgnoreLine
-				$rp_id                  = absint( $rp_id );
-				$userdata               = get_userdata( $rp_id );
+				$userdata               = get_userdata( absint( $rp_id ) );
 				$rp_login               = $userdata ? $userdata->user_login : '';
 				$user                   = self::check_password_reset_key( $rp_key, $rp_login );
-				$logged_in_user_id      = get_current_user_id();
 
-				// Reset key / login is correct, display reset password form with hidden key / login values.
 				// Only show reset form if logged-in user matches reset token or no user is logged in.
-				if ( is_object( $user ) && ( ! $logged_in_user_id || $logged_in_user_id === $rp_id ) ) {
+				if ( is_object( $user ) ) {
 					return wc_get_template(
 						'myaccount/form-reset-password.php',
 						array(

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -242,7 +242,7 @@ class WC_Shortcode_My_Account {
 				$rp_login               = $userdata ? $userdata->user_login : '';
 				$user                   = self::check_password_reset_key( $rp_key, $rp_login );
 
-				// Only show reset form if logged-in user matches reset token or no user is logged in.
+				// Reset key / login is correct, display reset password form with hidden key / login values.
 				if ( is_object( $user ) ) {
 					return wc_get_template(
 						'myaccount/form-reset-password.php',

--- a/includes/wc-page-functions.php
+++ b/includes/wc-page-functions.php
@@ -21,7 +21,8 @@ function wc_page_endpoint_title( $title ) {
 
 	if ( ! is_null( $wp_query ) && ! is_admin() && is_main_query() && in_the_loop() && is_page() && is_wc_endpoint_url() ) {
 		$endpoint       = WC()->query->get_current_endpoint();
-		$endpoint_title = WC()->query->get_endpoint_title( $endpoint );
+		$action         = isset( $_GET['action'] ) ? sanitize_text_field( wp_unslash( $_GET['action'] ) ) : '';
+		$endpoint_title = WC()->query->get_endpoint_title( $endpoint, $action );
 		$title          = $endpoint_title ? $endpoint_title : $title;
 
 		remove_filter( 'the_title', 'wc_page_endpoint_title' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR has two changes:

- The page title of the `my-account/lost-password` endpoint can be adjusted based on the `action` URL param.
- The lost password reset form can now be used to set a password when the user is logged in.

The `Lost password` reset form can be used for various scenarios:

- User has forgotten or lost their password.
- Brand new account, user needs to set an initial password.

#### Allow changing endpoint/page title to `Set password` for new account flow
In the checkout block we're implementing a new create account (signup) flow where the user is sent a email notification and then clicks a link to set their new account password. In this scenario, it's not ideal to show the page title "Lost password"; it's a bit jarring and could be confusing. 

This PR extends the method (`get_endpoint_title()`) which generates page titles so an optional `action` parameter can be passed. For `lost-password` endpoint if the action is related to setting a password, different page title is returned - `Set password`. This action param is also passed to the relevant hook (`woocommerce_endpoint_{$endpoint}_title`) so this can be customized or overridden.

Wherever `get_endpoint_title()` is called, the `action` url param is passed through. Note that [`action=rp` or `action=resetpass` are conventionally used in WordPress core](https://github.com/WordPress/WordPress/blob/1079647d30f6cc5eab56c992e0a5f508426439b0/wp-login.php#L912), so I've added support for them, and also a new `newaccount` which will be passed from checkout block signup flow (in an open PR: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3236).

#### Allow `Set password` in logged-in browser session (for new account flow)
In the checkout signup flow, the user is logged in when the account is created, and then sent an email with the password reset link. It's likely the user will open the reset link in a browser where they are logged in (i.e. where they just completed the order). 

So as part of this change, the reset form is now shown even if the user is logged in. Previously it was not shown unless no user was logged in.

To protect against accidentally changing another user's password, there's an extra check added before redirecting to set-password form. If a user is logged in, and they don't match the user in the reset key, the password reset is aborted, with a notice. This is an edge case but important to prevent any chance of setting the password for the wrong user.

<img width="1421" alt="Screen Shot 2020-10-14 at 12 29 13 PM" src="https://user-images.githubusercontent.com/4167300/95928626-59015780-0e1e-11eb-9a6d-093368d9773c.png">

Also, as a side effect, if a user does a password reset, they can now do the last step in a browser where they happen to be already logged in. This might be a common case, when the user is logged in but has forgotten their password and needs to reset.

Closes #27754 .

### Screenshots

<img width="1306" alt="Screen Shot 2020-10-08 at 9 46 17 AM" src="https://user-images.githubusercontent.com/4167300/95385925-1e457e00-094b-11eb-98c8-29940cb33c68.png">

### How to test the changes
There are two aspects to test:

- Confirm the new signup flow from checkout block works as expected. **Note: this requires running a custom branch of WooCommerce Blocks, and running a dev build of blocks (checkout signup is disabled in production builds - feature gated).**
- Confirm that other uses of the `lost-password` endpoint work correctly and aren't negatively impacted.

#### Test new signup flow from checkout block
0. Ensure you can see emails from your site (e.g. set up MailHog).
1. Checkout blocks branch from https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3236 and build, ensure is mapped into your test site as a plugin and is active. 
2. Add a checkout block to a page. Ensure you have a valid payment method set up.
3. Add something to cart and proceed to checkout block page.
3. Enter an email address and complete the form. 
3. Check the `Create an account` checkbox. (If you don't see it, ensure you are running a dev build of WooCommerce Blocks.)
2. Complete & submit checkout.
1. Find the `Your {store} account has been created!` email. Copy the `Click here to set your new password.` url.
    - Link should look something like this: `http://localhost:8333/my-account/lost-password/?action=newaccount&key=6lye4PPX11pbjWPJozSR&login=bob`
4. In an incognito window, or after logging out, navigate to set password url. 
6. Should see reset password form (2 password fields) with `Set password` title. 

Bonus points:

- Test using the reset password link in browsers with different users logged in:
   - Anon / no user.
   - Different user (from the new shopper account).
- Ensure the password reset only works if used with no logged in user or a browser where the same user is already logged in.

#### Test other uses of the `lost-password` endpoint
Test various password related flows - forgot/lost password. Whenever a my-account endpoint is rendered, ensure the page title is correct and makes sense (and the breadcrumb title matches). 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Enhancement: Use more relevant `Set password` title for lost password reset form when applicable.
