### PR TITLE
Remove unnecessary commands from Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,6 @@ jobs:
      - composer install
     script:
       - npm run build:assets
-      - npm install jest --global
       - npm run docker:up
       - npm run test:e2e
     after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ cache:
 
 # Since Xenial services are not started by default, we need to instruct it below to start.
 services:
-  - xvfb
   - mysql
   - docker
 
@@ -36,7 +35,6 @@ jobs:
      - nvm install
      - npm install
      - composer install
-     - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
     script:
       - npm run build:assets
       - npm install jest --global
@@ -80,7 +78,6 @@ install:
       bash tests/bin/install.sh woocommerce_test root '' localhost $WP_VERSION
       composer global require "phpunit/phpunit=6.5.*|7.5.*"
     fi
-  - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16"
 
 script:
   - bash tests/bin/phpunit.sh


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR cleans the Travis configuration file a bit by removing some unnecessary commands:

- Removes the xvfb service as I believe we don't need it anymore to run the E2E tests now that we are using a Docker container
- Removes the command to install jest globally when running E2E tests. This is also not necessary since everything is installed inside the Docker container.

cc @rrennick in case I'm missing something as I'm not super familiar with how the new E2E environment works.

### How to test the changes in this Pull Request:

1. Check that the Travis build is passing and that the tests as running as expected.