### PR TITLE
restore shipping setup test

### DIFF
--- a/tests/e2e/core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
+++ b/tests/e2e/core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
@@ -27,7 +27,7 @@ const runOnboardingFlowTest = () => {
 
 const runTaskListTest = () => {
 	describe('Store owner can go through setup Task List', () => {
-		it.skip('can setup shipping', async () => {
+		it('can setup shipping', async () => {
 			await page.evaluate(() => {
 				document.querySelector('.woocommerce-list__item-title').scrollIntoView();
 			});
@@ -37,7 +37,7 @@ const runTaskListTest = () => {
 
 			await Promise.all([
 				// Click on "Set up shipping" task to move to the next step
-				taskListItems[4].click(),
+				taskListItems[3].click(),
 
 				// Wait for shipping setup section to load
 				page.waitForNavigation({waitUntil: 'networkidle0'}),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This PR restores running the shipping setup step from the task list. The step was disabled in #27821
 
Closes #27950 .

### How to test the changes in this Pull Request:

1. Travis should pass.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A