### PR TITLE
Fix: Shipping methods with similar names could cause shipping method not selectable in order page

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-shipping.php
+++ b/includes/admin/meta-boxes/views/html-order-shipping.php
@@ -31,11 +31,11 @@ if ( ! defined( 'ABSPATH' ) ) {
 					$found_method = false;
 
 					foreach ( $shipping_methods as $method ) {
-						$current_method = ( 0 === strpos( $item->get_method_id(), $method->id ) ) ? $item->get_method_id() : $method->id;
+						$is_active = $item->get_method_id() === $method->id;
 
-						echo '<option value="' . esc_attr( $current_method ) . '" ' . selected( $item->get_method_id() === $current_method, true, false ) . '>' . esc_html( $method->get_method_title() ) . '</option>';
+						echo '<option value="' . esc_attr( $method->id ) . '" ' . selected( true, $is_active, false ) . '>' . esc_html( $method->get_method_title() ) . '</option>';
 
-						if ( $item->get_method_id() === $current_method ) {
+						if ( $is_active ) {
 							$found_method = true;
 						}
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29048.

### How to test the changes in this Pull Request:

1. Add two custom shipping methods when 1 shipping method ID consists of another shipping method id.
2. Go to the edit order page.
3. Choose the shipping method with the longer id.
4. Save
5. You can't choose the shipping method with a shorter id.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Shipping methods with similar names could cause shipping method not selectable in order page.