### PR TITLE
Removed extra closing brace ) from the Zone regions help text.

### DIFF
--- a/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
+++ b/includes/admin/settings/views/html-admin-page-shipping-zone-methods.php
@@ -66,7 +66,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<div class="wc-shipping-zone-postcodes">
 						<textarea name="zone_postcodes" data-attribute="zone_postcodes" id="zone_postcodes" placeholder="<?php esc_attr_e( 'List 1 postcode per line', 'woocommerce' ); ?>" class="input-text large-text" cols="25" rows="5"><?php echo esc_textarea( implode( "\n", $postcodes ) ); ?></textarea>
 						<?php /* translators: WooCommerce link to setting up shipping zones */ ?>
-						<span class="description"><?php printf( __( 'Postcodes containing wildcards (e.g. CB23*) or fully numeric ranges (e.g. <code>90210...99000</code>) are also supported. Please see the shipping zones <a href="%s" target="_blank">documentation</a>) for more information.', 'woocommerce' ), 'https://docs.woocommerce.com/document/setting-up-shipping-zones/#section-3' ); ?></span><?php // @codingStandardsIgnoreLine. ?>
+						<span class="description"><?php printf( __( 'Postcodes containing wildcards (e.g. CB23*) or fully numeric ranges (e.g. <code>90210...99000</code>) are also supported. Please see the shipping zones <a href="%s" target="_blank">documentation</a> for more information.', 'woocommerce' ), 'https://docs.woocommerce.com/document/setting-up-shipping-zones/#section-3' ); ?></span><?php // @codingStandardsIgnoreLine. ?>
 					</div>
 				</td>
 			<?php endif; ?>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28992 .

### How to test the changes in this Pull Request:
1. Go to `WooCommerce > Settings > Shipping`
2. Click on `Add shipping zone`
3. Under the `Zone regions` section, click on "Limit to specific ZIP/postcodes"

### Visuals
Before:
![image](https://user-images.githubusercontent.com/1852711/106945888-64bab600-674e-11eb-8906-fe6819207082.png)

After: 
![image](https://user-images.githubusercontent.com/1852711/106945705-245b3800-674e-11eb-959e-2fd25f574ac0.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Removed extra closing brace from the Zone regions help text.
