### PR TITLE
Update states.php

### DIFF
--- a/i18n/states.php
+++ b/i18n/states.php
@@ -1305,6 +1305,7 @@ return array(
 		'VN' => __( 'Vrancea', 'woocommerce' ),
 	),
 	'RS' => array(),
+	'RW' => array(),
 	'SG' => array(),
 	'SK' => array(),
 	'SI' => array(),


### PR DESCRIPTION
Adding Rwanda (RW) as an empty array to make sure that states/county is optional

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adding Rwanda (RW) as an empty array to make sure that states/county is optional

Closes # .

### How to test the changes in this Pull Request:

1. Select Rwanda on checkout
2. county/state field will disappear (before: mandantory field county/state, no selection)
