### PR TITLE
Fix the ability to add custom variation options when using class-wc-cart.php

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1101,9 +1101,11 @@ class WC_Cart extends WC_Legacy_Cart {
 						// Allow if valid or show error.
 						if ( $valid_value === $value ) {
 							$attributes[ $attribute_key ] = $value;
+							$variation[ $attribute_key ] = $value;
 						} elseif ( '' === $valid_value && in_array( $value, $attribute->get_slugs(), true ) ) {
 							// If valid values are empty, this is an 'any' variation so get all possible values.
 							$attributes[ $attribute_key ] = $value;
+							$variation[ $attribute_key ] = $value;
 						} else {
 							/* translators: %s: Attribute name. */
 							throw new Exception( sprintf( __( 'Invalid value posted for %s', 'woocommerce' ), wc_attribute_label( $attribute['name'] ) ) );
@@ -1111,8 +1113,6 @@ class WC_Cart extends WC_Legacy_Cart {
 					} elseif ( '' === $valid_value ) {
 						$missing_attributes[] = wc_attribute_label( $attribute['name'] );
 					}
-
-					$variation = $attributes;
 				}
 				if ( ! empty( $missing_attributes ) ) {
 					/* translators: %s: Attribute name. */


### PR DESCRIPTION
Fix the ability to add custom variation options when using class-wc-c…

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Need to create a custom add to cart function that adds custom variation options e.g. WC()->cart->add_to_cart($product_id(),$qty,$variation_id,['custom_variation_value'=>'test']);

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
