### PR TITLE
add test:e2e-debug command

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "docker:up": "npm explore @woocommerce/e2e-environment -- npm run docker:up",
     "docker:down": "npm explore @woocommerce/e2e-environment -- npm run docker:down",
     "test:e2e": "npm explore @woocommerce/e2e-environment -- npm run test:e2e",
+    "test:e2e-debug": "npm explore @woocommerce/e2e-environment -- npm run test:e2e-debug",
     "test:e2e-dev": "npm explore @woocommerce/e2e-environment -- npm run test:e2e-dev",
     "makepot": "composer run-script makepot",
     "packages:fix:textdomain": "node ./bin/package-update-textdomain.js",

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -16,6 +16,7 @@ Automated end-to-end tests for WooCommerce.
   - [Prep work for running tests](#prep-work-for-running-tests)
   - [How to run tests in headless mode](#how-to-run-tests-in-headless-mode) 
   - [How to run tests in non-headless mode](#how-to-run-tests-in-non-headless-mode)
+  - [How to run tests in debug mode](#how-to-run-tests-in-debug-mode)
   - [How to run an individual test](#how-to-run-an-individual-test)
   - [How to skip tests](#how-to-skip-tests)
   - [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions)
@@ -137,8 +138,8 @@ npm run test:e2e
 
 ### How to run tests in non-headless mode
 
-Tests are being run headless by default. However, sometimes it's useful to observe the browser while running tests. To do so, you can run tests in a non-headless (dev) mode:
-                                    
+Tests are run headless by default. However, sometimes it's useful to observe the browser while running tests. To do so, you can run tests in a non-headless (dev) mode:
+
 ```bash
 npm run test:e2e-dev
 ```
@@ -157,6 +158,16 @@ For example:
 
 - `PUPPETEER_SLOWMO=10` - will run tests faster
 - `PUPPETEER_SLOWMO=70` - will run tests slower
+
+### How to run tests in debug mode
+
+Tests are run headless by default. While writing tests it may be useful to have the debugger loaded while running a test in non-headless mode. To run tests in debug mode:
+            
+```bash
+npm run test:e2e-debug
+```
+
+When all tests have been completed the debugger is left active. Control doesn't return to the command line until the debugger is closed. Otherwise, debug mode functions the same as non-headless mode.
 
 ### How to run an individual test
 

--- a/tests/e2e/env/bin/e2e-test-integration.js
+++ b/tests/e2e/env/bin/e2e-test-integration.js
@@ -10,6 +10,7 @@ const { JEST_PUPPETEER_CONFIG } = process.env;
 program
 	.usage( '<file ...> [options]' )
 	.option( '--dev', 'Development mode' )
+	.option( '--debug', 'Debug mode' )
 	.parse( process.argv );
 
 const appPath = getAppRoot();
@@ -48,7 +49,7 @@ const jestArgs = [
 	...program.args,
 ];
 
-if ( program.dev ) {
+if ( program.debug ) {
 	jestCommand = 'npx';
 	jestArgs.unshift( 'ndb', 'jest' );
 }

--- a/tests/e2e/env/package-lock.json
+++ b/tests/e2e/env/package-lock.json
@@ -62,11 +62,6 @@
 							}
 						}
 					}
-				},
-				"prettier": {
-					"version": "npm:wp-prettier@1.19.1",
-					"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
-					"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg=="
 				}
 			}
 		},
@@ -9834,6 +9829,11 @@
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
+		},
+		"prettier": {
+			"version": "npm:wp-prettier@1.19.1",
+			"resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
+			"integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg=="
 		},
 		"prettier-linter-helpers": {
 			"version": "1.0.0",

--- a/tests/e2e/env/package.json
+++ b/tests/e2e/env/package.json
@@ -53,6 +53,7 @@
     "docker:ssh": "docker exec -it $(node utils/get-app-name.js)_wordpress-www /bin/bash",
     "install-wp-tests": "./bin/install-wp-tests.sh",
     "test:e2e": "bash ./bin/wait-for-build.sh && ./bin/e2e-test-integration.js",
+    "test:e2e-debug": "bash ./bin/wait-for-build.sh && ./bin/e2e-test-integration.js --dev --debug",
     "test:e2e-dev": "bash ./bin/wait-for-build.sh && ./bin/e2e-test-integration.js --dev"
   }
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the `run test:e2e-dev` command so that it doesn't load the debugger. It adds `run test:e2e-debug` to load the debugger in `dev` mode which may be useful while writing tests.

Closes #27820 .

### How to test the changes in this Pull Request:

1. Run `docker:down` and `docker:up` for each test cycle
2. `npm run test:e2e`
3. `npm run test:e2e-dev`
4. The browser should close and control return to the command line
5. `npm run test:e2e-debug`
6. The debugger should remain open
7. Closing the debugger returns control to the command line.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A
