### PR TITLE
Fix "bin not installed" error on "composer install no-dev"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -83,6 +83,9 @@
     ],
     "makepot": [
       "@makepot-audit --skip-audit"
+    ],
+    "bin": [
+      "echo 'bin not installed'"
     ]
   },
   "extra": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

We [introduced the Composer Bin package](https://github.com/woocommerce/woocommerce/pull/27753) as a dev dependency, and this required a `composer bin install` post-install/update Composer command to be introduced. However when doing _composer install --no-dev_ (e.g. in Travis) this throws a "Command 'bin' is not defined" error.

The solution is to add a dummy "bin" command in composer.json that will run in lieu of the Composer Bin one when doing a no-dev install.

### How to test the changes in this Pull Request:

Run `composer install --no-dev`. With the latest master it will fail, with this patch it will work.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

Not needed as it's a small fix for a not yet released feature.