### PR TITLE
Update changelog and bump version in preparation for WC 4.6.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,19 @@
 == Changelog ==
 
+= 4.6.1 - 2020-10-21 =
+
+**WooCommerce**
+
+* Update woocommerce-admin to 1.6.2. #28006
+
+**WooCommerce Admin - 1.6.2**
+
+* Fix for missing activity panels. #5400
+* Adds array casting on onboarding profile option. #5415
+* Gutenberg compatibility fix for home screen inbox. #5416
+* Gutenberg compat fix for empty reports (leaderboard, customers report). #5409
+* i18n fix for Performance Indicators labels Home Screen. #5405
+
 = 4.6.0 - 2020-10-14 =
 
 **WooCommerce**

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -22,7 +22,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '4.6.0';
+	public $version = '4.6.1';
 
 	/**
 	 * WooCommerce Schema version.

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 7.0
-Stable tag: 4.6.0
+Stable tag: 4.6.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -160,6 +160,20 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 == Changelog ==
 
+= 4.6.1 - 2020-10-21 =
+
+**WooCommerce**
+
+* Update woocommerce-admin to 1.6.2. #28006
+
+**WooCommerce Admin - 1.6.2**
+
+* Fix for missing activity panels. #5400
+* Adds array casting on onboarding profile option. #5415
+* Gutenberg compatibility fix for home screen inbox. #5416
+* Gutenberg compat fix for empty reports (leaderboard, customers report). #5409
+* i18n fix for Performance Indicators labels Home Screen. #5405
+
 = 4.6.0 - 2020-10-14 =
 
 **WooCommerce**

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 4.6.0
+ * Version: 4.6.1
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
This PR prepares the `release/4.6` branch for the release of the WC 4.6.1 version. It bumps the version to `4.6.1` in `woocommerce.php`, `includes/class-woocommerce.php`, and `readme.txt`. It also adds the changelog for the new version.