### PR TITLE
Added new tests for the merchant order refund flow

### DIFF
--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 - Merchant Order Status Filter tests
+- Merchant Order Refund tests
 
 ## Fixed
 

--- a/tests/e2e/core-tests/README.md
+++ b/tests/e2e/core-tests/README.md
@@ -53,6 +53,7 @@ The functions to access the core tests are:
 - `runProductSettingsTest` - Merchant can update product settings
 - `runTaxSettingsTest` - Merchant can update tax settings
 - `runOrderStatusFilterTest` - Merchant can filter orders by order status
+- `runOrderRefundTest` - Merchant can refund an order
 
 ### Shopper
 

--- a/tests/e2e/core-tests/specs/index.js
+++ b/tests/e2e/core-tests/specs/index.js
@@ -22,6 +22,7 @@ const runUpdateGeneralSettingsTest = require( './merchant/wp-admin-settings-gene
 const runProductSettingsTest = require( './merchant/wp-admin-settings-product.test' );
 const runTaxSettingsTest = require( './merchant/wp-admin-settings-tax.test' );
 const runOrderStatusFiltersTest = require( './merchant/wp-admin-order-status-filters.test' );
+const runOrderRefundTest = require( './merchant/wp-admin-order-refund.test' );
 
 const runSetupOnboardingTests = () => {
 	runActivationTest();
@@ -46,6 +47,7 @@ const runMerchantTests = () => {
 	runProductSettingsTest();
 	runTaxSettingsTest();
 	runOrderStatusFiltersTest();
+	runOrderRefundTest();
 }
 
 module.exports = {
@@ -67,5 +69,6 @@ module.exports = {
 	runProductSettingsTest,
 	runTaxSettingsTest,
 	runOrderStatusFiltersTest,
+	runOrderRefundTest,
 	runMerchantTests,
 };

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
@@ -1,0 +1,71 @@
+/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/no-standalone-expect */
+
+/**
+ * Internal dependencies
+ */
+const {
+	StoreOwnerFlow,
+	createSimpleProduct,
+	createSimpleOrder,
+	verifyCheckboxIsSet,
+	verifyValueOfInputField,
+	uiUnblocked,
+	addProductToOrder,
+} = require( '@woocommerce/e2e-utils' );
+
+const config = require( 'config' );
+const simpleProductName = config.get( 'products.simple.name' );
+
+let orderId;
+
+const runRefundOrderTest = () => {
+	describe('WooCommerce Orders > Refund an order', () => {
+		beforeAll(async () => {
+			await StoreOwnerFlow.login();
+
+			await createSimpleProduct();
+			orderId = await createSimpleOrder();
+			await addProductToOrder(orderId, simpleProductName);
+
+			// Update order status to `Completed` so we can issue a refund
+			await StoreOwnerFlow.updateOrderStatus(orderId, 'Completed');
+		});
+
+		it('can issue a refund by quantity', async () => {
+			// Click the Refund button
+			await expect(page).toClick('button.refund-items');
+
+			// Verify the refund section shows
+			await page.waitForSelector('div.wc-order-refund-items', { visible: true });
+			await verifyCheckboxIsSet('#restock_refunded_items');
+
+			// Initiate a refund
+			await expect(page).toFill('.refund_order_item_qty', '1');
+			await expect(page).toFill('#refund_reason', 'No longer wanted');
+
+			await Promise.all([
+				verifyValueOfInputField('.refund_line_total', '9.99'),
+				verifyValueOfInputField('#refund_amount', '9.99'),
+				expect(page).toMatchElement('.do-manual-refund', { text: 'Refund £9.99 manually' }),
+			]);
+
+			await expect(page).toClick('.do-manual-refund');
+
+			await uiUnblocked();
+
+			await Promise.all([
+				// Verify the product line item shows the refunded quantity and amount
+				expect(page).toMatchElement('.quantity .refunded', { text: '-1' }),
+				expect(page).toMatchElement('.line_cost .refunded', { text: '-£9.99' }),
+
+				// Verify the refund shows in the list with the amount
+				expect(page).toMatchElement('.refund .description', { text: 'No longer wanted' }),
+				expect(page).toMatchElement('.refund > .line_cost', { text: '-£9.99' }),
+			]);
+		});
+
+	});
+
+};
+
+module.exports = runRefundOrderTest;

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
@@ -72,6 +72,27 @@ const runRefundOrderTest = () => {
 			]);
 		});
 
+		it('can delete an issued refund', async () => {
+			// We need to use this here as `expect(page).toClick()` was unable to find the element
+			// See: https://github.com/puppeteer/puppeteer/issues/1769#issuecomment-637645219
+			page.$eval('a.delete_refund', elem => elem.click());
+
+			await uiUnblocked();
+
+			// Verify the refunded row item is no longer showing
+			await page.waitForSelector('tr.refund', { visible: false });
+
+			await Promise.all([
+				// Verify the product line item shows the refunded quantity and amount
+				expect(page).not.toMatchElement('.quantity .refunded', { text: '-1' }),
+				expect(page).not.toMatchElement('.line_cost .refunded', { text: `-${currencySymbol}9.99` }),
+
+				// Verify the refund shows in the list with the amount
+				expect(page).not.toMatchElement('.refund .description', { text: 'No longer wanted' }),
+				expect(page).not.toMatchElement('.refund > .line_cost', { text: `-${currencySymbol}9.99` }),
+			]);
+		});
+
 	});
 
 };

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
@@ -28,9 +28,9 @@ const runRefundOrderTest = () => {
 			await addProductToOrder(orderId, simpleProductName);
 
 			// Get the currency symbol for the store's selected currency
-			await page.waitForSelector('.woocommerce-Price-currencySymbol')
-			let currencyElement = await page.$('.woocommerce-Price-currencySymbol')
-			currencySymbol = await page.evaluate(el => el.textContent, currencyElement)
+			await page.waitForSelector('.woocommerce-Price-currencySymbol');
+			let currencyElement = await page.$('.woocommerce-Price-currencySymbol');
+			currencySymbol = await page.evaluate(el => el.textContent, currencyElement);
 
 			// Update order status to `Completed` so we can issue a refund
 			await StoreOwnerFlow.updateOrderStatus(orderId, 'Completed');

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
@@ -46,7 +46,7 @@ const runRefundOrderTest = () => {
 			await Promise.all([
 				verifyValueOfInputField('.refund_line_total', '9.99'),
 				verifyValueOfInputField('#refund_amount', '9.99'),
-				expect(page).toMatchElement('.do-manual-refund', { text: 'Refund £9.99 manually' }),
+				expect(page).toMatchElement('.do-manual-refund', { text: 'Refund $9.99 manually' }),
 			]);
 
 			await expect(page).toClick('.do-manual-refund');
@@ -56,11 +56,11 @@ const runRefundOrderTest = () => {
 			await Promise.all([
 				// Verify the product line item shows the refunded quantity and amount
 				expect(page).toMatchElement('.quantity .refunded', { text: '-1' }),
-				expect(page).toMatchElement('.line_cost .refunded', { text: '-£9.99' }),
+				expect(page).toMatchElement('.line_cost .refunded', { text: '-$9.99' }),
 
 				// Verify the refund shows in the list with the amount
 				expect(page).toMatchElement('.refund .description', { text: 'No longer wanted' }),
-				expect(page).toMatchElement('.refund > .line_cost', { text: '-£9.99' }),
+				expect(page).toMatchElement('.refund > .line_cost', { text: '-$9.99' }),
 			]);
 		});
 

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/no-standalone-expect */
+/* eslint-disable jest/no-export, jest/no-disabled-tests, */
 
 /**
  * Internal dependencies

--- a/tests/e2e/specs/wp-admin/test-order-refund.js
+++ b/tests/e2e/specs/wp-admin/test-order-refund.js
@@ -1,0 +1,6 @@
+/*
+ * Internal dependencies
+ */
+const { runOrderRefundTest } = require( '@woocommerce/e2e-core-tests' );
+
+runOrderRefundTest();

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -9,6 +9,11 @@
 - `clickFilter()` util helper method that clicks on a list page filter
 - `moveAllItemsToTrash()` util helper method that checks every item in a list page and moves them to the trash
 - `createSimpleOrder( status )` component which accepts an order status string and creates a basic order with that status
+- `addProductToOrder( orderId, productName )` component which adds the provided productName to the passed in orderId
+
+## Changes
+
+- `createSimpleOrder( status )` returns the ID of the order that was created
 
 # 0.1.1
 

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -38,20 +38,22 @@ describe( 'Cart page', () => {
 
 ### Merchant `StoreOwnerFlow`
 
-| Function | Description |
-|----------|-------------|
-| `login` | Log in as merchant |
-| `logout` | log out of merchant account |
-| `openAllOrdersView` | Go to the orders listing |
-| `openDashboard` | Go to the WordPress dashboard  |
-| `openNewCoupon` | Go to the new coupon editor |
-| `openNewOrder` | Go to the new order editor |
-| `openNewProduct` | Go to the new product editor |
-| `openPermalinkSettings` | Go to Settings -> Permalinks |
-| `openPlugins` | Go to the Plugins screen |
-| `openSettings` | Go to WooCommerce -> Settings |
-| `runSetupWizard` | Open the onboarding profiler |
-|----------|-------------|
+| Function | Parameters | Description |
+|----------|-------------|------------|
+| `login` | | Log in as merchant |
+| `logout` | | Log out of merchant account |
+| `openAllOrdersView` | | Go to the orders listing |
+| `openDashboard` | | Go to the WordPress dashboard  |
+| `openNewCoupon` | | Go to the new coupon editor |
+| `openNewOrder` | | Go to the new order editor |
+| `openNewProduct` | | Go to the new product editor |
+| `openPermalinkSettings` | | Go to Settings -> Permalinks |
+| `openPlugins` | | Go to the Plugins screen |
+| `openSettings` | | Go to WooCommerce -> Settings |
+| `runSetupWizard` | | Open the onboarding profiler |
+| `goToOrder` | `orderId` | Go to view a single order |
+| `updateOrderStatus` | `orderId, status` | Update the status of an order |
+|----------|-------------|-------------|
 
 ### Shopper `CustomerFlow`
 

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -368,7 +368,35 @@ const createSimpleOrder = async ( orderStatus = 'Pending payment' ) => {
 
 	// Verify
 	await expect( page ).toMatchElement( '#message', { text: 'Order updated.' } );
+
+	const variablePostId = await page.$( '#post_ID' );
+	let variablePostIdValue = ( await ( await variablePostId.getProperty( 'value' ) ).jsonValue() );
+	return variablePostIdValue;
 };
+
+/**
+ * Adds a product to an order in the StoreOwnerFlow.
+ *
+ * @param orderId ID of the order to add the product to.
+ * @param productName Name of the product being added to the order.
+ */
+const addProductToOrder = async ( orderId, productName ) => {
+	await StoreOwnerFlow.goToOrder( orderId );
+
+	// Add a product to the order
+	await expect( page ).toClick( 'button.add-line-item' );
+	await expect( page ).toClick( 'button.add-order-item' );
+	await page.waitForSelector( '.wc-backbone-modal-header' );
+	await expect( page ).toClick( '.wc-backbone-modal-content .wc-product-search' );
+	await expect( page ).toFill( '#wc-backbone-modal-dialog + .select2-container .select2-search__field', productName );
+	await expect( page ).toClick( 'li[aria-selected="true"]' );
+	await page.click( '.wc-backbone-modal-content #btn-ok' );
+
+	await uiUnblocked();
+
+	// Verify the product we added shows as a line item now
+	await expect( page ).toMatchElement( '.wc-order-item-name', { text: productName } );
+}
 
 export {
 	completeOnboardingWizard,
@@ -376,4 +404,5 @@ export {
 	createVariableProduct,
 	createSimpleOrder,
 	verifyAndPublish,
+	addProductToOrder,
 };

--- a/tests/e2e/utils/src/flows.js
+++ b/tests/e2e/utils/src/flows.js
@@ -25,6 +25,7 @@ const WP_ADMIN_NEW_ORDER = baseUrl + 'wp-admin/post-new.php?post_type=shop_order
 const WP_ADMIN_NEW_PRODUCT = baseUrl + 'wp-admin/post-new.php?post_type=product';
 const WP_ADMIN_WC_SETTINGS = baseUrl + 'wp-admin/admin.php?page=wc-settings&tab=';
 const WP_ADMIN_PERMALINK_SETTINGS = baseUrl + 'wp-admin/options-permalink.php';
+const WP_ADMIN_SINGLE_CPT_VIEW = ( postId ) => baseUrl + `wp-admin/post.php?post=${ postId }&action=edit`;
 
 const SHOP_PAGE = baseUrl + 'shop';
 const SHOP_PRODUCT_PAGE = baseUrl + '?p=';
@@ -310,6 +311,23 @@ const StoreOwnerFlow = {
 			waitUntil: 'networkidle0',
 		} );
 	},
+
+	goToOrder: async ( orderId ) => {
+		await page.goto( WP_ADMIN_SINGLE_CPT_VIEW( orderId ), {
+			waitUntil: 'networkidle0',
+		} );
+	},
+
+	updateOrderStatus: async ( orderId, status ) => {
+		await page.goto( WP_ADMIN_SINGLE_CPT_VIEW( orderId ), {
+			waitUntil: 'networkidle0',
+		} );
+		await expect( page ).toSelect( '#order_status', status );
+		await page.waitFor( 2000 );
+		await expect( page ).toClick( 'button.save_order' );
+		await page.waitForSelector( '#message' );
+		await expect( page ).toMatchElement( '#message', { text: 'Order updated.' } );
+	}
 };
 
 export { CustomerFlow, StoreOwnerFlow };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR adds a new suite of e2e tests covering the `Merchant / Orders / Refund Order` flow, testing refunding an order. The run time is around ~3-4s for the test.

This PR also updates the `createSimpleOrder()` helper to return the order (post) ID.

Additionally, the following helper methods were added:
- `goToOrder( orderId )`: go to view a single order
- `updateOrderStatus( orderId, status )`: updates the status of the provided order ID
- `addProductToOrder( orderId, productName )` component which adds the provided productName to the passed in orderId

Closes https://github.com/woocommerce/woocommerce/issues/28356.

### How to test the changes in this Pull Request:

1. Make sure the new e2e tests pass locally and on Travis. The tests can be ran following [these instructions](https://github.com/woocommerce/woocommerce/tree/master/tests/e2e#running-tests).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
N/A