### PR TITLE
Update Travis configuration for running unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,10 +44,10 @@ jobs:
     env: WP_VERSION=nightly WP_MULTISITE=0
   - name: "WP Latest - 1"
     php: 7.2
-    env: WP_VERSION=5.3 WP_MULTISITE=0
+    env: WP_VERSION=5.4 WP_MULTISITE=0
   - name: "WP Latest - 2"
     php: 7.2
-    env: WP_VERSION=5.2 WP_MULTISITE=0
+    env: WP_VERSION=5.3 WP_MULTISITE=0
   - name: "Code Standards"
     php: 7.4
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,6 @@ jobs:
   - name: "WP Nightly"
     php: 7.4
     env: WP_VERSION=nightly WP_MULTISITE=0
-  - name: "WP Latest"
-    php: 7.2
-    env: WP_VERSION=5.4 WP_MULTISITE=0
   - name: "WP Latest - 1"
     php: 7.2
     env: WP_VERSION=5.3 WP_MULTISITE=0


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces two changes to our Travis configuration file:

- Removes a redundant Travis build job added in https://github.com/woocommerce/woocommerce/commit/df7db728557ff9c8d5ecde274380e5c331cd8fba#diff-6ac3f79fc25d95cd1e3d51da53a4b21b939437392578a35ae8cd6d5366ca5485R47 (cc @ObliviousHarmony in case I'm missing something and we need this job for some reason). For more information see [this commit message](https://github.com/woocommerce/woocommerce/commit/22b231f6c4f09695f4a4ff8a02fc83451e7840cc).
- Bumps the numbers of old WP versions that we still support and run unit tests against.

### How to test the changes in this Pull Request:

1. Verify that the removed Travis build job is indeed redundant.
2. Check that the code changes make sense.
3. Check that the Travis build passed.
