### PR TITLE
Optimizing memory usage

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1572,15 +1572,15 @@ class WC_AJAX {
 		$data_store = WC_Data_Store::load( 'product' );
 		$ids        = $data_store->search_products( $term, '', (bool) $include_variations, false, $limit, $include_ids, $exclude_ids );
 
-		$products        = array();
+		$products = array();
 
 		foreach ( $ids as $id ) {
 			$product_object = wc_get_product( $id );
-			
+
 			if ( ! wc_products_array_filter_readable( $product_object ) ) {
 				continue;
 			}
-			
+
 			$formatted_name = $product_object->get_formatted_name();
 			$managing_stock = $product_object->managing_stock();
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1572,10 +1572,15 @@ class WC_AJAX {
 		$data_store = WC_Data_Store::load( 'product' );
 		$ids        = $data_store->search_products( $term, '', (bool) $include_variations, false, $limit, $include_ids, $exclude_ids );
 
-		$product_objects = array_filter( array_map( 'wc_get_product', $ids ), 'wc_products_array_filter_readable' );
 		$products        = array();
 
-		foreach ( $product_objects as $product_object ) {
+		foreach ( $ids as $id ) {
+			$product_object = wc_get_product( $id );
+			
+			if ( ! wc_products_array_filter_readable( $product_object ) ) {
+				continue;
+			}
+			
 			$formatted_name = $product_object->get_formatted_name();
 			$managing_stock = $product_object->managing_stock();
 


### PR DESCRIPTION
Removing the potential undesired retrieval of hundreds or thousands of unreadable WC_Product objects into memory just to filter them out immediately.
This change prevented some out-of-memory situations in our site.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Avoid bringing into memory the whole list of WC_Products for all existing products in the database before filtering it. And instead of having the whole list in memory, better bring the products one by one.

Closes #28176 .

### How to test the changes in this Pull Request:

1. Things should keep working when using /wp-admin/wp-ajax.php?action=woocommerce_json_search_products, but the amount of memory used should be dramatically reduced

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Tweak - Reduce memory usage when executing json_search_products and json_search_products_and_variations
