### PR TITLE
Verify country code on checkout

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -688,23 +688,25 @@ class WC_Checkout {
 			foreach ( $fieldset as $key => $field ) {
 				$type = sanitize_title( isset( $field['type'] ) ? $field['type'] : 'text' );
 
+				// phpcs:disable WordPress.Security.NonceVerification.Missing
 				switch ( $type ) {
 					case 'checkbox':
-						$value = isset( $_POST[ $key ] ) ? 1 : ''; // WPCS: input var ok, CSRF ok.
+						$value = isset( $_POST[ $key ] ) ? 1 : '';
 						break;
 					case 'multiselect':
-						$value = isset( $_POST[ $key ] ) ? implode( ', ', wc_clean( wp_unslash( $_POST[ $key ] ) ) ) : ''; // WPCS: input var ok, CSRF ok.
+						$value = isset( $_POST[ $key ] ) ? implode( ', ', wc_clean( wp_unslash( $_POST[ $key ] ) ) ) : '';
 						break;
 					case 'textarea':
-						$value = isset( $_POST[ $key ] ) ? wc_sanitize_textarea( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok.
+						$value = isset( $_POST[ $key ] ) ? wc_sanitize_textarea( wp_unslash( $_POST[ $key ] ) ) : '';
 						break;
 					case 'password':
-						$value = isset( $_POST[ $key ] ) ? wp_unslash( $_POST[ $key ] ) : ''; // WPCS: input var ok, CSRF ok, sanitization ok.
+						$value = isset( $_POST[ $key ] ) ? wp_unslash( $_POST[ $key ] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 						break;
 					default:
-						$value = isset( $_POST[ $key ] ) ? wc_clean( wp_unslash( $_POST[ $key ] ) ) : ''; // WPCS: input var ok, CSRF ok.
+						$value = isset( $_POST[ $key ] ) ? wc_clean( wp_unslash( $_POST[ $key ] ) ) : '';
 						break;
 				}
+				// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 				$data[ $key ] = apply_filters( 'woocommerce_process_checkout_' . $type . '_field', apply_filters( 'woocommerce_process_checkout_field_' . $key, $value ) );
 			}
@@ -835,7 +837,8 @@ class WC_Checkout {
 			WC()->countries->country_exists( $billing_country, true );
 		}
 
-		if ( empty( $data['woocommerce_checkout_update_totals'] ) && empty( $data['terms'] ) && ! empty( $_POST['terms-field'] ) ) { // WPCS: input var ok, CSRF ok.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( empty( $data['woocommerce_checkout_update_totals'] ) && empty( $data['terms'] ) && ! empty( $_POST['terms-field'] ) ) {
 			$errors->add( 'terms', __( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce' ) );
 		}
 
@@ -1211,8 +1214,8 @@ class WC_Checkout {
 	 */
 	public function get_value( $input ) {
 		// If the form was posted, get the posted value. This will only tend to happen when JavaScript is disabled client side.
-		if ( ! empty( $_POST[ $input ] ) ) { // WPCS: input var ok, CSRF OK.
-			return wc_clean( wp_unslash( $_POST[ $input ] ) ); // WPCS: input var ok, CSRF OK.
+		if ( ! empty( $_POST[ $input ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Missing
+			return wc_clean( wp_unslash( $_POST[ $input ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		}
 
 		// Allow 3rd parties to short circuit the logic and return their own default value.

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -746,8 +746,8 @@ class WC_Checkout {
 				$format      = array_filter( isset( $field['validate'] ) ? (array) $field['validate'] : array() );
 				$field_label = isset( $field['label'] ) ? $field['label'] : '';
 
-				if ( 'country' === $field['type'] &&
-					! ( 'shipping' === $fieldset_key && ! $data ['ship_to_different_address'] ) &&
+				if ( $validate_fieldset &&
+					'country' === $field['type'] &&
 					! WC()->countries->country_exists( $data[ $key ] ) ) {
 						/* translators: ISO 3166-1 alpha-2 country code */
 						$errors->add( $key . '_validation', sprintf( __( "'%s' is not a valid country code.", 'woocommerce' ), $data[ $key ] ) );

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -830,6 +830,11 @@ class WC_Checkout {
 		$this->validate_posted_data( $data, $errors );
 		$this->check_cart_items();
 
+		$billing_country = WC()->customer->get_shipping_country();
+		if ( $billing_country ) {
+			WC()->countries->country_exists( $billing_country, true );
+		}
+
 		if ( empty( $data['woocommerce_checkout_update_totals'] ) && empty( $data['terms'] ) && ! empty( $_POST['terms-field'] ) ) { // WPCS: input var ok, CSRF ok.
 			$errors->add( 'terms', __( 'Please read and accept the terms and conditions to proceed with your order.', 'woocommerce' ) );
 		}
@@ -839,6 +844,9 @@ class WC_Checkout {
 
 			if ( empty( $shipping_country ) ) {
 				$errors->add( 'shipping', __( 'Please enter an address to continue.', 'woocommerce' ) );
+			// phpcs:ignore Generic.CodeAnalysis.EmptyStatement.DetectedElseif
+			} elseif ( ! WC()->countries->country_exists( $shipping_country, true ) ) {
+				// Nothing to do, as an exception will have been thrown.
 			} elseif ( ! in_array( WC()->customer->get_shipping_country(), array_keys( WC()->countries->get_shipping_countries() ), true ) ) {
 				/* translators: %s: shipping location */
 				$errors->add( 'shipping', sprintf( __( 'Unfortunately <strong>we do not ship %s</strong>. Please enter an alternative shipping address.', 'woocommerce' ), WC()->countries->shipping_to_prefix() . ' ' . WC()->customer->get_shipping_country() ) );

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -850,9 +850,11 @@ class WC_Checkout {
 
 			if ( empty( $shipping_country ) ) {
 				$errors->add( 'shipping', __( 'Please enter an address to continue.', 'woocommerce' ) );
-			} elseif ( $this->is_country_we_dont_ship_to( $shipping_country ) ) {
-				/* translators: %s: shipping location (prefix e.g. 'to' + ISO 3166-1 alpha-2 country code) */
-				$errors->add( 'shipping', sprintf( __( 'Unfortunately <strong>we do not ship %s</strong>. Please enter an alternative shipping address.', 'woocommerce' ), WC()->countries->shipping_to_prefix() . ' ' . $shipping_country ) );
+			} elseif ( ! in_array( $shipping_country, array_keys( WC()->countries->get_shipping_countries() ), true ) ) {
+				if ( WC()->countries->country_exists( $shipping_country ) ) {
+					/* translators: %s: shipping location (prefix e.g. 'to' + ISO 3166-1 alpha-2 country code) */
+					$errors->add( 'shipping', sprintf( __( 'Unfortunately <strong>we do not ship %s</strong>. Please enter an alternative shipping address.', 'woocommerce' ), WC()->countries->shipping_to_prefix() . ' ' . $shipping_country ) );
+				}
 			} else {
 				$chosen_shipping_methods = WC()->session->get( 'chosen_shipping_methods' );
 
@@ -875,17 +877,6 @@ class WC_Checkout {
 		}
 
 		do_action( 'woocommerce_after_checkout_validation', $data, $errors );
-	}
-
-	/**
-	 * Checks if a given country is one which exists but we don't ship to.
-	 *
-	 * @param string $country ISO 3166-1 alpha-2 country code to check.
-	 * @return true if the country exists AND we don't ship to it (note that if country doesn't exist will return false).
-	 */
-	private function is_country_we_dont_ship_to( $country ) {
-		return WC()->countries->country_exists( $country ) &&
-			! in_array( $country, array_keys( WC()->countries->get_shipping_countries() ), true );
 	}
 
 	/**

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -834,7 +834,6 @@ class WC_Checkout {
 	 * @since  3.0.0
 	 * @param  array    $data   An array of posted data.
 	 * @param  WP_Error $errors Validation errors.
-	 * @throws Exception Invalid country code in billing or shipping address.
 	 */
 	protected function validate_checkout( &$data, &$errors ) {
 		$this->validate_posted_data( $data, $errors );

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -881,7 +881,7 @@ class WC_Checkout {
 	 * Checks if a given country is one which exists but we don't ship to.
 	 *
 	 * @param string $country ISO 3166-1 alpha-2 country code to check.
-	 * @return true if the country exists AND we don't ship to it (not that if country doesn't exist will return false).
+	 * @return true if the country exists AND we don't ship to it (note that if country doesn't exist will return false).
 	 */
 	private function is_country_we_dont_ship_to( $country ) {
 		return WC()->countries->country_exists( $country ) &&

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -65,7 +65,7 @@ class WC_Countries {
 	 * @return bool True if the country is known to us, false otherwise.
 	 */
 	public function country_exists( $country_code ) {
-		return array_key_exists( $country_code, $this->get_countries() );
+		return isset( $this->get_countries()[ $country_code ] );
 	}
 
 	/**

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -62,17 +62,10 @@ class WC_Countries {
 	 *
 	 * @since 5.1.0
 	 * @param string $country_code The country code to check as a ISO 3166-1 alpha-2 code.
-	 * @param bool   $throw True to throw an exception if the country code isn't recognized.
 	 * @return bool True if the country is known to us, false otherwise.
-	 * @throws Exception The country code isn't recognized, and the $throw argument was passed as true.
 	 */
-	public function country_exists( $country_code, $throw = false ) {
-		$exists = array_key_exists( $country_code, $this->get_countries() );
-		if ( ! $exists && $throw ) {
-			/* translators: %s: ISO 3166-1 alpha-2 country code. */
-			throw new Exception( sprintf( __( "'%s' is not a valid country code", 'woocommerce' ), $country_code ) );
-		}
-		return $exists;
+	public function country_exists( $country_code ) {
+		return array_key_exists( $country_code, $this->get_countries() );
 	}
 
 	/**

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -58,6 +58,24 @@ class WC_Countries {
 	}
 
 	/**
+	 * Check if a given code represents a valid ISO 3166-1 alpha-2 code for a country known to us.
+	 *
+	 * @since 5.1.0
+	 * @param string $country_code The country code to check as a ISO 3166-1 alpha-2 code.
+	 * @param bool   $throw True to throw an exception if the country code isn't recognized.
+	 * @return bool True if the country is known to us, false otherwise.
+	 * @throws Exception The country code isn't recognized, and the $throw argument was passed as true.
+	 */
+	public function country_exists( $country_code, $throw = false ) {
+		$exists = array_key_exists( $country_code, $this->get_countries() );
+		if ( ! $exists && $throw ) {
+			/* translators: %s: ISO 3166-1 alpha-2 country code. */
+			throw new Exception( sprintf( __( "'%s' is not a valid country code", 'woocommerce' ), $country_code ) );
+		}
+		return $exists;
+	}
+
+	/**
 	 * Get all continents.
 	 *
 	 * @return array
@@ -919,7 +937,7 @@ class WC_Countries {
 						),
 						'state'    => array(
 							'required' => false,
-							'hidden' => true,
+							'hidden'   => true,
 						),
 					),
 					'DK' => array(
@@ -928,7 +946,7 @@ class WC_Countries {
 						),
 						'state'    => array(
 							'required' => false,
-							'hidden' => true,
+							'hidden'   => true,
 						),
 					),
 					'EE' => array(
@@ -999,7 +1017,7 @@ class WC_Countries {
 						),
 					),
 					'HU' => array(
-						'last_name' => array(
+						'last_name'  => array(
 							'class'    => array( 'form-row-first' ),
 							'priority' => 10,
 						),
@@ -1007,20 +1025,20 @@ class WC_Countries {
 							'class'    => array( 'form-row-last' ),
 							'priority' => 20,
 						),
-						'postcode' => array(
+						'postcode'   => array(
 							'class'    => array( 'form-row-first', 'address-field' ),
 							'priority' => 65,
 						),
-						'city' => array(
+						'city'       => array(
 							'class' => array( 'form-row-last', 'address-field' ),
 						),
-						'address_1' => array(
+						'address_1'  => array(
 							'priority' => 71,
 						),
-						'address_2' => array(
+						'address_2'  => array(
 							'priority' => 72,
 						),
-						'state' => array(
+						'state'      => array(
 							'label' => __( 'County', 'woocommerce' ),
 						),
 					),
@@ -1242,7 +1260,7 @@ class WC_Countries {
 							'required' => true,
 						),
 						'state'    => array(
-							'label' => __( 'District', 'woocommerce' ),
+							'label'    => __( 'District', 'woocommerce' ),
 							'required' => false,
 						),
 					),
@@ -1314,7 +1332,7 @@ class WC_Countries {
 						),
 						'state'    => array(
 							'required' => false,
-							'hidden' => true,
+							'hidden'   => true,
 						),
 					),
 					'TR' => array(

--- a/tests/legacy/mockable-functions.php
+++ b/tests/legacy/mockable-functions.php
@@ -8,5 +8,5 @@
  */
 
 return array(
-	// 'get_option'
+	'wc_get_shipping_method_count',
 );

--- a/tests/php/includes/class-wc-checkout-test.php
+++ b/tests/php/includes/class-wc-checkout-test.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Unit tests for the WC_Cart_Test class.
+ *
+ * @package WooCommerce\Tests\Checkout.
+ */
+
+use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
+
+/**
+ * Class WC_Checkout
+ */
+class WC_Checkout_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * @var object The system under test.
+	 */
+	private $sut;
+
+	/**
+	 * Runs before each test.
+	 */
+	public function setUp() {
+		// phpcs:disable Generic.CodeAnalysis, Squiz.Commenting
+		$this->sut = new class() extends WC_Checkout {
+			public function validate_posted_data( &$data, &$errors ) {
+				return parent::validate_posted_data( $data, $errors );
+			}
+
+			public function validate_checkout( &$data, &$errors ) {
+				return parent::validate_checkout( $data, $errors );
+			}
+		};
+		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
+	}
+
+	/**
+	 * @testdox 'validate_posted_data' adds errors for non-existing billing/shipping countries.
+	 *
+	 * @testWith [true, true]
+	 *           [false, false]
+	 *
+	 * @param bool $ship_to_different_address True to simulate shipping to a different address than the billing address.
+	 * @param bool $expect_error_message_for_shipping_country True to expect an error to be generated for the shipping country.
+	 */
+	public function test_validate_posted_data_adds_error_for_non_existing_country( $ship_to_different_address, $expect_error_message_for_shipping_country ) {
+		$_POST = array(
+			'billing_country'           => 'XX',
+			'shipping_country'          => 'YY',
+			'ship_to_different_address' => $ship_to_different_address,
+		);
+		$data  = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		$errors = new WP_Error();
+
+		$this->sut->validate_posted_data( $data, $errors );
+
+		$this->assertEquals( "'XX' is not a valid country code.", $errors->get_error_message( 'billing_country_validation' ) );
+		$this->assertEquals(
+			$expect_error_message_for_shipping_country ? "'YY' is not a valid country code." : '',
+			$errors->get_error_message( 'shipping_country_validation' )
+		);
+	}
+
+	/**
+	 * @testdox 'validate_posted_data' doesn't add errors for existing billing/shipping countries.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $ship_to_different_address True to simulate shipping to a different address than the billing address.
+	 */
+	public function test_validate_posted_data_does_not_add_error_for_existing_country( $ship_to_different_address ) {
+		$_POST = array(
+			'billing_country'           => 'ES',
+			'shipping_country'          => 'ES',
+			'ship_to_different_address' => $ship_to_different_address,
+		);
+		$data  = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		$errors = new WP_Error();
+
+		$this->sut->validate_posted_data( $data, $errors );
+
+		$this->assertEmpty( $errors->get_error_message( 'billing_country_validation' ) );
+		$this->assertEmpty( $errors->get_error_message( 'shipping_country_validation' ) );
+	}
+
+	/**
+	 * @testdox 'validate_checkout' adds a "We don't ship to country X" error but only if the country exists.
+	 *
+	 * @testWith [ "XX", false ]
+	 *           [ "JP", true ]
+	 *
+	 * @param string $country The billing/shipping country.
+	 * @param bool   $expect_we_dont_ship_error True to expect a "We don't ship to X" error.
+	 */
+	public function test_validate_checkout_adds_we_dont_ship_error_only_if_country_exists( $country, $expect_we_dont_ship_error ) {
+		add_filter(
+			'woocommerce_countries_allowed_countries',
+			function() {
+				return array( 'ES' );
+			}
+		);
+
+		add_filter(
+			'woocommerce_cart_needs_shipping',
+			function() {
+				return true;
+			}
+		);
+
+		add_filter(
+			'wc_shipping_enabled',
+			function() {
+				return true;
+			}
+		);
+
+		FunctionsMockerHack::add_function_mocks(
+			array(
+				'wc_get_shipping_method_count' => function( $include_legacy = false, $enabled_only = false ) {
+					return 1;
+				},
+			)
+		);
+
+		$_POST = array(
+			'billing_country'           => $country,
+			'shipping_country'          => $country,
+			'ship_to_different_address' => false,
+		);
+		$data  = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		$errors = new WP_Error();
+
+		$this->sut->validate_checkout( $data, $errors );
+
+		$this->assertEquals(
+			$expect_we_dont_ship_error ? 'Unfortunately <strong>we do not ship to the JP</strong>. Please enter an alternative shipping address.' : '',
+			$errors->get_error_message( 'shipping' )
+		);
+	}
+}

--- a/tests/php/includes/class-wc-checkout-test.php
+++ b/tests/php/includes/class-wc-checkout-test.php
@@ -51,6 +51,13 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 		);
 		$data  = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
 
+		add_filter(
+			'woocommerce_cart_needs_shipping_address',
+			function() {
+				return true;
+			}
+		);
+
 		$errors = new WP_Error();
 
 		$this->sut->validate_posted_data( $data, $errors );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently the checkout process doesn't validate if the posted country codes (in `billing_country` and `shipping_country` POST keys) actually exist, so it's possible to post a non-existing country code e.g. "XX" and it will be recorded as such in the billing or shipping address. This pull request adds validation for these keys in the checkout process.

Closes #27521.

### How to test the changes in this Pull Request:

1. Start with `master`.
2. Add the following at the end of `woocommerce.php` to simulate tampering with the form data:

```php
if ( array_key_exists( 'billing_country', $_POST ) ) $_POST['billing_country'] = 'XX';
if ( array_key_exists( 'shipping_country', $_POST ) ) $_POST['shipping_country'] = 'YY';
```

3. Place an order where the shipping address is the same as the billing address. The checkout will succeed, go check the order details and see that the country in the billing address is "XX".
4. Switch to this branch.
5. Repeat 3. Now the checkout should fail with a _'XX' is not a valid country code_ error.
6. Place an order where the shipping address is different from the billing address. Now there are two errors on checkout, one for 'XX' and another one for 'YY'.
7. Remove the hack on `woocommerce.php`, try to complete checkout without specifying a country and verify that the error message is still the proper one ("is a required field").

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - add validation of the posted country codes on checkout
