### PR TITLE
Fix undefined variable name

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1483,7 +1483,7 @@ if ( ! function_exists( 'woocommerce_show_product_images' ) ) {
 				$post_thumbnail_id = array_shift( $gallery_image_ids );
 			}
 		}
-		wc_get_template( 'single-product/product-thumbnails.php', array( 'post_thumbnail_id' => $post_thumbnail_id ) );
+		wc_get_template( 'single-product/product-thumbnails.php', array( 'attachment_ids' => (array) $post_thumbnail_id ) );
 	}
 }
 if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There is a notice showing: `Notice: Undefined variable: attachment_ids in /srv/www/gitwooplugins/public_html/wp-content/plugins/woocommerce/templates/single-product/product-thumbnails.php on line 2`

This is due to a wrong variable name. This PR corrects the name and casts the single id as an array as that is what is expected from https://github.com/woocommerce/woocommerce/blob/master/templates/single-product/product-thumbnails.php


### How to test the changes in this Pull Request:

1. Setup a variable product with main and gallery images.
2. Go to the product page and ensure there are no more notices as stated above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
