### PR TITLE
Fix: Attributes on Edit Product page - "Select all" not working after "Select none" used

### DIFF
--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -355,7 +355,7 @@ jQuery( function( $ ) {
 	});
 
 	$( '.product_attributes' ).on( 'click', 'button.select_all_attributes', function() {
-		$( this ).closest( 'td' ).find( 'select option' ).attr( 'selected', 'selected' );
+		$( this ).closest( 'td' ).find( 'select option' ).prop( 'selected', 'selected' );
 		$( this ).closest( 'td' ).find( 'select' ).change();
 		return false;
 	});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Create a new product and go to the Attributes tab and add an attribute from the existing attributes.
2. Select all attributes item by pressing the "Select all" button then press the "Select none" button to remove them.
3. Again try to select all attributes items by pressing the "Select all" button then you can see all attributes are not selecting anymore.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix: Attributes on Edit Product page - "Select all" not working after "Select none" used

On the product edit once you press the "Select all" button 1st time it works fine, but if you remove all attributes items by pressing the "Select none" button then again if you want to select all attributes items by pressing the "Select all" button it will not work anymore. Here is the reproduced video https://www.loom.com/share/ec45b2c5360945c589eb202c2602c28b
