### PR TITLE
Add backend validation for 'Reviews can only be left by "verified owners"' #28352

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -22,6 +22,7 @@ class WC_Comments {
 		// Rating posts.
 		add_filter( 'comments_open', array( __CLASS__, 'comments_open' ), 10, 2 );
 		add_filter( 'preprocess_comment', array( __CLASS__, 'check_comment_rating' ), 0 );
+		add_filter( 'preprocess_comment', array( __CLASS__, 'check_comment_verified_owner_only' ), 0 );
 		add_action( 'comment_post', array( __CLASS__, 'add_comment_rating' ), 1 );
 		add_action( 'comment_moderation_recipients', array( __CLASS__, 'comment_moderation_recipients' ), 10, 2 );
 
@@ -148,6 +149,21 @@ class WC_Comments {
 		// If posting a comment (not trackback etc) and not logged in.
 		if ( ! is_admin() && isset( $_POST['comment_post_ID'], $_POST['rating'], $comment_data['comment_type'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) && empty( $_POST['rating'] ) && self::is_default_comment_type( $comment_data['comment_type'] ) && wc_review_ratings_enabled() && wc_review_ratings_required() ) { // WPCS: input var ok, CSRF ok.
 			wp_die( esc_html__( 'Please rate the product.', 'woocommerce' ) );
+			exit;
+		}
+		return $comment_data;
+	}
+
+	/**
+	 * Validate the 'Reviews can only be left by "verified owners"'.
+	 *
+	 * @param  array $comment_data Comment data.
+	 * @return array
+	 */
+	public static function check_comment_verified_owner_only( $comment_data ) {
+		// If posting a comment (not trackback etc) and not logged in.
+		if ( ! is_admin() && isset( $_POST['comment_post_ID'] ) && 'product' === get_post_type( absint( $_POST['comment_post_ID'] ) ) && 'yes' === get_option( 'woocommerce_review_rating_verification_required', 'no' ) && ! wc_customer_bought_product( '', get_current_user_id(), absint( $_POST['comment_post_ID'] ) ) ) { // WPCS: input var ok, CSRF ok.
+			wp_die( esc_html__( 'Only logged in customers who have purchased this product may leave a review.', 'woocommerce' ) );
 			exit;
 		}
 		return $comment_data;


### PR DESCRIPTION
added validation for 'Reviews can only be left by "verified owners"' feature

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/28352.

### How to test the changes in this Pull Request:

1. Setup 'Reviews can only be left by "verified owners"' to **true** on page `/wp-admin/admin.php?page=wc-settings&tab=products`
2. Open product where is you are "verified owners" and copy comment form from browser inspector
3. Open browser where you are not "verified owners" and change hidden input value name="comment_post_ID" to match to this current product ID. After submit form - should be displayed msg "Only logged in customers who have purchased this product may leave a review."

Alternative testing:
1. Setup 'Reviews can only be left by "verified owners"' to **false** on page `/wp-admin/admin.php?page=wc-settings&tab=products`
2. Open browser where you are not "verified owners".
3. Go back to admion and Setup 'Reviews can only be left by "verified owners"' to **true**.
4. Back to opened product and submit comment - should be displayed msg "Only logged in customers who have purchased this product may leave a review."

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
