### PR TITLE
Scope the CSS more tightly so it doesn't leak into the whole page

### DIFF
--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -61,7 +61,7 @@ p.demo_store,
 /**
  * Main WooCommerce styles
  */
-.woocommerce {
+.woocommerce-content {
 
 	.blockUI.blockOverlay {
 		position: relative;

--- a/templates/cart/mini-cart.php
+++ b/templates/cart/mini-cart.php
@@ -22,70 +22,71 @@ defined( 'ABSPATH' ) || exit;
 do_action( 'woocommerce_before_mini_cart' ); ?>
 
 <?php if ( ! WC()->cart->is_empty() ) : ?>
+	<div class="woocommerce-content">
+		<ul class="woocommerce-mini-cart cart_list product_list_widget <?php echo esc_attr( $args['list_class'] ); ?>">
+			<?php
+			do_action( 'woocommerce_before_mini_cart_contents' );
 
-	<ul class="woocommerce-mini-cart cart_list product_list_widget <?php echo esc_attr( $args['list_class'] ); ?>">
-		<?php
-		do_action( 'woocommerce_before_mini_cart_contents' );
+			foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
+				$_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
+				$product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
 
-		foreach ( WC()->cart->get_cart() as $cart_item_key => $cart_item ) {
-			$_product   = apply_filters( 'woocommerce_cart_item_product', $cart_item['data'], $cart_item, $cart_item_key );
-			$product_id = apply_filters( 'woocommerce_cart_item_product_id', $cart_item['product_id'], $cart_item, $cart_item_key );
-
-			if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_widget_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
-				$product_name      = apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key );
-				$thumbnail         = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
-				$product_price     = apply_filters( 'woocommerce_cart_item_price', WC()->cart->get_product_price( $_product ), $cart_item, $cart_item_key );
-				$product_permalink = apply_filters( 'woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink( $cart_item ) : '', $cart_item, $cart_item_key );
-				?>
-				<li class="woocommerce-mini-cart-item <?php echo esc_attr( apply_filters( 'woocommerce_mini_cart_item_class', 'mini_cart_item', $cart_item, $cart_item_key ) ); ?>">
-					<?php
-					echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
-						'woocommerce_cart_item_remove_link',
-						sprintf(
-							'<a href="%s" class="remove remove_from_cart_button" aria-label="%s" data-product_id="%s" data-cart_item_key="%s" data-product_sku="%s">&times;</a>',
-							esc_url( wc_get_cart_remove_url( $cart_item_key ) ),
-							esc_attr__( 'Remove this item', 'woocommerce' ),
-							esc_attr( $product_id ),
-							esc_attr( $cart_item_key ),
-							esc_attr( $_product->get_sku() )
-						),
-						$cart_item_key
-					);
+				if ( $_product && $_product->exists() && $cart_item['quantity'] > 0 && apply_filters( 'woocommerce_widget_cart_item_visible', true, $cart_item, $cart_item_key ) ) {
+					$product_name      = apply_filters( 'woocommerce_cart_item_name', $_product->get_name(), $cart_item, $cart_item_key );
+					$thumbnail         = apply_filters( 'woocommerce_cart_item_thumbnail', $_product->get_image(), $cart_item, $cart_item_key );
+					$product_price     = apply_filters( 'woocommerce_cart_item_price', WC()->cart->get_product_price( $_product ), $cart_item, $cart_item_key );
+					$product_permalink = apply_filters( 'woocommerce_cart_item_permalink', $_product->is_visible() ? $_product->get_permalink( $cart_item ) : '', $cart_item, $cart_item_key );
 					?>
-					<?php if ( empty( $product_permalink ) ) : ?>
-						<?php echo $thumbnail . $product_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-					<?php else : ?>
-						<a href="<?php echo esc_url( $product_permalink ); ?>">
+					<li class="woocommerce-mini-cart-item <?php echo esc_attr( apply_filters( 'woocommerce_mini_cart_item_class', 'mini_cart_item', $cart_item, $cart_item_key ) ); ?>">
+						<?php
+						echo apply_filters( // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+							'woocommerce_cart_item_remove_link',
+							sprintf(
+								'<a href="%s" class="remove remove_from_cart_button" aria-label="%s" data-product_id="%s" data-cart_item_key="%s" data-product_sku="%s">&times;</a>',
+								esc_url( wc_get_cart_remove_url( $cart_item_key ) ),
+								esc_attr__( 'Remove this item', 'woocommerce' ),
+								esc_attr( $product_id ),
+								esc_attr( $cart_item_key ),
+								esc_attr( $_product->get_sku() )
+							),
+							$cart_item_key
+						);
+						?>
+						<?php if ( empty( $product_permalink ) ) : ?>
 							<?php echo $thumbnail . $product_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-						</a>
-					<?php endif; ?>
-					<?php echo wc_get_formatted_cart_item_data( $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-					<?php echo apply_filters( 'woocommerce_widget_cart_item_quantity', '<span class="quantity">' . sprintf( '%s &times; %s', $cart_item['quantity'], $product_price ) . '</span>', $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
-				</li>
-				<?php
+						<?php else : ?>
+							<a href="<?php echo esc_url( $product_permalink ); ?>">
+								<?php echo $thumbnail . $product_name; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+							</a>
+						<?php endif; ?>
+						<?php echo wc_get_formatted_cart_item_data( $cart_item ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo apply_filters( 'woocommerce_widget_cart_item_quantity', '<span class="quantity">' . sprintf( '%s &times; %s', $cart_item['quantity'], $product_price ) . '</span>', $cart_item, $cart_item_key ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+					</li>
+					<?php
+				}
 			}
-		}
 
-		do_action( 'woocommerce_mini_cart_contents' );
-		?>
-	</ul>
+			do_action( 'woocommerce_mini_cart_contents' );
+			?>
+		</ul>
 
-	<p class="woocommerce-mini-cart__total total">
-		<?php
-		/**
-		 * Hook: woocommerce_widget_shopping_cart_total.
-		 *
-		 * @hooked woocommerce_widget_shopping_cart_subtotal - 10
-		 */
-		do_action( 'woocommerce_widget_shopping_cart_total' );
-		?>
-	</p>
+		<p class="woocommerce-mini-cart__total total">
+			<?php
+			/**
+			 * Hook: woocommerce_widget_shopping_cart_total.
+			 *
+			 * @hooked woocommerce_widget_shopping_cart_subtotal - 10
+			 */
+			do_action( 'woocommerce_widget_shopping_cart_total' );
+			?>
+		</p>
 
-	<?php do_action( 'woocommerce_widget_shopping_cart_before_buttons' ); ?>
+		<?php do_action( 'woocommerce_widget_shopping_cart_before_buttons' ); ?>
 
-	<p class="woocommerce-mini-cart__buttons buttons"><?php do_action( 'woocommerce_widget_shopping_cart_buttons' ); ?></p>
+		<p class="woocommerce-mini-cart__buttons buttons"><?php do_action( 'woocommerce_widget_shopping_cart_buttons' ); ?></p>
 
-	<?php do_action( 'woocommerce_widget_shopping_cart_after_buttons' ); ?>
+		<?php do_action( 'woocommerce_widget_shopping_cart_after_buttons' ); ?>
+	</div><!-- .woocommerce-content -->
 
 <?php else : ?>
 

--- a/templates/global/wrapper-end.php
+++ b/templates/global/wrapper-end.php
@@ -50,3 +50,5 @@ switch ( $template ) {
 		echo '</main></div>';
 		break;
 }
+
+echo '</div>'; // Closes .woocommerce-content

--- a/templates/global/wrapper-start.php
+++ b/templates/global/wrapper-start.php
@@ -47,3 +47,5 @@ switch ( $template ) {
 		echo '<div id="primary" class="content-area"><main id="main" class="site-main" role="main">';
 		break;
 }
+
+echo '<div class="woocommerce-content">';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Changes the scope of the CSS in woocommerce.scss, so that it only targets parts of the page with Woo content, rather than the whole page. This was causing issues in themes that had buttons with a button class. This CSS will be scoped to anything inside a .woocommerce-content selector. I have added this class to the mini cart and the output wrapper, but there might be more places that need it, so I'm looking for input from people who know the project better than me.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28821

### How to test the changes in this Pull Request:

1. Switch the theme on your site to Seedlet
2. Go to the Shop page
3. Collapse the page to a mobile view:

This is how it looks in the main branch:
<img width="441" alt="Screenshot 2021-01-22 at 19 33 44" src="https://user-images.githubusercontent.com/275961/105536770-c4de4080-5ce8-11eb-98d7-5916db54a11c.png">

This is how it looks in this PR:
<img width="452" alt="Screenshot 2021-01-22 at 19 30 16" src="https://user-images.githubusercontent.com/275961/105536816-d889a700-5ce8-11eb-9d02-26441b9198f0.png">


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Narrow the scope of CSS selectors to only target Woo page content.