### PR TITLE
Display *-product_<cat|tag>.php template overrides in Status page

### DIFF
--- a/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-v2-controller.php
@@ -1041,6 +1041,12 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 		$override_files     = array();
 		$outdated_templates = false;
 		$scan_files         = WC_Admin_Status::scan_template_files( WC()->plugin_path() . '/templates/' );
+
+		// Include *-product_<cat|tag> templates for backwards compatibility.
+		$scan_files[] = 'content-product_cat.php';
+		$scan_files[] = 'taxonomy-product_cat.php';
+		$scan_files[] = 'taxonomy-product_tag.php';
+
 		foreach ( $scan_files as $file ) {
 			$located = apply_filters( 'wc_get_template', $file, $file, array(), WC()->template_path(), WC()->plugin_path() . '/templates/' );
 
@@ -1059,7 +1065,14 @@ class WC_REST_System_Status_V2_Controller extends WC_REST_Controller {
 			}
 
 			if ( ! empty( $theme_file ) ) {
-				$core_version  = WC_Admin_Status::get_file_version( WC()->plugin_path() . '/templates/' . $file );
+				$core_file = $file;
+
+				// Update *-product_<cat|tag> template name before searching in core.
+				if ( false !== strpos( $core_file, '-product_cat' ) || false !== strpos( $core_file, '-product_tag' ) ) {
+					$core_file = str_replace( '_', '-', $core_file );
+				}
+
+				$core_version  = WC_Admin_Status::get_file_version( WC()->plugin_path() . '/templates/' . $core_file );
 				$theme_version = WC_Admin_Status::get_file_version( $theme_file );
 				if ( $core_version && ( empty( $theme_version ) || version_compare( $theme_version, $core_version, '<' ) ) ) {
 					if ( ! $outdated_templates ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In order to fully keep support for our old `*-product_<cat|tag>.php` templates we need to show overrides of those on the Status page.
This PR fixes it by checking `*-product_<cat|tag>.php` against `*-product-<cat|tag>.php` in WooCommerce, so outdated template notices will keep showing for those templates.

Closes #28256.

### How to test the changes in this Pull Request:

1. Inside a theme's `woocommerce` folder, place files `content-product_cat.php`, `taxonomy-product_cat.php` and `taxonomy-product_tag.php`
2. Change the files' `@since` version to a past version, e.g. `@since 1.0.0`
3. Go to Admin > WooCommerce > Status > System Status tab > Templates.
4. None of the step 1 files appears in the list of overridden templates.
5. Checkout this branch and reload the System Status tab.
6. Note that all templates get displayed now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Display overrides of `taxonomy-product_<cat|tag>.php` and `content-product_cat.php` templates in Status page.
