### PR TITLE
Add Auth token for search/featured extensions requests

### DIFF
--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -25,7 +25,7 @@ class WC_Admin_Addons {
 	public static function get_featured() {
 		$featured = get_transient( 'wc_addons_featured' );
 		if ( false === $featured ) {
-			$raw_featured = wp_safe_remote_get( 'https://d3t0oesq8995hv.cloudfront.net/add-ons/featured-v2.json', array( 'user-agent' => 'WooCommerce Addons Page' ) );
+			$raw_featured = wp_safe_remote_get( 'https://woocommerce.com/wp-json/wccom-extensions/1.0/featured', array( 'user-agent' => 'WooCommerce Addons Page' ) );
 			if ( ! is_wp_error( $raw_featured ) ) {
 				$featured = json_decode( wp_remote_retrieve_body( $raw_featured ) );
 				if ( $featured ) {

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -93,7 +93,7 @@ class WC_Admin_Addons {
 			$headers['Authorization'] = 'Bearer ' . $auth['access_token'];
 		}
 
-		$raw_extensions = wp_remote_get(
+		$raw_extensions = wp_safe_remote_get(
 			'https://woocommerce.com/wp-json/wccom-extensions/1.0/search' . $parameters,
 			array( 'headers' => $headers )
 		);

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -26,7 +26,7 @@ class WC_Admin_Addons {
 		$featured = get_transient( 'wc_addons_featured' );
 		if ( false === $featured ) {
 			$headers = array();
-			$auth = WC_Helper_Options::get( 'auth' );
+			$auth    = WC_Helper_Options::get( 'auth' );
 
 			if ( ! empty( $auth['access_token'] ) ) {
 				$headers['Authorization'] = 'Bearer ' . $auth['access_token'];
@@ -35,7 +35,7 @@ class WC_Admin_Addons {
 			$raw_featured = wp_safe_remote_get(
 				'https://woocommerce.com/wp-json/wccom-extensions/1.0/featured',
 				array(
-					'headers' => $headers,
+					'headers'    => $headers,
 					'user-agent' => 'WooCommerce Addons Page',
 				)
 			);
@@ -87,7 +87,7 @@ class WC_Admin_Addons {
 		$parameters     = self::build_parameter_string( $category, $term, $country );
 
 		$headers = array();
-		$auth = WC_Helper_Options::get( 'auth' );
+		$auth    = WC_Helper_Options::get( 'auth' );
 
 		if ( ! empty( $auth['access_token'] ) ) {
 			$headers['Authorization'] = 'Bearer ' . $auth['access_token'];

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -43,7 +43,7 @@ class WC_Admin_Addons {
 			if ( ! is_wp_error( $raw_featured ) ) {
 				$featured = json_decode( wp_remote_retrieve_body( $raw_featured ) );
 				if ( $featured ) {
-					set_transient( 'wc_addons_featured', $featured, WEEK_IN_SECONDS );
+					set_transient( 'wc_addons_featured', $featured, DAY_IN_SECONDS );
 				}
 			}
 		}

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -25,7 +25,21 @@ class WC_Admin_Addons {
 	public static function get_featured() {
 		$featured = get_transient( 'wc_addons_featured' );
 		if ( false === $featured ) {
-			$raw_featured = wp_safe_remote_get( 'https://woocommerce.com/wp-json/wccom-extensions/1.0/featured', array( 'user-agent' => 'WooCommerce Addons Page' ) );
+			$headers = array();
+			$auth = WC_Helper_Options::get( 'auth' );
+
+			if ( ! empty( $auth['access_token'] ) ) {
+				$headers['Authorization'] = 'Bearer ' . $auth['access_token'];
+			}
+
+			$raw_featured = wp_safe_remote_get(
+				'https://woocommerce.com/wp-json/wccom-extensions/1.0/featured',
+				array(
+					'headers' => $headers,
+					'user-agent' => 'WooCommerce Addons Page',
+				)
+			);
+
 			if ( ! is_wp_error( $raw_featured ) ) {
 				$featured = json_decode( wp_remote_retrieve_body( $raw_featured ) );
 				if ( $featured ) {
@@ -71,9 +85,19 @@ class WC_Admin_Addons {
 	 */
 	public static function get_extension_data( $category, $term, $country ) {
 		$parameters     = self::build_parameter_string( $category, $term, $country );
+
+		$headers = array();
+		$auth = WC_Helper_Options::get( 'auth' );
+
+		if ( ! empty( $auth['access_token'] ) ) {
+			$headers['Authorization'] = 'Bearer ' . $auth['access_token'];
+		}
+
 		$raw_extensions = wp_remote_get(
-			'https://woocommerce.com/wp-json/wccom-extensions/1.0/search' . $parameters
+			'https://woocommerce.com/wp-json/wccom-extensions/1.0/search' . $parameters,
+			array( 'headers' => $headers )
 		);
+
 		if ( ! is_wp_error( $raw_extensions ) ) {
 			$addons = json_decode( wp_remote_retrieve_body( $raw_extensions ) )->products;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

- Start using [this endpoint](https://woocommerce.com/wp-json/wccom-extensions/1.0/featured`) to fetch featured extensions. Also add the access token to this request.
- Add access token to the search request made to the [this endpoint](https://woocommerce.com/wp-json/wccom-extensions/1.0/search). Start using `wp_safe_remote_get` for it instead of `wp_remote_get`.
- Reduce the transient duration for featured extensions to one day

### How to test the changes in this Pull Request:

```php
// Disable this transient to make sure you are hitting the new endpoint
add_filter('transient_wc_addons_featured', function ($value, $transient) {
	return false;
}, 10, 2);
```

1. When not authenticated to the WooCommerce.com go to the `WooCommerce->Extensions `page. The featured tab should work as before. Making a search on the marketplace should also work as before. 

2. When authenticated to the WooCommerce.com, featured and search tabs should keep working the same. This time they should include the `Authorization` header containing the `access_token`.

```php
// Inspect headers sent in the requests made to the WooCommerce.com
function action_http_api_debug( $response, $context, $class, $args, $url ) {
	if ( $context !== 'response' ) {
		return;
	}

	if ( strpos( $url, 'woocommerce.com' ) !== false ) {
		wc_get_logger()->debug( implode( ', ', $args['headers'] ) );
	}
}

add_action( 'http_api_debug', 'action_http_api_debug', 10, 5 );
```
**Further testing for WooCommerce.com**

If you have WooCommerce.com running locally and would like to test this feature you can use [this repo](https://github.com/Automattic/woocommerce-core-development-environment) to create a new store using this branch of WooCommerce plug-in.

- Checkout [this branch](https://github.com/Automattic/woocommerce.com/tree/raicem/test-woocommerce-auth-tokens).
- Update references to `woocommerce.com` to `woocommerce.test` [on this file](https://github.com/woocommerce/woocommerce/pull/28719/files#diff-5b8d157d364552501e027e0d4ca8dcb2c369428350b58493b5ebce3cebff5c26)
- Visit [featured extensions](http://localhost:8100/wp-admin/admin.php?page=wc-addons&section=_featured) and [search request](http://localhost:8100/wp-admin/admin.php?search=test&page=wc-addons&section=_all) in your store
- You should see the `Authorization` header info printed in the `debug.log`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

- Update featured extensions API endpoint on WooCommerce/Extensions page
- Add Authorization header to the features extensions and search requests made to the marketplace