### PR TITLE
Correct Puerto Rico address validation

### DIFF
--- a/i18n/states.php
+++ b/i18n/states.php
@@ -1236,6 +1236,7 @@ return array(
 		'SD' => __( 'Sindh', 'woocommerce' ),
 	),
 	'PL' => array(),
+	'PR' => array(),
 	'PT' => array(),
 	'PY' => array( // Paraguay states.
 		'PY-ASU' => __( 'Asunción', 'woocommerce' ),
@@ -1501,7 +1502,7 @@ return array(
 		'TZ30' => __( 'Simiyu', 'woocommerce' ),
 	),
 	'LK' => array(),
-	'RS' => array( // Serbia districts. Ref: https://github.com/unicode-org/cldr/blob/release-37/common/subdivisions/en.xml#L4251-L4283
+	'RS' => array( // Serbia districts Ref: https://github.com/unicode-org/cldr/blob/release-37/common/subdivisions/en.xml#L4251-L4283.
 		'RS00' => _x( 'Belgrade', 'district', 'woocommerce' ),
 		'RS14' => _x( 'Bor', 'district', 'woocommerce' ),
 		'RS11' => _x( 'Braničevo', 'district', 'woocommerce' ),

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -528,7 +528,7 @@ class WC_Countries {
 					'NZ'      => "{name}\n{company}\n{address_1}\n{address_2}\n{city} {postcode}\n{country}",
 					'NO'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'PL'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
-					'PR'      => "{company}\n{name}\n{address_1} {address_2}\n{state} \n{country} {postcode}",
+					'PR'      => "{company}\n{name}\n{address_1} {address_2}\n{city} \n{country} {postcode}",
 					'PT'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'SK'      => "{company}\n{name}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
 					'RS'      => "{name}\n{company}\n{address_1}\n{address_2}\n{postcode} {city}\n{country}",
@@ -1205,11 +1205,11 @@ class WC_Countries {
 					),
 					'PR' => array(
 						'city'  => array(
-							'required' => false,
-							'hidden'   => true,
+							'label' => __( 'Municipality', 'woocommerce' ),
 						),
 						'state' => array(
-							'label' => __( 'Municipality', 'woocommerce' ),
+							'required' => false,
+							'hidden'   => true,
 						),
 					),
 					'PT' => array(

--- a/includes/class-wc-validation.php
+++ b/includes/class-wc-validation.php
@@ -91,6 +91,7 @@ class WC_Validation {
 			case 'PT':
 				$valid = (bool) preg_match( '/^([0-9]{4})([-])([0-9]{3})$/', $postcode );
 				break;
+			case 'PR':
 			case 'US':
 				$valid = (bool) preg_match( '/^([0-9]{5})(-[0-9]{4})?$/i', $postcode );
 				break;

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -962,6 +962,7 @@ function wc_format_postcode( $postcode, $country ) {
 		case 'PT':
 			$postcode = substr_replace( $postcode, '-', 4, 0 );
 			break;
+		case 'PR':
 		case 'US':
 			$postcode = rtrim( substr_replace( $postcode, '-', 5, 0 ), '-' );
 			break;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

For Puerto Rico we are currently hiding the "City" field and have renamed the "State" field to "Municipality". This is backwards as PR has no states (it's a U.S. territory), but does have cities (municipalities). In this PR I've switched these two, as well as added an empty `states` array for `PR` to ensure the `state` field is hidden in checkout. I've also added U.S. ZIP code validation since Puerto Rico uses that.

Closes #27711.

### How to test the changes in this Pull Request:

1. Go to checkout, try out "Puerto Rico" as your country
2. Without this PR, note that the "State" field is made into "Municipalities" and the "City" field is hidden entirely.
3. With this PR, note that the "State" field is hidden and the "City" field is named "Municipalities"
4. Check and ensure that the validation for postal code now follow the US ZIP code system

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Corrected Puerto Rico address validation.
