### PR TITLE
Add e2e tests for merchant edit order flows

### DIFF
--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -5,7 +5,6 @@
 ## Added
 
 - Registered Shopper Checkout tests
-- Merchant Edit Order tests
 - Merchant Order Status Filter tests
 - Merchant Order Refund tests
 - Merchant Apply Coupon tests

--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Added
 
 - Registered Shopper Checkout tests
+- Merchant Edit Order tests
 - Merchant Order Status Filter tests
 - Merchant Order Refund tests
 - Merchant Apply Coupon tests

--- a/tests/e2e/core-tests/specs/index.js
+++ b/tests/e2e/core-tests/specs/index.js
@@ -20,6 +20,7 @@ const runVariableProductUpdateTest = require( './shopper/front-end-variable-prod
 // Merchant tests
 const runCreateCouponTest = require( './merchant/wp-admin-coupon-new.test' );
 const runCreateOrderTest = require( './merchant/wp-admin-order-new.test' );
+const runEditOrderTest = require( './merchant/wp-admin-order-edit.test' );
 const { runAddSimpleProductTest, runAddVariableProductTest } = require( './merchant/wp-admin-product-new.test' );
 const runUpdateGeneralSettingsTest = require( './merchant/wp-admin-settings-general.test' );
 const runProductSettingsTest = require( './merchant/wp-admin-settings-product.test' );
@@ -51,6 +52,7 @@ const runShopperTests = () => {
 const runMerchantTests = () => {
 	runCreateCouponTest();
 	runCreateOrderTest();
+	runEditOrderTest();
 	runAddSimpleProductTest();
 	runAddVariableProductTest();
 	runUpdateGeneralSettingsTest();
@@ -80,6 +82,7 @@ module.exports = {
 	runShopperTests,
 	runCreateCouponTest,
 	runCreateOrderTest,
+	runEditOrderTest,
 	runAddSimpleProductTest,
 	runAddVariableProductTest,
 	runUpdateGeneralSettingsTest,

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-edit.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-edit.test.js
@@ -3,7 +3,7 @@
  * Internal dependencies
  */
 const {
-	StoreOwnerFlow,
+	merchant,
 	createSimpleOrder,
 	moveAllItemsToTrash
 } = require( '@woocommerce/e2e-utils' );
@@ -13,25 +13,25 @@ let orderId;
 const runEditOrderTest = () => {
 	describe('WooCommerce Orders > Edit order', () => {
 		beforeAll(async () => {
-			await StoreOwnerFlow.login();
+			await merchant.login();
 			orderId = await createSimpleOrder('Processing');
 		});
 
 		afterAll( async () => {
 			// Make sure we're on the all orders view and cleanup the orders we created
-			await StoreOwnerFlow.openAllOrdersView();
+			await merchant.openAllOrdersView();
 			await moveAllItemsToTrash();
 		});
 		
 		it('can view single order', async () => {
 			// Go to "orders" page
-			await StoreOwnerFlow.openAllOrdersView();
+			await merchant.openAllOrdersView();
 
 			// Make sure we're on the orders page
 			await expect(page.title()).resolves.toMatch('Orders');
 
 			//Open order we created
-			await StoreOwnerFlow.goToOrder(orderId);
+			await merchant.goToOrder(orderId);
 
 			// Make sure we're on the order details page
 			await expect(page.title()).resolves.toMatch('Edit order');
@@ -39,13 +39,13 @@ const runEditOrderTest = () => {
         
         it('can update order status', async () => {
 			//Open order we created
-			await StoreOwnerFlow.goToOrder(orderId);
+			await merchant.goToOrder(orderId);
 
 			// Make sure we're still on the order details page
 			await expect(page.title()).resolves.toMatch('Edit order');
 
 			// Update order status to `Completed` 
-			await StoreOwnerFlow.updateOrderStatus(orderId, 'Completed');
+			await merchant.updateOrderStatus(orderId, 'Completed');
 
 			// Verify order status changed note added
 			await expect( page ).toMatchElement( '#select2-order_status-container', { text: 'Completed' } );
@@ -59,7 +59,7 @@ const runEditOrderTest = () => {
         
         it('can update order details', async () => {
 			//Open order we created
-			await StoreOwnerFlow.goToOrder(orderId);
+			await merchant.goToOrder(orderId);
 
 			// Make sure we're still on the order details page
 			await expect(page.title()).resolves.toMatch('Edit order');

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-edit.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-edit.test.js
@@ -67,15 +67,17 @@ const runEditOrderTest = () => {
 			// Update order details
 			await expect(page).toFill('input[name=order_date]', '2018-12-14');
 
-				// Wait for auto save
+			// Wait for auto save
 			await page.waitFor( 2000 );
 
-			// Create the order
+			// Save the order changes
 			await expect( page ).toClick( 'button.save_order' );
 			await page.waitForSelector( '#message' );
 
 			// Verify
 			await expect( page ).toMatchElement( '#message', { text: 'Order updated.' } );
+			await expect( page ).toMatchElement( 'input[name=order_date]', { value: '2018-12-14' } );
+
 		});
 	});
 }

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-new.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-new.test.js
@@ -8,7 +8,7 @@ const {
 } = require( '@woocommerce/e2e-utils' );
 
 const runCreateOrderTest = () => {
-	describe('Add New Order Page', () => {
+	describe('WooCommerce Orders > Add new order', () => {
 		beforeAll(async () => {
 			await merchant.login();
 		});

--- a/tests/e2e/specs/wp-admin/test-edit-order.js
+++ b/tests/e2e/specs/wp-admin/test-edit-order.js
@@ -1,0 +1,6 @@
+/*
+ * Internal dependencies
+ */
+const { runEditOrderTest } = require( '@woocommerce/e2e-core-tests' );
+
+runEditOrderTest();


### PR DESCRIPTION
Replaces https://github.com/woocommerce/woocommerce/pull/28348

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This adds new e2e tests that cover the following Merchant / Orders flows.
View single order
Update order status
Update order details


Closes https://github.com/woocommerce/woocommerce/issues/27877 .

### How to test the changes in this Pull Request:

1. Make sure e2e tests pass locally and on Travis. Run tests as per [our docs](https://github.com/woocommerce/woocommerce/tree/master/tests/e2e#running-tests). 


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A