### PR TITLE
Fix billing email being parsed as a URL link when beginning of email …

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -344,8 +344,8 @@ class WC_Meta_Box_Order_Data {
 
 								if ( 'billing_phone' === $field_name ) {
 									$field_value = wc_make_phone_clickable( $field_value );
-								} else if ( 'billing_email' === $field_name ) {
-									$field_value = '<a href="mailto:' . $field_value . '">' . $field_value . '</a>';
+								} elseif ( 'billing_email' === $field_name ) {
+									$field_value = '<a href="mailto:' . esc_attr( $field_value ) . '">' . esc_html( $field_value ) . '</a>';
 								} else {
 									$field_value = make_clickable( esc_html( $field_value ) );
 								}

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -344,6 +344,8 @@ class WC_Meta_Box_Order_Data {
 
 								if ( 'billing_phone' === $field_name ) {
 									$field_value = wc_make_phone_clickable( $field_value );
+								} else if ( 'billing_email' === $field_name ) {
+									$field_value = '<a href="mailto:' . $field_value . '">' . $field_value . '</a>';
 								} else {
 									$field_value = make_clickable( esc_html( $field_value ) );
 								}

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -345,7 +345,7 @@ class WC_Meta_Box_Order_Data {
 								if ( 'billing_phone' === $field_name ) {
 									$field_value = wc_make_phone_clickable( $field_value );
 								} elseif ( 'billing_email' === $field_name ) {
-									$field_value = '<a href="mailto:' . esc_attr( $field_value ) . '">' . esc_html( $field_value ) . '</a>';
+									$field_value = '<a href="' . esc_url( 'mailto:' . $field_value ) . '">' . $field_value . '</a>';
 								} else {
 									$field_value = make_clickable( esc_html( $field_value ) );
 								}


### PR DESCRIPTION
…contains www closes #25099

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Make email clickable without it being transformed into a URL link because the email contains `www` at the beginning.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25099 

### How to test the changes in this Pull Request:

1. Make a test order with a billing email address that starts with `www` like `www.johndoe@test.com`
2. Go to the order detail page in admin and check the billing email and ensure the email link do not have `http` added to it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Email address starting with `www` being displayed as a URL link in the admin order details page.
