### PR TITLE
Improve the WooCommerce build process

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,8 @@
 /** @format */
 
-module.exports = {
+const { useE2EEsLintConfig } = require( './tests/e2e/env/config/use-config' );
+
+module.exports = useE2EEsLintConfig( {
 	root: true,
 	env: {
 		browser: true,
@@ -28,4 +30,4 @@ module.exports = {
 			jsx: true
 		}
 	},
-};
+} );

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,7 +1,6 @@
 /** @format */
-const { useE2EEsLintConfig } = require( '@woocommerce/e2e-environment' );
 
-module.exports = useE2EEsLintConfig( {
+module.exports = {
 	root: true,
 	env: {
 		browser: true,
@@ -29,4 +28,4 @@ module.exports = useE2EEsLintConfig( {
 			jsx: true
 		}
 	},
-} );
+};

--- a/bin/build-zip.sh
+++ b/bin/build-zip.sh
@@ -10,7 +10,7 @@ rm -rf "$BUILD_PATH"
 mkdir -p "$DEST_PATH"
 
 echo "Installing PHP and JS dependencies..."
-npm install
+npm run install:no-e2e
 composer install || exit "$?"
 echo "Running JS Build..."
 npm run build:core || exit "$?"

--- a/bin/package-update.sh
+++ b/bin/package-update.sh
@@ -25,17 +25,19 @@ output 3 "Updating autoloader classmaps..."
 composer dump-autoload
 output 2 "Done"
 
-# Convert textdomains
-output 3 "Updating package PHP textdomains..."
+if [ -z "$SKIP_UPDATE_TEXTDOMAINS" ]; then
+	# Convert textdomains
+	output 3 "Updating package PHP textdomains..."
 
-# Replace text domains within packages with woocommerce
-npm run packages:fix:textdomain
-output 2 "Done!"
+	# Replace text domains within packages with woocommerce
+	npm run packages:fix:textdomain
+	output 2 "Done!"
 
-output 3 "Updating package JS textdomains..."
-find ./packages/woocommerce-blocks -iname '*.js' -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" -e "s/\"woo-gutenberg-products-block\"/'woocommerce'/g" {} \;
-find ./packages/woocommerce-blocks -iname '*.js' -exec sed -i.bak -e "s/'woocommerce-admin'/'woocommerce'/g" -e "s/\"woocommerce-admin\"/'woocommerce'/g" {} \;
-find ./packages/woocommerce-admin -iname '*.js' -exec sed -i.bak -e "s/'woocommerce-admin'/'woocommerce'/g" -e "s/\"woocommerce-admin\"/'woocommerce'/g" {} \;
+	output 3 "Updating package JS textdomains..."
+	find ./packages/woocommerce-blocks -iname '*.js' -exec sed -i.bak -e "s/'woo-gutenberg-products-block'/'woocommerce'/g" -e "s/\"woo-gutenberg-products-block\"/'woocommerce'/g" {} \;
+	find ./packages/woocommerce-blocks -iname '*.js' -exec sed -i.bak -e "s/'woocommerce-admin'/'woocommerce'/g" -e "s/\"woocommerce-admin\"/'woocommerce'/g" {} \;
+	find ./packages/woocommerce-admin -iname '*.js' -exec sed -i.bak -e "s/'woocommerce-admin'/'woocommerce'/g" -e "s/\"woocommerce-admin\"/'woocommerce'/g" {} \;
+fi
 
 # Cleanup backup files
 find ./packages -name "*.bak" -type f -delete

--- a/bin/post-merge.sh
+++ b/bin/post-merge.sh
@@ -9,5 +9,5 @@ runOnChange() {
 	fi
 }
 
-runOnChange "package-lock.json" "npm install"
+runOnChange "package-lock.json" "npm run install:no-e2e"
 runOnChange "composer.lock" "composer install"

--- a/bin/post-merge.sh
+++ b/bin/post-merge.sh
@@ -10,4 +10,4 @@ runOnChange() {
 }
 
 runOnChange "package-lock.json" "npm run install:no-e2e"
-runOnChange "composer.lock" "composer install"
+runOnChange "composer.lock" "SKIP_UPDATE_TEXTDOMAINS=true composer install"

--- a/package.json
+++ b/package.json
@@ -13,10 +13,10 @@
     "wp_org_slug": "woocommerce"
   },
   "scripts": {
+    "install": " if [ -z \"$SKIP_LERNA_BOOTSTRAP\" ]; then npx lerna bootstrap --hoist; fi",
     "check:subset-installed": "npm list --depth 1 install-subset > /dev/null 2>&1",
     "install:subset-only": "npm install --no-package-lock --no-save install-subset",
-    "install:no-e2e": "npm run check:subset-installed --silent || npm run install:subset-only && npx install-subset i no-e2e",
-    "install:e2e": "npx lerna bootstrap --hoist && npm run check:subset-installed --silent || npm run install:subset-only && npx install-subset i e2e",
+    "install:no-e2e": "npm run check:subset-installed --silent || npm run install:subset-only && SKIP_LERNA_BOOTSTRAP=true npx install-subset i no-e2e",
     "build": "./bin/build-zip.sh",
     "build:core": "grunt && npm run makepot",
     "build:dev": "npm run build:core && npm run build:packages",
@@ -130,15 +130,6 @@
     "ie 9"
   ],
   "subsets": {
-    "no-e2e": {
-      "exclude": [
-        "@woocommerce/api",
-        "@woocommerce/e2e-core-tests",
-        "@woocommerce/e2e-environment",
-        "@woocommerce/e2e-utils",
-        "@wordpress/e2e-test-utils"
-      ]
-    },
     "e2e": {
       "include": [
         "@woocommerce/api",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build:dev": "npm run build:core && npm run build:packages",
     "build-watch": "grunt watch",
     "build:packages": "lerna run build",
-    "build:zip": "npm run build && composer install && npm run build:dev",
+    "build:zip": "npm run build",
     "build:assets": "grunt assets",
     "lint:js": "eslint assets/js --ext=js",
     "docker:down": "npx wc-e2e docker:down",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,10 @@
     "wp_org_slug": "woocommerce"
   },
   "scripts": {
-    "install": "lerna bootstrap --hoist",
+    "check:subset-installed": "npm list --depth 1 install-subset > /dev/null 2>&1",
+    "install:subset-only": "npm install --no-package-lock --no-save install-subset",
+    "install:no-e2e": "npm run check:subset-installed --silent || npm run install:subset-only && npx install-subset i no-e2e",
+    "install:e2e": "npx lerna bootstrap --hoist && npm run check:subset-installed --silent || npm run install:subset-only && npx install-subset i e2e",
     "build": "./bin/build-zip.sh",
     "build:core": "grunt && npm run makepot",
     "build:dev": "npm run build:core && npm run build:packages",
@@ -125,5 +128,25 @@
     "> 0.1%",
     "ie 8",
     "ie 9"
-  ]
+  ],
+  "subsets": {
+    "no-e2e": {
+      "exclude": [
+        "@woocommerce/api",
+        "@woocommerce/e2e-core-tests",
+        "@woocommerce/e2e-environment",
+        "@woocommerce/e2e-utils",
+        "@wordpress/e2e-test-utils"
+      ]
+    },
+    "e2e": {
+      "include": [
+        "@woocommerce/api",
+        "@woocommerce/e2e-core-tests",
+        "@woocommerce/e2e-environment",
+        "@woocommerce/e2e-utils",
+        "@wordpress/e2e-test-utils"
+      ]
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -130,8 +130,8 @@
     "ie 9"
   ],
   "subsets": {
-    "e2e": {
-      "include": [
+    "no-e2e": {
+      "exclude": [
         "@woocommerce/api",
         "@woocommerce/e2e-core-tests",
         "@woocommerce/e2e-environment",


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

* Create an e2e-less build script.
  * Use [the `install-subset` package](https://www.npmjs.com/package/install-subset) to define a subset of the NPM dependencies that doesn't include the e2e testing infrastructure.
  * Define a new NPM `install:no-e2e` command taht makes use of `install-subset` to do an e2e-less install.
  * Modify the git post-merge hook to use the new command instead of the full install.
  * `npm install` still installs everything, including e2e testing infrastructure.
<br/>

* Skip updating textdomains on `composer install` when it's triggered by the git post-merge hook.
<br/>

* Remove duplicate processing from the zip build process.
  * The `build:zip` NPM command was executing `build-zip.sh` and then doing `composer install`, `grunt` and `makepot`; but these three are already done as part of `build-zip.sh`.
<br/> 

* Exclude the e2e infrastructure packages from the zip build process.
  * As part of this the `require( '@woocommerce/e2e-environment' );` from `.eslintrc.js` has been removed, it doesn't seem to be needed and it prevents the build process to finish without the e2e infrastructure.

Closes https://github.com/woocommerce/woocommerce/issues/28717.

### How to test the changes in this Pull Request:

1. Try the new `npm run install:no-e2e` command, verify it installs everything needed but the e2e infrastructure (and lerna doesn't run).
2. Run `SKIP_UPDATE_TEXTDOMAINS=true composer install`, veryfy that text domains are not updated but otherwise the rest of the install is successful.
3. Verify that `npm install` still includes the e2e infrastructure in the install, and that you are still able to run the e2e tests after [following the instructions](https://github.com/woocommerce/woocommerce/blob/master/tests/e2e/README.md).

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Optimize the build process by de-duplicating processing and providing a new e2e-less NPM install command.





