### PR TITLE
Use new Note classes from wc-admin.

### DIFF
--- a/includes/admin/notes/class-wc-notes-run-db-update.php
+++ b/includes/admin/notes/class-wc-notes-run-db-update.php
@@ -10,7 +10,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use \Automattic\Jetpack\Constants;
-use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+use \Automattic\WooCommerce\Admin\Notes\Note;
 
 /**
  * WC_Notes_Run_Db_Update.
@@ -58,7 +58,7 @@ class WC_Notes_Run_Db_Update {
 			// Remove weird duplicates. Leave the first one.
 			$current_notice = array_shift( $note_ids );
 			foreach ( $note_ids as $note_id ) {
-				$note = new WC_Admin_Note( $note_id );
+				$note = new Note( $note_id );
 				$data_store->delete( $note );
 			}
 			return $current_notice;
@@ -77,8 +77,8 @@ class WC_Notes_Run_Db_Update {
 			return;
 		}
 
-		$note = new WC_Admin_Note( $note_id );
-		$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
+		$note = new Note( $note_id );
+		$note->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
 		$note->save();
 	}
 
@@ -89,7 +89,7 @@ class WC_Notes_Run_Db_Update {
 	 *  - actions are set up for the first 'Update database' notice, and
 	 *  - URL for note's action is equal to the given URL (to check for potential nonce update).
 	 *
-	 * @param WC_Admin_Note      $note            Note to check.
+	 * @param Note               $note            Note to check.
 	 * @param string             $update_url      URL to check the note against.
 	 * @param array<int, string> $current_actions List of actions to check for.
 	 * @return bool
@@ -135,9 +135,9 @@ class WC_Notes_Run_Db_Update {
 		);
 
 		if ( $note_id ) {
-			$note = new WC_Admin_Note( $note_id );
+			$note = new Note( $note_id );
 		} else {
-			$note = new WC_Admin_Note();
+			$note = new Note();
 		}
 
 		// Check if the note needs to be updated (e.g. expired nonce or different note type stored in the previous run).
@@ -151,13 +151,13 @@ class WC_Notes_Run_Db_Update {
 			/* translators: %1$s: opening <a> tag %2$s: closing </a> tag*/
 			. sprintf( ' ' . esc_html__( 'The database update process runs in the background and may take a little while, so please be patient. Advanced users can alternatively update via %1$sWP CLI%2$s.', 'woocommerce' ), '<a href="https://github.com/woocommerce/woocommerce/wiki/Upgrading-the-database-using-WP-CLI">', '</a>' )
 		);
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
+		$note->set_type( Note::E_WC_ADMIN_NOTE_UPDATE );
 		$note->set_name( self::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-core' );
 		// In case db version is out of sync with WC version or during the next update, the notice needs to show up again,
 		// so set it to unactioned.
-		$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED );
+		$note->set_status( Note::E_WC_ADMIN_NOTE_UNACTIONED );
 
 		// Set new actions.
 		$note->clear_actions();
@@ -181,7 +181,7 @@ class WC_Notes_Run_Db_Update {
 		$cron_disabled       = Constants::is_true( 'DISABLE_WP_CRON' );
 		$cron_cta            = $cron_disabled ? __( 'You can manually run queued updates here.', 'woocommerce' ) : __( 'View progress →', 'woocommerce' );
 
-		$note = new WC_Admin_Note( $note_id );
+		$note = new Note( $note_id );
 		$note->set_title( __( 'WooCommerce database update in progress', 'woocommerce' ) );
 		$note->set_content( __( 'WooCommerce is updating the database in the background. The database update process may take a little while, so please be patient.', 'woocommerce' ) );
 
@@ -227,7 +227,7 @@ class WC_Notes_Run_Db_Update {
 			),
 		);
 
-		$note = new WC_Admin_Note( $note_id );
+		$note = new Note( $note_id );
 
 		// Check if the note needs to be updated (e.g. expired nonce or different note type stored in the previous run).
 		if ( self::note_up_to_date( $note, $hide_notices_url, wp_list_pluck( $note_actions, 'name' ) ) ) {
@@ -266,8 +266,8 @@ class WC_Notes_Run_Db_Update {
 				return;
 			}
 
-			$note = new WC_Admin_Note( $note_id );
-			if ( $note::E_WC_ADMIN_NOTE_ACTIONED === $note->get_status() ) {
+			$note = new Note( $note_id );
+			if ( Note::E_WC_ADMIN_NOTE_ACTIONED === $note->get_status() ) {
 				// Db update not needed && note actioned -> don't show it.
 				return;
 			} else {

--- a/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
+++ b/tests/legacy/unit-tests/admin/notes/class-wc-tests-notes-run-db-update.php
@@ -5,7 +5,7 @@
  * @package WooCommerce\Tests\Admin\Notes
  */
 
-use \Automattic\WooCommerce\Admin\Notes\WC_Admin_Note;
+use \Automattic\WooCommerce\Admin\Notes\Note;
 
 /**
  * Tests for the WC_Notes_Run_Db_Update class.
@@ -51,7 +51,7 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 		$data_store = \WC_Data_Store::load( 'admin-note' );
 		$note_ids   = $data_store->get_notes_with_name( WC_Notes_Run_Db_Update::NOTE_NAME );
 		foreach ( $note_ids as $note_id ) {
-			$note = new WC_Admin_Note( $note_id );
+			$note = new Note( $note_id );
 			$data_store->delete( $note );
 		}
 	}
@@ -87,15 +87,15 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 			),
 		);
 
-		$note = new WC_Admin_Note();
+		$note = new Note();
 
 		$note->set_title( 'WooCommerce database update required' );
 		$note->set_content( 'To keep things running smoothly, we have to update your database to the newest version.' );
-		$note->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_UPDATE );
+		$note->set_type( Note::E_Note_UPDATE );
 		$note->set_name( WC_Notes_Run_Db_Update::NOTE_NAME );
 		$note->set_content_data( (object) array() );
 		$note->set_source( 'woocommerce-core' );
-		$note->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_UNACTIONED );
+		$note->set_status( Note::E_Note_UNACTIONED );
 
 		// Set new actions.
 		$note->clear_actions();
@@ -177,7 +177,7 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 		// An 'update required' notice should be created.
 		$this->assertEquals( 1, count( $note_ids ), 'A db update note should be created if db is NOT up to date.' );
 
-		$note = new WC_Admin_Note( $note_ids[0] );
+		$note    = new Note( $note_ids[0] );
 		$actions = $note->get_actions();
 		$this->assertEquals( 'update-db_run', $actions[0]->name, 'A db update note to update the database should be displayed now.' );
 
@@ -187,7 +187,7 @@ class WC_Tests_Notes_Run_Db_Update extends WC_Unit_Test_Case {
 		// Magic 2: update-db note to thank you note.
 		WC_Notes_Run_Db_Update::show_reminder();
 
-		$note = new WC_Admin_Note( $note_ids[0] );
+		$note    = new Note( $note_ids[0] );
 		$actions = $note->get_actions();
 		$this->assertEquals( 'update-db_done', $actions[0]->name, 'A db update note--Thanks for the update--should be displayed now.' );
 	}

--- a/tests/legacy/unit-tests/rest-api/Helpers/AdminNotesHelper.php
+++ b/tests/legacy/unit-tests/rest-api/Helpers/AdminNotesHelper.php
@@ -10,7 +10,7 @@ namespace Automattic\WooCommerce\RestApi\UnitTests\Helpers;
 defined( 'ABSPATH' ) || exit;
 
 use \WC_Data_Store;
-use \WC_Admin_Note;
+use \Automattic\WooCommerce\Admin\Notes\Note;
 
 /**
  * Class AdminNotesHelper.
@@ -34,11 +34,11 @@ class AdminNotesHelper {
 	public static function add_notes_for_tests() {
 		$data_store = WC_Data_Store::load( 'admin-note' );
 
-		$note_1 = new WC_Admin_Note();
+		$note_1 = new Note();
 		$note_1->set_title( 'PHPUNIT_TEST_NOTE_1_TITLE' );
 		$note_1->set_content( 'PHPUNIT_TEST_NOTE_1_CONTENT' );
 		$note_1->set_content_data( (object) array( 'amount' => 1.23 ) );
-		$note_1->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note_1->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note_1->set_icon( 'info' );
 		$note_1->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
 		$note_1->set_source( 'PHPUNIT_TEST' );
@@ -54,27 +54,27 @@ class AdminNotesHelper {
 		);
 		$note_1->save();
 
-		$note_2 = new WC_Admin_Note();
+		$note_2 = new Note();
 		$note_2->set_title( 'PHPUNIT_TEST_NOTE_2_TITLE' );
 		$note_2->set_content( 'PHPUNIT_TEST_NOTE_2_CONTENT' );
 		$note_2->set_content_data( (object) array( 'amount' => 4.56 ) );
-		$note_2->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_WARNING );
+		$note_2->set_type( Note::E_WC_ADMIN_NOTE_WARNING );
 		$note_2->set_icon( 'info' );
 		$note_2->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
 		$note_2->set_source( 'PHPUNIT_TEST' );
-		$note_2->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_ACTIONED );
+		$note_2->set_status( Note::E_WC_ADMIN_NOTE_ACTIONED );
 		// This note has no actions.
 		$note_2->save();
 
-		$note_3 = new WC_Admin_Note();
+		$note_3 = new Note();
 		$note_3->set_title( 'PHPUNIT_TEST_NOTE_3_TITLE' );
 		$note_3->set_content( 'PHPUNIT_TEST_NOTE_3_CONTENT' );
 		$note_3->set_content_data( (object) array( 'amount' => 7.89 ) );
-		$note_3->set_type( WC_Admin_Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
+		$note_3->set_type( Note::E_WC_ADMIN_NOTE_INFORMATIONAL );
 		$note_3->set_icon( 'info' );
 		$note_3->set_name( 'PHPUNIT_TEST_NOTE_NAME' );
 		$note_3->set_source( 'PHPUNIT_TEST' );
-		$note_3->set_status( WC_Admin_Note::E_WC_ADMIN_NOTE_SNOOZED );
+		$note_3->set_status( Note::E_WC_ADMIN_NOTE_SNOOZED );
 		$note_3->set_date_reminder( time() - HOUR_IN_SECONDS );
 		// This note has no actions.
 		$note_3->save();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes deprecation warnings that will occur when the WooCommerce Admin package is updated to `1.7.x`. See: https://github.com/woocommerce/woocommerce-admin/pull/5142

### How to test the changes in this Pull Request:

1. Verify WooCommerce Admin `1.7.x` is loaded (either from the standalone plugin or the included package) at WooCommerce > Status
2. Trigger the condition where a DB update is needed, or the DB update notice is shown
3. Verify there are no PHP deprecation notices for the `WC_Admin_Note` class

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
