### PR TITLE
The order of the full name returned by WC_Countries::get_formatted_address()

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -591,7 +591,12 @@ class WC_Countries {
 				array(
 					'{first_name}'       => $args['first_name'],
 					'{last_name}'        => $args['last_name'],
-					'{name}'             => sprintf( _x( '%1$s %2$s', 'full name', 'woocommerce' ), $args['first_name'], $args['last_name'] ),
+					'{name}'             => sprintf(
+						/* translators: 1: first name 2: last name */
+						_x( '%1$s %2$s', 'full name', 'woocommerce' ),
+						$args['first_name'],
+						$args['last_name']
+					),
 					'{company}'          => $args['company'],
 					'{address_1}'        => $args['address_1'],
 					'{address_2}'        => $args['address_2'],
@@ -601,7 +606,14 @@ class WC_Countries {
 					'{country}'          => $full_country,
 					'{first_name_upper}' => wc_strtoupper( $args['first_name'] ),
 					'{last_name_upper}'  => wc_strtoupper( $args['last_name'] ),
-					'{name_upper}'       => wc_strtoupper( sprintf( _x( '%1$s %2$s', 'full name', 'woocommerce' ), $args['first_name'], $args['last_name'] ) ),
+					'{name_upper}'       => wc_strtoupper(
+						sprintf(
+							/* translators: 1: first name 2: last name */
+							_x( '%1$s %2$s', 'full name', 'woocommerce' ),
+							$args['first_name'],
+							$args['last_name']
+						)
+					),
 					'{company_upper}'    => wc_strtoupper( $args['company'] ),
 					'{address_1_upper}'  => wc_strtoupper( $args['address_1'] ),
 					'{address_2_upper}'  => wc_strtoupper( $args['address_2'] ),

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -591,7 +591,7 @@ class WC_Countries {
 				array(
 					'{first_name}'       => $args['first_name'],
 					'{last_name}'        => $args['last_name'],
-					'{name}'             => $args['first_name'] . ' ' . $args['last_name'],
+					'{name}'             => sprintf( _x( '%1$s %2$s', 'full name', 'woocommerce' ), $args['first_name'], $args['last_name'] ),
 					'{company}'          => $args['company'],
 					'{address_1}'        => $args['address_1'],
 					'{address_2}'        => $args['address_2'],
@@ -601,7 +601,7 @@ class WC_Countries {
 					'{country}'          => $full_country,
 					'{first_name_upper}' => wc_strtoupper( $args['first_name'] ),
 					'{last_name_upper}'  => wc_strtoupper( $args['last_name'] ),
-					'{name_upper}'       => wc_strtoupper( $args['first_name'] . ' ' . $args['last_name'] ),
+					'{name_upper}'       => wc_strtoupper( sprintf( _x( '%1$s %2$s', 'full name', 'woocommerce' ), $args['first_name'], $args['last_name'] ) ),
 					'{company_upper}'    => wc_strtoupper( $args['company'] ),
 					'{address_1_upper}'  => wc_strtoupper( $args['address_1'] ),
 					'{address_2_upper}'  => wc_strtoupper( $args['address_2'] ),


### PR DESCRIPTION
`WC_Abstract_Order::get_formatted_billing_full_name()` and 
`WC_Abstract_Order::get_formatted_shipping_full_name()` displays the names in the correct order according to the language, but `WC_Countries::get_formatted_address()` does not.

### Changelog entry

> Fix - WC_Countries::get_formatted_address() not returning full name in correct order in some languages.