### PR TITLE
clean up sass variable names

### DIFF
--- a/plugins/woocommerce/changelog/enhancement-clean-up-of-sass-vars
+++ b/plugins/woocommerce/changelog/enhancement-clean-up-of-sass-vars
@@ -1,0 +1,4 @@
+Significance: patch
+Type: enhancement
+
+Change the sass variable names to more predictable ones.

--- a/plugins/woocommerce/client/legacy/css/_mixins.scss
+++ b/plugins/woocommerce/client/legacy/css/_mixins.scss
@@ -293,7 +293,7 @@
 	}
 
 	mark.yes {
-		color: $green;
+		color: var(--wc-green);
 	}
 
 	mark.no {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

We recently exported the WC sass variables as CSS varaibles, which was a great addition. However, the names we're a little poor. This RP changes names to kebab-case. While I was at it, I thought the names like $primary and $green were spamming the root namespace, so I prefixed all these vars with $wc-. It's now obvious when digging into a random sass file what $red actually means.

### How to test the changes in this Pull Request:

No testing is needed, no class names were changed, only variables names.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Clean up sass variable names into to prefixed kebab-case (i.e. from primarytext to  wc-primary-text).
