### PR TITLE
Version bump wc-admin 1.7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.7.0",
+    "woocommerce/woocommerce-admin": "1.7.2",
     "woocommerce/woocommerce-blocks": "3.8.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f522e53a63c340be24470829709cd7ae",
+    "content-hash": "3164dbf08d76ea06ac973e836bfe8a9b",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -512,16 +512,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "1.7.0",
+            "version": "1.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "14dc0c78ce163ed0d5daf8f83765b65a76f61010"
+                "reference": "efd94d917504fe71bae650233de47344c8d5c005"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/14dc0c78ce163ed0d5daf8f83765b65a76f61010",
-                "reference": "14dc0c78ce163ed0d5daf8f83765b65a76f61010",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/efd94d917504fe71bae650233de47344c8d5c005",
+                "reference": "efd94d917504fe71bae650233de47344c8d5c005",
                 "shasum": ""
             },
             "require": {
@@ -555,9 +555,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v1.7.0"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v1.7.2"
             },
-            "time": "2020-11-11T22:56:39+00:00"
+            "time": "2020-11-19T17:48:33+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
This branch updates the WooCommerce Admin package to `1.7.2`

The changes added here are:
[#5638](https://github.com/woocommerce/woocommerce-admin/pull/5638) Fix: Load wc-tracks in the homepage notice admin script.
[#5653](https://github.com/woocommerce/woocommerce-admin/pull/5653) Fix: Link component prop caused a React warning.
[#5655](https://github.com/woocommerce/woocommerce-admin/pull/5655) Fix: Flickering of order panel while loading.
[#5638](https://github.com/woocommerce/woocommerce-admin/pull/5661) Fix: Tax code duplicated when clicking the button to remove.
[#5650](https://github.com/woocommerce/woocommerce-admin/pull/5650) Fix: Restore Autoloading of WooCommerce Classes in PHP Tests.
[#5619](https://github.com/woocommerce/woocommerce-admin/pull/5619) Fix: Skip WC Payment plugin note if plugin not added through the onboarding process.