### PR TITLE
Replace usages of depracted jQuery.fn.click() event shorthand

### DIFF
--- a/assets/js/admin/marketplace-suggestions.js
+++ b/assets/js/admin/marketplace-suggestions.js
@@ -405,7 +405,7 @@
 				}
 
 				// Track when suggestions are displayed (and not already visible).
-				$( 'ul.product_data_tabs li.marketplace-suggestions_options a' ).click( function( e ) {
+				$( 'ul.product_data_tabs li.marketplace-suggestions_options a' ).on( 'click', function( e ) {
 					e.preventDefault();
 
 					if ( '#marketplace_suggestions' === currentTab ) {

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -25,7 +25,7 @@ jQuery( function ( $ ) {
 			$( '.js_field-country' ).selectWoo().change( this.change_country );
 			$( '.js_field-country' ).trigger( 'change', [ true ] );
 			$( document.body ).on( 'change', 'select.js_field-state', this.change_state );
-			$( '#woocommerce-order-actions input, #woocommerce-order-actions a' ).click(function() {
+			$( '#woocommerce-order-actions input, #woocommerce-order-actions a' ).on('click', function() {
 				window.onbeforeunload = '';
 			});
 			$( 'a.edit_address' ).on( 'click', this.edit_address );

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -25,7 +25,7 @@ jQuery( function ( $ ) {
 			$( '.js_field-country' ).selectWoo().change( this.change_country );
 			$( '.js_field-country' ).trigger( 'change', [ true ] );
 			$( document.body ).on( 'change', 'select.js_field-state', this.change_state );
-			$( '#woocommerce-order-actions input, #woocommerce-order-actions a' ).on('click', function() {
+			$( '#woocommerce-order-actions input, #woocommerce-order-actions a' ).on( 'click', function() {
 				window.onbeforeunload = '';
 			});
 			$( 'a.edit_address' ).on( 'click', this.edit_address );

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -28,7 +28,7 @@ jQuery( function ( $ ) {
 			$( '#woocommerce-order-actions input, #woocommerce-order-actions a' ).click(function() {
 				window.onbeforeunload = '';
 			});
-			$( 'a.edit_address' ).click( this.edit_address );
+			$( 'a.edit_address' ).on( 'click', this.edit_address );
 			$( 'a.billing-same-as-shipping' ).on( 'click', this.copy_billing_to_shipping );
 			$( 'a.load_customer_billing' ).on( 'click', this.load_billing );
 			$( 'a.load_customer_shipping' ).on( 'click', this.load_shipping );

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -49,14 +49,14 @@ jQuery( function( $ ) {
 	});
 
 	// Catalog Visibility.
-	$( '#catalog-visibility' ).find( '.edit-catalog-visibility' ).click( function() {
+	$( '#catalog-visibility' ).find( '.edit-catalog-visibility' ).on( 'click', function() {
 		if ( $( '#catalog-visibility-select' ).is( ':hidden' ) ) {
 			$( '#catalog-visibility-select' ).slideDown( 'fast' );
 			$( this ).hide();
 		}
 		return false;
 	});
-	$( '#catalog-visibility' ).find( '.save-post-visibility' ).click( function() {
+	$( '#catalog-visibility' ).find( '.save-post-visibility' ).on( 'click', function() {
 		$( '#catalog-visibility-select' ).slideUp( 'fast' );
 		$( '#catalog-visibility' ).find( '.edit-catalog-visibility' ).show();
 
@@ -70,7 +70,7 @@ jQuery( function( $ ) {
 		$( '#catalog-visibility-display' ).text( label );
 		return false;
 	});
-	$( '#catalog-visibility' ).find( '.cancel-post-visibility' ).click( function() {
+	$( '#catalog-visibility' ).find( '.cancel-post-visibility' ).on( 'click', function() {
 		$( '#catalog-visibility-select' ).slideUp( 'fast' );
 		$( '#catalog-visibility' ).find( '.edit-catalog-visibility' ).show();
 

--- a/assets/js/admin/meta-boxes.js
+++ b/assets/js/admin/meta-boxes.js
@@ -35,7 +35,7 @@ jQuery( function ( $ ) {
 	// Tabbed Panels
 	$( document.body ).on( 'wc-init-tabbed-panels', function() {
 		$( 'ul.wc-tabs' ).show();
-		$( 'ul.wc-tabs a' ).click( function( e ) {
+		$( 'ul.wc-tabs a' ).on( 'click', function( e ) {
 			e.preventDefault();
 			var panel_wrap = $( this ).closest( 'div.panel-wrap' );
 			$( 'ul.wc-tabs li', panel_wrap ).removeClass( 'active' );

--- a/assets/js/admin/reports.js
+++ b/assets/js/admin/reports.js
@@ -130,7 +130,7 @@ jQuery(function( $ ) {
 	}
 
 	// Export
-	$( '.export_csv' ).click( function() {
+	$( '.export_csv' ).on( 'click', function() {
 		var exclude_series = $( this ).data( 'exclude_series' ) || '';
 		exclude_series    = exclude_series.toString();
 		exclude_series    = exclude_series.split( ',' );

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -80,7 +80,7 @@
 				}
 			});
 
-			$( '.submit :input' ).click( function() {
+			$( '.submit :input' ).on( 'click', function() {
 				window.onbeforeunload = '';
 			});
 		});

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -235,7 +235,7 @@
 			$( this ).focus();
 		} );
 
-		$( '.wc_input_table .remove_rows' ).click( function() {
+		$( '.wc_input_table .remove_rows' ).on( 'click', function() {
 			var $tbody = $( this ).closest( '.wc_input_table' ).find( 'tbody' );
 			if ( $tbody.find( 'tr.current' ).length > 0 ) {
 				var $current = $tbody.find( 'tr.current' );

--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -85,7 +85,7 @@ jQuery( function( $ ) {
 	$( '.woocommerce form input' ).filter(':password').parent('span').addClass('password-input');
 	$( '.password-input' ).append( '<span class="show-password-input"></span>' );
 
-	$( '.show-password-input' ).click(
+	$( '.show-password-input' ).on( 'click',
 		function() {
 			$( this ).toggleClass( 'display-password' );
 			if ( $( this ).hasClass( 'display-password' ) ) {

--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -25,7 +25,7 @@ jQuery( function( $ ) {
 	}
 
 	// Set a cookie and hide the store notice when the dismiss button is clicked
-	$( '.woocommerce-store-notice__dismiss-link' ).click( function( event ) {
+	$( '.woocommerce-store-notice__dismiss-link' ).on( 'click', function( event ) {
 		Cookies.set( cookieName, 'hidden', { path: '/' } );
 		$( '.woocommerce-store-notice' ).hide();
 		event.preventDefault();

--- a/includes/admin/class-wc-admin-attributes.php
+++ b/includes/admin/class-wc-admin-attributes.php
@@ -462,7 +462,7 @@ class WC_Admin_Attributes {
 			<script type="text/javascript">
 			/* <![CDATA[ */
 
-				jQuery( 'a.delete' ).click( function() {
+				jQuery( 'a.delete' ).on( 'click', function() {
 					if ( window.confirm( '<?php esc_html_e( 'Are you sure you want to delete this attribute?', 'woocommerce' ); ?>' ) ) {
 						return true;
 					}

--- a/includes/admin/class-wc-admin.php
+++ b/includes/admin/class-wc-admin.php
@@ -236,7 +236,7 @@ class WC_Admin {
 					'<a href="https://wordpress.org/support/plugin/woocommerce/reviews?rate=5#new-post" target="_blank" class="wc-rating-link" aria-label="' . esc_attr__( 'five star', 'woocommerce' ) . '" data-rated="' . esc_attr__( 'Thanks :)', 'woocommerce' ) . '">&#9733;&#9733;&#9733;&#9733;&#9733;</a>'
 				);
 				wc_enqueue_js(
-					"jQuery( 'a.wc-rating-link' ).click( function() {
+					"jQuery( 'a.wc-rating-link' ).on( 'click', function() {
 						jQuery.post( '" . WC()->ajax_url() . "', { action: 'woocommerce_rated' } );
 						jQuery( this ).parent().text( jQuery( this ).data( 'rated' ) );
 					});"

--- a/includes/admin/reports/class-wc-report-coupon-usage.php
+++ b/includes/admin/reports/class-wc-report-coupon-usage.php
@@ -328,7 +328,7 @@ class WC_Report_Coupon_Usage extends WC_Admin_Report {
 			</table>
 		</div>
 		<script type="text/javascript">
-			jQuery('.section_title').click(function(){
+			jQuery('.section_title').on('click', function(){
 				var next_section = jQuery(this).next('.section');
 
 				if ( jQuery(next_section).is(':visible') )

--- a/includes/admin/reports/class-wc-report-coupon-usage.php
+++ b/includes/admin/reports/class-wc-report-coupon-usage.php
@@ -328,25 +328,26 @@ class WC_Report_Coupon_Usage extends WC_Admin_Report {
 			</table>
 		</div>
 		<script type="text/javascript">
-			jQuery('.section_title').on('click', function(){
-				var next_section = jQuery(this).next('.section');
+			jQuery( '.section_title' ).on( 'click', function() {
+				var next_section = jQuery( this ).next( '.section' );
 
-				if ( jQuery(next_section).is(':visible') )
+				if ( jQuery( next_section ).is( ':visible' ) ) {
 					return false;
+				}
 
-				jQuery('.section:visible').slideUp();
-				jQuery('.section_title').removeClass('open');
-				jQuery(this).addClass('open').next('.section').slideDown();
+				jQuery( '.section:visible' ).slideUp();
+				jQuery( '.section_title' ).removeClass( 'open' );
+				jQuery( this ).addClass( 'open' ).next( '.section' ).slideDown();
 
 				return false;
-			});
-			jQuery('.section').slideUp( 100, function() {
+			} );
+			jQuery( '.section' ).slideUp( 100, function() {
 				<?php if ( empty( $this->coupon_codes ) ) : ?>
-					jQuery('.section_title:eq(1)').click();
+					jQuery( '.section_title:eq(1)' ).click();
 				<?php else : ?>
-					jQuery('.section_title:eq(0)').click();
+					jQuery( '.section_title:eq(0)' ).click();
 				<?php endif; ?>
-			});
+			} );
 		</script>
 		<?php
 	}

--- a/includes/admin/reports/class-wc-report-coupon-usage.php
+++ b/includes/admin/reports/class-wc-report-coupon-usage.php
@@ -12,8 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * WC_Report_Coupon_Usage
  *
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */

--- a/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -374,7 +374,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 			</table>
 		</div>
 		<script type="text/javascript">
-			jQuery('.section_title').click(function(){
+			jQuery('.section_title').on('click', function(){
 				var next_section = jQuery(this).next('.section');
 
 				if ( jQuery(next_section).is(':visible') )

--- a/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -374,23 +374,24 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 			</table>
 		</div>
 		<script type="text/javascript">
-			jQuery('.section_title').on('click', function(){
-				var next_section = jQuery(this).next('.section');
+			jQuery( '.section_title' ).on( 'click', function() {
+				var next_section = jQuery( this ).next( '.section' );
 
-				if ( jQuery(next_section).is(':visible') )
+				if ( jQuery( next_section ).is( ':visible' ) ) {
 					return false;
+				}
 
-				jQuery('.section:visible').slideUp();
-				jQuery('.section_title').removeClass('open');
-				jQuery(this).addClass('open').next('.section').slideDown();
+				jQuery( '.section:visible' ).slideUp();
+				jQuery( '.section_title' ).removeClass( 'open' );
+				jQuery( this ).addClass( 'open' ).next( '.section' ).slideDown();
 
 				return false;
-			});
-			jQuery('.section').slideUp( 100, function() {
+			} );
+			jQuery( '.section' ).slideUp( 100, function() {
 				<?php if ( empty( $this->product_ids ) ) : ?>
-					jQuery('.section_title:eq(1)').click();
+					jQuery( '.section_title:eq(1)' ).click();
 				<?php endif; ?>
-			});
+			} );
 		</script>
 		<?php
 	}

--- a/includes/admin/views/html-admin-page-status-logs-db.php
+++ b/includes/admin/views/html-admin-page-status-logs-db.php
@@ -22,7 +22,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 </form>
 <?php
 wc_enqueue_js(
-	"jQuery( '#flush-logs' ).click( function() {
+	"jQuery( '#flush-logs' ).on( 'click', function() {
 		if ( window.confirm('" . esc_js( __( 'Are you sure you want to clear all logs from the database?', 'woocommerce' ) ) . "') ) {
 			return true;
 		}

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -1048,7 +1048,7 @@ class WC_Email extends WC_Settings_API {
 				var view = '" . esc_js( __( 'View template', 'woocommerce' ) ) . "';
 				var hide = '" . esc_js( __( 'Hide template', 'woocommerce' ) ) . "';
 
-				jQuery( 'a.toggle_editor' ).text( view ).click( function() {
+				jQuery( 'a.toggle_editor' ).text( view ).on( 'click', function() {
 					var label = hide;
 
 					if ( jQuery( this ).closest(' .template' ).find( '.editor' ).is(':visible') ) {
@@ -1059,7 +1059,7 @@ class WC_Email extends WC_Settings_API {
 					return false;
 				} );
 
-				jQuery( 'a.delete_template' ).click( function() {
+				jQuery( 'a.delete_template' ).on( 'click', function() {
 					if ( window.confirm('" . esc_js( __( 'Are you sure you want to delete this template file?', 'woocommerce' ) ) . "') ) {
 						return true;
 					}

--- a/includes/tracks/events/class-wc-products-tracking.php
+++ b/includes/tracks/events/class-wc-products-tracking.php
@@ -131,7 +131,7 @@ class WC_Products_Tracking {
 				var initialStockValue = $( '#_stock' ).val();
 				var hasRecordedEvent = false;
 
-				$( '#publish' ).click( function() {
+				$( '#publish' ).on( 'click', function() {
 					if ( hasRecordedEvent ) {
 						return;
 					}

--- a/includes/tracks/events/class-wc-status-tracking.php
+++ b/includes/tracks/events/class-wc-status-tracking.php
@@ -37,7 +37,7 @@ class WC_Status_Tracking {
 			if ( 'status' === $tab ) {
 				wc_enqueue_js(
 					"
-					$( 'a.debug-report' ).click( function() {
+					$( 'a.debug-report' ).on( 'click', function() {
 						window.wcTracks.recordEvent( 'status_view_reports' );
 					} );
 				"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR replaces all instances in the WooCommerce codebase where `jQuery.fn.click( handler )` event shorthand was used with `jQuery.fn.on( 'click', handler )`. This event shorthand was deprecated in jQuery 3.3 (see https://github.com/jquery/jquery/issues/3214). The jQuery documentation was not updated yet (see https://github.com/jquery/jquery-migrate/issues/288 and https://github.com/jquery/api.jquery.com/issues/972).

jQuery.click() was not deprecated, and so it was not replaced.

For context on why we are doing this change, see #28286 and #28285.

I also fixed PHPCS violations in the files modified in this PR in a separate commit.

### How to test the changes in this Pull Request:

For testing this PR, I suggest checking the code changes and making sure they make sense, and testing that the functionality of some of the changes was not affected and the old behavior was preserved. IMO, it is unnecessary to test all the changes as this would take a significant amount of time.

### Changelog entry

> Dev: replaces deprecated `jQuery.fn.click( handler )` with `jQuery.fn.on( 'click', handler )`
