### PR TITLE
Fix the Travis build job that runs PHPCS

### DIFF
--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -5,11 +5,6 @@ if [[ ${RUN_PHPCS} == 1 ]]; then
 	IGNORE="tests/cli/,includes/libraries/,includes/api/legacy/"
 
 	if [ "$CHANGED_FILES" != "" ]; then
-		if [ ! -f "./vendor/bin/phpcs" ]; then
-			# Install wpcs globally
-			composer global require woocommerce/woocommerce-sniffs --update-with-all-dependencies
-		fi
-
 		echo "Running Code Sniffer."
 		vendor/bin/phpcs --ignore=$IGNORE --encoding=utf-8 -s -n -p $CHANGED_FILES
 	fi

--- a/tests/bin/phpcs.sh
+++ b/tests/bin/phpcs.sh
@@ -11,6 +11,6 @@ if [[ ${RUN_PHPCS} == 1 ]]; then
 		fi
 
 		echo "Running Code Sniffer."
-		phpcs --ignore=$IGNORE --encoding=utf-8 -s -n -p $CHANGED_FILES
+		vendor/bin/phpcs --ignore=$IGNORE --encoding=utf-8 -s -n -p $CHANGED_FILES
 	fi
 fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

It is not clear to me why but recently the Travis build job that runs PHPCS started failing with the following error:

```
Running Code Sniffer.
tests/bin/phpcs.sh: line 14: phpcs: command not found
The command "bash tests/bin/phpcs.sh" exited with 127.
```

(see for example https://travis-ci.org/github/woocommerce/woocommerce/jobs/736440739#L508)

This PR fixes this problem by specifying the relative path where phpcs is installed via composer. It also removes code that was installing PHPCS as a global package only in the Travis build job that runs it. As far as I can tell, there is no reason to install PHPCS as a global package as it is already installed in the project vendor folder since we run `composer install` for all build jobs. The PR that introduced the change to install PHPCS globally doesn't mention why this change is necessary (#27614).

cc @claudiosanches in case we need to install PHPCS inside `tests/bin/phpcs.sh` for some reason that I'm missing.

### How to test the changes in this Pull Request:

1. Create a branch based on this branch.
2. Push changes to a PHP file.
3. Create a PR and check that the Travis build job for PHPCS runs sucessfully.
4. Alternatively, you can check the results of a PR that I created for that in my fork while testing this: https://github.com/rodrigoprimo/woocommerce/pull/40. You can see that when I introduced a coding standard violation the build failed as expected (https://travis-ci.org/github/rodrigoprimo/woocommerce/jobs/736478456#L505) and when I fixed the violation the build passed (https://travis-ci.org/github/rodrigoprimo/woocommerce/builds/736479749).