### PR TITLE
Update master branch after the release of WC 4.6.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,19 @@
 == Changelog ==
 
+= 4.6.1 - 2020-10-21 =
+
+**WooCommerce**
+
+* Update woocommerce-admin to 1.6.2. #28006
+
+**WooCommerce Admin - 1.6.2**
+
+* Fix for missing activity panels. #5400
+* Adds array casting on onboarding profile option. #5415
+* Gutenberg compatibility fix for home screen inbox. #5416
+* Gutenberg compat fix for empty reports (leaderboard, customers report). #5409
+* i18n fix for Performance Indicators labels Home Screen. #5405
+
 = 4.6.0 - 2020-10-14 =
 
 **WooCommerce**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.3
 Tested up to: 5.5
 Requires PHP: 7.0
-Stable tag: 4.6.0
+Stable tag: 4.6.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 


### PR DESCRIPTION
This PR adds updates the file changelog.txt with changes from WC 4.6.1 and bumps the `Stable tag` in readme.txt to 4.6.1. I'm not sure if we need to cherry-pick the commit that bumps the `Stable tag` to the `release/4.7` branch or not (cc @claudiosanches).