### PR TITLE
Remove woocommerce-rest-api from contributors.sh

### DIFF
--- a/bin/contributors.sh
+++ b/bin/contributors.sh
@@ -25,8 +25,4 @@ echo "<h2>Action Scheduler</h2>" >> $output_file
 echo "Generating contributor list for Action Scheduler since $from_date"
 ./node_modules/.bin/githubcontrib --repo action-scheduler $common_arguments >> $output_file
 
-echo "<h2>REST API</h2>" >> $output_file
-echo "Generating contributor list for REST API since $from_date"
-./node_modules/.bin/githubcontrib --repo woocommerce-rest-api $common_arguments >> $output_file
-
 echo "Output generated to $output_file."


### PR DESCRIPTION
Now that woocommerce-rest-api was merged back into the WC core repository, we don't need to check contributions in the deprecated woocommerce-rest-api repository.
