### PR TITLE
Tracker: Add tracking of woocommerce_admin_disabled usage.

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -113,7 +113,7 @@ class WC_Tracker {
 	 *
 	 * @return array
 	 */
-	public static function get_tracking_data() {
+	private static function get_tracking_data() {
 		$data = array();
 
 		// General site info.

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -113,7 +113,7 @@ class WC_Tracker {
 	 *
 	 * @return array
 	 */
-	private static function get_tracking_data() {
+	public static function get_tracking_data() {
 		$data = array();
 
 		// General site info.
@@ -165,6 +165,9 @@ class WC_Tracker {
 
 		// Cart & checkout tech (blocks or shortcodes).
 		$data['cart_checkout'] = self::get_cart_checkout_info();
+
+		// WooCommerce Admin info.
+		$data['wc_admin_disabled'] = apply_filters( 'woocommerce_admin_disabled', false ) ? 'yes' : 'no';
 
 		return apply_filters( 'woocommerce_tracker_data', $data );
 	}

--- a/tests/php/includes/class-wc-tracker-test.php
+++ b/tests/php/includes/class-wc-tracker-test.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Unit tests for the WC_Tracker class.
+ *
+ * @package WooCommerce\Tests\WC_Tracker.
+ */
+
+/**
+ * Class WC_Tracker_Test
+ */
+class WC_Tracker_Test extends \WC_Unit_Test_Case {
+
+    /**
+     * Utility method to add filter on woocommerce_admin_disabled
+     */
+    public function disable_woocommerce_admin() {
+        return true;
+    }
+
+	/**
+	 * Test the tracking of wc_admin being disabled via filter.
+	 */
+	public function test_wc_admin_disabled_get_tracking_data() {
+		$tracking_data = WC_Tracker::get_tracking_data();
+
+        // Test the default case of no filter for set for woocommerce_admin_disabled.
+        $this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data );
+		$this->assertEquals( 'no', $tracking_data['wc_admin_disabled'] );
+
+		// Test the case for woocommerce_admin_disabled filter returning true.
+        add_filter( 'wc_admin_disabled', $this->disable_woocommerce_admin() );
+        
+        $tracking_data_disabled_wc_admin = WC_Tracker::get_tracking_data();
+        $this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data_disabled_wc_admin );
+		$this->assertEquals( 'yes', $tracking_data['wc_admin_disabled'] );
+        remove_filter( 'wc_admin_disabled', $this->disable_woocommerce_admin() );
+	}
+
+}

--- a/tests/php/includes/class-wc-tracker-test.php
+++ b/tests/php/includes/class-wc-tracker-test.php
@@ -21,7 +21,16 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 	 * Test the tracking of wc_admin being disabled via filter.
 	 */
 	public function test_wc_admin_disabled_get_tracking_data() {
-		$tracking_data = WC_Tracker::get_tracking_data();
+		$posted_data = null;
+		add_filter(
+			'pre_http_request',
+			function( $pre, $args, $url ) use ( &$posted_data ) {
+				$posted_data = $args;
+				return true;
+			}, 3, 10
+		);
+		WC_Tracker::send_tracking_data( true );
+		$tracking_data = json_decode( $posted_data['body'], true );
 
         // Test the default case of no filter for set for woocommerce_admin_disabled.
         $this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data );
@@ -30,7 +39,13 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		// Test the case for woocommerce_admin_disabled filter returning true.
         add_filter( 'wc_admin_disabled', $this->disable_woocommerce_admin() );
         
-        $tracking_data_disabled_wc_admin = WC_Tracker::get_tracking_data();
+        // Bypass the 1h cooldown period so we can invoke send_tracking_data again.
+		add_filter(
+			'woocommerce_tracker_last_send_time',
+			function( $time ) { return $time - 10000; }
+		);
+		WC_Tracker::send_tracking_data( true );
+		$tracking_data_disabled_wc_admin = json_decode( $posted_data['body'], true );
         $this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data_disabled_wc_admin );
 		$this->assertEquals( 'yes', $tracking_data['wc_admin_disabled'] );
         remove_filter( 'wc_admin_disabled', $this->disable_woocommerce_admin() );

--- a/tests/php/includes/class-wc-tracker-test.php
+++ b/tests/php/includes/class-wc-tracker-test.php
@@ -9,46 +9,69 @@
  * Class WC_Tracker_Test
  */
 class WC_Tracker_Test extends \WC_Unit_Test_Case {
-
-    /**
-     * Utility method to add filter on woocommerce_admin_disabled
-     */
-    public function disable_woocommerce_admin() {
-        return true;
-    }
-
 	/**
 	 * Test the tracking of wc_admin being disabled via filter.
 	 */
 	public function test_wc_admin_disabled_get_tracking_data() {
 		$posted_data = null;
+
+		// Test the case for woocommerce_admin_disabled filter returning true.
+		add_filter(
+			'woocommerce_admin_disabled',
+			function( $default ) {
+				return true;
+			}
+		);
+
 		add_filter(
 			'pre_http_request',
 			function( $pre, $args, $url ) use ( &$posted_data ) {
+				if ( $posted_data ) {
+					$posted_data = null;
+				}
 				$posted_data = $args;
 				return true;
-			}, 3, 10
+			},
+			3,
+			10
 		);
 		WC_Tracker::send_tracking_data( true );
 		$tracking_data = json_decode( $posted_data['body'], true );
 
-        // Test the default case of no filter for set for woocommerce_admin_disabled.
-        $this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data );
-		$this->assertEquals( 'no', $tracking_data['wc_admin_disabled'] );
-
-		// Test the case for woocommerce_admin_disabled filter returning true.
-        add_filter( 'wc_admin_disabled', $this->disable_woocommerce_admin() );
-        
-        // Bypass the 1h cooldown period so we can invoke send_tracking_data again.
-		add_filter(
-			'woocommerce_tracker_last_send_time',
-			function( $time ) { return $time - 10000; }
-		);
-		WC_Tracker::send_tracking_data( true );
-		$tracking_data_disabled_wc_admin = json_decode( $posted_data['body'], true );
-        $this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data_disabled_wc_admin );
+		// Test the default case of no filter for set for woocommerce_admin_disabled.
+		$this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data );
 		$this->assertEquals( 'yes', $tracking_data['wc_admin_disabled'] );
-        remove_filter( 'wc_admin_disabled', $this->disable_woocommerce_admin() );
+		$posted_data = null;
+
+		// Bypass time delay so we can invoke send_tracking_data again.
+		update_option( 'woocommerce_tracker_last_send', strtotime( '-2 weeks' ) );
 	}
 
+	/**
+	 * Test the tracking of wc_admin being not disabled via filter.
+	 */
+	public function test_wc_admin_not_disabled_get_tracking_data() {
+		$posted_data = null;
+		// Bypass time delay so we can invoke send_tracking_data again.
+		update_option( 'woocommerce_tracker_last_send', strtotime( '-2 weeks' ) );
+
+		add_filter(
+			'pre_http_request',
+			function( $pre, $args, $url ) use ( &$posted_data ) {
+				if ( $posted_data ) {
+					$posted_data = null;
+				}
+				$posted_data = $args;
+				return true;
+			},
+			3,
+			10
+		);
+		WC_Tracker::send_tracking_data( true );
+		$tracking_data = json_decode( $posted_data['body'], true );
+
+		// Test the default case of no filter for set for woocommerce_admin_disabled.
+		$this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data );
+		$this->assertEquals( 'no', $tracking_data['wc_admin_disabled'] );
+	}
 }

--- a/tests/php/includes/class-wc-tracker-test.php
+++ b/tests/php/includes/class-wc-tracker-test.php
@@ -26,9 +26,6 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		add_filter(
 			'pre_http_request',
 			function( $pre, $args, $url ) use ( &$posted_data ) {
-				if ( $posted_data ) {
-					$posted_data = null;
-				}
 				$posted_data = $args;
 				return true;
 			},
@@ -41,10 +38,6 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		// Test the default case of no filter for set for woocommerce_admin_disabled.
 		$this->assertArrayHasKey( 'wc_admin_disabled', $tracking_data );
 		$this->assertEquals( 'yes', $tracking_data['wc_admin_disabled'] );
-		$posted_data = null;
-
-		// Bypass time delay so we can invoke send_tracking_data again.
-		update_option( 'woocommerce_tracker_last_send', strtotime( '-2 weeks' ) );
 	}
 
 	/**
@@ -58,9 +51,6 @@ class WC_Tracker_Test extends \WC_Unit_Test_Case {
 		add_filter(
 			'pre_http_request',
 			function( $pre, $args, $url ) use ( &$posted_data ) {
-				if ( $posted_data ) {
-					$posted_data = null;
-				}
 				$posted_data = $args;
 				return true;
 			},


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Context: pa1C6h-Rw-p2

This branch adds in another metric to the WC_Tracker payload to see if a site currently has the wc_admin package disabled via filter. If possible, this would be great to have included in 4.9 - thank you.

### How to test the changes in this Pull Request:

Verify the unit tests covering this addition pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Dev - Add tracking of woocommerce_admin_disabled usage.