### PR TITLE
Twenty Twenty-One Compat: Adjust Sale Badge

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -158,21 +158,28 @@ a.button {
 	position: absolute;
 	top: -0.7rem;
 	right: -0.7rem;
-	display: inline-block;
 	background: $highlights-color;
 	color: #fff;
 	font-family: $headings;
 	font-size: 1.2rem;
 	font-weight: 700;
 	letter-spacing: -0.02em;
-	line-height: 4rem;
 	z-index: 1;
 	border-radius: 50%;
-	height: 4.2rem;
-	width: 4.2rem;
 	text-align: center;
-	padding: 0;
+	padding: 0.8rem;
 	margin: 0;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+
+	&::after {
+		content: '';
+		display: block;
+		height: 0;
+		width: 100%;
+		padding-bottom: 100%;
+	}
 }
 
 .price {
@@ -2189,9 +2196,6 @@ a.reset_variations {
 
 		.onsale {
 			font-size: 1.2rem;
-			height: 4.2rem;
-			width: 4.2rem;
-			line-height: 4rem;
 		}
 	}
 }
@@ -2434,9 +2438,6 @@ a.reset_variations {
 
 		.onsale {
 			font-size: 1rem;
-			width: 3.4rem;
-			height: 3.4rem;
-			line-height: 3.2rem;
 		}
 	}
 
@@ -2589,9 +2590,6 @@ a.reset_variations {
 
 		.onsale {
 			font-size: 1.2rem;
-			height: 4.2rem;
-			width: 4.2rem;
-			line-height: 4rem;
 		}
 	}
 

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -8,7 +8,7 @@ $headings: -apple-system, blinkmacsystemfont, "Helvetica Neue", helvetica, sans-
 $body: nonbreakingspaceoverride, "Hoefler Text", garamond, "Times New Roman", serif;
 
 $body-color: currentColor;
-$highlights-color: #cd2653;
+$highlights-color: #88a171;
 
 /**
  * Fonts
@@ -156,8 +156,8 @@ a.button {
 
 .onsale {
 	position: absolute;
-	top: 0;
-	left: 0;
+	top: -0.7rem;
+	right: -0.7rem;
 	display: inline-block;
 	background: $highlights-color;
 	color: #fff;
@@ -165,10 +165,14 @@ a.button {
 	font-size: 1.2rem;
 	font-weight: 700;
 	letter-spacing: -0.02em;
-	line-height: 1.2;
-	padding: 1rem;
-	text-transform: uppercase;
+	line-height: 4rem;
 	z-index: 1;
+	border-radius: 50%;
+	height: 4.2rem;
+	width: 4.2rem;
+	text-align: center;
+	padding: 0;
+	margin: 0;
 }
 
 .price {
@@ -2157,7 +2161,7 @@ a.reset_variations {
 		ul.products[class*=columns-] {
 
 			li.product {
-				width: 100%;
+				width: auto;
 			}
 		}
 	}
@@ -2185,7 +2189,9 @@ a.reset_variations {
 
 		.onsale {
 			font-size: 1.2rem;
-			padding: 1rem;
+			height: 4.2rem;
+			width: 4.2rem;
+			line-height: 4rem;
 		}
 	}
 }
@@ -2428,7 +2434,9 @@ a.reset_variations {
 
 		.onsale {
 			font-size: 1rem;
-			padding: 0.8rem;
+			width: 3.4rem;
+			height: 3.4rem;
+			line-height: 3.2rem;
 		}
 	}
 
@@ -2581,7 +2589,9 @@ a.reset_variations {
 
 		.onsale {
 			font-size: 1.2rem;
-			padding: 1rem;
+			height: 4.2rem;
+			width: 4.2rem;
+			line-height: 4rem;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Updates the sale badge for compatibility with the Twenty Twenty-One theme. This is one of the common elements in the many pages that are part of #27766

Before:
![image](https://user-images.githubusercontent.com/363749/99982460-3133d680-2d70-11eb-833d-d161f74256fd.png)

After:
![image](https://user-images.githubusercontent.com/363749/99988674-6c85d380-2d77-11eb-982b-7d72fb188b47.png)


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Apply PR
2. Verify that the Sale badge looks good across the various pages using with the Twenty Twenty-One theme. Note: this change doesn't affect Blocks.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

No changelog entry required (changelog entry will be on main 2021 PR)
