### PR TITLE
Replaces some jQuery deprecated code

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -19,7 +19,7 @@ jQuery( function ( $ ) {
 				)
 			) {
 				/* State/Country select boxes */
-				this.states = $.parseJSON( woocommerce_admin_meta_boxes_order.countries.replace( /&quot;/g, '"' ) );
+				this.states = JSON.parse( woocommerce_admin_meta_boxes_order.countries.replace( /&quot;/g, '"' ) );
 			}
 
 			$( '.js_field-country' ).selectWoo().change( this.change_country );

--- a/assets/js/admin/users.js
+++ b/assets/js/admin/users.js
@@ -9,7 +9,7 @@ jQuery( function ( $ ) {
 		init: function() {
 			if ( typeof wc_users_params.countries !== 'undefined' ) {
 				/* State/Country select boxes */
-				this.states = $.parseJSON( wc_users_params.countries.replace( /&quot;/g, '"' ) );
+				this.states = JSON.parse( wc_users_params.countries.replace( /&quot;/g, '"' ) );
 			}
 
 			$( '.js_field-country' ).selectWoo().change( this.change_country );

--- a/assets/js/frontend/address-i18n.js
+++ b/assets/js/frontend/address-i18n.js
@@ -6,7 +6,7 @@ jQuery( function( $ ) {
 		return false;
 	}
 
-	var locale_json = wc_address_i18n_params.locale.replace( /&quot;/g, '"' ), locale = $.parseJSON( locale_json );
+	var locale_json = wc_address_i18n_params.locale.replace( /&quot;/g, '"' ), locale = JSON.parse( locale_json );
 
 	function field_is_required( field, is_required ) {
 		if ( is_required ) {
@@ -51,7 +51,7 @@ jQuery( function( $ ) {
 				$statefield.attr( 'data-o_class', $statefield.attr( 'class' ) );
 			}
 
-			var locale_fields = $.parseJSON( wc_address_i18n_params.locale_fields );
+			var locale_fields = JSON.parse( wc_address_i18n_params.locale_fields );
 
 			$.each( locale_fields, function( key, value ) {
 

--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -115,7 +115,7 @@ jQuery( function( $ ) {
 		} );
 
 		try {
-			var wc_fragments = $.parseJSON( sessionStorage.getItem( wc_cart_fragments_params.fragment_name ) ),
+			var wc_fragments = JSON.parse( sessionStorage.getItem( wc_cart_fragments_params.fragment_name ) ),
 				cart_hash    = sessionStorage.getItem( cart_hash_key ),
 				cookie_hash  = Cookies.get( 'woocommerce_cart_hash'),
 				cart_created = sessionStorage.getItem( 'wc_cart_created' );

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -191,7 +191,7 @@ jQuery( function( $ ) {
 		},
 		is_valid_json: function( raw_json ) {
 			try {
-				var json = $.parseJSON( raw_json );
+				var json = JSON.parse( raw_json );
 
 				return ( json && 'object' === typeof json );
 			} catch ( e ) {

--- a/assets/js/frontend/country-select.js
+++ b/assets/js/frontend/country-select.js
@@ -77,7 +77,7 @@ jQuery( function( $ ) {
 
 	/* State/Country select boxes */
 	var states_json       = wc_country_select_params.countries.replace( /&quot;/g, '"' ),
-		states            = $.parseJSON( states_json ),
+		states            = JSON.parse( states_json ),
 		wrapper_selectors = '.woocommerce-billing-fields,' +
 			'.woocommerce-shipping-fields,' +
 			'.woocommerce-address-fields,' +

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -1049,10 +1049,10 @@ class WC_Email extends WC_Settings_API {
 				var hide = '" . esc_js( __( 'Hide template', 'woocommerce' ) ) . "';
 
 				jQuery( 'a.toggle_editor' ).text( view ).click( function() {
+					var label = hide;
+
 					if ( jQuery( this ).closest(' .template' ).find( '.editor' ).is(':visible') ) {
 						var label = view;
-					} else {
-						var label = hide;
 					}
 
 					jQuery( this ).text( label ).closest(' .template' ).find( '.editor' ).slideToggle();

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -1048,11 +1048,14 @@ class WC_Email extends WC_Settings_API {
 				var view = '" . esc_js( __( 'View template', 'woocommerce' ) ) . "';
 				var hide = '" . esc_js( __( 'Hide template', 'woocommerce' ) ) . "';
 
-				jQuery( 'a.toggle_editor' ).text( view ).toggle( function() {
-					jQuery( this ).text( hide ).closest(' .template' ).find( '.editor' ).slideToggle();
-					return false;
-				}, function() {
-					jQuery( this ).text( view ).closest( '.template' ).find( '.editor' ).slideToggle();
+				jQuery( 'a.toggle_editor' ).text( view ).click( function() {
+					if ( jQuery( this ).closest(' .template' ).find( '.editor' ).is(':visible') ) {
+						var label = view;
+					} else {
+						var label = hide;
+					}
+
+					jQuery( this ).text( label ).closest(' .template' ).find( '.editor' ).slideToggle();
 					return false;
 				} );
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR replaces some jQuery deprecated code that were reported by @RiaanKnoetze and @khouya82 in #27937.

- It uses jQuery.click() instead of jQuery.fn.toggle(handler, handler...) (https://api.jquery.com/toggle-event/) in the code that handles hiding and displaying e-mail templates when admin are editing them (example: (example: wp-admin/admin.php?page=wc-settings&tab=email&section=wc_email_customer_on_hold_order).
- It replaces all the instances were we were using jQuery.parseJSON() (https://api.jquery.com/jquery.parsejson/) with JSON.parse().

There are probably other places where we are using deprecated jQuery code and we need to check when and if we need to get rid of it depending on WP core plans.

Closes #27937.

### How to test the changes in this Pull Request:

1. In wp-admin, go to WooCommerce > Settings > Emails and select an e-mail to edit. Check that the buttons "View template" and "Hide template" work as expected.
2. Check that jQuery.parseJSON() is fully compatible with JSON.parse() so the replacements should work without any issue.

### Changelog entry

> Replaces some jQuery deprecated code
