### PR TITLE
Improves i18n of string displayed during checkout

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -316,15 +316,16 @@ function wc_cart_totals_order_total_html() {
 
 		if ( ! empty( $tax_string_array ) ) {
 			$taxable_address = WC()->customer->get_taxable_address();
-			/* translators: %s: country name */
-			$estimated_text = WC()->customer->is_customer_outside_base() && ! WC()->customer->has_calculated_shipping() ? sprintf( ' ' . __( 'estimated for %s', 'woocommerce' ), WC()->countries->estimated_for_prefix( $taxable_address[0] ) . WC()->countries->countries[ $taxable_address[0] ] ) : '';
-			$value .= '<small class="includes_tax">('
-						/* translators: includes tax information */
-						. esc_html__( 'includes', 'woocommerce' )
-						. ' '
-						. wp_kses_post( implode( ', ', $tax_string_array ) )
-						. esc_html( $estimated_text )
-						. ')</small>';
+			if ( WC()->customer->is_customer_outside_base() && ! WC()->customer->has_calculated_shipping() ) {
+				$country = WC()->countries->estimated_for_prefix( $taxable_address[0] ) . WC()->countries->countries[ $taxable_address[0] ];
+				/* translators: 1: tax amount 2: country name */
+				$tax_text = wp_kses_post( sprintf( __( '(includes %1$s estimated for %2$s)', 'woocommerce' ), implode( ', ', $tax_string_array ), $country ) );
+			} else {
+				/* translators: %s: tax amount */
+				$tax_text = wp_kses_post( sprintf( __( '(includes %s)', 'woocommerce' ), implode( ', ', $tax_string_array ) ) );
+			}
+
+			$value .= '<small class="includes_tax">' . $tax_text . '</small>';
 		}
 	}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Commit https://github.com/woocommerce/woocommerce/commit/14a26aca2cde9c81ade02bdc6dd0a34e184a4202#diff-258e00eaddfa27b18ebd350e55997e8f8a52d245f26c4648fe4e7289cb4b7e22R321 changed the construction on a translatable string to make sure it was not possible to use it to inject JS code into a store, but it also make it harder to translate it. This PR improves the i18n this string while still preventing XSS. This stirng is displayed during checkout showing the total amount of the order when the store is configured to display prices inclusive of taxes.

Before string concatenation was used to build the final string, which is almost always a bad practice from the i18n point of view (https://codex.wordpress.org/I18n_for_WordPress_Developers#Best_Practices). This commit uses sprintf() and two separate strings instead of concatenating strings.

cc @peterfabian as we chatted about this issue

Closes #27087.

### How to test the changes in this Pull Request:

1. Go to WooCommerce -> Settings -> Tax (`/wp-admin/admin.php?page=wc-settings&tab=tax`)
2. Make sure that "Prices entered with tax" is set to "Yes, I will enter prices inclusive of tax" and that "Display prices during cart and checkout" is set to "Including tax".
3. Create a tax that is applied to all products.
4. Add a product to the cart and go to the checkout page.
5. In the other details section, the total amount of the other should include the order value and in parenthesis a string stating the tax amount included in the total.
6. Switch the site language to Brazilian Portuguese and install pt_BR translations for WooCommerce.
7. Go again to the checkout page and verify that the same string is translated as expected. You should see something like the screenshot below.
8. Check that there are no regressions in the changes included in https://github.com/Automattic/woocommerce/pull/82.

![Screenshot from 2020-10-22 15-52-50](https://user-images.githubusercontent.com/77215/96917042-bd579300-147e-11eb-967f-b1095610c3d6.png)

### Changelog entry

> Improves i18n of a string that is displayed during checkout
