### PR TITLE
Fix error in the sed commands used to prefix namespaces

### DIFF
--- a/bin/prefix-vendor-namespaces.sh
+++ b/bin/prefix-vendor-namespaces.sh
@@ -20,10 +20,10 @@ output 6 "Prefixing the appropriate vendor namespaces with Automattic\WooCommerc
 # Replace "League\Container" in "use" and "namespace" with "Automattic\WooCommerce\Vendor\League\Container".
 REGEX='s/^[[:space:]]*(use|namespace)[[:space:]]*(League\\Container)/\1 Automattic\\WooCommerce\\Vendor\\\2/g'
 
-find ./vendor/league/container -iname '*.php' -exec sed -i '.bak' -E -e "$REGEX" {} \;
+find ./vendor/league/container -iname '*.php' -exec sed -i'.bak' -E -e "$REGEX" {} \;
 find ./vendor/league/container -name "*.php.bak" -type f -delete
 
 # Replace too in the composer.json file for the package.
-sed -i '.bak' -E -e "s/\"(League\\\\\\\Container)/\"Automattic\\\\\\\WooCommerce\\\\\\\Vendor\\\\\\\\\1/g" vendor/league/container/composer.json
+sed -i'.bak' -E -e "s/\"(League\\\\\\\Container)/\"Automattic\\\\\\\WooCommerce\\\\\\\Vendor\\\\\\\\\1/g" vendor/league/container/composer.json
 rm -f vendor/league/container/composer.json.bak
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a minor error in the sed commands used to prefix namespaces in the vendor folder. Due to an extra space, sed was
considering `.bak` an extra parameter. If we use `-i.bak` instead (without the space), sed creates a backup file, which is the desired behavior.

With this change, we won't be getting the errors below when running `composer install` or `composer update`:

```
Generating autoload files
> sh ./bin/prefix-vendor-namespaces.sh
Prefixing the appropriate vendor namespaces with Automattic\WooCommerce\Vendor
sed: can't read .bak: No such file or directory
sed: can't read .bak: No such file or directory
sed: can't read .bak: No such file or directory
(...)
```

Since sed was working without creating a backup file, I wonder if we really need to create one. I tested and `sed -i -E -e "s/\"(League\\\\\\\Container)/\"Automattic\\\\\\\WooCommerce\\\\\\\Vendor\\\\\\\\\1/g"
vendor/league/container/composer.json` works well in Linux. If it also works on Mac, maybe we can use it and remove the code that deletes the .bak files? (cc @Konamiman)

### How to test the changes in this Pull Request:

1. Check that when running `composer install` or `composer update`, the files in `vendor/league/container` are correctly prefixed with `Automattic\WooCommerce\Vendor` and that you don't get the errors mentioned above.