### PR TITLE
Add shipping, tax and fee lines to refund response for better information in refund REST API.

### DIFF
--- a/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -58,7 +58,9 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 	 */
 	public function register_routes() {
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base, array(
+			$this->namespace,
+			'/' . $this->rest_base,
+			array(
 				'args'   => array(
 					'order_id' => array(
 						'description' => __( 'The order ID.', 'woocommerce' ),
@@ -82,7 +84,9 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 		);
 
 		register_rest_route(
-			$this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', array(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
+			array(
 				'args'   => array(
 					'order_id' => array(
 						'description' => __( 'The order ID.', 'woocommerce' ),
@@ -140,7 +144,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 		$data              = $object->get_data();
 		$format_decimal    = array( 'amount' );
 		$format_date       = array( 'date_created' );
-		$format_line_items = array( 'line_items' );
+		$format_line_items = array( 'line_items', 'shipping_lines', 'tax_lines', 'fee_lines' );
 
 		// Format decimal values.
 		foreach ( $format_decimal as $key ) {
@@ -169,6 +173,9 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 			'refunded_payment' => $data['refunded_payment'],
 			'meta_data'        => $data['meta_data'],
 			'line_items'       => $data['line_items'],
+			'shipping_lines'   => $data['shipping_lines'],
+			'tax_lines'        => $data['tax_lines'],
+			'fee_lines'        => $data['fee_lines'],
 		);
 	}
 

--- a/tests/legacy/framework/helpers/class-wc-helper-order.php
+++ b/tests/legacy/framework/helpers/class-wc-helper-order.php
@@ -119,4 +119,33 @@ class WC_Helper_Order {
 
 		return $order;
 	}
+
+	/**
+	 * Helper function to create order with fees and shipping objects.
+	 *
+	 * @param int        $customer_id The ID of the customer the order is for.
+	 * @param WC_Product $product The product to add to the order.
+	 *
+	 * @return WC_Order
+	 */
+	public static function create_order_with_fees_and_shipping( $customer_id = 1, $product = null ) {
+		$order = self::create_order( $customer_id, $product );
+
+		$fee_item = new WC_Order_Item_Fee();
+		$fee_item->set_order_id( $order->get_id() );
+		$fee_item->set_name( 'Testing fees' );
+		$fee_item->set_total( 100 );
+
+		$shipping_item = new WC_Order_Item_Shipping();
+		$shipping_item->set_order_id( $order->get_id() );
+		$shipping_item->set_name( 'Flat shipping' );
+		$shipping_item->set_total( 25 );
+
+		$order->add_item( $fee_item );
+		$order->add_item( $shipping_item );
+		$order->save();
+		$order->calculate_totals( true );
+
+		return $order;
+	}
 }

--- a/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller-test.php
+++ b/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller-test.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Class WC_REST_Order_Refunds_Controller_Test.
+ */
+class WC_REST_Order_Refunds_V2_Controller_Test extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Test if line, fees and shipping items are all included in refund response.
+	 */
+	public function test_items_response_fields() {
+		wp_set_current_user( 1 );
+		$order = WC_Helper_Order::create_order_with_fees_and_shipping();
+
+		$product_item  = current( $order->get_items( 'line_item' ) );
+		$fee_item      = current( $order->get_items( 'fee' ) );
+		$shipping_item = current( $order->get_items( 'shipping' ) );
+
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'reason'     => 'testing',
+				'line_items' => array(
+					$product_item->get_id()  =>
+						array(
+							'qty'          => 1,
+							'refund_total' => 1,
+						),
+					$fee_item->get_id()      =>
+						array(
+							'refund_total' => 10,
+						),
+					$shipping_item->get_id() =>
+						array(
+							'refund_total' => 20,
+						),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund );
+
+		$request = new WP_REST_Request( 'GET', '/wc/v2/orders/' . $order->get_id() . '/refunds/' . $refund->get_id() );
+
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertContains( 'line_items', array_keys( $data ) );
+		$this->assertEquals( -1, $data['line_items'][0]['total'] );
+
+		$this->assertContains( 'fee_lines', array_keys( $data ) );
+		$this->assertEquals( -10, $data['fee_lines'][0]['total'] );
+
+		$this->assertContains( 'shipping_lines', array_keys( $data ) );
+		$this->assertEquals( -20, $data['shipping_lines'][0]['total'] );
+	}
+}

--- a/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller-test.php
+++ b/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller-test.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Class WC_REST_Order_Refunds_Controller_Test.
+ */
+class WC_REST_Order_Refunds_Controller_Test extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Test if line, fees and shipping items are all included in refund response.
+	 */
+	public function test_items_response_fields() {
+		wp_set_current_user( 1 );
+		$order = WC_Helper_Order::create_order_with_fees_and_shipping();
+
+		$product_item  = current( $order->get_items( 'line_item' ) );
+		$fee_item      = current( $order->get_items( 'fee' ) );
+		$shipping_item = current( $order->get_items( 'shipping' ) );
+
+		$refund = wc_create_refund(
+			array(
+				'order_id'   => $order->get_id(),
+				'reason'     => 'testing',
+				'line_items' => array(
+					$product_item->get_id()  =>
+						array(
+							'qty'          => 1,
+							'refund_total' => 1,
+						),
+					$fee_item->get_id()      =>
+						array(
+							'refund_total' => 10,
+						),
+					$shipping_item->get_id() =>
+						array(
+							'refund_total' => 20,
+						),
+				),
+			)
+		);
+
+		$this->assertNotWPError( $refund );
+
+		$request = new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() . '/refunds/' . $refund->get_id() );
+
+		$response = $this->server->dispatch( $request );
+		$data = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertContains( 'line_items', array_keys( $data ) );
+		$this->assertEquals( -1, $data['line_items'][0]['total'] );
+
+		$this->assertContains( 'fee_lines', array_keys( $data ) );
+		$this->assertEquals( -10, $data['fee_lines'][0]['total'] );
+
+		$this->assertContains( 'shipping_lines', array_keys( $data ) );
+		$this->assertEquals( -20, $data['shipping_lines'][0]['total'] );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This adds shipping, tax, and fee lines to refund response in API V2 and V3.

Closes #27566

### How to test the changes in this Pull Request:

1. Create an order with shipping, tax and fee lines.
2. Refund these items.
3. Fetch the order refunds in API V2 or V3 using /orders/{order_id}/refunds endpoint.
4. Verify that fee_lines, shipping_lines and tax_lines are present.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - Add shipping, tax and fee lines to refund response for better information in refund REST API.