### PR TITLE
Add notice to deprecate old reports closes #27789

### DIFF
--- a/includes/admin/views/html-admin-page-reports.php
+++ b/includes/admin/views/html-admin-page-reports.php
@@ -9,6 +9,16 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="wrap woocommerce">
+	<div id="message" class="error inline">
+		<p>
+			<strong>
+			<?php
+			/* translators: 1: Link URL */
+			echo wp_kses_post( sprintf( __( 'With the release of WooCommerce 4.0, these reports are being replaced. There is a new and better Analytics section available for users running WordPress 5.3+. Head on over to the <a href="%1$s">WooCommerce Analytics</a> or learn more about the new experience in the <a href="https://docs.woocommerce.com/document/woocommerce-analytics/" target="_blank">WooCommerce Analytics documentation</a>.', 'woocommerce' ), esc_url( wc_admin_url( '&path=/analytics/overview' ) ) ) );
+			?>
+			</strong>
+		</p>
+	</div>
 	<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
 		<?php
 		foreach ( $reports as $key => $report_group ) {

--- a/includes/admin/views/html-admin-page-reports.php
+++ b/includes/admin/views/html-admin-page-reports.php
@@ -9,7 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="wrap woocommerce">
-	<div id="message" class="error inline">
+	<div id="message" class="error inline" style="margin-top:30px">
 		<p>
 			<strong>
 			<?php

--- a/includes/admin/views/html-report-by-date.php
+++ b/includes/admin/views/html-report-by-date.php
@@ -8,9 +8,17 @@
 if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
-
 ?>
-
+<div id="message" class="error inline">
+	<p>
+		<strong>
+		<?php
+		/* translators: 1: Link URL */
+		echo wp_kses_post( sprintf( __( 'With the release of WooCommerce 4.0, these reports are being replaced. There is a new and better Analytics section available for users running WordPress 5.3+. Head on over to the <a href="%1$s">WooCommerce Analytics</a> or learn more about the new experience in the <a href="https://docs.woocommerce.com/document/woocommerce-analytics/" target="_blank">WooCommerce Analytics documentation</a>.', 'woocommerce' ), esc_url( wc_admin_url( '&path=/analytics/overview' ) ) ) );
+		?>
+		</strong>
+	</p>
+</div>
 <div id="poststuff" class="woocommerce-reports-wide">
 	<div class="postbox">
 

--- a/includes/admin/views/html-report-by-date.php
+++ b/includes/admin/views/html-report-by-date.php
@@ -9,16 +9,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit; // Exit if accessed directly.
 }
 ?>
-<div id="message" class="error inline">
-	<p>
-		<strong>
-		<?php
-		/* translators: 1: Link URL */
-		echo wp_kses_post( sprintf( __( 'With the release of WooCommerce 4.0, these reports are being replaced. There is a new and better Analytics section available for users running WordPress 5.3+. Head on over to the <a href="%1$s">WooCommerce Analytics</a> or learn more about the new experience in the <a href="https://docs.woocommerce.com/document/woocommerce-analytics/" target="_blank">WooCommerce Analytics documentation</a>.', 'woocommerce' ), esc_url( wc_admin_url( '&path=/analytics/overview' ) ) ) );
-		?>
-		</strong>
-	</p>
-</div>
 <div id="poststuff" class="woocommerce-reports-wide">
 	<div class="postbox">
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27789

### How to test the changes in this Pull Request:

1. Go to the "legacy" woocommerce->reports.
2. Ensure you're seeing a notice that the report is being replaced with links to documentation and the new analytics page.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Notice to deprecate legacy reports in favor of the newer analytics page.

