### PR TITLE
Add protection around `func_get_arg` method for backward compatibility.

### DIFF
--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -384,7 +384,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	public function prepare_object_for_response( $object, $request ) {
 		$this->request       = $request;
 		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : absint( $this->request['dp'] );
-		$request['context']  = isset( $request['context'] ) ? $request['context'] : 'view';
+		$request['context']  = ! empty( $request['context'] ) ? $request['context'] : 'view';
 		$data                = $this->get_formatted_item_data( $object );
 		$data                = $this->add_additional_fields_to_object( $data, $request );
 		$data                = $this->filter_response_by_context( $data, $request['context'] );

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -263,14 +263,11 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 		$format_line_items = array( 'line_items', 'tax_lines', 'shipping_lines', 'fee_lines', 'coupon_lines' );
 
 		// Only fetch fields that we need.
-		$request = func_get_arg( 1 );
-		if ( $request ) {
-			$fields            = $this->get_fields_for_response( $request );
-			$extra_fields      = array_intersect( $extra_fields, $fields );
-			$format_decimal    = array_intersect( $format_decimal, $fields );
-			$format_date       = array_intersect( $format_date, $fields );
-			$format_line_items = array_intersect( $format_line_items, $fields );
-		}
+		$fields            = $this->get_fields_for_response( $this->request );
+		$extra_fields      = array_intersect( $extra_fields, $fields );
+		$format_decimal    = array_intersect( $format_decimal, $fields );
+		$format_date       = array_intersect( $format_date, $fields );
+		$format_line_items = array_intersect( $format_line_items, $fields );
 
 		$data = $order->get_base_data();
 
@@ -281,7 +278,7 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 					$data['meta_data'] = $order->get_meta_data();
 					break;
 				case 'line_items':
-					$data['line_items'] = $order->get_items( 'line_item');
+					$data['line_items'] = $order->get_items( 'line_item' );
 					break;
 				case 'tax_lines':
 					$data['tax_lines'] = $order->get_items( 'tax' );
@@ -387,10 +384,10 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 	public function prepare_object_for_response( $object, $request ) {
 		$this->request       = $request;
 		$this->request['dp'] = is_null( $this->request['dp'] ) ? wc_get_price_decimals() : absint( $this->request['dp'] );
-		$data                = $this->get_formatted_item_data( $object, $request );
-		$context             = ! empty( $request['context'] ) ? $request['context'] : 'view';
+		$request['context']  = isset( $request['context'] ) ? $request['context'] : 'view';
+		$data                = $this->get_formatted_item_data( $object );
 		$data                = $this->add_additional_fields_to_object( $data, $request );
-		$data                = $this->filter_response_by_context( $data, $context );
+		$data                = $this->filter_response_by_context( $data, $request['context'] );
 		$response            = rest_ensure_response( $data );
 		$response->add_links( $this->prepare_links( $object, $request ) );
 

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -591,6 +591,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 
 	/**
 	 * Fetch price HTML.
+	 *
 	 * @param WC_Product $product Product object.
 	 * @param string     $context Context of request, can be `view` or `edit`.
 	 *
@@ -602,6 +603,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 
 	/**
 	 * Fetch related IDs.
+	 *
 	 * @param WC_Product $product Product object.
 	 * @param string     $context Context of request, can be `view` or `edit`.
 	 *
@@ -613,6 +615,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 
 	/**
 	 * Fetch meta data.
+	 *
 	 * @param WC_Product $product Product object.
 	 * @param string     $context Context of request, can be `view` or `edit`.
 	 *
@@ -625,14 +628,17 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	/**
 	 * Get product data.
 	 *
-	 * @param WC_Product      $product Product instance.
-	 * @param string          $context Request context. Options: 'view' and 'edit'.
+	 * @param WC_Product $product Product instance.
+	 * @param string     $context Request context. Options: 'view' and 'edit'.
 	 *
 	 * @return array
 	 */
 	protected function get_product_data( $product, $context = 'view' ) {
-		/* @param WP_REST_Request $request Current request object. For backward compatibility, we pass this argument silently. */
-		// TODO: Refactor to fix this behavior when DI gets included to make it obvious and clean.
+		/*
+		 * @param WP_REST_Request $request Current request object. For backward compatibility, we pass this argument silently.
+		 *
+		 *  TODO: Refactor to fix this behavior when DI gets included to make it obvious and clean.
+		*/
 		$request = func_num_args() >= 2 ? func_get_arg( 2 ) : new WP_REST_Request( '', '', array( 'context' => $context ) );
 		$fields  = $this->get_fields_for_response( $request );
 
@@ -846,7 +852,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	 * @param WC_Data         $object  Object data.
 	 * @param WP_REST_Request $request Request object.
 	 *
-	 * @return array                   Links for the given post.
+	 * @return array Links for the given post.
 	 */
 	protected function prepare_links( $object, $request ) {
 		$links = array(

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -627,16 +627,15 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 	 *
 	 * @param WC_Product      $product Product instance.
 	 * @param string          $context Request context. Options: 'view' and 'edit'.
-	 * @param WP_REST_Request $request Current request object. For backward compatibility, we pass this argument silently.
 	 *
 	 * @return array
 	 */
 	protected function get_product_data( $product, $context = 'view' ) {
-		$fields = array();
-		$request = func_get_arg( 2 );
-		if ( $request instanceof WP_REST_Request ) {
-			$fields = $this->get_fields_for_response( $request );
-		}
+		/* @param WP_REST_Request $request Current request object. For backward compatibility, we pass this argument silently. */
+		// TODO: Refactor to fix this behavior when DI gets included to make it obvious and clean.
+		$request = func_num_args() >= 2 ? func_get_arg( 2 ) : new WP_REST_Request( '', '', array( 'context' => $context ) );
+		$fields  = $this->get_fields_for_response( $request );
+
 		$base_data = array();
 		foreach ( $fields as $field ) {
 			switch ( $field ) {
@@ -649,7 +648,6 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 				case 'slug':
 					$base_data['slug'] = $product->get_slug( $context );
 					break;
-
 				case 'permalink':
 					$base_data['permalink'] = $product->get_permalink();
 					break;

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -1343,24 +1343,19 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	 * Get product data.
 	 *
 	 * @param WC_Product $product Product instance.
-	 * @param string     $context Request context.
-	 *                            Options: 'view' and 'edit'.
-	 * @param array      $fields  List of fields to fetch. If empty, then all fields will be returned.
-	 *                            For backward compatibility, we pass this argument silently.
+	 * @param string     $context Request context. Options: 'view' and 'edit'.
+	 *
 	 * @return array
 	 */
 	protected function get_product_data( $product, $context = 'view' ) {
-		$request = func_get_arg( 2 );
-		$data = parent::get_product_data( $product, $context, $request );
-
+		$data = parent::get_product_data( ...func_get_args() );
 		// Replace in_stock with stock_status.
-		$pos             = array_search( 'in_stock', array_keys( $data ), true );
+		$pos = array_search( 'in_stock', array_keys( $data ), true );
 		if ( false !== $pos ) {
 			$array_section_1 = array_slice( $data, 0, $pos, true );
 			$array_section_2 = array_slice( $data, $pos + 1, null, true );
-			$data =  $array_section_1 + array( 'stock_status' => $product->get_stock_status( $context ) ) + $array_section_2;
+			$data = $array_section_1 + array( 'stock_status' => $product->get_stock_status( $context ) ) + $array_section_2;
 		}
-
 		return $data;
 	}
 }

--- a/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
+++ b/tests/php/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller-test.php
@@ -1,0 +1,19 @@
+<?php
+
+/**
+ * class WC_REST_Order_V2_Controller_Test.
+ * Orders controller test.
+ */
+class WC_REST_Order_V2_Controller_Test extends WC_REST_Unit_Test_case {
+
+	/**
+	 * Test that `prepare_object_for_response` method works.
+	 */
+	public function test_prepare_object_for_response() {
+		$order = WC_Helper_Order::create_order();
+		$order->save();
+		$response = ( new WC_REST_Orders_V2_Controller() )->prepare_object_for_response( $order, new WP_REST_Request() );
+		$this->assertArrayHasKey( 'id', $response->data );
+		$this->assertEquals( $order->get_id(), $response->data['id'] );
+	}
+}

--- a/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-producs-controller-tests.php
+++ b/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-producs-controller-tests.php
@@ -1,0 +1,24 @@
+<?php
+
+/**
+ * class WC_REST_Products_Controller_Tests.
+ * Product Controller tests for V3 REST API.
+ */
+class WC_REST_Products_Controller_Tests extends WC_REST_Unit_Test_Case {
+
+	/**
+	 * Test that `get_product_data` function works without silent `request` parameter as it used to.
+	 * TODO: Fix the underlying design issue when DI gets available.
+	 */
+	public function test_get_product_data_should_work_without_request_param() {
+		$product = WC_Helper_Product::create_simple_product();
+		$product->save();
+
+		// Workaround to call protected method.
+		$call_product_data_wrapper = function () use ( $product ) {
+			return $this->get_product_data( $product );
+		};
+		$response = $call_product_data_wrapper->call( new WC_REST_Products_Controller() );
+		$this->assertArrayHasKey( 'id', $response );
+	}
+}


### PR DESCRIPTION
We are using func_get_arg method to receive argument in a backward compatible way since we cannot modify function signature to add more params even with default params. Earlier I was hoping to use DI to create another child class with modified signature and load it depending upon where we are executing from, however since we had to revert DI, we add this workaround to unblock #27735.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### How to test the changes in this Pull Request:

1. Make sure test passes (this functionality is sufficiently covered by existing and new tests).
2. Try out get orders and get product endpoints and make sure it works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Add protection around `func_get_args_call` for backwards compatibility.
