### PR TITLE
Add filter to allow third-parties to filter exportable product types

### DIFF
--- a/includes/admin/class-wc-admin-exporters.php
+++ b/includes/admin/class-wc-admin-exporters.php
@@ -191,6 +191,30 @@ class WC_Admin_Exporters {
 			);
 		}
 	}
+
+	/**
+	 * Gets the product types that can be exported.
+	 *
+	 * @since 5.1.0
+	 * @return array The product types keys and labels.
+	 */
+	public static function get_product_types() {
+		$product_types = wc_get_product_types();
+		$product_types['variation'] = __( 'Product variations', 'woocommerce' );
+
+		/**
+		 * Allow third-parties to filter the exportable product types.
+		 *
+		 * @since 5.1.0
+		 * @param array $product_types {
+		 *     The product type key and label.
+		 *
+		 *     @type string Product type key - eg 'variable', 'simple' etc.
+		 *     @type string A translated product label which appears in the export product type dropdown.
+		 * }
+		 */
+		return apply_filters( 'woocommerce_exporter_product_types', $product_types );
+	}
 }
 
 new WC_Admin_Exporters();

--- a/includes/admin/views/html-admin-page-product-export.php
+++ b/includes/admin/views/html-admin-page-product-export.php
@@ -49,11 +49,10 @@ $exporter = new WC_Product_CSV_Exporter();
 							<td>
 								<select id="woocommerce-exporter-types" class="woocommerce-exporter-types wc-enhanced-select" style="width:100%;" multiple data-placeholder="<?php esc_attr_e( 'Export all products', 'woocommerce' ); ?>">
 									<?php
-									foreach ( wc_get_product_types() as $value => $label ) {
+									foreach ( WC_Admin_Exporters::get_product_types() as $value => $label ) {
 										echo '<option value="' . esc_attr( $value ) . '">' . esc_html( $label ) . '</option>';
 									}
 									?>
-									<option value="variation"><?php esc_html_e( 'Product variations', 'woocommerce' ); ?></option>
 								</select>
 							</td>
 						</tr>

--- a/includes/export/class-wc-product-csv-exporter.php
+++ b/includes/export/class-wc-product-csv-exporter.php
@@ -55,7 +55,7 @@ class WC_Product_CSV_Exporter extends WC_CSV_Batch_Exporter {
 	 */
 	public function __construct() {
 		parent::__construct();
-		$this->set_product_types_to_export( array_merge( array_keys( wc_get_product_types() ), array( 'variation' ) ) );
+		$this->set_product_types_to_export( array_keys( WC_Admin_Exporters::get_product_types() ) );
 	}
 
 	/**

--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -174,10 +174,8 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 
 		// Type is the most important part here because we need to be using the correct class and methods.
 		if ( isset( $data['type'] ) ) {
-			$types   = array_keys( wc_get_product_types() );
-			$types[] = 'variation';
 
-			if ( ! in_array( $data['type'], $types, true ) ) {
+			if ( ! array_key_exists( $data['type'], WC_Admin_Exporters::get_product_types() ) ) {
 				return new WP_Error( 'woocommerce_product_importer_invalid_type', __( 'Invalid product type.', 'woocommerce' ), array( 'status' => 401 ) );
 			}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Moves the functionality which generates the array of product types that can be imported/exported to a central function and then adds a filter to allow third-parties to add additional product types. 

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. On its own, this PR shouldn't change any behaviour from the front end. 
2. We need a filter like this in WC Subscriptions so we can register subscription variations as a separate product type. 

See 3970-gh-woocommerce/woocommerce-subscriptions for further details. 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Add the 'woocommerce_exporter_product_types' filter to allow third-parties to filter the product types which can be imported and exported. 