### PR TITLE
[PHP 8] Convert optional-before-required parameters into required parameters (take 2)

### DIFF
--- a/includes/admin/class-wc-admin-taxonomies.php
+++ b/includes/admin/class-wc-admin-taxonomies.php
@@ -387,7 +387,7 @@ class WC_Admin_Taxonomies {
 	 * @param object $term Term object.
 	 * @return array
 	 */
-	public function product_cat_row_actions( $actions = array(), $term ) {
+	public function product_cat_row_actions( $actions, $term ) {
 		$default_category_id = absint( get_option( 'default_product_cat', 0 ) );
 
 		if ( $default_category_id !== $term->term_id && current_user_can( 'edit_term', $term->term_id ) ) {

--- a/includes/walkers/class-wc-product-cat-dropdown-walker.php
+++ b/includes/walkers/class-wc-product-cat-dropdown-walker.php
@@ -93,7 +93,7 @@ class WC_Product_Cat_Dropdown_Walker extends Walker {
 	 * @param string $output            Passed by reference. Used to append additional content.
 	 * @return null Null on failure with no changes to parameters.
 	 */
-	public function display_element( $element, &$children_elements, $max_depth, $depth = 0, $args, &$output ) {
+	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
 		if ( ! $element || ( 0 === $element->count && ! empty( $args[0]['hide_empty'] ) ) ) {
 			return;
 		}

--- a/includes/walkers/class-wc-product-cat-list-walker.php
+++ b/includes/walkers/class-wc-product-cat-list-walker.php
@@ -144,7 +144,7 @@ class WC_Product_Cat_List_Walker extends Walker {
 	 * @param string $output            Passed by reference. Used to append additional content.
 	 * @return null Null on failure with no changes to parameters.
 	 */
-	public function display_element( $element, &$children_elements, $max_depth, $depth = 0, $args, &$output ) {
+	public function display_element( $element, &$children_elements, $max_depth, $depth, $args, &$output ) {
 		if ( ! $element || ( 0 === $element->count && ! empty( $args[0]['hide_empty'] ) ) ) {
 			return;
 		}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

See https://github.com/woocommerce/woocommerce/pull/27840.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

Not needed since this is the same as https://github.com/woocommerce/woocommerce/pull/27840.
