### PR TITLE
Refactor the WC_Shipping_Zone_Data_Store::read() method

### DIFF
--- a/tests/php/includes/data-stores/class-wc-shipping-zone-data-store-test.php
+++ b/tests/php/includes/data-stores/class-wc-shipping-zone-data-store-test.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ * Class WC_Shipping_Zone_Data_Store_CPT_Test.
+ */
+class WC_Shipping_Zone_Data_Store_CPT_Test extends WC_Unit_Test_Case {
+
+	/**
+	 * @testdox read() sets properties for normal, non-zero shipping zones.
+	 */
+	public function test_read_for_normal_shipping_zones() {
+		$zone = new WC_Shipping_Zone();
+		$zone->set_zone_name( 'California' );
+		$zone->set_zone_order( 3 );
+		$zone->add_location( 'US:CA', 'state' );
+		$zone->save();
+
+		$datastore = new WC_Shipping_Zone_Data_Store();
+		$datastore->read( $zone );
+		$this->assertSame( 'California', $zone->get_zone_name() );
+		$this->assertSame( 3, $zone->get_zone_order() );
+		$this->assertGreaterThan( 0, did_action( 'woocommerce_shipping_zone_loaded' ) );
+	}
+
+	/**
+	 * @testdox read() sets default properties for shipping zone with ID 0.
+	 */
+	public function test_read_for_shipping_zone_zero() {
+		$zone = new WC_Shipping_Zone( 0 );
+
+		$datastore = new WC_Shipping_Zone_Data_Store();
+		$datastore->read( $zone );
+		$this->assertSame( 0, $zone->get_zone_order() );
+		$this->assertGreaterThan( 0, did_action( 'woocommerce_shipping_zone_loaded' ) );
+	}
+
+	/**
+	 * @testdox read() throws an exception if the zone ID cannot be found.
+	 */
+	public function test_read_with_invalid_zone_id() {
+		$this->expectException( \Exception::class );
+
+		$zone = new WC_Shipping_Zone( -1 );
+
+		$datastore = new WC_Shipping_Zone_Data_Store();
+		$datastore->read( $zone );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR re-works the `WC_Shipping_Zone_Data_Store::read()` method in the following ways:

1. Remove a confusing conditional (`if ( 0 !== $zone->get_id() || '0' !== $zone->get_id() ) { ... }`)
2. Return early if we're dealing with Zone 0, eliminating additional conditional steps
3. Add documentation for the "woocommerce_shipping_zone_loaded" action hook

### How to test the changes in this Pull Request:

1. Create a new shipping zone within WooCommerce (if one does not exist)
2. Attempt to read the shipping zone from the database (WP Admin is a good place to do so)

The shipping zone should load as it did before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev- Clean up the `WC_Shipping_Zone_Data_Store::read()` method, documenting the `woocommerce_shipping_zone_loaded` hook.
