### PR TITLE
Prevent duplicate new order email from being sent when changing order…

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -118,7 +118,7 @@ class WC_Meta_Box_Order_Actions {
 
 				WC()->payment_gateways();
 				WC()->shipping();
-				WC()->mailer()->emails['WC_Email_New_Order']->trigger( $order->get_id(), $order );
+				WC()->mailer()->emails['WC_Email_New_Order']->trigger( $order->get_id(), $order, true );
 
 				do_action( 'woocommerce_after_resend_order_email', $order, 'new_order' );
 


### PR DESCRIPTION
… status closes #27791

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27791 

### How to test the changes in this Pull Request:

1. Go through checkout and use BACS as payment gateway so the initial order status is `on-hold`.
2. Check your email and ensure you're seeing the `New Order` email to the admin.
3. Change the order status to `pending payment`. At this point there shouldn't be any emails sent.
4. Change the order status to `completed`.
5. Check your email and ensure the `New Order` email is not sent again.
6. Go back to the order and use the `Order Actions` to resend the new order notification.
7. Check your email and ensure now you see the `New Order` email come through.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Fix - Duplicate New Order emails being sent when changing order status.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
