### PR TITLE
Fire after_password_reset during the my-account/lostpassword flow

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -379,6 +379,9 @@ class WC_Shortcode_My_Account {
 		if ( ! apply_filters( 'woocommerce_disable_password_change_notification', false ) ) {
 			wp_password_change_notification( $user );
 		}
+
+		// Ensure that the Wordpress after_password_reset action runs since we're bypassing that flow.
+		do_action( 'after_password_reset', $user, $new_pass );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a call to the WordPress hook `after_password_reset` to the `reset_password` function that runs when a user requests a password reset via the `my-account/lost-password` flow.  I noticed that #27864 focuses on this flow as well, but this change seems to address a different underlying issue.  Still, it would be worth checking to see if firing this action here results in the same doubled-notification bug mentioned in #27864.  I didn't see it on my end.

Closes #27795.

### How to test the changes in this Pull Request:

1. I tested this with a simple listener snippet.

```
function test_after_password_reset_hook() {
	error_log("The after_password_reset hook has fired.");
}
add_action('after_password_reset', 'test_after_password_reset_hook');
```

After going through the `lost-password` flow, there is an entry in my `debug.log` file showing that the hook fired.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fire the WordPress `after_password_reset` action when a user resets their password via `my-account/lost-password`

cc: @jackmcconnell, @jvdl-1
