### PR TITLE
fix import in get-app-name.js

### DIFF
--- a/tests/e2e/env/utils/get-app-name.js
+++ b/tests/e2e/env/utils/get-app-name.js
@@ -1,7 +1,7 @@
 /**
  * Provide the application name to bash scripts.
  */
-const getAppName = require( './app-name' );
+const { getAppName } = require( './app-name' );
 const appName = getAppName();
 
 console.log( appName );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes the `getAppName` import in `get-app-name.js`

### How to test the changes in this Pull Request:

1. Run `npx wc-e2e docker:up`
2. Run `npx wc-e2e docker:ssh`
3. In master this produces an error
4. In this branch you should SSH into `/var/www/html`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A
