### PR TITLE
Allow filtering of cookie flags, which enables setting of samesite

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1049,7 +1049,7 @@ function wc_print_js() {
  */
 function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = false ) {
 	if ( ! headers_sent() ) {
-		if (version_compare(PHP_VERSION, '7.3.0', '>=')) {
+		if ( version_compare( PHP_VERSION, '7.3.0', '>=' ) ) {
 			setcookie( $name, $value, apply_filters( 'woocommerce_set_cookie_options', array( 'expires' => $expire, 'secure' => $secure, 'path' => COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, 'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) ), $name, $value ) );
 		} else {
 			setcookie( $name, $value, $expire, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, $secure, apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) );

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1049,7 +1049,11 @@ function wc_print_js() {
  */
 function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = false ) {
 	if ( ! headers_sent() ) {
-		setcookie( $name, $value, apply_filters( 'woocommerce_set_cookie_options', array( 'expires' => $expire, 'secure' => $secure, 'path' => COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, 'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) ), $name, $value ) );
+		if (version_compare(PHP_VERSION, '7.3.0', '>=')) {
+			setcookie( $name, $value, apply_filters( 'woocommerce_set_cookie_options', array( 'expires' => $expire, 'secure' => $secure, 'path' => COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, 'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) ), $name, $value ) );
+		} else {
+			setcookie( $name, $value, $expire, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, $secure, apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) );
+		}
 	} elseif ( Constants::is_true( 'WP_DEBUG' ) ) {
 		headers_sent( $file, $line );
 		trigger_error( "{$name} cookie cannot be set - headers already sent by {$file} on line {$line}", E_USER_NOTICE ); // @codingStandardsIgnoreLine

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1049,8 +1049,7 @@ function wc_print_js() {
  */
 function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = false ) {
 	if ( ! headers_sent() ) {
-		setcookie( $name, $value, $expire, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, $secure, apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) );
-		setcookie( $name, $value, apply_filters( 'woocommerce_set_cookie_options', array( 'expires' => $expire, 'secure' => $secure, 'httponly' => $httponly ), $name, $value ) );
+		setcookie( $name, $value, apply_filters( 'woocommerce_set_cookie_options', array( 'expires' => $expire, 'secure' => $secure, 'path' => COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, 'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) ), $name, $value ) );
 	} elseif ( Constants::is_true( 'WP_DEBUG' ) ) {
 		headers_sent( $file, $line );
 		trigger_error( "{$name} cookie cannot be set - headers already sent by {$file} on line {$line}", E_USER_NOTICE ); // @codingStandardsIgnoreLine

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1054,7 +1054,7 @@ function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = 
 				$name,
 				$value,
 				apply_filters(
-					'woocommerce_set_cookie_options', 
+					'woocommerce_set_cookie_options',
 					array(
 						'expires' => $expire,
 						'secure' => $secure,

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1050,7 +1050,12 @@ function wc_print_js() {
 function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = false ) {
 	if ( ! headers_sent() ) {
 		if ( version_compare( PHP_VERSION, '7.3.0', '>=' ) ) {
-			setcookie( $name, $value, apply_filters( 'woocommerce_set_cookie_options', array( 'expires' => $expire, 'secure' => $secure, 'path' => COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, 'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) ), $name, $value ) );
+			setcookie( $name, $value, apply_filters( 'woocommerce_set_cookie_options', array(
+				'expires' => $expire,
+				'secure' => $secure
+				'path' => COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN,
+				'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure )
+			), $name, $value ) );
 		} else {
 			setcookie( $name, $value, $expire, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, $secure, apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) );
 		}

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1054,11 +1054,13 @@ function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = 
 				$name,
 				$value,
 				apply_filters(
-					'woocommerce_set_cookie_options', array(
+					'woocommerce_set_cookie_options', 
+					array(
 						'expires' => $expire,
-						'secure' => $secure
-						'path' => COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN,
-						'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure )
+						'secure' => $secure,
+						'path' => COOKIEPATH ? COOKIEPATH : '/',
+						COOKIE_DOMAIN,
+						'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ),
 					),
 					$name,
 					$value

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1050,6 +1050,7 @@ function wc_print_js() {
 function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = false ) {
 	if ( ! headers_sent() ) {
 		setcookie( $name, $value, $expire, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, $secure, apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) );
+		setcookie( $name, $value, apply_filters( 'woocommerce_set_cookie_options', array( 'expires' => $expire, 'secure' => $secure, 'httponly' => $httponly ), $name, $value ) );
 	} elseif ( Constants::is_true( 'WP_DEBUG' ) ) {
 		headers_sent( $file, $line );
 		trigger_error( "{$name} cookie cannot be set - headers already sent by {$file} on line {$line}", E_USER_NOTICE ); // @codingStandardsIgnoreLine

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1050,12 +1050,20 @@ function wc_print_js() {
 function wc_setcookie( $name, $value, $expire = 0, $secure = false, $httponly = false ) {
 	if ( ! headers_sent() ) {
 		if ( version_compare( PHP_VERSION, '7.3.0', '>=' ) ) {
-			setcookie( $name, $value, apply_filters( 'woocommerce_set_cookie_options', array(
-				'expires' => $expire,
-				'secure' => $secure
-				'path' => COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN,
-				'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure )
-			), $name, $value ) );
+			setcookie(
+				$name,
+				$value,
+				apply_filters(
+					'woocommerce_set_cookie_options', array(
+						'expires' => $expire,
+						'secure' => $secure
+						'path' => COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN,
+						'httponly' => apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure )
+					),
+					$name,
+					$value
+				)
+			);
 		} else {
 			setcookie( $name, $value, $expire, COOKIEPATH ? COOKIEPATH : '/', COOKIE_DOMAIN, $secure, apply_filters( 'woocommerce_cookie_httponly', $httponly, $name, $value, $expire, $secure ) );
 		}


### PR DESCRIPTION
Currently, it's not possible to set the "samesite" attribute on a cookie (or indeed, to do any filtering of what is set).

For us, this is breaking an embedded checkout which we use in all Chromium-based browsers, now that Chromium defaults to SameSite=Lax (https://www.chromestatus.com/feature/5088147346030592). However, it'd be useful generally to have a filter in `wc_setcookie()` to allow arbitrary changing of the cookie options.

By changing the parameter style for setcookie(), it becomes possible to allow samesite to be set, whilst retaining compatibility with the existing, limited `woocommerce_cookie_httponly` filter.

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

Closes: #28106

### Changes proposed in this Pull Request:

Add `woocommerce_set_cookie_options` filter, allowing `setcookie()` options to be filtered.

### How to test the changes in this Pull Request:

1. Put items in cart.
2. Verify in your browser that valid set-cookie headers exist in the HTTP response.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

* Add woocommerce_set_cookie_options filter