### PR TITLE
Pass email object to header and footer templates

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -190,7 +190,7 @@ class WC_Emails {
 		$this->init();
 
 		// Email Header, Footer and content hooks.
-		add_action( 'woocommerce_email_header', array( $this, 'email_header' ) );
+		add_action( 'woocommerce_email_header', array( $this, 'email_header' ), 10, 2 );
 		add_action( 'woocommerce_email_footer', array( $this, 'email_footer' ) );
 		add_action( 'woocommerce_email_order_details', array( $this, 'order_downloads' ), 10, 4 );
 		add_action( 'woocommerce_email_order_details', array( $this, 'order_details' ), 10, 4 );
@@ -264,16 +264,19 @@ class WC_Emails {
 	 * Get the email header.
 	 *
 	 * @param mixed $email_heading Heading for the email.
+	 * @param WC_Email $email      Email object for the email.
 	 */
-	public function email_header( $email_heading ) {
-		wc_get_template( 'emails/email-header.php', array( 'email_heading' => $email_heading ) );
+	public function email_header( $email_heading, $email ) {
+		wc_get_template( 'emails/email-header.php', array( 'email_heading' => $email_heading, 'email' => $email ) );
 	}
 
 	/**
 	 * Get the email footer.
+	 *
+	 * @param WC_Email $email Email object for the email.
 	 */
-	public function email_footer() {
-		wc_get_template( 'emails/email-footer.php' );
+	public function email_footer( $email ) {
+		wc_get_template( 'emails/email-footer.php', array( 'email' => $email ) );
 	}
 
 	/**

--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -263,11 +263,17 @@ class WC_Emails {
 	/**
 	 * Get the email header.
 	 *
-	 * @param mixed $email_heading Heading for the email.
-	 * @param WC_Email $email      Email object for the email.
+	 * @param mixed    $email_heading Heading for the email.
+	 * @param WC_Email $email         Email object for the email.
 	 */
 	public function email_header( $email_heading, $email ) {
-		wc_get_template( 'emails/email-header.php', array( 'email_heading' => $email_heading, 'email' => $email ) );
+		wc_get_template(
+			'emails/email-header.php',
+			array(
+				'email_heading' => $email_heading,
+				'email'         => $email,
+			)
+		);
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The email object is not accessible in the email header and footer templates. This limits the ability to modify these templates with content specific to a type of email.

This change passes the `$email` variable through to the template which is already supplied in all calls to this action such as `do_action( 'woocommerce_email_header', $email_heading, $email );` and `do_action( 'woocommerce_email_footer', $email );`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Added argument on `wc_get_template()` to pass email object to email header and footer templates.