### PR TITLE
Add `dates_are_gmt` parameter to REST API

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -300,16 +300,11 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			$args['date_query'][0]['after'] = $request['after'];
 		}
 
-		// Set before_gmt into date query. Date query must be specified as an array of an array.
-		if ( isset( $request['before_gmt'] ) ) {
-			$args['date_query'][0]['before'] = $request['before_gmt'];
-			$args['date_query']['column']    = 'post_date_gmt';
-		}
-
-		// Set after_gmt into date query. Date query must be specified as an array of an array.
-		if ( isset( $request['after_gmt'] ) ) {
-			$args['date_query'][0]['after'] = $request['after_gmt'];
-			$args['date_query']['column']   = 'post_date_gmt';
+		// Check flag to use post_date vs post_date_gmt.
+		if ( true === $request['dates_are_gmt'] ) {
+			if ( isset( $request['before'] ) || isset( $request['after'] ) ) {
+				$args['date_query']['column'] = 'post_date_gmt';
+			}
 		}
 
 		// Force the post_type argument, since it's not a user input variable.
@@ -573,6 +568,12 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			'type'               => 'string',
 			'format'             => 'date-time',
 			'validate_callback'  => 'rest_validate_request_arg',
+		);
+		$params['dates_are_gmt'] = array(
+			'description'       => __( 'Whether to use GMT post dates.', 'woocommerce' ),
+			'type'              => 'boolean',
+			'default'           => false,
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['exclude'] = array(
 			'description'       => __( 'Ensure result set excludes specific IDs.', 'woocommerce' ),

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -300,6 +300,18 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			$args['date_query'][0]['after'] = $request['after'];
 		}
 
+		// Set before_gmt into date query. Date query must be specified as an array of an array.
+		if ( isset( $request['before_gmt'] ) ) {
+			$args['date_query'][0]['before'] = $request['before_gmt'];
+			$args['date_query']['column']    = 'post_date_gmt';
+		}
+
+		// Set after_gmt into date query. Date query must be specified as an array of an array.
+		if ( isset( $request['after_gmt'] ) ) {
+			$args['date_query'][0]['after'] = $request['after_gmt'];
+			$args['date_query']['column']   = 'post_date_gmt';
+		}
+
 		// Force the post_type argument, since it's not a user input variable.
 		$args['post_type'] = $this->post_type;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added the `dates_are_gmt` parameters to allow the before and after parameters to use the `post_date_gmt` column if it is true.

Closes #28111 

**Related PR in documentation repository:** https://github.com/woocommerce/woocommerce-rest-api-docs/pull/203

### How to test the changes in this Pull Request:

1. Install WordPress/WooCommerce with testing data
2. Generate some API Keys
3. Make a REST API request to the 'https://localhost.com/wp-json/wc/v2/orders' end point and use the dates_are_gmt parameters to allow the before and after parameters to use the post_date_gmt column if it is true.
Example: https://localhost.com/wp-json/wc/v3/orders?dates_are_gmt=true&after=2021-04-24T06:00:00&before=2021-04-24T14:00:00&consumer_key=xxx&consumer_secret=xxx

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added the `dates_are_gmt` parameters to REST API to searched posts using the `post_date_gmt` column.