### PR TITLE
Revert "Load product category content with content-product-cat.php"

### DIFF
--- a/includes/class-wc-shortcodes.php
+++ b/includes/class-wc-shortcodes.php
@@ -220,7 +220,7 @@ class WC_Shortcodes {
 
 			foreach ( $product_categories as $category ) {
 				wc_get_template(
-					'content-product-cat.php',
+					'content-product_cat.php',
 					array(
 						'category' => $category,
 					)

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2491,7 +2491,7 @@ if ( ! function_exists( 'woocommerce_output_product_categories' ) ) {
 
 		foreach ( $product_categories as $category ) {
 			wc_get_template(
-				'content-product-cat.php',
+				'content-product_cat.php',
 				array(
 					'category' => $category,
 				)


### PR DESCRIPTION
Reverts woocommerce/woocommerce#28233

We need to keep `content-product_cat.php` to allow themes to override this template.