### PR TITLE
Minor docblock grammar/typo/casing fixes

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -135,7 +135,7 @@ final class WC_Cart_Totals {
 	}
 
 	/**
-	 * Run all calculations methods on the given items in sequence.
+	 * Run all calculation methods on the given items in sequence.
 	 *
 	 * @since 3.2.0
 	 */

--- a/includes/class-wc-product-variable.php
+++ b/includes/class-wc-product-variable.php
@@ -135,7 +135,7 @@ class WC_Product_Variable extends WC_Product {
 	 * Note: Variable prices do not show suffixes like other product types. This
 	 * is due to some things like tax classes being set at variation level which
 	 * could differ from the parent price. The only way to show accurate prices
-	 * would be to load the variation and get IT's price, which adds extra
+	 * would be to load the variation and get it's price, which adds extra
 	 * overhead and still has edge cases where the values would be inaccurate.
 	 *
 	 * Additionally, ranges of prices no longer show 'striked out' sale prices
@@ -464,7 +464,7 @@ class WC_Product_Variable extends WC_Product {
 		 * Trigger action before saving to the DB. Allows you to adjust object props before save.
 		 *
 		 * @param WC_Data          $this The object being saved.
-		 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+		 * @param WC_Data_Store_WP $data_store The data store persisting the data.
 		 */
 		do_action( 'woocommerce_before_' . $this->object_type . '_object_save', $this, $this->data_store );
 
@@ -485,7 +485,7 @@ class WC_Product_Variable extends WC_Product {
 		 * Trigger action after saving to the DB.
 		 *
 		 * @param WC_Data          $this The object being saved.
-		 * @param WC_Data_Store_WP $data_store THe data store persisting the data.
+		 * @param WC_Data_Store_WP $data_store The data store persisting the data.
 		 */
 		do_action( 'woocommerce_after_' . $this->object_type . '_object_save', $this, $this->data_store );
 
@@ -662,9 +662,9 @@ class WC_Product_Variable extends WC_Product {
 	}
 
 	/**
-	 * Sort an associativate array of $variation_id => $price pairs in order of min and max prices.
+	 * Sort an associative array of $variation_id => $price pairs in order of min and max prices.
 	 *
-	 * @param array $prices Associativate array of $variation_id => $price pairs.
+	 * @param array $prices associative array of $variation_id => $price pairs.
 	 * @return array
 	 */
 	protected function sort_variation_prices( $prices ) {

--- a/includes/class-wc-product-variation.php
+++ b/includes/class-wc-product-variation.php
@@ -286,7 +286,7 @@ class WC_Product_Variation extends WC_Product_Simple {
 	/**
 	 * Returns the tax class.
 	 *
-	 * Does not use get_prop so it can handle 'parent' Inheritance correctly.
+	 * Does not use get_prop so it can handle 'parent' inheritance correctly.
 	 *
 	 * @param  string $context view, edit, or unfiltered.
 	 * @return string


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

There were a few occurrences of spelling mistakes and incorrect casing within the docblocks. This PR corrects these minor mistakes.

### Changelog entry

> Fixed grammar and typos
