### PR TITLE
remove travis_retry from e2e test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,9 @@ jobs:
      - npm install
      - composer install --no-dev
     script:
-      - travis_retry npm run build:assets
-      - travis_retry npm run docker:up
-      - travis_retry npm run test:e2e
+      - npm run build:assets
+      - npm run docker:up
+      - npm run test:e2e
     after_script:
       - npm run docker:down
   - name: "WP Nightly"


### PR DESCRIPTION
`travis_retry` was added to the E2E test script in #28548. Recently, all E2E test runs have failed but Travis has marked the run as successful. The E2E test script runs to completion so from a retry perspective it was successful.

Example failure: https://travis-ci.com/github/woocommerce/woocommerce/jobs/472857696

The failing test is the test added in #28665 which was merged 4 days ago. That PR makes changes to the utilities package. Prior to merging, if you switched to that branch and ran the E2E tests you would see the same failures. If you ran `npm build:packages` before running the tests then the tests passed. 

Without further investigation it appears that `travis_retry` caches copies of the package builds and skips rebuilding on each retry.

### Testing

1. Verify E2E tests were successful in Travis without the `travis_retry`
2. Run E2E tests locally
3. If you have not done so, do the following after switching to `master` before running `npm run docker:up`
```
rm node_modules/@woocommerce/e2e-environment
rm -rf tests/e2e/env/node_modules
npm run build:packages
npm install
```
