### PR TITLE
add permalinks working test

### DIFF
--- a/tests/e2e/core-tests/specs/activate-and-setup/setup.test.js
+++ b/tests/e2e/core-tests/specs/activate-and-setup/setup.test.js
@@ -12,12 +12,14 @@ const {
 } = require( '@woocommerce/e2e-utils' );
 
 const {
+	getTestConfig,
 	waitAndClick
 } = require( '@woocommerce/e2e-environment' );
 
 /**
  * External dependencies
  */
+const { HTTPClientFactory } = require( '@woocommerce/api' );
 const {
 	it,
 	describe,
@@ -67,6 +69,18 @@ const runInitialStoreSettingsTest = () => {
 				verifyValueOfInputField('#permalink_structure', '/%postname%/'),
 				verifyValueOfInputField('#woocommerce_permalink_structure', '/product/'),
 			]);
+		});
+
+		it( 'can use api with pretty permalinks', async () => {
+			const testConfig = getTestConfig();
+			const admin = testConfig.users.admin;
+			const client = HTTPClientFactory.build( testConfig.url )
+				.withBasicAuth( admin.username, admin.password )
+				.withIndexPermalinks()
+				.create();
+
+			const response = await client.get( '/wc/v3/products' );
+			expect( response.statusCode ).toBe( 200 );
 		});
 	});
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
### Changes proposed in this Pull Request:

This is a follow up PR to #28186. It adds a test that uses pretty permalinks on a REST API request to verify that permalinks are working.

### How to test the changes in this Pull Request:

1. Run `npm run docker:up`
2. Run `npm run test:e2e tests/e2e/specs/activate-and-setup/test-initial-settings.js`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A