### PR TITLE
Add protective check to make sure WC()->session is initialized before  loading the data store.

### DIFF
--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -111,7 +111,7 @@ class WC_Customer extends WC_Legacy_Customer {
 		}
 
 		// If this is a session, set or change the data store to sessions. Changes do not persist in the database.
-		if ( $is_session ) {
+		if ( $is_session && isset( WC()->session ) ) {
 			$this->data_store = WC_Data_Store::load( 'customer-session' );
 			$this->data_store->read( $this );
 		}

--- a/tests/php/includes/class-wc-customer-test.php
+++ b/tests/php/includes/class-wc-customer-test.php
@@ -1,0 +1,20 @@
+<?php
+/**
+ * Tests for WC_Customer class.
+ */
+class WC_Customer_Test extends \WC_Unit_Test_Case {
+	/**
+	 * Test that customer object can be initialized even if wc session is not available.
+	 * There are cases when WC()->session is null but we are reading customer object with $session param set to true, for example, when calling methods from WC_Checkout object.
+	 */
+	public function test_can_create_customer_without_wc_session_initialized() {
+		$customer    = WC_Helper_Customer::create_customer();
+		$orig_session = WC()->session;
+		WC()->session = null;
+
+		$re_fetched_customer = new WC_Customer( $customer->get_id(), true );
+		WC()->session        = $orig_session;
+
+		$this->assertInstanceOf( 'WC_Customer', $re_fetched_customer );
+	}
+}


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

After https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/3371 we are also initialising checkout in admin calls to compute settings. Ideally this should not be necessary and we should have powerful enough static API to get all the settings, but while we consider that, this adds a workaround by adding checks to make WC()->session is intialized before loading the session data store.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28582.

### How to test the changes in this Pull Request:

1. Add the snippet in functions.php
```php
function issue_28582( $checkout ) {
	$checkout->get_checkout_fields();
}
add_action( 'woocommerce_checkout_init', 'issue_28582', 10, 1 );
```
2. Navigate to WC homepage at `wp-admin/admin.php?page=wc-admin`. See the error.
3. Apply this patch, there won't be an error anymore.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Add checks to make sure session is initialised before loading the data store.