### PR TITLE
Fix checkout page not displaying visual blocking when place order is …

### DIFF
--- a/assets/css/twenty-nineteen.scss
+++ b/assets/css/twenty-nineteen.scss
@@ -1122,16 +1122,6 @@ table.variations {
 	.select2-container--focus .select2-selection {
 		border-color: black;
 	}
-
-	form[name="checkout"] {
-		display: table;
-	}
-
-	.blockUI.blockOverlay {
-		position: relative;
-
-		@include loader();
-	}
 }
 
 .woocommerce-checkout-review-order-table {

--- a/assets/css/twenty-nineteen.scss
+++ b/assets/css/twenty-nineteen.scss
@@ -1122,6 +1122,16 @@ table.variations {
 	.select2-container--focus .select2-selection {
 		border-color: black;
 	}
+
+	form[name="checkout"] {
+		display: table;
+	}
+
+	.blockUI.blockOverlay {
+		position: relative;
+
+		@include loader();
+	}
 }
 
 .woocommerce-checkout-review-order-table {

--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -1661,6 +1661,16 @@ a.reset_variations {
 		}
 	}
 
+	form[name="checkout"] {
+		display: table;
+	}
+
+	.blockUI.blockOverlay {
+		position: relative;
+
+		@include loader();
+	}
+
 	form {
 
 		.col2-set {


### PR DESCRIPTION
…clicked closes #27656

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27656 

### How to test the changes in this Pull Request:

1. Switch to 2020 theme and do a place order from the checkout.
2. Ensure you see the feedback of a visual block with spinning loader after clicking place order.
3. Do steps 1 and 2 again but with 2019 theme enabled.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Fix - No visual feedback on progress after `Place Order` button has been clicked in checkout on Twenty Twenty and Twenty Nineteen themes.