### PR TITLE
Revert order and product controllers to use WP Post queries directly.

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -25,25 +25,6 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 	 */
 	protected $namespace = 'wc/v3';
 
-
-	/**
-	 * Get Orders.
-	 *
-	 * @param  array $query_args Query args.
-	 *
-	 * @return array Products.
-	 */
-	protected function get_objects( $query_args ) {
-		$query_args['paginate'] = true;
-		$results                = wc_get_orders( $query_args );
-
-		return array(
-			'objects' => $results->orders,
-			'total'   => $results->total,
-			'pages'   => $results->max_num_pages,
-		);
-	}
-
 	/**
 	 * Calculate coupons.
 	 *

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-products-controller.php
@@ -221,25 +221,6 @@ class WC_REST_Products_Controller extends WC_REST_Products_V2_Controller {
 	}
 
 	/**
-	 * Get products.
-	 *
-	 * @param  array $query_args Query args.
-	 *
-	 * @return array Products.
-	 */
-	protected function get_objects( $query_args ) {
-		$query_args['paginate'] = true;
-		$query_args['return']   = 'objects';
-		$results                = wc_get_products( $query_args );
-
-		return array(
-			'objects' => $results->products,
-			'total'   => $results->total,
-			'pages'   => $results->max_num_pages,
-		);
-	}
-
-	/**
 	 * Set product images.
 	 *
 	 * @throws WC_REST_Exception REST API exceptions.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28741.

This commit reverts some of the changes added in #27735 because wc_get_products and wc_get_orders are not fully compatible with API controller queries. Since we are close to releasing 4.9, it's better to revert and fix them properly than rush a fix. This undoes some of the performance improvements we achieved in 27735, in favor of more stability, hopefully, we will be able to restore this soon.

### How to test the changes in this Pull Request:

1. Create a new product and mark it as out of stock
2. Use wp-json/wc/v3/products/?stock_status=instock to retrieve 10 products
3. Newly created product will not be returned.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Revert some of the changes from 27735 as it was breaking stock_status filter.