### PR TITLE
Prevent non-numeric values from throwing a Warning on PHP 7.4+

### DIFF
--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -251,7 +251,12 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 		);
 
 		foreach ( $this->report_data->full_refunds as $key => $order ) {
-			$this->report_data->full_refunds[ $key ]->net_refund = $order->total_refund - ( $order->total_shipping + $order->total_tax + $order->total_shipping_tax );
+			$total_refund       = is_numeric( $order->total_refund ) ? $order->total_refund : 0;
+			$total_shipping     = is_numeric( $order->total_shipping ) ? $order->total_shipping : 0;
+			$total_tax          = is_numeric( $order->total_tax ) ? $order->total_tax : 0;
+			$total_shipping_tax = is_numeric( $order->total_shipping_tax ) ? $order->total_shipping_tax : 0;
+			
+			$this->report_data->full_refunds[ $key ]->net_refund = $total_refund - ( $total_shipping + $total_tax + $total_shipping_tax );
 		}
 
 		/**

--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -255,7 +255,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 			$total_shipping     = is_numeric( $order->total_shipping ) ? $order->total_shipping : 0;
 			$total_tax          = is_numeric( $order->total_tax ) ? $order->total_tax : 0;
 			$total_shipping_tax = is_numeric( $order->total_shipping_tax ) ? $order->total_shipping_tax : 0;
-			
+
 			$this->report_data->full_refunds[ $key ]->net_refund = $total_refund - ( $total_shipping + $total_tax + $total_shipping_tax );
 		}
 


### PR DESCRIPTION
Resolves #28291

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Closes #28291 .

<!-- Mark completed items with an [x] -->

### Changelog entry

> Prevent PHP 7.4+ warning on sales reports by date for non numeric calculation.
