### PR TITLE
Retry e2e tests automatically in case of failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,9 +35,9 @@ jobs:
      - npm install
      - composer install --no-dev
     script:
-      - npm run build:assets
-      - npm run docker:up
-      - npm run test:e2e
+      - travis_retry npm run build:assets
+      - travis_retry npm run docker:up
+      - travis_retry npm run test:e2e
     after_script:
       - npm run docker:down
   - name: "WP Nightly"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This commit adds again the Travis function `travis_retry` (https://docs.travis-ci.com/user/common-build-problems/#travis_retry) to all the commands used to execute the E2E tests as they sometimes fail due to factors outside our control and they pass if we retry them manually. See for example this issue for an instance where oftentimes the E2E tests fail, the issue describes a problem that happened in a local environment, but we see the same error happening on Travis as well: #27846. I actually just saw it and had to restart a Travis build job manually and that is what prompted me to create this commit. Having Travis retry the command automatically should save us some time when we review PRs as there is a chance the command will pass on a subsequent run and we won't have to retry it manually and wait for it to finish.

We have used this function in the past (see 67b5b27), but it got removed in 1658dd3. But after some conversation about it a couple of weeks ago, we decided to use it again.

### How to test the changes in this Pull Request:

1. Check that the Travis build passed.