### PR TITLE
Display Paypal fee and payout in the order totals

### DIFF
--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -473,4 +473,70 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 		return $text;
 	}
+
+    /**
+     * Displays the Paypal fee.
+     *
+     * @since 4.1.0
+     *
+     * @param int $order_id the ID of the order
+     */
+    public function display_order_fee($order_id)
+    {
+        $order = wc_get_order($order_id);
+
+        $fee = $order->get_meta('PayPal Transaction Fee', true);
+        $currency = $order->get_currency();
+
+        if (!$fee || !$currency) {
+            return;
+        } ?>
+
+		<tr>
+			<td class="label paypal-fee">
+				<?php echo wc_help_tip(__('This represents the fee Paypal collects for the transaction.', 'woocommerce')); // wpcs: xss ok.?>
+				<?php esc_html_e('Paypal Fee:', 'woocommerce'); ?>
+			</td>
+			<td width="1%"></td>
+			<td class="total">
+				-&nbsp;<?php echo wc_price($fee, ['currency' => $currency]); // wpcs: xss ok.?>
+			</td>
+		</tr>
+
+		<?php
+    }
+
+    /**
+     * Displays the net total of the transaction without the charges of Paypal.
+     *
+     * @since 4.1.0
+     *
+     * @param int $order_id the ID of the order
+     */
+    public function display_order_payout($order_id)
+    {
+        $order = wc_get_order($order_id);
+
+        $fee = $order->get_meta('PayPal Transaction Fee', true);
+        $currency = $order->get_currency();
+
+        $net = ($order->get_total() - (float) $fee);
+
+        if (!$fee || !$currency) {
+            return;
+        } ?>
+
+		<tr>
+			<td class="label paypal-payout">
+				<?php echo wc_help_tip(__('This represents the net total that will be credited to your Paypal account.', 'woocommerce')); // wpcs: xss ok.?>
+				<?php esc_html_e('Paypal Payout:', 'woocommerce'); ?>
+			</td>
+			<td width="1%"></td>
+			<td class="total">
+				<?php echo wc_price($net, ['currency' => $currency]); // wpcs: xss ok.?>
+			</td>
+		</tr>
+
+		<?php
+    }
 }


### PR DESCRIPTION
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This displays the Paypal fee and Paypal payout (net amount) to match how the Stripe Gateway displays the data; directly underneath the order total.

### How to test the changes in this Pull Request:

1. Create an order
2. Pay the order via Paypal
3. View the order details in the admin and view the fee and payout information

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry
This displays the Paypal fee and Paypal payout (net amount) to match how the Stripe Gateway displays the data; directly underneath the order total in the admin order details screen.