### PR TITLE
Add shipping zones test

### DIFF
--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Added
 - Merchant Order Status Filter tests
+- Merchant Settings Add Shipping Zones
 
 ## Fixed
 

--- a/tests/e2e/core-tests/specs/index.js
+++ b/tests/e2e/core-tests/specs/index.js
@@ -47,6 +47,7 @@ const runMerchantTests = () => {
 	runProductSettingsTest();
 	runTaxSettingsTest();
 	runOrderStatusFiltersTest();
+	runAddNewShippingZoneTest();
 }
 
 module.exports = {

--- a/tests/e2e/core-tests/specs/index.js
+++ b/tests/e2e/core-tests/specs/index.js
@@ -22,6 +22,7 @@ const runUpdateGeneralSettingsTest = require( './merchant/wp-admin-settings-gene
 const runProductSettingsTest = require( './merchant/wp-admin-settings-product.test' );
 const runTaxSettingsTest = require( './merchant/wp-admin-settings-tax.test' );
 const runOrderStatusFiltersTest = require( './merchant/wp-admin-order-status-filters.test' );
+const runAddNewShippingZoneTest = require("./merchant/wp-admin-settings-shiping-add-new-shiping-zone.test");
 
 const runSetupOnboardingTests = () => {
 	runActivationTest();
@@ -68,4 +69,5 @@ module.exports = {
 	runTaxSettingsTest,
 	runOrderStatusFiltersTest,
 	runMerchantTests,
+	runAddNewShippingZoneTest
 };

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shiping-add-new-shiping-zone.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shiping-add-new-shiping-zone.test.js
@@ -1,0 +1,109 @@
+/* eslint-disable jest/no-export, jest/no-disabled-tests */
+/**
+ * Internal dependencies
+ */
+const {
+	StoreOwnerFlow,
+	verifyValueOfInputField
+} = require( '@woocommerce/e2e-utils' );
+
+/**
+ * External dependencies
+ */
+const {
+	it,
+	describe,
+	afterEach,
+} = require( '@jest/globals' );
+
+const runAddNewShippingZoneTest = () => {
+	describe('WooCommerce Shipping Settings - Add new shipping zone', () => {
+		const zone_name = `test zone name`
+
+		it('Add new shipping zone', async () => {
+
+			const zone_name_input_field = '#zone_name'
+			const zone_location_dropdown = '#zone_locations'
+			const zone_location = '     Belgrade, Serbia'
+			const shipping_method = 'Flat rate'
+
+			// Go to general settings page
+			await StoreOwnerFlow.openSettings('shipping');
+
+			// Make sure the shipping tab is active
+			await expect(page).toMatchElement('a.nav-tab-active', {text: 'Shipping'});
+
+			// Click on 'Add new shipping zone'
+			await expect(page).toClick('a.page-title-action', {text:'Add shipping zone'});
+
+			// Wait for form to be opened
+			await page.waitForSelector(zone_location_dropdown);
+
+			// Set zone name
+			await expect(page).toFill(zone_name_input_field, zone_name);
+
+			// Set zone regions
+			await expect(page).toSelect(zone_location_dropdown, zone_location);
+
+
+			debugger;
+			// Open shipping method pop up
+			await expect(page).toClick('button.button.wc-shipping-zone-add-method');
+
+			// Select shipping method
+			await expect(page).toSelect('#wc-backbone-modal-dialog select[name="add_method_id"]', shipping_method);
+
+			// Confirm shipping method
+			await expect(page).toClick('#btn-ok');
+
+			// Wait for form to be opened
+			await page.waitForSelector(zone_location_dropdown);
+
+			// Save settings
+			await expect(page).toClick( '#submit' );
+
+			// Verify that settings have been saved
+			await Promise.all([
+				verifyValueOfInputField(zone_name_input_field, zone_name),
+				expect(page).toMatchElement('li.select2-selection__choice', {text: 'Belgrade, Serbia'}),
+				expect(page).toMatchElement('a.wc-shipping-zone-method-settings', {text: shipping_method})
+
+			]);
+
+			// Navigate to Shipping zones table
+			await expect(page).toClick('h2 a', {text:'Shipping zones'});
+
+			// Wait for table to be opened
+			await page.waitForSelector('tbody.wc-shipping-zone-rows');
+
+			// Verify that settings have been saved
+			await Promise.all([
+				expect(page).toMatchElement('tbody.wc-shipping-zone-rows tr td.wc-shipping-zone-name', {text: zone_name}),
+				expect(page).toMatchElement('tbody.wc-shipping-zone-rows tr td.wc-shipping-zone-methods', {text: shipping_method}),
+				expect(page).toMatchElement('tbody.wc-shipping-zone-rows tr td.wc-shipping-zone-region', {text: 'Belgrade'}),
+
+			]);
+		});
+
+		afterEach(async () => {
+			// Deleting created shipping zone
+
+			// Go to general settings page
+			await StoreOwnerFlow.openSettings('shipping');
+
+			// Hover over shipping zone
+			page.hover('tbody.wc-shipping-zone-rows tr td.wc-shipping-zone-name', {text: zone_name});
+
+			// Wait until delete button is displayed
+			await page.waitForSelector('a.wc-shipping-zone-delete',{visible:true});
+
+			// Click on delete
+			page.click('a.wc-shipping-zone-delete');
+
+			// Wait for conformation dialog to be closed
+			await page.waitForSelector('tbody.wc-shipping-zone-rows tr td.wc-shipping-zone-name');
+		});
+	});
+};
+
+module.exports = runAddNewShippingZoneTest;

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shiping-add-new-shiping-zone.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shiping-add-new-shiping-zone.test.js
@@ -15,17 +15,19 @@ const {
 	describe,
 	afterEach,
 } = require( '@jest/globals' );
+const config = require( 'config' );
 
 const runAddNewShippingZoneTest = () => {
 	describe('WooCommerce Shipping Settings - Add new shipping zone', () => {
-		const zone_name = `test zone name`
+		const zone_name = config.get( 'settings.shipping.zonename');
 
 		it('Add new shipping zone', async () => {
 
-			const zone_name_input_field = '#zone_name'
-			const zone_location_dropdown = '#zone_locations'
-			const zone_location = '     Belgrade, Serbia'
-			const shipping_method = 'Flat rate'
+			const zone_name_input_field = '#zone_name';
+			const zone_location_dropdown = '#zone_locations';
+			const zone_location = config.get( 'settings.shipping.zoneregions');
+			//
+			const shipping_method = config.get( 'settings.shipping.shippingmethod');
 
 			// Go to general settings page
 			await StoreOwnerFlow.openSettings('shipping');
@@ -43,10 +45,8 @@ const runAddNewShippingZoneTest = () => {
 			await expect(page).toFill(zone_name_input_field, zone_name);
 
 			// Set zone regions
-			await expect(page).toSelect(zone_location_dropdown, zone_location);
+			await expect(page).toSelect(zone_location_dropdown, "   " + zone_location);
 
-
-			debugger;
 			// Open shipping method pop up
 			await expect(page).toClick('button.button.wc-shipping-zone-add-method');
 
@@ -65,7 +65,7 @@ const runAddNewShippingZoneTest = () => {
 			// Verify that settings have been saved
 			await Promise.all([
 				verifyValueOfInputField(zone_name_input_field, zone_name),
-				expect(page).toMatchElement('li.select2-selection__choice', {text: 'Belgrade, Serbia'}),
+				expect(page).toMatchElement('li.select2-selection__choice', {text: zone_name}),
 				expect(page).toMatchElement('a.wc-shipping-zone-method-settings', {text: shipping_method})
 
 			]);
@@ -80,8 +80,7 @@ const runAddNewShippingZoneTest = () => {
 			await Promise.all([
 				expect(page).toMatchElement('tbody.wc-shipping-zone-rows tr td.wc-shipping-zone-name', {text: zone_name}),
 				expect(page).toMatchElement('tbody.wc-shipping-zone-rows tr td.wc-shipping-zone-methods', {text: shipping_method}),
-				expect(page).toMatchElement('tbody.wc-shipping-zone-rows tr td.wc-shipping-zone-region', {text: 'Belgrade'}),
-
+				expect(page).toMatchElement('tbody.wc-shipping-zone-rows tr td.wc-shipping-zone-region', {text: zone_location}),
 			]);
 		});
 
@@ -91,8 +90,8 @@ const runAddNewShippingZoneTest = () => {
 			// Go to general settings page
 			await StoreOwnerFlow.openSettings('shipping');
 
-			// Hover over shipping zone
-			page.hover('tbody.wc-shipping-zone-rows tr td.wc-shipping-zone-name', {text: zone_name});
+			// Click on sort button so delete button is displayed
+			page.click('tbody.wc-shipping-zone-rows tr td.wc-shipping-zone-sort');
 
 			// Wait until delete button is displayed
 			await page.waitForSelector('a.wc-shipping-zone-delete',{visible:true});

--- a/tests/e2e/specs/wp-admin/test-add-new-shipping-zone.js
+++ b/tests/e2e/specs/wp-admin/test-add-new-shipping-zone.js
@@ -1,0 +1,6 @@
+/*
+ * Internal dependencies
+ */
+const { runAddNewShippingZoneTest } = require( '@woocommerce/e2e-core-tests' );
+
+runAddNewShippingZoneTest();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Adding new core-test for Merchant Settings Add Shipping Zones

Closes #28490 .

### How to test the changes in this Pull Request:

1. Run test - npm run test:e2e-dev ./tests/e2e/specs/wp-admin/test-add-new-shipping-zone.js;  


### Other information:

* The test behaves differently in the headless mode due to puppeteer bug - https://github.com/puppeteer/puppeteer/issues/5255
https://forum.katalon.com/t/chrome-headless-mouseover-fail/36832
* If there isn't some API to clean up I will find a workaround for this issue.
Workaround added.

### Changelog entry
## Added
- Merchant Settings Add Shipping Zones

Adding new test - Merchant / Settings / Add Shipping Zones  #28490
