### PR TITLE
Remove Dockerfile as it is not used anymore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,1 +1,0 @@
-FROM wordpress:5.4.2


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This file was added in the past to help set up the old E2E testing infrastructure (see #25105), but the new E2E setup doesn't use it (see https://github.com/woocommerce/woocommerce/pull/28173#issuecomment-725617312).

### How to test the changes in this Pull Request:

1. Checking that the Travis build passes should be enough to test this PR.
2. If you want to be extra careful, you can test that you can still run the E2E tests on your local machine.