### PR TITLE
Wc 25076 wc emails in hebrew

### DIFF
--- a/templates/emails/email-header.php
+++ b/templates/emails/email-header.php
@@ -16,7 +16,7 @@
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 ?>
@@ -24,7 +24,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 <html <?php language_attributes(); ?>>
 	<head>
 		<meta http-equiv="Content-Type" content="text/html; charset=<?php bloginfo( 'charset' ); ?>" />
-		<title><?php echo get_bloginfo( 'name', 'display' ); ?></title>
+		<title><?php echo esc_attr( get_bloginfo( 'name', 'display' ) ); ?></title>
 	</head>
 	<body <?php echo is_rtl() ? 'rightmargin' : 'leftmargin'; ?>="0" marginwidth="0" topmargin="0" marginheight="0" offset="0">
 		<div id="wrapper" dir="<?php echo is_rtl() ? 'rtl' : 'ltr'; ?>">
@@ -33,19 +33,20 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<td align="center" valign="top">
 						<div id="template_header_image">
 							<?php
-							if ( $img = get_option( 'woocommerce_email_header_image' ) ) {
-								echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . get_bloginfo( 'name', 'display' ) . '" /></p>';
+							$img = get_option( 'woocommerce_email_header_image' );
+							if ( $img ) {
+								echo '<p style="margin-top:0;"><img src="' . esc_url( $img ) . '" alt="' . esc_attr( get_bloginfo( 'name', 'display' ) ) . '" /></p>';
 							}
 							?>
 						</div>
-						<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_container">
+						<table border="0" cellpadding="0" cellspacing="0" id="template_container" style="max-width:600px">
 							<tr>
 								<td align="center" valign="top">
 									<!-- Header -->
 									<table border="0" cellpadding="0" cellspacing="0" width="100%" id="template_header">
 										<tr>
 											<td id="header_wrapper">
-												<h1><?php echo $email_heading; ?></h1>
+												<h1><?php echo esc_attr( $email_heading ); ?></h1>
 											</td>
 										</tr>
 									</table>
@@ -55,7 +56,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 							<tr>
 								<td align="center" valign="top">
 									<!-- Body -->
-									<table border="0" cellpadding="0" cellspacing="0" width="600" id="template_body">
+									<table border="0" cellpadding="0" cellspacing="0" id="template_body" style="max-width:600px">
 										<tr>
 											<td valign="top" id="body_content">
 												<!-- Content -->

--- a/templates/emails/email-styles.php
+++ b/templates/emails/email-styles.php
@@ -50,7 +50,7 @@ body {
 #wrapper {
 	background-color: <?php echo esc_attr( $bg ); ?>;
 	margin: 0;
-	padding: 70px 0;
+	padding: 50px 0;
 	-webkit-text-size-adjust: none !important;
 	width: 100%;
 }
@@ -96,7 +96,7 @@ body {
 	font-size: 12px;
 	line-height: 150%;
 	text-align: center;
-	padding: 24px 0;
+	padding: 15px 0;
 }
 
 #template_footer #credit p {
@@ -108,7 +108,7 @@ body {
 }
 
 #body_content table td {
-	padding: 48px 48px 32px;
+	padding: 24px 24px 16px;
 }
 
 #body_content table td td {
@@ -169,7 +169,7 @@ body {
 }
 
 #header_wrapper {
-	padding: 36px 48px;
+	padding: 18px 24px;
 	display: block;
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR aims to resolve the bugs raised in WC issue:

"CSS fix for WooCommerce emails in `Hebrew` on mobile devices" #25076

[https://github.com/woocommerce/woocommerce/issues/25076](https://github.com/woocommerce/woocommerce/issues/25076)

Note: Best I could tell, the underlying markup + CSS "defects" impact more than rtl. Therefore, what you see in terms of changes might not be what you're expecting.  

Also, while I was under the hook I added escaping output where appropriate.

Closes #25076 

### How to test the changes in this Pull Request:

You'll have to be able to send test emails.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fixed email header and CSS that was buggy for rtl emails (Issue #25076)