### PR TITLE
Add new e2e page utils and update coupon tests

### DIFF
--- a/tests/e2e/config/default.json
+++ b/tests/e2e/config/default.json
@@ -1,6 +1,5 @@
 {
   "url": "http://localhost:8084/",
-  "appName": "woocommerce_e2e",
   "users": {
     "admin": {
       "username": "admin",

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
@@ -8,7 +8,8 @@ const {
 	createCoupon,
 	createSimpleProduct,
 	uiUnblocked,
-	clearAndFillInput,
+	applyCoupon,
+	removeCoupon,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -20,28 +21,6 @@ const {
 	beforeAll,
 } = require( '@jest/globals' );
 
-/**
- * Apply a coupon code to the cart.
- *
- * @param couponCode string
- * @returns {Promise<void>}
- */
-const applyCouponToCart = async ( couponCode ) => {
-	await clearAndFillInput('#coupon_code', couponCode);
-	await expect(page).toClick('button', {text: 'Apply coupon'});
-	await uiUnblocked();
-};
-
-/**
- * Remove one coupon from the cart.
- *
- * @returns {Promise<void>}
- */
-const removeCouponFromCart = async () => {
-	await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
-	await uiUnblocked();
-	await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon has been removed.'});
-}
 const runCartApplyCouponsTest = () => {
 	describe('Cart applying coupons', () => {
 		let couponFixedCart;
@@ -62,42 +41,42 @@ const runCartApplyCouponsTest = () => {
 		});
 
 		it('allows customer to apply fixed cart coupon', async () => {
-			await applyCouponToCart( couponFixedCart );
+			await applyCoupon( couponFixedCart );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Verify discount applied and order total
 			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
-			await removeCouponFromCart();
+			await removeCoupon();
 		});
 
 		it('allows customer to apply percentage coupon', async () => {
-			await applyCouponToCart( couponPercentage );
+			await applyCoupon( couponPercentage );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Verify discount applied and order total
 			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$4.99'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$5.00'});
-			await removeCouponFromCart();
+			await removeCoupon();
 		});
 
 		it('allows customer to apply fixed product coupon', async () => {
-			await applyCouponToCart( couponFixedProduct );
+			await applyCoupon( couponFixedProduct );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Verify discount applied and order total
 			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
-			await removeCouponFromCart();
+			await removeCoupon();
 		});
 
 		it('prevents customer applying same coupon twice', async () => {
-			await applyCouponToCart( couponFixedCart );
+			await applyCoupon( couponFixedCart );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
-			await applyCouponToCart( couponFixedCart );
+			await applyCoupon( couponFixedCart );
 			// Verify only one discount applied
 			// This is a work around for Puppeteer inconsistently finding 'Coupon code already applied'
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
@@ -105,7 +84,7 @@ const runCartApplyCouponsTest = () => {
 		});
 
 		it('allows customer to apply multiple coupons', async () => {
-			await applyCouponToCart( couponFixedProduct );
+			await applyCoupon( couponFixedProduct );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Verify discount applied and order total
@@ -114,8 +93,8 @@ const runCartApplyCouponsTest = () => {
 		});
 
 		it('restores cart total when coupons are removed', async () => {
-			await removeCouponFromCart();
-			await removeCouponFromCart();
+			await removeCoupon();
+			await removeCoupon();
 			await expect(page).toMatchElement('.order-total .amount', {text: '$9.99'});
 		});
 	});

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
@@ -41,42 +41,42 @@ const runCartApplyCouponsTest = () => {
 		});
 
 		it('allows customer to apply fixed cart coupon', async () => {
-			await applyCoupon( couponFixedCart );
+			await applyCoupon(couponFixedCart);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Verify discount applied and order total
 			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
-			await removeCoupon();
+			await removeCoupon(couponFixedCart);
 		});
 
 		it('allows customer to apply percentage coupon', async () => {
-			await applyCoupon( couponPercentage );
+			await applyCoupon(couponPercentage);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Verify discount applied and order total
 			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$4.99'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$5.00'});
-			await removeCoupon();
+			await removeCoupon(couponPercentage);
 		});
 
 		it('allows customer to apply fixed product coupon', async () => {
-			await applyCoupon( couponFixedProduct );
+			await applyCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Verify discount applied and order total
 			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
-			await removeCoupon();
+			await removeCoupon(couponFixedProduct);
 		});
 
 		it('prevents customer applying same coupon twice', async () => {
-			await applyCoupon( couponFixedCart );
+			await applyCoupon(couponFixedCart);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
-			await applyCoupon( couponFixedCart );
+			await applyCoupon(couponFixedCart);
 			// Verify only one discount applied
 			// This is a work around for Puppeteer inconsistently finding 'Coupon code already applied'
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
@@ -84,7 +84,7 @@ const runCartApplyCouponsTest = () => {
 		});
 
 		it('allows customer to apply multiple coupons', async () => {
-			await applyCoupon( couponFixedProduct );
+			await applyCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Verify discount applied and order total
@@ -93,8 +93,8 @@ const runCartApplyCouponsTest = () => {
 		});
 
 		it('restores cart total when coupons are removed', async () => {
-			await removeCoupon();
-			await removeCoupon();
+			await removeCoupon(couponFixedCart);
+			await removeCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.order-total .amount', {text: '$9.99'});
 		});
 	});

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -8,7 +8,8 @@ const {
 	createCoupon,
 	createSimpleProduct,
 	uiUnblocked,
-	clearAndFillInput,
+	applyCoupon,
+	removeCoupon,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -20,30 +21,6 @@ const {
 	beforeAll,
 } = require( '@jest/globals' );
 
-/**
- * Apply a coupon code to the cart.
- *
- * @param couponCode string
- * @returns {Promise<void>}
- */
-const applyCouponToCart = async ( couponCode ) => {
-	await expect(page).toClick('a', {text: 'Click here to enter your code'});
-	await uiUnblocked();
-	await clearAndFillInput('#coupon_code', couponCode);
-	await expect(page).toClick('button', {text: 'Apply coupon'});
-	await uiUnblocked();
-};
-
-/**
- * Remove one coupon from the cart.
- *
- * @returns {Promise<void>}
- */
-const removeCouponFromCart = async () => {
-	await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
-	await uiUnblocked();
-	await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon has been removed.'});
-}
 const runCheckoutApplyCouponsTest = () => {
 	describe('Checkout coupons', () => {
 		let couponFixedCart;
@@ -64,7 +41,7 @@ const runCheckoutApplyCouponsTest = () => {
 		});
 
 		it('allows customer to apply fixed cart coupon', async () => {
-			await applyCouponToCart( couponFixedCart );
+			await applyCoupon( couponFixedCart );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Wait for page to expand total calculations to avoid flakyness
@@ -73,31 +50,31 @@ const runCheckoutApplyCouponsTest = () => {
 			// Verify discount applied and order total
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
-			await removeCouponFromCart();
+			await removeCoupon();
 		});
 
 		it('allows customer to apply percentage coupon', async () => {
-			await applyCouponToCart( couponPercentage );
+			await applyCoupon( couponPercentage );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Verify discount applied and order total
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$4.99'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$5.00'});
-			await removeCouponFromCart();
+			await removeCoupon();
 		});
 
 		it('allows customer to apply fixed product coupon', async () => {
-			await applyCouponToCart( couponFixedProduct );
+			await applyCoupon( couponFixedProduct );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
-			await removeCouponFromCart();
+			await removeCoupon();
 		});
 
 		it('prevents customer applying same coupon twice', async () => {
-			await applyCouponToCart( couponFixedCart );
+			await applyCoupon( couponFixedCart );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
-			await applyCouponToCart( couponFixedCart );
+			await applyCoupon( couponFixedCart );
 			// Verify only one discount applied
 			// This is a work around for Puppeteer inconsistently finding 'Coupon code already applied'
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
@@ -105,14 +82,14 @@ const runCheckoutApplyCouponsTest = () => {
 		});
 
 		it('allows customer to apply multiple coupons', async () => {
-			await applyCouponToCart( couponFixedProduct );
+			await applyCoupon( couponFixedProduct );
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$0.00'});
 		});
 
 		it('restores cart total when coupons are removed', async () => {
-			await removeCouponFromCart();
-			await removeCouponFromCart();
+			await removeCoupon();
+			await removeCoupon();
 			await expect(page).toMatchElement('.order-total .amount', {text: '$9.99'});
 		});
 	});

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -41,7 +41,7 @@ const runCheckoutApplyCouponsTest = () => {
 		});
 
 		it('allows customer to apply fixed cart coupon', async () => {
-			await applyCoupon( couponFixedCart );
+			await applyCoupon(couponFixedCart);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Wait for page to expand total calculations to avoid flakyness
@@ -50,31 +50,31 @@ const runCheckoutApplyCouponsTest = () => {
 			// Verify discount applied and order total
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
-			await removeCoupon();
+			await removeCoupon(couponFixedCart);
 		});
 
 		it('allows customer to apply percentage coupon', async () => {
-			await applyCoupon( couponPercentage );
+			await applyCoupon(couponPercentage);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
 			// Verify discount applied and order total
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$4.99'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$5.00'});
-			await removeCoupon();
+			await removeCoupon(couponPercentage);
 		});
 
 		it('allows customer to apply fixed product coupon', async () => {
-			await applyCoupon( couponFixedProduct );
+			await applyCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
-			await removeCoupon();
+			await removeCoupon(couponFixedProduct);
 		});
 
 		it('prevents customer applying same coupon twice', async () => {
-			await applyCoupon( couponFixedCart );
+			await applyCoupon(couponFixedCart);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
-			await applyCoupon( couponFixedCart );
+			await applyCoupon(couponFixedCart);
 			// Verify only one discount applied
 			// This is a work around for Puppeteer inconsistently finding 'Coupon code already applied'
 			await expect(page).toMatchElement('.cart-discount .amount', {text: '$5.00'});
@@ -82,14 +82,14 @@ const runCheckoutApplyCouponsTest = () => {
 		});
 
 		it('allows customer to apply multiple coupons', async () => {
-			await applyCoupon( couponFixedProduct );
+			await applyCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 			await expect(page).toMatchElement('.order-total .amount', {text: '$0.00'});
 		});
 
 		it('restores cart total when coupons are removed', async () => {
-			await removeCoupon();
-			await removeCoupon();
+			await removeCoupon(couponFixedCart);
+			await removeCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.order-total .amount', {text: '$9.99'});
 		});
 	});

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -16,6 +16,8 @@
 - `createCoupon( couponAmount )` component which accepts a coupon amount string (it defaults to 5) and creates a basic coupon. Returns the generated coupon code.
 - `evalAndClick( selector )` use Puppeteer page.$eval to select and click and element.
 - `selectOptionInSelect2( selector, value )` util helper method that search and select in any select2 type field
+- `applyCoupon( couponName )` util helper method which applies previously created coupon to cart or checkout
+- `removeCoupon()` util helper method that removes a single coupon within cart or checkout
 
 ## Changes
 

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -99,6 +99,8 @@ describe( 'Cart page', () => {
 | `clickFilter` | `selector` | Click on a list page filter |
 | `moveAllItemsToTrash` |  | Moves all items in a list view to the Trash |
 | `selectOptionInSelect2` | `selector, value` | helper method that searchs for select2 type fields and select plus insert value inside
+| `applyCoupon` | `couponName` | helper method which applies a coupon in cart or checkout
+| `removeCoupon` | | helper method that removes a single coupon within cart or checkout
 
 ### Test Utilities
 

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -209,6 +209,38 @@ const selectOptionInSelect2 = async ( value, selector = 'input.select2-search__f
 	await page.keyboard.press('Enter');
 };
 
+/**
+ * Apply a coupon code within cart or checkout.
+ * Method will try to apply a coupon in the checkout, otherwise will try to apply in the cart.
+ *
+ * @param couponCode string
+ * @returns {Promise<void>}
+ */
+const applyCoupon = async ( couponCode ) => {
+	try {
+		await expect(page).toClick('a', {text: 'Click here to enter your code'});
+		await uiUnblocked();
+		await clearAndFillInput('#coupon_code', couponCode);
+		await expect(page).toClick('button', {text: 'Apply coupon'});
+		await uiUnblocked();
+	} catch (error) {
+		await clearAndFillInput('#coupon_code', couponCode);
+		await expect(page).toClick('button', {text: 'Apply coupon'});
+		await uiUnblocked();
+	};
+};
+
+/**
+ * Remove one coupon within cart or checkout.
+ *
+ * @returns {Promise<void>}
+ */
+const removeCoupon = async () => {
+	await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
+	await uiUnblocked();
+	await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon has been removed.'});
+};
+
 export {
 	clearAndFillInput,
 	clickTab,
@@ -225,4 +257,6 @@ export {
 	moveAllItemsToTrash,
 	evalAndClick,
 	selectOptionInSelect2,
+	applyCoupon,
+	removeCoupon,
 };

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -233,10 +233,11 @@ const applyCoupon = async ( couponCode ) => {
 /**
  * Remove one coupon within cart or checkout.
  *
+ * @param couponCode Coupon name.
  * @returns {Promise<void>}
  */
-const removeCoupon = async () => {
-	await expect(page).toClick('.woocommerce-remove-coupon', {text: '[Remove]'});
+const removeCoupon = async ( couponCode ) => {
+	await expect(page).toClick('[data-coupon="'+couponCode.toLowerCase()+'"]', {text: '[Remove]'});
 	await uiUnblocked();
 	await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon has been removed.'});
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added new page utils (`applyCoupon` and `removeCoupon` ) for adding and removing coupons within cart and checkout. These require previously created coupons in order to apply them. Now, with just these page utils, you could apply them in both places without carrying if you're in the cart or the checkout flow. Also updated coupon tests.

- Perform `shopper.test.js` locally

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A