### PR TITLE
Fixed woocommerce_activated_plugin docblock

### DIFF
--- a/src/Packages.php
+++ b/src/Packages.php
@@ -72,17 +72,18 @@ class Packages {
 		// Proxies "activated_plugin" hook for embedded packages listen on WC plugin activation
 		// https://github.com/woocommerce/woocommerce/issues/28697.
 		if ( is_admin() ) {
-			$is_activated = get_transient( 'woocommerce_activated_plugin' );
-			if ( $is_activated ) {
+			$activated_plugin = get_transient( 'woocommerce_activated_plugin' );
+			if ( $activated_plugin ) {
 				delete_transient( 'woocommerce_activated_plugin' );
 
 				/**
 				 * WooCommerce is activated hook.
 				 *
 				 * @since 5.0.0
-				 * @param bool $is_activated Indicates if WooCommerce is activated.
+				 * @param bool $activated_plugin Activated plugin path,
+				 *                               generally woocommerce/woocommerce.php.
 				 */
-				do_action( 'woocommerce_activated_plugin', $is_activated );
+				do_action( 'woocommerce_activated_plugin', $activated_plugin );
 			}
 		}
 	}


### PR DESCRIPTION
Updating the description to reflect what `woocommerce_activated_plugin` store.