### PR TITLE
use xpath to find onboarding set up shipping task

### DIFF
--- a/tests/e2e/core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
+++ b/tests/e2e/core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
@@ -35,9 +35,10 @@ const runTaskListTest = () => {
 			const taskListItems = await page.$$('.woocommerce-list__item-title');
 			expect(taskListItems).toHaveLength(6);
 
+			const [ setupTaskListItem ] = await page.$x( '//div[contains(text(),"Set up shipping")]' );
 			await Promise.all([
 				// Click on "Set up shipping" task to move to the next step
-				taskListItems[3].click(),
+				setupTaskListItem.click(),
 
 				// Wait for shipping setup section to load
 				page.waitForNavigation({waitUntil: 'networkidle0'}),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the E2E core onboarding task list shipping setup test to use `xpath` to find the `Set up shipping` task item in the task list. The current test clicks using an index on the list. This test has required updates whenever the task list was reordered (as is the case now).

### How to test the changes in this Pull Request:

1. Verify that the `customer can set shipping address` test passes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

N/A
