### PR TITLE
Use composer --no-dev in Travis for E2E

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ jobs:
     install:
      - nvm install
      - npm install
-     - composer install
+     - composer install --no-dev
     script:
       - npm run build:assets
       - npm run docker:up


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Due to other optimizations made in the Travis configuration and scripts, the E2E test run no longer requires the composer dev environment to be installed. This PR changes the E2E `composer install` to `composer install -no-dev` which will reduce the run time of the E2E test on every build by a few seconds.

### How to test the changes in this Pull Request:

1. Verify Travis build ran correctly

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

N/A