### PR TITLE
Map all possible taxonomy templates

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -155,6 +155,12 @@ class WC_Template_Loader {
 
 		if ( is_product_taxonomy() ) {
 			$object = get_queried_object();
+
+			$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
+			$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
+			$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
+			$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '.php';
+
 			if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
 				$cs_taxonomy = str_replace( '_', '-', $object->taxonomy );
 				$cs_default  = str_replace( '_', '-', $default_file );
@@ -163,11 +169,6 @@ class WC_Template_Loader {
 				$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
 				$templates[] = WC()->template_path() . 'taxonomy-' . $cs_taxonomy . '.php';
 				$templates[] = $cs_default;
-			} else {
-				$templates[] = 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
-				$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '-' . $object->slug . '.php';
-				$templates[] = 'taxonomy-' . $object->taxonomy . '.php';
-				$templates[] = WC()->template_path() . 'taxonomy-' . $object->taxonomy . '.php';
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR fixes two small issues introduced by #27736

1.  `taxonomy-product_cat-<SLUG>.php` templates doesn't work anymore, only `taxonomy-product-cat-<SLUG>.php`.
2. `taxonomy-product-cat.php` have a higher priority over `taxonomy-product_cat.php`, to help with backwards compatibility this PR changes it too. 

Closes #28254.

### How to test the changes in this Pull Request:

1. Create a category called "Music", and apply to some products
2. Select Twenty Twenty as your theme and create a `woocommerce/taxonomy-product_cat-music.php` template inside your theme's folder, you can use `<?php echo 'product_cat template'; ?>` as content to help you check if it's working
3. Go to `/product-category/music/` and check that your custom template isn't loaded
4. Now try rename to `woocommerce/taxonomy-product-cat-music.php` and check that now works fine
5. Rename the template back to `woocommerce/taxonomy-product_cat-music.php`
6. Checkout this branch
7. Reload `/product-category/music/` and check that the custom template is loaded correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Restored support for custom `taxonomy-product_cat-<SLUG>.php` and `taxonomy-product_tag-<SLUG>.php` templates.