### PR TITLE
add support for custom container initialization script

### DIFF
--- a/tests/e2e/docker/init-wp-beta.sh
+++ b/tests/e2e/docker/init-wp-beta.sh
@@ -9,7 +9,7 @@ wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=pas
 # we cannot create API keys for the API, so we using basic auth, this plugin allows that.
 wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
 
-echo "Updating to WordPress Nightly"
+echo "Updating to WordPress Nightly Point Release"
 
 wp plugin install wordpress-beta-tester --activate
 wp core check-update

--- a/tests/e2e/docker/init-wp-beta.sh
+++ b/tests/e2e/docker/init-wp-beta.sh
@@ -9,6 +9,7 @@ wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=pas
 # we cannot create API keys for the API, so we using basic auth, this plugin allows that.
 wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
 
-# update to WP beta
+echo "Updating to WordPress Nightly"
+
 wp plugin install wordpress-beta-tester --activate
 wp core check-update

--- a/tests/e2e/docker/init-wp-beta.sh
+++ b/tests/e2e/docker/init-wp-beta.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+echo "Initializing WooCommerce E2E"
+
+wp plugin install woocommerce --activate
+wp theme install twentynineteen --activate
+wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=password --role=customer --path=/var/www/html
+
+# we cannot create API keys for the API, so we using basic auth, this plugin allows that.
+wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
+
+# update to WP beta
+wp plugin install wordpress-beta-tester --activate
+wp core check-update

--- a/tests/e2e/env/bin/docker-compose.sh
+++ b/tests/e2e/env/bin/docker-compose.sh
@@ -39,4 +39,4 @@ if [[ $1 ]]; then
 fi
 #
 # Run Docker
-./bin/docker-compose.js $1
+./bin/docker-compose.js $@


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds support for running a custom initialization script and includes an initialization script for testing with the WP nightly.

### How to test the changes in this Pull Request:

1. Run `npm run docker:up tests/e2e/docker/init-wp-beta.sh`
2. Go to Dashboard -> Updates
3. Verify the container is running the WP nightly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A
