### PR TITLE
Fix filter woocommerce_shipping_rate_cost backwards compatibility

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -82,7 +82,13 @@ class WC_Tax {
 	 * @return array
 	 */
 	public static function calc_shipping_tax( $price, $rates ) {
+		// Backwards compatible from WC_Shipping_Rate::get_cost().
+		if ( has_filter( 'woocommerce_shipping_rate_cost' ) ) {
+			$rate  = new WC_Shipping_Rate();
+			$price = $rate->get_cost();
+		}
 		$taxes = self::calc_exclusive_tax( $price, $rates );
+
 		return apply_filters( 'woocommerce_calc_shipping_tax', $taxes, $price, $rates );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fixed issue with woocommerce_shipping_rate_cost filter if some third party change value through it, than we have wrong taxes on a cart page. Key point of issue that we do not have a shipping taxes with new setted filter value.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28008 .

### How to test the changes in this Pull Request:
The same scenario as Konamiman described above but with more easy pricing math

1. Create a product with price 100 
2. Create a taxable shipping flat rate of 10
3. Create a tax of 5%, applied to shipping
4. Use the filter to change the shipping rate to 1000
Add code below to active theme functions.php file
```
add_filter( 'woocommerce_shipping_rate_cost', 'woocommerce_shipping_rate_cost');
function woocommerce_shipping_rate_cost( $cost ) {
	$cost = 1000;
	return $cost;
}

```
5. Add product to cart and go cart page (please clear cache of your browser before or use incognito chrome mode, cos we have some caches with tax shipping rates)
6. Expected cart totals https://i.imgur.com/xiN8XbV.png
7. Actual (wrong) cart totals https://i.imgur.com/9UF30F1.png

The main problem that we have taxes for a old shipping value 10 but we must have for new value 1000
 
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Update shipping taxes when the `woocommerce_shipping_rate_cost` filter is used to change costs.
