### PR TITLE
Implement peer dependencies in E2E packages

### DIFF
--- a/tests/e2e/core-tests/package.json
+++ b/tests/e2e/core-tests/package.json
@@ -10,8 +10,10 @@
   "license": "GPL-3.0+",
   "main": "index.js",
   "dependencies": {
-    "@jest/globals": "^26.4.2",
-    "@woocommerce/e2e-utils": "file:../utils"
+    "@jest/globals": "^26.4.2"
+  },
+  "peerDependencies": {
+    "@woocommerce/e2e-utils": "^0.1.1"
   },
   "publishConfig": {
     "access": "public"

--- a/tests/e2e/utils/package.json
+++ b/tests/e2e/utils/package.json
@@ -11,10 +11,12 @@
   "main": "build/index.js",
   "module": "build-module/index.js",
   "dependencies": {
-    "@woocommerce/api": "0.1.0",
     "@wordpress/e2e-test-utils": "^4.6.0",
     "faker": "^5.1.0",
     "fishery": "^1.0.1"
+  },
+  "peerDependencies": {
+    "@woocommerce/api": "^0.1.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR implements `peerDependencies` in the `e2e-utils` & `e2e-core-tests` packages. This addresses the issue where the core tests package was looking for the utils package in `..\utils` and in a consuming project the path to the packkage was `..\e2e-utils`.

Closes #28347.

### How to test the changes in this Pull Request:

1. Run `npm install`
2. Run E2E tests

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A
