### PR TITLE
Add transient and action for proxying WC plugin activation hook

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -801,6 +801,10 @@ final class WooCommerce {
 	public function activated_plugin( $filename ) {
 		include_once dirname( __FILE__ ) . '/admin/helper/class-wc-helper.php';
 
+		if ( 'woocommerce/woocommerce.php' === $filename ) {
+			set_transient( 'woocommerce_activated_plugin', true );
+		}
+
 		WC_Helper::activated_plugin( $filename );
 	}
 

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -801,8 +801,8 @@ final class WooCommerce {
 	public function activated_plugin( $filename ) {
 		include_once dirname( __FILE__ ) . '/admin/helper/class-wc-helper.php';
 
-		if ( 'woocommerce/woocommerce.php' === $filename ) {
-			set_transient( 'woocommerce_activated_plugin', true );
+		if ( '/woocommerce.php' === substr( $filename, -16 ) ) {
+			set_transient( 'woocommerce_activated_plugin', $filename );
 		}
 
 		WC_Helper::activated_plugin( $filename );

--- a/src/Packages.php
+++ b/src/Packages.php
@@ -68,6 +68,16 @@ class Packages {
 			}
 			call_user_func( array( $package_class, 'init' ) );
 		}
+
+		// Proxies "activated_plugin" hook for embedded packages listen on WC plugin activation
+		// https://github.com/woocommerce/woocommerce/issues/28697
+		if ( is_admin() ) {
+			$is_woocommerce_just_activated = get_transient( 'woocommerce_activated_plugin' );
+			if ( $is_woocommerce_just_activated ) {
+				do_action( 'woocommerce_activated_plugin' );
+				delete_transient( 'woocommerce_activated_plugin' );
+			}
+		}
 	}
 
 	/**

--- a/src/Packages.php
+++ b/src/Packages.php
@@ -70,11 +70,11 @@ class Packages {
 		}
 
 		// Proxies "activated_plugin" hook for embedded packages listen on WC plugin activation
-		// https://github.com/woocommerce/woocommerce/issues/28697
+		// https://github.com/woocommerce/woocommerce/issues/28697.
 		if ( is_admin() ) {
 			$is_woocommerce_just_activated = get_transient( 'woocommerce_activated_plugin' );
 			if ( $is_woocommerce_just_activated ) {
-				do_action( 'woocommerce_activated_plugin' );
+				do_action( 'woocommerce_activated_plugin', 'woocommerce/woocommerce.php' );
 				delete_transient( 'woocommerce_activated_plugin' );
 			}
 		}

--- a/src/Packages.php
+++ b/src/Packages.php
@@ -74,8 +74,8 @@ class Packages {
 		if ( is_admin() ) {
 			$is_woocommerce_just_activated = get_transient( 'woocommerce_activated_plugin' );
 			if ( $is_woocommerce_just_activated ) {
-				do_action( 'woocommerce_activated_plugin', 'woocommerce/woocommerce.php' );
 				delete_transient( 'woocommerce_activated_plugin' );
+				do_action( 'woocommerce_activated_plugin', 'woocommerce/woocommerce.php' );
 			}
 		}
 	}

--- a/src/Packages.php
+++ b/src/Packages.php
@@ -72,10 +72,10 @@ class Packages {
 		// Proxies "activated_plugin" hook for embedded packages listen on WC plugin activation
 		// https://github.com/woocommerce/woocommerce/issues/28697.
 		if ( is_admin() ) {
-			$is_woocommerce_just_activated = get_transient( 'woocommerce_activated_plugin' );
-			if ( $is_woocommerce_just_activated ) {
+			$woocommerce_activated_plugin = get_transient( 'woocommerce_activated_plugin' );
+			if ( $woocommerce_activated_plugin ) {
 				delete_transient( 'woocommerce_activated_plugin' );
-				do_action( 'woocommerce_activated_plugin', 'woocommerce/woocommerce.php' );
+				do_action( 'woocommerce_activated_plugin', $woocommerce_activated_plugin );
 			}
 		}
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
This PR allows packages embedded under WooCommerce to listen on WooCommerce plugin activation. Currently we have these use cases in WooCommerce Admin:
1. Running a check for RemoteInboxNotifications on plugin activation to run its specs
2. For attempt to fix issue with generating JSON translation caches https://github.com/woocommerce/woocommerce-admin/issues/4615#issuecomment-737293336

Closes https://github.com/woocommerce/woocommerce/issues/28697.

### How to test the changes in this Pull Request:

1. Checkout PR branch
2. Make sure WooCommerce Admin plugin is not activated
2. Deactivate WooCommerce plugin
2. Modify `packages/woocommerce-admin/src/Composer/Package.php` and add the following to the first line of `init()`:
```php
add_action( 'woocommerce_activated_plugin', function() { error_log( 'This is called' ); } );
```
3. Activate WooCommerce plugin
4. View `wp-content/debug.log` and verify that text "This is called" is appended

### Documentation
Example usage:
```php
public function __construct() {
  // Handle activation from WooCommerce plugin
  add_action( 'woocommerce_activated_plugin', array( __CLASS__, 'activated_plugin' ) );

  // Handle activation from feature plugin
  add_action( 'activated_plugin', array( __CLASS__, 'activated_plugin' ) );
}

public static function activated_plugin( $plugin ) {
  // Ensure we're only running only on activation hook that originates from our plugin
  if ( explode( '/', plugin_basename( __FILE__ ) )[ 0 ] === explode( '/', $plugin )[ 0 ] ) {
    self::run_once();
  }
}

public static function run_once() {
  // ...
}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Introduced `woocommerce_activated_plugin` hook.
