### PR TITLE
Allow $0 orders, again

### DIFF
--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -394,7 +394,9 @@ class WC_Form_Handler {
 			$order_id  = absint( $wp->query_vars['order-pay'] );
 			$order     = wc_get_order( $order_id );
 
-			if ( $order_id === $order->get_id() && hash_equals( $order->get_order_key(), $order_key ) && $order->needs_payment() ) {
+			$valid_order_statuses = apply_filters( 'woocommerce_valid_order_statuses_for_payment', array( 'pending', 'failed' ), $order );
+
+			if ( $order_id === $order->get_id() && hash_equals( $order->get_order_key(), $order_key ) && $order->has_status( $valid_order_statuses ) ) {
 
 				do_action( 'woocommerce_before_pay_action', $order );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The commit at https://github.com/woocommerce/woocommerce/commit/164b39ea428b1d72f1db81aa3e3720d736304f90?branch=164b39ea428b1d72f1db81aa3e3720d736304f90&diff=split broke logic when checking if a order can be paid.

[1] Originally, it checked to see if the order is either 'pending' or 'failed'. If true, it allowed you to process an order. Additionally [2], it checked to see if a payment was needed (i.e. the order total is greater that 0), if true, a payment is made, else just redirect to the thank you page.

The mentioned commit above changed the condition to check against the status AND check if you order is greater than 0. This means the second condition [2] is **never** excuted. So there's no way to processing a $0 order, which previously just skipped straight to the thank you page.

This commit reverts it.

Closes #28761

### How to test the changes in this Pull Request:

1. Create a $0 order
2. When going through the checkout, Woocomms signs off the order and goes straight to the thank you page

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Allow $0 orders, again.
