### PR TITLE
Update wc-admin to 1.9.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.9.0-rc.3",
+    "woocommerce/woocommerce-admin": "1.9.0",
     "woocommerce/woocommerce-blocks": "4.0.0"
   },
   "require-dev": {


### PR DESCRIPTION
Bumps wc-admin version to `1.9.0`.

**Note**: running ` composer update` produced this error, so I did not commit those changes as a result. Please let me know the best way to handle this.

```
Script @composer bin all update --ansi handling the post-update-cmd event returned with error code 2
```

## Changes since 1.9.0-rc.3

* Fix for translation chunks not generated on plugin activation https://github.com/woocommerce/woocommerce-admin/pull/6028
* Return countryInfo as an empty object if not in locale info https://github.com/woocommerce/woocommerce-admin/pull/6188
* Hide Inventory and Reviews panels if store setup task list is visible https://github.com/woocommerce/woocommerce-admin/pull/6182

Plus, one change to eCommerce plan sites' Navigation, which does not require testing in this context.

* Navigation: Change default location and add Product category items https://github.com/woocommerce/woocommerce-admin/pull/6179

## Testing Instructions

https://github.com/woocommerce/woocommerce-admin/pull/6028

1. Set language to Español in `Settings > General`
5. Go to WooCommerce store profiler screen and see that it is translated to Spanish 

https://github.com/woocommerce/woocommerce-admin/pull/6188

1. In the Onboarding Wizard select an address in Aland Islands or India.
2. The Onboarding Wizard should finish without error.

https://github.com/woocommerce/woocommerce-admin/pull/6182

1. Finish the OBW.
2. Add a new product.
3. Hide the task list named "Finish setup".
4. Verify the `Reviews` panel is visible now.
5 Go to a non-js page (e.g.: `/wp-admin/admin.php?page=wc-settings`).
6. Click on `Help` > `Setup wizard` and enable the `Task list`.
7. Go to the `Home` screen.
8. Verify the `Reviews` panel is not visible anymore.