### PR TITLE
Load product category content with content-product-cat.php

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -220,7 +220,7 @@ class WC_Shortcodes {
 
 			foreach ( $product_categories as $category ) {
 				wc_get_template(
-					'content-product_cat.php',
+					'content-product-cat.php',
 					array(
 						'category' => $category,
 					)

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2491,7 +2491,7 @@ if ( ! function_exists( 'woocommerce_output_product_categories' ) ) {
 
 		foreach ( $product_categories as $category ) {
 			wc_get_template(
-				'content-product_cat.php',
+				'content-product-cat.php',
 				array(
 					'category' => $category,
 				)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

`content-product_cat.php` doesn't exists anymore, now we should use `content-product-cat.php`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Load product category page and shortcode content with `content-product-cat.php`.