### PR TITLE
Check if WC Admin is active before showing message

### DIFF
--- a/includes/admin/views/html-admin-page-reports.php
+++ b/includes/admin/views/html-admin-page-reports.php
@@ -9,6 +9,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 
 ?>
 <div class="wrap woocommerce">
+	<?php if ( WC()->is_wc_admin_active() ) { ?>
 	<div id="message" class="error inline" style="margin-top:30px">
 		<p>
 			<strong>
@@ -19,6 +20,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 			</strong>
 		</p>
 	</div>
+	<?php } ?>
 	<nav class="nav-tab-wrapper woo-nav-tab-wrapper">
 		<?php
 		foreach ( $reports as $key => $report_group ) {
@@ -33,7 +35,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		?>
 	</nav>
 	<?php
-	if ( sizeof( $reports[ $current_tab ]['reports'] ) > 1 ) {
+	if ( count( $reports[ $current_tab ]['reports'] ) > 1 ) {
 		?>
 		<ul class="subsubsub">
 			<li>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Makes sure WC Admin is active before showing message to redirect people to WC Admin.

### How to test the changes in this Pull Request:

1. Add this snippet to your theme's functions.php `add_filter( 'woocommerce_admin_disabled', '__return_true' );`
2. Go to WooCommerce->Reports
3. Check and make sure the deprecation notice does not show any PHP errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Error in notice message of reports when WC Admin is disabled via a filter.
