### PR TITLE
Bump "Tested up to" tag to WP 5.6

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho
 Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, downloads, payments, paypal, storefront, stripe, woo commerce
 Requires at least: 5.3
-Tested up to: 5.5
+Tested up to: 5.6
 Requires PHP: 7.0
 Stable tag: 4.6.2
 License: GPLv3


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR just bumps the "Tested up to" tag to WP 5.6. I believe we should include this in WC 4.8 as it will be released the same that WP 5.6 will be released.

### Changelog entry

> Dev: bump "Tested up to" tag to WP 5.6
