### PR TITLE
add e2e-environment package changelog

### DIFF
--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -1,3 +1,30 @@
-1.0.0 (unreleased)
+# 0.16
 
-- Initial release
+## Added
+
+- `useE2EEsLintConfig`, `useE2EBabelConfig` config functions
+- support for local Jest and Puppeteer configuration with `useE2EJestConfig`, `useE2EJestPuppeteerConfig` config functions
+- support for local node configuration
+- support for custom port use in included container
+- support for running tests against URLs without a port
+- support for PHP, MariaDB & WP versions
+- support for a non-plugin folder mapping (theme or project)
+- support for `JEST_PUPPETEER_CONFIG` environment variable
+- implement `@automattic/puppeteer-utils`
+- implement `@wordpress/e2e-test-utils`
+- enable test debugging with `test:e2e-debug` script
+
+## Fixed
+
+- support for local test configuration 
+- support for local Jest setup
+- `docker:ssh` script works in any repo
+
+## Changes
+
+- removed the products and orders delete resets
+- eliminated the use of docker-compose.yaml in the root of the project
+
+# 0.15
+
+- Initial/beta release

--- a/tests/e2e/env/package.json
+++ b/tests/e2e/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/e2e-environment",
-  "version": "0.1.5",
+  "version": "0.1.6",
   "description": "WooCommerce End to End Testing Environment Configuration.",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",


### PR DESCRIPTION
This PR bumps the version and updates the changelog for `@woocommerce/e2e-environment` version 0.1.6.
