### PR TITLE
Replace call to deprecated woocommerce_reset_loop()

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -230,7 +230,7 @@ class WC_Shortcodes {
 			woocommerce_product_loop_end();
 		}
 
-		woocommerce_reset_loop();
+		wc_reset_loop();
 
 		return '<div class="woocommerce columns-' . $columns . '">' . ob_get_clean() . '</div>';
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR simply replaces the single call in WooCommerce core codebase to the deprecated woocommerce_reset_loop() function with its replacement wc_reset_loop(). I found this while reviewing #28233.

### How to test the changes in this Pull Request:

1. The modified code is inside WC_Shortcodes::product_categories(). So test that the shortcode `[product_categories]` still work as expected.

### Changelog entry

> Dev - Replace deprecated `woocommerce_reset_loop()` function in `WC_Shortcodes::product_categories()`.
