### PR TITLE
Respect the $limit parameter (0)

### DIFF
--- a/plugins/woocommerce/includes/wc-webhook-functions.php
+++ b/plugins/woocommerce/includes/wc-webhook-functions.php
@@ -164,13 +164,13 @@ function wc_load_webhooks( $status = '', $limit = null ) {
 	$loaded     = 0;
 
 	foreach ( $webhooks as $webhook_id ) {
-		$webhook = new WC_Webhook( $webhook_id );
-		$webhook->enqueue();
-		$loaded ++;
-
 		if ( ! is_null( $limit ) && $loaded >= $limit ) {
 			break;
 		}
+
+		$webhook = new WC_Webhook( $webhook_id );
+		$webhook->enqueue();
+		$loaded ++;
 	}
 
 	return 0 < $loaded;

--- a/plugins/woocommerce/tests/legacy/unit-tests/webhooks/functions.php
+++ b/plugins/woocommerce/tests/legacy/unit-tests/webhooks/functions.php
@@ -172,6 +172,10 @@ class WC_Tests_Webhook_Functions extends WC_Unit_Test_Case {
 		$webhook_one = $this->create_webhook( 'action.woocommerce_one_test' );
 		$webhook_two = $this->create_webhook( 'action.woocommerce_two_test' );
 
+		$this->assertFalse( wc_load_webhooks( '', 0 ) );
+		$this->assertFalse( isset( $wp_filter['woocommerce_one_test'] ) );
+		$this->assertFalse( isset( $wp_filter['woocommerce_two_test'] ) );
+
 		$this->assertTrue( wc_load_webhooks( '', 1 ) );
 		$this->assertFalse( isset( $wp_filter['woocommerce_one_test'] ) );
 		$this->assertTrue( isset( $wp_filter['woocommerce_two_test'] ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

If `woocommerce_load_webhooks_limit` is set to 0, at least one webhook would still be loaded.  Rearrange the check before loading the webhook.

### How to test the changes in this Pull Request:

1. Create some webhooks
2. Add a filter to return 0: `add_filter( 'woocommerce_load_webhooks_limit', function () { return 0; } );`
3. Go to Webhooks page -- no webhooks should be loaded.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
