### PR TITLE
Deactivate untested plugin's notices

### DIFF
--- a/includes/admin/class-wc-admin-status.php
+++ b/includes/admin/class-wc-admin-status.php
@@ -377,7 +377,7 @@ class WC_Admin_Status {
 	private static function output_plugins_info( $plugins, $untested_plugins ) {
 		$wc_version = Constants::get_constant( 'WC_VERSION' );
 
-		if ( 'major' === WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE ) {
+		if ( 'major' === Constants::get_constant( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE' ) ) {
 			// Since we're only testing against major, we don't need to show minor and patch version.
 			$wc_version = $wc_version[0] . '.0';
 		}

--- a/includes/admin/plugin-updates/class-wc-plugin-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugin-updates.php
@@ -150,10 +150,15 @@ class WC_Plugin_Updates {
 	 * with the $new_version.
 	 *
 	 * @param string $new_version WooCommerce version to test against.
-	 * @param string $release 'major' or 'minor'.
+	 * @param string $release 'major', 'minor', or 'none'.
 	 * @return array of plugin info arrays
 	 */
 	public function get_untested_plugins( $new_version, $release ) {
+		// Since 5.0 all versions are backwards compatible.
+		if ( 'none' === $release ) {
+			return array();
+		}
+
 		$extensions        = array_merge( $this->get_plugins_with_header( self::VERSION_TESTED_HEADER ), $this->get_plugins_for_woocommerce() );
 		$untested          = array();
 		$new_version_parts = explode( '.', $new_version );

--- a/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
@@ -42,9 +42,14 @@ class WC_Plugins_Screen_Updates extends WC_Plugin_Updates {
 	 * @param stdClass $response Plugin update response.
 	 */
 	public function in_plugin_update_message( $args, $response ) {
+		$version_type = Constants::get_constant( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE' );
+		if ( ! is_string( $version_type ) ) {
+			$version_type = 'none';
+		}
+
 		$this->new_version            = $response->new_version;
 		$this->upgrade_notice         = $this->get_upgrade_notice( $response->new_version );
-		$this->major_untested_plugins = $this->get_untested_plugins( $response->new_version, 'major' );
+		$this->major_untested_plugins = $this->get_untested_plugins( $response->new_version, $version_type );
 
 		$current_version_parts = explode( '.', Constants::get_constant( 'WC_VERSION' ) );
 		$new_version_parts     = explode( '.', $this->new_version );

--- a/includes/admin/plugin-updates/views/html-notice-untested-extensions-modal.php
+++ b/includes/admin/plugin-updates/views/html-notice-untested-extensions-modal.php
@@ -18,7 +18,7 @@ $untested_plugins_msg = sprintf(
 ?>
 <div id="wc_untested_extensions_modal">
 	<div class="wc_untested_extensions_modal--content">
-		<h1><?php esc_html_e( "This is a major update, are you sure you're ready?", 'woocommerce' ); ?></h1>
+		<h1><?php esc_html_e( "Are you sure you're ready?", 'woocommerce' ); ?></h1>
 		<div class="wc_plugin_upgrade_notice extensions_warning">
 			<p><?php echo esc_html( $untested_plugins_msg ); ?></p>
 
@@ -41,7 +41,7 @@ $untested_plugins_msg = sprintf(
 				</table>
 			</div>
 
-			<p><?php esc_html_e( 'As this is a major update, we strongly recommend creating a backup of your site before updating.', 'woocommerce' ); ?> <a href="https://woocommerce.com/2017/05/create-use-backups-woocommerce/" target="_blank"><?php esc_html_e( 'Learn more', 'woocommerce' ); ?></a></p>
+			<p><?php esc_html_e( 'We strongly recommend creating a backup of your site before updating.', 'woocommerce' ); ?> <a href="https://woocommerce.com/2017/05/create-use-backups-woocommerce/" target="_blank"><?php esc_html_e( 'Learn more', 'woocommerce' ); ?></a></p>
 
 			<?php if ( current_user_can( 'update_plugins' ) ) : ?>
 				<div class="actions">

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -11,7 +11,8 @@ global $wpdb;
 
 if ( ! defined( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE' ) ) {
 	// Define if we're checking against major or minor versions.
-	define( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE', 'major' );
+	// Since 5.0 all versions are backwards compatible, so there's no more check.
+	define( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE', 'none' );
 }
 
 $report             = wc()->api->get_endpoint_data( '/wc/v3/system_status' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR disables the untested plugin's notice from WooCommerce's Status page and from the Plugin's page.
Since we should release everything backwards compatible now and move way from SemVer, there's no more reason to keep those banners.

Closes #28806

### How to test the changes in this Pull Request:

1. Checkout this branch, edit `woocommerce.php` and change the version number to `3.0`.
2. Install WooCommerce Stripe (`wp plugin install --activate woocommerce-gateway-stripe`)
3. Edit Stripe's version number back to `4.6.0` in `wp-content/plugins/woocommerce-gateway-stripe/woocommerce-gateway-stripe.php`
4. Go to `/wp-admin/update-core.php` and check for new updates.
5. Now go to `/wp-admin/admin.php?page=wc-status` and check if there's no notices in the plugin's section.
6. Finally check `/wp-admin/plugins.php` to see if WooCommerce keeps any banner about upgrading to the next Major version.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Disable untested plugin's notice from System Status and Plugin's page.
