### PR TITLE
Add migration to fix incorrect product review count.

### DIFF
--- a/includes/class-wc-comments.php
+++ b/includes/class-wc-comments.php
@@ -341,6 +341,46 @@ class WC_Comments {
 	}
 
 	/**
+	 * Utility function for getting review counts for multiple products in one query. This is not cached.
+	 *
+	 * @since 5.0.0
+	 *
+	 * @param array $product_ids Array of product IDs.
+	 *
+	 * @return array
+	 */
+	public static function get_review_counts_for_product_ids( $product_ids ) {
+		global $wpdb;
+
+		if ( empty( $product_ids ) ) {
+			return array();
+		}
+
+		$product_id_string = implode( "','", array_map( 'esc_sql', $product_ids ) );
+
+		$review_counts = $wpdb->get_results(
+			// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			"
+				SELECT comment_post_ID as product_id, COUNT( comment_post_ID ) as review_count
+				FROM $wpdb->comments
+				WHERE
+					comment_parent = 0
+					AND comment_post_ID IN ( '$product_id_string' )
+					AND comment_approved = '1'
+					AND comment_type in ( 'review', '', 'comment' )
+				GROUP BY product_id
+			",
+			// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+			ARRAY_A
+		);
+
+		// Convert to key value pairs.
+		$counts = array_replace( array_fill_keys( $product_ids, 0 ), array_column( $review_counts, 'review_count', 'product_id' ) );
+
+		return $counts;
+	}
+
+	/**
 	 * Get product review count for a product (not replies). Please note this is not cached.
 	 *
 	 * @since 3.0.0
@@ -348,22 +388,9 @@ class WC_Comments {
 	 * @return int
 	 */
 	public static function get_review_count_for_product( &$product ) {
-		global $wpdb;
+		$counts = self::get_review_counts_for_product_ids( array( $product->get_id() ) );
 
-		$count = $wpdb->get_var(
-			$wpdb->prepare(
-				"
-			SELECT COUNT(*) FROM $wpdb->comments
-			WHERE comment_parent = 0
-			AND comment_post_ID = %d
-			AND comment_approved = '1'
-			AND comment_type in ( 'review', '', 'comment' )
-				",
-				$product->get_id()
-			)
-		);
-
-		return $count;
+		return $counts[ $product->get_id() ];
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -157,6 +157,10 @@ class WC_Install {
 			'wc_update_450_sanitize_coupons_code',
 			'wc_update_450_db_version',
 		),
+		'5.0.0' => array(
+			'wc_update_500_fix_product_review_count',
+			'wc_update_500_db_version',
+		),
 	);
 
 	/**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2219,3 +2219,67 @@ function wc_update_450_sanitize_coupons_code() {
 	delete_option( 'woocommerce_update_450_last_coupon_id' );
 	return false;
 }
+
+/**
+ * Fixes product review count that might have been incorrect.
+ *
+ * See @link https://github.com/woocommerce/woocommerce/issues/27688.
+ */
+function wc_update_500_fix_product_review_count() {
+	global $wpdb;
+
+	$product_id      = 0;
+	$last_product_id = get_option( 'woocommerce_update_500_last_product_id', '0' );
+
+	$products_data = $wpdb->get_results(
+		$wpdb->prepare(
+			"
+				SELECT post_id, meta_value
+				FROM $wpdb->postmeta
+				JOIN $wpdb->posts 
+					ON $wpdb->postmeta.post_id = $wpdb->posts.ID
+				WHERE
+					post_type = 'product'
+					AND post_status = 'publish'
+					AND post_id > %d
+					AND meta_key = '_wc_review_count'
+				ORDER BY post_id ASC
+				LIMIT 10
+			",
+			$last_product_id
+		),
+		ARRAY_A
+	);
+
+	if ( empty( $products_data ) ) {
+		delete_option( 'woocommerce_update_500_last_product_id' );
+		return false;
+	}
+
+	$product_ids_to_check = array_column( $products_data, 'post_id' );
+	$actual_review_counts = WC_Comments::get_review_counts_for_product_ids( $product_ids_to_check );
+
+	foreach ( $products_data as $product_data ) {
+		$product_id           = intval( $product_data['post_id'] );
+		$current_review_count = intval( $product_data['meta_value'] );
+
+		if ( intval( $actual_review_counts[ $product_id ] ) !== $current_review_count ) {
+			WC_Comments::clear_transients( $product_id );
+		}
+	}
+
+	// Start the run again.
+	if ( $product_id ) {
+		return update_option( 'woocommerce_update_500_last_product_id', $product_id );
+	}
+
+	delete_option( 'woocommerce_update_500_last_product_id' );
+	return false;
+}
+
+/**
+ * Update DB version to 4.5.0.
+ */
+function wc_update_500_db_version() {
+	WC_Install::update_db_version( '5.0.0' );
+}

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2236,7 +2236,7 @@ function wc_update_500_fix_product_review_count() {
 			"
 				SELECT post_id, meta_value
 				FROM $wpdb->postmeta
-				JOIN $wpdb->posts 
+				JOIN $wpdb->posts
 					ON $wpdb->postmeta.post_id = $wpdb->posts.ID
 				WHERE
 					post_type = 'product'
@@ -2278,7 +2278,7 @@ function wc_update_500_fix_product_review_count() {
 }
 
 /**
- * Update DB version to 4.5.0.
+ * Update DB version to 5.0.0.
  */
 function wc_update_500_db_version() {
 	WC_Install::update_db_version( '5.0.0' );

--- a/tests/php/includes/class-wc-comments-test.php
+++ b/tests/php/includes/class-wc-comments-test.php
@@ -1,0 +1,49 @@
+<?php
+/**
+ * Tests for WC_Comments class.
+ */
+class WC_Comments_Tests extends \WC_Unit_Test_Case {
+	/**
+	 * Test get_review_counts_for_product_ids().
+	 */
+	public function test_get_review_counts_for_product_ids() {
+		$product1 = WC_Helper_Product::create_simple_product();
+		$product2 = WC_Helper_Product::create_simple_product();
+		$product3 = WC_Helper_Product::create_simple_product();
+
+		$expected_review_count = array(
+			$product1->get_id() => 0,
+			$product2->get_id() => 0,
+			$product3->get_id() => 0,
+		);
+		$product_id_array = array_keys( $expected_review_count );
+
+		$this->assertEquals( $expected_review_count, WC_Comments::get_review_counts_for_product_ids( $product_id_array ) );
+
+		\Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_product_review( $product2->get_id() );
+
+		\Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_product_review( $product3->get_id() );
+		\Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_product_review( $product3->get_id() );
+
+		$expected_review_count = array(
+			$product1->get_id() => 0,
+			$product2->get_id() => 1,
+			$product3->get_id() => 2,
+		);
+		$this->assertEquals( $expected_review_count, WC_Comments::get_review_counts_for_product_ids( $product_id_array ) );
+	}
+
+	/**
+	 * Test get_review_count_for_product.
+	 */
+	public function test_get_review_count_for_product() {
+		$product = WC_Helper_Product::create_simple_product();
+		$this->assertEquals( 0, WC_Comments::get_review_count_for_product( $product ) );
+
+		\Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_product_review( $product->get_id() );
+		$this->assertEquals( 1, WC_Comments::get_review_count_for_product( $product ) );
+
+		\Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_product_review( $product->get_id() );
+		$this->assertEquals( 2, WC_Comments::get_review_count_for_product( $product ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In https://github.com/woocommerce/woocommerce/pull/28624 we fixed the root cause for $27688, however, we still needed a migration to fix the product review counts. This PR adds that migration, to fix the counts, we loop over all meta props with keys `_wc_review_count` and update them if they are incorrect and post belongs to a product.

Closes #27688.

### How to test the changes in this Pull Request:

1. Run this query to invalidate all product review count in your shop:
```sql
UPDATE %postmeta_table_name%
SET meta_value = '9999'
WHERE meta_key = '_wc_review_count';
```
2. Go to any product page in the frontend and check that the review count is incorrect.
3. Open a WP shell and run this command:
```php
include_once dirname( WC_PLUGIN_FILE ) . '/includes/wc-update-functions.php';
WC_Install::run_update_callback('wc_update_500_fix_product_review_count'); // Keep on calling this till output is false. 
```
4. Go back to the product page in the frontend, refresh and check that the review count is now correct.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Add migration to fix existing product review count.
