### PR TITLE
Fixed method "adjust_download_permissions"

### DIFF
--- a/src/Internal/DownloadPermissionsAdjuster.php
+++ b/src/Internal/DownloadPermissionsAdjuster.php
@@ -83,6 +83,9 @@ class DownloadPermissionsAdjuster {
 	 */
 	public function adjust_download_permissions( int $product_id ) {
 		$product = wc_get_product( $product_id );
+		if ( ! $product ) {
+			return;
+		}
 
 		$children_ids = $product->get_children();
 		if ( ! $children_ids ) {


### PR DESCRIPTION
This PR adds a check to the method `adjust_download_permissions`, in order to make it more robust.
Currently, we will get an error if the method receives a not valid `product_id`, since we're not controlling the returned value of [wc_get_product](https://github.com/woocommerce/woocommerce/blob/master/src/Internal/DownloadPermissionsAdjuster.php#L85).
We'll get an error if the returned value is [null or false](https://woocommerce.github.io/code-reference/namespaces/default.html#function_wc_get_product) at the [next line](https://github.com/woocommerce/woocommerce/blob/master/src/Internal/DownloadPermissionsAdjuster.php#L87).
This issue is also affecting the [WC-Admin tests](https://github.com/woocommerce/woocommerce-admin/blob/main/tests/framework/helpers/class-wc-helper-queue.php#L41).

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:

1. Run `WooCommerce` and `WooCommerce Admin` tests.
2. Be sure the action scheduler works as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Additional protection after `wc_get_product` to account for invalid ID.