### PR TITLE
Revert "pass email object to header and footer templates"

### DIFF
--- a/includes/class-wc-emails.php
+++ b/includes/class-wc-emails.php
@@ -190,7 +190,7 @@ class WC_Emails {
 		$this->init();
 
 		// Email Header, Footer and content hooks.
-		add_action( 'woocommerce_email_header', array( $this, 'email_header' ), 10, 2 );
+		add_action( 'woocommerce_email_header', array( $this, 'email_header' ) );
 		add_action( 'woocommerce_email_footer', array( $this, 'email_footer' ) );
 		add_action( 'woocommerce_email_order_details', array( $this, 'order_downloads' ), 10, 4 );
 		add_action( 'woocommerce_email_order_details', array( $this, 'order_details' ), 10, 4 );
@@ -263,26 +263,17 @@ class WC_Emails {
 	/**
 	 * Get the email header.
 	 *
-	 * @param mixed    $email_heading Heading for the email.
-	 * @param WC_Email $email         Email object for the email.
+	 * @param mixed $email_heading Heading for the email.
 	 */
-	public function email_header( $email_heading, $email ) {
-		wc_get_template(
-			'emails/email-header.php',
-			array(
-				'email_heading' => $email_heading,
-				'email'         => $email,
-			)
-		);
+	public function email_header( $email_heading ) {
+		wc_get_template( 'emails/email-header.php', array( 'email_heading' => $email_heading ) );
 	}
 
 	/**
 	 * Get the email footer.
-	 *
-	 * @param WC_Email $email Email object for the email.
 	 */
-	public function email_footer( $email ) {
-		wc_get_template( 'emails/email-footer.php', array( 'email' => $email ) );
+	public function email_footer() {
+		wc_get_template( 'emails/email-footer.php' );
 	}
 
 	/**

--- a/tests/php/includes/class-wc-emails-tests.php
+++ b/tests/php/includes/class-wc-emails-tests.php
@@ -1,0 +1,37 @@
+<?php
+
+/**
+ * Class WC_Emails_Tests.
+ */
+class WC_Emails_Tests extends \WC_Unit_Test_Case {
+
+	/**
+	 * Test that email_header hooks are compitable with do_action calls with only param.
+	 * This test should be dropped after all extensions are using compitable do_action calls.
+	 */
+	public function test_email_header_is_compatible_with_legacy_do_action() {
+		$email_object = new WC_Emails();
+		// 10 is expected priority of the hook.
+		$this->assertEquals( 10, has_action( 'woocommerce_email_header', array( $email_object, 'email_header' ) ) );
+		ob_start();
+		do_action( 'woocommerce_email_header', 'header' );
+		$content = ob_get_contents();
+		ob_end_clean();
+		$this->assertFalse( empty( $content ) );
+	}
+
+	/**
+	 * Test that email_footer hooks are compitable with do_action calls with only param.
+	 * This test should be dropped after all extensions are using compitable do_action calls.
+	 */
+	public function test_email_footer_is_compatible_with_legacy_do_action() {
+		$email_object = new WC_Emails();
+		// 10 is expected priority of the hook.
+		$this->assertEquals( 10, has_action( 'woocommerce_email_footer', array( $email_object, 'email_footer' ) ) );
+		ob_start();
+		do_action( 'woocommerce_email_footer' );
+		$content = ob_get_contents();
+		ob_end_clean();
+		$this->assertFalse( empty( $content ) );
+	}
+}

--- a/tests/php/includes/class-wc-emails-tests.php
+++ b/tests/php/includes/class-wc-emails-tests.php
@@ -6,8 +6,8 @@
 class WC_Emails_Tests extends \WC_Unit_Test_Case {
 
 	/**
-	 * Test that email_header hooks are compitable with do_action calls with only param.
-	 * This test should be dropped after all extensions are using compitable do_action calls.
+	 * Test that email_header hooks are compatible with do_action calls with only param.
+	 * This test should be dropped after all extensions are using compatible do_action calls.
 	 */
 	public function test_email_header_is_compatible_with_legacy_do_action() {
 		$email_object = new WC_Emails();
@@ -21,8 +21,8 @@ class WC_Emails_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test that email_footer hooks are compitable with do_action calls with only param.
-	 * This test should be dropped after all extensions are using compitable do_action calls.
+	 * Test that email_footer hooks are compatible with do_action calls with only param.
+	 * This test should be dropped after all extensions are using compatible do_action calls.
 	 */
 	public function test_email_footer_is_compatible_with_legacy_do_action() {
 		$email_object = new WC_Emails();


### PR DESCRIPTION
This reverts commit 8821bf41c519065cef192717a9458999f6479784.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR restores compatibility with extensions that are calling do_action methods not compatible with core's do_action method for email_headers and email_footers.

Note that this revert is only temporary, we will add back the functionality in a near future release in a compatible way soon.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Install WooCommerce Bookings 1.15.33
2. Set up a bookable product.
3. Purchase a booking on the front end.
4. Edit the booking and set status to Confirmed.
5. Save booking.
6. Make sure you receive the confirmation mail, and there is no error logged in the error log.

OR

1. Open a wp shell and run this script:
```php
$email_object = new WC_Emails();
do_action( 'woocommerce_email_header', 'header' );
```
Make sure that there is mail header content printed on the console.
2.  Open another wp shell and run this script
```php
$email_object = new WC_Emails();
do_action( 'woocommerce_email_footer' );
```
Make sure that there is mail footer content printed on the console.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Reverts #28204 to ensure compatibility with extensions using legacy do_action calls.

