### PR TITLE
Move admin menu manipulation from admin_head to admin_menu

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -31,8 +31,8 @@ class WC_Admin_Menus {
 			add_action( 'admin_menu', array( $this, 'addons_menu' ), 70 );
 		}
 
-		add_action( 'admin_head', array( $this, 'menu_highlight' ) );
-		add_action( 'admin_head', array( $this, 'menu_order_count' ) );
+		add_action( 'admin_menu', array( $this, 'menu_highlight' ) );
+		add_action( 'admin_menu', array( $this, 'menu_order_count' ) );
 		add_filter( 'menu_order', array( $this, 'menu_order' ) );
 		add_filter( 'custom_menu_order', array( $this, 'custom_menu_order' ) );
 		add_filter( 'set-screen-option', array( $this, 'set_screen_option' ), 10, 3 );

--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -22,6 +22,8 @@ class WC_Admin_Menus {
 	 */
 	public function __construct() {
 		// Add menus.
+		add_action( 'admin_menu', array( $this, 'menu_highlight' ) );
+		add_action( 'admin_menu', array( $this, 'menu_order_count' ) );
 		add_action( 'admin_menu', array( $this, 'admin_menu' ), 9 );
 		add_action( 'admin_menu', array( $this, 'reports_menu' ), 20 );
 		add_action( 'admin_menu', array( $this, 'settings_menu' ), 50 );
@@ -31,8 +33,6 @@ class WC_Admin_Menus {
 			add_action( 'admin_menu', array( $this, 'addons_menu' ), 70 );
 		}
 
-		add_action( 'admin_menu', array( $this, 'menu_highlight' ) );
-		add_action( 'admin_menu', array( $this, 'menu_order_count' ) );
 		add_filter( 'menu_order', array( $this, 'menu_order' ) );
 		add_filter( 'custom_menu_order', array( $this, 'custom_menu_order' ) );
 		add_filter( 'set-screen-option', array( $this, 'set_screen_option' ), 10, 3 );


### PR DESCRIPTION
**_Note: This PR should be tested in conjunction with https://github.com/woocommerce/woocommerce-admin/pull/6310_**

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR move WooCommerce's admin menu manipulation from `admin_head` hooks to `admin_menu` hooks. This, along with a corresponding fix in `woocommerce/woocommerce-admin`, addresses the issues seen when the WooCommerce admin menu is displayed in Calypso when WordPress.com's Nav Unification is enabled (currently only for Automatticians). See pbIJXs-Ee-p2 for more details.

Specifically, the following issues are fixed when using Calypso with WordPress.com's Nav Unification enabled:

- The WooCommerce submenu item gets replaced by the Home submenu item, and clicking on it correctly shows the WooCommerce Admin home screen
- The Orders count appears

When accessing wp-admin, there should be no change to the WooCommerce admin menus.

#### Before

![Before admin_menu](https://user-images.githubusercontent.com/2098816/107539529-0dc04100-6b93-11eb-9517-1fc97aca8bca.png)

#### After

![After admin_menu](https://user-images.githubusercontent.com/2098816/107539561-144eb880-6b93-11eb-8a43-0a0cdc7a8440.png)

Note: The following issues will be addressed in separate PRs:

- Products menu item position: May be fixed by either https://github.com/woocommerce/woocommerce/pull/28763 or https://github.com/Automattic/jetpack/pull/18758
- WooCommerce and Products menu icons: Issue https://github.com/Automattic/wp-calypso/issues/49145; may be fixed by switching to SVG icons (issue with that: https://github.com/Automattic/wp-calypso/issues/49145)

### How to test the changes in this Pull Request:

#### General wp-admin testing without Nav Unification

1. Checkout this branch.
2. Checkout the corresponding `woocommerce/woocommerce-admin` branch (https://github.com/woocommerce/woocommerce-admin/pull/6310) and activate the plugin.
3. Access wp-admin.
4. Verify that all WooCommerce admin menus appear and function the same as before.

#### Testing Nav Unification

Make your test site act like an "Atomic" site:

5. Connect Jetpack on your test site to WordPress.com.
6. Clone `wpcomsh` repo (see https://github.com/Automattic/wpcomsh for details)
7. Checkout the `add/admin-menu-request-impersonation` branch (577-gh-Automattic/wpcomsh)
8. Add a plugin to `mu-plugins` with the following line, to enable Nav Unification:

```
add_filter( 'jetpack_load_admin_menu_class', '__return_true' );
```

9. Access your connected site from WordPress.com (Calypso) and verify that the menu items appear correctly (excluding issues described above)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Dev: Admin menu modification has been moved from `admin_head` hooks to `admin_menu` hooks.