### PR TITLE
Force array values to be marked as dirty

### DIFF
--- a/includes/abstracts/abstract-wc-data.php
+++ b/includes/abstracts/abstract-wc-data.php
@@ -737,7 +737,7 @@ abstract class WC_Data {
 	protected function set_prop( $prop, $value ) {
 		if ( array_key_exists( $prop, $this->data ) ) {
 			if ( true === $this->object_read ) {
-				if ( $value !== $this->data[ $prop ] || array_key_exists( $prop, $this->changes ) ) {
+				if ( $value !== $this->data[ $prop ] || array_key_exists( $prop, $this->changes ) || is_array( $value ) ) {
 					$this->changes[ $prop ] = $value;
 				}
 			} else {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `set_prop()` method on `abstract-wc-data.php` checks to see if the new `$value` is different to the previous, if it is, it adds it to a `$changes` member, so the database only updates what properties are needed. The problem lies with arrays of objects.

When using a method that returns an array of objects (such as `$downloads = $product->get_downloads()`). This method returns an array of `WC_Product_Download`. One would assume that changing a value on a child (`$download[0]->setName('new name')`) and setting the array back on the prop (`$product->set_downloads($downloads)`) would mark it as dirty, and therefore add it to the `changes` member. Unfortuantly, it doesn't. The problem lies in how PHP returns these Objects, they're just references. So when you're amending the `WC_Product_Download`, you're just amending the value on the downloads prop. So when the comparision is done to mark it as dirty (and add it to `changes`), it doesn't see a difference. This PR forces all arrays to be marked as dirty, so code like this correctly works:

```php
$product = wc_get_product( 1 );

$downloads = $product->get_downloads();

foreach ($downloads as $download) {
	$download->set_name( 'new filename' );
	$download->set_file( 'http://www.downloads.com/my-new-path' );
}

$product->set_downloads($downloads);
$product->save();
```

Whereas before, it didn't write the new downloads name, or file.

Closes #28705 .

### How to test the changes in this Pull Request:

1. Add a product
2. Add a download to the product
3. Run the snippet, notice how the download gets updated as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Ensure arrays passed to `set_props()` are correctly updated when saving a product.
