### PR TITLE
Added do_action( 'after_password_reset'...) to match WP core function…

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -379,6 +379,15 @@ class WC_Shortcode_My_Account {
 		if ( ! apply_filters( 'woocommerce_disable_password_change_notification', false ) ) {
 			wp_password_change_notification( $user );
 		}
+		/**
+		 * Fires after the user's password is reset.
+		 *
+		 * @since 4.9.0-dev
+		 *
+		 * @param WP_User $user     The user.
+		 * @param string  $new_pass New user password.
+		 */
+		do_action( 'after_password_reset', $user, $new_pass );
 	}
 
 	/**

--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -387,7 +387,7 @@ class WC_Shortcode_My_Account {
 		 * @param WP_User $user     The user.
 		 * @param string  $new_pass New user password.
 		 */
-		do_action( 'after_password_reset', $user, $new_pass );
+		do_action( 'woocommerce_after_password_reset', $user, $new_pass );
 	}
 
 	/**


### PR DESCRIPTION
…: reset_password()

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The purpose of this PR is to address the issue(s) raised in:

Issue 27795 - "Password reset via my-account/lost-password does not trigger after_password_reset action"


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Added hook to WC's /shortcodes/class-wc-shortcode-my-account.php to match WP Core.
