### PR TITLE
Update class-wc-shipping.php

### DIFF
--- a/includes/class-wc-shipping.php
+++ b/includes/class-wc-shipping.php
@@ -332,7 +332,7 @@ class WC_Shipping {
 		// Calculate the hash for this package so we can tell if it's changed since last calculation.
 		$package_hash = 'wc_ship_' . md5( wp_json_encode( $package_to_hash ) . WC_Cache_Helper::get_transient_version( 'shipping' ) );
 
-		if ( ! is_array( $stored_rates ) || $package_hash !== $stored_rates['package_hash'] || 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' ) ) {
+		if ( ! is_array( $stored_rates ) || $package_hash !== $stored_rates['package_hash'] || 'yes' === get_option( 'woocommerce_shipping_debug_mode', 'no' ) || apply_filters( 'woocommerce_shipping_stored_rates_cache_disable', false ) ) {
 			foreach ( $this->load_shipping_methods( $package ) as $shipping_method ) {
 				if ( ! $shipping_method->supports( 'shipping-zones' ) || $shipping_method->get_instance_id() ) {
 					/**


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
A hook to be able to avoid the shipping stored rates cache would be very useful if we need to disable it without activating the debug mode (that always shows also a notice with the shipping zone found).

Closes #29013 .

### How to test the changes in this Pull Request:

1. In your child theme or in a plugin, you can add this filter: add_filter( 'woocommerce_shipping_stored_rates_cache_disable', function(){ return true; } );
2. Shipping cache won't be used and you can do some operations over shipping methods like enable/disable it by hours/days
3. But notice about detected shipping zone won't be shown because debug would not be activated (this is the current way to disable this cache)

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### Changelog entry
Created new filter to disable shipping method cache when necessary