### PR TITLE
[PHP 8] Fixes in the dependency injection engine for PHP 8 compatibility

### DIFF
--- a/src/Internal/DependencyManagement/AbstractServiceProvider.php
+++ b/src/Internal/DependencyManagement/AbstractServiceProvider.php
@@ -72,6 +72,11 @@ abstract class AbstractServiceProvider extends \Automattic\WooCommerce\Vendor\Le
 	 * @return \ReflectionClass|null The class of the parameter, or null if it hasn't any.
 	 */
 	private function get_class( \ReflectionParameter $parameter ) {
+		// TODO: Remove this 'if' block once minimum PHP version for WooCommerce is bumped to at least 7.1.
+		if ( version_compare( PHP_VERSION, '7.1', '<' ) ) {
+			return $parameter->getClass();
+		}
+
 		return $parameter->getType() && ! $parameter->getType()->isBuiltin()
 			? new \ReflectionClass( $parameter->getType()->getName() )
 			: null;

--- a/src/Internal/DependencyManagement/AbstractServiceProvider.php
+++ b/src/Internal/DependencyManagement/AbstractServiceProvider.php
@@ -45,7 +45,7 @@ abstract class AbstractServiceProvider extends \Automattic\WooCommerce\Vendor\Le
 					$default_value = $argument->getDefaultValue();
 					$definition->addArgument( new RawArgument( $default_value ) );
 				} else {
-					$argument_class = $argument->getClass();
+					$argument_class = $this->get_class( $argument );
 					if ( is_null( $argument_class ) ) {
 						throw new ContainerException( "Argument '{$argument->getName()}' of class '$class_name' doesn't have a type hint or has one that doesn't specify a class." );
 					}
@@ -59,6 +59,22 @@ abstract class AbstractServiceProvider extends \Automattic\WooCommerce\Vendor\Le
 		$this->getContainer()->add( $definition->getAlias(), $definition, $shared );
 
 		return $definition;
+	}
+
+	/**
+	 * Gets the class of a parameter.
+	 *
+	 * This method is a replacement for ReflectionParameter::getClass,
+	 * which is deprecated as of PHP 8.
+	 *
+	 * @param \ReflectionParameter $parameter The parameter to get the class for.
+	 *
+	 * @return \ReflectionClass|null The class of the parameter, or null if it hasn't any.
+	 */
+	private function get_class( \ReflectionParameter $parameter ) {
+		return $parameter->getType() && ! $parameter->getType()->isBuiltin()
+			? new \ReflectionClass( $parameter->getType()->getName() )
+			: null;
 	}
 
 	/**

--- a/tests/php/src/Internal/DependencyManagement/AbstractServiceProviderTest.php
+++ b/tests/php/src/Internal/DependencyManagement/AbstractServiceProviderTest.php
@@ -94,7 +94,7 @@ class AbstractServiceProviderTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_add_with_auto_arguments_throws_on_class_private_method_injection() {
 		$this->expectException( ContainerException::class );
-		$this->expectExceptionMessage( "Method '" . Definition::INJECTION_METHOD . "' of class '" . ClassWithPrivateInjectionMethod::class . "' isn't 'public', instances can't be created." );
+		$this->expectExceptionMessage( "Method '" . Definition::INJECTION_METHOD . "' of class '" . ClassWithPrivateInjectionMethod::class . "' isn't 'final public', instances can't be created." );
 
 		$this->sut->add_with_auto_arguments( ClassWithPrivateInjectionMethod::class );
 	}
@@ -114,7 +114,7 @@ class AbstractServiceProviderTest extends \WC_Unit_Test_Case {
 	 */
 	public function test_add_with_auto_arguments_throws_on_concrete_private_method_injection() {
 		$this->expectException( ContainerException::class );
-		$this->expectExceptionMessage( "Method '" . Definition::INJECTION_METHOD . "' of class '" . ClassWithPrivateInjectionMethod::class . "' isn't 'public', instances can't be created." );
+		$this->expectExceptionMessage( "Method '" . Definition::INJECTION_METHOD . "' of class '" . ClassWithPrivateInjectionMethod::class . "' isn't 'final public', instances can't be created." );
 
 		$this->sut->add_with_auto_arguments( ClassWithDependencies::class, ClassWithPrivateInjectionMethod::class );
 	}

--- a/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithPrivateInjectionMethod.php
+++ b/tests/php/src/Internal/DependencyManagement/ExampleClasses/ClassWithPrivateInjectionMethod.php
@@ -12,13 +12,15 @@ namespace Automattic\WooCommerce\Tests\Internal\DependencyManagement\ExampleClas
  */
 class ClassWithPrivateInjectionMethod {
 
-	// phpcs:disable WooCommerce.Functions.InternalInjectionMethod.MissingPublic
+	// phpcs:disable WooCommerce.Functions.InternalInjectionMethod.MissingPublic, WooCommerce.Functions.InternalInjectionMethod.MissingFinal
 
 	/**
 	 * Initialize the class instance.
 	 *
 	 * @internal
 	 */
-	final private function init() {
+	private function init() {
 	}
+
+	// phpcs:enable
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- One dummy class used for tests had a `final private` method, this is not allowed in PHP 8 and so the method is now just `private`.

- The `AbstractServiceProvider` class was using `ReflectionParameter::getClass`. This is deprecated in PHP8 and thus that usage has been replaced with an utility method that uses the recommended replacement.

### How to test the changes in this Pull Request:

Run the unit tests and smoketest (if the site loads at all without erroring that's enough).

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

Not needed since this is a fix for the reintroduction of the dependency injection container, which is new in the milestoned release.