### PR TITLE
Make is_request() public. Closes #27888.

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -312,7 +312,7 @@ final class WooCommerce {
 	 * @param  string $type admin, ajax, cron or frontend.
 	 * @return bool
 	 */
-	private function is_request( $type ) {
+	public function is_request( $type ) {
 		switch ( $type ) {
 			case 'admin':
 				return is_admin();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The WooCommerce class has an `is_request()` that is useful for determining when to load assets. But it's access is private so other plugins wishing to take advantage of this function need to duplicate it entirely. By making it public access, developers can use `wc()->is_request()` to test the environment.

Closes #27888 .

### How to test the changes in this Pull Request:

1. Run `wc()->is_request('frontend')` from another plugin


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Make is_request() method public
