### PR TITLE
switch to api package, bump utils package version

### DIFF
--- a/tests/e2e/utils/package.json
+++ b/tests/e2e/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/e2e-utils",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "End-To-End (E2E) test utils for WooCommerce",
   "homepage": "https://github.com/woocommerce/woocommerce/tree/master/tests/e2e-utils/README.md",
   "repository": {
@@ -11,7 +11,7 @@
   "main": "build/index.js",
   "module": "build-module/index.js",
   "dependencies": {
-    "@woocommerce/api": "file:../api",
+    "@woocommerce/api": "0.1.0",
     "@wordpress/e2e-test-utils": "4.6.0",
     "faker": "^5.1.0",
     "fishery": "^1.0.1"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR switches the `e2e-utils` package to use the api package instead of the relative path. It bump the `e2e-utils` package version for releasing a new version of the package.

Closes #27874 .

### How to test the changes in this Pull Request:

1. `npm install`
2. `npm run docker:up`
3. `npm run test:e2e`
4. E2E tests should run

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A
