### PR TITLE
Admin Menu: Use menu position to order menu items

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -33,7 +33,6 @@ class WC_Admin_Menus {
 
 		add_action( 'admin_head', array( $this, 'menu_highlight' ) );
 		add_action( 'admin_head', array( $this, 'menu_order_count' ) );
-		add_filter( 'menu_order', array( $this, 'menu_order' ) );
 		add_filter( 'custom_menu_order', array( $this, 'custom_menu_order' ) );
 		add_filter( 'set-screen-option', array( $this, 'set_screen_option' ), 10, 3 );
 
@@ -56,7 +55,7 @@ class WC_Admin_Menus {
 		global $menu;
 
 		if ( current_user_can( 'edit_others_shop_orders' ) ) {
-			$menu[] = array( '', 'read', 'separator-woocommerce', '', 'wp-menu-separator woocommerce' ); // WPCS: override ok.
+			$menu['55.4'] = array( '', 'read', 'separator-woocommerce', '', 'wp-menu-separator woocommerce' ); // WPCS: override ok.
 		}
 
 		add_menu_page( __( 'WooCommerce', 'woocommerce' ), __( 'WooCommerce', 'woocommerce' ), 'edit_others_shop_orders', 'woocommerce', null, null, '55.5' );

--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -339,6 +339,7 @@ class WC_Post_Types {
 					'description'         => __( 'This is where you can add new products to your store.', 'woocommerce' ),
 					'public'              => true,
 					'show_ui'             => true,
+					'menu_position'       => 56,
 					'capability_type'     => 'product',
 					'map_meta_cap'        => true,
 					'publicly_queryable'  => true,


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Removes the need for the menu_order callback by setting menu positions when registered.

[`register_post_type` accepts a `menu_position` parameter](https://developer.wordpress.org/reference/functions/register_post_type/#menu_position). Setting that to a value higher than WooCommerce's `55.5` will render it in the right position, while not interfering with subsequent menu items.

Setting an array key for the menu separator makes its placement deliberate and removes the need for moving it around later.

### How to test the changes in this Pull Request:

1. In wp-admin, make sure the `Product` menu item still shows up below `WooCommerce` and both are preceded by a separator.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Probably not needed since nothing really changes?