### PR TITLE
Remove WP nightly from the list of Travis jobs that can fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,7 +58,6 @@ jobs:
   allow_failures:
   - php: 7.4
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
-  - name: "WP Nightly"
 
 install:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"


### PR DESCRIPTION
In #27977, we added the Travis build job that runs using WP nightly to the list of jobs that can fail due to a problem in WP itself. Now this problem was fixed, the build job is passing and we can remove it from this list (https://travis-ci.org/github/woocommerce/woocommerce/jobs/737513448).