### PR TITLE
WC Issue: 26857 - Add action remove order item

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1302,7 +1302,7 @@ class WC_AJAX {
 			/**
 			 * Fires after order items are removed.
 			 *
-			 * @since 4.9.0
+			 * @since 5.1.0
 			 *
 			 * @param int $item_id WC item ID.
 			 * @param WC_Order_Item|false $item As returned by $order->get_item( $item_id ).

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1273,7 +1273,6 @@ class WC_AJAX {
 			}
 
 			if ( ! empty( $order_item_ids ) ) {
-				$order_notes = array();
 
 				foreach ( $order_item_ids as $item_id ) {
 					$item_id = absint( $item_id );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1300,6 +1300,8 @@ class WC_AJAX {
 			$order->calculate_taxes( $calculate_tax_args );
 			$order->calculate_totals( false );
 
+			do_action( 'woocommerce_ajax_order_items_removed', $item_id, $item, $changed_stock, $order );
+
 			// Get HTML to return.
 			ob_start();
 			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1299,6 +1299,16 @@ class WC_AJAX {
 			$order->calculate_taxes( $calculate_tax_args );
 			$order->calculate_totals( false );
 
+			/**
+			 * Fires after order items are removed.
+			 *
+			 * @since 4.9.0
+			 *
+			 * @param int $item_id WC item ID.
+			 * @param WC_Order_Item|false $item As returned by $order->get_item( $item_id ).
+			 * @param bool|array|WP_Error $changed_store Result of wc_maybe_adjust_line_item_product_stock().
+			 * @param bool|WC_Order|WC_Order_Refund $order As returned by wc_get_order().
+			 */
 			do_action( 'woocommerce_ajax_order_items_removed', $item_id, $item, $changed_stock, $order );
 
 			// Get HTML to return.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The purpose of this PR is to address the request of Issue #26857 "Add action for after remove_order_item"

Note: It also cleans up a stray line of code that my IDE recognized as not used. 



### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Added `woocommerce_ajax_order_items_removed` hook.
