### PR TITLE
Pass original price in filters to improve compatibility

### DIFF
--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -588,7 +588,7 @@ function wc_price( $price, $args = array() ) {
 	 * @param float        $raw_price      Raw price.
 	 * @param float|string $original_price Original price as float, or empty string. Since 5.0.0.
 	 */
-	$price = apply_filters( 'raw_woocommerce_price', floatval( $negative ? $price * -1 : $price ), $original_price );
+	$price = apply_filters( 'raw_woocommerce_price', $negative ? $price * -1 : $price, $original_price );
 
 	/**
 	 * Filter formatted price.

--- a/includes/wc-formatting-functions.php
+++ b/includes/wc-formatting-functions.php
@@ -574,13 +574,33 @@ function wc_price( $price, $args = array() ) {
 		)
 	);
 
+	$original_price = $price;
+
 	// Convert to float to avoid issues on PHP 8.
 	$price = (float) $price;
 
 	$unformatted_price = $price;
 	$negative          = $price < 0;
-	$price             = apply_filters( 'raw_woocommerce_price', floatval( $negative ? $price * -1 : $price ) );
-	$price             = apply_filters( 'formatted_woocommerce_price', number_format( $price, $args['decimals'], $args['decimal_separator'], $args['thousand_separator'] ), $price, $args['decimals'], $args['decimal_separator'], $args['thousand_separator'] );
+
+	/**
+	 * Filter raw price.
+	 *
+	 * @param float        $raw_price      Raw price.
+	 * @param float|string $original_price Original price as float, or empty string. Since 5.0.0.
+	 */
+	$price = apply_filters( 'raw_woocommerce_price', floatval( $negative ? $price * -1 : $price ), $original_price );
+
+	/**
+	 * Filter formatted price.
+	 *
+	 * @param float        $formatted_price    Formatted price.
+	 * @param float        $price              Unformatted price.
+	 * @param int          $decimals           Number of decimals.
+	 * @param string       $decimal_separator  Decimal separator.
+	 * @param string       $thousand_separator Thousand separator.
+	 * @param float|string $original_price     Original price as float, or empty string. Since 5.0.0.
+	 */
+	$price = apply_filters( 'formatted_woocommerce_price', number_format( $price, $args['decimals'], $args['decimal_separator'], $args['thousand_separator'] ), $price, $args['decimals'], $args['decimal_separator'], $args['thousand_separator'], $original_price );
 
 	if ( apply_filters( 'woocommerce_price_trim_zeros', false ) && $args['decimals'] > 0 ) {
 		$price = wc_trim_zeros( $price );
@@ -596,12 +616,13 @@ function wc_price( $price, $args = array() ) {
 	/**
 	 * Filters the string of price markup.
 	 *
-	 * @param string $return            Price HTML markup.
-	 * @param string $price             Formatted price.
-	 * @param array  $args              Pass on the args.
-	 * @param float  $unformatted_price Price as float to allow plugins custom formatting. Since 3.2.0.
+	 * @param string       $return            Price HTML markup.
+	 * @param string       $price             Formatted price.
+	 * @param array        $args              Pass on the args.
+	 * @param float        $unformatted_price Price as float to allow plugins custom formatting. Since 3.2.0.
+	 * @param float|string $original_price    Original price as float, or empty string. Since 5.0.0.
 	 */
-	return apply_filters( 'wc_price', $return, $price, $args, $unformatted_price );
+	return apply_filters( 'wc_price', $return, $price, $args, $unformatted_price, $original_price );
 }
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This improves #28900 by keeping the original price in a variable and passing it to all filters to help developers.

Closes #28888.

### How to test the changes in this Pull Request:

See #28900

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

