### PR TITLE
Add single product page compatibility for Twenty Twenty-One

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -528,6 +528,10 @@ dl.variation,
 		p.price {
 			margin-bottom: 2rem;
 		}
+
+		.woocommerce-product-details__short-description {
+			margin-bottom: 1rem;
+		}
 	}
 
 	.woocommerce-product-rating {

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -530,7 +530,7 @@ dl.variation,
 		margin-bottom: 8rem;
 
 		p.price {
-			margin-bottom: 3.5rem;
+			margin-bottom: 2rem;
 		}
 	}
 
@@ -605,6 +605,7 @@ dl.variation,
 }
 
 table.variations {
+	margin: 1rem 0;
 
 	label {
 		margin: 0;
@@ -924,6 +925,10 @@ a.reset_variations {
 
 .related.products,
 .up-sells {
+
+	h2 {
+		margin-bottom: 2rem;
+	}
 
 	clear: both;
 
@@ -2285,7 +2290,6 @@ a.reset_variations {
 		}
 
 		.related.products {
-
 			ul.products {
 				display: flex;
 				flex-direction: column;

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -765,21 +765,23 @@ a.reset_variations {
 		margin: 0 0 1.5rem;
 		padding: 0;
 		font-family: $headings;
+		border-bottom: var(--button--border-width) solid var(--button--color-background);
 
 		li {
-			margin: 0.5rem 4rem 2rem 0;
-
+			display: inline-flex !important;
 			a {
 				color: $body-color;
 				text-decoration: none;
 				font-weight: 700;
+				padding: var(--button--padding-vertical) var(--button--padding-horizontal);
 			}
 
 			&.active {
 
 				a {
-					color: $highlights-color;
-					box-shadow: 0 2px 0 $highlights-color;
+					color: var(--button--color-text);
+					background-color: var(--button--color-background);
+					border: var(--button--border-width) solid var(--button--color-background);
 				}
 			}
 		}

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -535,6 +535,10 @@ dl.variation,
 		}
 	}
 
+	.woocommerce-variation-price {
+		margin: 2rem 0;
+	}
+
 	.woocommerce-product-rating {
 		margin: -1rem 0 4rem;
 		line-height: 1;

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -2173,6 +2173,15 @@ a.reset_variations {
 	.woocommerce,
 	.woocommerce-page {
 
+		.related.products {
+			ul.products[class*=columns-] {
+				li.product {
+					padding: 0 2vw 3em 0 !important;
+					margin-bottom: 2em;
+				}
+			}
+		}
+
 		ul.products[class*=columns-] {
 
 			li.product {

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -505,8 +505,9 @@ dl.variation,
 	}
 
 	.single_add_to_cart_button {
-		padding-top: 1.55rem;
-		padding-bottom: 1.59rem;
+		line-height: var(--global--line-height-body) !important;
+		padding-top: var(--form--spacing-unit) !important;
+		padding-bottom: var(--form--spacing-unit) !important;
 		font-size: 1.6rem;
 	}
 

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -2208,6 +2208,10 @@ a.reset_variations {
 
 @media only screen and (max-width: 768px) {
 
+	.woocommerce section.content-area {
+		padding-top: 0;
+	}
+
 	#main {
 
 		.woocommerce {

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -211,11 +211,6 @@ a.button {
 	}
 }
 
-.woocommerce-message {
-	background: #eee;
-	color: $body-color;
-}
-
 .woocommerce-error {
 	color: #fff;
 	background: #b22222;
@@ -245,6 +240,7 @@ a.button {
 	}
 }
 
+.woocommerce-message,
 .woocommerce-info {
 	background: #eee;
 	color: #000;
@@ -2012,7 +2008,7 @@ a.reset_variations {
 		}
 
 		input[type=checkbox] {
-		    width: 25px !important;
+			width: 25px !important;
 		}
 	}
 
@@ -2174,7 +2170,9 @@ a.reset_variations {
 	.woocommerce-page {
 
 		.related.products {
+
 			ul.products[class*=columns-] {
+
 				li.product {
 					padding: 0 2vw 3em 0 !important;
 					margin-bottom: 2em;
@@ -2299,6 +2297,7 @@ a.reset_variations {
 		}
 
 		.related.products {
+
 			ul.products {
 				display: flex;
 				flex-direction: column;


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the CSS for the single product page for compatibility with Twenty Twenty-one

wide screen layout
![2021 local_product_hoodie_ (1)](https://user-images.githubusercontent.com/363749/99578006-c5352500-29a1-11eb-8a1c-7449448f5b3b.png)

middle screen (ipad) layout
![2021 local_product_hoodie_(iPad)](https://user-images.githubusercontent.com/363749/99578251-307ef700-29a2-11eb-9fff-3af849f409c1.png)

narrow screen (iphone) layout
![2021 local_product_hoodie_(iPhone 6_7_8)](https://user-images.githubusercontent.com/363749/99579355-b51e4500-29a3-11eb-80a6-92ba1a3472ea.png)

nonsquare product image
![2021 local_product_sunglasses_](https://user-images.githubusercontent.com/363749/99580661-56f26180-29a5-11eb-90a3-8f9a197e4295.png)

add to cart notice
![2021 local_product_sunglasses_ (1)](https://user-images.githubusercontent.com/363749/99580874-a042b100-29a5-11eb-914a-279ddfe24812.png)


Closes #28303.

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
