### PR TITLE
Add in optional semicolon closes #28805

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -352,7 +352,7 @@ function wc_no_js() {
 			var c = document.body.className;
 			c = c.replace(/woocommerce-no-js/, 'woocommerce-js');
 			document.body.className = c;
-		})()
+		})();
 	</script>
 	<?php
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Technically JS does not require semicolons. However I can see how this may be a problem if you have "run-on" JS code that is in the same line as the line of code that does not have the semicolon. So to be safe, let's add this.

Closes #28805

### How to test the changes in this Pull Request:

1. Load the shop page on frontend and inspect the console and make there are no JS errors.
2.
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Add - Optional semicolon to JS code for better compatibility.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
