### PR TITLE
add support for custom E2E container name

### DIFF
--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -119,9 +119,9 @@ Puppeteer will still automatically download Chromium when needed.
 
 ```
 CONTAINER ID        IMAGE               COMMAND                  CREATED             STATUS              PORTS                  NAMES
-c380e1964506        env_wordpress-cli   "entrypoint.sh"          7 seconds ago       Up 5 seconds                               woocommerce_wordpress-cli
-2ab8e8439e9f        wordpress:5.5.1     "docker-entrypoint.s…"   8 seconds ago       Up 7 seconds        0.0.0.0:8084->80/tcp   woocommerce_wordpress-www
-4c1e3f2a49db        mariadb:10.5.5      "docker-entrypoint.s…"   10 seconds ago      Up 8 seconds        3306/tcp               woocommerce_db
+c380e1964506        env_wordpress-cli   "entrypoint.sh"          7 seconds ago       Up 5 seconds                               woocommerce_e2e_wordpress-cli
+2ab8e8439e9f        wordpress:5.5.1     "docker-entrypoint.s…"   8 seconds ago       Up 7 seconds        0.0.0.0:8084->80/tcp   woocommerce_e2e_wordpress-www
+4c1e3f2a49db        mariadb:10.5.5      "docker-entrypoint.s…"   10 seconds ago      Up 8 seconds        3306/tcp               woocommerce_e2e_db
 ```
 
 Note that by default, Docker will download the latest images available for WordPress, PHP and MariaDB. In the example above, you can see that WordPress 5.5.1 and MariaDB 10.5.5 were used. 

--- a/tests/e2e/config/default.json
+++ b/tests/e2e/config/default.json
@@ -1,0 +1,76 @@
+{
+  "url": "http://localhost:8084/",
+  "appName": "woocommerce_e2e",
+  "users": {
+    "admin": {
+      "username": "admin",
+      "password": "password"
+    },
+    "customer": {
+      "username": "customer",
+      "password": "password"
+    }
+  },
+  "products": {
+    "simple": {
+      "name": "Simple product"
+    },
+    "variable": {
+      "name": "Variable Product with Three Variations"
+    }
+  },
+  "addresses": {
+    "admin": {
+      "store": {
+        "firstname": "John",
+        "lastname": "Doe",
+        "company": "Automattic",
+        "country": "United States (US)",
+        "addressfirstline": "addr 1",
+        "addresssecondline": "addr 2",
+        "countryandstate": "United States (US) — California",
+        "city": "San Francisco",
+        "state": "CA",
+        "postcode": "94107"
+      }
+    },
+    "customer": {
+      "billing": {
+        "firstname": "John",
+        "lastname": "Doe",
+        "company": "Automattic",
+        "country": "United States (US)",
+        "addressfirstline": "addr 1",
+        "addresssecondline": "addr 2",
+        "city": "San Francisco",
+        "state": "CA",
+        "postcode": "94107",
+        "phone": "123456789",
+        "email": "john.doe@example.com"
+      },
+      "shipping": {
+        "firstname": "John",
+        "lastname": "Doe",
+        "company": "Automattic",
+        "country": "United States (US)",
+        "addressfirstline": "addr 1",
+        "addresssecondline": "addr 2",
+        "city": "San Francisco",
+        "state": "CA",
+        "postcode": "94107"
+      }
+    }
+  },
+  "onboardingwizard": {
+    "industry": "Test industry",
+    "numberofproducts": "1 - 10",
+    "sellingelsewhere": "No"
+  },
+  "settings": {
+    "shipping": {
+      "zonename": "United States",
+      "zoneregions": "United States (US)",
+      "shippingmethod": "Free shipping"
+    }
+  }
+}

--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Added
+- support for custom container name
+
 ## Fixed
 
 - Remove redundant `puppeteer` dependency

--- a/tests/e2e/env/builtin.md
+++ b/tests/e2e/env/builtin.md
@@ -42,6 +42,7 @@ The built in container initialization needs to know the particulars of your test
 ```
 {
   "url": "http://localhost:8084/",
+  "appName": "{repository-folder-name}",
   "users": {
     "admin": {
       "username": "admin",
@@ -57,8 +58,10 @@ The built in container initialization needs to know the particulars of your test
 }
 ```
 
-You can override these in `/tests/e2e/config/default.json`. The `customer` entry is not required by the sequencer but is required for the core test suite. 
+You can override these in `/tests/e2e/config/default.json`.
 
+- The `appName` entry is optional. If present, it is used as a prefix for the docker container names.
+- The `customer` entry is not required by the sequencer but is required for the core test suite.
 - The test sequencer does not use the user account email addresses.
 
 ```

--- a/tests/e2e/env/utils/app-name.js
+++ b/tests/e2e/env/utils/app-name.js
@@ -1,0 +1,20 @@
+/**
+ * External dependencies
+ */
+const path = require( 'path' );
+/**
+ * Internal dependencies
+ */
+const getTestConfig = require( './test-config' );
+const getAppRoot = require( './app-root' );
+
+const getAppName = () => {
+	const testConfig = getTestConfig();
+	if ( testConfig.appName ) {
+		return testConfig.appName;
+	}
+	const appRoot = getAppRoot();
+	return path.basename( appRoot );
+};
+
+module.exports = getAppName;

--- a/tests/e2e/env/utils/app-root.js
+++ b/tests/e2e/env/utils/app-root.js
@@ -1,3 +1,6 @@
+/**
+ * External dependencies
+ */
 const path = require( 'path' );
 
 const getAppRoot = () => {
@@ -16,12 +19,4 @@ const getAppRoot = () => {
     return appPath;
 };
 
-const getAppName = () => {
-	const appRoot = getAppRoot();
-	return path.basename( appRoot );
-};
-
-module.exports = {
-	getAppRoot,
-	getAppName,
-};
+module.exports = getAppRoot;

--- a/tests/e2e/env/utils/get-app-name.js
+++ b/tests/e2e/env/utils/get-app-name.js
@@ -1,7 +1,7 @@
 /**
  * Provide the application name to bash scripts.
  */
-const { getAppName } = require( './app-root' );
+const getAppName = require( './app-name' );
 const appName = getAppName();
 
 console.log( appName );

--- a/tests/e2e/env/utils/index.js
+++ b/tests/e2e/env/utils/index.js
@@ -1,4 +1,5 @@
-const { getAppRoot, getAppName } = require( './app-root' );
+const getAppRoot = require( './app-root' );
+const getAppName = require( './app-name' );
 const getTestConfig = require( './test-config' );
 
 module.exports = {

--- a/tests/e2e/env/utils/test-config.js
+++ b/tests/e2e/env/utils/test-config.js
@@ -1,6 +1,6 @@
 const path = require( 'path' );
 const fs = require( 'fs' );
-const { getAppRoot } = require( './app-root' );
+const getAppRoot = require( './app-root' );
 
 // Copy local test configuration file if it exists.
 const appPath = getAppRoot();

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -137,7 +137,7 @@ const completeOnboardingWizard = async () => {
 
 	// Query for the extensions toggles
 	const extensionsToggles = await page.$$( '.components-form-toggle__input' );
-	expect( extensionsToggles ).toHaveLength( 3 );
+	expect( extensionsToggles ).toHaveLength( 4 );
 
 	// Disable download of the onboarding suggested extensions
 	for ( let i = 0; i < extensionsToggles.length; i++ ) {

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -137,10 +137,10 @@ const completeOnboardingWizard = async () => {
 
 	// Query for the extensions toggles
 	const extensionsToggles = await page.$$( '.components-form-toggle__input' );
-	expect( extensionsToggles ).toHaveLength( 4 );
+	expect( extensionsToggles ).toHaveLength( 3 );
 
-	// Disable download of the 4 extensions
-	for ( let i = 0; i < 4; i++ ) {
+	// Disable download of the onboarding suggested extensions
+	for ( let i = 0; i < extensionsToggles.length; i++ ) {
 		await extensionsToggles[i].click();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds support for configuring a customer container name prefix. It updates the core container prefix from `woocommerce` to `woocommerce_e2e`

Closes #28012 .

### How to test the changes in this Pull Request:

1. Ensure you have run `npm run docker:down` before switching to this branch
2. Switch to branch and run `npm run docker:up`
3. Note container name changes
4. `npm run docker:down`
5. Edit `tests/e2e/config/default.json` and change the appName entry `woocommerce_{your-name}`
6. `docker:up`, `'test:e2e`, `docker:down`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A