### PR TITLE
Add e2e test: merchant order customer payment page

### DIFF
--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -11,8 +11,7 @@
 - Added new config variable for Simple Product price to `tests/e2e/env/config/default.json`. Defaults to 9.99
 - Shopper Single Product tests
 - Shopper Checkout Apply Coupon
-
-
+- Merchant Orders Customer Checkout Page
 - Shopper Cart Apply Coupon
 
 ## Fixed

--- a/tests/e2e/core-tests/README.md
+++ b/tests/e2e/core-tests/README.md
@@ -55,6 +55,7 @@ The functions to access the core tests are:
   - `runOrderStatusFilterTest` - Merchant can filter orders by order status
   - `runOrderRefundTest` - Merchant can refund an order
   - `runOrderApplyCouponTest` - Merchant can apply a coupon to an order
+  - `runMerchantOrdersCustomerPaymentPage` - Merchant can visit the customer payment page
 
 ### Shopper
 

--- a/tests/e2e/core-tests/specs/index.js
+++ b/tests/e2e/core-tests/specs/index.js
@@ -26,6 +26,7 @@ const runTaxSettingsTest = require( './merchant/wp-admin-settings-tax.test' );
 const runOrderStatusFiltersTest = require( './merchant/wp-admin-order-status-filters.test' );
 const runOrderRefundTest = require( './merchant/wp-admin-order-refund.test' );
 const runOrderApplyCouponTest = require( './merchant/wp-admin-order-apply-coupon.test' );
+const runMerchantOrdersCustomerPaymentPage = require( './merchant/wp-admin-order-customer-payment-page.test' );
 
 const runSetupOnboardingTests = () => {
 	runActivationTest();
@@ -54,6 +55,7 @@ const runMerchantTests = () => {
 	runOrderStatusFiltersTest();
 	runOrderRefundTest();
 	runOrderApplyCouponTest();
+	runMerchantOrdersCustomerPaymentPage();
 }
 
 module.exports = {
@@ -79,5 +81,6 @@ module.exports = {
 	runOrderStatusFiltersTest,
 	runOrderRefundTest,
 	runOrderApplyCouponTest,
+	runMerchantOrdersCustomerPaymentPage,
 	runMerchantTests,
 };

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
@@ -34,7 +34,7 @@ const runMerchantOrdersCustomerPaymentPage = () => {
 				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 			]);
 
-			// Verify the customer payment page link it showing
+			// Verify the customer payment page link is displayed
 			await expect(page).toMatchElement( 'label[for=order_status] > a' , { text: 'Customer payment page →' });
 
 			// Visit the page

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
@@ -1,0 +1,68 @@
+/* eslint-disable jest/no-export, jest/no-disabled-tests */
+import {createSimpleProduct} from "@woocommerce/e2e-utils";
+
+/**
+ * Internal dependencies
+ */
+const {
+	merchant,
+	createSimpleOrder,
+	addProductToOrder,
+} = require( '@woocommerce/e2e-utils' );
+
+const config = require( 'config' );
+const simpleProductName = config.get( 'products.simple.name' );
+const simpleProductPrice = config.has( 'products.simple.price' ) ? config.get( 'products.simple.price' ) : '9.99';
+
+let orderId;
+
+const runMerchantOrdersCustomerPaymentPage = () => {
+	describe('WooCommerce Merchant Flow: Orders > Customer Payment Page', () => {
+		beforeAll(async () => {
+			await merchant.login();
+			await createSimpleProduct();
+			orderId = await createSimpleOrder();
+			await addProductToOrder( orderId, simpleProductName );
+		});
+
+		it('should be able to view the customer order page and complete payment', async () => {
+			await merchant.goToOrder( orderId );
+
+			// We first need to click "Update" otherwise the link doesn't show
+			await Promise.all([
+				expect(page).toClick( 'button.save_order' ),
+				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			]);
+
+			// Verify the customer payment page link it showing
+			await expect(page).toMatchElement( 'label[for=order_status] > a' , { text: 'Customer payment page →' });
+
+			// Visit the page
+			await Promise.all([
+				expect(page).toClick( 'label[for=order_status] > a' ),
+				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			]);
+
+			// Verify we landed on the customer payment page
+			await expect(page).toMatchElement( 'h1.entry-title' , { text: 'Pay for order' });
+			await expect(page).toMatchElement( 'td.product-name' , { text: simpleProductName });
+			await expect(page).toMatchElement( 'span.woocommerce-Price-amount.amount' , { text: simpleProductPrice });
+
+			// Pay for the order
+			await Promise.all([
+				expect(page).toClick( '#place_order'),
+				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			]);
+
+			// Verify we landed on the order received page
+			await expect(page).toMatchElement( 'h1.entry-title', { text: 'Order received' });
+			await expect(page).toMatchElement( 'li.woocommerce-order-overview__order.order' , { text: orderId.toString() });
+			await expect(page).toMatchElement( 'span.woocommerce-Price-amount.amount' , { text: simpleProductPrice });
+
+		});
+
+	});
+
+};
+
+module.exports = runMerchantOrdersCustomerPaymentPage;

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
@@ -1,4 +1,4 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests */
+/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/no-standalone-expect */
 import {createSimpleProduct} from "@woocommerce/e2e-utils";
 
 /**
@@ -10,6 +10,7 @@ const {
 	addProductToOrder,
 } = require( '@woocommerce/e2e-utils' );
 
+// TODO create a function for the logic below getConfigSimpleProduct(), see: https://github.com/woocommerce/woocommerce/issues/29072
 const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );
 const simpleProductPrice = config.has( 'products.simple.price' ) ? config.get( 'products.simple.price' ) : '9.99';
@@ -23,10 +24,6 @@ const runMerchantOrdersCustomerPaymentPage = () => {
 			await createSimpleProduct();
 			orderId = await createSimpleOrder();
 			await addProductToOrder( orderId, simpleProductName );
-		});
-
-		it('should be able to view the customer order page and complete payment', async () => {
-			await merchant.goToOrder( orderId );
 
 			// We first need to click "Update" otherwise the link doesn't show
 			await Promise.all([
@@ -34,6 +31,20 @@ const runMerchantOrdersCustomerPaymentPage = () => {
 				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
 			]);
 
+		});
+
+		it('should show the customer payment page link on a pending payment order', async () => {
+			await merchant.goToOrder( orderId );
+
+			// Verify the order is still pending payment
+			await expect( page ).toMatchElement( '#order_status', { text: 'Pending payment' } );
+
+			// Verify the customer payment page link is displayed
+			await expect(page).toMatchElement( 'label[for=order_status] > a' , { text: 'Customer payment page →' });
+		});
+
+
+		it('should load the customer payment page', async () => {
 			// Verify the customer payment page link is displayed
 			await expect(page).toMatchElement( 'label[for=order_status] > a' , { text: 'Customer payment page →' });
 
@@ -47,6 +58,11 @@ const runMerchantOrdersCustomerPaymentPage = () => {
 			await expect(page).toMatchElement( 'h1.entry-title' , { text: 'Pay for order' });
 			await expect(page).toMatchElement( 'td.product-name' , { text: simpleProductName });
 			await expect(page).toMatchElement( 'span.woocommerce-Price-amount.amount' , { text: simpleProductPrice });
+		});
+
+		it('can pay for the order through the customer payment page', async () => {
+			// Make sure we're still on the customer payment page
+			await expect(page).toMatchElement( 'h1.entry-title' , { text: 'Pay for order' });
 
 			// Pay for the order
 			await Promise.all([
@@ -58,7 +74,6 @@ const runMerchantOrdersCustomerPaymentPage = () => {
 			await expect(page).toMatchElement( 'h1.entry-title', { text: 'Order received' });
 			await expect(page).toMatchElement( 'li.woocommerce-order-overview__order.order' , { text: orderId.toString() });
 			await expect(page).toMatchElement( 'span.woocommerce-Price-amount.amount' , { text: simpleProductPrice });
-
 		});
 
 	});

--- a/tests/e2e/specs/wp-admin/test-order-customer-payment-page.js
+++ b/tests/e2e/specs/wp-admin/test-order-customer-payment-page.js
@@ -1,0 +1,6 @@
+/*
+ * Internal dependencies
+ */
+const { runMerchantOrdersCustomerPaymentPage } = require( '@woocommerce/e2e-core-tests' );
+
+runMerchantOrdersCustomerPaymentPage();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds tests around the `Merchant / Orders > Customer Order Page` workflow.

Closes https://github.com/woocommerce/woocommerce/issues/27878.

### How to test the changes in this Pull Request:

1. Make sure the new and existing tests pass locally and on Travis. Tests can be ran following [these instructions](https://github.com/woocommerce/woocommerce/tree/master/tests/e2e#running-tests)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A