### PR TITLE
Bump WP versions in Travis after WP 5.6 release.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,10 +45,10 @@ jobs:
     env: WP_VERSION=nightly WP_MULTISITE=0
   - name: "WP Latest - 1"
     php: "7.2"
-    env: WP_VERSION=5.4 WP_MULTISITE=0
+    env: WP_VERSION=5.5 WP_MULTISITE=0
   - name: "WP Latest - 2"
     php: "7.2"
-    env: WP_VERSION=5.3 WP_MULTISITE=0
+    env: WP_VERSION=5.4 WP_MULTISITE=0
   - name: "Code Standards"
     php: "7.4"
     env: WP_VERSION=latest WP_MULTISITE=0 RUN_PHPCS=1


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Bumps the WP-1 and WP-2 versions to 5.5 and 5.4, respectively, since latest is 5.6 now. We should make this dynamic.

### How to test the changes in this Pull Request:

1. Check WP-1 and WP-2 jobs, they should point to correct WP versions now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->


