### PR TITLE
Remove backorder data from email customer for completed orders

### DIFF
--- a/includes/class-wc-order-item.php
+++ b/includes/class-wc-order-item.php
@@ -53,6 +53,14 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 	protected $object_type = 'order_item';
 
 	/**
+	 * File path to item invoke template.
+	 *
+	 * @since 4.8.0
+	 * @var string
+	 */
+	protected $invoke_template = '';
+
+	/**
 	 * Constructor.
 	 *
 	 * @param int|object|array $item ID to load from the DB, or WC_Order_Item object.
@@ -284,6 +292,14 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 				continue;
 			}
 
+			if ( strpos( $this->invoke_template, 'email-order-items' ) !== false ) {
+				$order = $this->get_order();
+				// Skip backorder meta for a completed orders.
+				if ( $order && 'completed' === $order->get_status() && 'Backordered' === $meta->key ) {
+					continue;
+				}
+			}
+
 			$formatted_meta[ $meta->id ] = (object) array(
 				'key'           => $meta->key,
 				'value'         => $meta->value,
@@ -405,5 +421,15 @@ class WC_Order_Item extends WC_Data implements ArrayAccess {
 		}
 
 		return null;
+	}
+
+	/**
+	 * Set item ivoke tempalte property
+	 *
+	 * @since 4.8.0
+	 * @param string $invoke_template File path to item invoke template.
+	 */
+	public function set_item_invoke_template( $invoke_template ) {
+		$this->invoke_template = $invoke_template;
 	}
 }

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -26,6 +26,8 @@ foreach ( $items as $item_id => $item ) :
 	$purchase_note = '';
 	$image         = '';
 
+	$item->set_item_invoke_template( __FILE__ );
+
 	if ( ! apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
 		continue;
 	}
@@ -54,7 +56,7 @@ foreach ( $items as $item_id => $item ) :
 			echo wp_kses_post( ' (#' . $sku . ')' );
 		}
 
-		// allow other plugins to add additional product information here.
+		// Allow other plugins to add additional product information here.
 		do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, $plain_text );
 
 		wc_display_item_meta(
@@ -64,7 +66,7 @@ foreach ( $items as $item_id => $item ) :
 			)
 		);
 
-		// allow other plugins to add additional product information here.
+		// Allow other plugins to add additional product information here.
 		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );
 
 		?>

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -23,6 +23,8 @@ foreach ( $items as $item_id => $item ) :
 		$sku           = '';
 		$purchase_note = '';
 
+		$item->set_item_invoke_template( __FILE__ );
+
 		if ( is_object( $product ) ) {
 			$sku           = $product->get_sku();
 			$purchase_note = $product->get_purchase_note();

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -15,9 +15,7 @@
  * @version     3.7.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
+defined( 'ABSPATH' ) || exit;
 
 foreach ( $items as $item_id => $item ) :
 	if ( apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
@@ -30,16 +28,17 @@ foreach ( $items as $item_id => $item ) :
 			$purchase_note = $product->get_purchase_note();
 		}
 
-		echo apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false );
+		echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) );
 		if ( $show_sku && $sku ) {
-			echo ' (#' . $sku . ')';
+			echo wp_kses_post( ' (#' . $sku . ')' );
 		}
-		echo ' X ' . apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item );
-		echo ' = ' . $order->get_formatted_line_subtotal( $item ) . "\n";
+		echo ' X ' . wp_kses_post( apply_filters( 'woocommerce_email_order_item_quantity', $item->get_quantity(), $item ) );
+		echo ' = ' . wp_kses_post( $order->get_formatted_line_subtotal( $item ) ) . "\n";
 
-		// allow other plugins to add additional product information here
+		// Allow other plugins to add additional product information here.
 		do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, $plain_text );
-		echo strip_tags(
+
+		echo wp_strip_all_tags( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 			wc_display_item_meta(
 				$item,
 				array(
@@ -52,10 +51,10 @@ foreach ( $items as $item_id => $item ) :
 			)
 		);
 
-		// allow other plugins to add additional product information here
+		// Allow other plugins to add additional product information here.
 		do_action( 'woocommerce_order_item_meta_end', $item_id, $item, $order, $plain_text );
 	}
-	// Note
+	// Note.
 	if ( $show_purchase_note && $purchase_note ) {
 		echo "\n" . do_shortcode( wp_kses_post( $purchase_note ) );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
First commit just fixes phpcs notices, without it we can not add new changes to file.
Second commit fixes issue described in linked task and description below.

Fix issue when customer emails with completed order status contain backorder item meta data.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28195 .

### How to test the changes in this Pull Request:

1. Create a product with backorder allowed.
2. Put new created product to cart and finish checkout process with it.
3. Then change order status to completed in admin area.
Issue: customer email with completed order has backorder item info 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Please note, this  pull request removed backorder information only for a customer email with completed order status, all other area with backorder info like admin dashboard order info https://i.imgur.com/pKWLwMm.png  we  keep the same. 

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
