### PR TITLE
[TASK] documented introduction of wc_get_container function

### DIFF
--- a/woocommerce.php
+++ b/woocommerce.php
@@ -51,6 +51,7 @@ function WC() { // phpcs:ignore WordPress.NamingConventions.ValidFunctionName.Fu
  * Returns the WooCommerce PSR11-compatible object container.
  * Code in the `includes` directory should use the container to get instances of classes in the `src` directory.
  *
+ * @since  4.4.0
  * @return \Psr\Container\ContainerInterface The WooCommerce PSR11 container.
  */
 function wc_get_container() : \Psr\Container\ContainerInterface {


### PR DESCRIPTION
[TASK] documented introduction of wc_get_container function as it has a new syntax

### All Submissions:

* [x ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry


[TASK] documented introduction of wc_get_container function as it has a new syntax, some PHP-cli calls break on the 4.4.0 version. The very least we can do is document the introduction of this function. (tested PHP 7.2 PHP 7.4 commandline )

wp-cli.phar action-scheduler run 
Parse error: syntax error, unexpected ':', expecting '{' in /home/user/public_html/wp-content/plugins/woocommerce/woocommerce.php on line 56