### PR TITLE
add 12 hour delay to pulling new docker tags

### DIFF
--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Added
+
+- Insert a 12 hour delay in using new docker image tags
+
 ## Fixed
 
 - Remove redundant `puppeteer` dependency

--- a/tests/e2e/env/bin/get-latest-docker-tag.js
+++ b/tests/e2e/env/bin/get-latest-docker-tag.js
@@ -36,12 +36,22 @@ async function fetchLatestTagFromPage( image, nameSearch, page ) {
 					if ( ! data.count ) {
 						reject( "No image '" + image + '" found' );
 					} else {
+						// Implement a 12 hour delay on pulling newly released docker tags.
+						const delayMilliseconds = 12 * 3600 * 1000;
+						const currentTime = Date.now();
 						let latestTag = null;
+						let lastUpdated = null;
 						for ( let tag of data.results ) {
 							tag.semver = tag.name.match( /^\d+\.\d+(.\d+)*$/ );
 							if ( ! tag.semver ) {
 								continue;
 							}
+
+							lastUpdated = Date.parse( tag.last_updated );
+							if ( currentTime - lastUpdated < delayMilliseconds ) {
+								continue;
+							}
+
 							tag.semver = semver.coerce( tag.semver[0] );
 							if ( ! latestTag || semver.gt( tag.semver, latestTag.semver ) ) {
 								latestTag = tag;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR inserts a 12 hour delay in using a newly published Docker image tag to allow for the image to be available for download after being pushed to `hub.docker.com`.

Closes #27846  .

### How to test the changes in this Pull Request:

1. Run `npm docker:up` then `npm docker:down`
2. The test environment should have configured WP 5.6.0  
3. Edit `tests/e2e/env/bin/get-latest-docker-tag.js`
4. Change the `const delayMilliseconds = 12 * 3600 * 1000;` line added in this PR where `12` is changed to a number of hours greater than time of review and Dec 10, 2020. (At time of creating the PR, `120` is enough.)
5. Run `npm docker:up` then `npm docker:down`
6. The test environment should have configured WP 5.5.3

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A