### PR TITLE
[PHP 8] Fix Unknown named parameter error when running database update routines

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -221,16 +221,17 @@ class WC_Install {
 	/**
 	 * Run an update callback when triggered by ActionScheduler.
 	 *
+	 * @param string $update_callback Callback name.
+	 *
 	 * @since 3.6.0
-	 * @param string $callback Callback name.
 	 */
-	public static function run_update_callback( $callback ) {
+	public static function run_update_callback( $update_callback ) {
 		include_once dirname( __FILE__ ) . '/wc-update-functions.php';
 
-		if ( is_callable( $callback ) ) {
-			self::run_update_callback_start( $callback );
-			$result = (bool) call_user_func( $callback );
-			self::run_update_callback_end( $callback, $result );
+		if ( is_callable( $update_callback ) ) {
+			self::run_update_callback_start( $update_callback );
+			$result = (bool) call_user_func( $update_callback );
+			self::run_update_callback_end( $update_callback, $result );
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Database update callbacks fail on PHP 8 with the following error:

> CRITICAL Uncaught Error: Unknown named parameter $update_callback in /app/wordpress/wp-includes/class-wp-hook.php:287

The reason is because WooCommerce specify "args" for action callbacks as associative arrays. In PHP 8, when `call_user_func_array` is passed an associative array for the $args, they key => value pairs [will be treated as named parameters](https://php.watch/versions/8.0/named-parameters#named-params-call_user_func_array).

This is how the action is being queued:

```php
WC()->queue()->schedule_single(
	time() + $loop,
	'woocommerce_run_update_callback',
	array(
		'update_callback' => $update_callback,
	),
	'woocommerce-db-updates'
);
```

The signature of the function added to `woocommerce_run_update_callback` hook accepts a parameter named `$callback` rather than `$update_callback`:

```php
public static function run_update_callback( $callback ) { }
```

Changing that parameter from `$callback` to `$update_callback` fixed the issue for me.

### How to test the changes in this Pull Request:

1. Trigger the database update notice.
1. Run the database update
1. Go to WooCommerce > Status > Scheduled Action
1. Without the fix, you will see failed actions with "Unknown named parameter" errors. With the fix, you will no longer see failed database updates.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix Unknown named parameter error on PHP 8 causing database update routine to fail