### PR TITLE
Increase WordPress minimum to 5.4

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WooCommerce ===
 Contributors: automattic, mikejolley, jameskoster, claudiosanches, rodrigosprimo, peterfabian1000, vedjain, jamosova, obliviousharmony, konamiman, sadowski, wpmuguru, royho
 Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, downloads, payments, paypal, storefront, stripe, woo commerce
-Requires at least: 5.3
+Requires at least: 5.4
 Tested up to: 5.6
 Requires PHP: 7.0
 Stable tag: 4.9.2


### PR DESCRIPTION
As per the [L-2 support policy](https://developer.woocommerce.com/2020/05/08/wordpress-core-support-policy/) we should increase the WordPress minimum version to 5.4.