### PR TITLE
Fix/issue 28284

### DIFF
--- a/assets/js/admin/api-keys.js
+++ b/assets/js/admin/api-keys.js
@@ -53,7 +53,7 @@
 				.on( 'click', css_class, function( evt ) {
 					evt.preventDefault();
 					if ( ! document.queryCommandSupported( 'copy' ) ) {
-						$( css_class ).parent().find( 'input' ).focus().select();
+						$( css_class ).parent().find( 'input' ).trigger( 'focus' ).trigger( 'select' );
 						$( '#copy-error' ).text( woocommerce_admin_api_keys.clipboard_failed );
 					} else {
 						$( '#copy-error' ).text( '' );
@@ -69,10 +69,10 @@
 						'fadeIn':     50,
 						'fadeOut':    50,
 						'delay':      0
-					} ).focus();
+					} ).trigger( 'focus' );
 				} )
 				.on( 'aftercopyerror', css_class, function() {
-					$( css_class ).parent().find( 'input' ).focus().select();
+					$( css_class ).parent().find( 'input' ).trigger( 'focus' ).trigger( 'select' );
 					$( '#copy-error' ).text( woocommerce_admin_api_keys.clipboard_failed );
 				} );
 		},

--- a/assets/js/admin/backbone-modal.js
+++ b/assets/js/admin/backbone-modal.js
@@ -72,7 +72,7 @@
 			_.bindAll( this, 'render' );
 			this.render();
 
-			$( window ).resize(function() {
+			$( window ).on( 'resize', function() {
 				view.resizeContent();
 			});
 		},
@@ -88,7 +88,7 @@
 			}).append( this.$el );
 
 			this.resizeContent();
-			this.$( '.wc-backbone-modal-content' ).attr( 'tabindex' , '0' ).focus();
+			this.$( '.wc-backbone-modal-content' ).attr( 'tabindex' , '0' ).trigger( 'focus' );
 
 			$( document.body ).trigger( 'init_tooltips' );
 

--- a/assets/js/admin/meta-boxes-coupon.js
+++ b/assets/js/admin/meta-boxes-coupon.js
@@ -61,7 +61,7 @@ jQuery(function( $ ) {
 				);
 			}
 			$result = woocommerce_admin_meta_boxes_coupon.prefix + $result + woocommerce_admin_meta_boxes_coupon.suffix;
-			$coupon_code_field.focus().val( $result );
+			$coupon_code_field.trigger( 'focus' ).val( $result );
 			$coupon_code_label.addClass( 'screen-reader-text' );
 		}
 	};

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -1470,7 +1470,7 @@ jQuery( function ( $ ) {
 				'fadeIn':     50,
 				'fadeOut':    50,
 				'delay':      0
-			}).focus();
+			}).trigger( 'focus' );
 		},
 
 		/**
@@ -1483,7 +1483,7 @@ jQuery( function ( $ ) {
 				'fadeIn':     50,
 				'fadeOut':    50,
 				'delay':      0
-			}).focus();
+			}).trigger( 'focus' );
 		}
 	};
 

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -117,8 +117,8 @@ jQuery( function ( $ ) {
 		},
 
 		init_tiptip: function() {
-			$( '#tiptip_holder' )[0].removeAttribute( 'style' );
-			$( '#tiptip_arrow' )[0].removeAttribute( 'style' );
+			$( '#tiptip_holder' ).removeAttr( 'style' );
+			$( '#tiptip_arrow' ).removeAttr( 'style' );
 			$( '.tips' ).tipTip({
 				'attribute': 'data-tip',
 				'fadeIn': 50,

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -22,7 +22,7 @@ jQuery( function ( $ ) {
 				this.states = JSON.parse( woocommerce_admin_meta_boxes_order.countries.replace( /&quot;/g, '"' ) );
 			}
 
-			$( '.js_field-country' ).selectWoo().change( this.change_country );
+			$( '.js_field-country' ).selectWoo().on( 'change', this.change_country );
 			$( '.js_field-country' ).trigger( 'change', [ true ] );
 			$( document.body ).on( 'change', 'select.js_field-state', this.change_state );
 			$( '#woocommerce-order-actions input, #woocommerce-order-actions a' ).on( 'click', function() {
@@ -117,8 +117,8 @@ jQuery( function ( $ ) {
 		},
 
 		init_tiptip: function() {
-			$( '#tiptip_holder' ).removeAttr( 'style' );
-			$( '#tiptip_arrow' ).removeAttr( 'style' );
+			$( '#tiptip_holder' )[0].removeAttribute( 'style' );
+			$( '#tiptip_arrow' )[0].removeAttribute( 'style' );
 			$( '.tips' ).tipTip({
 				'attribute': 'data-tip',
 				'fadeIn': 50,
@@ -140,7 +140,7 @@ jQuery( function ( $ ) {
 				is_billing     = Boolean( $edit_address.find( 'input[name^="_billing_"]' ).length );
 
 			$address.hide();
-			$this.parent().find( 'a' ).toggle();
+			$this.parent().find( 'a' ).trigger( 'toggle' );
 
 			if ( ! $country_input.val() ) {
 				$country_input.val( woocommerce_admin_meta_boxes_order.default_country ).trigger( 'change' );

--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -117,8 +117,8 @@ jQuery( function ( $ ) {
 		},
 
 		init_tiptip: function() {
-			$( '#tiptip_holder' ).removeAttr( 'style' );
-			$( '#tiptip_arrow' ).removeAttr( 'style' );
+			$( '#tiptip_holder' )[0].removeAttribute( 'style' );
+			$( '#tiptip_arrow' )[0].removeAttribute( 'style' );
 			$( '.tips' ).tipTip({
 				'attribute': 'data-tip',
 				'fadeIn': 50,

--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -116,8 +116,8 @@ jQuery( function( $ ) {
 			}
 
 			// Init TipTip
-			$( '#tiptip_holder' ).removeAttr( 'style' );
-			$( '#tiptip_arrow' ).removeAttr( 'style' );
+			$( '#tiptip_holder' )[0].removeAttribute( 'style' );
+			$( '#tiptip_arrow' )[0].removeAttribute( 'style' );
 			$( '.woocommerce_variations .tips, .woocommerce_variations .help_tip, .woocommerce_variations .woocommerce-help-tip', wrapper )
 				.tipTip({
 					'attribute': 'data-tip',
@@ -594,7 +594,7 @@ jQuery( function( $ ) {
 
 				$( '.woocommerce-notice-invalid-variation' ).remove();
 				$( '#variable_product_options' ).find( '.woocommerce_variations' ).prepend( variation );
-				$( 'button.cancel-variation-changes, button.save-variation-changes' ).removeAttr( 'disabled' );
+				$( 'button.cancel-variation-changes, button.save-variation-changes' )[0].removeAttribute( 'disabled' );
 				$( '#variable_product_options' ).trigger( 'woocommerce_variations_added', 1 );
 				wc_meta_boxes_product_variations_ajax.unblock();
 			});
@@ -700,7 +700,7 @@ jQuery( function( $ ) {
 				.closest( '.woocommerce_variation' )
 				.addClass( 'variation-needs-update' );
 
-			$( 'button.cancel-variation-changes, button.save-variation-changes' ).removeAttr( 'disabled' );
+			$( 'button.cancel-variation-changes, button.save-variation-changes' )[0].removeAttribute( 'disabled' );
 
 			$( '#variable_product_options' ).trigger( 'woocommerce_variations_input_changed' );
 		},
@@ -714,7 +714,7 @@ jQuery( function( $ ) {
 				.find( '.woocommerce_variation:first' )
 				.addClass( 'variation-needs-update' );
 
-			$( 'button.cancel-variation-changes, button.save-variation-changes' ).removeAttr( 'disabled' );
+			$( 'button.cancel-variation-changes, button.save-variation-changes' )[0].removeAttribute( 'disabled' );
 
 			$( '#variable_product_options' ).trigger( 'woocommerce_variations_defaults_changed' );
 		},

--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -116,8 +116,8 @@ jQuery( function( $ ) {
 			}
 
 			// Init TipTip
-			$( '#tiptip_holder' )[0].removeAttribute( 'style' );
-			$( '#tiptip_arrow' )[0].removeAttribute( 'style' );
+			$( '#tiptip_holder' ).removeAttr( 'style' );
+			$( '#tiptip_arrow' ).removeAttr( 'style' );
 			$( '.woocommerce_variations .tips, .woocommerce_variations .help_tip, .woocommerce_variations .woocommerce-help-tip', wrapper )
 				.tipTip({
 					'attribute': 'data-tip',
@@ -594,7 +594,7 @@ jQuery( function( $ ) {
 
 				$( '.woocommerce-notice-invalid-variation' ).remove();
 				$( '#variable_product_options' ).find( '.woocommerce_variations' ).prepend( variation );
-				$( 'button.cancel-variation-changes, button.save-variation-changes' )[0].removeAttribute( 'disabled' );
+				$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
 				$( '#variable_product_options' ).trigger( 'woocommerce_variations_added', 1 );
 				wc_meta_boxes_product_variations_ajax.unblock();
 			});
@@ -700,7 +700,7 @@ jQuery( function( $ ) {
 				.closest( '.woocommerce_variation' )
 				.addClass( 'variation-needs-update' );
 
-			$( 'button.cancel-variation-changes, button.save-variation-changes' )[0].removeAttribute( 'disabled' );
+			$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
 
 			$( '#variable_product_options' ).trigger( 'woocommerce_variations_input_changed' );
 		},
@@ -714,7 +714,7 @@ jQuery( function( $ ) {
 				.find( '.woocommerce_variation:first' )
 				.addClass( 'variation-needs-update' );
 
-			$( 'button.cancel-variation-changes, button.save-variation-changes' )[0].removeAttribute( 'disabled' );
+			$( 'button.cancel-variation-changes, button.save-variation-changes' ).prop( 'disabled', false );
 
 			$( '#variable_product_options' ).trigger( 'woocommerce_variations_defaults_changed' );
 		},

--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -116,8 +116,8 @@ jQuery( function( $ ) {
 			}
 
 			// Init TipTip
-			$( '#tiptip_holder' )[0].removeAttribute( 'style' );
-			$( '#tiptip_arrow' )[0].removeAttribute( 'style' );
+			$( '#tiptip_holder' ).removeAttr( 'style' );
+			$( '#tiptip_arrow' ).removeAttr( 'style' );
 			$( '.woocommerce_variations .tips, .woocommerce_variations .help_tip, .woocommerce_variations .woocommerce-help-tip', wrapper )
 				.tipTip({
 					'attribute': 'data-tip',

--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -116,8 +116,8 @@ jQuery( function( $ ) {
 			}
 
 			// Init TipTip
-			$( '#tiptip_holder' ).removeAttr( 'style' );
-			$( '#tiptip_arrow' ).removeAttr( 'style' );
+			$( '#tiptip_holder' )[0].removeAttribute( 'style' );
+			$( '#tiptip_arrow' )[0].removeAttribute( 'style' );
 			$( '.woocommerce_variations .tips, .woocommerce_variations .help_tip, .woocommerce_variations .woocommerce-help-tip', wrapper )
 				.tipTip({
 					'attribute': 'data-tip',

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -495,7 +495,7 @@ jQuery( function( $ ) {
 				var this_page = window.location.toString();
 				this_page = this_page.replace( 'post-new.php?', 'post.php?post=' + woocommerce_admin_meta_boxes.post_id + '&action=edit&' );
 
-				$( '#variable_product_options' ).on( 'load', this_page + ' #variable_product_options_inner', function() {
+				$( '#variable_product_options' ).load( this_page + ' #variable_product_options_inner', function() {
 					$( '#variable_product_options' ).trigger( 'reload' );
 				} );
 			}

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -77,7 +77,7 @@ jQuery( function( $ ) {
 		var current_visibility = $( '#current_visibility' ).val();
 		var current_featured   = $( '#current_featured' ).val();
 
-		$( 'input[name=_visibility]' )[0].removeAttribute( 'checked' );
+		$( 'input[name=_visibility]' ).prop( 'checked', false );
 		$( 'input[name=_visibility][value=' + current_visibility + ']' ).attr( 'checked', 'checked' );
 
 		var label = $( 'input[name=_visibility]:checked' ).attr( 'data-label' );
@@ -86,7 +86,7 @@ jQuery( function( $ ) {
 			label = label + ', ' + woocommerce_admin_meta_boxes.featured_label;
 			$( 'input[name=_featured]' ).attr( 'checked', 'checked' );
 		} else {
-			$( 'input[name=_featured]' )[0].removeAttribute( 'checked' );
+			$( 'input[name=_featured]' ).prop( 'checked', false );
 		}
 
 		$( '#catalog-visibility-display' ).text( label );
@@ -102,13 +102,13 @@ jQuery( function( $ ) {
 		if ( 'variable' === select_val ) {
 			$( 'input#_manage_stock' ).trigger( 'change' );
 			$( 'input#_downloadable' ).prop( 'checked', false );
-			$( 'input#_virtual' )[0].removeAttribute( 'checked' );
+			$( 'input#_virtual' ).prop( 'checked', false );
 		} else if ( 'grouped' === select_val ) {
 			$( 'input#_downloadable' ).prop( 'checked', false );
-			$( 'input#_virtual' )[0].removeAttribute( 'checked' );
+			$( 'input#_virtual' ).prop( 'checked', false );
 		} else if ( 'external' === select_val ) {
 			$( 'input#_downloadable' ).prop( 'checked', false );
-			$( 'input#_virtual' )[0].removeAttribute( 'checked' );
+			$( 'input#_virtual' ).prop( 'checked', false );
 		}
 
 		show_and_hide_panels();
@@ -361,7 +361,7 @@ jQuery( function( $ ) {
 	});
 
 	$( '.product_attributes' ).on( 'click', 'button.select_no_attributes', function() {
-		$( this ).closest( 'td' ).find( 'select option' )[0].removeAttribute( 'selected' );
+		$( this ).closest( 'td' ).find( 'select option' ).prop( 'selected', false );
 		$( this ).closest( 'td' ).find( 'select' ).trigger( 'change' );
 		return false;
 	});
@@ -373,7 +373,7 @@ jQuery( function( $ ) {
 			if ( $parent.is( '.taxonomy' ) ) {
 				$parent.find( 'select, input[type=text]' ).val( '' );
 				$parent.hide();
-				$( 'select.attribute_taxonomy' ).find( 'option[value="' + $parent.data( 'taxonomy' ) + '"]' )[0].removeAttribute( 'disabled' );
+				$( 'select.attribute_taxonomy' ).find( 'option[value="' + $parent.data( 'taxonomy' ) + '"]' ).prop( 'disabled', false );
 			} else {
 				$parent.find( 'select, input[type=text]' ).val( '' );
 				$parent.hide();
@@ -398,7 +398,7 @@ jQuery( function( $ ) {
 			ui.item.css( 'background-color', '#f6f6f6' );
 		},
 		stop: function( event, ui ) {
-			ui.item[0].removeAttribute( 'style' );
+			ui.item.removeAttr( 'style' );
 			attribute_row_indexes();
 		}
 	});
@@ -655,7 +655,7 @@ jQuery( function( $ ) {
 			ui.item.css( 'background-color', '#f6f6f6' );
 		},
 		stop: function( event, ui ) {
-			ui.item[0].removeAttribute( 'style' );
+			ui.item.removeAttr( 'style' );
 		},
 		update: function() {
 			var attachment_ids = '';
@@ -683,8 +683,8 @@ jQuery( function( $ ) {
 		$image_gallery_ids.val( attachment_ids );
 
 		// Remove any lingering tooltips.
-		$( '#tiptip_holder' )[0].removeAttribute( 'style' );
-		$( '#tiptip_arrow' )[0].removeAttribute( 'style' );
+		$( '#tiptip_holder' ).removeAttr( 'style' );
+		$( '#tiptip_arrow' ).removeAttr( 'style' );
 
 		return false;
 	});

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -34,17 +34,23 @@ jQuery( function( $ ) {
 	}
 
 	$( function() {
-		// Prevent inputs in meta box headings opening/closing contents.
-		$( '#woocommerce-product-data' ).find( '.hndle' ).off( 'click.postboxes' );
+		var woocommerce_product_data = $( '#woocommerce-product-data' );
 
-		$( '#woocommerce-product-data' ).on( 'click', '.hndle', function( event ) {
+		// Prevent inputs in meta box headings opening/closing contents.
+		woocommerce_product_data.find( '.hndle' ).off( 'click.postboxes' );
+
+		woocommerce_product_data.on( 'click', '.hndle', function( event ) {
 
 			// If the user clicks on some form input inside the h3 the box should not be toggled.
 			if ( $( event.target ).filter( 'input, option, label, select' ).length ) {
 				return;
 			}
 
-			$( '#woocommerce-product-data' ).toggleClass( 'closed' );
+			if ( woocommerce_product_data.hasClass( 'closed' ) ) {
+				woocommerce_product_data.removeClass( 'closed' );
+			} else {
+				woocommerce_product_data.addClass( 'closed' );
+			}
 		});
 	});
 

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -35,7 +35,7 @@ jQuery( function( $ ) {
 
 	$( function() {
 		// Prevent inputs in meta box headings opening/closing contents.
-		$( '#woocommerce-product-data' ).find( '.hndle' ).unbind( 'click.postboxes' );
+		$( '#woocommerce-product-data' ).find( '.hndle' ).off( 'click.postboxes' );
 
 		$( '#woocommerce-product-data' ).on( 'click', '.hndle', function( event ) {
 
@@ -77,7 +77,7 @@ jQuery( function( $ ) {
 		var current_visibility = $( '#current_visibility' ).val();
 		var current_featured   = $( '#current_featured' ).val();
 
-		$( 'input[name=_visibility]' ).removeAttr( 'checked' );
+		$( 'input[name=_visibility]' )[0].removeAttribute( 'checked' );
 		$( 'input[name=_visibility][value=' + current_visibility + ']' ).attr( 'checked', 'checked' );
 
 		var label = $( 'input[name=_visibility]:checked' ).attr( 'data-label' );
@@ -86,7 +86,7 @@ jQuery( function( $ ) {
 			label = label + ', ' + woocommerce_admin_meta_boxes.featured_label;
 			$( 'input[name=_featured]' ).attr( 'checked', 'checked' );
 		} else {
-			$( 'input[name=_featured]' ).removeAttr( 'checked' );
+			$( 'input[name=_featured]' )[0].removeAttribute( 'checked' );
 		}
 
 		$( '#catalog-visibility-display' ).text( label );
@@ -94,7 +94,7 @@ jQuery( function( $ ) {
 	});
 
 	// Product type specific options.
-	$( 'select#product-type' ).change( function() {
+	$( 'select#product-type' ).on( 'change', function() {
 
 		// Get value.
 		var select_val = $( this ).val();
@@ -102,13 +102,13 @@ jQuery( function( $ ) {
 		if ( 'variable' === select_val ) {
 			$( 'input#_manage_stock' ).trigger( 'change' );
 			$( 'input#_downloadable' ).prop( 'checked', false );
-			$( 'input#_virtual' ).removeAttr( 'checked' );
+			$( 'input#_virtual' )[0].removeAttribute( 'checked' );
 		} else if ( 'grouped' === select_val ) {
 			$( 'input#_downloadable' ).prop( 'checked', false );
-			$( 'input#_virtual' ).removeAttr( 'checked' );
+			$( 'input#_virtual' )[0].removeAttribute( 'checked' );
 		} else if ( 'external' === select_val ) {
 			$( 'input#_downloadable' ).prop( 'checked', false );
-			$( 'input#_virtual' ).removeAttr( 'checked' );
+			$( 'input#_virtual' )[0].removeAttribute( 'checked' );
 		}
 
 		show_and_hide_panels();
@@ -119,7 +119,7 @@ jQuery( function( $ ) {
 
 	}).trigger( 'change' );
 
-	$( 'input#_downloadable, input#_virtual' ).change( function() {
+	$( 'input#_downloadable, input#_virtual' ).on( 'change', function() {
 		show_and_hide_panels();
 	});
 
@@ -239,7 +239,7 @@ jQuery( function( $ ) {
 	});
 
 	// Stock options.
-	$( 'input#_manage_stock' ).change( function() {
+	$( 'input#_manage_stock' ).on( 'change', function() {
 		if ( $( this ).is( ':checked' ) ) {
 			$( 'div.stock_fields' ).show();
 			$( 'p.stock_status_field' ).hide();
@@ -361,7 +361,7 @@ jQuery( function( $ ) {
 	});
 
 	$( '.product_attributes' ).on( 'click', 'button.select_no_attributes', function() {
-		$( this ).closest( 'td' ).find( 'select option' ).removeAttr( 'selected' );
+		$( this ).closest( 'td' ).find( 'select option' )[0].removeAttribute( 'selected' );
 		$( this ).closest( 'td' ).find( 'select' ).trigger( 'change' );
 		return false;
 	});
@@ -373,7 +373,7 @@ jQuery( function( $ ) {
 			if ( $parent.is( '.taxonomy' ) ) {
 				$parent.find( 'select, input[type=text]' ).val( '' );
 				$parent.hide();
-				$( 'select.attribute_taxonomy' ).find( 'option[value="' + $parent.data( 'taxonomy' ) + '"]' ).removeAttr( 'disabled' );
+				$( 'select.attribute_taxonomy' ).find( 'option[value="' + $parent.data( 'taxonomy' ) + '"]' )[0].removeAttribute( 'disabled' );
 			} else {
 				$parent.find( 'select, input[type=text]' ).val( '' );
 				$parent.hide();
@@ -398,7 +398,7 @@ jQuery( function( $ ) {
 			ui.item.css( 'background-color', '#f6f6f6' );
 		},
 		stop: function( event, ui ) {
-			ui.item.removeAttr( 'style' );
+			ui.item[0].removeAttribute( 'style' );
 			attribute_row_indexes();
 		}
 	});
@@ -495,7 +495,7 @@ jQuery( function( $ ) {
 				var this_page = window.location.toString();
 				this_page = this_page.replace( 'post-new.php?', 'post.php?post=' + woocommerce_admin_meta_boxes.post_id + '&action=edit&' );
 
-				$( '#variable_product_options' ).load( this_page + ' #variable_product_options_inner', function() {
+				$( '#variable_product_options' ).on( 'load', this_page + ' #variable_product_options_inner', function() {
 					$( '#variable_product_options' ).trigger( 'reload' );
 				} );
 			}
@@ -655,7 +655,7 @@ jQuery( function( $ ) {
 			ui.item.css( 'background-color', '#f6f6f6' );
 		},
 		stop: function( event, ui ) {
-			ui.item.removeAttr( 'style' );
+			ui.item[0].removeAttribute( 'style' );
 		},
 		update: function() {
 			var attachment_ids = '';
@@ -683,8 +683,8 @@ jQuery( function( $ ) {
 		$image_gallery_ids.val( attachment_ids );
 
 		// Remove any lingering tooltips.
-		$( '#tiptip_holder' ).removeAttr( 'style' );
-		$( '#tiptip_arrow' ).removeAttr( 'style' );
+		$( '#tiptip_holder' )[0].removeAttribute( 'style' );
+		$( '#tiptip_arrow' )[0].removeAttribute( 'style' );
 
 		return false;
 	});

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -404,7 +404,7 @@ jQuery( function( $ ) {
 			ui.item.css( 'background-color', '#f6f6f6' );
 		},
 		stop: function( event, ui ) {
-			ui.item.removeAttr( 'style' );
+			ui.item[0].removeAttribute( 'style' );
 			attribute_row_indexes();
 		}
 	});
@@ -501,7 +501,7 @@ jQuery( function( $ ) {
 				var this_page = window.location.toString();
 				this_page = this_page.replace( 'post-new.php?', 'post.php?post=' + woocommerce_admin_meta_boxes.post_id + '&action=edit&' );
 
-				$( '#variable_product_options' ).load( this_page + ' #variable_product_options_inner', function() {
+				$( '#variable_product_options' ).on( 'load', this_page + ' #variable_product_options_inner', function() {
 					$( '#variable_product_options' ).trigger( 'reload' );
 				} );
 			}
@@ -661,7 +661,7 @@ jQuery( function( $ ) {
 			ui.item.css( 'background-color', '#f6f6f6' );
 		},
 		stop: function( event, ui ) {
-			ui.item.removeAttr( 'style' );
+			ui.item[0].removeAttribute( 'style' );
 		},
 		update: function() {
 			var attachment_ids = '';
@@ -689,8 +689,8 @@ jQuery( function( $ ) {
 		$image_gallery_ids.val( attachment_ids );
 
 		// Remove any lingering tooltips.
-		$( '#tiptip_holder' ).removeAttr( 'style' );
-		$( '#tiptip_arrow' ).removeAttr( 'style' );
+		$( '#tiptip_holder' )[0].removeAttribute( 'style' );
+		$( '#tiptip_arrow' )[0].removeAttribute( 'style' );
 
 		return false;
 	});

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -404,7 +404,7 @@ jQuery( function( $ ) {
 			ui.item.css( 'background-color', '#f6f6f6' );
 		},
 		stop: function( event, ui ) {
-			ui.item[0].removeAttribute( 'style' );
+			ui.item.removeAttr( 'style' );
 			attribute_row_indexes();
 		}
 	});
@@ -661,7 +661,7 @@ jQuery( function( $ ) {
 			ui.item.css( 'background-color', '#f6f6f6' );
 		},
 		stop: function( event, ui ) {
-			ui.item[0].removeAttribute( 'style' );
+			ui.item.removeAttr( 'style' );
 		},
 		update: function() {
 			var attachment_ids = '';
@@ -689,8 +689,8 @@ jQuery( function( $ ) {
 		$image_gallery_ids.val( attachment_ids );
 
 		// Remove any lingering tooltips.
-		$( '#tiptip_holder' )[0].removeAttribute( 'style' );
-		$( '#tiptip_arrow' )[0].removeAttribute( 'style' );
+		$( '#tiptip_holder' ).removeAttr( 'style' );
+		$( '#tiptip_arrow' ).removeAttr( 'style' );
 
 		return false;
 	});

--- a/assets/js/admin/meta-boxes-product.js
+++ b/assets/js/admin/meta-boxes-product.js
@@ -501,7 +501,7 @@ jQuery( function( $ ) {
 				var this_page = window.location.toString();
 				this_page = this_page.replace( 'post-new.php?', 'post.php?post=' + woocommerce_admin_meta_boxes.post_id + '&action=edit&' );
 
-				$( '#variable_product_options' ).on( 'load', this_page + ' #variable_product_options_inner', function() {
+				$( '#variable_product_options' ).load( this_page + ' #variable_product_options_inner', function() {
 					$( '#variable_product_options' ).trigger( 'reload' );
 				} );
 			}

--- a/assets/js/admin/meta-boxes.js
+++ b/assets/js/admin/meta-boxes.js
@@ -17,7 +17,19 @@ jQuery( function ( $ ) {
 	runTipTip();
 
 	$( '.wc-metaboxes-wrapper' ).on( 'click', '.wc-metabox > h3', function() {
-		$( this ).parent( '.wc-metabox' ).toggleClass( 'closed' ).toggleClass( 'open' );
+		var metabox = $( this ).parent( '.wc-metabox' );
+
+		if ( metabox.hasClass( 'closed' ) ) {
+			metabox.removeClass( 'closed' );
+		} else {
+			metabox.addClass( 'closed' );
+		}
+
+		if ( metabox.hasClass( 'open' ) ) {
+			metabox.removeClass( 'open' );
+		} else {
+			metabox.addClass( 'open' );
+		}
 	});
 
 	// Tabbed Panels

--- a/assets/js/admin/quick-edit.js
+++ b/assets/js/admin/quick-edit.js
@@ -57,7 +57,7 @@ jQuery(
 					'select[name="_visibility"] option, ' +
 					'select[name="_stock_status"] option, ' +
 					'select[name="_backorders"] option'
-				).removeAttr( 'selected' );
+				).prop( 'selected', false );
 
 				var is_variable_product = 'variable' === product_type;
 				$( 'select[name="_stock_status"] ~ .wc-quick-edit-warning', '.inline-edit-row' ).toggle( is_variable_product );
@@ -72,7 +72,7 @@ jQuery(
 				if ( 'yes' === featured ) {
 					$( 'input[name="_featured"]', '.inline-edit-row' ).attr( 'checked', 'checked' );
 				} else {
-					$( 'input[name="_featured"]', '.inline-edit-row' ).removeAttr( 'checked' );
+					$( 'input[name="_featured"]', '.inline-edit-row' ).prop( 'checked', false );
 				}
 
 				// Conditional display.

--- a/assets/js/admin/settings-views-html-settings-tax.js
+++ b/assets/js/admin/settings-views-html-settings-tax.js
@@ -167,7 +167,7 @@
 
 					// Postcode and city don't have `name` values by default.
 					// They're only created if the contents changes, to save on database queries (I think)
-					this.$el.find( 'td.postcode input, td.city input' ).change( function() {
+					this.$el.find( 'td.postcode input, td.city input' ).on( 'change', function() {
 						$( this ).attr( 'name', $( this ).data( 'name' ) );
 					});
 

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -48,15 +48,15 @@
 				event.stopPropagation();
 				$( '.iris-picker' ).hide();
 				$( this ).closest( 'td' ).find( '.iris-picker' ).show();
-				$( this ).data( 'original-value', $( this ).val() );
+				$( this ).data( 'originalValue', $( this ).val() );
 			})
 
 			.on( 'change', function() {
 				if ( $( this ).is( '.iris-error' ) ) {
-					var original_value = $( this ).data( 'original-value' );
+					var original_value = $( this ).data( 'originalValue' );
 
 					if ( original_value.match( /^\#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$/ ) ) {
-						$( this ).val( $( this ).data( 'original-value' ) ).trigger( 'change' );
+						$( this ).val( $( this ).data( 'originalValue' ) ).trigger( 'change' );
 					} else {
 						$( this ).val( '' ).trigger( 'change' );
 					}

--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -2,7 +2,7 @@
 ( function( $, params, wp ) {
 	$( function() {
 		// Sell Countries
-		$( 'select#woocommerce_allowed_countries' ).change( function() {
+		$( 'select#woocommerce_allowed_countries' ).on( 'change', function() {
 			if ( 'specific' === $( this ).val() ) {
 				$( this ).closest('tr').next( 'tr' ).hide();
 				$( this ).closest('tr').next().next( 'tr' ).show();
@@ -16,7 +16,7 @@
 		}).trigger( 'change' );
 
 		// Ship Countries
-		$( 'select#woocommerce_ship_to_countries' ).change( function() {
+		$( 'select#woocommerce_ship_to_countries' ).on( 'change', function() {
 			if ( 'specific' === $( this ).val() ) {
 				$( this ).closest('tr').next( 'tr' ).show();
 			} else {
@@ -25,7 +25,7 @@
 		}).trigger( 'change' );
 
 		// Stock management
-		$( 'input#woocommerce_manage_stock' ).change( function() {
+		$( 'input#woocommerce_manage_stock' ).on( 'change', function() {
 			if ( $( this ).is(':checked') ) {
 				$( this ).closest('tbody').find( '.manage_stock_field' ).closest( 'tr' ).show();
 			} else {
@@ -71,7 +71,7 @@
 		$( function() {
 			var changed = false;
 
-			$( 'input, textarea, select, checkbox' ).change( function() {
+			$( 'input, textarea, select, checkbox' ).on( 'change', function() {
 				if ( ! changed ) {
 					window.onbeforeunload = function() {
 						return params.i18n_nav_warning;
@@ -116,7 +116,7 @@
 		});
 
 		$( '.woocommerce' ).on( 'click', '.select_none', function() {
-			$( this ).closest( 'td' ).find( 'select option' ).removeAttr( 'selected' );
+			$( this ).closest( 'td' ).find( 'select option' ).prop( 'selected', false );
 			$( this ).closest( 'td' ).find( 'select' ).trigger( 'change' );
 			return false;
 		});
@@ -126,7 +126,7 @@
 			var moveBtn = $( this ),
 				$row    = moveBtn.closest( 'tr' );
 
-			moveBtn.focus();
+			moveBtn.trigger( 'focus' );
 
 			var isMoveUp = moveBtn.is( '.wc-move-up' ),
 				isMoveDown = moveBtn.is( '.wc-move-down' );
@@ -147,7 +147,7 @@
 				}
 			}
 
-			moveBtn.focus(); // Re-focus after the container was moved.
+			moveBtn.trigger( 'focus' ); // Re-focus after the container was moved.
 			moveBtn.closest( 'table' ).trigger( 'updateMoveButtons' );
 		} );
 

--- a/assets/js/admin/system-status.js
+++ b/assets/js/admin/system-status.js
@@ -68,7 +68,7 @@ jQuery( function ( $ ) {
 
 			try {
 				$( '#debug-report' ).slideDown();
-				$( '#debug-report' ).find( 'textarea' ).val( '`' + report + '`' ).focus().select();
+				$( '#debug-report' ).find( 'textarea' ).val( '`' + report + '`' ).trigger( 'focus' ).trigger( 'select' );
 				$( this ).fadeOut();
 				return false;
 			} catch ( e ) {
@@ -100,7 +100,7 @@ jQuery( function ( $ ) {
 				'fadeIn':     50,
 				'fadeOut':    50,
 				'delay':      0
-			}).focus();
+			}).trigger( 'focus' );
 		},
 
 		/**
@@ -108,7 +108,7 @@ jQuery( function ( $ ) {
 		 */
 		copyFail: function() {
 			$( '.copy-error' ).removeClass( 'hidden' );
-			$( '#debug-report' ).find( 'textarea' ).focus().select();
+			$( '#debug-report' ).find( 'textarea' ).trigger( 'focus' ).trigger( 'select' );
 		}
 	};
 

--- a/assets/js/admin/system-status.js
+++ b/assets/js/admin/system-status.js
@@ -33,11 +33,11 @@ jQuery( function ( $ ) {
 
 			$( '.wc_status_table thead, .wc_status_table tbody' ).each( function() {
 				if ( $( this ).is( 'thead' ) ) {
-					var label = $( this ).find( 'th:eq(0)' ).data( 'export-label' ) || $( this ).text();
+					var label = $( this ).find( 'th:eq(0)' ).data( 'exportLabel' ) || $( this ).text();
 					report = report + '\n### ' + label.trim() + ' ###\n\n';
 				} else {
 					$( 'tr', $( this ) ).each( function() {
-						var label       = $( this ).find( 'td:eq(0)' ).data( 'export-label' ) || $( this ).find( 'td:eq(0)' ).text();
+						var label       = $( this ).find( 'td:eq(0)' ).data( 'exportLabel' ) || $( this ).find( 'td:eq(0)' ).text();
 						var the_name    = label.trim().replace( /(<([^>]+)>)/ig, '' ); // Remove HTML.
 
 						// Find value

--- a/assets/js/admin/users.js
+++ b/assets/js/admin/users.js
@@ -12,7 +12,7 @@ jQuery( function ( $ ) {
 				this.states = JSON.parse( wc_users_params.countries.replace( /&quot;/g, '"' ) );
 			}
 
-			$( '.js_field-country' ).selectWoo().change( this.change_country );
+			$( '.js_field-country' ).selectWoo().on( 'change', this.change_country );
 			$( '.js_field-country' ).trigger( 'change', [ true ] );
 			$( document.body ).on( 'change', 'select.js_field-state', this.change_state );
 

--- a/assets/js/admin/wc-clipboard.js
+++ b/assets/js/admin/wc-clipboard.js
@@ -17,7 +17,7 @@ function wcSetClipboard( data, $el ) {
 	}
 	var $temp_input = jQuery( '<textarea style="opacity:0">' );
 	jQuery( 'body' ).append( $temp_input );
-	$temp_input.val( data ).select();
+	$temp_input.val( data ).trigger( 'select' );
 
 	$el.trigger( 'beforecopy' );
 	try {

--- a/assets/js/admin/wc-orders.js
+++ b/assets/js/admin/wc-orders.js
@@ -45,12 +45,12 @@ jQuery( function( $ ) {
 	 */
 	WCOrdersTable.prototype.onPreview = function() {
 		var $previewButton    = $( this ),
-			$order_id         = $previewButton.data( 'order-id' );
+			$order_id         = $previewButton.data( 'orderId' );
 
 		if ( $previewButton.data( 'order-data' ) ) {
 			$( this ).WCBackboneModal({
 				template: 'wc-modal-view-order',
-				variable : $previewButton.data( 'order-data' )
+				variable : $previewButton.data( 'orderData' )
 			});
 		} else {
 			$previewButton.addClass( 'disabled' );
@@ -67,7 +67,7 @@ jQuery( function( $ ) {
 					$( '.order-preview' ).removeClass( 'disabled' );
 
 					if ( response.success ) {
-						$previewButton.data( 'order-data', response.data );
+						$previewButton.data( 'orderData', response.data );
 
 						$( this ).WCBackboneModal({
 							template: 'wc-modal-view-order',

--- a/assets/js/admin/wc-product-export.js
+++ b/assets/js/admin/wc-product-export.js
@@ -11,7 +11,7 @@
 		this.$form.find('.woocommerce-exporter-progress').val( 0 );
 
 		// Methods.
-		this.processStep = this.processStep.on( this );
+		this.processStep = this.processStep.bind( this );
 
 		// Events.
 		$form.on( 'submit', { productExportForm: this }, this.onSubmit );

--- a/assets/js/admin/wc-product-export.js
+++ b/assets/js/admin/wc-product-export.js
@@ -11,7 +11,7 @@
 		this.$form.find('.woocommerce-exporter-progress').val( 0 );
 
 		// Methods.
-		this.processStep = this.processStep.bind( this );
+		this.processStep = this.processStep.on( this );
 
 		// Events.
 		$form.on( 'submit', { productExportForm: this }, this.onSubmit );

--- a/assets/js/admin/wc-product-import.js
+++ b/assets/js/admin/wc-product-import.js
@@ -23,7 +23,7 @@
 		// Initial state.
 		this.$form.find('.woocommerce-importer-progress').val( 0 );
 
-		this.run_import = this.run_import.on( this );
+		this.run_import = this.run_import.bind( this );
 
 		// Start importing.
 		this.run_import();

--- a/assets/js/admin/wc-product-import.js
+++ b/assets/js/admin/wc-product-import.js
@@ -23,7 +23,7 @@
 		// Initial state.
 		this.$form.find('.woocommerce-importer-progress').val( 0 );
 
-		this.run_import = this.run_import.bind( this );
+		this.run_import = this.run_import.on( this );
 
 		// Start importing.
 		this.run_import();

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -139,7 +139,14 @@ jQuery( function( $ ) {
 	} );
 
 	$( '.wc-wizard-services-list-toggle' ).on( 'click', function() {
-		$( this ).closest( '.wc-wizard-services-list-toggle' ).toggleClass( 'closed' );
+		var listToggle = $( this ).closest( '.wc-wizard-services-list-toggle' );
+
+		if ( listToggle.hasClass( 'closed' ) ) {
+			listToggle.removeClass( 'closed' );
+		} else {
+			listToggle.addClass( 'closed' );
+		}
+
 		$( this ).closest( '.wc-wizard-services' ).find( '.wc-wizard-service-item' )
 			.slideToggle()
 			.css( 'display', 'flex' );

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -37,7 +37,7 @@ jQuery( function( $ ) {
 		} );
 
 		$( document.body ).on( 'wc_backbone_modal_response', function() {
-			form.unbind( 'submit' ).trigger( 'submit' );
+			form.off( 'submit' ).trigger( 'submit' );
 		} );
 
 		$( '#wc_tracker_checkbox_dialog' ).on( 'change', function( e ) {
@@ -46,7 +46,7 @@ jQuery( function( $ ) {
 		} );
 
 		$( '#wc_tracker_submit' ).on( 'click', function () {
-			form.unbind( 'submit' ).trigger( 'submit' );
+			form.off( 'submit' ).trigger( 'submit' );
 		} );
 
 		return true;

--- a/assets/js/admin/wc-setup.js
+++ b/assets/js/admin/wc-setup.js
@@ -96,7 +96,7 @@ jQuery( function( $ ) {
 		if ( $.isEmptyObject( country_postcode_obj ) || country_postcode_obj.required  ) {
 			$store_postcode_input.attr( 'required', 'true' );
 		} else {
-			$store_postcode_input.removeAttr( 'required' );
+			$store_postcode_input.prop( 'required', false );
 		}
 	} );
 

--- a/assets/js/admin/wc-shipping-classes.js
+++ b/assets/js/admin/wc-shipping-classes.js
@@ -202,7 +202,7 @@
 				},
 				setUnloadConfirmation: function() {
 					this.needsUnloadConfirm = true;
-					$save_button.removeAttr( 'disabled' );
+					$save_button.prop( 'disabled', false );
 				},
 				clearUnloadConfirmation: function() {
 					this.needsUnloadConfirm = false;

--- a/assets/js/admin/wc-shipping-zone-methods.js
+++ b/assets/js/admin/wc-shipping-zone-methods.js
@@ -221,7 +221,7 @@
 				},
 				setUnloadConfirmation: function() {
 					this.needsUnloadConfirm = true;
-					$save_button.removeAttr( 'disabled' );
+					$save_button.prop( 'disabled', false );
 				},
 				clearUnloadConfirmation: function() {
 					this.needsUnloadConfirm = false;

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -232,7 +232,7 @@
 		});
 		// Focus on inputs within the table if clicked instead of trying to sort.
 		$( '.wc_input_table.sortable tbody input' ).on( 'click', function() {
-			$( this ).focus();
+			$( this ).trigger( 'focus' );
 		} );
 
 		$( '.wc_input_table .remove_rows' ).on( 'click', function() {
@@ -309,7 +309,7 @@
 		});
 
 		// Select availability
-		$( 'select.availability' ).change( function() {
+		$( 'select.availability' ).on( 'change', function() {
 			if ( $( this ).val() === 'all' ) {
 				$( this ).closest( 'tr' ).next( 'tr' ).hide();
 			} else {
@@ -319,7 +319,7 @@
 
 		// Hidden options
 		$( '.hide_options_if_checked' ).each( function() {
-			$( this ).find( 'input:eq(0)' ).change( function() {
+			$( this ).find( 'input:eq(0)' ).on( 'change', function() {
 				if ( $( this ).is( ':checked' ) ) {
 					$( this )
 						.closest( 'fieldset, tr' )
@@ -335,7 +335,7 @@
 		});
 
 		$( '.show_options_if_checked' ).each( function() {
-			$( this ).find( 'input:eq(0)' ).change( function() {
+			$( this ).find( 'input:eq(0)' ).on( 'change', function() {
 				if ( $( this ).is( ':checked' ) ) {
 					$( this )
 						.closest( 'fieldset, tr' )
@@ -351,7 +351,7 @@
 		});
 
 		// Reviews.
-		$( 'input#woocommerce_enable_reviews' ).change(function() {
+		$( 'input#woocommerce_enable_reviews' ).on( 'change', function() {
 			if ( $( this ).is( ':checked' ) ) {
 				$( '#woocommerce_enable_review_rating' ).closest( 'tr' ).show();
 			} else {

--- a/assets/js/flexslider/jquery.flexslider.js
+++ b/assets/js/flexslider/jquery.flexslider.js
@@ -137,9 +137,9 @@
         // SLIDSESHOW
         if (slider.vars.slideshow) {
           if (slider.vars.pauseOnHover) {
-            slider.hover(function() {
+            slider.on( 'mouseenter', function() {
               if (!slider.manualPlay && !slider.manualPause) { slider.pause(); }
-            }, function() {
+            } ).on( 'mouseleave', function() {
               if (!slider.manualPause && !slider.manualPlay && !slider.stopped) { slider.play(); }
             });
           }

--- a/assets/js/flexslider/jquery.flexslider.js
+++ b/assets/js/flexslider/jquery.flexslider.js
@@ -104,7 +104,7 @@
 
         // KEYBOARD:
         if (slider.vars.keyboard && ($(slider.containerSelector).length === 1 || slider.vars.multipleKeyboard)) {
-          $(document).bind('keyup', function(event) {
+          $(document).on('keyup', function(event) {
             var keycode = event.keyCode;
             if (!slider.animating && (keycode === 39 || keycode === 37)) {
               var target = (slider.vars.rtl?
@@ -121,7 +121,7 @@
         }
         // MOUSEWHEEL:
         if (slider.vars.mousewheel) {
-          slider.bind('mousewheel', function(event, delta, deltaX, deltaY) {
+          slider.on('mousewheel', function(event, delta, deltaX, deltaY) {
             event.preventDefault();
             var target = (delta < 0) ? slider.getTarget('next') : slider.getTarget('prev');
             slider.flexAnimate(target, slider.vars.pauseOnAction);
@@ -157,7 +157,7 @@
         if (touch && slider.vars.touch) { methods.touch(); }
 
         // FADE&&SMOOTHHEIGHT || SLIDE:
-        if (!fade || (fade && slider.vars.smoothHeight)) { $(window).bind("resize orientationchange focus", methods.resize); }
+        if (!fade || (fade && slider.vars.smoothHeight)) { $(window).on("resize orientationchange focus", methods.resize); }
 
         slider.find("img").attr("draggable", "false");
 
@@ -237,27 +237,27 @@
             for (var i = 0; i < slider.pagingCount; i++) {
               slide = slider.slides.eq(i);
 
-              if ( undefined === slide.attr( 'data-thumb-alt' ) ) { 
-                slide.attr( 'data-thumb-alt', '' ); 
+              if ( undefined === slide.attr( 'data-thumb-alt' ) ) {
+                slide.attr( 'data-thumb-alt', '' );
               }
-              
+
               item = $( '<a></a>' ).attr( 'href', '#' ).text( j );
               if ( slider.vars.controlNav === "thumbnails" ) {
                 item = $( '<img/>' ).attr( 'src', slide.attr( 'data-thumb' ) );
               }
-              
+
               if ( '' !== slide.attr( 'data-thumb-alt' ) ) {
                 item.attr( 'alt', slide.attr( 'data-thumb-alt' ) );
               }
 
               if ( 'thumbnails' === slider.vars.controlNav && true === slider.vars.thumbCaptions ) {
                 var captn = slide.attr( 'data-thumbcaption' );
-                if ( '' !== captn && undefined !== captn ) { 
+                if ( '' !== captn && undefined !== captn ) {
                   var caption = $('<span></span>' ).addClass( namespace + 'caption' ).text( captn );
                   item.append( caption );
                 }
               }
-              
+
               var liElement = $( '<li>' );
               item.appendTo( liElement );
               liElement.append( '</li>' );
@@ -274,7 +274,7 @@
 
           methods.controlNav.active();
 
-          slider.controlNavScaffold.delegate('a, img', eventType, function(event) {
+          slider.controlNavScaffold.on(eventType, 'a, img', function(event) {
             event.preventDefault();
 
             if (watchedEvent === "" || watchedEvent === event.type) {
@@ -299,7 +299,7 @@
           slider.controlNav = slider.manualControls;
           methods.controlNav.active();
 
-          slider.controlNav.bind(eventType, function(event) {
+          slider.controlNav.on(eventType, function(event) {
             event.preventDefault();
 
             if (watchedEvent === "" || watchedEvent === event.type) {
@@ -356,7 +356,7 @@
 
           methods.directionNav.update();
 
-          slider.directionNav.bind(eventType, function(event) {
+          slider.directionNav.on(eventType, function(event) {
             event.preventDefault();
             var target;
 
@@ -404,7 +404,7 @@
 
           methods.pausePlay.update((slider.vars.slideshow) ? namespace + 'pause' : namespace + 'play');
 
-          slider.pausePlay.bind(eventType, function(event) {
+          slider.pausePlay.on(eventType, function(event) {
             event.preventDefault();
 
             if (watchedEvent === "" || watchedEvent === event.type) {
@@ -794,8 +794,8 @@
             }
 
             // Unbind previous transitionEnd events and re-bind new transitionEnd event
-            slider.container.unbind("webkitTransitionEnd transitionend");
-            slider.container.bind("webkitTransitionEnd transitionend", function() {
+            slider.container.off("webkitTransitionEnd transitionend");
+            slider.container.on("webkitTransitionEnd transitionend", function() {
               clearTimeout(slider.ensureAnimationEnd);
               slider.wrapup(dimension);
             });
@@ -1133,9 +1133,9 @@
   };
 
   // Ensure the slider isn't focussed if the window loses focus.
-  $( window ).blur( function ( e ) {
+  $( window ).on( 'blur', function ( e ) {
     focused = false;
-  }).focus( function ( e ) {
+  }).on( 'focus', function ( e ) {
     focused = true;
   });
 

--- a/assets/js/flexslider/jquery.flexslider.js
+++ b/assets/js/flexslider/jquery.flexslider.js
@@ -372,7 +372,7 @@
             methods.setToClearWatchedEvent();
           });
         },
-        update: function() {
+        update: function() {console.log('updating...');
           var disabledClass = namespace + 'disabled';
           if (slider.pagingCount === 1) {
             slider.directionNav.addClass(disabledClass).attr('tabindex', '-1');
@@ -382,10 +382,10 @@
             } else if (slider.animatingTo === slider.last) {
               slider.directionNav.removeClass(disabledClass).filter('.' + namespace + "next").addClass(disabledClass).attr('tabindex', '-1');
             } else {
-              slider.directionNav.removeClass(disabledClass).removeAttr('tabindex');
+              slider.directionNav.removeClass(disabledClass).prop( 'tabindex', '-1' );
             }
           } else {
-            slider.directionNav.removeClass(disabledClass).removeAttr('tabindex');
+            slider.directionNav.removeClass(disabledClass).prop( 'tabindex', '-1' );
           }
         }
       },

--- a/assets/js/frontend/add-payment-method.js
+++ b/assets/js/frontend/add-payment-method.js
@@ -26,7 +26,7 @@ jQuery( function( $ ) {
 	// Trigger initial click
 	.find( 'input[name=payment_method]:checked' ).trigger( 'click' );
 
-	$( '#add_payment_method' ).submit( function() {
+	$( '#add_payment_method' ).on( 'submit', function() {
 		$( '#add_payment_method' ).block({ message: null, overlayCSS: { background: '#fff', opacity: 0.6 } });
 	});
 

--- a/assets/js/frontend/add-to-cart-variation.js
+++ b/assets/js/frontend/add-to-cart-variation.js
@@ -379,7 +379,7 @@
 			if ( ! current_attr_select.data( 'attribute_html' ) ) {
 				var refSelect = current_attr_select.clone();
 
-				refSelect.find( 'option' ).prop( 'disabled attached', false ).prop( 'selected', false );
+				refSelect.find( 'option' ).removeAttr( 'attached' ).prop( 'disabled', false ).prop( 'selected', false );
 
 				// Legacy data attribute.
 				current_attr_select.data(

--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -180,7 +180,7 @@ jQuery( function( $ ) {
 		wp.customize.widgetsPreview.WidgetPartial
 	);
 	if ( hasSelectiveRefresh ) {
-		wp.customize.selectiveRefresh.on( 'partial-content-rendered', function() {
+		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function() {
 			refresh_cart_fragment();
 		} );
 	}

--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -180,7 +180,7 @@ jQuery( function( $ ) {
 		wp.customize.widgetsPreview.WidgetPartial
 	);
 	if ( hasSelectiveRefresh ) {
-		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function() {
+		wp.customize.selectiveRefresh.on( 'partial-content-rendered', function() {
 			refresh_cart_fragment();
 		} );
 	}

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -58,7 +58,7 @@ jQuery( function( $ ) {
 				$( document.body ).trigger( 'init_checkout' );
 			}
 			if ( wc_checkout_params.option_guest_checkout === 'yes' ) {
-				$( 'input#createaccount' ).change( this.toggle_create_account ).trigger( 'change' );
+				$( 'input#createaccount' ).on( 'change', this.toggle_create_account ).trigger( 'change' );
 			}
 		},
 		init_payment_methods: function() {
@@ -449,7 +449,7 @@ jQuery( function( $ ) {
 			$( window ).on('beforeunload', this.handleUnloadEvent);
 		},
 		detachUnloadEventsOnSubmit: function() {
-			$( window ).unbind('beforeunload', this.handleUnloadEvent);
+			$( window ).off('beforeunload', this.handleUnloadEvent);
 		},
 		blockOnSubmit: function( $form ) {
 			var form_data = $form.data();
@@ -589,11 +589,11 @@ jQuery( function( $ ) {
 		init: function() {
 			$( document.body ).on( 'click', 'a.showcoupon', this.show_coupon_form );
 			$( document.body ).on( 'click', '.woocommerce-remove-coupon', this.remove_coupon );
-			$( 'form.checkout_coupon' ).hide().submit( this.submit );
+			$( 'form.checkout_coupon' ).hide().on( 'submit', this.submit );
 		},
 		show_coupon_form: function() {
 			$( '.checkout_coupon' ).slideToggle( 400, function() {
-				$( '.checkout_coupon' ).find( ':input:eq(0)' ).focus();
+				$( '.checkout_coupon' ).find( ':input:eq(0)' ).trigger( 'focus' );
 			});
 			return false;
 		},

--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -452,9 +452,9 @@ jQuery( function( $ ) {
 			$( window ).off('beforeunload', this.handleUnloadEvent);
 		},
 		blockOnSubmit: function( $form ) {
-			var form_data = $form.data();
+			var isBlocked = $form.data( 'blockUI.isBlocked' );
 
-			if ( 1 !== form_data['blockUI.isBlocked'] ) {
+			if ( 1 !== isBlocked ) {
 				$form.block({
 					message: null,
 					overlayCSS: {

--- a/assets/js/frontend/country-select.js
+++ b/assets/js/frontend/country-select.js
@@ -65,7 +65,7 @@ jQuery( function( $ ) {
 
 				$( this )
 					.on( 'select2:select', function() {
-						$( this ).focus(); // Maintain focus after select https://github.com/select2/select2/issues/4384
+						$( this ).trigger( 'focus' ); // Maintain focus after select https://github.com/select2/select2/issues/4384
 					} )
 					.selectWoo( select2_args );
 			});

--- a/assets/js/frontend/password-strength-meter.js
+++ b/assets/js/frontend/password-strength-meter.js
@@ -48,7 +48,7 @@
 			) {
 				submit.attr( 'disabled', 'disabled' ).addClass( 'disabled' );
 			} else {
-				submit.removeAttr( 'disabled', 'disabled' ).removeClass( 'disabled' );
+				submit.prop( 'disabled', false ).removeClass( 'disabled' );
 			}
 		},
 

--- a/assets/js/frontend/price-slider.js
+++ b/assets/js/frontend/price-slider.js
@@ -76,7 +76,7 @@ jQuery( function( $ ) {
 		wp.customize.widgetsPreview.WidgetPartial
 	);
 	if ( hasSelectiveRefresh ) {
-		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function() {
+		wp.customize.selectiveRefresh.on( 'partial-content-rendered', function() {
 			init_price_filter();
 		} );
 	}

--- a/assets/js/frontend/tokenization-form.js
+++ b/assets/js/frontend/tokenization-form.js
@@ -30,7 +30,7 @@ jQuery( function( $ ) {
 		);
 
 		// OR if create account is checked.
-		$( 'input#createaccount' ).change( { tokenizationForm: this }, this.onCreateAccountChange );
+		$( 'input#createaccount' ).on( 'change', { tokenizationForm: this }, this.onCreateAccountChange );
 
 		// First display.
 		this.onDisplay();

--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -87,7 +87,11 @@ jQuery( function( $ ) {
 
 	$( '.show-password-input' ).on( 'click',
 		function() {
-			$( this ).toggleClass( 'display-password' );
+			if ( $( this ).hasClass( 'display-password' ) ) {
+				$( this ).removeClass( 'display-password' );
+			} else {
+				$( this ).addClass( 'display-password' );
+			}
 			if ( $( this ).hasClass( 'display-password' ) ) {
 				$( this ).siblings( ['input[type="password"]'] ).prop( 'type', 'text' );
 			} else {

--- a/assets/js/frontend/woocommerce.js
+++ b/assets/js/frontend/woocommerce.js
@@ -14,7 +14,7 @@ jQuery( function( $ ) {
 		}
 	});
 
-	var noticeID   = $( '.woocommerce-store-notice' ).data( 'notice-id' ) || '',
+	var noticeID   = $( '.woocommerce-store-notice' ).data( 'noticeId' ) || '',
 		cookieName = 'store_notice' + noticeID;
 
 	// Check the value of that cookie and show/hide the notice accordingly

--- a/assets/js/jquery-blockui/jquery.blockUI.js
+++ b/assets/js/jquery-blockui/jquery.blockUI.js
@@ -25,7 +25,7 @@
 		var msie = /MSIE/.test(navigator.userAgent);
 		var ie6  = /MSIE 6.0/.test(navigator.userAgent) && ! /MSIE 8.0/.test(navigator.userAgent);
 		var mode = document.documentMode || 0;
-		var setExpr = $.isFunction( document.createElement('div').style.setExpression );
+		var setExpr = 'function' === typeof document.createElement('div').style.setExpression ? document.createElement('div').style.setExpression : false;
 
 		// global $ methods for blocking/unblocking the entire page
 		$.blockUI   = function(opts) { install(window, opts); };
@@ -56,7 +56,7 @@
 
 			callBlock();
 			var nonmousedOpacity = $m.css('opacity');
-			$m.mouseover(function() {
+			$m.on( 'mouseover', function() {
 				callBlock({
 					fadeIn: 0,
 					timeout: 30000
@@ -65,7 +65,7 @@
 				var displayBlock = $('.blockMsg');
 				displayBlock.stop(); // cancel fadeout if it has started
 				displayBlock.fadeTo(300, 1); // make it easier to read the message by removing transparency
-			}).mouseout(function() {
+			}).on( 'mouseout', function() {
 				$('.blockMsg').fadeOut(1000);
 			});
 			// End konapun additions
@@ -550,9 +550,9 @@
 			// bind anchors and inputs for mouse and key events
 			var events = 'mousedown mouseup keydown keypress keyup touchstart touchend touchmove';
 			if (b)
-				$(document).bind(events, opts, handler);
+				$(document).on(events, opts, handler);
 			else
-				$(document).unbind(events, handler);
+				$(document).off(events, handler);
 
 		// former impl...
 		//		var $e = $('a,:input');
@@ -591,7 +591,7 @@
 				return;
 			var e = pageBlockEls[back===true ? pageBlockEls.length-1 : 0];
 			if (e)
-				e.focus();
+				e.trigger( 'focus' );
 		}
 
 		function center(el, x, y) {

--- a/assets/js/jquery-cookie/jquery.cookie.js
+++ b/assets/js/jquery-cookie/jquery.cookie.js
@@ -49,14 +49,14 @@
 
 	function read(s, converter) {
 		var value = config.raw ? s : parseCookieValue(s);
-		return $.isFunction(converter) ? converter(value) : value;
+		return 'function' === typeof converter ? converter(value) : value;
 	}
 
 	var config = $.cookie = function (key, value, options) {
 
 		// Write
 
-		if (value !== undefined && !$.isFunction(value)) {
+		if (value !== undefined && 'function' !== typeof value) {
 			options = $.extend({}, config.defaults, options);
 
 			if (typeof options.expires === 'number') {

--- a/assets/js/jquery-flot/jquery.flot.js
+++ b/assets/js/jquery-flot/jquery.flot.js
@@ -29,7 +29,7 @@ Licensed under the MIT license.
  * V. 1.1: Fix error handling so e.g. parsing an empty string does
  * produce a color rather than just crashing.
  */
-(function(B){B.color={};B.color.make=function(F,E,C,D){var G={};G.r=F||0;G.g=E||0;G.b=C||0;G.a=D!=null?D:1;G.add=function(J,I){for(var H=0;H<J.length;++H){G[J.charAt(H)]+=I}return G.normalize()};G.scale=function(J,I){for(var H=0;H<J.length;++H){G[J.charAt(H)]*=I}return G.normalize()};G.toString=function(){if(G.a>=1){return"rgb("+[G.r,G.g,G.b].join(",")+")"}else{return"rgba("+[G.r,G.g,G.b,G.a].join(",")+")"}};G.normalize=function(){function H(J,K,I){return K<J?J:(K>I?I:K)}G.r=H(0,parseInt(G.r),255);G.g=H(0,parseInt(G.g),255);G.b=H(0,parseInt(G.b),255);G.a=H(0,G.a,1);return G};G.clone=function(){return B.color.make(G.r,G.b,G.g,G.a)};return G.normalize()};B.color.extract=function(D,C){var E;do{E=D.css(C).toLowerCase();if(E!=""&&E!="transparent"){break}D=D.parent()}while(!B.nodeName(D.get(0),"body"));if(E=="rgba(0, 0, 0, 0)"){E="transparent"}return B.color.parse(E)};B.color.parse=function(F){var E,C=B.color.make;if(E=/rgb\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*\)/.exec(F)){return C(parseInt(E[1],10),parseInt(E[2],10),parseInt(E[3],10))}if(E=/rgba\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]+(?:\.[0-9]+)?)\s*\)/.exec(F)){return C(parseInt(E[1],10),parseInt(E[2],10),parseInt(E[3],10),parseFloat(E[4]))}if(E=/rgb\(\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*\)/.exec(F)){return C(parseFloat(E[1])*2.55,parseFloat(E[2])*2.55,parseFloat(E[3])*2.55)}if(E=/rgba\(\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\s*\)/.exec(F)){return C(parseFloat(E[1])*2.55,parseFloat(E[2])*2.55,parseFloat(E[3])*2.55,parseFloat(E[4]))}if(E=/#([a-fA-F0-9]{2})([a-fA-F0-9]{2})([a-fA-F0-9]{2})/.exec(F)){return C(parseInt(E[1],16),parseInt(E[2],16),parseInt(E[3],16))}if(E=/#([a-fA-F0-9])([a-fA-F0-9])([a-fA-F0-9])/.exec(F)){return C(parseInt(E[1]+E[1],16),parseInt(E[2]+E[2],16),parseInt(E[3]+E[3],16))}var D=B.trim(F).toLowerCase();if(D=="transparent"){return C(255,255,255,0)}else{E=A[D]||[0,0,0];return C(E[0],E[1],E[2])}};var A={aqua:[0,255,255],azure:[240,255,255],beige:[245,245,220],black:[0,0,0],blue:[0,0,255],brown:[165,42,42],cyan:[0,255,255],darkblue:[0,0,139],darkcyan:[0,139,139],darkgrey:[169,169,169],darkgreen:[0,100,0],darkkhaki:[189,183,107],darkmagenta:[139,0,139],darkolivegreen:[85,107,47],darkorange:[255,140,0],darkorchid:[153,50,204],darkred:[139,0,0],darksalmon:[233,150,122],darkviolet:[148,0,211],fuchsia:[255,0,255],gold:[255,215,0],green:[0,128,0],indigo:[75,0,130],khaki:[240,230,140],lightblue:[173,216,230],lightcyan:[224,255,255],lightgreen:[144,238,144],lightgrey:[211,211,211],lightpink:[255,182,193],lightyellow:[255,255,224],lime:[0,255,0],magenta:[255,0,255],maroon:[128,0,0],navy:[0,0,128],olive:[128,128,0],orange:[255,165,0],pink:[255,192,203],purple:[128,0,128],violet:[128,0,128],red:[255,0,0],silver:[192,192,192],white:[255,255,255],yellow:[255,255,0]}})(jQuery);
+(function(B){B.color={};B.color.make=function(F,E,C,D){var G={};G.r=F||0;G.g=E||0;G.b=C||0;G.a=D!=null?D:1;G.add=function(J,I){for(var H=0;H<J.length;++H){G[J.charAt(H)]+=I}return G.normalize()};G.scale=function(J,I){for(var H=0;H<J.length;++H){G[J.charAt(H)]*=I}return G.normalize()};G.toString=function(){if(G.a>=1){return"rgb("+[G.r,G.g,G.b].join(",")+")"}else{return"rgba("+[G.r,G.g,G.b,G.a].join(",")+")"}};G.normalize=function(){function H(J,K,I){return K<J?J:(K>I?I:K)}G.r=H(0,parseInt(G.r),255);G.g=H(0,parseInt(G.g),255);G.b=H(0,parseInt(G.b),255);G.a=H(0,G.a,1);return G};G.clone=function(){return B.color.make(G.r,G.b,G.g,G.a)};return G.normalize()};B.color.extract=function(D,C){var E;do{E=D.css(C).toLowerCase();if(E!=""&&E!="transparent"){break}D=D.parent()}while(!B.nodeName(D.get(0),"body"));if(E=="rgba(0, 0, 0, 0)"){E="transparent"}return B.color.parse(E)};B.color.parse=function(F){var E,C=B.color.make;if(E=/rgb\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*\)/.exec(F)){return C(parseInt(E[1],10),parseInt(E[2],10),parseInt(E[3],10))}if(E=/rgba\(\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]{1,3})\s*,\s*([0-9]+(?:\.[0-9]+)?)\s*\)/.exec(F)){return C(parseInt(E[1],10),parseInt(E[2],10),parseInt(E[3],10),parseFloat(E[4]))}if(E=/rgb\(\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*\)/.exec(F)){return C(parseFloat(E[1])*2.55,parseFloat(E[2])*2.55,parseFloat(E[3])*2.55)}if(E=/rgba\(\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\%\s*,\s*([0-9]+(?:\.[0-9]+)?)\s*\)/.exec(F)){return C(parseFloat(E[1])*2.55,parseFloat(E[2])*2.55,parseFloat(E[3])*2.55,parseFloat(E[4]))}if(E=/#([a-fA-F0-9]{2})([a-fA-F0-9]{2})([a-fA-F0-9]{2})/.exec(F)){return C(parseInt(E[1],16),parseInt(E[2],16),parseInt(E[3],16))}if(E=/#([a-fA-F0-9])([a-fA-F0-9])([a-fA-F0-9])/.exec(F)){return C(parseInt(E[1]+E[1],16),parseInt(E[2]+E[2],16),parseInt(E[3]+E[3],16))}if('string'===typeof F){var D=F.trim().toLowerCase()}else{var D=''};if(D=="transparent"){return C(255,255,255,0)}else{E=A[D]||[0,0,0];return C(E[0],E[1],E[2])}};var A={aqua:[0,255,255],azure:[240,255,255],beige:[245,245,220],black:[0,0,0],blue:[0,0,255],brown:[165,42,42],cyan:[0,255,255],darkblue:[0,0,139],darkcyan:[0,139,139],darkgrey:[169,169,169],darkgreen:[0,100,0],darkkhaki:[189,183,107],darkmagenta:[139,0,139],darkolivegreen:[85,107,47],darkorange:[255,140,0],darkorchid:[153,50,204],darkred:[139,0,0],darksalmon:[233,150,122],darkviolet:[148,0,211],fuchsia:[255,0,255],gold:[255,215,0],green:[0,128,0],indigo:[75,0,130],khaki:[240,230,140],lightblue:[173,216,230],lightcyan:[224,255,255],lightgreen:[144,238,144],lightgrey:[211,211,211],lightpink:[255,182,193],lightyellow:[255,255,224],lime:[0,255,0],magenta:[255,0,255],maroon:[128,0,0],navy:[0,0,128],olive:[128,128,0],orange:[255,165,0],pink:[255,192,203],purple:[128,0,128],violet:[128,0,128],red:[255,0,0],silver:[192,192,192],white:[255,255,255],yellow:[255,255,0]}})(jQuery);
 
 // the actual Flot code
 (function($) {
@@ -1265,7 +1265,7 @@ Licensed under the MIT license.
             octx = overlay.context;
 
             // define which element we're listening for events on
-            eventHolder = $(overlay.element).unbind();
+            eventHolder = $(overlay.element).off();
 
             // If we're re-using a plot object, shut down the old one
 
@@ -1291,11 +1291,11 @@ Licensed under the MIT license.
                 // was fixed somewhere around 1.3.x.  We can return to using
                 // .mouseleave when we drop support for 1.2.6.
 
-                eventHolder.bind("mouseleave", onMouseLeave);
+                eventHolder.on("mouseleave", onMouseLeave);
             }
 
             if (options.grid.clickable)
-                eventHolder.click(onClick);
+                eventHolder.on( 'click', onClick );
 
             executeHooks(hooks.bindEvents, [eventHolder]);
         }
@@ -1304,9 +1304,9 @@ Licensed under the MIT license.
             if (redrawTimeout)
                 clearTimeout(redrawTimeout);
 
-            eventHolder.unbind("mousemove", onMouseMove);
-            eventHolder.unbind("mouseleave", onMouseLeave);
-            eventHolder.unbind("click", onClick);
+            eventHolder.off("mousemove", onMouseMove);
+            eventHolder.off("mouseleave", onMouseLeave);
+            eventHolder.off("click", onClick);
 
             executeHooks(hooks.shutdown, [eventHolder]);
         }
@@ -1704,7 +1704,7 @@ Licensed under the MIT license.
                 };
             }
 
-            if ($.isFunction(opts.tickFormatter))
+            if ( 'function' === typeof opts.tickFormatter )
                 axis.tickFormatter = function (v, axis) { return "" + opts.tickFormatter(v, axis); };
 
             if (opts.alignTicksWithAxis != null) {
@@ -1751,7 +1751,7 @@ Licensed under the MIT license.
             if (oticks == null || (typeof oticks == "number" && oticks > 0))
                 ticks = axis.tickGenerator(axis);
             else if (oticks) {
-                if ($.isFunction(oticks))
+                if ( 'function' === typeof oticks )
                     // generate the ticks
                     ticks = oticks(axis);
                 else
@@ -1875,7 +1875,7 @@ Licensed under the MIT license.
             // draw markings
             var markings = options.grid.markings;
             if (markings) {
-                if ($.isFunction(markings)) {
+                if ( 'function' === typeof markings ) {
                     axes = plot.getAxes();
                     // xmin etc. is backwards compatibility, to be
                     // removed in the future
@@ -2439,9 +2439,9 @@ Licensed under the MIT license.
                 radius = series.points.radius,
                 symbol = series.points.symbol;
 
-            // If the user sets the line width to 0, we change it to a very 
+            // If the user sets the line width to 0, we change it to a very
             // small value. A line width of 0 seems to force the default of 1.
-            // Doing the conditional here allows the shadow setting to still be 
+            // Doing the conditional here allows the shadow setting to still be
             // optional even with a lineWidth of 0.
 
             if( lw == 0 )
@@ -2659,7 +2659,7 @@ Licensed under the MIT license.
             // Sort the legend using either the default or a custom comparator
 
             if (options.legend.sorted) {
-                if ($.isFunction(options.legend.sorted)) {
+                if ( 'function' === typeof options.legend.sorted ) {
                     entries.sort(options.legend.sorted);
                 } else if (options.legend.sorted == "reverse") {
                 	entries.reverse();

--- a/assets/js/jquery-flot/jquery.flot.pie.js
+++ b/assets/js/jquery-flot/jquery.flot.pie.js
@@ -120,10 +120,10 @@ More detail and specific examples can be found in the included HTML file.
 			var options = plot.getOptions();
 			if (options.series.pie.show) {
 				if (options.grid.hoverable) {
-					eventHolder.unbind("mousemove").mousemove(onMouseMove);
+					eventHolder.off("mousemove").on( 'mousemove', onMouseMove );
 				}
 				if (options.grid.clickable) {
-					eventHolder.unbind("click").click(onClick);
+					eventHolder.off("click").on( 'click', onClick );
 				}
 			}
 		});
@@ -180,11 +180,11 @@ More detail and specific examples can be found in the included HTML file.
 				// new one; this is more efficient and preserves any extra data
 				// that the user may have stored in higher indexes.
 
-				if ($.isArray(value) && value.length == 1) {
+				if (Array.isArray(value) && value.length == 1) {
     				value = value[0];
 				}
 
-				if ($.isArray(value)) {
+				if (Array.isArray(value)) {
 					// Equivalent to $.isNumeric() but compatible with jQuery < 1.7
 					if (!isNaN(parseFloat(value[1])) && isFinite(value[1])) {
 						value[1] = +value[1];

--- a/assets/js/jquery-flot/jquery.flot.resize.js
+++ b/assets/js/jquery-flot/jquery.flot.resize.js
@@ -20,7 +20,7 @@ can just fix the size of their placeholders.
  * http://benalman.com/about/license/
  */
 
-(function($,h,c){var a=$([]),e=$.resize=$.extend($.resize,{}),i,k="setTimeout",j="resize",d=j+"-special-event",b="delay",f="throttleWindow";e[b]=250;e[f]=true;$.event.special[j]={setup:function(){if(!e[f]&&this[k]){return false}var l=$(this);a=a.add(l);$.data(this,d,{w:l.width(),h:l.height()});if(a.length===1){g()}},teardown:function(){if(!e[f]&&this[k]){return false}var l=$(this);a=a.not(l);l.removeData(d);if(!a.length){clearTimeout(i)}},add:function(l){if(!e[f]&&this[k]){return false}var n;function m(s,o,p){var q=$(this),r=$.data(this,d);r.w=o!==c?o:q.width();r.h=p!==c?p:q.height();n.apply(this,arguments)}if($.isFunction(l)){n=l;return m}else{n=l.handler;l.handler=m}}};function g(){i=h[k](function(){a.each(function(){var n=$(this),m=n.width(),l=n.height(),o=$.data(this,d);if(m!==o.w||l!==o.h){n.trigger(j,[o.w=m,o.h=l])}});g()},e[b])}})(jQuery,this);
+(function($,h,c){var a=$([]),e=$.resize=$.extend($.resize,{}),i,k="setTimeout",j="resize",d=j+"-special-event",b="delay",f="throttleWindow";e[b]=250;e[f]=true;$.event.special[j]={setup:function(){if(!e[f]&&this[k]){return false}var l=$(this);a=a.add(l);$.data(this,d,{w:l.width(),h:l.height()});if(a.length===1){g()}},teardown:function(){if(!e[f]&&this[k]){return false}var l=$(this);a=a.not(l);l.removeData(d);if(!a.length){clearTimeout(i)}},add:function(l){if(!e[f]&&this[k]){return false}var n;function m(s,o,p){var q=$(this),r=$.data(this,d);r.w=o!==c?o:q.width();r.h=p!==c?p:q.height();n.apply(this,arguments)}if('function'===typeof l){n=l;return m}else{n=l.handler;l.handler=m}}};function g(){i=h[k](function(){a.each(function(){var n=$(this),m=n.width(),l=n.height(),o=$.data(this,d);if(m!==o.w||l!==o.h){n.trigger(j,[o.w=m,o.h=l])}});g()},e[b])}})(jQuery,this);
 
 (function ($) {
     var options = { }; // no options
@@ -38,19 +38,19 @@ can just fix the size of their placeholders.
             plot.setupGrid();
             plot.draw();
         }
-        
+
         function bindEvents(plot, eventHolder) {
             plot.getPlaceholder().resize(onResize);
         }
 
         function shutdown(plot, eventHolder) {
-            plot.getPlaceholder().unbind("resize", onResize);
+            plot.getPlaceholder().off("resize", onResize);
         }
-        
+
         plot.hooks.bindEvents.push(bindEvents);
         plot.hooks.shutdown.push(shutdown);
     }
-    
+
     $.plot.plugins.push({
         init: init,
         options: options,

--- a/assets/js/jquery-flot/jquery.flot.resize.js
+++ b/assets/js/jquery-flot/jquery.flot.resize.js
@@ -40,7 +40,7 @@ can just fix the size of their placeholders.
         }
 
         function bindEvents(plot, eventHolder) {
-            plot.getPlaceholder().resize(onResize);
+            plot.getPlaceholder().on( 'resize', onResize );
         }
 
         function shutdown(plot, eventHolder) {

--- a/assets/js/jquery-payment/jquery.payment.js
+++ b/assets/js/jquery-payment/jquery.payment.js
@@ -554,8 +554,8 @@ jQuery( function( $ ) {
     if (!(month && year)) {
       return false;
     }
-    month = $.trim(month);
-    year = $.trim(year);
+    month = 'string' === typeof month ? month.trim() : '';
+    year = 'string' === typeof year ? year.trim() : '';
     if (!/^\d+$/.test(month)) {
       return false;
     }
@@ -584,7 +584,7 @@ jQuery( function( $ ) {
 
   $.payment.validateCardCVC = function(cvc, type) {
     var card, _ref;
-    cvc = $.trim(cvc);
+    cvc = 'string' === typeof cvc ? cvc.trim() : '';
     if (!/^\d+$/.test(cvc)) {
       return false;
     }

--- a/assets/js/jquery-serializejson/jquery.serializejson.js
+++ b/assets/js/jquery-serializejson/jquery.serializejson.js
@@ -131,7 +131,7 @@
 
       if (opts.typeFunctions && type && opts.typeFunctions[type]) { // use a type if available
         parsedVal = opts.typeFunctions[type](valStr);
-      } else if (opts.parseNumbers  && f.isNumeric(valStr)) { // auto: number
+      } else if (opts.parseNumbers  && (! isNaN(valStr) && isFinite(valStr))) { // auto: number
         parsedVal = Number(valStr);
       } else if (opts.parseBooleans && (valStr === "true" || valStr === "false")) { // auto: boolean
         parsedVal = (valStr === "true");
@@ -201,17 +201,17 @@
     // depending on the options to skip values by name or type, and the data-skip-falsy attribute.
     shouldSkipFalsy: function($form, name, nameWithNoType, type, opts) {
       var f = $.serializeJSON;
-      
+
       var skipFromDataAttr = f.attrFromInputWithName($form, name, 'data-skip-falsy');
       if (skipFromDataAttr != null) {
-        return skipFromDataAttr !== 'false'; // any value is true, except if explicitly using 'false' 
+        return skipFromDataAttr !== 'false'; // any value is true, except if explicitly using 'false'
       }
 
       var optForFields = opts.skipFalsyValuesForFields;
       if (optForFields && (optForFields.indexOf(nameWithNoType) !== -1 || optForFields.indexOf(name) !== -1)) {
         return true;
       }
-      
+
       var optForTypes = opts.skipFalsyValuesForTypes;
       if (type == null) type = 'string'; // assume fields with no type are targeted as string
       if (optForTypes && optForTypes.indexOf(type) !== -1) {
@@ -314,12 +314,12 @@
 
         // '' is used to push values into the array "array[]"
         if (nextKey === '') {
-          if (f.isUndefined(o[key]) || !$.isArray(o[key])) {
+          if (f.isUndefined(o[key]) || !Array.isArray(o[key])) {
             o[key] = []; // define (or override) as array to push values
           }
         } else {
           if (opts.useIntKeysAsArrayIndex && f.isValidArrayIndex(nextKey)) { // if 1, 2, 3 ... then use an array, where nextKey is the index
-            if (f.isUndefined(o[key]) || !$.isArray(o[key])) {
+            if (f.isUndefined(o[key]) || !Array.isArray(o[key])) {
               o[key] = []; // define (or override) as array, to insert values using int keys as array indexes
             }
           } else { // for anything else, use an object, where nextKey is going to be the attribute name

--- a/assets/js/jquery-tiptip/jquery.tipTip.js
+++ b/assets/js/jquery-tiptip/jquery.tipTip.js
@@ -58,7 +58,7 @@
 			}
 			if(org_title != ""){
 				if(!opts.content){
-					org_elem.removeAttr(opts.attribute); //remove original Attribute
+					org_elem[0].removeAttribute(opts.attribute); //remove original Attribute
 				}
 				var timeout = false;
 
@@ -76,16 +76,16 @@
 						});
 					}
 				} else if(opts.activation == "focus"){
-					org_elem.focus(function(){
+					org_elem.on( 'focus', function(){
 						active_tiptip();
-					}).blur(function(){
+					}).on( 'blur', function(){
 						deactive_tiptip();
 					});
 				} else if(opts.activation == "click"){
-					org_elem.click(function(){
+					org_elem.on( 'click', function(){
 						active_tiptip();
 						return false;
-					}).hover(function(){},function(){
+					}).on( 'hover', function(){},function(){
 						if(!opts.keepAlive){
 							deactive_tiptip();
 						}
@@ -100,8 +100,9 @@
 				function active_tiptip(){
 					opts.enter.call(this);
 					tiptip_content.html(org_title);
-					tiptip_holder.hide().removeAttr("class").css("margin","0");
-					tiptip_arrow.removeAttr("style");
+					tiptip_holder.hide().css("margin","0");
+					tiptip_holder[0].removeAttribute('class');
+					tiptip_arrow[0].removeAttribute("style");
 
 					var top = parseInt(org_elem.offset()['top']);
 					var left = parseInt(org_elem.offset()['left']);

--- a/assets/js/jquery-tiptip/jquery.tipTip.js
+++ b/assets/js/jquery-tiptip/jquery.tipTip.js
@@ -58,7 +58,7 @@
 			}
 			if(org_title != ""){
 				if(!opts.content){
-					org_elem[0].removeAttribute(opts.attribute); //remove original Attribute
+					org_elem.prop(opts.attribute, false); //remove original Attribute
 				}
 				var timeout = false;
 
@@ -101,8 +101,8 @@
 					opts.enter.call(this);
 					tiptip_content.html(org_title);
 					tiptip_holder.hide().css("margin","0");
-					tiptip_holder[0].removeAttribute('class');
-					tiptip_arrow[0].removeAttribute("style");
+					tiptip_holder.removeAttr('class');
+					tiptip_arrow.removeAttr("style");
 
 					var top = parseInt(org_elem.offset()['top']);
 					var left = parseInt(org_elem.offset()['left']);

--- a/assets/js/jquery-tiptip/jquery.tipTip.js
+++ b/assets/js/jquery-tiptip/jquery.tipTip.js
@@ -63,15 +63,15 @@
 				var timeout = false;
 
 				if(opts.activation == "hover"){
-					org_elem.hover(function(){
+					org_elem.on( 'mouseenter', function(){
 						active_tiptip();
-					}, function(){
+					} ).on( 'mouseleave', function(){
 						if(!opts.keepAlive || !tiptip_holder.is(':hover')){
 							deactive_tiptip();
 						}
 					});
 					if(opts.keepAlive){
-						tiptip_holder.hover(function(){}, function(){
+						tiptip_holder.on( 'mouseenter', function(){} ).on( 'mouseleave', function(){
 							deactive_tiptip();
 						});
 					}
@@ -85,13 +85,13 @@
 					org_elem.on( 'click', function(){
 						active_tiptip();
 						return false;
-					}).on( 'hover', function(){},function(){
+					}).on( 'mouseenter', function(){} ).on( 'mouseleave' ,function(){
 						if(!opts.keepAlive){
 							deactive_tiptip();
 						}
 					});
 					if(opts.keepAlive){
-						tiptip_holder.hover(function(){}, function(){
+						tiptip_holder.on( 'mouseenter', function(){} ).on( 'mouseleave', function(){
 							deactive_tiptip();
 						});
 					}

--- a/assets/js/jquery-ui-touch-punch/jquery-ui-touch-punch.js
+++ b/assets/js/jquery-ui-touch-punch/jquery-ui-touch-punch.js
@@ -149,7 +149,7 @@
     var self = this;
 
     // Delegate the touch handlers to the widget's element
-    self.element.bind({
+    self.element.on({
       touchstart: $.proxy(self, '_touchStart'),
       touchmove: $.proxy(self, '_touchMove'),
       touchend: $.proxy(self, '_touchEnd')
@@ -167,7 +167,7 @@
     var self = this;
 
     // Delegate the touch handlers to the widget's element
-    self.element.unbind({
+    self.element.off({
       touchstart: $.proxy(self, '_touchStart'),
       touchmove: $.proxy(self, '_touchMove'),
       touchend: $.proxy(self, '_touchEnd')

--- a/assets/js/prettyPhoto/jquery.prettyPhoto.js
+++ b/assets/js/prettyPhoto/jquery.prettyPhoto.js
@@ -108,10 +108,10 @@
 		doresize = true, scroll_pos = _get_scroll();
 
 		// Window/Keyboard events
-		$(window).unbind('resize.prettyphoto').bind('resize.prettyphoto',function(){ _center_overlay(); _resize_overlay(); });
+		$(window).off('resize.prettyphoto').on('resize.prettyphoto',function(){ _center_overlay(); _resize_overlay(); });
 
 		if(pp_settings.keyboard_shortcuts) {
-			$(document).unbind('keydown.prettyphoto').bind('keydown.prettyphoto',function(e){
+			$(document).off('keydown.prettyphoto').on('keydown.prettyphoto',function(e){
 				if(typeof $pp_pic_holder != 'undefined'){
 					if($pp_pic_holder.is(':visible')){
 						switch(e.keyCode){
@@ -162,7 +162,7 @@
 			_build_overlay(this); // Build the overlay {this} being the caller
 
 			if(settings.allow_resize)
-				$(window).bind('scroll.prettyphoto',function(){ _center_overlay(); });
+				$(window).on('scroll.prettyphoto',function(){ _center_overlay(); });
 
 
 			$.prettyPhoto.open();
@@ -431,7 +431,7 @@
 		*/
 		$.prettyPhoto.startSlideshow = function(){
 			if(typeof pp_slideshow == 'undefined'){
-				$pp_pic_holder.find('.pp_play').unbind('click').removeClass('pp_play').addClass('pp_pause').click(function(){
+				$pp_pic_holder.find('.pp_play').off('click').removeClass('pp_play').addClass('pp_pause').on( 'click', function(){
 					$.prettyPhoto.stopSlideshow();
 					return false;
 				});
@@ -446,7 +446,7 @@
 		* Stop the slideshow...
 		*/
 		$.prettyPhoto.stopSlideshow = function(){
-			$pp_pic_holder.find('.pp_pause').unbind('click').removeClass('pp_pause').addClass('pp_play').click(function(){
+			$pp_pic_holder.find('.pp_pause').off('click').removeClass('pp_pause').addClass('pp_play').on( 'click', function(){
 				$.prettyPhoto.startSlideshow();
 				return false;
 			});
@@ -473,7 +473,7 @@
 
 				$(this).remove(); // No more need for the prettyPhoto markup
 
-				$(window).unbind('scroll.prettyphoto');
+				$(window).off('scroll.prettyphoto');
 
 				clearHashtag();
 
@@ -739,7 +739,7 @@
 
 				$pp_gallery_li.filter(':eq('+set_position+')').addClass('selected');
 			}else{
-				$pp_pic_holder.find('.pp_content').unbind('mouseenter mouseleave');
+				$pp_pic_holder.find('.pp_content').off('mouseenter mouseleave');
 				// $pp_gallery.hide();
 			}
 		}
@@ -776,13 +776,13 @@
 
 				$pp_gallery = $('.pp_pic_holder .pp_gallery'), $pp_gallery_li = $pp_gallery.find('li'); // Set the gallery selectors
 
-				$pp_gallery.find('.pp_arrow_next').click(function(){
+				$pp_gallery.find('.pp_arrow_next').on( 'click', function(){
 					$.prettyPhoto.changeGalleryPage('next');
 					$.prettyPhoto.stopSlideshow();
 					return false;
 				});
 
-				$pp_gallery.find('.pp_arrow_previous').click(function(){
+				$pp_gallery.find('.pp_arrow_previous').on( 'click', function(){
 					$.prettyPhoto.changeGalleryPage('previous');
 					$.prettyPhoto.stopSlideshow();
 					return false;
@@ -800,7 +800,7 @@
 				$pp_gallery_li.each(function(i){
 					$(this)
 						.find('a')
-						.click(function(){
+						.on( 'click', function(){
 							$.prettyPhoto.changePage(i);
 							$.prettyPhoto.stopSlideshow();
 							return false;
@@ -812,7 +812,7 @@
 			// Inject the play/pause if it's a slideshow
 			if(settings.slideshow){
 				$pp_pic_holder.find('.pp_nav').prepend('<a href="#" class="pp_play">Play</a>')
-				$pp_pic_holder.find('.pp_nav .pp_play').click(function(){
+				$pp_pic_holder.find('.pp_nav .pp_play').on( 'click', function(){
 					$.prettyPhoto.startSlideshow();
 					return false;
 				});
@@ -826,15 +826,15 @@
 					'height':$(document).height(),
 					'width':$(window).width()
 					})
-				.bind('click',function(){
+				.on('click',function(){
 					if(!settings.modal) $.prettyPhoto.close();
 				});
 
-			$('a.pp_close').bind('click',function(){ $.prettyPhoto.close(); return false; });
+			$('a.pp_close').on('click',function(){ $.prettyPhoto.close(); return false; });
 
 
 			if(settings.allow_expand) {
-				$('a.pp_expand').bind('click',function(e){
+				$('a.pp_expand').on('click',function(e){
 					// Expand the image
 					if($(this).hasClass('pp_expand')){
 						$(this).removeClass('pp_expand').addClass('pp_contract');
@@ -850,13 +850,13 @@
 				});
 			}
 
-			$pp_pic_holder.find('.pp_previous, .pp_nav .pp_arrow_previous').bind('click',function(){
+			$pp_pic_holder.find('.pp_previous, .pp_nav .pp_arrow_previous').on('click',function(){
 				$.prettyPhoto.changePage('previous');
 				$.prettyPhoto.stopSlideshow();
 				return false;
 			});
 
-			$pp_pic_holder.find('.pp_next, .pp_nav .pp_arrow_next').bind('click',function(){
+			$pp_pic_holder.find('.pp_next, .pp_nav .pp_arrow_next').on('click',function(){
 				$.prettyPhoto.changePage('next');
 				$.prettyPhoto.stopSlideshow();
 				return false;
@@ -879,7 +879,7 @@
 			setTimeout(function(){ $("a["+pp_settings.hook+"^='"+hashRel+"']:eq("+hashIndex+")").trigger('click'); },50);
 		}
 
-		return this.unbind('click.prettyphoto').bind('click.prettyphoto',$.prettyPhoto.initialize); // Return the jQuery object for chaining. The unbind method is used to avoid click conflict when the plugin is called more than once
+		return this.off('click.prettyphoto').on('click.prettyphoto',$.prettyPhoto.initialize); // Return the jQuery object for chaining. The unbind method is used to avoid click conflict when the plugin is called more than once
 	};
 
 	function getHashtag(){

--- a/assets/js/prettyPhoto/jquery.prettyPhoto.js
+++ b/assets/js/prettyPhoto/jquery.prettyPhoto.js
@@ -788,10 +788,10 @@
 					return false;
 				});
 
-				$pp_pic_holder.find('.pp_content').hover(
+				$pp_pic_holder.find('.pp_content').on( 'mouseenter',
 					function(){
 						$pp_pic_holder.find('.pp_gallery:not(.disabled)').fadeIn();
-					},
+					} ).on( 'mouseleave',
 					function(){
 						$pp_pic_holder.find('.pp_gallery:not(.disabled)').fadeOut();
 					});

--- a/assets/js/select2/select2.full.js
+++ b/assets/js/select2/select2.full.js
@@ -6378,7 +6378,7 @@ S2.define('select2/selection/stopPropagation',[
         },
 
         unmousewheel: function(fn) {
-            return this.unbind('mousewheel', fn);
+            return this.off('mousewheel', fn);
         }
     });
 

--- a/assets/js/select2/select2.full.js
+++ b/assets/js/select2/select2.full.js
@@ -3707,7 +3707,7 @@ S2.define('select2/data/tags',[
   };
 
   Tags.prototype.createTag = function (decorated, params) {
-    var term = $.trim(params.term);
+    var term = params.term.trim();
 
     if (term === '') {
       return null;
@@ -4941,7 +4941,7 @@ S2.define('select2/defaults',[
 
     function matcher (params, data) {
       // Always return the object if there is nothing to compare
-      if ($.trim(params.term) === '') {
+      if ( params.term.trim() === '' ) {
         return data;
       }
 
@@ -5801,7 +5801,7 @@ S2.define('select2/compat/utils',[
   function syncCssClasses ($dest, $src, adapter) {
     var classes, replacements = [], adapted;
 
-    classes = $.trim($dest.attr('class'));
+    classes = $dest.attr('class').trim();
 
     if (classes) {
       classes = '' + classes; // for IE which returns object
@@ -5814,7 +5814,7 @@ S2.define('select2/compat/utils',[
       });
     }
 
-    classes = $.trim($src.attr('class'));
+    classes = $src.attr('class').trim();
 
     if (classes) {
       classes = '' + classes; // for IE which returns object
@@ -6131,7 +6131,7 @@ S2.define('select2/compat/matcher',[
     function wrappedMatcher (params, data) {
       var match = $.extend(true, {}, data);
 
-      if (params.term == null || $.trim(params.term) === '') {
+      if (params.term == null || params.term.trim() === '') {
         return match;
       }
 

--- a/assets/js/select2/select2.full.js
+++ b/assets/js/select2/select2.full.js
@@ -3547,7 +3547,7 @@ S2.define('select2/data/ajax',[
 
     if (this._request != null) {
       // JSONP requests cannot always be aborted
-      if ($.isFunction(this._request.abort)) {
+      if ( typeof this._request.abort === 'function' ) {
         this._request.abort();
       }
 
@@ -5855,7 +5855,7 @@ S2.define('select2/compat/containerCss',[
 
     var containerCssClass = this.options.get('containerCssClass') || '';
 
-    if ($.isFunction(containerCssClass)) {
+    if ( typeof containerCssClass === 'function' ) {
       containerCssClass = containerCssClass(this.$element);
     }
 
@@ -5881,7 +5881,7 @@ S2.define('select2/compat/containerCss',[
 
     var containerCss = this.options.get('containerCss') || {};
 
-    if ($.isFunction(containerCss)) {
+    if ( typeof containerCss === 'function' ) {
       containerCss = containerCss(this.$element);
     }
 
@@ -5912,7 +5912,7 @@ S2.define('select2/compat/dropdownCss',[
 
     var dropdownCssClass = this.options.get('dropdownCssClass') || '';
 
-    if ($.isFunction(dropdownCssClass)) {
+    if ( typeof dropdownCssClass === 'function' ) {
       dropdownCssClass = dropdownCssClass(this.$element);
     }
 
@@ -5938,7 +5938,7 @@ S2.define('select2/compat/dropdownCss',[
 
     var dropdownCss = this.options.get('dropdownCss') || {};
 
-    if ($.isFunction(dropdownCss)) {
+    if ( typeof dropdownCss === 'function' ) {
       dropdownCss = dropdownCss(this.$element);
     }
 

--- a/assets/js/select2/select2.full.js
+++ b/assets/js/select2/select2.full.js
@@ -3572,7 +3572,7 @@ S2.define('select2/data/ajax',[
 
         if (self.options.get('debug') && window.console && console.error) {
           // Check to make sure that the response included a `results` key.
-          if (!results || !results.results || !$.isArray(results.results)) {
+          if (!results || !results.results || ! Array.isArray( results.results ) ) {
             console.error(
               'Select2: The AJAX results did not return an array in the ' +
               '`results` key of the response.'
@@ -3631,7 +3631,7 @@ S2.define('select2/data/tags',[
 
     decorated.call(this, $element, options);
 
-    if ($.isArray(tags)) {
+    if ( Array.isArray( tags ) ) {
       for (var t = 0; t < tags.length; t++) {
         var tag = tags[t];
         var item = this._normalizeItem(tag);
@@ -4878,7 +4878,7 @@ S2.define('select2/defaults',[
       }
     }
 
-    if ($.isArray(options.language)) {
+    if ( Array.isArray( options.language ) ) {
       var languages = new Translation();
       options.language.push('en');
 
@@ -5724,7 +5724,7 @@ S2.define('select2/core',[
 
     var newVal = args[0];
 
-    if ($.isArray(newVal)) {
+    if ( Array.isArray( newVal ) ) {
       newVal = $.map(newVal, function (obj) {
         return obj.toString();
       });
@@ -5985,7 +5985,7 @@ S2.define('select2/compat/initSelection',[
     this.initSelection.call(null, this.$element, function (data) {
       self._isInitialized = true;
 
-      if (!$.isArray(data)) {
+      if ( ! Array.isArray( data ) ) {
         data = [data];
       }
 

--- a/assets/js/select2/select2.full.js
+++ b/assets/js/select2/select2.full.js
@@ -6374,7 +6374,7 @@ S2.define('select2/selection/stopPropagation',[
 
     $.fn.extend({
         mousewheel: function(fn) {
-            return fn ? this.bind('mousewheel', fn) : this.trigger('mousewheel');
+            return fn ? this.on('mousewheel', fn) : this.trigger('mousewheel');
         },
 
         unmousewheel: function(fn) {

--- a/assets/js/select2/select2.full.js
+++ b/assets/js/select2/select2.full.js
@@ -1430,7 +1430,7 @@ S2.define('select2/selection/base',[
       // This needs to be delayed as the active element is the body when the
       // key is pressed.
       window.setTimeout(function () {
-        self.$selection.focus();
+        self.$selection.trigger( 'focus' );
       }, 1);
 
       self._detachCloseHandler(container);
@@ -1591,7 +1591,7 @@ S2.define('select2/selection/single',[
 
     container.on('focus', function (evt) {
       if (!container.isOpen()) {
-        self.$selection.focus();
+        self.$selection.trigger( 'focus' );
       }
     });
 
@@ -2109,7 +2109,7 @@ S2.define('select2/selection/search',[
 
     this.resizeSearch();
     if (searchHadFocus) {
-      this.$search.focus();
+      this.$search.trigger( 'focus' );
     }
   };
 
@@ -3800,7 +3800,7 @@ S2.define('select2/data/tokenizer',[
       // Replace the search term if we have the search box
       if (this.$search.length) {
         this.$search.val(tokenData.term);
-        this.$search.focus();
+        this.$search.trigger( 'focus' );
       }
 
       params.term = tokenData.term;
@@ -4047,10 +4047,10 @@ S2.define('select2/dropdown/search',[
     container.on('open', function () {
       self.$search.attr('tabindex', 0);
       self.$search.attr('aria-owns', resultsId);
-      self.$search.focus();
+      self.$search.trigger( 'focus' );
 
       window.setTimeout(function () {
-        self.$search.focus();
+        self.$search.trigger( 'focus' );
       }, 0);
     });
 
@@ -4063,7 +4063,7 @@ S2.define('select2/dropdown/search',[
 
     container.on('focus', function () {
       if (!container.isOpen()) {
-        self.$search.focus();
+        self.$search.trigger( 'focus' );
       }
     });
 

--- a/assets/js/select2/select2.js
+++ b/assets/js/select2/select2.js
@@ -3707,7 +3707,7 @@ S2.define('select2/data/tags',[
   };
 
   Tags.prototype.createTag = function (decorated, params) {
-    var term = $.trim(params.term);
+    var term = params.term.trim();
 
     if (term === '') {
       return null;
@@ -4941,7 +4941,7 @@ S2.define('select2/defaults',[
 
     function matcher (params, data) {
       // Always return the object if there is nothing to compare
-      if ($.trim(params.term) === '') {
+      if ( params.term.trim() === '' ) {
         return data;
       }
 

--- a/assets/js/select2/select2.js
+++ b/assets/js/select2/select2.js
@@ -3572,7 +3572,7 @@ S2.define('select2/data/ajax',[
 
         if (self.options.get('debug') && window.console && console.error) {
           // Check to make sure that the response included a `results` key.
-          if (!results || !results.results || !$.isArray(results.results)) {
+          if (!results || !results.results || ! Array.isArray( results.results ) ) {
             console.error(
               'Select2: The AJAX results did not return an array in the ' +
               '`results` key of the response.'
@@ -3631,7 +3631,7 @@ S2.define('select2/data/tags',[
 
     decorated.call(this, $element, options);
 
-    if ($.isArray(tags)) {
+    if ( Array.isArray( tags ) ) {
       for (var t = 0; t < tags.length; t++) {
         var tag = tags[t];
         var item = this._normalizeItem(tag);
@@ -4878,7 +4878,7 @@ S2.define('select2/defaults',[
       }
     }
 
-    if ($.isArray(options.language)) {
+    if ( Array.isArray( options.language ) ) {
       var languages = new Translation();
       options.language.push('en');
 
@@ -5724,7 +5724,7 @@ S2.define('select2/core',[
 
     var newVal = args[0];
 
-    if ($.isArray(newVal)) {
+    if ( Array.isArray( newVal ) ) {
       newVal = $.map(newVal, function (obj) {
         return obj.toString();
       });

--- a/assets/js/select2/select2.js
+++ b/assets/js/select2/select2.js
@@ -3547,7 +3547,7 @@ S2.define('select2/data/ajax',[
 
     if (this._request != null) {
       // JSONP requests cannot always be aborted
-      if ($.isFunction(this._request.abort)) {
+      if ( typeof this._request.abort === 'function' ) {
         this._request.abort();
       }
 

--- a/assets/js/select2/select2.js
+++ b/assets/js/select2/select2.js
@@ -1430,7 +1430,7 @@ S2.define('select2/selection/base',[
       // This needs to be delayed as the active element is the body when the
       // key is pressed.
       window.setTimeout(function () {
-        self.$selection.focus();
+        self.$selection.trigger( 'focus' );
       }, 1);
 
       self._detachCloseHandler(container);
@@ -1591,7 +1591,7 @@ S2.define('select2/selection/single',[
 
     container.on('focus', function (evt) {
       if (!container.isOpen()) {
-        self.$selection.focus();
+        self.$selection.trigger( 'focus' );
       }
     });
 
@@ -2109,7 +2109,7 @@ S2.define('select2/selection/search',[
 
     this.resizeSearch();
     if (searchHadFocus) {
-      this.$search.focus();
+      this.$search.trigger( 'focus' );
     }
   };
 
@@ -3800,7 +3800,7 @@ S2.define('select2/data/tokenizer',[
       // Replace the search term if we have the search box
       if (this.$search.length) {
         this.$search.val(tokenData.term);
-        this.$search.focus();
+        this.$search.trigger( 'focus' );
       }
 
       params.term = tokenData.term;
@@ -4047,10 +4047,10 @@ S2.define('select2/dropdown/search',[
     container.on('open', function () {
       self.$search.attr('tabindex', 0);
       self.$search.attr('aria-owns', resultsId);
-      self.$search.focus();
+      self.$search.trigger( 'focus' );
 
       window.setTimeout(function () {
-        self.$search.focus();
+        self.$search.trigger( 'focus' );
       }, 0);
     });
 
@@ -4063,7 +4063,7 @@ S2.define('select2/dropdown/search',[
 
     container.on('focus', function () {
       if (!container.isOpen()) {
-        self.$search.focus();
+        self.$search.trigger( 'focus' );
       }
     });
 

--- a/assets/js/selectWoo/selectWoo.full.js
+++ b/assets/js/selectWoo/selectWoo.full.js
@@ -1430,7 +1430,7 @@ S2.define('select2/selection/base',[
       // This needs to be delayed as the active element is the body when the
       // key is pressed.
       window.setTimeout(function () {
-        self.$selection.focus();
+        self.$selection.trigger( 'focus' );
       }, 1);
 
       self._detachCloseHandler(container);
@@ -1486,8 +1486,8 @@ S2.define('select2/selection/base',[
         // Remove any focus when dropdown is closed by clicking outside the select area.
         // Timeout of 1 required for close to finish wrapping up.
         setTimeout(function(){
-         $this.find('*:focus').blur();
-         $target.focus();
+         $this.find('*:focus').trigger( 'blur' );
+         $target.trigger( 'focus' );
         }, 1);
       });
     });
@@ -1591,7 +1591,7 @@ S2.define('select2/selection/single',[
 
     container.on('focus', function (evt) {
       if (!container.isOpen()) {
-        self.$selection.focus();
+        self.$selection.trigger( 'focus' );
       }
     });
 
@@ -1737,7 +1737,7 @@ S2.define('select2/selection/multiple',[
         // This gets reset automatically when focus is triggered.
         self._keyUpPrevented = true;
 
-        self.$search.focus();
+        self.$search.trigger( 'focus' );
       }, 1);
     }
   }
@@ -2109,7 +2109,7 @@ S2.define('select2/selection/search',[
 
     this.resizeSearch();
     if (searchHadFocus) {
-      this.$search.focus();
+      this.$search.trigger( 'focus' );
     }
   };
 
@@ -3547,7 +3547,7 @@ S2.define('select2/data/ajax',[
 
     if (this._request != null) {
       // JSONP requests cannot always be aborted
-      if ($.isFunction(this._request.abort)) {
+      if ('function' === typeof this._request.abort) {
         this._request.abort();
       }
 
@@ -3572,7 +3572,7 @@ S2.define('select2/data/ajax',[
 
         if (self.options.get('debug') && window.console && console.error) {
           // Check to make sure that the response included a `results` key.
-          if (!results || !results.results || !$.isArray(results.results)) {
+          if (!results || !results.results || !Array.isArray(results.results)) {
             console.error(
               'Select2: The AJAX results did not return an array in the ' +
               '`results` key of the response.'
@@ -3631,7 +3631,7 @@ S2.define('select2/data/tags',[
 
     decorated.call(this, $element, options);
 
-    if ($.isArray(tags)) {
+    if (Array.isArray(tags)) {
       for (var t = 0; t < tags.length; t++) {
         var tag = tags[t];
         var item = this._normalizeItem(tag);
@@ -3707,7 +3707,7 @@ S2.define('select2/data/tags',[
   };
 
   Tags.prototype.createTag = function (decorated, params) {
-    var term = $.trim(params.term);
+    var term = 'string' === typeof params.term ? params.term.trim() : '';
 
     if (term === '') {
       return null;
@@ -3800,7 +3800,7 @@ S2.define('select2/data/tokenizer',[
       // Replace the search term if we have the search box
       if (this.$search.length) {
         this.$search.val(tokenData.term);
-        this.$search.focus();
+        this.$search.trigger( 'focus' );
       }
 
       params.term = tokenData.term;
@@ -4047,10 +4047,10 @@ S2.define('select2/dropdown/search',[
     container.on('open', function () {
       self.$search.attr('tabindex', 0);
       self.$search.attr('aria-owns', resultsId);
-      self.$search.focus();
+      self.$search.trigger( 'focus' );
 
       window.setTimeout(function () {
-        self.$search.focus();
+        self.$search.trigger( 'focus' );
       }, 0);
     });
 
@@ -4063,7 +4063,7 @@ S2.define('select2/dropdown/search',[
 
     container.on('focus', function () {
       if (!container.isOpen()) {
-        self.$search.focus();
+        self.$search.trigger( 'focus' );
       }
     });
 
@@ -4878,7 +4878,7 @@ S2.define('select2/defaults',[
       }
     }
 
-    if ($.isArray(options.language)) {
+    if (Array.isArray(options.language)) {
       var languages = new Translation();
       options.language.push('en');
 
@@ -4941,7 +4941,7 @@ S2.define('select2/defaults',[
 
     function matcher (params, data) {
       // Always return the object if there is nothing to compare
-      if ($.trim(params.term) === '') {
+      if ( 'undefined' === typeof params.term || ( 'string' === typeof params.term && '' === params.term.trim() ) ) {
         return data;
       }
 
@@ -5513,7 +5513,7 @@ S2.define('select2/core',[
             self.focusOnActiveElement();
         } else {
           // Focus on the search if user starts typing.
-          $searchField.focus();
+          $searchField.trigger( 'focus' );
           // Focus back to active selection when finished typing.
           // Small delay so typed character can be read by screen reader.
           setTimeout(function(){
@@ -5533,7 +5533,7 @@ S2.define('select2/core',[
   Select2.prototype.focusOnActiveElement = function () {
     // Don't mess with the focus on touchscreens because it causes havoc with on-screen keyboards.
     if (this.isOpen() && ! Utils.isTouchscreen()) {
-      this.$results.find('li.select2-results__option--highlighted').focus();
+      this.$results.find('li.select2-results__option--highlighted').trigger( 'focus' );
     }
   };
 
@@ -5724,7 +5724,7 @@ S2.define('select2/core',[
 
     var newVal = args[0];
 
-    if ($.isArray(newVal)) {
+    if (Array.isArray(newVal)) {
       newVal = $.map(newVal, function (obj) {
         return obj.toString();
       });
@@ -5801,7 +5801,7 @@ S2.define('select2/compat/utils',[
   function syncCssClasses ($dest, $src, adapter) {
     var classes, replacements = [], adapted;
 
-    classes = $.trim($dest.attr('class'));
+    classes = 'string' === typeof $dest.attr('class') ? $dest.attr('class').trim() : '';
 
     if (classes) {
       classes = '' + classes; // for IE which returns object
@@ -5814,7 +5814,7 @@ S2.define('select2/compat/utils',[
       });
     }
 
-    classes = $.trim($src.attr('class'));
+    classes = 'string' === typeof $src.attr('class') ? $src.attr('class').trim() : '';
 
     if (classes) {
       classes = '' + classes; // for IE which returns object
@@ -5855,7 +5855,7 @@ S2.define('select2/compat/containerCss',[
 
     var containerCssClass = this.options.get('containerCssClass') || '';
 
-    if ($.isFunction(containerCssClass)) {
+    if ('function' === typeof containerCssClass) {
       containerCssClass = containerCssClass(this.$element);
     }
 
@@ -5881,7 +5881,7 @@ S2.define('select2/compat/containerCss',[
 
     var containerCss = this.options.get('containerCss') || {};
 
-    if ($.isFunction(containerCss)) {
+    if ('function' === typeof containerCss) {
       containerCss = containerCss(this.$element);
     }
 
@@ -5912,7 +5912,7 @@ S2.define('select2/compat/dropdownCss',[
 
     var dropdownCssClass = this.options.get('dropdownCssClass') || '';
 
-    if ($.isFunction(dropdownCssClass)) {
+    if ('function' === typeof dropdownCssClass) {
       dropdownCssClass = dropdownCssClass(this.$element);
     }
 
@@ -5938,7 +5938,7 @@ S2.define('select2/compat/dropdownCss',[
 
     var dropdownCss = this.options.get('dropdownCss') || {};
 
-    if ($.isFunction(dropdownCss)) {
+    if ('function' === typeof dropdownCss) {
       dropdownCss = dropdownCss(this.$element);
     }
 
@@ -5985,7 +5985,7 @@ S2.define('select2/compat/initSelection',[
     this.initSelection.call(null, this.$element, function (data) {
       self._isInitialized = true;
 
-      if (!$.isArray(data)) {
+      if (!Array.isArray(data)) {
         data = [data];
       }
 
@@ -6131,7 +6131,7 @@ S2.define('select2/compat/matcher',[
     function wrappedMatcher (params, data) {
       var match = $.extend(true, {}, data);
 
-      if (params.term == null || $.trim(params.term) === '') {
+      if ( params.term == null || ( 'string' === typeof params.term && '' === params.term.trim() ) ) {
         return match;
       }
 
@@ -6374,11 +6374,11 @@ S2.define('select2/selection/stopPropagation',[
 
     $.fn.extend({
         mousewheel: function(fn) {
-            return fn ? this.bind('mousewheel', fn) : this.trigger('mousewheel');
+            return fn ? this.on('mousewheel', fn) : this.trigger('mousewheel');
         },
 
         unmousewheel: function(fn) {
-            return this.unbind('mousewheel', fn);
+            return this.off('mousewheel', fn);
         }
     });
 

--- a/assets/js/selectWoo/selectWoo.js
+++ b/assets/js/selectWoo/selectWoo.js
@@ -1486,7 +1486,7 @@ S2.define('select2/selection/base',[
         // Remove any focus when dropdown is closed by clicking outside the select area.
         // Timeout of 1 required for close to finish wrapping up.
         setTimeout(function(){
-         $this.find('*:focus').blur();
+         $this.find('*:focus').trigger( 'blur' );
          $target.trigger( 'focus' );
         }, 1);
       });

--- a/assets/js/selectWoo/selectWoo.js
+++ b/assets/js/selectWoo/selectWoo.js
@@ -1430,7 +1430,7 @@ S2.define('select2/selection/base',[
       // This needs to be delayed as the active element is the body when the
       // key is pressed.
       window.setTimeout(function () {
-        self.$selection.focus();
+        self.$selection.trigger( 'focus' );
       }, 1);
 
       self._detachCloseHandler(container);
@@ -1487,7 +1487,7 @@ S2.define('select2/selection/base',[
         // Timeout of 1 required for close to finish wrapping up.
         setTimeout(function(){
          $this.find('*:focus').blur();
-         $target.focus();
+         $target.trigger( 'focus' );
         }, 1);
       });
     });
@@ -1591,7 +1591,7 @@ S2.define('select2/selection/single',[
 
     container.on('focus', function (evt) {
       if (!container.isOpen()) {
-        self.$selection.focus();
+        self.$selection.trigger( 'focus' );
       }
     });
 
@@ -1737,7 +1737,7 @@ S2.define('select2/selection/multiple',[
         // This gets reset automatically when focus is triggered.
         self._keyUpPrevented = true;
 
-        self.$search.focus();
+        self.$search.trigger( 'focus' );
       }, 1);
     }
   }
@@ -2109,7 +2109,7 @@ S2.define('select2/selection/search',[
 
     this.resizeSearch();
     if (searchHadFocus) {
-      this.$search.focus();
+      this.$search.trigger( 'focus' );
     }
   };
 
@@ -3800,7 +3800,7 @@ S2.define('select2/data/tokenizer',[
       // Replace the search term if we have the search box
       if (this.$search.length) {
         this.$search.val(tokenData.term);
-        this.$search.focus();
+        this.$search.trigger( 'focus' );
       }
 
       params.term = tokenData.term;
@@ -4047,10 +4047,10 @@ S2.define('select2/dropdown/search',[
     container.on('open', function () {
       self.$search.attr('tabindex', 0);
       self.$search.attr('aria-owns', resultsId);
-      self.$search.focus();
+      self.$search.trigger( 'focus' );
 
       window.setTimeout(function () {
-        self.$search.focus();
+        self.$search.trigger( 'focus' );
       }, 0);
     });
 
@@ -4063,7 +4063,7 @@ S2.define('select2/dropdown/search',[
 
     container.on('focus', function () {
       if (!container.isOpen()) {
-        self.$search.focus();
+        self.$search.trigger( 'focus' );
       }
     });
 
@@ -5513,7 +5513,7 @@ S2.define('select2/core',[
             self.focusOnActiveElement();
         } else {
           // Focus on the search if user starts typing.
-          $searchField.focus();
+          $searchField.trigger( 'focus' );
           // Focus back to active selection when finished typing.
           // Small delay so typed character can be read by screen reader.
           setTimeout(function(){
@@ -5533,7 +5533,7 @@ S2.define('select2/core',[
   Select2.prototype.focusOnActiveElement = function () {
     // Don't mess with the focus on touchscreens because it causes havoc with on-screen keyboards.
     if (this.isOpen() && ! Utils.isTouchscreen()) {
-      this.$results.find('li.select2-results__option--highlighted').focus();
+      this.$results.find('li.select2-results__option--highlighted').trigger( 'focus' );
     }
   };
 

--- a/assets/js/selectWoo/selectWoo.js
+++ b/assets/js/selectWoo/selectWoo.js
@@ -3707,7 +3707,7 @@ S2.define('select2/data/tags',[
   };
 
   Tags.prototype.createTag = function (decorated, params) {
-    var term = $.trim(params.term);
+    var term = params.term.trim();
 
     if (term === '') {
       return null;
@@ -4941,7 +4941,7 @@ S2.define('select2/defaults',[
 
     function matcher (params, data) {
       // Always return the object if there is nothing to compare
-      if ($.trim(params.term) === '') {
+      if ( params.term.trim() === '' ) {
         return data;
       }
 

--- a/assets/js/selectWoo/selectWoo.js
+++ b/assets/js/selectWoo/selectWoo.js
@@ -3572,7 +3572,7 @@ S2.define('select2/data/ajax',[
 
         if (self.options.get('debug') && window.console && console.error) {
           // Check to make sure that the response included a `results` key.
-          if (!results || !results.results || !$.isArray(results.results)) {
+          if (!results || !results.results || ! Array.isArray( results.results ) ) {
             console.error(
               'Select2: The AJAX results did not return an array in the ' +
               '`results` key of the response.'
@@ -3631,7 +3631,7 @@ S2.define('select2/data/tags',[
 
     decorated.call(this, $element, options);
 
-    if ($.isArray(tags)) {
+    if ( Array.isArray( tags ) ) {
       for (var t = 0; t < tags.length; t++) {
         var tag = tags[t];
         var item = this._normalizeItem(tag);
@@ -4878,7 +4878,7 @@ S2.define('select2/defaults',[
       }
     }
 
-    if ($.isArray(options.language)) {
+    if ( Array.isArray( options.language ) ) {
       var languages = new Translation();
       options.language.push('en');
 
@@ -5724,7 +5724,7 @@ S2.define('select2/core',[
 
     var newVal = args[0];
 
-    if ($.isArray(newVal)) {
+    if ( Array.isArray( newVal ) ) {
       newVal = $.map(newVal, function (obj) {
         return obj.toString();
       });

--- a/assets/js/selectWoo/selectWoo.js
+++ b/assets/js/selectWoo/selectWoo.js
@@ -3547,7 +3547,7 @@ S2.define('select2/data/ajax',[
 
     if (this._request != null) {
       // JSONP requests cannot always be aborted
-      if ($.isFunction(this._request.abort)) {
+      if ( typeof this._request.abort === 'function' ) {
         this._request.abort();
       }
 

--- a/assets/js/stupidtable/stupidtable.js
+++ b/assets/js/stupidtable/stupidtable.js
@@ -32,9 +32,9 @@
         th_index = th_index - 1;
 
         // Determine (and/or reverse) sorting direction, default `asc`
-        var sort_dir = $this.data("sort-default") || dir.ASC;
-        if ($this.data("sort-dir"))
-           sort_dir = $this.data("sort-dir") === dir.ASC ? dir.DESC : dir.ASC;
+        var sort_dir = $this.data("sortDefault") || dir.ASC;
+        if ($this.data("sortDir"))
+           sort_dir = $this.data("sortDir") === dir.ASC ? dir.DESC : dir.ASC;
 
         // Choose appropriate sorting function.
         var type = $this.data("sort") || null;
@@ -65,7 +65,7 @@
               // with the TR itself into a tuple
               trs.each(function(index,tr) {
                 var $e = $(tr).children().eq(th_index);
-                var sort_val = $e.data("sort-value");
+                var sort_val = $e.data("sortValue");
                 var order_by = typeof(sort_val) !== "undefined" ? sort_val : $e.text();
                 column.push([order_by, tr]);
               });
@@ -83,8 +83,8 @@
           });
 
           // Reset siblings
-          $table.find("th").data("sort-dir", null).removeClass("sorting-desc sorting-asc");
-          $this.data("sort-dir", sort_dir).addClass("sorting-"+sort_dir);
+          $table.find("th").data("sortDir", null).removeClass("sorting-desc sorting-asc");
+          $this.data("sortDir", sort_dir).addClass("sorting-"+sort_dir);
 
           // Trigger `aftertablesort` event. Similar to `beforetablesort`
           $table.trigger("aftertablesort", {column: $this.index(), direction: sort_dir});

--- a/assets/js/zeroclipboard/jquery.zeroclipboard.js
+++ b/assets/js/zeroclipboard/jquery.zeroclipboard.js
@@ -1,7 +1,7 @@
 /*!
  * jquery.zeroclipboard
  * Bind to the `beforecopy`, `copy`, `aftercopy`, and `copy-error` events, custom DOM-like events for clipboard injection generated using jQuery's Special Events API and ZeroClipboard's Core module.
- * Copyright (c) 2014 
+ * Copyright (c) 2014
  * Licensed MIT
  * https://github.com/zeroclipboard/jquery.zeroclipboard
  * v0.2.0
@@ -474,7 +474,7 @@
  * The underlying implementation of `ZeroClipboard.destroy`.
  * @private
  */
-    var _destroy = function() {
+    var _destroy = function() {console.log('zero', ZeroClipboard);
       ZeroClipboard.clearData();
       ZeroClipboard.blur();
       ZeroClipboard.emit("destroy");

--- a/assets/js/zeroclipboard/jquery.zeroclipboard.js
+++ b/assets/js/zeroclipboard/jquery.zeroclipboard.js
@@ -474,7 +474,7 @@
  * The underlying implementation of `ZeroClipboard.destroy`.
  * @private
  */
-    var _destroy = function() {console.log('zero', ZeroClipboard);
+    var _destroy = function() {
       ZeroClipboard.clearData();
       ZeroClipboard.blur();
       ZeroClipboard.emit("destroy");

--- a/assets/js/zeroclipboard/jquery.zeroclipboard.js
+++ b/assets/js/zeroclipboard/jquery.zeroclipboard.js
@@ -474,7 +474,7 @@
  * The underlying implementation of `ZeroClipboard.destroy`.
  * @private
  */
-    var _destroy = function() {
+    var _destroy = function() {console.log('zero', ZeroClipboard);
       ZeroClipboard.clearData();
       ZeroClipboard.blur();
       ZeroClipboard.emit("destroy");

--- a/assets/js/zoom/jquery.zoom.js
+++ b/assets/js/zoom/jquery.zoom.js
@@ -125,12 +125,12 @@
 					// Skip the fade-in for IE8 and lower since it chokes on fading-in
 					// and changing position based on mousemovement at the same time.
 					$img.stop()
-					.fadeTo($.support.opacity ? settings.duration : 0, 1, $.isFunction(settings.onZoomIn) ? settings.onZoomIn.call(img) : false);
+					.fadeTo($.support.opacity ? settings.duration : 0, 1, 'function' === typeof settings.onZoomIn ? settings.onZoomIn.call(img) : false);
 				}
 
 				function stop() {
 					$img.stop()
-					.fadeTo(settings.duration, 0, $.isFunction(settings.onZoomOut) ? settings.onZoomOut.call(img) : false);
+					.fadeTo(settings.duration, 0, 'function' === typeof settings.onZoomOut ? settings.onZoomOut.call(img) : false);
 				}
 
 				// Mouse events
@@ -221,8 +221,8 @@
 							}
 						});
 				}
-				
-				if ($.isFunction(settings.callback)) {
+
+				if ('function' === typeof settings.callback) {
 					settings.callback.call(img);
 				}
 			};

--- a/includes/admin/class-wc-admin-permalink-settings.php
+++ b/includes/admin/class-wc-admin-permalink-settings.php
@@ -140,23 +140,23 @@ class WC_Admin_Permalink_Settings {
 		<?php wp_nonce_field( 'wc-permalinks', 'wc-permalinks-nonce' ); ?>
 		<script type="text/javascript">
 			jQuery( function() {
-				jQuery('input.wctog').change(function() {
+				jQuery('input.wctog').on( 'change', function() {
 					jQuery('#woocommerce_permalink_structure').val( jQuery( this ).val() );
 				});
-				jQuery('.permalink-structure input').change(function() {
+				jQuery('.permalink-structure input').on( 'change', function() {
 					jQuery('.wc-permalink-structure').find('code.non-default-example, code.default-example').hide();
 					if ( jQuery(this).val() ) {
 						jQuery('.wc-permalink-structure code.non-default-example').show();
-						jQuery('.wc-permalink-structure input').removeAttr('disabled');
+						jQuery('.wc-permalink-structure input').prop('disabled', false);
 					} else {
 						jQuery('.wc-permalink-structure code.default-example').show();
-						jQuery('.wc-permalink-structure input:eq(0)').click();
+						jQuery('.wc-permalink-structure input:eq(0)').trigger( 'click' );
 						jQuery('.wc-permalink-structure input').attr('disabled', 'disabled');
 					}
 				});
-				jQuery('.permalink-structure input:checked').change();
-				jQuery('#woocommerce_permalink_structure').focus( function(){
-					jQuery('#woocommerce_custom_selection').click();
+				jQuery('.permalink-structure input:checked').trigger( 'change' );
+				jQuery('#woocommerce_permalink_structure').on( 'focus', function(){
+					jQuery('#woocommerce_custom_selection').trigger( 'click' );
 				} );
 			} );
 		</script>

--- a/includes/admin/class-wc-admin-permalink-settings.php
+++ b/includes/admin/class-wc-admin-permalink-settings.php
@@ -3,8 +3,6 @@
  * Adds settings to the permalinks admin settings page
  *
  * @class       WC_Admin_Permalink_Settings
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce\Admin
  * @version     2.3.0
  */

--- a/includes/admin/class-wc-admin-pointers.php
+++ b/includes/admin/class-wc-admin-pointers.php
@@ -254,12 +254,12 @@ class WC_Admin_Pointers {
 								button2 = $( '<a class=\"button button-primary\" href=\"#\">' + next + '</a>' ),
 								wrapper = $( '<div class=\"wc-pointer-buttons\" />' );
 
-							button.bind( 'click.pointer', function(e) {
+							button.on( 'click.pointer', function(e) {
 								e.preventDefault();
 								t.element.pointer('destroy');
 							});
 
-							button2.bind( 'click.pointer', function(e) {
+							button2.on( 'click.pointer', function(e) {
 								e.preventDefault();
 								t.element.pointer('close');
 							});

--- a/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-plugins-screen-updates.php
@@ -157,7 +157,7 @@ class WC_Plugins_Screen_Updates extends WC_Plugin_Updates {
 					$update_link.removeClass( 'wc-thickbox open-plugin-details-modal' );
 					$update_link.addClass( 'update-link' );
 					$update_link.attr( 'href', update_url );
-					$update_link.click();
+					$update_link.trigger( 'click' );
 				});
 
 				$( '#wc_untested_extensions_modal .cancel' ).on( 'click', function( evt ) {

--- a/includes/admin/plugin-updates/class-wc-updates-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-updates-screen-updates.php
@@ -69,7 +69,7 @@ class WC_Updates_Screen_Updates extends WC_Plugin_Updates {
 					}
 					var $checkbox = $( 'input[value="woocommerce/woocommerce.php"]' );
 					if ( $checkbox.prop( 'checked' ) ) {
-						$( '#wc-upgrade-warning' ).click();
+						$( '#wc-upgrade-warning' ).trigger( 'click' );
 					}
 				}
 

--- a/includes/admin/reports/class-wc-report-coupon-usage.php
+++ b/includes/admin/reports/class-wc-report-coupon-usage.php
@@ -556,10 +556,10 @@ class WC_Report_Coupon_Usage extends WC_Admin_Report {
 
 				drawGraph();
 
-				jQuery('.highlight_series').hover(
+				jQuery('.highlight_series').on( 'mouseenter',
 					function() {
 						drawGraph( jQuery(this).data('series') );
-					},
+					} ).on( 'mouseleave',
 					function() {
 						drawGraph();
 					}

--- a/includes/admin/reports/class-wc-report-coupon-usage.php
+++ b/includes/admin/reports/class-wc-report-coupon-usage.php
@@ -343,9 +343,9 @@ class WC_Report_Coupon_Usage extends WC_Admin_Report {
 			} );
 			jQuery( '.section' ).slideUp( 100, function() {
 				<?php if ( empty( $this->coupon_codes ) ) : ?>
-					jQuery( '.section_title:eq(1)' ).click();
+					jQuery( '.section_title:eq(1)' ).trigger( 'click' );
 				<?php else : ?>
-					jQuery( '.section_title:eq(0)' ).click();
+					jQuery( '.section_title:eq(0)' ).trigger( 'click' );
 				<?php endif; ?>
 			} );
 		</script>
@@ -551,7 +551,7 @@ class WC_Report_Coupon_Usage extends WC_Admin_Report {
 						}
 					);
 
-					jQuery('.chart-placeholder').resize();
+					jQuery('.chart-placeholder').trigger( 'resize' );
 				}
 
 				drawGraph();

--- a/includes/admin/reports/class-wc-report-customers.php
+++ b/includes/admin/reports/class-wc-report-customers.php
@@ -417,10 +417,10 @@ class WC_Report_Customers extends WC_Admin_Report {
 
 				drawGraph();
 
-				jQuery('.highlight_series').hover(
+				jQuery('.highlight_series').on( 'mouseenter',
 					function() {
 						drawGraph( jQuery(this).data('series') );
-					},
+					} ).on( 'mouseleave',
 					function() {
 						drawGraph();
 					}

--- a/includes/admin/reports/class-wc-report-customers.php
+++ b/includes/admin/reports/class-wc-report-customers.php
@@ -155,7 +155,7 @@ class WC_Report_Customers extends WC_Admin_Report {
 					}
 				);
 
-				jQuery('.chart-placeholder.customers_vs_guests').resize();
+				jQuery('.chart-placeholder.customers_vs_guests').trigger( 'resize' );
 			});
 		</script>
 		<?php
@@ -412,7 +412,7 @@ class WC_Report_Customers extends WC_Admin_Report {
 							],
 						}
 					);
-					jQuery('.chart-placeholder').resize();
+					jQuery('.chart-placeholder').trigger( 'resize' );
 				}
 
 				drawGraph();

--- a/includes/admin/reports/class-wc-report-sales-by-category.php
+++ b/includes/admin/reports/class-wc-report-sales-by-category.php
@@ -244,13 +244,13 @@ class WC_Report_Sales_By_Category extends WC_Admin_Report {
 					// Select all/None
 					jQuery( '.chart-widget' ).on( 'click', '.select_all', function() {
 						jQuery(this).closest( 'div' ).find( 'select option' ).attr( 'selected', 'selected' );
-						jQuery(this).closest( 'div' ).find('select').change();
+						jQuery(this).closest( 'div' ).find('select').trigger( 'change' );
 						return false;
 					});
 
 					jQuery( '.chart-widget').on( 'click', '.select_none', function() {
-						jQuery(this).closest( 'div' ).find( 'select option' ).removeAttr( 'selected' );
-						jQuery(this).closest( 'div' ).find('select').change();
+						jQuery(this).closest( 'div' ).find( 'select option' ).prop( 'selected', false );
+						jQuery(this).closest( 'div' ).find('select').trigger( 'change' );
 						return false;
 					});
 				});
@@ -430,7 +430,7 @@ class WC_Report_Sales_By_Category extends WC_Admin_Report {
 							}
 						);
 
-						jQuery('.chart-placeholder').resize();
+						jQuery('.chart-placeholder').trigger( 'resize' );
 
 					}
 

--- a/includes/admin/reports/class-wc-report-sales-by-category.php
+++ b/includes/admin/reports/class-wc-report-sales-by-category.php
@@ -436,10 +436,10 @@ class WC_Report_Sales_By_Category extends WC_Admin_Report {
 
 					drawGraph();
 
-					jQuery('.highlight_series').hover(
+					jQuery('.highlight_series').on( 'mouseenter',
 						function() {
 							drawGraph( jQuery(this).data('series') );
-						},
+						} ).on( 'mouseleave',
 						function() {
 							drawGraph();
 						}

--- a/includes/admin/reports/class-wc-report-sales-by-category.php
+++ b/includes/admin/reports/class-wc-report-sales-by-category.php
@@ -12,8 +12,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * WC_Report_Sales_By_Category
  *
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce\Admin\Reports
  * @version     2.1.0
  */
@@ -171,11 +169,11 @@ class WC_Report_Sales_By_Category extends WC_Admin_Report {
 
 					switch ( $this->chart_groupby ) {
 						case 'day':
-							$time = strtotime( date( 'Ymd', strtotime( $order_item->post_date ) ) ) * 1000;
+							$time = strtotime( gmdate( 'Ymd', strtotime( $order_item->post_date ) ) ) * 1000;
 							break;
 						case 'month':
 						default:
-							$time = strtotime( date( 'Ym', strtotime( $order_item->post_date ) ) . '01' ) * 1000;
+							$time = strtotime( gmdate( 'Ym', strtotime( $order_item->post_date ) ) . '01' ) * 1000;
 							break;
 					}
 
@@ -307,11 +305,11 @@ class WC_Report_Sales_By_Category extends WC_Admin_Report {
 
 					switch ( $this->chart_groupby ) {
 						case 'day':
-							$time = strtotime( date( 'Ymd', strtotime( "+{$i} DAY", $this->start_date ) ) ) * 1000;
+							$time = strtotime( gmdate( 'Ymd', strtotime( "+{$i} DAY", $this->start_date ) ) ) * 1000;
 							break;
 						case 'month':
 						default:
-							$time = strtotime( date( 'Ym', strtotime( "+{$i} MONTH", $this->start_date ) ) . '01' ) * 1000;
+							$time = strtotime( gmdate( 'Ym', strtotime( "+{$i} MONTH", $this->start_date ) ) . '01' ) * 1000;
 							break;
 					}
 

--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -849,7 +849,7 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 						}
 					);
 
-					jQuery('.chart-placeholder').resize();
+					jQuery('.chart-placeholder').trigger( 'resize' );
 				}
 
 				drawGraph();

--- a/includes/admin/reports/class-wc-report-sales-by-date.php
+++ b/includes/admin/reports/class-wc-report-sales-by-date.php
@@ -854,10 +854,10 @@ class WC_Report_Sales_By_Date extends WC_Admin_Report {
 
 				drawGraph();
 
-				jQuery('.highlight_series').hover(
+				jQuery('.highlight_series').on( 'mouseenter',
 					function() {
 						drawGraph( jQuery(this).data('series') );
-					},
+					} ).on( 'mouseleave',
 					function() {
 						drawGraph();
 					}

--- a/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -389,7 +389,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 			} );
 			jQuery( '.section' ).slideUp( 100, function() {
 				<?php if ( empty( $this->product_ids ) ) : ?>
-					jQuery( '.section_title:eq(1)' ).click();
+					jQuery( '.section_title:eq(1)' ).trigger( 'click' );
 				<?php endif; ?>
 			} );
 		</script>
@@ -610,7 +610,7 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 							}
 						);
 
-						jQuery('.chart-placeholder').resize();
+						jQuery('.chart-placeholder').trigger( 'resize' );
 					}
 
 					drawGraph();

--- a/includes/admin/reports/class-wc-report-sales-by-product.php
+++ b/includes/admin/reports/class-wc-report-sales-by-product.php
@@ -615,10 +615,10 @@ class WC_Report_Sales_By_Product extends WC_Admin_Report {
 
 					drawGraph();
 
-					jQuery('.highlight_series').hover(
+					jQuery('.highlight_series').on( 'mouseenter',
 						function() {
 							drawGraph( jQuery(this).data('series') );
-						},
+						} ).on( 'mouseleave',
 						function() {
 							drawGraph();
 						}

--- a/includes/admin/settings/views/html-webhooks-edit.php
+++ b/includes/admin/settings/views/html-webhooks-edit.php
@@ -221,6 +221,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 			if ( 'action' === current ) {
 				action_event_field.show();
 			}
-		}).change();
+		}).trigger( 'change' );
 	});
 </script>

--- a/includes/admin/settings/views/html-webhooks-edit.php
+++ b/includes/admin/settings/views/html-webhooks-edit.php
@@ -63,7 +63,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 							$topic_data = WC_Admin_Webhooks::get_topic_data( $webhook );
 
 							$topics = apply_filters(
-								'woocommerce_webhook_topics', array(
+								'woocommerce_webhook_topics',
+								array(
 									''                 => __( 'Select an option&hellip;', 'woocommerce' ),
 									'coupon.created'   => __( 'Coupon created', 'woocommerce' ),
 									'coupon.updated'   => __( 'Coupon updated', 'woocommerce' ),
@@ -197,8 +198,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 								add_query_arg(
 									array(
 										'delete' => $webhook->get_id(),
-									), admin_url( 'admin.php?page=wc-settings&tab=advanced&section=webhooks' )
-								), 'delete-webhook'
+									),
+									admin_url( 'admin.php?page=wc-settings&tab=advanced&section=webhooks' )
+								),
+								'delete-webhook'
 							);
 							?>
 							<a style="color: #a00; text-decoration: none; margin-left: 10px;" href="<?php echo esc_url( $delete_url ); ?>"><?php esc_html_e( 'Delete permanently', 'woocommerce' ); ?></a>

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -128,7 +128,7 @@ class WC_Shop_Customizer {
 				} );
 
 				wp.customize.bind( 'ready', function() { // Ready?
-					$( '.woocommerce-cropping-control' ).find( 'input:checked' ).change();
+					$( '.woocommerce-cropping-control' ).find( 'input:checked' ).trigger( 'change' );
 				} );
 
 				wp.customize( 'woocommerce_demo_store', function( setting ) {

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -1029,7 +1029,7 @@ class WC_Email extends WC_Settings_API {
 
 			<?php
 			wc_enqueue_js(
-				"jQuery( 'select.email_type' ).change( function() {
+				"jQuery( 'select.email_type' ).on( 'change', function() {
 
 					var val = jQuery( this ).val();
 
@@ -1043,7 +1043,7 @@ class WC_Email extends WC_Settings_API {
 						jQuery('.template_plain').hide();
 					}
 
-				}).change();
+				}).trigger( 'change' );
 
 				var view = '" . esc_js( __( 'View template', 'woocommerce' ) ) . "';
 				var hide = '" . esc_js( __( 'Hide template', 'woocommerce' ) ) . "';
@@ -1067,7 +1067,7 @@ class WC_Email extends WC_Settings_API {
 					return false;
 				});
 
-				jQuery( '.editor textarea' ).change( function() {
+				jQuery( '.editor textarea' ).on( 'change', function() {
 					var name = jQuery( this ).attr( 'data-name' );
 
 					if ( name ) {

--- a/includes/gateways/paypal/assets/js/paypal-admin.js
+++ b/includes/gateways/paypal/assets/js/paypal-admin.js
@@ -38,7 +38,7 @@ jQuery( function( $ ) {
 				}
 			} );
 
-			$( '#woocommerce_paypal_testmode' ).change();
+			$( '#woocommerce_paypal_testmode' ).trigger( 'change' );
 		}
 	};
 

--- a/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
+++ b/includes/shipping/free-shipping/class-wc-shipping-free-shipping.php
@@ -233,7 +233,7 @@ class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
 				});
 
 				// Change while load.
-				$( '#woocommerce_free_shipping_requires' ).change();
+				$( '#woocommerce_free_shipping_requires' ).trigger( 'change' );
 				$( document.body ).on( 'wc_backbone_modal_loaded', function( evt, target ) {
 					if ( 'wc-modal-shipping-method-settings' === target ) {
 						wcFreeShippingShowHideMinAmountField( $( '#wc-backbone-modal-dialog #woocommerce_free_shipping_requires', evt.currentTarget ) );

--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -297,13 +297,13 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			wc_enqueue_js(
 				"
 				// Update value on change.
-				jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).change( function() {
+				jQuery( '.dropdown_layered_nav_" . esc_js( $taxonomy_filter_name ) . "' ).on( 'change', function() {
 					var slug = jQuery( this ).val();
 					jQuery( ':input[name=\"filter_" . esc_js( $taxonomy_filter_name ) . "\"]' ).val( slug );
 
 					// Submit form on change if standard dropdown.
 					if ( ! jQuery( this ).attr( 'multiple' ) ) {
-						jQuery( this ).closest( 'form' ).submit();
+						jQuery( this ).closest( 'form' ).trigger( 'submit' );
 					}
 				});
 

--- a/includes/widgets/class-wc-widget-product-categories.php
+++ b/includes/widgets/class-wc-widget-product-categories.php
@@ -245,7 +245,7 @@ class WC_Widget_Product_Categories extends WC_Widget {
 
 			wc_enqueue_js(
 				"
-				jQuery( '.dropdown_product_cat' ).change( function() {
+				jQuery( '.dropdown_product_cat' ).on( 'change', function() {
 					if ( jQuery(this).val() != '' ) {
 						var this_page = '';
 						var home_url  = '" . esc_js( home_url( '/' ) ) . "';


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates WooCommerce for compatibility with jQuery 3 in preparation of the removal of jQuery Migrate in a future version of WordPress.

closes #28284 #28286

For reference, I am using this documentation here https://jquery.com/upgrade-guide/3.0/ and here https://github.com/jquery/jquery-migrate/blob/master/warnings.md

### How to test the changes in this Pull Request:

**IMPORTANT NOTE**

It is quite difficult or not feasible to test every line changes. You may not even know how or where to try and produce the results. We can only test everything we do know such as critical flows and little tidbits.

There are some gotchas that I've found and will document that here p7bje6-2VM-p2#comment-5896.

1. Install [this plugin](https://wordpress.org/plugins/wp-jquery-update-test/) and disable jQuery Migrate.
2. Open your browser's javascript console and look for errors while testing the critical flows.
3. Go through the critical flows in WooCommerce and verify that they still function.


### Changelog entry
> Fix - Migrate deprecated jQuery 3 functions.