### PR TITLE
Add filter before available variations are JSON-encoded

### DIFF
--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
 global $product;
 
 $attribute_keys  = array_keys( $attributes );
-$variations_json = wp_json_encode( $available_variations );
+$variations_json = wp_json_encode( apply_filters( 'woocommerce_pre_json_available_variations', $available_variations ) );
 $variations_attr = function_exists( 'wc_esc_json' ) ? wc_esc_json( $variations_json ) : _wp_specialchars( $variations_json, ENT_QUOTES, 'UTF-8', true );
 
 do_action( 'woocommerce_before_add_to_cart_form' ); ?>


### PR DESCRIPTION
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This is to allow other plugins to modify and add to the available variations before they are JSON encoded and attached to form.variations_form. For example, this adds the opportunity for EWWW Image Optimizer to add WebP derivatives of images. These WebP derivatives can then be swapped into place of the originals on the front-end using JS WebP Rewriting.

### Changelog entry

Add woocommerce_pre_json_available_variations filter to allow modifying variations data before available variations are JSON-encoded and attached to form.variations_form.
