### PR TITLE
Introduced "add comment" step to pr-build workflow

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -28,5 +28,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: ':package: Artifacts ready for [download](https://github.com/${{ context.repo.owner }}/${{ context.repo.repo }}/actions/runs/${{ github.run_id }})!'
+              body: ':package: Artifacts ready for [download](https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/runs/${{ github.run_id }})!'
             })

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -28,5 +28,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: ':package: Artifacts ready for [download](https://github.com/${{ github.repository_owner }}/${{ github.repository }}/actions/runs/${{ github.run_id }})!'
+              body: ':package: Artifacts ready for [download](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})!'
             })

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -28,5 +28,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              body: 'Testing comment...'
+              body: ':package: Artifacts ready for [download](https://github.com/${{ context.repo.owner }}/${{ context.repo.repo }}/actions/runs/${{ github.run_id }})!'
             })

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -19,3 +19,14 @@ jobs:
           name: woocommerce.zip
           path: ${{ steps.build.outputs.zip_path }}
           retention-days: 7
+      - name: Add comment
+        uses: actions/github-script@v3
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Testing comment...'
+            })


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

There's some challenges to download artifacts and upload into comments, for example the GitHub API will only fetch the artifact URL if the job is already done, it can be solved by adding another job that runs after we build the artifact, still GitHub will expire the URL in some minutes according to its documentation.
GitHub also doesn't provide any REST API endpoint to upload attachments for issue comments, so even if we decide to download we need to upload into an external service if we want to display a direct link in the PR.
Anyway, I decided to show the page where the artifact gets stored, so we can find it anytime.

Closes #28921.
