### PR TITLE
Tracker return string values for order related data

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -446,23 +446,23 @@ class WC_Tracker {
 			$orders_count = count( $orders );
 		}
 
-		if( $first !== $first_time ) {
+		if ( $first !== $first_time ) {
 			$order_data['first'] = gmdate( 'Y-m-d H:i:s', $first );
 		}
 
-		if( $processing_first !== $first_time ) {
+		if ( $processing_first !== $first_time ) {
 			$order_data['processing_first'] = gmdate( 'Y-m-d H:i:s', $processing_first );
 		}
 
-		if( $last ) {
+		if ( $last ) {
 			$order_data['last'] = gmdate( 'Y-m-d H:i:s', $last );
 		}
 
-		if( $processing_last ) {
+		if ( $processing_last ) {
 			$order_data['processing_last']  = gmdate( 'Y-m-d H:i:s', $processing_last );
 		}
 
-		return $order_data;
+		return array_map( 'strval', $order_data );
 	}
 
 	/**

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -368,6 +368,7 @@ class WC_Tracker {
 		$first_time       = $first;
 		$last             = 0;
 		$processing_last  = 0;
+		$order_data       = array();
 
 		$orders       = wc_get_orders( $args );
 		$orders_count = count( $orders );
@@ -462,7 +463,11 @@ class WC_Tracker {
 			$order_data['processing_last']  = gmdate( 'Y-m-d H:i:s', $processing_last );
 		}
 
-		return array_map( 'strval', $order_data );
+		foreach ( $order_data as $key => $value ) {
+			$order_data[ $key ] = (string) $value;
+		}
+
+		return $order_data;
 	}
 
 	/**

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -364,8 +364,9 @@ class WC_Tracker {
 		);
 
 		$first            = time();
+		$processing_first = $first;
+		$first_time       = $first;
 		$last             = 0;
-		$processing_first = time();
 		$processing_last  = 0;
 
 		$orders       = wc_get_orders( $args );
@@ -445,10 +446,21 @@ class WC_Tracker {
 			$orders_count = count( $orders );
 		}
 
-		$order_data['first']            = gmdate( 'Y-m-d H:i:s', $first );
-		$order_data['last']             = gmdate( 'Y-m-d H:i:s', $last );
-		$order_data['processing_first'] = gmdate( 'Y-m-d H:i:s', $processing_first );
-		$order_data['processing_last']  = gmdate( 'Y-m-d H:i:s', $processing_last );
+		if( $first !== $first_time ) {
+			$order_data['first'] = gmdate( 'Y-m-d H:i:s', $first );
+		}
+
+		if( $processing_first !== $first_time ) {
+			$order_data['processing_first'] = gmdate( 'Y-m-d H:i:s', $processing_first );
+		}
+
+		if( $last ) {
+			$order_data['last'] = gmdate( 'Y-m-d H:i:s', $last );
+		}
+
+		if( $processing_last ) {
+			$order_data['processing_last']  = gmdate( 'Y-m-d H:i:s', $processing_last );
+		}
 
 		return $order_data;
 	}


### PR DESCRIPTION
### All Submissions:
Just before merging #28584, @peterfabian  made an observation [here](https://github.com/woocommerce/woocommerce/pull/28584#pullrequestreview-571110861) about the type of the values returned.

On verifying with test data, I found that  the non-string values were not logged by the tracker. So, this pull request converts all the values calculated in the `get_orders()` function into string.

In addition, I've added code to ensure that default value for first and last order dates are not returned.

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->



### How to test the changes in this Pull Request:

1. Opt to share usage data on a test site.
2. Trigger a snapshot send using `WC_Tracker::send_tracking_data(true)`
3. Verify the values in Tracker after a day. 
4. On master, I could find only 4 values(the first and last order dates which are string). With this branch, the other values are also found.


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Ensure that all tracker values collected for orders are of string type.