### PR TITLE
Add new e2e test shopper grouped product

### DIFF
--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -9,7 +9,7 @@
 - Merchant Order Refund tests
 - Merchant Apply Coupon tests
 - Added new config variable for Simple Product price to `tests/e2e/env/config/default.json`. Defaults to 9.99
-
+- Shopper Single Product tests
 - Shopper Checkout Apply Coupon
 
 

--- a/tests/e2e/core-tests/README.md
+++ b/tests/e2e/core-tests/README.md
@@ -62,7 +62,7 @@ The functions to access the core tests are:
   - `runCartPageTest` - Shopper can view and update cart
   - `runCheckoutPageTest` - Shopper can complete checkout
   - `runMyAccountPageTest` - Shopper can access my account page
-  - `runSingleProductPageTest` - Shopper can view single product page
+  - `runSingleProductPageTest` - Shopper can view single product page in many variations (simple, variable, grouped)
 
 ## Contributing a new test
 

--- a/tests/e2e/core-tests/specs/shopper/front-end-single-product.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-single-product.test.js
@@ -35,7 +35,9 @@ const runSingleProductPageTest = () => {
 			// Verify cart contents
 			await shopper.goToCart();
 			await shopper.productIsInCart(simpleProductName, 5);
+		});
 
+		it('should be able to remove simple products from the cart', async () => {
 			// Remove items from cart
 			await shopper.removeFromCart(simpleProductName);
 			await uiUnblocked();
@@ -62,7 +64,9 @@ const runSingleProductPageTest = () => {
 			// Verify cart contents
 			await shopper.goToCart();
 			await shopper.productIsInCart('Variable Product with Three Variations');
+		});
 
+		it('should be able to remove variation products from the cart', async () => {
 			// Remove items from cart
 			await shopper.removeFromCart('Variable Product with Three Variations');
 			await uiUnblocked();
@@ -75,7 +79,7 @@ const runSingleProductPageTest = () => {
 			await merchant.login();
 			groupedPostIdValue = await createGroupedProduct();
 			await merchant.logout();
-		})
+		});
 
 		it('should be able to add grouped products to the cart', async () => {
 			// Add a grouped product to cart
@@ -97,7 +101,9 @@ const runSingleProductPageTest = () => {
 			await shopper.goToCart();
 			await shopper.productIsInCart(simpleProductName+' 1');
 			await shopper.productIsInCart(simpleProductName+' 2');
+		});
 
+		it('should be able to remove grouped products from the cart', async () => {
 			// Remove items from cart
 			await shopper.removeFromCart(simpleProductName+' 1');
 			await uiUnblocked();
@@ -111,8 +117,8 @@ const runSingleProductPageTest = () => {
 			await uiUnblocked();
 			await expect(page).toMatchElement('.woocommerce-message', {text: '“'+simpleProductName+' 2” removed.'});
 			await expect(page).toMatchElement('.cart-empty', {text: 'Your cart is currently empty.'});
-		})
-	})
+		});
+	});
 };
 
 module.exports = runSingleProductPageTest;

--- a/tests/e2e/core-tests/specs/shopper/front-end-single-product.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-single-product.test.js
@@ -7,11 +7,13 @@ const {
 	merchant,
 	createSimpleProduct,
 	createVariableProduct,
+	createGroupedProduct,
 	uiUnblocked
 } = require( '@woocommerce/e2e-utils' );
 
 let simplePostIdValue;
 let variablePostIdValue;
+let groupedPostIdValue;
 const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );
 
@@ -67,6 +69,50 @@ const runSingleProductPageTest = () => {
 			await expect(page).toMatchElement('.cart-empty', {text: 'Your cart is currently empty.'});
 		});
 	});
+
+	describe('Grouped Product Page', () => {
+		beforeAll(async () => {
+			await merchant.login();
+			groupedPostIdValue = await createGroupedProduct();
+			await merchant.logout();
+		})
+
+		it('should be able to add grouped products to the cart', async () => {
+			// Add a grouped product to cart
+			await shopper.goToProduct(groupedPostIdValue);
+			await page.waitForSelector('form.grouped_form');
+			await shopper.addToCart();
+			await expect(page).toMatchElement('.woocommerce-error',
+			 {text: 'Please choose the quantity of items you wish to add to your cart…'});
+			const quantityFields = await page.$$('div.quantity input.qty');
+			await quantityFields[0].click({clickCount: 3});
+			await quantityFields[0].type('5');
+			await quantityFields[1].click({clickCount: 3});
+			await quantityFields[1].type('5');
+			await shopper.addToCart();
+			await expect(page).toMatchElement('.woocommerce-message',
+			 {text: '“'+simpleProductName+' 1” and “'+simpleProductName+' 2” have been added to your cart.'});
+
+			// Verify cart contents
+			await shopper.goToCart();
+			await shopper.productIsInCart(simpleProductName+' 1');
+			await shopper.productIsInCart(simpleProductName+' 2');
+
+			// Remove items from cart
+			await shopper.removeFromCart(simpleProductName+' 1');
+			await uiUnblocked();
+			await expect(page).toMatchElement('.woocommerce-message', {text: '“'+simpleProductName+' 1” removed.'});
+			await Promise.all( [
+				// Reload page and perform item removal, since removeFromCart won't remove it when placed in a row
+				page.reload(),
+				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			] );
+			await shopper.removeFromCart(simpleProductName+' 2');
+			await uiUnblocked();
+			await expect(page).toMatchElement('.woocommerce-message', {text: '“'+simpleProductName+' 2” removed.'});
+			await expect(page).toMatchElement('.cart-empty', {text: 'Your cart is currently empty.'});
+		})
+	})
 };
 
 module.exports = runSingleProductPageTest;

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -13,6 +13,7 @@
 - `addProductToOrder( orderId, productName )` component which adds the provided productName to the passed in orderId
 - `createCoupon( couponAmount )` component which accepts a coupon amount string (it defaults to 5) and creates a basic coupon. Returns the generated coupon code.
 - `evalAndClick( selector )` use Puppeteer page.$eval to select and click and element.
+- `selectOptionInSelect2( selector, value )` util helper method that search and select in any select2 type field
 
 ## Changes
 

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -98,6 +98,7 @@ describe( 'Cart page', () => {
 | `verifyValueOfInputField` | `selector, value` | Verify an input contains the passed value |
 | `clickFilter` | `selector` | Click on a list page filter |
 | `moveAllItemsToTrash` |  | Moves all items in a list view to the Trash |
+| `selectOptionInSelect2` | `selector, value` | helper method that searchs for select2 type fields and select plus insert value inside
 
 ### Test Utilities
 

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -333,9 +333,9 @@ const createGroupedProduct = async () => {
 	// Set product data and save the product
 	await expect( page ).toFill( '#title', 'Grouped Product' );
 	await expect( page ).toSelect( '#product-type', 'Grouped product' );
-	await clickTab('Linked Products');
-	await selectOptionInSelect2(simpleProductName + ' 1');
-	await selectOptionInSelect2(simpleProductName + ' 2');
+	await clickTab( 'Linked Products' );
+	await selectOptionInSelect2( simpleProductName + ' 1' );
+	await selectOptionInSelect2( simpleProductName + ' 2' );
 	await verifyAndPublish();
 
 	// Get product ID

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -6,7 +6,7 @@
  * Internal dependencies
  */
 import { merchant } from './flows';
-import { clickTab, uiUnblocked, verifyCheckboxIsUnset } from './page-utils';
+import { clickTab, uiUnblocked, verifyCheckboxIsUnset, selectOptionInSelect2 } from './page-utils';
 import factories from './factories';
 
 const config = require( 'config' );
@@ -346,6 +346,40 @@ const createVariableProduct = async () => {
 };
 
 /**
+ * Create grouped product.
+ */
+const createGroupedProduct = async () => {
+	// Create two products to be linked in a grouped product after
+	await factories.products.simple.create( {
+		name: simpleProductName + ' 1',
+		regularPrice: simpleProductPrice
+	} );
+	await factories.products.simple.create( {
+		name: simpleProductName + ' 2',
+		regularPrice: simpleProductPrice
+	} );
+
+	// Go to "add product" page
+	await merchant.openNewProduct();
+
+	// Make sure we're on the add product page
+	await expect( page.title() ).resolves.toMatch( 'Add new product' );
+
+	// Set product data and save the product
+	await expect( page ).toFill( '#title', 'Grouped Product' );
+	await expect( page ).toSelect( '#product-type', 'Grouped product' );
+	await clickTab('Linked Products');
+	await selectOptionInSelect2(simpleProductName + ' 1');
+	await selectOptionInSelect2(simpleProductName + ' 2');
+	await verifyAndPublish();
+
+	// Get product ID
+	const groupedPostId = await page.$( '#post_ID' );
+	let groupedPostIdValue = ( await ( await groupedPostId.getProperty( 'value' ) ).jsonValue() );
+	return groupedPostIdValue;
+}
+
+/**
  * Create a basic order with the provided order status.
  *
  * @param orderStatus Status of the new order. Defaults to `Pending payment`.
@@ -431,6 +465,7 @@ export {
 	completeOnboardingWizard,
 	createSimpleProduct,
 	createVariableProduct,
+	createGroupedProduct,
 	createSimpleOrder,
 	verifyAndPublish,
 	addProductToOrder,

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -196,6 +196,19 @@ const evalAndClick = async ( selector ) => {
 	page.$eval( selector, elem => elem.click() );
 };
 
+/**
+ * Select a value from select2 input field.
+ *
+ * @param {string} value Value of what to be selected
+ * @param {string} selector Selector of the select2
+ */
+const selectOptionInSelect2 = async (value, selector = 'input.select2-search__field') => {
+	await page.waitForSelector(selector);
+	await page.type(selector, value);
+	await page.waitForSelector(selector); // to avoid flakyness, must wait before pressing Enter
+	await page.keyboard.press('Enter');
+};
+
 export {
 	clearAndFillInput,
 	clickTab,
@@ -211,4 +224,5 @@ export {
 	clickFilter,
 	moveAllItemsToTrash,
 	evalAndClick,
+	selectOptionInSelect2,
 };

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -205,7 +205,7 @@ const evalAndClick = async ( selector ) => {
 const selectOptionInSelect2 = async (value, selector = 'input.select2-search__field') => {
 	await page.waitForSelector(selector);
 	await page.type(selector, value);
-	await page.waitForSelector(selector); // to avoid flakyness, must wait before pressing Enter
+	await page.waitFor(2000); // to avoid flakyness, must wait before pressing Enter
 	await page.keyboard.press('Enter');
 };
 

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -202,7 +202,7 @@ const evalAndClick = async ( selector ) => {
  * @param {string} value Value of what to be selected
  * @param {string} selector Selector of the select2
  */
-const selectOptionInSelect2 = async (value, selector = 'input.select2-search__field') => {
+const selectOptionInSelect2 = async ( value, selector = 'input.select2-search__field' ) => {
 	await page.waitForSelector(selector);
 	await page.type(selector, value);
 	await page.waitFor(2000); // to avoid flakyness, must wait before pressing Enter


### PR DESCRIPTION
### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
Adding new core-test for Shopper / Shop & Product (simple, grouped)
Closes #27882

### How to test the changes in this Pull Request:

1. Run test - npm run test:e2e-dev ./tests/e2e/specs/front-end/test-single-product-page.js


### Other information:

* Added new util helper selectOptionInSelect2 that can be used for any select2 type field
* Added new createGroupedProduct in components.js
* For adding simple product to the cart from the shop page, it has already been covered so I skipped it

### Changelog entry
## Added
- Shopper / Shop & Product (simple, grouped)
Adding new test - Shopper / Shop & Product (simple, grouped)  #27882