### PR TITLE
Add tracks event for WooCommerce Payments install via wc-addons page

### DIFF
--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -704,7 +704,9 @@ class WC_Admin_Addons {
 			'repo-slug' => 'woocommerce-payments',
 		);
 
-		WC_Install::background_installer( $services_plugin_id, $wcpay_plugin );
+		WC_Install::background_installer( $wcpay_plugin_id, $wcpay_plugin );
+
+		do_action( 'wc_addons_woocommerce_payments_installed' );
 
 		wp_safe_redirect( remove_query_arg( array( 'install-addon', '_wpnonce' ) ) );
 		exit;

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -706,7 +706,7 @@ class WC_Admin_Addons {
 
 		WC_Install::background_installer( $wcpay_plugin_id, $wcpay_plugin );
 
-		do_action( 'wc_addons_woocommerce_payments_installed' );
+		do_action( 'woocommerce_addon_installed', $wcpay_plugin_id );
 
 		wp_safe_redirect( remove_query_arg( array( 'install-addon', '_wpnonce' ) ) );
 		exit;

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -641,7 +641,7 @@ class WC_Admin_Addons {
 					self::install_woocommerce_services_addon();
 					break;
 				case 'woocommerce-payments':
-					self::install_woocommerce_payments_addon();
+					self::install_woocommerce_payments_addon( $section );
 					break;
 				default:
 					// Do nothing.
@@ -693,9 +693,11 @@ class WC_Admin_Addons {
 	/**
 	 * Install WooCommerce Payments from the Extensions screens.
 	 *
+	 * @param string $section Optional. Extenstions tab.
+	 *
 	 * @return void
 	 */
-	public static function install_woocommerce_payments_addon() {
+	public static function install_woocommerce_payments_addon( $section = '_featured' ) {
 		check_admin_referer( 'install-addon_woocommerce-payments' );
 
 		$wcpay_plugin_id = 'woocommerce-payments';
@@ -706,7 +708,7 @@ class WC_Admin_Addons {
 
 		WC_Install::background_installer( $wcpay_plugin_id, $wcpay_plugin );
 
-		do_action( 'woocommerce_addon_installed', $wcpay_plugin_id );
+		do_action( 'woocommerce_addon_installed', $wcpay_plugin_id, $section );
 
 		wp_safe_redirect( remove_query_arg( array( 'install-addon', '_wpnonce' ) ) );
 		exit;

--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -21,6 +21,7 @@ class WC_Extensions_Tracking {
 		add_action( 'woocommerce_helper_connected', array( $this, 'track_helper_connection_complete' ) );
 		add_action( 'woocommerce_helper_disconnected', array( $this, 'track_helper_disconnected' ) );
 		add_action( 'woocommerce_helper_subscriptions_refresh', array( $this, 'track_helper_subscriptions_refresh' ) );
+		add_action( 'wc_addons_woocommerce_payments_installed', array( $this, 'track_woocommerce_payments_install' ) );
 	}
 
 	/**
@@ -75,5 +76,15 @@ class WC_Extensions_Tracking {
 	 */
 	public function track_helper_subscriptions_refresh() {
 		WC_Tracks::record_event( 'extensions_subscriptions_update' );
+	}
+
+	/**
+	 * Send a Tracks event when WooCommerce Payments is installed from the Extensions page.
+	 */
+	public function track_woocommerce_payments_install() {
+
+		$properties = array( 'context' => 'extensions' );
+
+		WC_Tracks::record_event( 'woocommerce_payments_install', $properties );
 	}
 }

--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -21,7 +21,7 @@ class WC_Extensions_Tracking {
 		add_action( 'woocommerce_helper_connected', array( $this, 'track_helper_connection_complete' ) );
 		add_action( 'woocommerce_helper_disconnected', array( $this, 'track_helper_disconnected' ) );
 		add_action( 'woocommerce_helper_subscriptions_refresh', array( $this, 'track_helper_subscriptions_refresh' ) );
-		add_action( 'wc_addons_woocommerce_payments_installed', array( $this, 'track_woocommerce_payments_install' ) );
+		add_action( 'woocommerce_addon_installed', array( $this, 'track_addon_install' ) );
 	}
 
 	/**
@@ -79,12 +79,19 @@ class WC_Extensions_Tracking {
 	}
 
 	/**
-	 * Send a Tracks event when WooCommerce Payments is installed from the Extensions page.
+	 * Send a Tracks event when addon is installed via the Extensions page.
+	 *
+	 * @param string $addon_id Addon slug.
 	 */
-	public function track_woocommerce_payments_install() {
+	public function track_addon_install( $addon_id = '' ) {
+		if ( empty( $addon_id ) ) {
+			return;
+		}
 
 		$properties = array( 'context' => 'extensions' );
 
-		WC_Tracks::record_event( 'woocommerce_payments_install', $properties );
+		if ( 'woocommerce-payments' === $addon_id ) {
+			WC_Tracks::record_event( 'woocommerce_payments_install', $properties );
+		}
 	}
 }

--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -21,7 +21,7 @@ class WC_Extensions_Tracking {
 		add_action( 'woocommerce_helper_connected', array( $this, 'track_helper_connection_complete' ) );
 		add_action( 'woocommerce_helper_disconnected', array( $this, 'track_helper_disconnected' ) );
 		add_action( 'woocommerce_helper_subscriptions_refresh', array( $this, 'track_helper_subscriptions_refresh' ) );
-		add_action( 'woocommerce_addon_installed', array( $this, 'track_addon_install' ) );
+		add_action( 'woocommerce_addon_installed', array( $this, 'track_addon_install' ), 10, 2 );
 	}
 
 	/**
@@ -82,13 +82,13 @@ class WC_Extensions_Tracking {
 	 * Send a Tracks event when addon is installed via the Extensions page.
 	 *
 	 * @param string $addon_id Addon slug.
+	 * @param string $section  Extensions tab.
 	 */
-	public function track_addon_install( $addon_id = '' ) {
-		if ( empty( $addon_id ) ) {
-			return;
-		}
-
-		$properties = array( 'context' => 'extensions' );
+	public function track_addon_install( $addon_id, $section ) {
+		$properties = array(
+			'context' => 'extensions',
+			'section' => $section,
+		);
 
 		if ( 'woocommerce-payments' === $addon_id ) {
 			WC_Tracks::record_event( 'woocommerce_payments_install', $properties );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
This adds a tracks event for WooCommerce Payments installs via the
wc-addons page.

See p1612278892009000-slack-C0144BMA170 for more details.

### How to test the changes in this Pull Request:

1. Make sure your store location is set to within the US and WooCommerce Payments is not installed.
2. Go to the wc-addons page (**WooCommerce > Home > Extensions**) and look for the following banner: https://cloudup.com/c2tYAq7O4Wp
3. Install via the button, and after 5-10 minutes check tracks live view for a `wcadmin_woocommerce_payments_install` with the context prop of `extensions`.

Note this event is also implemented in https://github.com/woocommerce/woocommerce-admin/pull/6285 with the context of `tasklist`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Dev - Track the number of installations of WooCommerce Payments via that extensions banner for stores that have opted in to tracking.