### PR TITLE
Exclude dev. files and /packages from archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,11 +6,15 @@
 
 # Remove files for archives generated using `git archive`.
 /.*                export-ignore
+/packages          export-ignore
 bin                export-ignore
+babel.config.js    export-ignore
 CODE_OF_CONDUCT.md export-ignore
 changelog.txt      export-ignore
 composer.*         export-ignore
+Dockerfile         export-ignore
 Gruntfile.js       export-ignore
+lerna.json         export-ignore
 package.json       export-ignore
 package-lock.json  export-ignore
 phpcs.xml          export-ignore
@@ -18,3 +22,5 @@ phpunit.*          export-ignore
 README.md          export-ignore
 renovate.json      export-ignore
 tests              export-ignore
+tsconfig.*         export-ignore
+webpack.config.js  export-ignore


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Exclude dev. files and empty /packages from archives
"archives" meaning GitHub ZIP-s and Composer packages

