### PR TITLE
Add 'Ladakh' to the list of Indian states

### DIFF
--- a/i18n/states.php
+++ b/i18n/states.php
@@ -1502,7 +1502,7 @@ return array(
 		'TZ30' => __( 'Simiyu', 'woocommerce' ),
 	),
 	'LK' => array(),
-	'RS' => array( // Serbia districts. Ref: https://github.com/unicode-org/cldr/blob/release-37/common/subdivisions/en.xml#L4251-L4283
+	'RS' => array( // Serbia districts. Ref: https://github.com/unicode-org/cldr/blob/release-37/common/subdivisions/en.xml#L4251-L4283.
 		'RS00' => _x( 'Belgrade', 'district', 'woocommerce' ),
 		'RS14' => _x( 'Bor', 'district', 'woocommerce' ),
 		'RS11' => _x( 'Braničevo', 'district', 'woocommerce' ),

--- a/i18n/states.php
+++ b/i18n/states.php
@@ -583,6 +583,7 @@ return array(
 		'JH' => __( 'Jharkhand', 'woocommerce' ),
 		'KA' => __( 'Karnataka', 'woocommerce' ),
 		'KL' => __( 'Kerala', 'woocommerce' ),
+		'LA' => __( 'Ladakh', 'woocommerce' ),
 		'MP' => __( 'Madhya Pradesh', 'woocommerce' ),
 		'MH' => __( 'Maharashtra', 'woocommerce' ),
 		'MN' => __( 'Manipur', 'woocommerce' ),


### PR DESCRIPTION
### Changes proposed in this Pull Request:

'Ladakh' is a new Indian state that is listed in CLDR (https://github.com/unicode-org/cldr/blob/release-37/common/subdivisions/en.xml#L2257), but it was missing in WooCommerce. This PR  simply adds it to `i18n/states.php`.

This PR includes PHPCS fixes to the modified file in a separate commit.

Closes #28434 

### How to test the changes in this Pull Request:

1. Check that Ladakh is listed as one of the states for India in the checkout page or somewhere else in WooCommerce where we list states of a given country.

### Changelog entry

> Localization: Add 'Ladakh' to the list of Indian states
