### PR TITLE
expand e2e-utils readme, simplify exports

### DIFF
--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -33,3 +33,66 @@ describe( 'Cart page', () => {
 	} );
 } );
 ~~~
+
+## Test Function
+
+### Merchant `StoreOwnerFlow`
+
+| Function | Description |
+|----------|-------------|
+| `login` | Log in as merchant |
+| `logout` | log out of merchant account |
+| `openAllOrdersView` | Go to the orders listing |
+| `openDashboard` | Go to the WordPress dashboard  |
+| `openNewCoupon` | Go to the new coupon editor |
+| `openNewOrder` | Go to the new order editor |
+| `openNewProduct` | Go to the new product editor |
+| `openPermalinkSettings` | Go to Settings -> Permalinks |
+| `openPlugins` | Go to the Plugins screen |
+| `openSettings` | Go to WooCommerce -> Settings |
+| `runSetupWizard` | Open the onboarding profiler |
+|----------|-------------|
+
+### Shopper `CustomerFlow`
+
+| Function | Parameters | Description |
+|----------|------------|-------------|
+| `addToCart` | | Add an item to the cart from a single product page |
+| `addToCartFromShopPage` | `productTitle` | Add an item to the cart from a single product page |
+| `fillBillingDetails` | `customerBillingDetails` | Fill billing fields in checkout form using configured address |
+| `fillShippingDetails` | `customerShippingDetails` | Fill shipping fields in checkout form using configured address |
+| `goToAddresses` |  | Go to My Account -> Address Details |
+| `goToAccountDetails` |  | Go to My Account -> Details |
+| `goToCart` |  | Go to the cart page |
+| `goToCheckout` |  | Go to the checkout page |
+| `goToShop` |  | Go to the shop page |
+| `goToProduct` | `productId` | Go to a single product in the shop |
+| `goToOrders` |  | Go to My Account -> Orders |
+| `goToDownloads` |  | Go to My Account -> Downloads |
+| `login` |  | Log in as the shopper |
+| `placeOrder` |  | Place an order from the checkout page |
+| `productIsInCheckout` | `productTitle, quantity, total, cartSubtotal` | Verify product is in cart on checkout page |
+| `removeFromCart` | `productTitle` | Remove a product from the cart on the cart page |
+| `setCartQuantity` | `productTitle, quantityValue` | Change the quantity of a product on the cart page |
+|----------|------------|-------------|
+
+### Page Utilities
+
+| Function | Parameters | Description |
+|----------|------------|-------------|
+| `clearAndFillInput` | `selector, value` | Replace the contents of an input with the passed value |
+| `clickTab` | `tabName` | Click on a WooCommerce -> Settings tab |
+| `settingsPageSaveChanges` |  | Save the current WooCommerce settings page |
+| `permalinkSettingsPageSaveChanges` |  | Save the current Permalink settings |
+| `setCheckbox` | `selector` | Check a checkbox |
+| `unsetCheckbox` | `selector` | Uncheck a checkbox |
+| `uiUnblocked` |  | Wait until the page is unblocked |
+| `verifyPublishAndTrash` | `button, publishNotice, publishVerification, trashVerification` | Verify that an item can be published and trashed |
+| `verifyCheckboxIsSet` | `selector` | Verify that a checkbox is checked |
+| `verifyCheckboxIsUnset` | `selector` | Verify that a checkbox is unchecked |
+| `verifyValueOfInputField` | `selector, value` | Verify an input contains the passed value |
+|----------|------------|-------------|
+
+### Test Utilities
+
+As of version 0.1.2, all test utilities from [`@wordpress/e2e-test-utils`](https://www.npmjs.com/package/@wordpress/e2e-test-utils) are available through this package.

--- a/tests/e2e/utils/src/flows.js
+++ b/tests/e2e/utils/src/flows.js
@@ -125,7 +125,6 @@ const CustomerFlow = {
 		} );
 	},
 
-
 	goToShop: async () => {
 		await page.goto(SHOP_PAGE, {
 			waitUntil: 'networkidle0',

--- a/tests/e2e/utils/src/index.js
+++ b/tests/e2e/utils/src/index.js
@@ -1,44 +1,17 @@
-import { CustomerFlow, StoreOwnerFlow } from './flows';
-
-import {
-	completeOnboardingWizard,
-	completeOldSetupWizard,
-	createSimpleProduct,
-	createVariableProduct,
-	verifyAndPublish,
-} from './components';
-
-import {
-	clearAndFillInput,
-	clickTab,
-	settingsPageSaveChanges,
-	permalinkSettingsPageSaveChanges,
-	setCheckbox,
-	unsetCheckbox,
-	uiUnblocked,
-	verifyPublishAndTrash,
-	verifyCheckboxIsSet,
-	verifyCheckboxIsUnset,
-	verifyValueOfInputField,
-} from './page-utils';
+/*
+ * External dependencies
+ */
+import allWPUtilities from '@wordpress/e2e-test-utils';
+/*
+ * Internal dependencies
+ */
+import allFlows from './flows';
+import allComponents from './components';
+import allUtilities from './page-utils';
 
 module.exports = {
-	CustomerFlow,
-	StoreOwnerFlow,
-	completeOnboardingWizard,
-	completeOldSetupWizard,
-	createSimpleProduct,
-	createVariableProduct,
-	verifyAndPublish,
-	clearAndFillInput,
-	clickTab,
-	settingsPageSaveChanges,
-	permalinkSettingsPageSaveChanges,
-	setCheckbox,
-	unsetCheckbox,
-	uiUnblocked,
-	verifyPublishAndTrash,
-	verifyCheckboxIsSet,
-	verifyCheckboxIsUnset,
-	verifyValueOfInputField
-}
+	...allWPUtilities,
+	...allFlows,
+	...allComponents,
+	...allUtilities,
+};

--- a/tests/e2e/utils/src/index.js
+++ b/tests/e2e/utils/src/index.js
@@ -1,17 +1,11 @@
 /*
  * External dependencies
  */
-import allWPUtilities from '@wordpress/e2e-test-utils';
+export * from '@wordpress/e2e-test-utils';
 /*
  * Internal dependencies
  */
-import allFlows from './flows';
-import allComponents from './components';
-import allUtilities from './page-utils';
+export * from './flows';
+export * from './components';
+export * from './page-utils';
 
-module.exports = {
-	...allWPUtilities,
-	...allFlows,
-	...allComponents,
-	...allUtilities,
-};


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR expand the `@woocommerce/e2e-utils` readme to include details on the available functions. 

It makes a small code change that simplifies the package exports. Any new exports in `flows` or `page-utils` are automatically added to the package export.

Per my added note on the issue, `@wordpress/e2e-test-utils` exports are included in this package's exports.

Closes #27979 .

### How to test the changes in this Pull Request:

1. Editorial review of readme
2. Run E2E test suite
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A
