### PR TITLE
Add inline file delivery to WC_Download_Handler

### DIFF
--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1633,7 +1633,6 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				continue;
 			}
 			$saved_rate_ids[] = $tax->get_rate_id();
-			$tax->set_rate( $tax->get_rate_id() );
 			$tax->set_tax_total( isset( $cart_taxes[ $tax->get_rate_id() ] ) ? $cart_taxes[ $tax->get_rate_id() ] : 0 );
 			$tax->set_label( WC_Tax::get_rate_label( $tax->get_rate_id() ) );
 			$tax->set_shipping_tax_total( ! empty( $shipping_taxes[ $tax->get_rate_id() ] ) ? $shipping_taxes[ $tax->get_rate_id() ] : 0 );

--- a/includes/abstracts/abstract-wc-order.php
+++ b/includes/abstracts/abstract-wc-order.php
@@ -1610,6 +1610,7 @@ abstract class WC_Abstract_Order extends WC_Abstract_Legacy_Order {
 				continue;
 			}
 			$saved_rate_ids[] = $tax->get_rate_id();
+			$tax->set_rate( $tax->get_rate_id() );
 			$tax->set_tax_total( isset( $cart_taxes[ $tax->get_rate_id() ] ) ? $cart_taxes[ $tax->get_rate_id() ] : 0 );
 			$tax->set_shipping_tax_total( ! empty( $shipping_taxes[ $tax->get_rate_id() ] ) ? $shipping_taxes[ $tax->get_rate_id() ] : 0 );
 			$tax->save();

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -252,7 +252,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 						'desc'          => __( 'Deliver downloadable files inline', 'woocommerce' ),
 						'id'            => 'woocommerce_downloads_deliver_inline',
 						'type'          => 'checkbox',
-						'default'       => 'yes',
+						'default'       => false,
 						'desc_tip'      => __( 'Enable this option to have downloadable files open in browser', 'woocommerce' ),
 						'autoload'      => false,
 					),

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -242,10 +242,19 @@ class WC_Settings_Products extends WC_Settings_Page {
 						'options'  => array(
 							'force'     => __( 'Force downloads', 'woocommerce' ),
 							'xsendfile' => __( 'X-Accel-Redirect/X-Sendfile', 'woocommerce' ),
-							'inline'    => __( 'Inline Delivery', 'woocommerce' ),
 							'redirect'  => apply_filters( 'woocommerce_redirect_only_method_is_secure', false ) ? __( 'Redirect only', 'woocommerce' ) : __( 'Redirect only (Insecure)', 'woocommerce' ),
 						),
 						'autoload' => false,
+					),
+
+					array(
+						'title'         => __( 'Content-Disposition', 'woocommerce' ),
+						'desc'          => __( 'Deliver downloadable files inline', 'woocommerce' ),
+						'id'            => 'woocommerce_downloads_deliver_inline',
+						'type'          => 'checkbox',
+						'default'       => 'yes',
+						'desc_tip'      => __( 'Enable this option to have downloadable files open in browser', 'woocommerce' ),
+						'autoload'      => false,
 					),
 
 					array(

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -242,6 +242,7 @@ class WC_Settings_Products extends WC_Settings_Page {
 						'options'  => array(
 							'force'     => __( 'Force downloads', 'woocommerce' ),
 							'xsendfile' => __( 'X-Accel-Redirect/X-Sendfile', 'woocommerce' ),
+							'inline'    => __( 'Inline Delivery', 'woocommerce' ),
 							'redirect'  => apply_filters( 'woocommerce_redirect_only_method_is_secure', false ) ? __( 'Redirect only', 'woocommerce' ) : __( 'Redirect only (Insecure)', 'woocommerce' ),
 						),
 						'autoload' => false,
@@ -269,11 +270,11 @@ class WC_Settings_Products extends WC_Settings_Page {
 					),
 
 					array(
-						'title' => __( 'Filename', 'woocommerce' ),
-						'desc' => __( 'Append a unique string to filename for security', 'woocommerce' ),
-						'id' => 'woocommerce_downloads_add_hash_to_filename',
-						'type' => 'checkbox',
-						'default' => 'yes',
+						'title'    => __( 'Filename', 'woocommerce' ),
+						'desc'     => __( 'Append a unique string to filename for security', 'woocommerce' ),
+						'id'       => 'woocommerce_downloads_add_hash_to_filename',
+						'type'     => 'checkbox',
+						'default'  => 'yes',
 						'desc_tip' => sprintf(
 							// translators: Link to WooCommerce Docs.
 							__( "Not required if your download directory is protected. <a href='%s'>See this guide</a> for more details. Files already uploaded will not be affected.", 'woocommerce' ),

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -549,7 +549,7 @@ class WC_Download_Handler {
 
 		header( 'X-Robots-Tag: noindex, nofollow', true );
 		header( 'Content-Description: File Transfer' );
-		header( 'Content-Type: text/html' );
+		header( 'Content-Type: ' . self::get_download_content_type( $file_path ) );
 		header( 'Content-Disposition: inline' );
 		header( 'Content-Transfer-Encoding: binary' );
 

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -25,6 +25,7 @@ class WC_Download_Handler {
 		add_action( 'woocommerce_download_file_redirect', array( __CLASS__, 'download_file_redirect' ), 10, 2 );
 		add_action( 'woocommerce_download_file_xsendfile', array( __CLASS__, 'download_file_xsendfile' ), 10, 2 );
 		add_action( 'woocommerce_download_file_force', array( __CLASS__, 'download_file_force' ), 10, 2 );
+		add_action( 'woocommerce_download_file_inline', array( __CLASS__, 'download_file_inline' ), 10, 2 );
 	}
 
 	/**
@@ -446,6 +447,31 @@ class WC_Download_Handler {
 	}
 
 	/**
+	 * Inline download - For deliverying the file without downloading
+	 *
+	 * @param string $file_path File path.
+	 * @param string $filename  File name.
+	 */
+	public static function download_file_inline( $file_path, $filename ) {
+		$parsed_file_path = self::parse_file_path( $file_path );
+		$download_range   = self::get_download_range( @filesize( $parsed_file_path['file_path'] ) ); // @codingStandardsIgnoreLine.
+
+		self::inline_download_headers( $parsed_file_path['file_path'], $filename, $download_range );
+
+		$start  = isset( $download_range['start'] ) ? $download_range['start'] : 0;
+		$length = isset( $download_range['length'] ) ? $download_range['length'] : 0;
+		if ( ! self::readfile_chunked( $parsed_file_path['file_path'], $start, $length ) ) {
+			if ( $parsed_file_path['remote_file'] ) {
+				self::download_file_redirect( $file_path );
+			} else {
+				self::download_error( __( 'File not found', 'woocommerce' ) );
+			}
+		}
+
+		exit;
+	}
+
+	/**
 	 * Get content type of a download.
 	 *
 	 * @param  string $file_path File path.
@@ -482,6 +508,49 @@ class WC_Download_Handler {
 		header( 'Content-Type: ' . self::get_download_content_type( $file_path ) );
 		header( 'Content-Description: File Transfer' );
 		header( 'Content-Disposition: attachment; filename="' . $filename . '";' );
+		header( 'Content-Transfer-Encoding: binary' );
+
+		$file_size = @filesize( $file_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
+		if ( ! $file_size ) {
+			return;
+		}
+
+		if ( isset( $download_range['is_range_request'] ) && true === $download_range['is_range_request'] ) {
+			if ( false === $download_range['is_range_valid'] ) {
+				header( 'HTTP/1.1 416 Requested Range Not Satisfiable' );
+				header( 'Content-Range: bytes 0-' . ( $file_size - 1 ) . '/' . $file_size );
+				exit;
+			}
+
+			$start  = $download_range['start'];
+			$end    = $download_range['start'] + $download_range['length'] - 1;
+			$length = $download_range['length'];
+
+			header( 'HTTP/1.1 206 Partial Content' );
+			header( "Accept-Ranges: 0-$file_size" );
+			header( "Content-Range: bytes $start-$end/$file_size" );
+			header( "Content-Length: $length" );
+		} else {
+			header( 'Content-Length: ' . $file_size );
+		}
+	}
+
+	/**
+	 * Set headers for the inline delivery.
+	 *
+	 * @param string $file_path      File path.
+	 * @param string $filename       File name.
+	 * @param array  $download_range Array containing info about range download request (see {@see get_download_range} for structure).
+	 */
+	private static function inline_download_headers( $file_path, $filename, $download_range = array() ) {
+		self::check_server_config();
+		self::clean_buffers();
+		wc_nocache_headers();
+
+		header( 'X-Robots-Tag: noindex, nofollow', true );
+		header( 'Content-Description: File Transfer' );
+		header( 'Content-Type: text/html' );
+		header( 'Content-Disposition: inline' );
 		header( 'Content-Transfer-Encoding: binary' );
 
 		$file_size = @filesize( $file_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -550,7 +550,7 @@ class WC_Download_Handler {
 		header( 'X-Robots-Tag: noindex, nofollow', true );
 		header( 'Content-Description: File Transfer' );
 		header( 'Content-Type: ' . self::get_download_content_type( $file_path ) );
-		header( 'Content-Disposition: inline' );
+		header( "Content-Disposition: inline; filename=$filename" );
 		header( 'Content-Transfer-Encoding: binary' );
 
 		$file_size = @filesize( $file_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -543,6 +543,12 @@ class WC_Download_Handler {
 		}
 	}
 
+	/**
+	 *
+	 * Get selected content disposition
+	 *
+	 * Defaults to attachment if `woocommerce_downloads_deliver_inline` setting is not selected.
+	 */
 	private static function get_content_disposition() {
 		$disposition = 'attachment';
 		if ( 'yes' === get_option( 'woocommerce_downloads_deliver_inline' ) ) {

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -25,7 +25,6 @@ class WC_Download_Handler {
 		add_action( 'woocommerce_download_file_redirect', array( __CLASS__, 'download_file_redirect' ), 10, 2 );
 		add_action( 'woocommerce_download_file_xsendfile', array( __CLASS__, 'download_file_xsendfile' ), 10, 2 );
 		add_action( 'woocommerce_download_file_force', array( __CLASS__, 'download_file_force' ), 10, 2 );
-		add_action( 'woocommerce_download_file_inline', array( __CLASS__, 'download_file_inline' ), 10, 2 );
 	}
 
 	/**
@@ -452,25 +451,6 @@ class WC_Download_Handler {
 	 * @param string $file_path File path.
 	 * @param string $filename  File name.
 	 */
-	public static function download_file_inline( $file_path, $filename ) {
-		$parsed_file_path = self::parse_file_path( $file_path );
-		$download_range   = self::get_download_range( @filesize( $parsed_file_path['file_path'] ) ); // @codingStandardsIgnoreLine.
-
-		self::inline_download_headers( $parsed_file_path['file_path'], $filename, $download_range );
-
-		$start  = isset( $download_range['start'] ) ? $download_range['start'] : 0;
-		$length = isset( $download_range['length'] ) ? $download_range['length'] : 0;
-		if ( ! self::readfile_chunked( $parsed_file_path['file_path'], $start, $length ) ) {
-			if ( $parsed_file_path['remote_file'] ) {
-				self::download_file_redirect( $file_path );
-			} else {
-				self::download_error( __( 'File not found', 'woocommerce' ) );
-			}
-		}
-
-		exit;
-	}
-
 	/**
 	 * Get content type of a download.
 	 *
@@ -507,50 +487,7 @@ class WC_Download_Handler {
 		header( 'X-Robots-Tag: noindex, nofollow', true );
 		header( 'Content-Type: ' . self::get_download_content_type( $file_path ) );
 		header( 'Content-Description: File Transfer' );
-		header( 'Content-Disposition: attachment; filename="' . $filename . '";' );
-		header( 'Content-Transfer-Encoding: binary' );
-
-		$file_size = @filesize( $file_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
-		if ( ! $file_size ) {
-			return;
-		}
-
-		if ( isset( $download_range['is_range_request'] ) && true === $download_range['is_range_request'] ) {
-			if ( false === $download_range['is_range_valid'] ) {
-				header( 'HTTP/1.1 416 Requested Range Not Satisfiable' );
-				header( 'Content-Range: bytes 0-' . ( $file_size - 1 ) . '/' . $file_size );
-				exit;
-			}
-
-			$start  = $download_range['start'];
-			$end    = $download_range['start'] + $download_range['length'] - 1;
-			$length = $download_range['length'];
-
-			header( 'HTTP/1.1 206 Partial Content' );
-			header( "Accept-Ranges: 0-$file_size" );
-			header( "Content-Range: bytes $start-$end/$file_size" );
-			header( "Content-Length: $length" );
-		} else {
-			header( 'Content-Length: ' . $file_size );
-		}
-	}
-
-	/**
-	 * Set headers for the inline delivery.
-	 *
-	 * @param string $file_path      File path.
-	 * @param string $filename       File name.
-	 * @param array  $download_range Array containing info about range download request (see {@see get_download_range} for structure).
-	 */
-	private static function inline_download_headers( $file_path, $filename, $download_range = array() ) {
-		self::check_server_config();
-		self::clean_buffers();
-		wc_nocache_headers();
-
-		header( 'X-Robots-Tag: noindex, nofollow', true );
-		header( 'Content-Description: File Transfer' );
-		header( 'Content-Type: ' . self::get_download_content_type( $file_path ) );
-		header( "Content-Disposition: inline; filename=$filename" );
+		header( 'Content-Disposition: ' . self::get_content_disposition() . '; filename="' . $filename . '";' );
 		header( 'Content-Transfer-Encoding: binary' );
 
 		$file_size = @filesize( $file_path ); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
@@ -604,6 +541,14 @@ class WC_Download_Handler {
 		} else {
 			@ob_end_clean(); // phpcs:ignore Generic.PHP.NoSilencedErrors.Discouraged
 		}
+	}
+
+	private static function get_content_disposition() {
+		$disposition = 'attachment';
+		if ( 'yes' === get_option( 'woocommerce_downloads_deliver_inline' ) ) {
+			$disposition = 'inline';
+		}
+		return $disposition;
 	}
 
 	/**


### PR DESCRIPTION
Create a new setting option for inline file delivery for downloadable
products. In the Download Handler create a new method for the new
setting as well as a method for returning the proper headers to deliver
files inline.

Resolves: #28410

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Creates a new setting for allowing downloadable product files to be delivered inline so they would open directly in the browser. This would be useful for stores selling HTML or PDF files so customers can access them directly without the need to download.

Only other change was aligning `=>` signs in an array to match [WordPress indentation coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/php/#indentation).

Closes #28410 .

### How to test the changes in this Pull Request:

1. Create a downloadable/virtual product.
2. From Woocommerce Settings > Products > Downloadable Products select Inline File Delivery
3. Create a test purchase of the downloadable product
4. Test download delivery

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
