### PR TITLE
Added product image thumbnail attributes filter

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1359,8 +1359,9 @@ if ( ! function_exists( 'woocommerce_get_product_thumbnail' ) ) {
 		global $product;
 
 		$image_size = apply_filters( 'single_product_archive_thumbnail_size', $size );
+		$image_attributes = apply_filters( 'single_product_archive_image_attributes', [] );
 
-		return $product ? $product->get_image( $image_size ) : '';
+		return $product ? $product->get_image( $image_size, $image_attributes ) : '';
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

I have added a filter to allow additional attributes on single product archive images. 

I was looking into adding `loading="lazy"` to related products images and discovered that there's no way to parse attributes into `woocommerce_get_product_thumbnail()`. Internally the function calls the `get_image()` method on `WC_Product` and the second argument allows you to parse in image attributes.

A quick test with the following code successfully added the lazy loading attribute to product thumbnails:

```php
add_filter('single_product_archive_image_attributes', fn() => [
  'loading' => 'lazy',
]);
```

A side note, would it make sense to set `'loading' => 'lazy'` as a default? Seems like it would have a decent affect on browser performance and has native support in 75% of browsers. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Added product image thumbnail attributes filter
