### PR TITLE
Also include empty string and comment types for backward compat.

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -357,7 +357,7 @@ class WC_Comments {
 			WHERE comment_parent = 0
 			AND comment_post_ID = %d
 			AND comment_approved = '1'
-			AND comment_type = 'review'
+			AND comment_type in ( 'review', '', 'comment' )
 				",
 				$product->get_id()
 			)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In #26928, we added `WHERE` clause to only count the reviews which have `review` comment type. However, we also display comments with empty string or `comment` in type column. This means that those reviews are displayed but are not counted.

This PR fixes the issue by also counting reviews with empty string or `comment` in the comment type column (since we also display them). 

This fixes the root cause for #27688, but to close the issue we would need a migration that will correct the review count for existing products.

### How to test the changes in this Pull Request:

1. Add a new review comment for a product via admin.
2. With this PR, you will see the count updated in frontend view, without this PR the new comment will not be counted.

Note that the counter for review comment is cached in meta value for `product`, so already existing reviews will still not be counted unless the postmeta with meta key `_wc_rating_count` for the product is deleted or a new review is added.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Also count comment types with '' and 'comment' in the review count query.