### PR TITLE
Prevent local relative downloadable products to be treated as "absolute"

### DIFF
--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -52,11 +52,13 @@ class WC_Product_Download implements ArrayAccess {
 	 */
 	public function get_type_of_file_path( $file_path = '' ) {
 		$file_path = $file_path ? $file_path : $this->get_file();
+		$parsed_url = parse_url( $file_path );
 		if (
-			0 === strpos( $file_path, 'http' ) ||
-			(
-				0 === strpos( $file_path, '//' ) &&
-				substr( $file_path, 0, 3 ) !== '///' // This will prevent local file paths to be treated as "absolute".
+			$parsed_url &&
+			isset( $parsed_url['host'] ) && // Absolute url means that it has a host.
+			( // Theoretically we could permit any scheme (like ftp as well), but that has not been the case before. So we allow none or http(s).
+				! isset( $parsed_url['scheme'] ) ||
+				in_array( $parsed_url['scheme'], array( 'http', 'https' ) )
 			)
 		) {
 			return 'absolute';

--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -173,9 +173,9 @@ class WC_Product_Download implements ArrayAccess {
 	 */
 	public function set_file( $value ) {
 		// A `///` is recognized as an "absolute", but on the filesystem, so it bypasses the mime check in `self::is_allowed_filetype`.
-		// This will change the file value to the `relative` beginning with `/` and it will be parsed accordingly.
-		if ( substr( $value, 0, 3 ) === '///' ) {
-			$value = substr( $value, 2 );
+		// This will strip extra prepending / to the maximum of 2.
+		if ( preg_match( '#^/+(//[^/].+)$#i', $value, $matches ) ) {
+			$value = $matches[1];
 		}
 		switch ( $this->get_type_of_file_path( $value ) ) {
 			case 'absolute':

--- a/includes/class-wc-product-download.php
+++ b/includes/class-wc-product-download.php
@@ -174,7 +174,7 @@ class WC_Product_Download implements ArrayAccess {
 	public function set_file( $value ) {
 		// A `///` is recognized as an "absolute", but on the filesystem, so it bypasses the mime check in `self::is_allowed_filetype`.
 		// This will strip extra prepending / to the maximum of 2.
-		if ( preg_match( '#^/+(//[^/].+)$#i', $value, $matches ) ) {
+		if ( preg_match( '#^//+(/[^/].+)$#i', $value, $matches ) ) {
 			$value = $matches[1];
 		}
 		switch ( $this->get_type_of_file_path( $value ) ) {

--- a/tests/legacy/unit-tests/product/class-wc-tests-product-download.php
+++ b/tests/legacy/unit-tests/product/class-wc-tests-product-download.php
@@ -156,6 +156,6 @@ class WC_Tests_Product_Download extends WC_Unit_Test_Case {
 		$download = new WC_Product_Download();
 
 		$download->set_file( '////////test/path' );
-		$this->assertEquals( '//test/path', $download->get_file() );
+		$this->assertEquals( '/test/path', $download->get_file() );
 	}
 }

--- a/tests/legacy/unit-tests/product/class-wc-tests-product-download.php
+++ b/tests/legacy/unit-tests/product/class-wc-tests-product-download.php
@@ -50,6 +50,7 @@ class WC_Tests_Product_Download extends WC_Unit_Test_Case {
 		$this->assertEquals( 'absolute', $download->get_type_of_file_path( 'http://example.com/file.jpg' ) );
 		$this->assertEquals( 'absolute', $download->get_type_of_file_path( site_url( '/wp-content/uploads/test.jpg' ) ) );
 		$this->assertEquals( 'relative', $download->get_type_of_file_path( trailingslashit( WP_PLUGIN_DIR ) . 'woocommerce/assets/images/help.png' ) );
+		$this->assertEquals( 'relative', $download->get_type_of_file_path( '//' . trailingslashit( WP_PLUGIN_DIR ) . 'woocommerce/assets/images/help.png' ) );
 		$this->assertEquals( 'shortcode', $download->get_type_of_file_path( '[s3 bucket ="" file=""]' ) );
 	}
 
@@ -137,6 +138,10 @@ class WC_Tests_Product_Download extends WC_Unit_Test_Case {
 		$this->assertEquals( true, $download->is_allowed_filetype() );
 
 		$download->set_file( trailingslashit( WP_PLUGIN_DIR ) . 'woocommerce/woocommerce.php' );
+		$this->assertEquals( false, $download->is_allowed_filetype() );
+
+		// For triple-slash overwriting of "local" to "absolute" - see https://github.com/woocommerce/woocommerce/pull/28699.
+		$download->set_file( '//' . trailingslashit( WP_PLUGIN_DIR ) . 'woocommerce/woocommerce.php' );
 		$this->assertEquals( false, $download->is_allowed_filetype() );
 	}
 }

--- a/tests/legacy/unit-tests/product/class-wc-tests-product-download.php
+++ b/tests/legacy/unit-tests/product/class-wc-tests-product-download.php
@@ -51,6 +51,7 @@ class WC_Tests_Product_Download extends WC_Unit_Test_Case {
 		$this->assertEquals( 'absolute', $download->get_type_of_file_path( site_url( '/wp-content/uploads/test.jpg' ) ) );
 		$this->assertEquals( 'relative', $download->get_type_of_file_path( trailingslashit( WP_PLUGIN_DIR ) . 'woocommerce/assets/images/help.png' ) );
 		$this->assertEquals( 'relative', $download->get_type_of_file_path( '//' . trailingslashit( WP_PLUGIN_DIR ) . 'woocommerce/assets/images/help.png' ) );
+		$this->assertEquals( 'relative', $download->get_type_of_file_path( '/////' . trailingslashit( WP_PLUGIN_DIR ) . 'woocommerce/assets/images/help.png' ) );
 		$this->assertEquals( 'shortcode', $download->get_type_of_file_path( '[s3 bucket ="" file=""]' ) );
 	}
 

--- a/tests/legacy/unit-tests/product/class-wc-tests-product-download.php
+++ b/tests/legacy/unit-tests/product/class-wc-tests-product-download.php
@@ -145,4 +145,17 @@ class WC_Tests_Product_Download extends WC_Unit_Test_Case {
 		$download->set_file( '//' . trailingslashit( WP_PLUGIN_DIR ) . 'woocommerce/woocommerce.php' );
 		$this->assertEquals( false, $download->is_allowed_filetype() );
 	}
+
+	/**
+	 * Tests if we are trimming prepending slashes which can confuse system and change the file type to a filesystem path.
+	 * @see https://github.com/woocommerce/woocommerce/pull/28699
+	 *
+	 * @since 5.0.1
+	 */
+	public function test_trim_extra_prepending_slashes() {
+		$download = new WC_Product_Download();
+
+		$download->set_file( '////////test/path' );
+		$this->assertEquals( '//test/path', $download->get_file() );
+	}
 }


### PR DESCRIPTION
This PR has no functional change. It will strengthen security by making sure downloadable file paths are properly recognized.

## Motivation

Downloadable products have 3 "types":

- shortcodes that evaluate to a shortcode
- `relative` which correspond to relative location on a file disk
- `absolute` which begin with `//` and are meant to represent remote location of a file in the web.

There is however a way to sneak in `absolute` product via `///`, like `///home/server/public_html/wp-config.php`. This way also bypasses the mime type check, because this check is done only for `relative` products.
This PR strips `///` and replaces with `/` for these cases and prevents file paths with `///` to be treated as absolute ones.

Additionally, since file paths beginning with `///` will now be treated as relative ones, they will also be subject to `woocommerce_downloadable_file_exists` filter. We use that filter in D54789-code to prevent one user retrieving file path from another user's site.


## Q&A

**Is this a security problem?**

Using a file path with `///` in a downloadable product allows for bypassing allowed_mime_types and creating a download with `wp-config.php`. However this will not be downloadable - read along

**Will this break existing functionality?**

Maybe somebody wants to create a download with wp-config? This was a major consideration. I am convinced this is a bug, since class-wc-downloads.php already prevents from using `///`

https://github.com/woocommerce/woocommerce/blob/3aee9f2dbd1da2d4505aa23f77bd08561253c3c2/includes/class-wc-download-handler.php#L276


So currently it's posisble to create a downloadable file with wp-config, but not possible to download it.

**Will this break existing sites?**

If somebody would be very determined to provide a download for wp-config, they could hook in to allow to download it.
In that case, this PR only prevents adding new files with incorrect mime type. All the files previously configured will continue to work.


## Testing instructions
(Added by @peterfabian )
1. Create a downloadable product, add files that refer to 
  - absolute web address (e.g. https://via.placeholder.com/300/09f/fff.png)
  - file picked from media library
  - relative file (relative to plugin folder)
  - file starting with two slashes // that is considered a remote absolute path
  - file starting with 3 slashes that is considered a local absolute path
2. Buy the product and try to download all the files, see which work and which don't.
2. Update WC.
3. Try to download all the files again. All should work, except for local file download via 3 slashes---that should not be possible.

### Changelog entry

> Enhancement - Make sure downloadable file paths are properly recognized for strengthened security.