### PR TITLE
Use single quotes inside MySQL query to avoid issues with ANSI_QUOTES

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1614,7 +1614,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 				// Variations should also search the parent's meta table for fallback fields.
 				if ( $include_variations ) {
-					$variation_query = $wpdb->prepare( ' OR ( wc_product_meta_lookup.sku = "" AND parent_wc_product_meta_lookup.sku LIKE %s ) ', $like );
+					$variation_query = $wpdb->prepare( " OR ( wc_product_meta_lookup.sku = '' AND parent_wc_product_meta_lookup.sku LIKE %s ) ", $like );
 				} else {
 					$variation_query = '';
 				}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR replaces double quotes with single quotes inside a MySQL query to avoid a syntax error when the SQL mode ANSI_QUOTES is enabled in MySQL (https://dev.mysql.com/doc/refman/8.0/en/sql-mode.html#sqlmode_ansi_quotes).

When this mode is enabled, MySQL treats double quotes as identifiers (like the backtick character) instead of as string delimiters. Before this change, sites running with this mode enabled wouldn't be able to add products to orders created manually in the admin as the modified query would fail (other places that also use product search, including variations, would fail as well). The commit that introduced this issue shipped in WC 4.5.0 (see https://github.com/woocommerce/woocommerce/pull/27171).

Unfortunately, I don't think there is an easy way to automatically identify places where we are using double quotes inside queries, so we might suffer from this problem again in the future (cc @woocommerce/proton for awareness). I'm opting to fix this instance of the issue as it seems that WordPress also avoids using double quotes (https://core.trac.wordpress.org/ticket/1498).

There is an open issue on WPCS to add a sniff to automatically detect double quotes in database queries, which would definitely help, but there was no progress since it was opened a couple of years ago: https://github.com/WordPress/WordPress-Coding-Standards/issues/1332

Closes #28417.

### How to test the changes in this Pull Request:

1. Add `sql-mode=ANSI_QUOTES` to the `mysqld` section of your MySQL configuration file and restart it.
2. On master, check that it is not possible to add a product to an order created manually in the admin (the ajax request used to search for products returns an error).
3. Switch to this branch, and check that the issue is fixed and it is possible to add products to an order created in the admin.

### Changelog entry

> Fix - Use single quotes inside MySQL query to avoid issues when `ANSI_QUOTES` is enabled.
