### PR TITLE
Add "My Account" page compatibility for Twenty Twenty-One

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -2632,12 +2632,19 @@ a.reset_variations {
 		}
 	}
 
-	.woocommerce-MyAccount-navigation-link a {
-		color: #666 !important;
+	.woocommerce-MyAccount-navigation-link {
 
-		&:hover {
-			color: black !important;
-			text-decoration: underline solid black 1px !important;
+		margin-bottom: 20px !important;
+
+		a {
+			color: #444 !important;
+			font-weight: normal !important;
+			font-size: 1.8rem;
+
+			&:hover {
+				color: black !important;
+				text-decoration: underline solid black 1px !important;
+			}
 		}
 	}
 }

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -2516,7 +2516,7 @@ a.reset_variations {
 	}
 }
 
-.post-9 {
+.woocommerce-account {
 
 	.entry-header {
 

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -2616,3 +2616,28 @@ a.reset_variations {
 		}
 	}
 }
+
+
+.post-9 {
+
+	.entry-header {
+
+		padding-bottom: 20px !important;
+	}
+
+	.woocommerce-MyAccount-content {
+
+		p:first-of-type {
+			margin-bottom: 2rem;
+		}
+	}
+
+	.woocommerce-MyAccount-navigation-link a {
+		color: #666 !important;
+
+		&:hover {
+			color: black !important;
+			text-decoration: underline solid black 1px !important;
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Adjust padding under the "My Account" title (was too big)
- Adjust color of menu items (was too light)
- Adjust size of menu items (was too big)
- Reduce space between menu items
- Adjust thickness of underline on menu items hover (was too thick)
- Add some space between the "Hello" line and the next paragraph

Before:

![image](https://user-images.githubusercontent.com/937723/100079948-8f7eb900-2e45-11eb-9a84-1dea31fdc593.png)

After:

![image](https://user-images.githubusercontent.com/937723/100114607-e4382900-2e71-11eb-82b4-fa7c4cde5e97.png)

Closes https://github.com/woocommerce/woocommerce/issues/28306.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Enhancement: Add compatibility for Twenty Twenty-One theme on the "My Account" page.
