### PR TITLE
Added merchant email note switch

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -203,7 +203,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'id'            => 'woocommerce_merchant_email_notifications',
 					'type'          => 'checkbox',
 					'checkboxgroup' => 'start',
-					'default'       => 'no',
+					'default'       => 'yes',
 					'autoload'      => false,
 				),
 

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -199,7 +199,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 
 				array(
 					'title'         => __( 'Enable email insights', 'woocommerce' ),
-					'desc'          => __( 'Receive email notifications with additional guidance to complete the basic store setup and helpful insights.', 'woocommerce' ),
+					'desc'          => __( 'Receive email notifications with additional guidance to complete the basic store setup and helpful insights', 'woocommerce' ),
 					'id'            => 'woocommerce_merchant_email_notifications',
 					'type'          => 'checkbox',
 					'checkboxgroup' => 'start',

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -191,6 +191,22 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'id'   => 'email_template_options',
 				),
 
+				array(
+					'title' => __( 'Store management insights', 'woocommerce' ),
+					'type'  => 'title',
+					'id'    => 'email_merchant_notes',
+				),
+
+				array(
+					'title'         => __( 'Enable email insights', 'woocommerce' ),
+					'desc'          => __( 'Receive email notifications with additional guidance to complete the basic store setup and helpful insights.', 'woocommerce' ),
+					'id'            => 'woocommerce_merchant_email_notifications',
+					'type'          => 'checkbox',
+					'checkboxgroup' => 'start',
+					'default'       => 'no',
+					'autoload'      => false,
+				),
+
 			)
 		);
 


### PR DESCRIPTION
This PR adds an option to enable/disable the merchant email notes.
The merchant email notes are notes with a new type that are sent by email. The code in this PR was added in order to turn on/off this kind of note. 

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Related to [issue 5300](https://github.com/woocommerce/woocommerce-admin/issues/5300).

### How to test the changes in this Pull Request:

1. Go to `WooCommerce` > `Settings` > `Emails`.
2. Click the checkbox next to `Enable email insights` and `Save changes`.
3. Verify the variable `woocommerce_merchant_email_notifications` now is set as `yes`.
4. Click the checkbox again and `Save changes`.
5. Verify the variable `woocommerce_merchant_email_notifications` now is set as `no`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Added "Store management insights" option.
