### PR TITLE
Add e2e test for merchant orders > apply coupon

### DIFF
--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 - Merchant Order Status Filter tests
 - Merchant Order Refund tests
+- Merchant Apply Coupon tests
 
 ## Fixed
 

--- a/tests/e2e/core-tests/README.md
+++ b/tests/e2e/core-tests/README.md
@@ -54,6 +54,7 @@ The functions to access the core tests are:
 - `runTaxSettingsTest` - Merchant can update tax settings
 - `runOrderStatusFilterTest` - Merchant can filter orders by order status
 - `runOrderRefundTest` - Merchant can refund an order
+- `runOrderApplyCouponTest` - Merchant can apply a coupon to an order
 
 ### Shopper
 

--- a/tests/e2e/core-tests/specs/index.js
+++ b/tests/e2e/core-tests/specs/index.js
@@ -23,6 +23,7 @@ const runProductSettingsTest = require( './merchant/wp-admin-settings-product.te
 const runTaxSettingsTest = require( './merchant/wp-admin-settings-tax.test' );
 const runOrderStatusFiltersTest = require( './merchant/wp-admin-order-status-filters.test' );
 const runOrderRefundTest = require( './merchant/wp-admin-order-refund.test' );
+const runOrderApplyCouponTest = require( './merchant/wp-admin-order-apply-coupon.test' );
 
 const runSetupOnboardingTests = () => {
 	runActivationTest();
@@ -48,6 +49,7 @@ const runMerchantTests = () => {
 	runTaxSettingsTest();
 	runOrderStatusFiltersTest();
 	runOrderRefundTest();
+	runOrderApplyCouponTest();
 }
 
 module.exports = {
@@ -70,5 +72,6 @@ module.exports = {
 	runTaxSettingsTest,
 	runOrderStatusFiltersTest,
 	runOrderRefundTest,
+	runOrderApplyCouponTest,
 	runMerchantTests,
 };

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests */
+/* eslint-disable jest/no-export */
 
 /**
  * Internal dependencies

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
@@ -1,0 +1,84 @@
+/* eslint-disable jest/no-export, jest/no-disabled-tests */
+
+/**
+ * Internal dependencies
+ */
+const {
+	StoreOwnerFlow,
+	createSimpleProduct,
+	createSimpleOrder,
+	createCoupon,
+	uiUnblocked,
+	addProductToOrder,
+} = require( '@woocommerce/e2e-utils' );
+
+const config = require( 'config' );
+const simpleProductName = config.get( 'products.simple.name' );
+
+const couponDialogMessage = 'Enter a coupon code to apply. Discounts are applied to line totals, before taxes.';
+
+let couponCode;
+let orderId;
+
+const runOrderApplyCouponTest = () => {
+	describe('WooCommerce Orders > Apply coupon', () => {
+		beforeAll(async () => {
+			await StoreOwnerFlow.login();
+			await Promise.all([
+				await createSimpleProduct(),
+				couponCode = await createCoupon(),
+				orderId = await createSimpleOrder('Pending payment', simpleProductName),
+				await addProductToOrder(orderId, simpleProductName),
+
+				// We need to remove any listeners on the `dialog` event otherwise we can't catch the dialog below
+				page.removeAllListeners('dialog'),
+			]);
+		} );
+
+		it('can apply a coupon', async () => {
+			const couponDialog = await expect(page).toDisplayDialog(async () => {
+				await expect(page).toClick('button.add-coupon');
+			});
+
+			expect(couponDialog.message()).toMatch(couponDialogMessage);
+
+			// Accept the dialog with the coupon code
+			await couponDialog.accept(couponCode);
+
+			await uiUnblocked();
+
+			// Verify the coupon list is showing
+			await page.waitForSelector('.wc-used-coupons');
+			await expect(page).toMatchElement('.wc_coupon_list', { text: 'Coupon(s)' });
+			await expect(page).toMatchElement('.wc_coupon_list li.code.editable', { text: couponCode });
+
+			// Check that the coupon has been applied
+			await expect(page).toMatchElement('.wc-order-item-discount', { text: '5.00' });
+			await expect(page).toMatchElement('.line_cost > .view > .woocommerce-Price-amount', { text: '4.99' });
+		});
+
+		it('can remove a coupon', async () => {
+			// Make sure we have a coupon on the page to use
+			await page.waitForSelector('.wc-used-coupons');
+			await expect(page).toMatchElement('.wc_coupon_list li.code.editable', { text: couponCode });
+
+			// We need to use this here as `expect(page).toClick()` was unable to find the element
+			// See: https://github.com/puppeteer/puppeteer/issues/1769#issuecomment-637645219
+			page.$eval('a.remove-coupon', elem => elem.click());
+
+			await uiUnblocked();
+
+			// Verify the coupon pricing has been removed
+			await expect(page).not.toMatchElement('.wc_coupon_list li.code.editable', { text: couponCode });
+			await expect(page).not.toMatchElement('.wc-order-item-discount', { text: '5.00' });
+			await expect(page).not.toMatchElement('.line-cost .view .woocommerce-Price-amount', { text: '4.99' });
+
+			// Verify the original price is the order total
+			await expect(page).toMatchElement('.line_cost > .view > .woocommerce-Price-amount', { text: '9.99' });
+		});
+
+	});
+
+};
+
+module.exports = runOrderApplyCouponTest;

--- a/tests/e2e/specs/wp-admin/test-order-apply-coupon.js
+++ b/tests/e2e/specs/wp-admin/test-order-apply-coupon.js
@@ -1,0 +1,6 @@
+/*
+ * Internal dependencies
+ */
+const { runOrderApplyCouponTest } = require( '@woocommerce/e2e-core-tests' );
+
+runOrderApplyCouponTest();

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `moveAllItemsToTrash()` util helper method that checks every item in a list page and moves them to the trash
 - `createSimpleOrder( status )` component which accepts an order status string and creates a basic order with that status
 - `addProductToOrder( orderId, productName )` component which adds the provided productName to the passed in orderId
-- `createCoupon( couponAmount )` component which accepts a cooupon amount string (it defaults to 5) and creates a basic coupon. Returns the generated coupon code.
+- `createCoupon( couponAmount )` component which accepts a coupon amount string (it defaults to 5) and creates a basic coupon. Returns the generated coupon code.
 
 ## Changes
 

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `moveAllItemsToTrash()` util helper method that checks every item in a list page and moves them to the trash
 - `createSimpleOrder( status )` component which accepts an order status string and creates a basic order with that status
 - `addProductToOrder( orderId, productName )` component which adds the provided productName to the passed in orderId
+- `createCoupon( couponAmount )` component which accepts a cooupon amount string (it defaults to 5) and creates a basic coupon. Returns the generated coupon code.
 
 ## Changes
 

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -398,6 +398,33 @@ const addProductToOrder = async ( orderId, productName ) => {
 	await expect( page ).toMatchElement( '.wc-order-item-name', { text: productName } );
 }
 
+/**
+ * Creates a basic coupon with the provided coupon amount. Returns the coupon code.
+ *
+ * @param couponAmount Amount to be applied. Defaults to 5.
+ */
+const createCoupon = async ( couponAmount = '5' ) => {
+	await StoreOwnerFlow.openNewCoupon();
+
+	// Fill in coupon code
+	let couponCode = 'code-' + new Date().getTime().toString();
+	await expect(page).toFill( '#title', couponCode );
+
+	// Set general coupon data
+	await clickTab( 'General' );
+	await expect(page).toSelect( '#discount_type', 'Fixed cart discount' );
+	await expect(page).toFill( '#coupon_amount', couponAmount );
+
+	// Publish coupon
+	await expect( page ).toClick( '#publish' );
+	await page.waitForSelector( '.updated.notice' );
+
+	// Verify
+	await expect( page ).toMatchElement( '.updated.notice', { text: 'Coupon updated.' } );
+
+	return couponCode;
+};
+
 export {
 	completeOnboardingWizard,
 	createSimpleProduct,
@@ -405,4 +432,5 @@ export {
 	createSimpleOrder,
 	verifyAndPublish,
 	addProductToOrder,
+	createCoupon,
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a new suite of e2e tests covering the `Merchant / Orders / Apply Coupon` flow, testing applying a coupon to an order. The run time is around less than a second for the test:

![Screen Shot 2020-12-15 at 8 11 30 PM](https://user-images.githubusercontent.com/71906536/102300507-500e2e80-3f12-11eb-9584-c69dce222317.png)

Additionally, the following helper methods was added:
- `createCoupon( couponAmount )`: creates a basic coupon with the provided coupon amount (defaults to 5). Returns the generated coupon code.

Closes https://github.com/woocommerce/woocommerce/issues/28359.

### How to test the changes in this Pull Request:

1. Make sure the new e2e tests pass locally and on Travis. The tests can be ran following [these instructions](https://github.com/woocommerce/woocommerce/tree/master/tests/e2e#running-tests).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

N/A