### PR TITLE
Improve Travis build performance by running `npm install` only when needed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,11 @@ jobs:
   - name: "Core E2E Tests"
     php: 7.4
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_E2E=1
+    install:
+     - nvm install
+     - npm install
+     - composer install
+     - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
     script:
       - npm run build:assets
       - npm install jest --global
@@ -67,8 +72,6 @@ install:
     else
       echo "xdebug.ini does not exist"
     fi
-  - nvm install
-  - npm install
   - composer install
   - |
     # Install WP Test suite, install PHPUnit globally:


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the .travis.yml file to run `npm install` (and two associated commands) only when running the build job that executes the E2E tests. Running `npm install` takes about 160 seconds to complete and, before this commit, we were running it for all build jobs unnecessarily.

After merging this PR, all Travis build jobs except the one that runs the E2E will run almost three minutes faster than before.

### How to test the changes in this Pull Request:

1. Check that the Travis build passes and all expected jobs run correctly.