### PR TITLE
Revert changes introduced in #27289

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1475,18 +1475,7 @@ if ( ! function_exists( 'woocommerce_show_product_images' ) ) {
 	 * Output the product image before the single product summary.
 	 */
 	function woocommerce_show_product_images() {
-		global $product;
-		$post_thumbnail_id = $product->get_image_id();
-		$gallery_image_ids = '';
-
-		if ( ! $post_thumbnail_id ) {
-			$gallery_image_ids = $product->get_gallery_image_ids();
-			if ( ! empty( $gallery_image_ids ) ) {
-				$post_thumbnail_id = array_shift( $gallery_image_ids );
-			}
-		}
-		$args = compact( 'post_thumbnail_id', 'gallery_image_ids' );
-		wc_get_template( 'single-product/product-image.php', $args );
+		wc_get_template( 'single-product/product-image.php' );
 	}
 }
 if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
@@ -1495,13 +1484,7 @@ if ( ! function_exists( 'woocommerce_show_product_thumbnails' ) ) {
 	 * Output the product thumbnails.
 	 */
 	function woocommerce_show_product_thumbnails() {
-		global $product;
-		$attachment_ids = $product->get_gallery_image_ids();
-
-		if ( $attachment_ids && ! $product->get_image_id() ) {
-			array_shift( $attachment_ids );
-		}
-		wc_get_template( 'single-product/product-thumbnails.php', array( 'attachment_ids' => $attachment_ids ) );
+		wc_get_template( 'single-product/product-thumbnails.php' );
 	}
 }
 

--- a/templates/single-product/product-image.php
+++ b/templates/single-product/product-image.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 4.7.0
+ * @version 3.5.1
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -25,11 +25,12 @@ if ( ! function_exists( 'wc_get_gallery_image_html' ) ) {
 global $product;
 
 $columns           = apply_filters( 'woocommerce_product_thumbnails_columns', 4 );
+$post_thumbnail_id = $product->get_image_id();
 $wrapper_classes   = apply_filters(
 	'woocommerce_single_product_image_gallery_classes',
 	array(
 		'woocommerce-product-gallery',
-		'woocommerce-product-gallery--' . ( $post_thumbnail_id ? 'with-images' : 'without-images' ),
+		'woocommerce-product-gallery--' . ( $product->get_image_id() ? 'with-images' : 'without-images' ),
 		'woocommerce-product-gallery--columns-' . absint( $columns ),
 		'images',
 	)
@@ -38,7 +39,7 @@ $wrapper_classes   = apply_filters(
 <div class="<?php echo esc_attr( implode( ' ', array_map( 'sanitize_html_class', $wrapper_classes ) ) ); ?>" data-columns="<?php echo esc_attr( $columns ); ?>" style="opacity: 0; transition: opacity .25s ease-in-out;">
 	<figure class="woocommerce-product-gallery__wrapper">
 		<?php
-		if ( $post_thumbnail_id ) {
+		if ( $product->get_image_id() ) {
 			$html = wc_get_gallery_image_html( $post_thumbnail_id, true );
 		} else {
 			$html  = '<div class="woocommerce-product-gallery__image--placeholder">';

--- a/templates/single-product/product-thumbnails.php
+++ b/templates/single-product/product-thumbnails.php
@@ -12,7 +12,7 @@
  *
  * @see         https://docs.woocommerce.com/document/template-structure/
  * @package     WooCommerce\Templates
- * @version     4.7.0
+ * @version     3.5.1
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -24,7 +24,9 @@ if ( ! function_exists( 'wc_get_gallery_image_html' ) ) {
 
 global $product;
 
-if ( $attachment_ids ) {
+$attachment_ids = $product->get_gallery_image_ids();
+
+if ( $attachment_ids && $product->get_image_id() ) {
 	foreach ( $attachment_ids as $attachment_id ) {
 		echo apply_filters( 'woocommerce_single_product_image_thumbnail_html', wc_get_gallery_image_html( $attachment_id ), $attachment_id ); // phpcs:disable WordPress.XSS.EscapeOutput.OutputNotEscaped
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR reverts all changes introduced by #27289 and #27908.

After checking feedback from the community we decided to not include this feature on 4.7, since it only works in the single product page for just one image.

Closes #28053

Reopens #27222 #27247

### How to test the changes in this Pull Request:

1. Apply this patch and check any product single page.
2. Check for the product thumbnail and for the image gallery 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
