### PR TITLE
Remove GB and IM from EU VAT countries

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -359,8 +359,6 @@ class WC_Countries {
 		if ( 'eu_vat' === $type ) {
 			$countries[] = 'MC';
 			$countries[] = 'IM';
-			// The UK is still part of the EU VAT zone.
-			$countries[] = 'GB';
 		}
 
 		return apply_filters( 'woocommerce_european_union_countries', $countries, $type );

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -358,7 +358,6 @@ class WC_Countries {
 
 		if ( 'eu_vat' === $type ) {
 			$countries[] = 'MC';
-			$countries[] = 'IM';
 		}
 
 		return apply_filters( 'woocommerce_european_union_countries', $countries, $type );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to #28484.

Since the transition period is about to end on December 31st, 2020, it is assumed that GB will stop being part of the EU VAT zone. Therefore, I think we should remove it from the list.

https://www.instituteforgovernment.org.uk/explainers/tax-brexit 

I'm assuming Isle of Man as a separate territory with a close relationship to the UK won't be able to retain any of its EU VAT rules, so removed it, too.

### How to test the changes in this Pull Request:

1. Call `WC()->countries->get_european_union_countries()` and `WC()->countries->get_european_union_countries('eu_vat')`, first should exclude GB & IM, second should include it.
2. Apply branch.
3. Both calls should now exclude GB and IM.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Remove GB and IM from EU VAT countries.
