### PR TITLE
Put Travis configuration in chronological order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,24 +1,24 @@
 version: ~> 1.0
 
+# Specifies that Travis should create builds for master and release branches and also tags.
+branches:
+  only:
+    - master
+    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
+    - /^release\//
+
 language: php
+os:
+  - linux
 dist: xenial
-
-cache:
-  directories:
-    - $HOME/.composer/cache
-
-# Since Xenial services are not started by default, we need to instruct it below to start.
-services:
-  - mysql
-  - docker
 
 # Test main supported versions of PHP against latest WP.
 php:
-  - 7.0
-  - 7.1
-  - 7.2
-  - 7.3
-  - 7.4
+  - "7.0"
+  - "7.1"
+  - "7.2"
+  - "7.3"
+  - "7.4"
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
@@ -41,23 +41,41 @@ jobs:
     after_script:
       - npm run docker:down
   - name: "WP Nightly"
-    php: 7.4
+    php: "7.4"
     env: WP_VERSION=nightly WP_MULTISITE=0
   - name: "WP Latest - 1"
-    php: 7.2
+    php: "7.2"
     env: WP_VERSION=5.4 WP_MULTISITE=0
   - name: "WP Latest - 2"
-    php: 7.2
+    php: "7.2"
     env: WP_VERSION=5.3 WP_MULTISITE=0
   - name: "Code Standards"
-    php: 7.4
+    php: "7.4"
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1
   - name: "Code Coverage"
-    php: 7.4
+    php: "7.4"
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
   allow_failures:
-  - php: 7.4
+  - php: "7.4"
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_CODE_COVERAGE=1
+
+# Git clone depth
+# By default Travis CI clones repositories to a depth of 50 commits. Using a depth of 1 makes this step a bit faster.
+git:
+  depth: 1
+
+# Since Xenial services are not started by default, we need to instruct it below to start.
+services:
+  - mysql
+  - docker
+
+cache:
+  directories:
+    - $HOME/.composer/cache
+
+# Composer 2.0.7 introduced a change that broke the jetpack autoloader in PHP 7.0 - 7.3.
+before_install:
+  - composer self-update 2.0.6
 
 install:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
@@ -81,20 +99,3 @@ script:
 
 after_script:
   - bash tests/bin/travis.sh after
-
-# Specifies that Travis should create builds for master and release branches and also tags.
-branches:
-  only:
-    - master
-    - /^\d+\.\d+(\.\d+)?(-\S*)?$/
-    - /^release\//
-
-# Composer 2.0.7 introduced a change that broke the jetpack autoloader in PHP 7.0 - 7.3.
-before_install:
-  - composer self-update 2.0.6
-
-# Git clone depth
-# By default Travis CI clones repositories to a depth of 50 commits. Using a depth of 1 makes this step a bit faster.
-git:
-  depth: 1
-


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Put Travis config key in order of execution to make it readable for us, humans.
And fix floats in YAML.
And add missing OS to be nice and explicit.

### How to test the changes in this Pull Request:

1. See Travis running https://travis-ci.com/github/woocommerce/woocommerce/builds/204070408
