### PR TITLE
Remove jQuery code that does nothing

### DIFF
--- a/assets/js/admin/meta-boxes.js
+++ b/assets/js/admin/meta-boxes.js
@@ -16,18 +16,6 @@ jQuery( function ( $ ) {
 
 	runTipTip();
 
-	// Allow Tabbing
-	$( '#titlediv' ).find( '#title' ).keyup( function( event ) {
-		var code = event.keyCode || event.which;
-
-		// Tab key
-		if ( code === '9' && $( '#woocommerce-coupon-description' ).length > 0 ) {
-			event.stopPropagation();
-			$( '#woocommerce-coupon-description' ).focus();
-			return false;
-		}
-	});
-
 	$( '.wc-metaboxes-wrapper' ).on( 'click', '.wc-metabox > h3', function() {
 		$( this ).parent( '.wc-metabox' ).toggleClass( 'closed' ).toggleClass( 'open' );
 	});


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR replaces a block of jQuery code that I believe does nothing. I found it while starting the work to make our JS code compatible with jQuery 3 as it uses jQuery.fn.keyup(), which has been deprecated.

As far as I can understand, this block of code is supposed to change the focus to the coupon description when the user hits the tab key while the focus is on the title field. It doesn't work because the keyup event is not fired for the tab key. The current behavior is that when the user hits the tab key, the focus changes to the "Generate coupon code" button, and if the tab key is pressed another time, the focus changes to the description text field. Which seems fine to me, and that is why I'm suggesting we remove this code instead of fixing it.

I believe it was added in this c15b8e817cb523a5534d935bcb138e47642f76b4 commit six years ago, and unfortunately, the commit doesn't provide much information on why it was added.

### How to test the changes in this Pull Request:

1. On the master branch, go to the page to add a new coupon and check that the code removed in this PR does nothing and that when the title field is selected and you hit "Tab", the focus changes to the "Generate coupon code" button and not to the description field.
2. Read the removed code and verify that my understanding about it is correct.

### Changelog entry

> Dev: removed jQuery code that didn't work that was supposed to interact with the coupon page.
