### PR TITLE
Update the woo widget stock links to new analytics page

### DIFF
--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -107,6 +107,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 		public function status_widget() {
 			include_once dirname( __FILE__ ) . '/reports/class-wc-admin-report.php';
 
+			$is_wc_admin_disabled = apply_filters( 'woocommerce_admin_disabled', false );
+
 			$reports = new WC_Admin_Report();
 
 			echo '<ul class="wc_status_list">';
@@ -151,7 +153,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			}
 
 			$this->status_widget_order_rows();
-			$this->status_widget_stock_rows();
+			$this->status_widget_stock_rows( $is_wc_admin_disabled );
 
 			do_action( 'woocommerce_after_dashboard_status_widget', $reports );
 			echo '</ul>';
@@ -200,8 +202,10 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 
 		/**
 		 * Show stock data is status widget.
+		 *
+		 * @param bool $is_wc_admin_disabled if woocommerce admin is disabled.
 		 */
-		private function status_widget_stock_rows() {
+		private function status_widget_stock_rows( $is_wc_admin_disabled ) {
 			global $wpdb;
 
 			// Requires lookup table added in 3.6.
@@ -246,6 +250,13 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 
 			$transient_name   = 'wc_outofstock_count';
 			$outofstock_count = get_transient( $transient_name );
+			$lowstock_link    = 'admin.php?page=wc-reports&tab=stock&report=low_in_stock';
+			$outofstock_link  = 'admin.php?page=wc-reports&tab=stock&report=out_of_stock';
+
+			if ( false === $is_wc_admin_disabled ) {
+				$lowstock_link   = 'wp-admin/admin.php?page=wc-admin&type=lowstock&path=%2Fanalytics%2Fstock';
+				$outofstock_link = 'wp-admin/admin.php?page=wc-admin&type=outofstock&path=%2Fanalytics%2Fstock';
+			}
 
 			if ( false === $outofstock_count ) {
 				/**
@@ -274,7 +285,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			}
 			?>
 			<li class="low-in-stock">
-			<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=stock&report=low_in_stock' ) ); ?>">
+			<a href="<?php echo esc_url( admin_url( $lowstock_link ) ); ?>">
 				<?php
 					printf(
 						/* translators: %s: order count */
@@ -285,7 +296,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 				</a>
 			</li>
 			<li class="out-of-stock">
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=wc-reports&tab=stock&report=out_of_stock' ) ); ?>">
+				<a href="<?php echo esc_url( admin_url( $outofstock_link ) ); ?>">
 				<?php
 					printf(
 						/* translators: %s: order count */

--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -254,8 +254,8 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 			$outofstock_link  = 'admin.php?page=wc-reports&tab=stock&report=out_of_stock';
 
 			if ( false === $is_wc_admin_disabled ) {
-				$lowstock_link   = 'wp-admin/admin.php?page=wc-admin&type=lowstock&path=%2Fanalytics%2Fstock';
-				$outofstock_link = 'wp-admin/admin.php?page=wc-admin&type=outofstock&path=%2Fanalytics%2Fstock';
+				$lowstock_link   = 'admin.php?page=wc-admin&type=lowstock&path=%2Fanalytics%2Fstock';
+				$outofstock_link = 'admin.php?page=wc-admin&type=outofstock&path=%2Fanalytics%2Fstock';
 			}
 
 			if ( false === $outofstock_count ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Updates the out of stock, low stock links in the WooCommerce widget in the WP dashboard. The point to the new analytics page now if WooCommerce admin is not disabled.

Closes #28570 

### How to test the changes in this Pull Request:

1.  Pull down this branch and make sure Woo is enabled
2. Navigate to the WP dashboard (**Dashboard > Home**) and scroll down to the **WooCommerce Status** widget
3. If no products it should show. **0 products** and **out of stock**, click on this
4. This should direct to `/wp-admin/wp-admin/admin.php?page=wc-admin&type=outofstock&path=%2Fanalytics%2Fstock` and have **Out of Stock** select in the dropdown.
5. Navigate back to the **Woocommerce Status** widget in the WP dashboard
6. This time click on the **low in stock** button
7. This should redirect you to the same analytics page, but this time have **Low Stock** selected in the dropdown.
8. Add `add_filter( 'woocommerce_admin_disabled', '__return_true' );` to your themes `functions.php` file.
9. Load the WP dashboard again
10. Both the above buttons should now be directing to the old **WooCommerce > Reports** screen (check both low stock and out of stock)

![product-stock-links](https://user-images.githubusercontent.com/2240960/107563993-20993c80-6bb8-11eb-99fa-3a3942ba9ef8.gif)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Enhancement - Update the woo widget stock links to the new analytics page.
