### PR TITLE
Tracks: Add woo version as global track prop.

### DIFF
--- a/includes/tracks/class-wc-tracks.php
+++ b/includes/tracks/class-wc-tracks.php
@@ -39,6 +39,7 @@ class WC_Tracks {
 				'blog_lang'      => get_user_locale( $user_id ),
 				'blog_id'        => class_exists( 'Jetpack_Options' ) ? Jetpack_Options::get_option( 'id' ) : null,
 				'products_count' => self::get_products_count(),
+				'wc_version'     => WC()->version,
 			);
 			set_transient( 'wc_tracks_blog_details', $blog_details, DAY_IN_SECONDS );
 		}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Context: pbIJXs-vP-p2

TL;DR; In order to have a more effective way to measure impact of new features, we would like to add the WC Version as a global prop on all track events. This branch implements that. If possibly this would be super cool to get in 4.9, but not the end of the world if it doesn't make it.

### Changelog entry

Tweak: Add Woo Version as global prop in track events
