### PR TITLE
Update class-wc-product-variable.php

### DIFF
--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -413,7 +413,7 @@ class WC_Product_Variable extends WC_Product {
 	 * Sets an array of children for the product.
 	 *
 	 * @since 3.0.0
-	 * @param array $children Childre products.
+	 * @param array $children Children products.
 	 */
 	public function set_children( $children ) {
 		$this->children = array_filter( wp_parse_id_list( (array) $children ) );


### PR DESCRIPTION
Fix the typo on line 416 according to Issue  #28066

### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Change Line #416 to spell children correctly.

Closes  #28066

### How to test the changes in this Pull Request:

1. Check spelling on line 416 of children

### Changelog entry

> Change typo on line 416
