### PR TITLE
Return default date and time formats if options are empty

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -638,7 +638,12 @@ function wc_let_to_num( $size ) {
  * @return string
  */
 function wc_date_format() {
-	return apply_filters( 'woocommerce_date_format', get_option( 'date_format' ) );
+    $date_format = get_option( 'date_format' );
+	if ( empty( $date_format ) ) {
+		# Return default date format if the option is empty
+        $date_format = 'F j, Y';
+	}
+	return apply_filters( 'woocommerce_date_format', $date_format );
 }
 
 /**
@@ -647,7 +652,12 @@ function wc_date_format() {
  * @return string
  */
 function wc_time_format() {
-	return apply_filters( 'woocommerce_time_format', get_option( 'time_format' ) );
+    $time_format = get_option( 'time_format' );
+	if ( empty( $time_format ) ) {
+		# Return default time format if the option is empty
+        $time_format = 'g:i a';
+	}
+    return apply_filters( 'woocommerce_time_format', $time_format );
 }
 
 /**

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -638,10 +638,10 @@ function wc_let_to_num( $size ) {
  * @return string
  */
 function wc_date_format() {
-    $date_format = get_option( 'date_format' );
+	$date_format = get_option( 'date_format' );
 	if ( empty( $date_format ) ) {
-		# Return default date format if the option is empty
-        $date_format = 'F j, Y';
+		// Return default date format if the option is empty
+		$date_format = 'F j, Y';
 	}
 	return apply_filters( 'woocommerce_date_format', $date_format );
 }
@@ -652,12 +652,12 @@ function wc_date_format() {
  * @return string
  */
 function wc_time_format() {
-    $time_format = get_option( 'time_format' );
+	$time_format = get_option( 'time_format' );
 	if ( empty( $time_format ) ) {
-		# Return default time format if the option is empty
-        $time_format = 'g:i a';
+		// Return default time format if the option is empty
+		$time_format = 'g:i a';
 	}
-    return apply_filters( 'woocommerce_time_format', $time_format );
+	return apply_filters( 'woocommerce_time_format', $time_format );
 }
 
 /**

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -640,7 +640,7 @@ function wc_let_to_num( $size ) {
 function wc_date_format() {
 	$date_format = get_option( 'date_format' );
 	if ( empty( $date_format ) ) {
-		// Return default date format if the option is empty
+		// Return default date format if the option is empty.
 		$date_format = 'F j, Y';
 	}
 	return apply_filters( 'woocommerce_date_format', $date_format );
@@ -654,7 +654,7 @@ function wc_date_format() {
 function wc_time_format() {
 	$time_format = get_option( 'time_format' );
 	if ( empty( $time_format ) ) {
-		// Return default time format if the option is empty
+		// Return default time format if the option is empty.
 		$time_format = 'g:i a';
 	}
 	return apply_filters( 'woocommerce_time_format', $time_format );


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Return WordPress core's default date/time formats from `wc_date_format ` and `wc_time_format` if the WP core settings are empty. It's very edge case-ish, but has happened to multiple users. See #28319 for some examples.

Closes #28319.

### How to test the changes in this Pull Request:

1. With the current release of WooCommerce installed, go to **Settings > General** in WP.
2. Set your **Date Format** and **Time Format** to **Custom**, but don't put anything in the boxes. WP does not warn you about this.
3. Place a test order and view it in wp-admin.
4. Notice this:
![Markup on 2020-11-17 at 10:32:12](https://user-images.githubusercontent.com/5512652/99410206-356b7a00-28c0-11eb-8a50-bbfc8929f356.png)
5. Apply this patch.
6. Refresh the order page.
7. The WP core default formats are used:
![Markup on 2020-11-17 at 10:37:18](https://user-images.githubusercontent.com/5512652/99410826-ea059b80-28c0-11eb-9e93-55fc5154dae4.png)

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

Not sure if tests are needed for this or how to write them, but can learn if need be. :) 

### Changelog entry

> Return default date/time formats from `wc_date_format` and `wc_time_format` if WP core formats are empty.
