### PR TITLE
simplify imports/exports in api package

### DIFF
--- a/tests/e2e/api/src/__test_data__/dummy-model.ts
+++ b/tests/e2e/api/src/__test_data__/dummy-model.ts
@@ -1,4 +1,4 @@
-import { Model } from '../models/model';
+import { Model } from '../models';
 
 /**
  * A dummy model that can be used in test files.

--- a/tests/e2e/api/src/framework/__tests__/model-repository.spec.ts
+++ b/tests/e2e/api/src/framework/__tests__/model-repository.spec.ts
@@ -1,4 +1,4 @@
-import { Model } from '../../models/model';
+import { Model } from '../../models';
 import {
 	CreatesModels,
 	DeletesChildModels,

--- a/tests/e2e/api/src/framework/index.ts
+++ b/tests/e2e/api/src/framework/index.ts
@@ -1,0 +1,3 @@
+export * from './transformations';
+export * from './model-repository';
+export * from './model-transformer';

--- a/tests/e2e/api/src/framework/model-repository.ts
+++ b/tests/e2e/api/src/framework/model-repository.ts
@@ -1,4 +1,4 @@
-import { Model, ModelID } from '../models/model';
+import { Model, ModelID } from '../models';
 
 /**
  * An interface for describing the shape of parent identifiers for repositories.
@@ -6,7 +6,7 @@ import { Model, ModelID } from '../models/model';
  * @typedef ModelParentID
  * @alias Object.<string,ModelID>
  */
-interface ModelParentID {
+export interface ModelParentID {
 	[ key: number ]: ModelID
 }
 

--- a/tests/e2e/api/src/framework/model-transformer.ts
+++ b/tests/e2e/api/src/framework/model-transformer.ts
@@ -1,5 +1,4 @@
-import { Model } from '../models/model';
-import { ModelConstructor } from '../models/shared-types';
+import { Model, ModelConstructor } from '../models';
 
 /**
  * An interface for an object that can perform transformations both to and from a representation

--- a/tests/e2e/api/src/framework/transformations/index.ts
+++ b/tests/e2e/api/src/framework/transformations/index.ts
@@ -1,0 +1,6 @@
+export * from './add-property-transformation';
+export * from './custom-transformation';
+export * from './ignore-property-transformation';
+export * from './key-change-transformation';
+export * from './model-transformer-transformation';
+export * from './property-type-transformation';

--- a/tests/e2e/api/src/framework/transformations/key-change-transformation.ts
+++ b/tests/e2e/api/src/framework/transformations/key-change-transformation.ts
@@ -1,5 +1,5 @@
 import { ModelTransformation, TransformationOrder } from '../model-transformer';
-import { Model } from '../../models/model';
+import { Model } from '../../models';
 
 /**
  * @typedef KeyChanges

--- a/tests/e2e/api/src/framework/transformations/model-transformer-transformation.ts
+++ b/tests/e2e/api/src/framework/transformations/model-transformer-transformation.ts
@@ -1,6 +1,5 @@
 import { ModelTransformation, ModelTransformer, TransformationOrder } from '../model-transformer';
-import { Model } from '../../models/model';
-import { ModelConstructor } from '../../models/shared-types';
+import { Model, ModelConstructor } from '../../models';
 
 /**
  * A model transformation that applies another transformer to a property.

--- a/tests/e2e/api/src/models/index.ts
+++ b/tests/e2e/api/src/models/index.ts
@@ -1,4 +1,4 @@
-export { SimpleProduct } from './products/simple-product';
-
-export { SettingGroup } from './settings/setting-group';
-export { Setting } from './settings/setting';
+export * from './products';
+export * from './model';
+export * from './settings';
+export * from './shared-types';

--- a/tests/e2e/api/src/models/products/index.ts
+++ b/tests/e2e/api/src/models/products/index.ts
@@ -1,0 +1,3 @@
+export * from './abstract-product';
+export * from './shared-types';
+export * from './simple-product';

--- a/tests/e2e/api/src/models/products/simple-product.ts
+++ b/tests/e2e/api/src/models/products/simple-product.ts
@@ -1,13 +1,14 @@
 import { AbstractProduct, ProductSearchParams, ProductUpdateParams } from './abstract-product';
 import { HTTPClient } from '../../http';
-import { simpleProductRESTRepository } from '../../repositories/rest/products/simple-product';
+import { simpleProductRESTRepository } from '../../repositories';
 import {
 	CreatesModels,
-	DeletesModels, ListsModels,
+	DeletesModels,
+	ListsModels,
 	ModelRepositoryParams,
 	ReadsModels,
 	UpdatesModels,
-} from '../../framework/model-repository';
+} from '../../framework';
 
 /**
  * The parameters embedded in this generic can be used in the ModelRepository in order to give

--- a/tests/e2e/api/src/models/settings/index.ts
+++ b/tests/e2e/api/src/models/settings/index.ts
@@ -1,0 +1,2 @@
+export * from './setting-group';
+export * from './setting';

--- a/tests/e2e/api/src/models/settings/setting-group.ts
+++ b/tests/e2e/api/src/models/settings/setting-group.ts
@@ -1,7 +1,7 @@
 import { Model, ModelID } from '../model';
 import { HTTPClient } from '../../http';
-import { settingGroupRESTRepository } from '../../repositories/rest/settings/setting-group';
-import { ListsModels, ModelRepositoryParams } from '../../framework/model-repository';
+import { settingGroupRESTRepository } from '../../repositories';
+import { ListsModels, ModelRepositoryParams } from '../../framework';
 
 /**
  * The parameters embedded in this generic can be used in the ModelRepository in order to give

--- a/tests/e2e/api/src/models/settings/setting.ts
+++ b/tests/e2e/api/src/models/settings/setting.ts
@@ -1,12 +1,12 @@
 import { Model, ModelID } from '../model';
 import { HTTPClient } from '../../http';
-import { settingRESTRepository } from '../../repositories/rest/settings/setting';
+import { settingRESTRepository } from '../../repositories';
 import {
 	ModelRepositoryParams,
 	ListsChildModels,
 	ReadsChildModels,
 	UpdatesChildModels,
-} from '../../framework/model-repository';
+} from '../../framework';
 
 /**
  * The parameters embedded in this generic can be used in the ModelRepository in order to give

--- a/tests/e2e/api/src/repositories/index.ts
+++ b/tests/e2e/api/src/repositories/index.ts
@@ -1,0 +1,1 @@
+export * from './rest';

--- a/tests/e2e/api/src/repositories/rest/__tests__/shared.spec.ts
+++ b/tests/e2e/api/src/repositories/rest/__tests__/shared.spec.ts
@@ -1,6 +1,6 @@
 import { mock, MockProxy } from 'jest-mock-extended';
 import { HTTPClient, HTTPResponse } from '../../../http';
-import { ModelTransformer } from '../../../framework/model-transformer';
+import { ModelTransformer, ModelRepositoryParams } from '../../../framework';
 import { DummyModel } from '../../../__test_data__/dummy-model';
 import {
 	restCreate,
@@ -12,8 +12,7 @@ import {
 	restUpdate,
 	restUpdateChild,
 } from '../shared';
-import { ModelRepositoryParams } from '../../../framework/model-repository';
-import { Model } from '../../../models/model';
+import { Model } from '../../../models';
 
 type DummyModelParams = ModelRepositoryParams< DummyModel, never, { search: string }, 'name' >
 

--- a/tests/e2e/api/src/repositories/rest/index.ts
+++ b/tests/e2e/api/src/repositories/rest/index.ts
@@ -1,0 +1,2 @@
+export * from './products';
+export * from './settings';

--- a/tests/e2e/api/src/repositories/rest/products/index.ts
+++ b/tests/e2e/api/src/repositories/rest/products/index.ts
@@ -1,0 +1,7 @@
+import { createProductTransformer } from './shared';
+import { simpleProductRESTRepository } from './simple-product';
+
+export {
+	createProductTransformer,
+	simpleProductRESTRepository,
+};

--- a/tests/e2e/api/src/repositories/rest/products/shared.ts
+++ b/tests/e2e/api/src/repositories/rest/products/shared.ts
@@ -1,16 +1,23 @@
-import { ModelTransformation, ModelTransformer, TransformationOrder } from '../../../framework/model-transformer';
-import { KeyChangeTransformation } from '../../../framework/transformations/key-change-transformation';
-import { AbstractProduct } from '../../../models/products/abstract-product';
-import { AddPropertyTransformation } from '../../../framework/transformations/add-property-transformation';
-import { IgnorePropertyTransformation } from '../../../framework/transformations/ignore-property-transformation';
 import {
+	ModelTransformation,
+	ModelTransformer,
+	TransformationOrder,
+	KeyChangeTransformation,
+	AddPropertyTransformation,
+	IgnorePropertyTransformation,
 	PropertyType,
 	PropertyTypeTransformation,
-} from '../../../framework/transformations/property-type-transformation';
-import { CustomTransformation } from '../../../framework/transformations/custom-transformation';
-import { ProductAttribute, ProductDownload, ProductImage, ProductTerm } from '../../../models/products/shared-types';
-import { ModelTransformerTransformation } from '../../../framework/transformations/model-transformer-transformation';
-import { MetaData } from '../../../models/shared-types';
+	CustomTransformation,
+	ModelTransformerTransformation,
+} from '../../../framework';
+import {
+	AbstractProduct,
+	ProductAttribute,
+	ProductDownload,
+	ProductImage,
+	ProductTerm,
+	MetaData,
+} from '../../../models';
 import { createMetaDataTransformer } from '../shared';
 
 /**

--- a/tests/e2e/api/src/repositories/rest/products/simple-product.ts
+++ b/tests/e2e/api/src/repositories/rest/products/simple-product.ts
@@ -1,17 +1,23 @@
 import { HTTPClient } from '../../../http';
-import { ModelRepository } from '../../../framework/model-repository';
-import { SimpleProduct } from '../../../models';
+import { ModelRepository } from '../../../framework';
 import {
+	SimpleProduct,
+	ModelID,
 	CreatesSimpleProducts,
 	DeletesSimpleProducts,
 	ListsSimpleProducts,
 	ReadsSimpleProducts,
 	SimpleProductRepositoryParams,
 	UpdatesSimpleProducts,
-} from '../../../models/products/simple-product';
+} from '../../../models';
 import { createProductTransformer } from './shared';
-import { restCreate, restDelete, restList, restRead, restUpdate } from '../shared';
-import { ModelID } from '../../../models/model';
+import {
+	restCreate,
+	restDelete,
+	restList,
+	restRead,
+	restUpdate,
+} from '../shared';
 
 /**
  * Creates a new ModelRepository instance for interacting with models via the REST API.

--- a/tests/e2e/api/src/repositories/rest/settings/index.ts
+++ b/tests/e2e/api/src/repositories/rest/settings/index.ts
@@ -1,0 +1,7 @@
+import settingRESTRepository from './setting';
+import settingGroupRESTRepository from './setting-group';
+
+export {
+	settingRESTRepository,
+	settingGroupRESTRepository,
+};

--- a/tests/e2e/api/src/repositories/rest/settings/setting-group.ts
+++ b/tests/e2e/api/src/repositories/rest/settings/setting-group.ts
@@ -1,9 +1,14 @@
 import { HTTPClient } from '../../../http';
-import { ModelRepository } from '../../../framework/model-repository';
-import { SettingGroup } from '../../../models';
-import { ListsSettingGroups, SettingGroupRepositoryParams } from '../../../models/settings/setting-group';
-import { ModelTransformer } from '../../../framework/model-transformer';
-import { KeyChangeTransformation } from '../../../framework/transformations/key-change-transformation';
+import {
+	ModelRepository,
+	ModelTransformer,
+	KeyChangeTransformation,
+} from '../../../framework';
+import {
+	SettingGroup,
+	ListsSettingGroups,
+	SettingGroupRepositoryParams,
+} from '../../../models';
 import { restList } from '../shared';
 
 function createTransformer(): ModelTransformer< SettingGroup > {
@@ -20,7 +25,7 @@ function createTransformer(): ModelTransformer< SettingGroup > {
  * @param {HTTPClient} httpClient The HTTP client for the REST requests to be made using.
  * @return {ListsSettingGroups} The created repository.
  */
-export function settingGroupRESTRepository( httpClient: HTTPClient ): ListsSettingGroups {
+export default function settingGroupRESTRepository( httpClient: HTTPClient ): ListsSettingGroups {
 	const transformer = createTransformer();
 
 	return new ModelRepository(

--- a/tests/e2e/api/src/repositories/rest/settings/setting.ts
+++ b/tests/e2e/api/src/repositories/rest/settings/setting.ts
@@ -1,15 +1,18 @@
 import { HTTPClient } from '../../../http';
-import { ModelRepository, ParentID } from '../../../framework/model-repository';
-import { Setting } from '../../../models';
 import {
+	ModelRepository,
+	ParentID,
+	ModelTransformer,
+} from '../../../framework';
+import {
+	ModelID,
+	Setting,
 	ListsSettings,
 	ReadsSettings,
 	SettingRepositoryParams,
 	UpdatesSettings,
-} from '../../../models/settings/setting';
-import { ModelTransformer } from '../../../framework/model-transformer';
+} from '../../../models';
 import { restListChild, restReadChild, restUpdateChild } from '../shared';
-import { ModelID } from '../../../models/model';
 
 function createTransformer(): ModelTransformer< Setting > {
 	return new ModelTransformer( [] );
@@ -21,7 +24,7 @@ function createTransformer(): ModelTransformer< Setting > {
  * @param {HTTPClient} httpClient The HTTP client for the REST requests to be made using.
  * @return {ListsSettings|ReadsSettings|UpdatesSettings} The created repository.
  */
-export function settingRESTRepository( httpClient: HTTPClient ): ListsSettings & ReadsSettings & UpdatesSettings {
+export default function settingRESTRepository( httpClient: HTTPClient ): ListsSettings & ReadsSettings & UpdatesSettings {
 	const buildURL = ( parent: ParentID< SettingRepositoryParams >, id: ModelID ) => '/wc/v3/settings/' + parent + '/' + id;
 	const transformer = createTransformer();
 

--- a/tests/e2e/api/src/repositories/rest/shared.ts
+++ b/tests/e2e/api/src/repositories/rest/shared.ts
@@ -15,6 +15,7 @@ import {
 	CreateFn,
 	ModelTransformer,
 	IgnorePropertyTransformation,
+	// @ts-ignore
 	ModelParentID,
 } from '../../framework';
 import {

--- a/tests/e2e/api/src/repositories/rest/shared.ts
+++ b/tests/e2e/api/src/repositories/rest/shared.ts
@@ -1,6 +1,3 @@
-import { ModelTransformer } from '../../framework/model-transformer';
-import { MetaData, ModelConstructor } from '../../models/shared-types';
-import { IgnorePropertyTransformation } from '../../framework/transformations/ignore-property-transformation';
 import { HTTPClient } from '../../http';
 import {
 	ListFn,
@@ -16,8 +13,15 @@ import {
 	UpdateChildFn,
 	DeleteChildFn,
 	CreateFn,
-} from '../../framework/model-repository';
-import { ModelID } from '../../models/model';
+	ModelTransformer,
+	IgnorePropertyTransformation,
+	ModelParentID,
+} from '../../framework';
+import {
+	ModelID,
+	MetaData,
+	ModelConstructor,
+} from '../../models';
 
 /**
  * Creates a new transformer for metadata models.

--- a/tests/e2e/api/src/services/__tests__/setting-service.spec.ts
+++ b/tests/e2e/api/src/services/__tests__/setting-service.spec.ts
@@ -1,5 +1,5 @@
 import { mock, MockProxy } from 'jest-mock-extended';
-import { UpdatesSettings } from '../../models/settings/setting';
+import { UpdatesSettings } from '../../models';
 import { SettingService } from '../setting-service';
 
 describe( 'SettingService', () => {

--- a/tests/e2e/api/src/services/setting-service.ts
+++ b/tests/e2e/api/src/services/setting-service.ts
@@ -1,4 +1,4 @@
-import { Setting, UpdatesSettings } from '../models/settings/setting';
+import { Setting, UpdatesSettings } from '../models';
 
 /**
  * A service that wraps setting changes in convenient methods.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR is the first step for #28886. It updates the `api` package to

- Change all `import`s to be from descendent folders to the current folder, from the current folder, or from a root folder
- Adds the `export`s needed to support the support the `import` changes
- Eliminates implicit access to types gained by importing directly from source files

The main reasons for implementing this are:

- Allows for code reorganization as needed in upcoming and future development work without having to update files throughout the package.
- Prepares for exposing types, interfaces, etc. to consumers of the package to allow other projects to use those as a foundation for their own types (eg. another product type).

### How to test the changes in this Pull Request:

1. Verify CI run
2. Locally run `npm install`
3. Run E2E tests locally

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A