### PR TITLE
Fix fatal error problems by no longer adding false to the list of orders

### DIFF
--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -906,7 +906,14 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		$this->prime_order_item_caches_for_orders( $order_ids, $query_vars );
 
 		foreach ( $query->posts as $post ) {
-			$orders[] = wc_get_order( $post );
+			$order = wc_get_order( $post );
+
+			// If the order returns false, don't add it to the list.
+			if ( false === $order ) {
+				continue;
+			}
+
+			$orders[] = $order;
 		}
 
 		return $orders;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

By adding this prevention, it also stops fatal errors (calling method on non-object) from happening down the line when working with the orders list that is always assumed to be a proper order object.

Example error this prevents:

```
Fatal error: Uncaught Error: Call to a member function get_items() on bool in /wp-content/plugins/woocommerce/includes/class-wc-order.php on line 1902
```

_If the assumption here is **incorrect** (The orders list should always be order objects and not false) -- then all usage of the orders array needs to check for proper objects before calling methods off of each order._

### How to test the changes in this Pull Request:

This one is tricky to recreate, but I've been seeing the fatal error more often on customer sites that I work with (as part of my work with the The Events Calendar / Event Tickets plugin team).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

Fix orders list from returning false values if orders are missing.