### PR TITLE
Allow for passing context into the get_image for product variation.

### DIFF
--- a/plugins/woocommerce/changelog/fix-variation-image-empty
+++ b/plugins/woocommerce/changelog/fix-variation-image-empty
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Fixed image array in edit context for product/variations endpoint.

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -64,8 +64,8 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	 * @return WP_REST_Response
 	 */
 	public function prepare_object_for_response( $object, $request ) {
-		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
-		$data = array(
+		$context = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$data    = array(
 			'id'                    => $object->get_id(),
 			'date_created'          => wc_rest_prepare_date_response( $object->get_date_created(), false ),
 			'date_created_gmt'      => wc_rest_prepare_date_response( $object->get_date_created() ),

--- a/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
+++ b/plugins/woocommerce/includes/rest-api/Controllers/Version3/class-wc-rest-product-variations-controller.php
@@ -64,6 +64,7 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	 * @return WP_REST_Response
 	 */
 	public function prepare_object_for_response( $object, $request ) {
+		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data = array(
 			'id'                    => $object->get_id(),
 			'date_created'          => wc_rest_prepare_date_response( $object->get_date_created(), false ),
@@ -105,13 +106,12 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 			),
 			'shipping_class'        => $object->get_shipping_class(),
 			'shipping_class_id'     => $object->get_shipping_class_id(),
-			'image'                 => $this->get_image( $object ),
+			'image'                 => $this->get_image( $object, $context ),
 			'attributes'            => $this->get_attributes( $object ),
 			'menu_order'            => $object->get_menu_order(),
 			'meta_data'             => $object->get_meta_data(),
 		);
 
-		$context  = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data     = $this->add_additional_fields_to_object( $data, $request );
 		$data     = $this->filter_response_by_context( $data, $context );
 		$response = rest_ensure_response( $data );
@@ -352,10 +352,11 @@ class WC_REST_Product_Variations_Controller extends WC_REST_Product_Variations_V
 	 * Get the image for a product variation.
 	 *
 	 * @param WC_Product_Variation $variation Variation data.
+	 * @param string               $context   Context of the request: 'view' or 'edit'.
 	 * @return array
 	 */
-	protected function get_image( $variation ) {
-		if ( ! $variation->get_image_id() ) {
+	protected function get_image( $variation, $context = 'view' ) {
+		if ( ! $variation->get_image_id( $context ) ) {
 			return;
 		}
 


### PR DESCRIPTION
Problem statement: When the product variation’s image is null, the API response will be set to the same as the parent product, so it will be never null.

p7bje6-2E9-p2

Before writing unit tests, let's discuss if this approach makes sense.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Since get_image behaves differently in edit and view contexts, it is important to pass the context down. In view context, if there is no image set for variation, it returns the parent's image. However, this is wrong for WP admin or mobile app running from the perspective of the admin user.


### How to test the changes in this Pull Request:

1. Create a variation product with 2 variations, assign an image to the parent and to one of the variations.
2. Run a GET on wp-json/wc/v3/productsPARENT_ID/variations/VARIATION_ID_WITHOUT_IMAGE
3. Observe that the image array is populated
4. Apply this patch
4. Run the same request as for 2, response should be the same
4. Run the same request as above, but append `?context=edit` at the end, e.g. `http://one.wordpress.test/wp-json/wc/v3/products/48/variations/62?context=edit`
4. Observe the image is now `null`
4. Try if both contexts (`view` and `edit`) work and return the same response for variation with the image defined.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fixed image array in `edit` context for product/variations endpoint.
