### PR TITLE
Remove leftover jQuery code related to old shipping settings

### DIFF
--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -308,15 +308,6 @@
 			return false;
 		});
 
-		// Select availability
-		$( 'select.availability' ).change( function() {
-			if ( $( this ).val() === 'all' ) {
-				$( this ).closest( 'tr' ).next( 'tr' ).hide();
-			} else {
-				$( this ).closest( 'tr' ).next( 'tr' ).show();
-			}
-		}).change();
-
 		// Hidden options
 		$( '.hide_options_if_checked' ).each( function() {
 			$( this ).find( 'input:eq(0)' ).change( function() {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes a jQuery code that is not used anymore. Each shipping method in WooCommerce until 2.6.0 had a setting called "Availability" that could be set to either "All allowed countries" or "Specific countries". The jQuery code removed in this commit was used to show or hide another setting called "Specific countries" that was only visible when "Availability" was set to "Specific countries". When shipping methods were refactored for 2.6.0 and the "Availability" code was removed in #9826, we forgot to remove the related jQuery code that I found today when working on making sure our JS code is compatible with jQuery 3.

See GIF below for a representation of how the removed code was used until WC 2.5.x:

![Peek 2020-11-14 16-23](https://user-images.githubusercontent.com/77215/99155452-d4149280-2696-11eb-979c-dc80c79d7327.gif)


### How to test the changes in this Pull Request:

1. Check that my assumption is correct and that the removed code is indeed not used anymore.

### Changelog entry

> Dev: remove jQuery code that was used to display or hide a shipping setting that was removed in WooCommerce 2.6.0
