### PR TITLE
Fix/27989 unintended product change with non unique SKU

### DIFF
--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -647,23 +647,22 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		$has_filter_applied = has_filter( 'wc_product_has_unique_sku', '__return_false' );
 
 		if ( ! empty( $has_filter_applied ) && $has_filter_applied > 0 ) {
-			// If a filter is applied we cannot check for SKU uniqueness. Use ID first
-			if ( ! empty ( $posted['variation_id'] ) ) {
+			// If a filter is applied we cannot check for SKU uniqueness. Use ID first.
+			if ( ! empty( $posted['variation_id'] ) ) {
 				$product_id = (int) $posted['variation_id'];
 			} elseif ( ! empty( $posted['product_id'] ) ) {
 				$product_id = (int) $posted['product_id'];
 			} elseif ( ! empty( $posted['sku'] ) ) {
 				$product_id = (int) wc_get_product_id_by_sku( $posted['sku'] );
-			}  elseif ( 'update' === $action ) {
+			} elseif ( 'update' === $action ) {
 				$product_id = 0;
 			} else {
 				throw new WC_REST_Exception( 'woocommerce_rest_required_product_reference', __( 'Product ID or SKU is required.', 'woocommerce' ), 400 );
 			}
-
 		} else {
 			if ( ! empty( $posted['sku'] ) ) {
-				// Priority should always be SKU (to not break compatibility)
-				if ( ! empty ( $posted['variation_id'] ) ) {
+				// Priority should always be SKU (to not break compatibility).
+				if ( ! empty( $posted['variation_id'] ) ) {
 					$is_unique_sku = wc_product_has_unique_sku( $posted['variation_id'], $posted['sku'] );
 					if ( $is_unique_sku ) {
 						$product_id = (int) wc_get_product_id_by_sku( $posted['sku'] );
@@ -682,7 +681,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 				$product_id = (int) $posted['variation_id'];
 			} elseif ( ! empty( $posted['product_id'] ) ) {
 				$product_id = (int) $posted['product_id'];
-			}  elseif ( 'update' === $action ) {
+			} elseif ( 'update' === $action ) {
 				$product_id = 0;
 			} else {
 				throw new WC_REST_Exception( 'woocommerce_rest_required_product_reference', __( 'Product ID or SKU is required.', 'woocommerce' ), 400 );

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -646,7 +646,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 
 		$has_filter_applied = has_filter( 'wc_product_has_unique_sku', '__return_false' );
 
-		if ( $has_filter_applied > 0 ) {
+		if ( ! empty( $has_filter_applied ) && $has_filter_applied > 0 ) {
 			// If a filter is applied we cannot check for SKU uniqueness. Use ID first
 			if ( ! empty ( $posted['variation_id'] ) ) {
 				$product_id = (int) $posted['variation_id'];
@@ -654,6 +654,8 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 				$product_id = (int) $posted['product_id'];
 			} elseif ( ! empty( $posted['sku'] ) ) {
 				$product_id = (int) wc_get_product_id_by_sku( $posted['sku'] );
+			}  elseif ( 'update' === $action ) {
+				$product_id = 0;
 			} else {
 				throw new WC_REST_Exception( 'woocommerce_rest_required_product_reference', __( 'Product ID or SKU is required.', 'woocommerce' ), 400 );
 			}
@@ -680,6 +682,8 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 				$product_id = (int) $posted['variation_id'];
 			} elseif ( ! empty( $posted['product_id'] ) ) {
 				$product_id = (int) $posted['product_id'];
+			}  elseif ( 'update' === $action ) {
+				$product_id = 0;
 			} else {
 				throw new WC_REST_Exception( 'woocommerce_rest_required_product_reference', __( 'Product ID or SKU is required.', 'woocommerce' ), 400 );
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27989 .

Follows the proposal "Add a check for wc_product_has_unique_sku". 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix unintended product change with non unique SKU
