### PR TITLE
Add time of generation to the system status report

### DIFF
--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -1018,3 +1018,19 @@ if ( 0 < count( $dropins_mu_plugins['mu_plugins'] ) ) :
 </table>
 
 <?php do_action( 'woocommerce_system_status_report' ); ?>
+
+<table class="wc_status_table widefat" cellspacing="0">
+	<thead>
+	<tr>
+		<th colspan="3" data-export-label="Status report information"><h2><?php esc_html_e( 'Status report information', 'woocommerce' ); ?><?php echo wc_help_tip( esc_html__( 'This section shows information about this status report.', 'woocommerce' ) ); ?></h2></th>
+	</tr>
+	</thead>
+	<tbody>
+	<tr>
+		<td data-export-label="Generated at"><?php esc_html_e( 'Generated at', 'woocommerce' ); ?>:</td>
+		<td class="help">&nbsp;</td>
+		<td><?php echo esc_html( current_time( 'Y-m-d H:i:s P' ) ); ?></td>
+
+	</tr>
+	</tbody>
+</table>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This adds an additional section to the system status report, *after* the hook that allows third parties to add to the report. This final section contains the date & time that the status report was generated. 

This helps people dealing with support tickets qualify if the status report is up to date or not (some people submit stale reports believe it or not ...)

### How to test the changes in this Pull Request:

1. Visit WooCommerce » Status
2. Verify that the "Status Report Information" section is present at the bottom of the report, and that the "Generate at:" date & time is correct.
3. Click "Get status report" and confirm that the information is included in the plain text representation as well. 

### Changelog entry

> Adds status report generation time to the Status Report.
