### PR TITLE
Uniform order customer search and display code

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -292,18 +292,19 @@ class WC_Meta_Box_Order_Data {
 							$user_id     = '';
 							if ( $order->get_user_id() ) {
 								$user_id = absint( $order->get_user_id() );
-								$user    = get_user_by( 'id', $user_id );
+								$customer = new WC_Customer( $user_id );
 								/* translators: 1: user display name 2: user ID 3: user email */
 								$user_string = sprintf(
+									/* translators: $1: customer name, $2 customer id, $3: customer email */
 									esc_html__( '%1$s (#%2$s &ndash; %3$s)', 'woocommerce' ),
-									$user->display_name,
-									absint( $user->ID ),
-									$user->user_email
-								);
+									$customer->get_first_name() . ' ' . $customer->get_last_name(),
+									$customer->get_id(),
+									$customer->get_email()
+								);	
 							}
 							?>
 							<select class="wc-customer-search" id="customer_user" name="customer_user" data-placeholder="<?php esc_attr_e( 'Guest', 'woocommerce' ); ?>" data-allow_clear="true">
-								<option value="<?php echo esc_attr( $user_id ); ?>" selected="selected"><?php echo htmlspecialchars( wp_kses_post( $user_string ) ); // htmlspecialchars to prevent XSS when rendered by selectWoo. ?></option>
+								<option value="<?php echo esc_attr( $user_id ); ?>" selected="selected"><?php echo htmlspecialchars( wp_kses_post( apply_filters( 'woocommerce_json_search_found_customers', $user_string ) ) ); // htmlspecialchars to prevent XSS when rendered by selectWoo. ?></option>
 							</select>
 							<!--/email_off-->
 						</p>

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -291,7 +291,7 @@ class WC_Meta_Box_Order_Data {
 							$user_string = '';
 							$user_id     = '';
 							if ( $order->get_user_id() ) {
-								$user_id = absint( $order->get_user_id() );
+								$user_id  = absint( $order->get_user_id() );
 								$customer = new WC_Customer( $user_id );
 								/* translators: 1: user display name 2: user ID 3: user email */
 								$user_string = sprintf(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Uniform two similar code sections and apply the same hook filter:

https://github.com/woocommerce/woocommerce/blob/e6251955f236eb19432cb586c21fd6af9e408858/includes/admin/meta-boxes/class-wc-meta-box-order-data.php#L293-L307

https://github.com/woocommerce/woocommerce/blob/231ab353ddde0a747316580ed7ff5f04656d14e8/includes/class-wc-ajax.php#L1691-L1703

This way any changes performed by the filter will reflect in the order customer search results and the current order customer display.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?
