### PR TITLE
Add home page compatibility for Twenty Twenty-One theme

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -2433,6 +2433,16 @@ a.reset_variations {
 	}
 
 	/**
+     * Home page
+     */
+	.home #main {
+
+		.wp-block-cover {
+			max-width: none;
+		}
+	}
+
+	/**
 	* Shop page
 	*/
 	.woocommerce-products-header__title.page-title {

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -2011,7 +2011,7 @@ a.reset_variations {
 		}
 
 		input[type=checkbox] {
-		    width: 25px !important;
+			width: 25px !important;
 		}
 	}
 
@@ -2120,32 +2120,37 @@ a.reset_variations {
 		min-width: 12vw;
 
 		&.columns-2 {
+
 			li.product {
-				width: calc( 100% / 2 - 16px ) !important;
+				width: calc(100% / 2 - 16px) !important;
 			}
 		}
 
 		&.columns-3 {
+
 			li.product {
-				width: calc( 100% / 3 - 16px ) !important;
+				width: calc(100% / 3 - 16px) !important;
 			}
 		}
 
 		&.columns-4 {
+
 			li.product {
-				width: calc( 100% / 4 - 16px ) !important;
+				width: calc(100% / 4 - 16px) !important;
 			}
 		}
 
 		&.columns-5 {
+
 			li.product {
-				width: calc( 100% / 5 - 16px ) !important;
+				width: calc(100% / 5 - 16px) !important;
 			}
 		}
 
 		&.columns-6 {
+
 			li.product {
-				width: calc( 100% / 6 - 16px ) !important;
+				width: calc(100% / 6 - 16px) !important;
 			}
 		}
 
@@ -2217,6 +2222,7 @@ a.reset_variations {
 
 		ul.products[class*=columns-] {
 			justify-content: center;
+
 			li.product {
 				width: 50%;
 				padding: 0 2vw 3em 0;
@@ -2477,11 +2483,6 @@ a.reset_variations {
      * Home page
      */
 	.home #main {
-
-		.wp-block-cover {
-			max-width: none;
-		}
-
 		[class*="woocommerce columns-"] {
 			word-break: break-word;
 			max-width: var(--responsive--aligndefault-width);

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -249,11 +249,6 @@ a.button {
 }
 
 #main {
-
-	h2 {
-		font-weight: 500;
-	}
-
 	.woocommerce-error,
 	.woocommerce-info {
 		font-family: $headings;

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -2116,28 +2116,36 @@ a.reset_variations {
 		flex-direction: row;
 		flex-wrap: wrap;
 		box-sizing: border-box;
+		word-break: break-word;
+		min-width: 12vw;
 
 		&.columns-2 {
 			li.product {
-				width: 50% !important;
+				width: calc( 100% / 2 - 16px ) !important;
 			}
 		}
 
 		&.columns-3 {
 			li.product {
-				width: 33.33% !important;
+				width: calc( 100% / 3 - 16px ) !important;
+			}
+		}
+
+		&.columns-4 {
+			li.product {
+				width: calc( 100% / 4 - 16px ) !important;
 			}
 		}
 
 		&.columns-5 {
 			li.product {
-				width: 20% !important;
+				width: calc( 100% / 5 - 16px ) !important;
 			}
 		}
 
 		&.columns-6 {
 			li.product {
-				width:16.66% !important;
+				width: calc( 100% / 6 - 16px ) !important;
 			}
 		}
 
@@ -2146,8 +2154,7 @@ a.reset_variations {
 			flex-direction: column;
 			justify-content: space-between;
 			align-items: flex-start;
-			padding: 0 8px 16px 8px !important;
-			margin: 0;
+			margin: 0 8px 16px 8px;
 			box-sizing: border-box;
 
 			img.attachment-woocommerce_thumbnail {
@@ -2195,7 +2202,9 @@ a.reset_variations {
 		ul.products[class*=columns-] {
 
 			li.product {
-				width: 100%;
+				width: auto !important;
+				margin-left: auto;
+				margin-right: auto;
 			}
 		}
 	}
@@ -2207,18 +2216,12 @@ a.reset_variations {
 	.woocommerce-page {
 
 		ul.products[class*=columns-] {
-
+			justify-content: center;
 			li.product {
 				width: 50%;
-			}
-
-			li.product:nth-of-type(2n+1) {
 				padding: 0 2vw 3em 0;
 			}
 
-			li.product:nth-of-type(2n) {
-				padding: 0 0 3em 2vw;
-			}
 		}
 
 		.onsale {

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -2115,13 +2115,40 @@ a.reset_variations {
 		align-items: stretch;
 		flex-direction: row;
 		flex-wrap: wrap;
+		box-sizing: border-box;
+
+		&.columns-2 {
+			li.product {
+				width: 50% !important;
+			}
+		}
+
+		&.columns-3 {
+			li.product {
+				width: 33.33% !important;
+			}
+		}
+
+		&.columns-5 {
+			li.product {
+				width: 20% !important;
+			}
+		}
+
+		&.columns-6 {
+			li.product {
+				width:16.66% !important;
+			}
+		}
 
 		li.product {
 			display: flex;
 			flex-direction: column;
 			justify-content: space-between;
 			align-items: flex-start;
-			margin: 0 8px 16px 8px;
+			padding: 0 8px 16px 8px !important;
+			margin: 0;
+			box-sizing: border-box;
 
 			img.attachment-woocommerce_thumbnail {
 				height: auto !important;
@@ -2131,11 +2158,18 @@ a.reset_variations {
 		li.product-category {
 
 			a {
-				text-align: center;
+				text-align: left;
+				text-decoration: none;
 
 				h2.woocommerce-loop-category__title {
+					margin-top: 0.4rem;
 					font-family: $headings;
-					font-size: 20px;
+					font-size: 1rem;
+
+					.count {
+						background-color: transparent;
+						color: $body-color;
+					}
 				}
 			}
 		}
@@ -2446,6 +2480,7 @@ a.reset_variations {
 		}
 
 		[class*="woocommerce columns-"] {
+			word-break: break-word;
 			max-width: var(--responsive--aligndefault-width);
 			margin-left: auto;
 			margin-right: auto;

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -2121,7 +2121,7 @@ a.reset_variations {
 			flex-direction: column;
 			justify-content: space-between;
 			align-items: flex-start;
-			margin-bottom: 5em;
+			margin: 0 8px 16px 8px;
 
 			img.attachment-woocommerce_thumbnail {
 				height: auto !important;
@@ -2135,7 +2135,7 @@ a.reset_variations {
 
 				h2.woocommerce-loop-category__title {
 					font-family: $headings;
-					font-size: 3rem;
+					font-size: 20px;
 				}
 			}
 		}
@@ -2443,6 +2443,12 @@ a.reset_variations {
 
 		.wp-block-cover {
 			max-width: none;
+		}
+
+		[class*="woocommerce columns-"] {
+			max-width: var(--responsive--aligndefault-width);
+			margin-left: auto;
+			margin-right: auto;
 		}
 	}
 

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -239,6 +239,10 @@ a.button {
 
 #main {
 
+	h2 {
+		font-weight: 500;
+	}
+
 	.woocommerce-error,
 	.woocommerce-info {
 		font-family: $headings;


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I'm starting this PR to make the changes necessary so that the home page is displayed nicely when using the Twenty Twenty-One theme.

So far, I have adjusted the size of the background image in the cover block, the `<h2>` elements used as section titles, and started to adjust the shortcode that displays a list of categories.

To finish this PR, we have to make some remaining changes to the list of categories, work on the list of products, and check the Figma design to see if something else is missing. We should probably coordinate with @nerrad's regarding the list of products that are displayed on the home page as it uses a product block.

I don't write CSS very often so there is a high chance that there are better ways to implement the changes proposed in this PR. Any feedback is welcome. cc @claudiosanches as you have more experience with CSS.

As we discussed, I'm opening this PR against `add/2021-compat` instead of `master`.

Closes #28308

### How to test the changes in this Pull Request:

Pending

### Changelog entry

Pending