### PR TITLE
Adjust spacing and font sizes for Twenty Twenty-One

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -126,11 +126,17 @@ a.button {
 	}
 }
 
-.woocommerce-breadcrumb {
-	margin-bottom: 5rem;
-	font-size: 0.88889em;
-	font-family: $headings;
+.site-main {
+	.woocommerce-breadcrumb {
+		margin-bottom: var(--global--spacing-vertical);
+		font-size: 0.88889em;
+		font-family: $headings;
+	}
+	.woocommerce-products-header {
+		margin-top: var(--global--spacing-vertical);
+	}
 }
+
 
 .woocommerce-pagination {
 	font-family: $headings;
@@ -350,6 +356,10 @@ a.button {
 			border-left: none;
 			border-right: none;
 		}
+
+		.product-thumbnail {
+			max-width: 120px;
+		}
 	}
 }
 
@@ -537,11 +547,16 @@ dl.variation,
 		display: none;
 	}
 
-	.entry-title {
-		margin: 0 0 2.5rem;
 
-		&::before {
-			margin-top: 0;
+	&.singular { // Needed for higher specificity to target the entry title font size
+		.entry-title {
+			font-size: var(--global--font-size-xl);
+			font-weight: normal;
+			margin: 0 0 2.5rem;
+
+			&::before {
+				margin-top: 0;
+			}
 		}
 	}
 
@@ -829,7 +844,7 @@ a.reset_variations {
 		}
 
 		h2:first-of-type {
-			font-size: 3rem;
+			font-size: var(--global--font-size-lg);
 			margin: 0 0 2rem !important;
 		}
 	}
@@ -1423,10 +1438,6 @@ a.reset_variations {
 	}
 
 	#main {
-
-		.entry-header {
-			padding: 3vw 0 1.5vw;
-		}
 
 		.woocommerce {
 			max-width: var(--responsive--alignwide-width);
@@ -2787,11 +2798,6 @@ a.reset_variations {
 }
 
 .woocommerce-account {
-
-	.entry-header {
-
-		padding-bottom: 20px !important;
-	}
 
 	.woocommerce-MyAccount-content {
 


### PR DESCRIPTION
This pull request makes some style changes specific to Twenty Twenty-One. See: pNEWy-duL-p2#comment-52564 for more background. 

Closes https://github.com/Automattic/themes/issues/3029.

Before | After
------- | -------
<img width="1273" alt="Screen Shot 2021-01-15 at 12 40 45 PM" src="https://user-images.githubusercontent.com/5375500/104760152-f4141100-572e-11eb-93fa-adb73ab4ffca.png"> | <img width="1281" alt="Screen Shot 2021-01-15 at 12 39 48 PM" src="https://user-images.githubusercontent.com/5375500/104760162-f8402e80-572e-11eb-936c-4b0443baea63.png">


### How to test the changes in this Pull Request:

1. Check out this PR and rebuild the styles
2. Navigate between an Account Page, Checkout page, and non Woo page 
3. Ensure the heading titles are consistent, product and checkout pages look okay

### Changelog entry

- Makes entry heading padding more consistent with the rest of the theme
- Reduces the maximum thumbnail size of the image displayed in the cart
- Reduces entry 