### PR TITLE
Make City and Postcode mandatory fields for Serbia

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -1230,10 +1230,10 @@ class WC_Countries {
 					),
 					'RS' => array(
 						'city'     => array(
-							'required' => false,
+							'required' => true,
 						),
 						'postcode' => array(
-							'required' => false,
+							'required' => true,
 						),
 						'state'    => array(
 							'label' => __( 'District', 'woocommerce' ),


### PR DESCRIPTION
As these fields were mandatory for Serbia from the beginning, making them optional by default is causing shop owners additional effort to set them back to mandatory. This PR is making them mandatory by default.

Fixes #28366


* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

> Localization: Revert change and make city and postcode required again for Serbia