### PR TITLE
Exclude user table columns as well while setting metadata props

### DIFF
--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -152,10 +152,11 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 
 		$customer_id = $customer->get_id();
 
-		// Load meta but exclude deprecated props.
+		// Load meta but exclude deprecated props and parent keys.
 		$user_meta = array_diff_key(
 			array_change_key_case( array_map( 'wc_flatten_meta_callback', get_user_meta( $customer_id ) ) ),
-			array_flip( array( 'country', 'state', 'postcode', 'city', 'address', 'address_2', 'default', 'location' ) )
+			array_flip( array( 'country', 'state', 'postcode', 'city', 'address', 'address_2', 'default', 'location' ) ),
+			array_change_key_case( (array) $user_object->data )
 		);
 
 		$customer->set_props( $user_meta );

--- a/tests/php/includes/data-stores/class-wc-customer-data-store-test.php
+++ b/tests/php/includes/data-stores/class-wc-customer-data-store-test.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Class WC_Customer_Data_Store_CPT_Test.
+ */
+class WC_Customer_Data_Store_CPT_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * Test that metadata cannot overwrite customer's column data.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/28100
+	 */
+	public function test_meta_data_cannot_overwrite_column_data() {
+		$customer    = WC_Helper_Customer::create_customer();
+		$customer_id = $customer->get_id();
+		$username    = $customer->get_username();
+		$customer->add_meta_data( 'id', '99999' );
+		$customer->add_meta_data( 'username', 'abcde' );
+		$customer->save();
+
+		$customer_datastore = new WC_Customer_Data_Store();
+		$customer_datastore->read( $customer );
+		$this->assertEquals( $customer_id, $customer->get_id() );
+		$this->assertEquals( $username, $customer->get_username() );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Current checks for preventing overwriting metadata are not enough, as it still permits updating column data with meta_data because of `set_props` method. Ideally this should be an allow list, instead of a block list, but doing that will possibly be backwards incompatible, so sticking with blocked list for now.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28100 .

### How to test the changes in this Pull Request:

1. In a shell, do the following:
2. Fetch any existing customer by ID using `$customer = new WC_Customer( $id );`
3. Add an `id` metadata to this customer using: ` $customer->add_meta_data( 'id', '99999' );`
4. Save the customer object: `$customer->save();`
5. Load the customer data store: `$customer_datastore = new WC_Customer_Data_Store();`
6. Read the customer object again: `$customer_datastore->read( $customer );`
7. With this patch, $customer->get_id() will return correct ID, without this patch there will be an exception.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Prevent meta_data from overwriting column data in customer's read.
