### PR TITLE
Remove Composer 2.0.7 usage in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -73,10 +73,6 @@ cache:
   directories:
     - $HOME/.composer/cache
 
-# Composer 2.0.7 introduced a change that broke the jetpack autoloader in PHP 7.0 - 7.3.
-before_install:
-  - composer self-update 2.0.6
-
 install:
   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The jetpack autoloader problem was fixed in [Composer 2.0.8](https://getcomposer.org/changelog/2.0.8)

### How to test the changes in this Pull Request:

See ✔️ in CI.

