### PR TITLE
👌 IMPROVE: Add body class woocommerce-shop to shop page

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -303,11 +303,11 @@ function wc_body_class( $classes ) {
 
 	if ( is_shop() ) {
 
-		$classes[] = 'woocommerce';
 		$classes[] = 'woocommerce-shop';
-		$classes[] = 'woocommerce-page';
 
-	} elseif ( is_woocommerce() ) {
+	} 
+	
+	if ( is_woocommerce() ) {
 
 		$classes[] = 'woocommerce';
 		$classes[] = 'woocommerce-page';

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -305,8 +305,8 @@ function wc_body_class( $classes ) {
 
 		$classes[] = 'woocommerce-shop';
 
-	} 
-	
+	}
+
 	if ( is_woocommerce() ) {
 
 		$classes[] = 'woocommerce';

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -301,7 +301,13 @@ function wc_generator_tag( $gen, $type ) {
 function wc_body_class( $classes ) {
 	$classes = (array) $classes;
 
-	if ( is_woocommerce() ) {
+	if ( is_shop() ) {
+
+		$classes[] = 'woocommerce';
+		$classes[] = 'woocommerce-shop';
+		$classes[] = 'woocommerce-page';
+
+	} elseif ( is_woocommerce() ) {
 
 		$classes[] = 'woocommerce';
 		$classes[] = 'woocommerce-page';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add the body class `woocommerce-shop` to the WooCommerce shop page, so that it can be targeted to add custom CSS code.

Closes #28724 | See also p9F6qB-6sW-p2

### How to test the changes in this Pull Request:

1. Check out this PR
2. Go to `/shop/` 
3. Open the inspector
4. Look up the body classes
5. See the class `woocommerce-shop`

<table>
<tr>
<td valign="top">Before:
<br><br>

`<body class="archive post-type-archive post-type-archive-product logged-in admin-bar wp-embed-responsive theme-storefront woocommerce woocommerce-page woocommerce-js storefront-full-width-content storefront-align-wide right-sidebar woocommerce-active customize-support">`
</td>
<td valign="top">After:
<br><br>

`<body class="archive post-type-archive post-type-archive-product logged-in admin-bar wp-embed-responsive theme-storefront woocommerce woocommerce-shop woocommerce-page woocommerce-js storefront-full-width-content storefront-align-wide right-sidebar woocommerce-active customize-support">`
</td>
</tr>
</table>

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Additional note

To keep backwards compatibility, the body class `woocommerce-shop` had been added to the existing body classes `woocommerce` and `woocommerce-page`. Using the same body class structure as for the cart, checkout and account page, thus, removing the body class `woocommerce` would break functionality such as showing the sales labels correctly.

### Changelog entry

> Enhancement - Added the body class `woocommerce-shop` to the shop page, so that it can be targeted via CSS. (#28724)
