### PR TITLE
Allow currencies to be sorted by title

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -470,9 +470,10 @@ function get_woocommerce_currency() {
  *
  * Currency symbols and names should follow the Unicode CLDR recommendation (http://cldr.unicode.org/translation/currency-names)
  *
+ * @param $sort Optionally allow sorting by currency title. Accepts asc, desc.
  * @return array
  */
-function get_woocommerce_currencies() {
+function get_woocommerce_currencies($sort = '') {
 	static $currencies;
 
 	if ( ! isset( $currencies ) ) {
@@ -648,6 +649,14 @@ function get_woocommerce_currencies() {
 		);
 	}
 
+	if($sort === 'asc') {
+		asort($currencies, SORT_STRING);
+	}
+
+	if($sort === 'desc') {
+		arsort($currencies, SORT_STRING);
+	}
+	
 	return $currencies;
 }
 


### PR DESCRIPTION
Added the ability to sort currencies in ascending or descending order. It will be optional.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Allow the ability to sort currencies in ascending or descending order. It will visually help users search through currencies quickly.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?


### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
- get_woocommerce_currencies() accepts 'asc' or 'desc' argument to enable currencies sorting. Default is ''.
