### PR TITLE
Small doc fix: REST API no longer external

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,9 +41,7 @@ If you have questions about the process to contribute code or want to discuss de
 - Make sure to write good and detailed commit messages (see [this post](https://chris.beams.io/posts/git-commit/) for more on this) and follow all the applicable sections of the pull request template.
 - Please avoid modifying the changelog directly or updating the .pot files. These will be updated by the WooCommerce team.
 
-If you are contributing code to the REST API or editor blocks, these are developed in external packages.
-- [WooCommerce REST API package](https://github.com/woocommerce/woocommerce-rest-api)
-- [Blocks](https://github.com/woocommerce/woocommerce-gutenberg-products-block)
+If you are contributing code to editor blocks, visit the [external repository](https://github.com/woocommerce/woocommerce-gutenberg-products-block).
 
 ## Feature Requests 🚀
 


### PR DESCRIPTION
This is just a small change to contributing guidelines, I was reading how to contribute and the REST API repo said development should happen in the core.
