### PR TITLE
Use wp_robots_no_robots() when available

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3568,7 +3568,12 @@ function wc_empty_cart_message() {
  */
 function wc_page_noindex() {
 	if ( is_page( wc_get_page_id( 'cart' ) ) || is_page( wc_get_page_id( 'checkout' ) ) || is_page( wc_get_page_id( 'myaccount' ) ) ) {
-		wp_no_robots();
+		// Adds support for WP 5.7.
+		if ( function_exists( 'wp_robots_no_robots' ) ) {
+			wp_robots_no_robots();
+		} else {
+			wp_no_robots();
+		}
 	}
 }
 add_action( 'wp_head', 'wc_page_noindex' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds support for WP 5.7 `wp_robots_no_robots()`.
Note that `wp_no_robots()` is deprecated in WP 5.7.

Closes #28947.

### How to test the changes in this Pull Request:

1. Use WordPress Beta tester to get latest nightly build of WordPress 5.7 ( I have 5.7-alpha-50017)
2. Install Query Monitor
3. Navigate to Cart, Checkout or My Account
4. See error
5. Checkout this branch and navigate again to Cart, Checkout or My Account
6. Error is gone now

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Use `wp_robots_no_robots()` when available to support WP 5.7.
