### PR TITLE
Switch to general panel when virtual is enabled and on shipping tab c…

### DIFF
--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -146,6 +146,11 @@ jQuery( function( $ ) {
 		}
 		if ( is_virtual ) {
 			$( '.show_if_virtual' ).show();
+
+			// If user enables virtual while on shipping tab, switch to general tab.
+			if ( $( '.shipping_options.shipping_tab' ).hasClass( 'active' ) ) {
+				$( '.general_options.general_tab > a' ).trigger( 'click' );
+			}
 		}
 
         $( '.show_if_' + product_type ).show();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Switch to the general tab when on shipping tab and user clicks on virtual.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28267

### How to test the changes in this Pull Request:

1. Go to a product with shipping enabled.
2. Click on the shipping tab to show the shipping settings.
3. Then enable virtual by clicking on the virtual checkbox.
4. Ensure the shipping tab is completely gone and that you are now in general settings tab.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Switch to general tab when enabling virtual on a product setting.