### PR TITLE
Fix price filtering when there are variations.

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -622,9 +622,9 @@ class WC_Query {
 
 		$args['join']   = $this->append_product_sorting_table_join( $args['join'] );
 		$args['where'] .= $wpdb->prepare(
-			' AND wc_product_meta_lookup.min_price >= %f AND wc_product_meta_lookup.max_price <= %f ',
-			$current_min_price,
-			$current_max_price
+			' AND NOT (%f<wc_product_meta_lookup.min_price OR %f>wc_product_meta_lookup.max_price ) ',
+			$current_max_price,
+			$current_min_price
 		);
 		return $args;
 	}

--- a/tests/php/includes/class-wc-query-test.php
+++ b/tests/php/includes/class-wc-query-test.php
@@ -1,0 +1,35 @@
+<?php
+
+/**
+ * Tests for WC_Query.
+ */
+class WC_Query_Test extends \WC_Unit_Test_Case {
+
+	/**
+	 * @testdox 'price_filter_post_clauses' generates the proper 'where' clause when there are 'max_price' and 'min_price' arguments in the query.
+	 */
+	public function test_price_filter_post_clauses_creates_the_proper_where_clause() {
+		// phpcs:disable Squiz.Commenting
+		$wp_query = new class() {
+			public function is_main_query() {
+				return true;
+			}
+		};
+		// phpcs:enable Squiz.Commenting
+
+		$_GET['min_price'] = '100';
+		$_GET['max_price'] = '200';
+
+		$sut = new WC_Query();
+
+		$args = array(
+			'join'  => '(JOIN CLAUSE)',
+			'where' => '(WHERE CLAUSE)',
+		);
+
+		$args     = $sut->price_filter_post_clauses( $args, $wp_query );
+		$expected = '(WHERE CLAUSE) AND NOT (200.000000<wc_product_meta_lookup.min_price OR 100.000000>wc_product_meta_lookup.max_price ) ';
+
+		$this->assertEquals( $expected, $args['where'] );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The price filtering query wasn't working properly when there are variations with different prices: if at least one variation was
outside of the price range but other were inside, the product wasn't being listed.

This pull request fixes the generation of the `where` clause in `WC_Query->price_filter_post_clauses` to account for this case.

Closes https://github.com/woocommerce/woocommerce/issues/25261

### How to test the changes in this Pull Request:

Create a variable product having two variations with prices 1000 and 1200. Install the price filtering widget and try the following combinations of min and max price:

1. 0, 950
2. 0,1000
3. 0, 1050
3. 1000, 1100
4. 1050, 1100
5. 1050, 1300
6. 1200, 1300
7. 1250, 1300

The product should **not** be listed in the cases 1 and 7, in all the other cases it should be listed.

Note: if you don't have products with a price higher than 1220 you won't be able to use the widget for the last three combinations, but you can just modify the query string and reload manually.

Note: that's not a complete fix and will 100% work only when the "Hide out of stock products" option is disable. See [this comment in the original issue](https://github.com/woocommerce/woocommerce/issues/25261#issuecomment-774116877).

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - price filtering not working properly with variable products whose variations have different prices.
