### PR TITLE
Add the WP nightly build job to the allow_failures list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ jobs:
   allow_failures:
   - php: 7.4
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
+  - name: "WP Nightly"
 
 install:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds the Travis build job that runs using WP nightly to the list of jobs that are allowed to fail. Two days ago a change
(https://github.com/WordPress/WordPress/commit/fa5a6c8622003a7a4a4dee0b0097dd92d4b07be6) was introduced to WP nightly that broke hundreds of our unit tests. I'm suggesting we move this build job to the list of jobs that are allowed to fail while we work on a fix for this problem either on our side or on WP core side. Having the build always failing due to a known issue in a yet to be released WP version has the potential to hide other more important failures.

### How to test the changes in this Pull Request:

1. Open the Travis build for this PR and check that the WP nightly job is included in the list of jobs that can fail.