### PR TITLE
Make cart coupons test more granular

### DIFF
--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
@@ -65,10 +65,8 @@ const runCartApplyCouponsTest = () => {
 			await applyCouponToCart( couponFixedCart );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
-			// Wait for page to expand total calculations to avoid flakyness
-			await page.waitForSelector('.order-total');
-
 			// Verify discount applied and order total
+			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
 			await removeCouponFromCart();
@@ -79,6 +77,7 @@ const runCartApplyCouponsTest = () => {
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Verify discount applied and order total
+			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$4.99'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$5.00'});
 			await removeCouponFromCart();
@@ -87,6 +86,9 @@ const runCartApplyCouponsTest = () => {
 		it('allows customer to apply fixed product coupon', async () => {
 			await applyCouponToCart( couponFixedProduct );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
+
+			// Verify discount applied and order total
+			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
 			await removeCouponFromCart();
@@ -105,6 +107,9 @@ const runCartApplyCouponsTest = () => {
 		it('allows customer to apply multiple coupons', async () => {
 			await applyCouponToCart( couponFixedProduct );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
+
+			// Verify discount applied and order total
+			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.order-total .amount', {text: '$0.00'});
 		});
 

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
@@ -7,7 +7,8 @@ const {
 	merchant,
 	createCoupon,
 	createSimpleProduct,
-	uiUnblocked
+	uiUnblocked,
+	clearAndFillInput,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -19,11 +20,36 @@ const {
 	beforeAll,
 } = require( '@jest/globals' );
 
+/**
+ * Apply a coupon code to the cart.
+ *
+ * @param couponCode string
+ * @returns {Promise<void>}
+ */
+const applyCouponToCart = async ( couponCode ) => {
+	await expect(page).toClick('a', {text: 'Click here to enter your code'});
+	await uiUnblocked();
+	await clearAndFillInput('#coupon_code', couponCode);
+	await expect(page).toClick('button', {text: 'Apply coupon'});
+	await uiUnblocked();
+};
+
+/**
+ * Remove one coupon from the cart.
+ *
+ * @returns {Promise<void>}
+ */
+const removeCouponFromCart = async () => {
+	await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
+	await uiUnblocked();
+	await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon has been removed.'});
+}
 const runCartApplyCouponsTest = () => {
 	describe('Cart applying coupons', () => {
-			let couponFixedCart;
-			let couponPercentage;
-			let couponFixedProduct;
+		let couponFixedCart;
+		let couponPercentage;
+		let couponFixedProduct;
+		
 		beforeAll(async () => {
 			await merchant.login();
 			await createSimpleProduct();
@@ -31,76 +57,63 @@ const runCartApplyCouponsTest = () => {
 			couponPercentage = await createCoupon('50', 'Percentage discount');
 			couponFixedProduct = await createCoupon('5', 'Fixed product discount');
 			await merchant.logout();
-		});
-
-		it('allows customer to apply coupons in the cart', async () => {
 			await shopper.goToShop();
 			await shopper.addToCartFromShopPage('Simple product');
-			await shopper.goToCart();
-			await shopper.productIsInCart('Simple product');
-
-			// Apply Fixed cart discount coupon
-			await expect(page).toFill('#coupon_code', couponFixedCart);
-			await expect(page).toClick('button', {text: 'Apply coupon'});
 			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon code applied successfully.'});
+			await shopper.goToCart();
+		});
+
+		it('allows customer to apply fixed cart coupon', async () => {
+			await applyCouponToCart( couponFixedCart );
+			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Wait for page to expand total calculations to avoid flakyness
 			await page.waitForSelector('.order-total');
 
 			// Verify discount applied and order total
-			await page.waitForSelector('.cart-discount .amount', {text: '$5.00'});
-			await page.waitForSelector('.order-total .amount', {text: '$4.99'});
+			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
+			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
+			await removeCouponFromCart();
+		});
 
-			// Remove coupon
-			await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon has been removed.'});
+		it('allows customer to apply percentage coupon', async () => {
+			await applyCouponToCart( couponPercentage );
+			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
-			// Apply Percentage discount coupon
-			await expect(page).toFill('#coupon_code', couponPercentage);
-			await expect(page).toClick('button', {text: 'Apply coupon'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon code applied successfully.'});
-			await page.waitForSelector('.cart-discount .amount', {text: '$4.99'});
-			await page.waitForSelector('.order-total .amount', {text: '$5.00'});
+			// Verify discount applied and order total
+			await expect(page).toMatchElement('.cart-discount .amount', {text: '$4.99'});
+			await expect(page).toMatchElement('.order-total .amount', {text: '$5.00'});
+			await removeCouponFromCart();
+		});
 
-			// Remove coupon
-			await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon has been removed.'});
+		it('allows customer to apply fixed product coupon', async () => {
+			await applyCouponToCart( couponFixedProduct );
+			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
+			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
+			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
+			await removeCouponFromCart();
+		});
 
-			// Apply Fixed product discount coupon
-			await expect(page).toFill('#coupon_code', couponFixedProduct);
-			await expect(page).toClick('button', {text: 'Apply coupon'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon code applied successfully.'});
-			await page.waitForSelector('.cart-discount .amount', {text: '$5.00'});
-			await page.waitForSelector('.order-total .amount', {text: '$4.99'});
+		it('prevents customer applying same coupon twice', async () => {
+			await applyCouponToCart( couponFixedCart );
+			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
+			await applyCouponToCart( couponFixedCart );
+			// Verify only one discount applied
+			// This is a work around for Puppeteer inconsistently finding 'Coupon code already applied'
+			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
+			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
+		});
 
-			// Try to apply the same coupon
-			await expect(page).toFill('#coupon_code', couponFixedProduct);
-			await expect(page).toClick('button', {text: 'Apply coupon'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-error', { text: 'Coupon code already applied!' });
+		it('allows customer to apply multiple coupons', async () => {
+			await applyCouponToCart( couponFixedProduct );
+			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
+			await expect(page).toMatchElement('.order-total .amount', {text: '$0.00'});
+		});
 
-			// Try to apply multiple coupons
-			await expect(page).toFill('#coupon_code', couponFixedCart);
-			await expect(page).toClick('button', {text: 'Apply coupon'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon code applied successfully.'});
-			await page.waitForSelector('.order-total .amount', {text: '$0.00'});
-
-			// Remove coupon
-			await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon has been removed.'});
-			await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
-			await uiUnblocked();
-			await page.waitForSelector('.woocommerce-message', {text: 'Coupon has been removed.'});
-
-			// Verify the total amount after all coupons removal
-			await page.waitForSelector('.order-total .amount', {text: '$9.99'});
+		it('restores cart total when coupons are removed', async () => {
+			await removeCouponFromCart();
+			await removeCouponFromCart();
+			await expect(page).toMatchElement('.order-total .amount', {text: '$9.99'});
 		});
 	});
 };

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
@@ -27,8 +27,6 @@ const {
  * @returns {Promise<void>}
  */
 const applyCouponToCart = async ( couponCode ) => {
-	await expect(page).toClick('a', {text: 'Click here to enter your code'});
-	await uiUnblocked();
 	await clearAndFillInput('#coupon_code', couponCode);
 	await expect(page).toClick('button', {text: 'Apply coupon'});
 	await uiUnblocked();
@@ -49,7 +47,7 @@ const runCartApplyCouponsTest = () => {
 		let couponFixedCart;
 		let couponPercentage;
 		let couponFixedProduct;
-		
+
 		beforeAll(async () => {
 			await merchant.login();
 			await createSimpleProduct();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR breaks the cart coupon test into multiple tests to make it easier to determine which part of the test failed. The two intermittent issues that I found were. We did the same thing for the checkout coupons previously.

- the second `expect(page).toFill(` in the apply coupon twice test was appending the second coupon code to the first instead of replacing it
- Puppeteer would not consistently find/recognize `Coupon code already applied!` notice
- I will make another pull request to move methods from tests to page-utils and to update both cart and checkout tests to have it included.

### How to test the changes in this Pull Request:

1. Verify Travis E2E run
2. Run shopper.test.js locally

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A