### PR TITLE
Document disabling puppeteer download

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -11,7 +11,8 @@ Automated end-to-end tests for WooCommerce.
 - [Configuration](#configuration)
   - [Test Environment](#test-environment)
   - [Test Variables](#test-variables)
-  - [Jest test sequencer](#jest-test-sequencer)      
+  - [Jest test sequencer](#jest-test-sequencer)
+  - [Chromium Download](#chromium-download)
 - [Running tests](#running-tests)
   - [Prep work for running tests](#prep-work-for-running-tests)
   - [How to run tests in headless mode](#how-to-run-tests-in-headless-mode) 
@@ -19,7 +20,7 @@ Automated end-to-end tests for WooCommerce.
   - [How to run an individual test](#how-to-run-an-individual-test)
   - [How to skip tests](#how-to-skip-tests)
   - [How to run tests using custom WordPress, PHP and MariaDB versions](#how-to-run-tests-using-custom-wordpress,-php-and-mariadb-versions)
-- [Writing tests](#writing-tests) 
+- [Writing tests](#writing-tests)
 - [Debugging tests](#debugging-tests)
 
 ## Pre-requisites
@@ -78,6 +79,16 @@ If you need to modify the port for your local test environment (eg. port is alre
 [Jest](https://jestjs.io/) is being used to run e2e tests. By default, jest runs tests ordered by the time it takes to run the test (the test that takes longer to run will be run first, the test that takes less time to run will run last). Jest sequencer introduces tools that can be used to specify the order in which the tests are being run. In our case, they are being run in alphabetical order of the directories where tests are located. This way, tests in the new directory `activate-and-setup` will run first. 
 
 Setup Wizard e2e test (located in `activate-and-setup` directory) will run before all other tests. This will allow making sure that WooCommerce is activated on the site and for the setup wizard to be completed on a brand new install of WooCommerce. 
+
+### Chromium Download
+
+By default, `Puppeteer` downloads the `Chromium` package every time you run `npm install` or `npm update`. To disable that download add the following to your `.bash_profile` or `.zshrc` (whichever you use):
+
+```shell script
+export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+```
+
+Puppeteer will still automatically download Chromium when needed.
 
 ## Running tests
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR supersedes #27777 by providing instructions on disabling the download in the local test environment. The issue with that PR is that Puppeteer doesn't look at the value of `PUPPETEER_SKIP_CHROMIUM_DOWNLOAD` only whether or not it is set. 

Closes #27493  .

### How to test the changes in this Pull Request:

1. Add `export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true` to your `.bash_profile`
2. Open a new terminal tab/window
3. Change branches
4. Run `npm install`
5. Chromium should not download

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A
