### PR TITLE
fix flaky e2e coupon test

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -259,6 +259,12 @@
                 "provider",
                 "service"
             ],
+            "funding": [
+                {
+                    "url": "https://github.com/philipobenito",
+                    "type": "github"
+                }
+            ],
             "time": "2020-09-28T13:38:44+00:00"
         },
         {
@@ -446,27 +452,22 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v3.4.45",
+            "version": "v3.4.46",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "9ccf6e78077a3fc1596e6c7b5958008965a11518"
+                "reference": "da3d9da2ce0026771f5fe64cb332158f1bd2bc33"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/9ccf6e78077a3fc1596e6c7b5958008965a11518",
-                "reference": "9ccf6e78077a3fc1596e6c7b5958008965a11518",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/da3d9da2ce0026771f5fe64cb332158f1bd2bc33",
+                "reference": "da3d9da2ce0026771f5fe64cb332158f1bd2bc33",
                 "shasum": ""
             },
             "require": {
                 "php": "^5.5.9|>=7.0.8"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.4-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "Symfony\\Component\\CssSelector\\": ""
@@ -495,7 +496,21 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2020-03-16T08:31:04+00:00"
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-10-24T10:57:07+00:00"
         },
         {
             "name": "woocommerce/action-scheduler",
@@ -686,5 +701,6 @@
     "platform-dev": [],
     "platform-overrides": {
         "php": "7.1"
-    }
+    },
+    "plugin-api-version": "1.1.0"
 }

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-coupon-new.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-coupon-new.test.js
@@ -42,7 +42,7 @@ const runCreateCouponTest = () => {
 			// Publish coupon, verify that it was published. Trash coupon, verify that it was trashed.
 			await verifyPublishAndTrash(
 				'#publish',
-				'#message',
+				'.notice',
 				'Coupon updated.',
 				'1 coupon moved to the Trash.'
 			);

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-product-new.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-product-new.test.js
@@ -196,9 +196,8 @@ const runAddVariableProductTest = () => {
 			// Publish product, verify that it was published. Trash product, verify that it was trashed.
 			await verifyPublishAndTrash(
 				'#publish',
-				'.updated.notice',
+				'.notice',
 				'Product published.',
-				'Move to Trash',
 				'1 product moved to the Trash.'
 			);
 		});

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -110,7 +110,7 @@ const verifyPublishAndTrash = async ( button, publishNotice, publishVerification
 	}
 
 	// Trash
-	await page.scrollTo( '#submitdiv' );
+	await page.focus( '#submitdiv' );
 	await expect( page ).toClick( 'a.submitdelete' );
 	await page.waitForSelector( '#message' );
 

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -110,7 +110,7 @@ const verifyPublishAndTrash = async ( button, publishNotice, publishVerification
 	}
 
 	// Trash
-	await page.focus( '#submitdiv' );
+	await page.focus( 'a.submitdelete' );
 	await expect( page ).toClick( 'a.submitdelete' );
 	await page.waitForSelector( '#message' );
 

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -110,7 +110,8 @@ const verifyPublishAndTrash = async ( button, publishNotice, publishVerification
 	}
 
 	// Trash
-	await expect( page ).toClick( 'a', { text: "Move to Trash" } );
+	await page.scrollTo( '#submitdiv' );
+	await expect( page ).toClick( 'a.submitdelete' );
 	await page.waitForSelector( '#message' );
 
 	// Verify


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The coupon test has been consistently failing in my local dev environment recently. This PR changes the test by
- Changing `#message` to `.notice`. There are multiple `#message` elements on the page. Some browser versions will not find elements by ID when there is more than one of the ID on the page. By using the class Chromium will search all the elements that have that class.
- Adding a `focus()` to publish meta box to ensure that the meta box is rendered and in the view port.
- Change the selector for the move to trash link to `a.submitdelete` from searching for the link text.

Closes #25960 .

### How to test the changes in this Pull Request:

1. Ensure E2E tests run locally.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A
