### PR TITLE
Return jest error for Travis

### DIFF
--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 0.2.0
 
+## Fixed
+
+- Return jest exit code from `npx wc-e2e test:e2e*`
+
 ## Added
 
 - support for custom container name

--- a/tests/e2e/env/bin/wc-e2e.sh
+++ b/tests/e2e/env/bin/wc-e2e.sh
@@ -25,6 +25,9 @@ fi
 # Store original path
 OLDPATH=$(pwd)
 
+# Return value for CI test runs
+TESTRESULT=0
+
 # Use the script symlink to find and change directory to the root of the package
 SCRIPTPATH=$(dirname "$0")
 REALPATH=$(readlink $0)
@@ -46,12 +49,15 @@ case $1 in
 		;;
 	'test:e2e')
 		./bin/wait-for-build.sh && ./bin/e2e-test-integration.js $2
+		TESTRESULT=$?
 		;;
 	'test:e2e-dev')
 		./bin/wait-for-build.sh && ./bin/e2e-test-integration.js --dev $2
+		TESTRESULT=$?
 		;;
 	'test:e2e-debug')
 		./bin/wait-for-build.sh && ./bin/e2e-test-integration.js --dev --debug $2
+		TESTRESULT=$?
 		;;
 	*)
 		usage
@@ -60,3 +66,5 @@ esac
 
 # Restore working path
 cd $OLDPATH
+
+exit $TESTRESULT

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -6,7 +6,7 @@
  * Internal dependencies
  */
 import { merchant } from './flows';
-import { clickTab, uiUnblocked, verifyCheckboxIsUnset } from './page-utils';
+import { clickTab, uiUnblocked, verifyCheckboxIsUnset, evalAndClick } from './page-utils';
 import factories from './factories';
 
 const config = require( 'config' );
@@ -25,6 +25,20 @@ const verifyAndPublish = async () => {
 	await expect( page ).toMatchElement( '.updated.notice', { text: 'Product published.' } );
 };
 
+/**
+ * Wait for primary button to be enabled and click.
+ *
+ * @param waitForNetworkIdle - Wait for network idle after click
+ * @returns {Promise<void>}
+ */
+const waitAndClickPrimary = async ( waitForNetworkIdle = true ) => {
+	// Wait for "Continue" button to become active
+	await page.waitForSelector( 'button.is-primary:not(:disabled)' );
+	await page.click( 'button.is-primary' );
+	if ( waitForNetworkIdle ) {
+		await page.waitForNavigation( { waitUntil: 'networkidle0' } );
+	}
+};
 /**
  * Complete onboarding wizard.
  */
@@ -88,15 +102,7 @@ const completeOnboardingWizard = async () => {
 	await expect( page ).toFill( '.components-text-control__input', config.get( 'onboardingwizard.industry' ) );
 
 	// Wait for "Continue" button to become active
-	await page.waitForSelector( 'button.is-primary:not(:disabled)' );
-
-	await Promise.all( [
-		// Click on "Continue" button to move to the next step
-		page.click( 'button.is-primary' ),
-
-		// Wait for "What type of products will be listed?" section to load
-		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-	] );
+	await waitAndClickPrimary();
 
 	// Product types section
 
@@ -110,15 +116,7 @@ const completeOnboardingWizard = async () => {
 	}
 
 	// Wait for "Continue" button to become active
-	await page.waitForSelector( 'button.is-primary:not(:disabled)' );
-
-	await Promise.all( [
-		// Click on "Continue" button to move to the next step
-		page.click( 'button.is-primary' ),
-
-		// Wait for "Tell us about your business" section to load
-		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-	] );
+	await waitAndClickPrimary();
 
 	// Business Details section
 
@@ -136,48 +134,15 @@ const completeOnboardingWizard = async () => {
 	await page.waitForSelector( '.woocommerce-select-control__control' );
 	await expect( page ).toClick( '.woocommerce-select-control__option', { text: config.get( 'onboardingwizard.sellingelsewhere' ) } );
 
-	// Query for the extensions toggles
-	const extensionsToggles = await page.$$( '.components-form-toggle__input' );
-	expect( extensionsToggles ).toHaveLength( 4 );
-
-	// Disable download of the onboarding suggested extensions
-	for ( let i = 0; i < extensionsToggles.length; i++ ) {
-		await extensionsToggles[i].click();
-	}
-
 	// Wait for "Continue" button to become active
-	await page.waitForSelector( 'button.is-primary:not(:disabled)' );
+	await waitAndClickPrimary( false );
 
-	await Promise.all( [
-		// Click on "Continue" button to move to the next step
-		page.click( 'button.is-primary' ),
-
-		// Wait for "Theme" section to load
-		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-	] );
+	// Skip installing extensions
+	await evalAndClick( '.components-checkbox-control__input' );
+	await waitAndClickPrimary();
 
 	// Theme section
-
-	// Wait for "Continue with my active theme" button to become active
-	await page.waitForSelector( 'button.is-primary:not(:disabled)' );
-
-	await Promise.all( [
-		// Click on "Continue with my active theme" button to move to the next step
-		page.click( 'button.is-primary' ),
-
-		// Wait for "Enhance your store with WooCommerce Services" section to load
-		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-	] );
-
-	// Benefits section
-
-	// Wait for Benefits section to appear
-	await page.waitForSelector( '.woocommerce-profile-wizard__benefits' );
-
-	// Wait for "No thanks" button to become active
-	await page.waitForSelector( 'button.is-secondary:not(:disabled)' );
-	// Click on "No thanks" button to move to the next step
-	await page.click( 'button.is-secondary' );
+	await waitAndClickPrimary();
 
 	// End of onboarding wizard
 


### PR DESCRIPTION
**Note**: The original version of this PR deliberately causes some E2E tests to fail to verify that the failure will be caught in the Travis run. Travis did fail the run in https://travis-ci.com/github/woocommerce/woocommerce/jobs/475145976.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- Return the `jest` exit code from `npx wc-e2e test:e2e*`.
- Update onboarding flow for WC Admin 1.9.0.

Closes # .

### How to test the changes in this Pull Request:

1. Review failure log above
2. Review E2E log in travis run in `Return jest error for travis commit`. Note onboarding test error.
3. Review Travis E2E log on PR to verify it ran and passed correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A