### PR TITLE
Add additional store information to tracks closes #27990

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -323,13 +323,13 @@ class WC_Tracker {
 	 * @return int $days Number of days the store was active.
 	 */
 	public static function get_age_of_store() {
-		$wc_admin_installed = get_option( 'woocommerce_admin_install_timestamp', 0 );
+		$wc_admin_installed = (int) get_option( 'woocommerce_admin_install_timestamp', 0 );
 
 		if ( 0 === $wc_admin_installed ) {
 			return 0;
 		}
 
-		return ceil( ( time() - intval( $wc_admin_installed ) ) / DAY_IN_SECONDS );
+		return (int) ceil( ( time() - $wc_admin_installed ) / DAY_IN_SECONDS );
 	}
 
 	/**
@@ -393,24 +393,6 @@ class WC_Tracker {
 		$order_totals = self::get_order_totals();
 
 		return array_merge( $order_dates, $order_counts, $order_totals );
-	}
-
-	/**
-	 * Get order counts by status.
-	 *
-	 * @param string $status The string of the order status without `wc-` prefix.
-	 * @return int $count The count of orders per status.
-	 */
-	public static function get_orders_count_by_status( $status = '' ) {
-		if ( empty( $status ) ) {
-			return 0;
-		}
-
-		$status = 'wc-' . $status;
-
-		$count = wp_count_posts( 'shop_order' );
-
-		return intval( $count->{$status} );
 	}
 
 	/**

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -76,7 +76,7 @@ class WC_Site_Tracking {
 				var eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
 				var eventProperties = properties || {};
 				eventProperties.url = '<?php echo esc_html( home_url() ); ?>'
-				eventProperties.products_count = '<?php echo intval( $product_counts['total'] ); ?>';
+				eventProperties.products_count = '<?php echo (int) esc_attr( $product_counts['total'] ); ?>';
 				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
 					eventProperties = window.wp.hooks.applyFilters( 'woocommerce_tracks_client_event_properties', eventProperties, eventName );
 					delete( eventProperties._ui );

--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -62,6 +62,7 @@ class WC_Site_Tracking {
 	 * Adds the tracking function to the admin footer.
 	 */
 	public static function add_tracking_function() {
+		$product_counts = WC_Tracker::get_product_counts();
 		?>
 		<!-- WooCommerce Tracks -->
 		<script type="text/javascript">
@@ -75,7 +76,7 @@ class WC_Site_Tracking {
 				var eventName = '<?php echo esc_attr( WC_Tracks::PREFIX ); ?>' + name;
 				var eventProperties = properties || {};
 				eventProperties.url = '<?php echo esc_html( home_url() ); ?>'
-				eventProperties.products_count = '<?php echo intval( WC_Tracks::get_products_count() ); ?>';
+				eventProperties.products_count = '<?php echo intval( $product_counts['total'] ); ?>';
 				if ( window.wp && window.wp.hooks && window.wp.hooks.applyFilters ) {
 					eventProperties = window.wp.hooks.applyFilters( 'woocommerce_tracks_client_event_properties', eventProperties, eventName );
 					delete( eventProperties._ui );

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -38,16 +38,16 @@ class WC_Tracks {
 	public static function get_blog_details( $user_id ) {
 		$blog_details = get_transient( 'wc_tracks_blog_details' );
 
-		$product_counts = WC_Tracker::get_product_counts();
-
 		if ( false === $blog_details ) {
+			$product_counts = WC_Tracker::get_product_counts();
+
 			$blog_details = array(
 				'url'              => home_url(),
 				'blog_lang'        => get_user_locale( $user_id ),
 				'blog_id'          => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
 				'products_count'   => $product_counts['total'],
 				'age_of_store'     => WC_Tracker::get_age_of_store(),
-				'completed_orders' => WC_Tracker::get_orders_count_by_status( 'completed' ),
+				'completed_orders' => wc_orders_count( 'completed' ),
 			);
 
 			// No longer needed as already displayed above for `products_count`.
@@ -56,6 +56,7 @@ class WC_Tracks {
 			$blog_details = array_merge( $blog_details, $product_counts );
 			set_transient( 'wc_tracks_blog_details', $blog_details, DAY_IN_SECONDS );
 		}
+
 		return $blog_details;
 	}
 

--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -18,10 +18,14 @@ class WC_Tracks {
 	/**
 	 * Get total product counts.
 	 *
+	 * @deprecated deprecated since 4.9.
 	 * @return int Number of products.
 	 */
 	public static function get_products_count() {
+		wc_deprecated_function( 'WC_Tracks::get_products_count', '4.9', 'WC_Tracker::get_product_counts' );
+
 		$product_counts = WC_Tracker::get_product_counts();
+
 		return $product_counts['total'];
 	}
 
@@ -33,13 +37,23 @@ class WC_Tracks {
 	 */
 	public static function get_blog_details( $user_id ) {
 		$blog_details = get_transient( 'wc_tracks_blog_details' );
+
+		$product_counts = WC_Tracker::get_product_counts();
+
 		if ( false === $blog_details ) {
 			$blog_details = array(
-				'url'            => home_url(),
-				'blog_lang'      => get_user_locale( $user_id ),
-				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
-				'products_count' => self::get_products_count(),
+				'url'              => home_url(),
+				'blog_lang'        => get_user_locale( $user_id ),
+				'blog_id'          => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
+				'products_count'   => $product_counts['total'],
+				'age_of_store'     => WC_Tracker::get_age_of_store(),
+				'completed_orders' => WC_Tracker::get_orders_count_by_status( 'completed' ),
 			);
+
+			// No longer needed as already displayed above for `products_count`.
+			unset( $product_counts['total'] );
+
+			$blog_details = array_merge( $blog_details, $product_counts );
 			set_transient( 'wc_tracks_blog_details', $blog_details, DAY_IN_SECONDS );
 		}
 		return $blog_details;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27990 

Adds additional store information to tracks:
* Store age
* Total orders completed
* Count of each product types

![](https://d.pr/i/8Ar4nI+)

### How to test the changes in this Pull Request:

1. Ensure your Tracker is enabled/opted in on your site.
2. Go to any page that is being tracked such as the order list page.
3. Go to Tracks page and witness the additional information as stated above.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Add - Store age to Tracks.
* Add - Total orders completed to Tracks.
* Add - Total count of products by type to Tracks.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
