### PR TITLE
Coerce variable type of form field argument 'class' in woocommerce_form_field()

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -153,7 +153,8 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 			}
 
 			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
-				$args, array(
+				$args,
+				array(
 					'key'     => '_sku',
 					'value'   => $skus,
 					'compare' => 'IN',
@@ -164,7 +165,8 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		// Filter by tax class.
 		if ( ! empty( $request['tax_class'] ) ) {
 			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
-				$args, array(
+				$args,
+				array(
 					'key'   => '_tax_class',
 					'value' => 'standard' !== $request['tax_class'] ? $request['tax_class'] : '',
 				)
@@ -179,7 +181,8 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 		// Filter product by stock_status.
 		if ( ! empty( $request['stock_status'] ) ) {
 			$args['meta_query'] = $this->add_meta_query( // WPCS: slow query ok.
-				$args, array(
+				$args,
+				array(
 					'key'   => '_stock_status',
 					'value' => $request['stock_status'],
 				)
@@ -332,7 +335,9 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 
 		if ( 'variation' === $product->get_type() ) {
 			return new WP_Error(
-				"woocommerce_rest_invalid_{$this->post_type}_id", __( 'To manipulate product variations you should use the /products/&lt;product_id&gt;/variations/&lt;id&gt; endpoint.', 'woocommerce' ), array(
+				"woocommerce_rest_invalid_{$this->post_type}_id",
+				__( 'To manipulate product variations you should use the /products/&lt;product_id&gt;/variations/&lt;id&gt; endpoint.', 'woocommerce' ),
+				array(
 					'status' => 404,
 				)
 			);

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2684,6 +2684,10 @@ if ( ! function_exists( 'woocommerce_form_field' ) ) {
 		$args = wp_parse_args( $args, $defaults );
 		$args = apply_filters( 'woocommerce_form_field_args', $args, $key, $value );
 
+		if ( is_string( $args['class'] ) ) {
+			$args['class'] = array( $args['class'] );
+		}
+
 		if ( $args['required'] ) {
 			$args['class'][] = 'validate-required';
 			$required        = '&nbsp;<abbr class="required" title="' . esc_attr__( 'required', 'woocommerce' ) . '">*</abbr>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

If a non-array value (eg empty string) is supplied as the `class` in the arguments collection a fatal error is thrown. Other arguments in the `woocommerce_form_field` method have the type validated (eg label_class), so it makes sense to do a check on the class property as well.

### How to test the changes in this Pull Request:

Add the following code as a theme or plugin snippet:
```
add_filter(
  'woocommerce_form_field_args' ,
  function($args, $key, $value)
  {
    $args['class'] = 'my-class';
    return $args;
  },
  10,
  3
);
```
At current, the filter will result in the following error when $args['required'] is true:
PHP Fatal error:  Uncaught Error: [] operator not supported for strings in /woocommerce/includes/wc-template-functions.php:2688

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Coerced variable type of form field argument 'class' from String to Array in woocommerce_form_field()
