### PR TITLE
Fix #28158. Override update_term_meta_fields() method on attribute te…

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-product-attribute-terms-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-product-attribute-terms-controller.php
@@ -24,4 +24,19 @@ class WC_REST_Product_Attribute_Terms_Controller extends WC_REST_Product_Attribu
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Update term meta fields.
+	 *
+	 * @param WP_Term         $term The term to update.
+	 * @param WP_REST_Request $request Request data.
+	 * @return bool|WP_Error
+	 */
+	protected function update_term_meta_fields( $term, $request ) {
+		$id = (int) $term->term_id;
+
+		update_term_meta( $id, 'order', $request['menu_order'] );
+
+		return true;
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28158

I've overridden the _**update_term_meta_fields()**_ method from the REST API product attribute terms controller, for V3 fixing a wrong behaviour. 

The V1 version of the REST API sets the 'menu_order' meta as 'order_*taxonomy_name*' which is currently not working. When manually reordering attribute terms you can check that the meta concerning the order is saved, in the DB, at _wp_term_meta_ table as 'order'. V3 is using the same implementation. 

Reimplementing the method for V3 version fixed the bug, so adding attribute terms from the REST API, with custom order, works fine now.

V1 and V2 versions were not changed!

### How to test the changes in this Pull Request:

1. Add a product attribute with ordering as "Custom".
2. Add some attribute terms using **/wp-json/wc/v3/products/attributes** with custom 'menu_order' field.
3. Check in WooCommerce that the attribute terms has been added with the correct ordering.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
Fix custom ordering bug when creating product attribute terms via REST API.