### PR TITLE
Update woocommerce-admin to 1.6.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.6.1",
+    "woocommerce/woocommerce-admin": "1.6.2",
     "woocommerce/woocommerce-blocks": "3.4.0",
     "league/container": "3.3.3"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "177fa175c12c63dd29d3241469dc07b7",
+    "content-hash": "d5aad48faec90c3c5c76243d9fcf3cf7",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -259,12 +259,6 @@
                 "provider",
                 "service"
             ],
-            "funding": [
-                {
-                    "url": "https://github.com/philipobenito",
-                    "type": "github"
-                }
-            ],
             "time": "2020-09-28T13:38:44+00:00"
         },
         {
@@ -501,20 +495,6 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
             "time": "2020-03-16T08:31:04+00:00"
         },
         {
@@ -554,16 +534,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "1.6.1",
+            "version": "1.6.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "4be058217d90b7f15b711d018b899260b38d011a"
+                "reference": "0978d750472813aa21e5c80651005a3ccd1fc0a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/4be058217d90b7f15b711d018b899260b38d011a",
-                "reference": "4be058217d90b7f15b711d018b899260b38d011a",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0978d750472813aa21e5c80651005a3ccd1fc0a3",
+                "reference": "0978d750472813aa21e5c80651005a3ccd1fc0a3",
                 "shasum": ""
             },
             "require": {
@@ -597,7 +577,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2020-10-14T14:21:15+00:00"
+            "time": "2020-10-16T19:24:07+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -706,6 +686,5 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    },
-    "plugin-api-version": "1.1.0"
+    }
 }


### PR DESCRIPTION
This branch updates the WooCommerce Admin package to 1.6.2 which includes fixes for the following bugs reported after the release of WooCommerce 4.6:

[#5400](https://github.com/woocommerce/woocommerce-admin/pull/5400) fix for missing activity panels.
[#5415](https://github.com/woocommerce/woocommerce-admin/pull/5415) adds array casting on onboarding profile option
[#5416](https://github.com/woocommerce/woocommerce-admin/pull/5416) Gutenberg compatibility fix for home screen inbox.
[#5409](https://github.com/woocommerce/woocommerce-admin/pull/5409) Gutenberg compat fix for empty reports ( leaderboard, customers report ).
[#5405](https://github.com/woocommerce/woocommerce-admin/pull/5405) i18n fix for Performance Indicators labels Home Screen