### PR TITLE
Export sass vars to css var

### DIFF
--- a/assets/css/_variables.scss
+++ b/assets/css/_variables.scss
@@ -8,7 +8,7 @@ $red:           	#a00 !default;
 $orange:        	#ffba00 !default;
 $blue:          	#2ea2cc !default;
 
-$primary:           #a46497 !default;                                    // Primary color for buttons (alt)
+$primary:           #a46497 !default;                                  // Primary color for buttons (alt)
 $primarytext:       desaturate(lighten($primary, 50%), 18%) !default;    // Text on primary color bg
 
 $secondary:         desaturate(lighten($primary, 40%), 21%) !default;    // Secondary buttons
@@ -17,5 +17,22 @@ $secondarytext:     desaturate(darken($secondary, 60%), 21%) !default;   // Text
 $highlight:         adjust-hue($primary, 150deg) !default;               // Prices, In stock labels, sales flash
 $highlightext:      desaturate(lighten($highlight, 50%), 18%) !default;  // Text on highlight color bg
 
-$contentbg:         #fff !default;                                       // Content BG - Tabs (active state)
-$subtext:           #767676 !default;                                    // small, breadcrumbs etc
+$contentbg:         #fff !default;                                     // Content BG - Tabs (active state)
+$subtext:           #767676 !default;                                  // small, breadcrumbs etc
+
+// export vars as CSS vars
+:root {
+	--woocommerce: $woocommerce;
+	--wc-green: $green;
+	--wc-red: $red;
+	--wc-orange: $orange;
+	--wc-blue: $blue;
+	--wc-primary: $primary;
+	--wc-primarytext: $primarytext;
+	--wc-secondary: $secondary;
+	--wc-secondarytext: $secondarytext;
+	--wc-highlight: $highlight;
+	--wc-highlightext: $highlightext;
+	--wc-contentbg: $contentbg;
+	--wc-subtext: $subtext;
+}

--- a/assets/css/_variables.scss
+++ b/assets/css/_variables.scss
@@ -28,11 +28,11 @@ $subtext:           #767676 !default;                                  // small,
 	--wc-orange: $orange;
 	--wc-blue: $blue;
 	--wc-primary: $primary;
-	--wc-primarytext: $primarytext;
+	--wc-primary-text: $primarytext;
 	--wc-secondary: $secondary;
-	--wc-secondarytext: $secondarytext;
+	--wc-secondary-text: $secondarytext;
 	--wc-highlight: $highlight;
-	--wc-highlightext: $highlightext;
-	--wc-contentbg: $contentbg;
+	--wc-highligh-text: $highlightext;
+	--wc-content-bg: $contentbg;
 	--wc-subtext: $subtext;
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Simply exports the SASS variables in _variables as CSS variables, so aid with front-end development.

Closes #28707.

### How to test the changes in this Pull Request:

1. Add `h1 {color: var(--wc-green) !important;}` to your stylesheet to see the h1 header be the WooComms green colour.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

### Changelog entry

> Enhancement - Export SASS variables as CSS variables.
