### PR TITLE
Update `lostpassword_post` action and add missing parameter

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -293,7 +293,7 @@ class WC_Shortcode_My_Account {
 
 		$errors = new WP_Error();
 
-		do_action( 'lostpassword_post', $errors );
+		do_action( 'lostpassword_post', $errors, $user_data );
 
 		if ( $errors->get_error_code() ) {
 			wc_add_notice( $errors->get_error_message(), 'error' );


### PR DESCRIPTION
### Changes proposed in this Pull Request:

`lostpassword_post` is a WP action that is duplicated in WooCommerce to replicate the functionality to retrieve user password in the 'My Account' pages. WP recently added the variable `$user_data` as a second parameter to this action (https://github.com/WordPress/WordPress/commit/a6cecef42f22ab635684052e0d3011e5d985e1d3). This commit simply copies this change to the version of the action that we maintain. Similar to what was done in 1a99235dc85193b43b43e03fa225aef9a69fde89 when a first parameter was added to the action in WP and we had to do the same in WC core.

Closes #28428

### How to test the changes in this Pull Request:

1. Check that resetting the password in `/my-account/lost-password/` still works.
2. Check that when the action `lostpassword_post` is called via `/my-account/lost-password/` any functions hooked to it will receive two parameters (`$errors` and `$user_data`).

### Changelog entry

> Dev: add a missing second parameter to our copy of the WP action `lostpassword_post`
