### PR TITLE
Hide add to cart button if all products in group are out of stock clo…

### DIFF
--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -36,6 +36,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 				),
 				$product
 			);
+			$show_add_to_cart_button = false;
 
 			do_action( 'woocommerce_grouped_product_list_before', $grouped_product_columns, $quantites_required, $product );
 
@@ -44,6 +45,10 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 				$quantites_required = $quantites_required || ( $grouped_product_child->is_purchasable() && ! $grouped_product_child->has_options() );
 				$post               = $post_object; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
 				setup_postdata( $post );
+
+				if ( $grouped_product_child->is_in_stock() ) {
+					$show_add_to_cart_button = true;
+				}
 
 				echo '<tr id="product-' . esc_attr( $grouped_product_child->get_id() ) . '" class="woocommerce-grouped-product-list-item ' . esc_attr( implode( ' ', wc_get_product_class( '', $grouped_product_child ) ) ) . '">';
 
@@ -107,7 +112,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 
 	<input type="hidden" name="add-to-cart" value="<?php echo esc_attr( $product->get_id() ); ?>" />
 
-	<?php if ( $quantites_required ) : ?>
+	<?php if ( $quantites_required && $show_add_to_cart_button ) : ?>
 
 		<?php do_action( 'woocommerce_before_add_to_cart_button' ); ?>
 


### PR DESCRIPTION
…ses #27710

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27710 

Hides the `add to cart` button when all linked products in a group is out of stock to improve user experience. We've also decided in the team to defer the fix for hiding the grouped product when all is out of stock until we get a vote as currently it doesn't seem like a major issue.

### How to test the changes in this Pull Request:

1. Create a grouped product and add several products to it.
2. Make sure the linked products have manage stock enabled and set to zero stocks for all of them.
3. Go to the grouped product page and ensure the `add to cart` button no longer displays when all linked products are out of stock.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Tweak - Hide `add to cart` button on grouped product when all linked products are out of stock.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
