### PR TITLE
4.8.0-beta.1 Preparation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -88,3 +88,7 @@ branches:
     - master
     - /^\d+\.\d+(\.\d+)?(-\S*)?$/
     - /^release\//
+
+# Composer 2.0.7 introduced a change that broke the jetpack autoloader in PHP 7.0 - 7.3.
+before_install:
+  - composer self-update 2.0.6

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -507,9 +507,8 @@ jQuery( function( $ ) {
 				$.ajax({
 					type:		'POST',
 					url:		wc_checkout_params.checkout_url,
-					data:		new FormData( this ),
-					contentType: false,
-					processData: false,
+					data:		$form.serialize(),
+					dataType:   'json',
 					success:	function( result ) {
 						// Detach the unload handler that prevents a reload / redirect
 						wc_checkout_form.detachUnloadEventsOnSubmit();

--- a/readme.txt
+++ b/readme.txt
@@ -167,6 +167,7 @@ WooCommerce comes with some sample data you can use to see how products look; im
 * Tweak - Reduced the memory usage of AJAX product searches. #28177
 * Tweak - Replaced deprecated jQuery functionality. #28005, #28058
 * Tweak - Hid "Add to cart" button for out of stock grouped products. #28169
+* Tweak - Made product date deserialization more explicit. #28052
 * Fix - Stock adjustment when deleting a refunded order item. #28069
 * Fix - Avatar display for recent reviews widget in admin area. #28067
 * Fix - Incorrect product sorting user capability. #28062

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,24 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 = 4.8.0 - 2020-12-xx =
 
+* Enhancement - Limited the system status report's "not tested with version" warning to major versions. #28114
+* Enhancement - Add shipping, tax, and fee lines to refund REST API response. #28241
+* Tweak - Reduced the memory usage of AJAX product searches. #28177
+* Tweak - Replaced deprecated jQuery functionality. #28005, #28058
+* Tweak - Hid "Add to cart" button for out of stock grouped products. #28169
+* Fix - Stock adjustment when deleting a refunded order item. #28069
+* Fix - Avatar display for recent reviews widget in admin area. #28067
+* Fix - Incorrect product sorting user capability. #28062
+* Fix - PayPal response emptying uninitialized cart. #28027
+* Fix - Display of visual feedback after pressing "Place Order" in `Twenty Twenty` and `Twenty Nineteen` themes #27997
+* Fix - Category and tag bulk deletion message. #27856
+* Dev - Filter: `woocommerce_product_has_options` to products. #27514
+* Dev - Added error message to `checkout_error` JS event. #28101
+* Dev - Replaced usage of deprecated `woocommerce_reset_loop()` in product category shortcodes. #28242
+* Localization - Jamaican currency, states, and address structure. #27723
+* Localization - Better display of inclusive taxes during checkout. #28064
+* Localization - Validation for Belgium postcodes. #28145
+
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce/master/changelog.txt).
 
 == Upgrade Notice ==

--- a/readme.txt
+++ b/readme.txt
@@ -162,6 +162,8 @@ WooCommerce comes with some sample data you can use to see how products look; im
 
 = 4.8.0 - 2020-12-xx =
 
+**WooCommerce**
+
 * Enhancement - Limited the system status report's "not tested with version" warning to major versions. #28114
 * Enhancement - Add shipping, tax, and fee lines to refund REST API response. #28241
 * Tweak - Reduced the memory usage of AJAX product searches. #28177
@@ -180,6 +182,80 @@ WooCommerce comes with some sample data you can use to see how products look; im
 * Localization - Jamaican currency, states, and address structure. #27723
 * Localization - Better display of inclusive taxes during checkout. #28064
 * Localization - Validation for Belgium postcodes. #28145
+
+**WooCommerce Admin - 1.7.0**
+
+* Enhancement - Variations report.  #5167
+* Enhancement - Add ability to toggle homescreen layouts. #5429
+* Enhancement - Accordion component  #5474
+* Enhancement - Badge component #5520
+* Fix - Added support for custom actionable statuses. #5550
+* Fix - wrong casing used on the PayPal brand name  #5514 🎉 @rtpHarry
+* Fix - Import @wordpress/base-styles/default-custom-properties #5491
+* Fix - downloads report  #5441
+* Fix - missing custom autocompleter attribute in Search component of Advanced Filter #5448
+* Fix - empty no posts state on Marketing page. #5411
+* Fix - visual issues in the Search component.  #5199
+* Fix - Inconsistent line endings in readme.txt. #5281
+* Fix - popover menu to expand menu item width to 100%  #5519
+* Fix - Wrong class name for querying Categories Report #5522 🎉 @zzap
+* Fix - Remove label printing mention for non us countries #5527
+* Fix - First product script navigation dependency #5584
+* Fix - Added support for custom actionable statuses #5550
+* Fix - Display the store management links last on the homescreen #5579
+* Fix - Ensure the "Set up additional payment providers" inbox notification is shown when relevant after completing the OBW. #5547
+* Tweak - Remove customer analytics data upon order deletion  #5171
+* Tweak - Updating Stripe key field validation to support test keys  #5201
+* Tweak - Wrap search control selected items in list  #5231
+* Tweak - Update store setup link to redirect to setup wizard  #5200
+* Tweak - Removing breadcrumbs from wc-admin header #5232
+* Tweak - Use consistent markdown headers in navigation readme #5417
+* Tweak - Remove Store Setup Alert #5499
+* Tweak - Customers: Update column heading for date registered #5542
+* Tweak - alter homescreen layout. #5465
+* Dev - Home Screen - migrate orders panel. #5455
+* Dev - Store Profiler - include Creative Mail as a free extension #5543
+* Dev - Add undefined check in intervals data util #5546
+* Dev - Fix wakeup visibility for PHP 8 compatibility  #5211
+* Dev - Fix header height and positioning for wc nav  #5173
+* Dev - Add remote inbox notification rule processors for country and state  #5203
+* Dev - Rename admin notes classes and file names to fit conventions  #514
+* Dev - remove checks of store registration that are no longer needed.  #5170
+* Dev - Fix version update script for composer.json  #5165
+* Dev - Remove getAdminLink from data package  #5158
+* Dev - Bump @woocommerce/components dependencies.  #5153
+* Dev - Add note status remote inbox notifications rule processor #5207
+* Dev - Make code chunk filenames more stable.  #5229
+* Dev - Inbox Panel component moved #5252
+* Dev - Added animation to Inbox note deletion  #5263
+* Dev - Update starter pack dependencies #5254
+* Dev - Ensure test zips have latest packages from npm and composer. #5313
+* Dev - Add remote inbox notifications rule allowing access to any option #5206
+* Dev - Add manage orders on the go admin note #5159
+* Dev - Add WooCommerceDependencyExtractionWebpackPlugin package  #5198
+* Dev - Migrate devdocs examples to Storybook stories #5271
+* Dev - Remove Enzyme in favor of React Testing Library #5299
+* Dev - Add exclusion rule to PHPCS config for TODO comments  #5388
+* Dev - Remove no longer used isPanelEmpty logic. #5423
+* Dev - Use new @wordpress/components Card on Marketing page.  #5428
+* Dev - Add PSR-4 naming checks to PHP linting. #5512
+* Dev - Rearrange the store management links under categories add filter woocommerce_admin_homescreen_quicklinks. #5476
+* Dev - Restyle the setup task list header to display incomplete tasks #5520
+
+**WooCommerce Blocks - 3.7.0 & 3.7.1 & 3.8.0**
+
+* Enhancement - Allow shoppers to sign-up for an account from the Checkout block. #3331
+* Enhancement - Standardise & refactor colors scss to align with Gutenberg colors and WooCommerce brand. #3300
+* Tweak - Show the phone number field in the billing section when shipping is disabled in settings. #3376
+* Tweak - Add new doc referencing feature flags and experimental interfaces. #3348
+* Tweak - Add __experimental_woocommerce_blocks_checkout_order_processed action. #3238
+* Fix - Fix PHP 8 error when argument is not invocable in AssetsDataRegistry::Add_data. #3315
+* Fix - Improve layout of Cart block line item quantity selector & price on smaller screens. #3299
+* Fix - Correctly process orders with $0 total (e.g. via coupon) in Checkout block. #3298
+* Fix - Respect Enable Taxes setting for checkout block taxes display. #3291
+* Fix - Fix 3D secure payment errors. #3272
+* Fix - Show current selected attributes when re-edit Products by Attribute block. #3185
+* Fix - Ensure that accounts are not created via checkout block request if account registration is disabled for WooCommerce. #3371
 
 [See changelog for all versions](https://raw.githubusercontent.com/woocommerce/woocommerce/master/changelog.txt).
 

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 4.8.0-dev
+ * Version: 4.8.0-beta.1
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
This PR prepares the 4.8.0 release branch for the beta.

- Version Adjustment
- Changelog
- Revert https://github.com/woocommerce/woocommerce/pull/25988 for testing
