### PR TITLE
Check the cart exists before emptying it after handling PayPal response

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php
@@ -66,7 +66,10 @@ abstract class WC_Gateway_Paypal_Response {
 		if ( ! $order->has_status( array( 'processing', 'completed' ) ) ) {
 			$order->add_order_note( $note );
 			$order->payment_complete( $txn_id );
-			WC()->cart->empty_cart();
+
+			if ( isset( WC()->cart ) ) {
+				WC()->cart->empty_cart();
+			}
 		}
 	}
 
@@ -78,6 +81,9 @@ abstract class WC_Gateway_Paypal_Response {
 	 */
 	protected function payment_on_hold( $order, $reason = '' ) {
 		$order->update_status( 'on-hold', $reason );
-		WC()->cart->empty_cart();
+
+		if ( isset( WC()->cart ) ) {
+			WC()->cart->empty_cart();
+		}
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:
We haven't been able to replicate the error ourselves, given the nature of testing specific PayPal transaction types (in this case `'merch_pmt'`), however, we have PHP errors that indicate that there exists the possibility that these functions can be called when a cart object doesn't exist. 

```
Error processing PayPal IPN message: Uncaught Error: Call to a member function empty_cart() on null in content/plugins/woocommerce/includes/gateways/paypal/includes/class-wc-gateway-paypal-response.php:81
```


Related to:
https://github.com/woocommerce/woocommerce-subscriptions/pull/3736
https://github.com/woocommerce/woocommerce-subscriptions/issues/3614

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.