### PR TITLE
Flush term cache when saving product and settings closes #25375

### DIFF
--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -64,6 +64,10 @@ class WC_Settings_Products extends WC_Settings_Page {
 		$settings = $this->get_settings( $current_section );
 		WC_Admin_Settings::save_fields( $settings );
 
+		// Any time we update the product settings, we should flush the term count cache.
+		$tools_controller = new WC_REST_System_Status_Tools_Controller();
+		$tools_controller->execute_tool( 'recount_terms' );
+
 		if ( $current_section ) {
 			do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
 		}

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -272,6 +272,9 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 
 		$product->apply_changes();
 
+		// Any time we update the product, we should flush the term count cache.
+		$tools_controller = new WC_REST_System_Status_Tools_Controller();
+		$tools_controller->execute_tool( 'recount_terms' );
 		do_action( 'woocommerce_update_product', $product->get_id(), $product );
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25375

### How to test the changes in this Pull Request:

1. Add the Product Categories widget to your site. Enable show counts option.
2. Make sure to have a hand full of products that belong to a category that is listed in that widget.
3. For couple of the products, set the stock level to out of stock and save the product.
4. Go back to the frontend shop page and ensure the widget shows the product count correctly.
5. Go to your woocommerce->settings->products->inventory and set `Hide out of stock items from the catalog` to enabled.
6. Go back to the frontend shop page and ensure the widget shows the product count correctly. Should show less than in step 5 as now it suppose to hide the product from catalog if it is out of stock.
7. Disable `Hide out of stock items from the catalog` setting and save.
8. Go back to the frontend shop page and ensure the widget shows the product count correctly.

### Other information:

Simple PR to just flush the caches during the product save operation and product settings page.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Fix - Product categories widget item count not always showing the correct number.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
