### PR TITLE
Widget: Price Slider - trigger to re-initialize

### DIFF
--- a/assets/js/frontend/price-slider.js
+++ b/assets/js/frontend/price-slider.js
@@ -66,6 +66,7 @@ jQuery( function( $ ) {
 	}
 
 	init_price_filter();
+	$( document.body ).on( 'init_price_filter', init_price_filter );
 
 	var hasSelectiveRefresh = (
 		'undefined' !== typeof wp &&

--- a/assets/js/frontend/price-slider.js
+++ b/assets/js/frontend/price-slider.js
@@ -6,7 +6,7 @@ jQuery( function( $ ) {
 		return false;
 	}
 
-	$( document.body ).bind( 'price_slider_create price_slider_slide', function( event, min, max ) {
+	$( document.body ).on( 'price_slider_create price_slider_slide', function( event, min, max ) {
 
 		$( '.price_slider_amount span.from' ).html( accounting.formatMoney( min, {
 			symbol:    woocommerce_price_slider_params.currency_format_symbol,
@@ -76,7 +76,7 @@ jQuery( function( $ ) {
 		wp.customize.widgetsPreview.WidgetPartial
 	);
 	if ( hasSelectiveRefresh ) {
-		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function() {
+		wp.customize.selectiveRefresh.on( 'partial-content-rendered', function() {
 			init_price_filter();
 		} );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
1: Added a document trigger to re-init the price slider widget.
2: Changed `bind` to `on` since bind will be deprecated.

Closes # .

### How to test the changes in this Pull Request:

1. Reload content with Price slider using AJAX and do `$( document.body ).trigger( 'init_price_filter' )` to re-init the price slider.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

(No tests needed)

<!-- Mark completed items with an [x] -->

### Changelog entry

> Option to re-init the price slider using JavaScript.
