### PR TITLE
Fix/issue 27154

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-coupon-data.php
@@ -194,7 +194,7 @@ class WC_Meta_Box_Coupon_Data {
 						foreach ( $product_ids as $product_id ) {
 							$product = wc_get_product( $product_id );
 							if ( is_object( $product ) ) {
-								echo '<option value="' . esc_attr( $product_id ) . '"' . selected( true, true, false ) . '>' . htmlspecialchars( wp_kses_post( $product->get_formatted_name() ) ) . '</option>';
+								echo '<option value="' . esc_attr( $product_id ) . '"' . selected( true, true, false ) . '>' . esc_html( wp_strip_all_tags( $product->get_formatted_name() ) ) . '</option>';
 							}
 						}
 						?>
@@ -212,7 +212,7 @@ class WC_Meta_Box_Coupon_Data {
 						foreach ( $product_ids as $product_id ) {
 							$product = wc_get_product( $product_id );
 							if ( is_object( $product ) ) {
-								echo '<option value="' . esc_attr( $product_id ) . '"' . selected( true, true, false ) . '>' . htmlspecialchars( wp_kses_post( $product->get_formatted_name() ) ) . '</option>';
+								echo '<option value="' . esc_attr( $product_id ) . '"' . selected( true, true, false ) . '>' . esc_html( wp_strip_all_tags( $product->get_formatted_name() ) ) . '</option>';
 							}
 						}
 						?>

--- a/includes/admin/meta-boxes/views/html-product-data-linked-products.php
+++ b/includes/admin/meta-boxes/views/html-product-data-linked-products.php
@@ -19,7 +19,7 @@ defined( 'ABSPATH' ) || exit;
 				foreach ( $product_ids as $product_id ) {
 					$product = wc_get_product( $product_id );
 					if ( is_object( $product ) ) {
-						echo '<option value="' . esc_attr( $product_id ) . '"' . selected( true, true, false ) . '>' . htmlspecialchars( wp_kses_post( $product->get_formatted_name() ) ) . '</option>';
+						echo '<option value="' . esc_attr( $product_id ) . '"' . selected( true, true, false ) . '>' . esc_html( wp_strip_all_tags( $product->get_formatted_name() ) ) . '</option>';
 					}
 				}
 				?>
@@ -37,7 +37,7 @@ defined( 'ABSPATH' ) || exit;
 				foreach ( $product_ids as $product_id ) {
 					$product = wc_get_product( $product_id );
 					if ( is_object( $product ) ) {
-						echo '<option value="' . esc_attr( $product_id ) . '"' . selected( true, true, false ) . '>' . htmlspecialchars( wp_kses_post( $product->get_formatted_name() ) ) . '</option>';
+						echo '<option value="' . esc_attr( $product_id ) . '"' . selected( true, true, false ) . '>' . esc_html( wp_strip_all_tags( $product->get_formatted_name() ) ) . '</option>';
 					}
 				}
 				?>
@@ -53,7 +53,7 @@ defined( 'ABSPATH' ) || exit;
 				foreach ( $product_ids as $product_id ) {
 					$product = wc_get_product( $product_id );
 					if ( is_object( $product ) ) {
-						echo '<option value="' . esc_attr( $product_id ) . '"' . selected( true, true, false ) . '>' . htmlspecialchars( wp_kses_post( $product->get_formatted_name() ) ) . '</option>';
+						echo '<option value="' . esc_attr( $product_id ) . '"' . selected( true, true, false ) . '>' . esc_html( wp_strip_all_tags( $product->get_formatted_name() ) ) . '</option>';
 					}
 				}
 				?>

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1594,7 +1594,7 @@ class WC_AJAX {
 				$formatted_name .= ' &ndash; ' . sprintf( __( 'Stock: %d', 'woocommerce' ), wc_format_stock_quantity_for_display( $stock_amount, $product_object ) );
 			}
 
-			$products[ $product_object->get_id() ] = rawurldecode( $formatted_name );
+			$products[ $product_object->get_id() ] = rawurldecode( wp_strip_all_tags( $formatted_name ) );
 		}
 
 		wp_send_json( apply_filters( 'woocommerce_json_search_found_products', $products ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

For all select2 search fields, to remove any HTML. This will remove the description fields as well however I don't believe we need to show that when searching for a variation. As long as it shows the variation ID and name of the variation, should be sufficient. This also ensures the name + description doesn't get too long.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27154 

### How to test the changes in this Pull Request:

1. Go to any of the Select2 fields where you can search for products such as Order->Add Product/Item, Coupon item restrictions, Grouped linked products, Product upsell.
2. In those above listed fields, search for a variation.
3. Ensure what comes up does not show any HTML.
4. Save. Reload page and ensure no HTML is shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Fix - Unwanted HTML is showing up on the product search fields when searching for a product variation.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
