### PR TITLE
Orders API: Add parent_name for variations in line_items

### DIFF
--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -170,9 +170,14 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
 			$data['sku']   = $item->get_product() ? $item->get_product()->get_sku() : null;
 			$data['price'] = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
+		}
 
-			if ( is_callable( array( $item->get_product(), 'get_parent_data' ) ) ) {
-				$data['parent_name'] = $item->get_product()->get_title();
+		// Add parent_name if the product is a variation.
+		if ( is_callable( array( $item, 'get_product' ) ) ) {
+			$product = $item->get_product();
+
+			if ( is_callable( array( $product, 'get_parent_data' ) ) ) {
+				$data['parent_name'] = $product->get_title();
 			} else {
 				$data['parent_name'] = null;
 			}

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1242,6 +1242,11 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 								'type'        => 'mixed',
 								'context'     => array( 'view', 'edit' ),
 							),
+							'parent_name'  => array(
+								'description' => __( 'Parent product name if the product is a variation.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+							),
 							'product_id'   => array(
 								'description' => __( 'Product ID.', 'woocommerce' ),
 								'type'        => 'mixed',

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -170,6 +170,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
 			$data['sku']   = $item->get_product() ? $item->get_product()->get_sku() : null;
 			$data['price'] = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
+
+			if ( is_callable( array( $item->get_product(), 'get_parent_data' ) ) ) {
+				$data['parent_name'] = $item->get_product()->get_title();
+			} else {
+				$data['parent_name'] = null;
+			}
 		}
 
 		// Format taxes.

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -544,6 +544,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 			'meta_data'    => array(),
 			'sku'          => null,
 			'price'        => 4,
+			'parent_name'  => null,
 		);
 
 		$this->assertEquals( 200, $response->get_status() );

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -785,9 +785,10 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 
 		$line_item_properties = $data['schema']['properties']['line_items']['items']['properties'];
-		$this->assertEquals( 14, count( $line_item_properties ) );
+		$this->assertEquals( 15, count( $line_item_properties ) );
 		$this->assertArrayHasKey( 'id', $line_item_properties );
 		$this->assertArrayHasKey( 'meta_data', $line_item_properties );
+		$this->assertArrayHasKey( 'parent_name', $line_item_properties );
 
 		$meta_data_item_properties = $line_item_properties['meta_data']['items']['properties'];
 		$this->assertEquals( 5, count( $meta_data_item_properties ) );

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -5,6 +5,10 @@
  * @package WooCommerce\Tests\API
  * @since 3.0.0
  */
+
+/**
+ * Class WC_Tests_API_Orders_V2
+ */
 class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 
 	/**
@@ -77,7 +81,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 		$site_level_attribute_id = wc_create_attribute( array( 'name' => 'Site Level Color' ) );
 		$site_level_attribute_slug = wc_attribute_taxonomy_name_by_id( $site_level_attribute_id );
 
-		// Register the attribute so that wp_insert_term will be successful
+		// Register the attribute so that wp_insert_term will be successful.
 		register_taxonomy( $site_level_attribute_slug, array( 'product' ), array() );
 
 		$site_level_term_insertion_result = wp_insert_term( 'Site Level Value - Blue', $site_level_attribute_slug );
@@ -88,9 +92,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 
 		$line_item = new WC_Order_Item_Product();
 		$line_item->set_product( $variation );
-		$line_item->set_props( array(
-			'variation' => array( "attribute_{$site_level_attribute_slug}" => $site_level_term->slug )
-		) );
+		$line_item->set_props( array( 'variation' => array( "attribute_{$site_level_attribute_slug}" => $site_level_term->slug ) ) );
 
 		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
 		$order->add_item( $line_item );
@@ -358,7 +360,7 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 		wp_set_current_user( $this->user );
 		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
 
-		// non-existent customer
+		// Non-existent customer.
 		$request = new WP_REST_Request( 'POST', '/wc/v2/orders' );
 		$request->set_body_params(
 			array(
@@ -788,6 +790,6 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 
 		$meta_data_item_properties = $line_item_properties['meta_data']['items']['properties'];
 		$this->assertEquals( 5, count( $meta_data_item_properties ) );
-		$this->assertEquals( [ 'id', 'key', 'value', 'display_key', 'display_value' ], array_keys( $meta_data_item_properties ) );
+		$this->assertEquals( array( 'id', 'key', 'value', 'display_key', 'display_value' ), array_keys( $meta_data_item_properties ) );
 	}
 }

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -912,9 +912,10 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 
 		$line_item_properties = $data['schema']['properties']['line_items']['items']['properties'];
-		$this->assertEquals( 14, count( $line_item_properties ) );
+		$this->assertEquals( 15, count( $line_item_properties ) );
 		$this->assertArrayHasKey( 'id', $line_item_properties );
 		$this->assertArrayHasKey( 'meta_data', $line_item_properties );
+		$this->assertArrayHasKey( 'parent_name', $line_item_properties );
 
 		$meta_data_item_properties = $line_item_properties['meta_data']['items']['properties'];
 		$this->assertEquals( 5, count( $meta_data_item_properties ) );

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -612,6 +612,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 			'meta_data'    => array(),
 			'sku'          => null,
 			'price'        => 4,
+			'parent_name'  => null,
 		);
 
 		$this->assertEquals( 200, $response->get_status() );

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -225,11 +225,11 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 		// The name property contains the parent product name and the attribute value (ex. "Dummy Variable Product - small").
 		$this->assertEquals( $variation->get_name(), $last_line_item['name'] );
-		$this->assertStringContainsString( $variation->get_attribute( 'pa_size' ), $last_line_item['name'] );
+		$this->assertTrue( false !== strpos( $last_line_item['name'], $variation->get_attribute( 'pa_size' ) ) );
 		// The parent_name property only contains the parent product name (ex. "Dummy Variable Product").
 		$this->assertEquals( $product->get_name(), $last_line_item['parent_name'] );
 		$this->assertNotEquals( $variation->get_name(), $last_line_item['parent_name'] );
-		$this->assertStringNotContainsString( $variation->get_attribute( 'pa_size' ), $last_line_item['parent_name'] );
+		$this->assertTrue( false === strpos( $last_line_item['parent_name'], $variation->get_attribute( 'pa_size' ) ) );
 	}
 
 	/**


### PR DESCRIPTION
## All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

## Changes proposed in this Pull Request:

### Background

This is a continuation of https://github.com/woocommerce/woocommerce/pull/27492. That PR allows the WooCommerce iOS and Android apps to solve part of a very common user request — showing all the attribute names when fulfilling their orders using the app (https://github.com/woocommerce/woocommerce-ios/issues/1127). 

This is how the Android app looks like right now with the #27492 changes: 

<img src="https://user-images.githubusercontent.com/198826/97031988-5093d580-151e-11eb-9cb3-95b097c3645f.png" width="300">

We are now able to reliably show all the attributes. 🎉 

### Parent Name Proposal

A remaining issue, as I described in https://github.com/woocommerce/woocommerce-rest-api/pull/229, is that the product name that we receive from the API still shows the attribute names. 

```
"line_items": [
    {
        "id": 44,
        "name": "Snowboard Bindings - All Mountain", <--- this is still showing one of the attributes
        "product_id": 65,
        "variation_id": 70,

        "meta_data": [
            {
                "id": 413,
                "key": "pa_bindingtype",
                "value": "all-mountain",
                "display_key": "Type",
                "display_value": "All Mountain"
            },
            {
                "id": 414,
                "key": "pa_size",
                "value": "s",
                "display_key": "Size",
                "display_value": "S"
            }
        ]
    }
],
```

From what I can tell, the attributes were added using [`generate_product_title`](https://github.com/woocommerce/woocommerce/blob/c5028be0ed79465d68738e3c5070bbb8b1d97a02/includes/data-stores/class-wc-product-variation-data-store-cpt.php#L291). Depending on some conditions, the attributes are sometimes not included in the name too. 

This PR adds a new property named `parent_name` that contains the parent product name only if the product in the line item is a variation. Using the JSON example, this is how it would look like:

```
"line_items": [
    {
        "id": 44,
        "name": "Snowboard Bindings - All Mountain", 
        "parent_name": "Snowboard Bindings", <--- new property (excludes the attribute)
```

I opted to add a new property to keep it backwards compatible. 

This change would allow us to reliably show only the product name in this area:

<img src="https://user-images.githubusercontent.com/198826/97035426-8b4c3c80-1523-11eb-839f-45d3895f35a6.png" width="300">

## How to test the changes in this Pull Request:

This is just a suggestion but please feel free to test other scenarios. 🙂

1. Add a new Variable product in wp-admin → Products → Add New.
2. In the product's Attributes section, add **two** attributes to be used for variations. Set these as "Used for variations". Add values.

    ![image](https://user-images.githubusercontent.com/198826/97035945-4ecd1080-1524-11eb-9c35-05d46f3fdf30.png)

    Please make sure to only pick attributes whose names are only one word. For example, “Color” and not ”Sleeves Color”. 

3. In the product's Variations section, create variations for all the options. Or create a few variations only. Set prices for all the variations.
4. Publish the product.
5. As a customer, place an order of the created Variable product. Make note of the Order ID.
6. In the API, run `GET /wp-json/wc/v3/orders/{OrderID}`.
7. Confirm that the `line_items` contains a `parent_name` and the value is the name of the parent product. It should not contain the selected attribute values.

## Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Adds `parent_name` the `line_items` of the `GET /orders` endpoint. If the ordered product is a variable product, the value will be the name of the parent product.  

