### PR TITLE
Bump versions to 4.9.2

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -22,7 +22,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '4.9.1';
+	public $version = '4.9.2';
 
 	/**
 	 * WooCommerce Schema version.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce",
   "title": "WooCommerce",
-  "version": "4.9.1",
+  "version": "4.9.2",
   "homepage": "https://woocommerce.com/",
   "repository": {
     "type": "git",

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 4.9.1
+ * Version: 4.9.2
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
Updates versions in the code and metadata to 4.9.2, this change targets only the release branch.

Stable tag, readme, and changelog updates are part of #28918 that targets master.