### PR TITLE
Ensure the orders status is reverted correctly when restoring it.

### DIFF
--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -500,7 +500,7 @@ class WC_Post_Data {
 	 * @return string
 	 */
 	public function wp_untrash_post_status( $new_status, $post_id, $previous_status ) {
-		$post_types = array_merge( wc_get_order_types(), array( 'product', 'product_variation' ) );
+		$post_types = array( 'shop_order', 'shop_coupon', 'product', 'product_variation' );
 
 		if ( in_array( get_post_type( $post_id ), $post_types, true ) ) {
 			$new_status = $previous_status;

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -500,7 +500,7 @@ class WC_Post_Data {
 	 * @return string
 	 */
 	public function wp_untrash_post_status( $new_status, $post_id, $previous_status ) {
-		$post_types = array_merge( wc_get_order_types(), array( 'product' ) );
+		$post_types = array_merge( wc_get_order_types(), array( 'product', 'product_variation' ) );
 
 		if ( in_array( get_post_type( $post_id ), $post_types, true ) ) {
 			$new_status = $previous_status;

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -499,7 +499,7 @@ class WC_Post_Data {
 	 * @param string $previous_status The status of the post at the point where it was trashed.
 	 * @return string
 	 */
-	public function wp_untrash_post_status( $new_status, $post_id, $previous_status ) {
+	public static function wp_untrash_post_status( $new_status, $post_id, $previous_status ) {
 		$post_types = array( 'shop_order', 'shop_coupon', 'product', 'product_variation' );
 
 		if ( in_array( get_post_type( $post_id ), $post_types, true ) ) {

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -41,6 +41,7 @@ class WC_Post_Data {
 		add_filter( 'update_post_metadata', array( __CLASS__, 'update_post_metadata' ), 10, 5 );
 		add_filter( 'wp_insert_post_data', array( __CLASS__, 'wp_insert_post_data' ) );
 		add_filter( 'oembed_response_data', array( __CLASS__, 'filter_oembed_response_data' ), 10, 2 );
+		add_filter( 'wp_untrash_post_status', array( __CLASS__, 'wp_untrash_post_status' ), 10, 3 );
 
 		// Status transitions.
 		add_action( 'transition_post_status', array( __CLASS__, 'transition_post_status' ), 10, 3 );
@@ -488,6 +489,22 @@ class WC_Post_Data {
 				wp_set_post_terms( $object_id, array( $default_term ), 'product_cat', true );
 			}
 		}
+	}
+
+	/**
+	 * Ensure statuses are correctly reassigned when restoring orders.
+	 *
+	 * @param string $new_status      The new status of the post being restored.
+	 * @param int    $post_id         The ID of the post being restored.
+	 * @param string $previous_status The status of the post at the point where it was trashed.
+	 * @return string
+	 */
+	public function wp_untrash_post_status( $new_status, $post_id, $previous_status ) {
+		if ( in_array( get_post_type( $post_id ), wc_get_order_types(), true ) ) {
+			$new_status = $previous_status;
+		}
+
+		return $new_status;
 	}
 
 	/**

--- a/includes/class-wc-post-data.php
+++ b/includes/class-wc-post-data.php
@@ -492,7 +492,7 @@ class WC_Post_Data {
 	}
 
 	/**
-	 * Ensure statuses are correctly reassigned when restoring orders.
+	 * Ensure statuses are correctly reassigned when restoring orders and products.
 	 *
 	 * @param string $new_status      The new status of the post being restored.
 	 * @param int    $post_id         The ID of the post being restored.
@@ -500,7 +500,9 @@ class WC_Post_Data {
 	 * @return string
 	 */
 	public function wp_untrash_post_status( $new_status, $post_id, $previous_status ) {
-		if ( in_array( get_post_type( $post_id ), wc_get_order_types(), true ) ) {
+		$post_types = array_merge( wc_get_order_types(), array( 'product' ) );
+
+		if ( in_array( get_post_type( $post_id ), $post_types, true ) ) {
 			$new_status = $previous_status;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

As per https://github.com/woocommerce/woocommerce/issues/28652, WP5.6 defaults all restored post to the "draft" status. They have provided a filter to override this, and saves the previous status to the DB. This ensure restored orders and products are correctly put back to their previous status.

Closes #28652 .

### How to test the changes in this Pull Request:

1. Create a simple product
2. Create an order
3. Make order as complete
4. Trash order
5. Restore order, it should be complete (not draft).

Also:

1. Create a product
2. Publish it
3. Trash it
4. Restore it
5. It should now be published, instead of draft.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Ensure the orders and products statuses are reverted correctly when restoring them.
