### PR TITLE
Introduce new filter to avoid changing a method signature in WC_Email_New_Order

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -118,6 +118,7 @@ class WC_Meta_Box_Order_Actions {
 
 				WC()->payment_gateways();
 				WC()->shipping();
+				add_filter( 'woocommerce_new_order_email_allows_resend', '__return_true' );
 				WC()->mailer()->emails['WC_Email_New_Order']->trigger( $order->get_id(), $order, true );
 
 				do_action( 'woocommerce_after_resend_order_email', $order, 'new_order' );

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -120,6 +120,7 @@ class WC_Meta_Box_Order_Actions {
 				WC()->shipping();
 				add_filter( 'woocommerce_new_order_email_allows_resend', '__return_true' );
 				WC()->mailer()->emails['WC_Email_New_Order']->trigger( $order->get_id(), $order, true );
+				remove_filter( 'woocommerce_new_order_email_allows_resend', '__return_true' );
 
 				do_action( 'woocommerce_after_resend_order_email', $order, 'new_order' );
 

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -80,9 +80,8 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 		 *
 		 * @param int            $order_id The order ID.
 		 * @param WC_Order|false $order Order object.
-		 * @param bool           $force_send Whether to force send the email.
 		 */
-		public function trigger( $order_id, $order = false, $force_send = false ) {
+		public function trigger( $order_id, $order = false ) {
 			$this->setup_locale();
 
 			if ( $order_id && ! is_a( $order, 'WC_Order' ) ) {
@@ -97,7 +96,8 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 				$email_already_sent = $order->get_meta( '_new_order_email_sent' );
 			}
 
-			if ( 'true' === $email_already_sent && ! $force_send ) {
+			// Prevent sending multiple times.
+			if ( 'true' === $email_already_sent && ! apply_filters( 'woocommerce_new_order_email_allows_resend', false ) ) {
 				return;
 			}
 

--- a/includes/emails/class-wc-email-new-order.php
+++ b/includes/emails/class-wc-email-new-order.php
@@ -96,7 +96,12 @@ if ( ! class_exists( 'WC_Email_New_Order' ) ) :
 				$email_already_sent = $order->get_meta( '_new_order_email_sent' );
 			}
 
-			// Prevent sending multiple times.
+			/**
+			 * Controls if new order emails can be resend multiple times.
+			 *
+			 * @since 5.0.0
+			 * @param bool $allows Defaults to true.
+			 */
 			if ( 'true' === $email_already_sent && ! apply_filters( 'woocommerce_new_order_email_allows_resend', false ) ) {
 				return;
 			}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->
We changed a method signature in #28809 and it causes some warnings in PHP, this PR reverts it and introduces a new filter instead, to keep backwards compatibility while we still fix the initial issue.

### How to test the changes in this Pull Request:

You can use the same steps from #28809

1. Go through checkout and use BACS as payment gateway so the initial order status is `on-hold`.
2. Check your email and ensure you're seeing the `New Order` email to the admin.
3. Change the order status to `pending payment`. At this point there shouldn't be any emails sent.
4. Change the order status to `completed`.
5. Check your email and ensure the `New Order` email is not sent again.
6. Go back to the order and use the `Order Actions` to resend the new order notification.
7. Check your email and ensure now you see the `New Order` email come through.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

No need to a changelog since this a new feature on 5.0.
