### PR TITLE
Add WC_Query chosen attributes filter

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -872,6 +872,7 @@ class WC_Query {
 					}
 				}
 			}
+			self::$chosen_attributes = apply_filters( 'woocommerce_layered_nav_chosen_attributes', self::$chosen_attributes );
 		}
 		return self::$chosen_attributes;
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add a possibility to filter chosen attributes (`woocommerce_layered_nav_chosen_attributes` filter hook) so filtering products by
custom taxonomies can be easier to accomplish.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### Changelog entry

Added `woocommerce_layered_nav_chosen_attributes` filter hook for chosen attributes of WC_Query so they can be easily modified now.
