### PR TITLE
Fix error tooltip misaligned on tax country field closes #28260

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -3169,6 +3169,12 @@ table.wc_input_table {
 	}
 }
 
+table.wc_tax_rates {
+	td.country {
+		position: relative;
+	}
+}
+
 table.wc_gateways,
 table.wc_emails,
 table.wc_shipping {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28260 

### How to test the changes in this Pull Request:

1. Go to WooCommerce->Settings->Tax->Standard rates table.
2. Add a rate with the country code that is more than 2 characters and ensure you see an error tooltip that is aligned under the country field.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Fix - Error tooltip misaligned on tax country field.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
