### PR TITLE
Left align content in tfoot in checkout-review-order-table

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -1871,6 +1871,10 @@ a.reset_variations {
 			}
 		}
 	}
+	
+	tfoot {
+		text-align: left;
+	}
 }
 
 .woocommerce-order-received {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
When using Twenty Twenty-One with WooCommerce, the content in the `tfoot` in the `checkout-order-review form` is aligned in the center, while everything else is aligned to the left. This is caused by [a change in Twenty Twenty-One 1.1](https://core.trac.wordpress.org/browser/trunk/src/wp-content/themes/twentytwentyone/assets/sass/05-blocks/table/_style.scss?rev=50000#L9). This PR makes sure the content in the `tfoot` is aligned to the left again.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. Checkout the current `master`
2. Activate Twenty Twenty-One as theme
2. Put a product in your cart and go to the checkout
3. Subtotal, shipping and total are aligned in the center, while the products and payments options are left aligned.
4. Checkout this branch
5. In the checkout, subtotal, shipping and total should be aligned to the left now.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Correctly aligns content in the checkout with Twenty Twenty-One
