### PR TITLE
Fix toggle chevron issue in admin edit product data attribute section

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-attribute.php
+++ b/includes/admin/meta-boxes/views/html-product-attribute.php
@@ -3,7 +3,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 ?>
-<div data-taxonomy="<?php echo esc_attr( $attribute->get_taxonomy() ); ?>" class="woocommerce_attribute wc-metabox closed <?php echo esc_attr( implode( ' ', $metabox_class ) ); ?>" rel="<?php echo esc_attr( $attribute->get_position() ); ?>">
+<div data-taxonomy="<?php echo esc_attr( $attribute->get_taxonomy() ); ?>" class="woocommerce_attribute wc-metabox postbox closed <?php echo esc_attr( implode( ' ', $metabox_class ) ); ?>" rel="<?php echo esc_attr( $attribute->get_position() ); ?>">
 	<h3>
 		<a href="#" class="remove_row delete"><?php esc_html_e( 'Remove', 'woocommerce' ); ?></a>
 		<div class="handlediv" title="<?php esc_attr_e( 'Click to toggle', 'woocommerce' ); ?>"></div>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

When editing a product, clicking on the chevron beside an attribute in the Attributes tab closes the whole Product Data area.

Right now we have click event on chevron provided by wordpress postbox.js library and also we have one more event for a whole block where chevron located provided by woocommerce/assets/js/admin/meta-boxes.js .
After chevron clicking we fire up posbox.js handle_click function that trying to find closes element with 'posbox' class and toggle it, but our toogled block do not has one, and closes become whole Product Data area.
These pull request added missing class.

Anyway even with such class wordpress postbox.js do not working for us we use it only for a chevron displaying, but our  woocommerce/assets/js/admin/meta-boxes.js do the job. For now it seem quite enough to fix issue.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27923 .

### How to test the changes in this Pull Request:

1. Creata prodcut addribute.
2. Create product and  add attribute to it through Product Data attribute area.
3. Save it and refresh the page ( without refreshing we do not detect issue )
4. Go back to Product Data attribute area and try to toggle chevron that correspong to new attribute.

There are also a great video describing issue that pull request fixing
`https://camo.githubusercontent.com/aeafdacb0ec2744e5211ae6b224f1163ed3e68ea14737069c59437cd11e368cc/687474703a2f2f672e7265636f726469742e636f2f3939564270314e5554462e676966`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Fix - On product variation editing section, clicking on the chevron icon collapses entire settings container.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
