### PR TITLE
Replace jQuery.ready function with recommended way since jQuery 3.0 c…

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -565,7 +565,7 @@ class WC_Shortcodes {
 			$single_product = new WP_Query( $args );
 			?>
 			<script type="text/javascript">
-				jQuery( document ).ready( function( $ ) {
+				jQuery( function( $ ) {
 					var $variations_form = $( '[data-product-page-preselected-id="<?php echo esc_attr( $preselected_id ); ?>"]' ).find( 'form.variations_form' );
 
 					<?php foreach ( $attributes as $attr => $value ) { ?>

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -102,7 +102,7 @@ class WC_Shop_Customizer {
 		$max_notice = __( 'The maximum allowed setting is %d', 'woocommerce' );
 		?>
 		<script type="text/javascript">
-			jQuery( document ).ready( function( $ ) {
+			jQuery( function( $ ) {
 				$( document.body ).on( 'change', '.woocommerce-cropping-control input[type="radio"]', function() {
 					var $wrapper = $( this ).closest( '.woocommerce-cropping-control' ),
 						value    = $wrapper.find( 'input:checked' ).val();


### PR DESCRIPTION
…loses #27945

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Replaces jQuery.ready method with recommended syntax as referenced in the docs. See #27945 

Closes #27945


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Tweak - Replace jQuery.ready method with recommended syntax.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
