### PR TITLE
Only attempt to run E2E tests if testing host is ready

### DIFF
--- a/tests/e2e/env/bin/wait-for-build.sh
+++ b/tests/e2e/env/bin/wait-for-build.sh
@@ -21,7 +21,7 @@ do
 
   if [[ $count -gt ${MAX_ATTEMPTS} ]]; then
   	echo "$(date) - Docker container couldn't be built"
-  	exit
+  	exit 1
   fi
 done
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently the `run test:e2e*` scripts wait up to 5 minutes for the testing host to be ready. At the end of the 5 minutes, the test sequencer is started. The test(s) fail because the host isn't available. With this PR, the test(s) only run if the testing host is found.

### How to test the changes in this Pull Request:

1. `npm run docker:up`
2. `npm run test:e2e`
3. `npm run docker:down`
4. `npm run test:e2e`
5. After 5 minutes you should get
```
Fri  9 Oct 2020 05:13:03 ADT - Docker container couldn't be built
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! @woocommerce/e2e-environment@0.1.5 test:e2e: `bash ./bin/wait-for-build.sh && ./bin/e2e-test-integration.js`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the @woocommerce/e2e-environment@0.1.5 test:e2e script.
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A