### PR TITLE
Do not exclude composer.json while releasing on Packagist

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,7 +9,7 @@
 bin                export-ignore
 CODE_OF_CONDUCT.md export-ignore
 changelog.txt      export-ignore
-composer.*         export-ignore
+composer.lock      export-ignore
 Gruntfile.js       export-ignore
 package.json       export-ignore
 package-lock.json  export-ignore


### PR DESCRIPTION
### Changes proposed in this Pull Request:

I cannot convince you.
Try installing *any* Composer package and you will find `vendor/vendor-name/package-name/composer.json`
