### PR TITLE
Update stable tag to WC 4.6.0

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 7.0
-Stable tag: 4.5.2
+Stable tag: 4.6.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This PR just updates the stable tag to WC 4.6.0 in preparation for the final release of WC 4.6.0. I already updated the stable tag on the `release/4.6` branch. Doing this change here against `master` as well just to avoid potential issues for future releases (for example, when we create the `release/4.7` branch).