### PR TITLE
Fix issue where customer could checkout although mandatory field "Country" was not given

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2748,7 +2748,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				} else {
 
-					$field = '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" class="country_to_state country_select ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" ' . implode( ' ', $custom_attributes ) . '><option value="">' . esc_html__( 'Select a country / region&hellip;', 'woocommerce' ) . '</option>';
+					$field = '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" class="country_to_state country_select ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" ' . implode( ' ', $custom_attributes ) . ' data-placeholder="' . esc_attr( $args['placeholder'] ? $args['placeholder'] : esc_attr__( 'Select a country / region&hellip;', 'woocommerce' ) ) . '"><option value="">' . esc_html__( 'Select a country / region&hellip;', 'woocommerce' ) . '</option>';
 
 					foreach ( $countries as $ckey => $cvalue ) {
 						$field .= '<option value="' . esc_attr( $ckey ) . '" ' . selected( $value, $ckey, false ) . '>' . esc_html( $cvalue ) . '</option>';

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2748,7 +2748,7 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 
 				} else {
 
-					$field = '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" class="country_to_state country_select ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" ' . implode( ' ', $custom_attributes ) . '><option value="default">' . esc_html__( 'Select a country / region&hellip;', 'woocommerce' ) . '</option>';
+					$field = '<select name="' . esc_attr( $key ) . '" id="' . esc_attr( $args['id'] ) . '" class="country_to_state country_select ' . esc_attr( implode( ' ', $args['input_class'] ) ) . '" ' . implode( ' ', $custom_attributes ) . '><option value="">' . esc_html__( 'Select a country / region&hellip;', 'woocommerce' ) . '</option>';
 
 					foreach ( $countries as $ckey => $cvalue ) {
 						$field .= '<option value="' . esc_attr( $ckey ) . '" ' . selected( $value, $ckey, false ) . '>' . esc_html( $cvalue ) . '</option>';


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR reverts the changes from #26554 as they were causing an issue reported in #27521 where users could checkout without providing a country even though this field is mandatory. It also proposes a different way to fix the problem that #26554 intended to fix.

If the option "Default customer location" is set to "No location by default", WooCommerce would show an empty select box for the country field during checkout. This was reported in #26435. The changes that are reverted here attempted to fix this by adding `default` as the value of the first empty option in the select box. This solved the problem, but caused an issue where users could buy virtual products without providing a country even though this field is mandatory. In this PR, I'm proposing that instead of setting `default` as the value of the first and empty option, we use `selectWoo` placeholder parameter. This way a placeholder is set by selectWoo, but the value of the option is not modified and thus the validation for the field works.

Closes #27521

### How to test the changes in this Pull Request:

1. Using the master branch, purchase a virtual product leaving the country field empty. Check that the process is completed without any errors and that if you go to the order page in the admin, `default` is set as the name of the country in the billing address.
2. Switch to this branch, and try again purchasing a virtual product. See that this time if you leave the country field empty, you will get a validation error as expected.
3. Go to WooCommerce -> Settings and set "Default customer location" to "No location by default".
4. In a anonymous tab, add a product to cart and go to the checkout page. Check that the placeholder text "Select a country / region..." is displayed for the "Country / region" field.

### Changelog entry

> Fix issue where customer could checkout although mandatory field "Country" was not given
