### PR TITLE
Remove the remaining uses of $order->get_product_from_item()

### DIFF
--- a/includes/rest-api/Controllers/Version1/class-wc-rest-order-refunds-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-order-refunds-v1-controller.php
@@ -145,7 +145,7 @@ class WC_REST_Order_Refunds_V1_Controller extends WC_REST_Orders_V1_Controller {
 
 		// Add line items.
 		foreach ( $refund->get_items() as $item_id => $item ) {
-			$product      = $refund->get_product_from_item( $item );
+			$product      = $item->get_product();
 			$product_id   = 0;
 			$variation_id = 0;
 			$product_sku  = null;

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php
@@ -173,7 +173,7 @@ class WC_REST_Orders_V1_Controller extends WC_REST_Posts_Controller {
 
 		// Add line items.
 		foreach ( $order->get_items() as $item_id => $item ) {
-			$product      = $order->get_product_from_item( $item );
+			$product      = $item->get_product();
 			$product_id   = 0;
 			$variation_id = 0;
 			$product_sku  = null;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27729

### How to test the changes in this Pull Request:
Subscriptions still supports legacy versions of the base WC REST API classes. To replicate you'd need to set up Subscriptions, and webhooks etc. I've included them below, however, the changes in this PR just replaces the use of the deprecated functions with its replacement. 

1. Install Subscriptions.
2. Create a [subscription product](https://docs.woocommerce.com/document/subscriptions/store-manager-guide/#section-1) 
3. Create a `subscription.created` or `subscription.updated` webhook. Something like this for example: https://d.pr/i/6iJOlm
4. Purchase the subscription product as normal through the cart. 
4. Wait for the scheduled action to run. In you're error log you should see the following error. 

```
PHP Deprecated:  WC_Abstract_Legacy_Order::get_product_from_item is <strong>deprecated</strong> since version 4.4.0! Use $item->get_product() instead. in /app/public/wp-includes/functions.php on line 4773
PHP Stack trace:
PHP   1. {main}() /app/public/wp-cron.php:0
PHP   2. do_action_ref_array() /app/public/wp-cron.php:138
PHP   3. WP_Hook->do_action() /app/public/wp-includes/plugin.php:544
PHP   4. WP_Hook->apply_filters() /app/public/wp-includes/class-wp-hook.php:311
PHP   5. ActionScheduler_QueueRunner->run() /app/public/wp-includes/class-wp-hook.php:287
PHP   6. ActionScheduler_QueueRunner->do_batch() /app/public/wp-content/plugins/woocommerce/packages/action-scheduler/classes/ActionScheduler_QueueRunner.php:132
PHP   7. ActionScheduler_QueueRunner->process_action() /app/public/wp-content/plugins/woocommerce/packages/action-scheduler/classes/ActionScheduler_QueueRunner.php:162
PHP   8. ActionScheduler_Action->execute() /app/public/wp-content/plugins/woocommerce/packages/action-scheduler/classes/abstracts/ActionScheduler_Abstract_QueueRunner.php:65
PHP   9. do_action_ref_array() /app/public/wp-content/plugins/woocommerce/packages/action-scheduler/classes/actions/ActionScheduler_Action.php:22
PHP  10. WP_Hook->do_action() /app/public/wp-includes/plugin.php:544
PHP  11. WP_Hook->apply_filters() /app/public/wp-includes/class-wp-hook.php:311
PHP  12. wc_deliver_webhook_async() /app/public/wp-includes/class-wp-hook.php:287
PHP  13. WC_Webhook->deliver() /app/public/wp-content/plugins/woocommerce/includes/wc-webhook-functions.php:78
PHP  14. WC_Webhook->build_payload() /app/public/wp-content/plugins/woocommerce/includes/class-wc-webhook.php:317
PHP  15. apply_filters() /app/public/wp-content/plugins/woocommerce/includes/class-wc-webhook.php:480
PHP  16. WP_Hook->apply_filters() /app/public/wp-includes/plugin.php:206
PHP  17. WCS_Webhooks::create_payload() /app/public/wp-includes/class-wp-hook.php:287
PHP  18. WC_REST_Subscriptions_Controller->get_item() /app/public/wp-content/plugins/woocommerce-subscriptions/includes/class-wcs-webhooks.php:147
PHP  19. WC_REST_Subscriptions_Controller->prepare_item_for_response() /app/public/wp-content/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-posts-controller.php:156
PHP  20. WC_Subscription->get_product_from_item() /app/public/wp-content/plugins/woocommerce/includes/rest-api/Controllers/Version1/class-wc-rest-orders-v1-controller.php:176
PHP  21. wc_deprecated_function() /app/public/wp-content/plugins/woocommerce/includes/legacy/abstract-wc-legacy-order.php:320
PHP  22. _deprecated_function() /app/public/wp-content/plugins/woocommerce/includes/wc-deprecated-functions.php:54
PHP  23. trigger_error() /app/public/wp-includes/functions.php:4773
```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
