### PR TITLE
make cart coupon test more granular

### DIFF
--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -45,11 +45,11 @@ const removeCouponFromCart = async () => {
 	await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon has been removed.'});
 }
 const runCheckoutApplyCouponsTest = () => {
-	let couponFixedCart;
-	let couponPercentage;
-	let couponFixedProduct;
-
 	describe('Checkout coupons', () => {
+		let couponFixedCart;
+		let couponPercentage;
+		let couponFixedProduct;
+
 		beforeAll(async () => {
 			await merchant.login();
 			await createSimpleProduct();
@@ -98,7 +98,10 @@ const runCheckoutApplyCouponsTest = () => {
 			await applyCouponToCart( couponFixedCart );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 			await applyCouponToCart( couponFixedCart );
-			await expect(page).toMatchElement('.woocommerce-error li', { text: 'Coupon code already applied!' });
+			// Verify only one discount applied
+			// This is a work around for Puppeteer inconsistently finding 'Coupon code already applied'
+			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
+			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
 		});
 
 		it('allows customer to apply multiple coupons', async () => {

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -49,7 +49,7 @@ const runCheckoutApplyCouponsTest = () => {
 	let couponPercentage;
 	let couponFixedProduct;
 
-	describe('Checkout applying coupons', () => {
+	describe('Checkout coupons', () => {
 		beforeAll(async () => {
 			await merchant.login();
 			await createSimpleProduct();
@@ -95,14 +95,14 @@ const runCheckoutApplyCouponsTest = () => {
 		});
 
 		it('prevents customer applying same coupon twice', async () => {
-			await applyCouponToCart( couponPercentage );
+			await applyCouponToCart( couponFixedCart );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
-			await applyCouponToCart( couponPercentage );
+			await applyCouponToCart( couponFixedCart );
 			await expect(page).toMatchElement('.woocommerce-error li', { text: 'Coupon code already applied!' });
 		});
 
-		it('allows customer to apply multiple coupon', async () => {
-			await applyCouponToCart( couponFixedCart );
+		it('allows customer to apply multiple coupons', async () => {
+			await applyCouponToCart( couponFixedProduct );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$0.00'});
 		});

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -7,7 +7,8 @@ const {
 	merchant,
 	createCoupon,
 	createSimpleProduct,
-	uiUnblocked
+	uiUnblocked,
+	clearAndFillInput,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -28,7 +29,7 @@ const {
 const applyCouponToCart = async ( couponCode ) => {
 	await expect(page).toClick('a', {text: 'Click here to enter your code'});
 	await uiUnblocked();
-	await expect(page).toFill('#coupon_code', couponCode);
+	await clearAndFillInput('#coupon_code', couponCode);
 	await expect(page).toClick('button', {text: 'Apply coupon'});
 	await uiUnblocked();
 };
@@ -94,9 +95,10 @@ const runCheckoutApplyCouponsTest = () => {
 		});
 
 		it('prevents customer applying same coupon twice', async () => {
-			await applyCouponToCart( couponFixedProduct );
-			await applyCouponToCart( couponFixedProduct );
-			await expect(page).toMatchElement('.woocommerce-error', { text: 'Coupon code already applied!' });
+			await applyCouponToCart( couponPercentage );
+			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
+			await applyCouponToCart( couponPercentage );
+			await expect(page).toMatchElement('.woocommerce-error li', { text: 'Coupon code already applied!' });
 		});
 
 		it('allows customer to apply multiple coupon', async () => {

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -19,11 +19,36 @@ const {
 	beforeAll,
 } = require( '@jest/globals' );
 
+/**
+ * Apply a coupon code to the cart.
+ *
+ * @param couponCode string
+ * @returns {Promise<void>}
+ */
+const applyCouponToCart = async ( couponCode ) => {
+	await expect(page).toClick('a', {text: 'Click here to enter your code'});
+	await uiUnblocked();
+	await expect(page).toFill('#coupon_code', couponCode);
+	await expect(page).toClick('button', {text: 'Apply coupon'});
+	await uiUnblocked();
+};
+
+/**
+ * Remove one coupon from the cart.
+ *
+ * @returns {Promise<void>}
+ */
+const removeCouponFromCart = async () => {
+	await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
+	await uiUnblocked();
+	await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon has been removed.'});
+}
 const runCheckoutApplyCouponsTest = () => {
+	let couponFixedCart;
+	let couponPercentage;
+	let couponFixedProduct;
+
 	describe('Checkout applying coupons', () => {
-			let couponFixedCart;
-			let couponPercentage;
-			let couponFixedProduct;
 		beforeAll(async () => {
 			await merchant.login();
 			await createSimpleProduct();
@@ -31,86 +56,59 @@ const runCheckoutApplyCouponsTest = () => {
 			couponPercentage = await createCoupon('50', 'Percentage discount');
 			couponFixedProduct = await createCoupon('5', 'Fixed product discount');
 			await merchant.logout();
-		});
-
-		it('allows customer to apply coupons in the checkout', async () => {
 			await shopper.goToShop();
 			await shopper.addToCartFromShopPage('Simple product');
 			await uiUnblocked();
 			await shopper.goToCheckout();
+		});
 
-			// Apply Fixed cart discount coupon
-			await expect(page).toClick('a', {text: 'Click here to enter your code'});
-			await uiUnblocked();
-			await expect(page).toFill('#coupon_code', couponFixedCart);
-			await expect(page).toClick('button', {text: 'Apply coupon'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon code applied successfully.'});
+		it('allows customer to apply fixed cart coupon', async () => {
+			await applyCouponToCart( couponFixedCart );
+			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Wait for page to expand total calculations to avoid flakyness
 			await page.waitForSelector('.order-total');
 
 			// Verify discount applied and order total
-			await page.waitForSelector('.cart-discount .amount', {text: '$5.00'});
-			await page.waitForSelector('.order-total .amount', {text: '$4.99'});
+			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
+			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
+			await removeCouponFromCart();
+		});
 
-			// Remove coupon
-			await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon has been removed.'});
+		it('allows customer to apply percentage coupon', async () => {
+			await applyCouponToCart( couponPercentage );
+			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
-			// Apply Percentage discount coupon
-			await expect(page).toClick('a', {text: 'Click here to enter your code'});
-			await uiUnblocked();
-			await expect(page).toFill('#coupon_code', couponPercentage);
-			await expect(page).toClick('button', {text: 'Apply coupon'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon code applied successfully.'});
-			await page.waitForSelector('.cart-discount .amount', {text: '$4.99'});
-			await page.waitForSelector('.order-total .amount', {text: '$5.00'});
+			// Verify discount applied and order total
+			await expect(page).toMatchElement('.cart-discount .amount', {text: '$4.99'});
+			await expect(page).toMatchElement('.order-total .amount', {text: '$5.00'});
+			await removeCouponFromCart();
+		});
 
-			// Remove coupon
-			await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon has been removed.'});
+		it('allows customer to apply fixed product coupon', async () => {
+			await applyCouponToCart( couponFixedProduct );
+			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
+			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
+			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
+			await removeCouponFromCart();
+		});
 
-			// Apply Fixed product discount coupon
-			await expect(page).toClick('a', {text: 'Click here to enter your code'});
-			await uiUnblocked();
-			await expect(page).toFill('#coupon_code', couponFixedProduct);
-			await expect(page).toClick('button', {text: 'Apply coupon'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon code applied successfully.'});
-			await page.waitForSelector('.cart-discount .amount', {text: '$5.00'});
-			await page.waitForSelector('.order-total .amount', {text: '$4.99'});
+		it('prevents customer applying same coupon twice', async () => {
+			await applyCouponToCart( couponFixedProduct );
+			await applyCouponToCart( couponFixedProduct );
+			await expect(page).toMatchElement('.woocommerce-error', { text: 'Coupon code already applied!' });
+		});
 
-			// Try to apply the same coupon
-			await expect(page).toClick('a', {text: 'Click here to enter your code'});
-			await uiUnblocked();
-			await expect(page).toFill('#coupon_code', couponFixedProduct);
-			await expect(page).toClick('button', {text: 'Apply coupon'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-error', { text: 'Coupon code already applied!' });
+		it('allows customer to apply multiple coupon', async () => {
+			await applyCouponToCart( couponFixedCart );
+			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
+			await expect(page).toMatchElement('.order-total .amount', {text: '$0.00'});
+		});
 
-			// Try to apply multiple coupons
-			await expect(page).toClick('a', {text: 'Click here to enter your code'});
-			await uiUnblocked();
-			await expect(page).toFill('#coupon_code', couponFixedCart);
-			await expect(page).toClick('button', {text: 'Apply coupon'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon code applied successfully.'});
-			await page.waitForSelector('.order-total .amount', {text: '$0.00'});
-
-			// Remove coupon
-			await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon has been removed.'});
-			await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon has been removed.'});
-
-			// Verify the total amount after all coupons removal
-			await page.waitForSelector('.order-total .amount', {text: '$9.99'});
+		it('restores cart total when coupons are removed', async () => {
+			await removeCouponFromCart();
+			await removeCouponFromCart();
+			await expect(page).toMatchElement('.order-total .amount', {text: '$9.99'});
 		});
 	});
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR breaks the cart coupon test into multiple tests to make it easier to determine which part of the test failed. The two intermittent issues that I found were

- the second `expect(page).toFill(` in the apply coupon twice test was appending the second coupon code to the first instead of replacing it
- Puppeteer would not consistently find/recognize `Coupon code already applied!` notice

### How to test the changes in this Pull Request:

1. Verify Travis E2E run
2. Run full test suite locally

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A
