### PR TITLE
Add mini cart item filter woocommerce_mini_cart_items

### DIFF
--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -27,7 +27,9 @@ do_action( 'woocommerce_before_mini_cart' ); ?>
 		<?php
 		do_action( 'woocommerce_before_mini_cart_contents' );
 
-		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+		$cart_items = apply_filters( 'woocommerce_mini_cart_items', WC()->cart->get_cart() );
+
+		foreach ( $cart_items as $cart_item_key => $cart_item ) {
 			$_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
 			$product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add `woocommerce_mini_cart_items` filter for mini cart items to enable filtering the mini cart items before they're iterated and displayed in the mini cart.

### How to test the changes in this Pull Request:

Example of reversing mini cart items:

```php
function filter_woocommerce_mini_cart_items( $mini_cart_items ) {
  return array_reverse( $mini_cart_items );
}
apply_filter( 'woocommerce_mini_cart_items', 'filter_woocommerce_mini_cart_items', 10, 1 );
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Add `woocommerce_mini_cart_items` filter for mini cart items to enable filtering the mini cart items before they're iterated and displayed in the mini cart.
