### PR TITLE
Add requires_php support

### DIFF
--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -57,6 +57,10 @@ class WC_Helper_Updater {
 				'upgrade_notice' => $data['upgrade_notice'],
 			);
 
+			if ( $data['requires_php'] ) {
+				$item['requires_php'] = $data['requires_php'];
+			}
+
 			// We don't want to deliver a valid upgrade package when their subscription has expired.
 			// To avoid the generic "no_package" error that empty strings give, we will store an
 			// indication of expiration for the `upgrader_pre_download` filter to error on.

--- a/includes/admin/helper/class-wc-helper-updater.php
+++ b/includes/admin/helper/class-wc-helper-updater.php
@@ -57,7 +57,7 @@ class WC_Helper_Updater {
 				'upgrade_notice' => $data['upgrade_notice'],
 			);
 
-			if ( $data['requires_php'] ) {
+			if ( isset( $data['requires_php'] ) ) {
 				$item['requires_php'] = $data['requires_php'];
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is a dependency for another change in the _Woo helper API_, which checks the required PHP version for WooCommerce extensions and avoid updates if the user contains unsupported PHP version. It uses the WordPress feature introduced in https://core.trac.wordpress.org/ticket/44350 and https://core.trac.wordpress.org/ticket/40934.

### How to test the changes in this Pull Request:

1. Remove the transient `_woocommerce_helper_updates` and the site transient `update_plugins`.
2. Install any WooCommerce extension.
3. Make sure your [WooCommerce.com Subscriptions](https://docs.woocommerce.com/document/managing-woocommerce-com-subscriptions/) is connected.
4. Intercept through the `wp_safe_remote_request` the WooCommerce endpoint that checks the plugins to update (`https://woocommerce.com/wp-json/helper/1.0/update-check?token=[xxxxxxxxxxxx]`) and returns one of the items with `requires_php: '8.0'` (set the version to be bigger than your environment PHP version). Or you can just force it in the code with `$item['requires_php'] = 8.0` instead of the `if`.
5. Reload the screen _WP Admin -> Plugins -> Installed Plugins_.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Add the ability to avoid unsupported updates based on the PHP version.

### Screenshot

Expected result in the screen:

<img width="1195" alt="Screen Shot 2020-10-30 at 18 28 55" src="https://user-images.githubusercontent.com/876340/97760343-b1547c80-1ae1-11eb-893c-74f3d979e9db.png">
