### PR TITLE
Remove PHP 7.4 from the Travis job that runs E2E tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,6 @@ jobs:
   fast_finish: true
   include:
   - name: "Core E2E Tests"
-    php: 7.4
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_E2E=1
     install:
      - nvm install


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This should reduce in about ten seconds (https://travis-ci.org/github/woocommerce/woocommerce/jobs/736437593#L198) the time to run this Travis job. PHP 7.4 is not installed by default in the image user by Travis and it is not needed to run the E2E tests.

### How to test the changes in this Pull Request:

1. Check that the Travis build passes and that E2E tests are correctly executed.