### PR TITLE
Remove deprecated PayPal Standard "Page style" setting

### DIFF
--- a/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
+++ b/includes/gateways/paypal/includes/class-wc-gateway-paypal-request.php
@@ -127,7 +127,6 @@ class WC_Gateway_Paypal_Request {
 				'upload'        => 1,
 				'return'        => esc_url_raw( add_query_arg( 'utm_nooverride', '1', $this->gateway->get_return_url( $order ) ) ),
 				'cancel_return' => esc_url_raw( $order->get_cancel_order_url_raw() ),
-				'page_style'    => $this->gateway->get_option( 'page_style' ),
 				'image_url'     => esc_url_raw( $this->gateway->get_option( 'image_url' ) ),
 				'paymentaction' => $this->gateway->get_option( 'paymentaction' ),
 				'invoice'       => $this->limit_length( $this->gateway->get_option( 'invoice_prefix' ) . $order->get_order_number(), 127 ),

--- a/includes/gateways/paypal/includes/settings-paypal.php
+++ b/includes/gateways/paypal/includes/settings-paypal.php
@@ -113,14 +113,6 @@ return array(
 			'authorization' => __( 'Authorize', 'woocommerce' ),
 		),
 	),
-	'page_style'            => array(
-		'title'       => __( 'Page style', 'woocommerce' ),
-		'type'        => 'text',
-		'description' => __( 'Optionally enter the name of the page style you wish to use. These are defined within your PayPal account. This affects classic PayPal checkout screens.', 'woocommerce' ),
-		'default'     => '',
-		'desc_tip'    => true,
-		'placeholder' => __( 'Optional', 'woocommerce' ),
-	),
 	'image_url'             => array(
 		'title'       => __( 'Image url', 'woocommerce' ),
 		'type'        => 'text',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the setting "Page style" from WooCommerce -> Settings -> Payments -> PayPal Standard. This setting was used to define the value of the parameter "page_style" passed to the PayPal Standard API, but PayPal deprecated this parameter and ignores it. According to PayPal in https://developer.paypal.com/docs/paypal-payments-standard/integration-guide/Appx-websitestandard-htmlvariables/?mark=page_style#deprecated-variables: "Deprecated variables are ignored when you pass them to PayPal". In the same link, you can see that "page_style" is included in the list of deprecated parameters.

Closes #26494.

### How to test the changes in this Pull Request:

1. Check the PayPal documentation to confirm that "page_style" has been deprecated and is now ignored by PayPal.
2. Test that PayPal Standard gateway still works.

### Changelog entry

> Fix: Remove deprecated PayPal Standard "Page Style" setting
