### PR TITLE
Fixed placeholders and translators style WC_Form_Handler::add_to_cart_handler_variable

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -910,8 +910,8 @@ class WC_Form_Handler {
 			$url          = get_permalink( $product_id );
 			$product_name = $product->get_name();
 
-			/* translators: %1$s: Product link, %2$s: Product title, %3$s: Product name. */
-			wc_add_notice( sprintf( __( 'Please choose product options by visiting <a href="%1$s" title="%2$s">%3$s</a>.', 'woocommerce' ), esc_url( $url ), esc_html( $product_name ), esc_html( $product_name ) ), 'error' );
+			/* translators: 1: product link, 2: product name */
+			wc_add_notice( sprintf( __( 'Please choose product options by visiting <a href="%1$s" title="%2$s">%2$s</a>.', 'woocommerce' ), esc_url( $url ), esc_html( $product_name ) ), 'error' );
 
 			return false;
 		}

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -906,12 +906,9 @@ class WC_Form_Handler {
 		}
 
 		// Prevent parent variable product from being added to cart.
-		if ( empty( $variation_id ) && $product->is_type( 'variable' ) ) {
-			$url          = get_permalink( $product_id );
-			$product_name = $product->get_name();
-
+		if ( empty( $variation_id ) && $product && $product->is_type( 'variable' ) ) {
 			/* translators: 1: product link, 2: product name */
-			wc_add_notice( sprintf( __( 'Please choose product options by visiting <a href="%1$s" title="%2$s">%2$s</a>.', 'woocommerce' ), esc_url( $url ), esc_html( $product_name ) ), 'error' );
+			wc_add_notice( sprintf( __( 'Please choose product options by visiting <a href="%1$s" title="%2$s">%2$s</a>.', 'woocommerce' ), esc_url( get_permalink( $product_id ) ), esc_html( $product->get_name() ) ), 'error' );
 
 			return false;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR just fix the placeholder and use the same styling that WP core does for the translators notation.
Also checks if `$product` exists before calling it as a class.

There's no need for a changelog, since this is a new change introduced in #28103.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->