### PR TITLE
Revert jQuery function change as these are not jQuery objects

### DIFF
--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -180,7 +180,7 @@ jQuery( function( $ ) {
 		wp.customize.widgetsPreview.WidgetPartial
 	);
 	if ( hasSelectiveRefresh ) {
-		wp.customize.selectiveRefresh.on( 'partial-content-rendered', function() {
+		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function() {
 			refresh_cart_fragment();
 		} );
 	}

--- a/assets/js/frontend/price-slider.js
+++ b/assets/js/frontend/price-slider.js
@@ -76,7 +76,7 @@ jQuery( function( $ ) {
 		wp.customize.widgetsPreview.WidgetPartial
 	);
 	if ( hasSelectiveRefresh ) {
-		wp.customize.selectiveRefresh.on( 'partial-content-rendered', function() {
+		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function() {
 			init_price_filter();
 		} );
 	}


### PR DESCRIPTION
Reverting a change from a PR that was not the correct use of `on()`. It should only be used on jQuery objects. No review necessary as I am only reverting.