### PR TITLE
Make the refunds creation REST API behave more as documented

### DIFF
--- a/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-order-refunds-v2-controller.php
@@ -348,7 +348,7 @@ class WC_REST_Order_Refunds_V2_Controller extends WC_REST_Orders_V2_Controller {
 	}
 
 	/**
-	 * Get the Order's schema, conforming to JSON Schema.
+	 * Get the refund schema, conforming to JSON Schema.
 	 *
 	 * @return array
 	 */

--- a/src/Internal/RestApiUtil.php
+++ b/src/Internal/RestApiUtil.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * ApiUtil class file.
+ */
+
+namespace Automattic\WooCommerce\Internal;
+
+/**
+ * Helper methos for the REST API.
+ *
+ * Class ApiUtil
+ *
+ * @package Automattic\WooCommerce\Internal
+ */
+class RestApiUtil {
+
+	/**
+	 * Converts a create refund request from the public API format:
+	 *
+	 * [
+	 *   "reason" => "",
+	 *   "api_refund" => "x",
+	 *   "line_items" => [
+	 *     "id" => "111",
+	 *     "quantity" => 222,
+	 *     "refund_total" => 333,
+	 *     "refund_tax" => [
+	 *       [
+	 *          "id": "444",
+	 *          "refund_total": 555
+	 *       ],...
+	 *   ],...
+	 * ]
+	 *
+	 * ...to the internally used format:
+	 *
+	 * [
+	 *   "reason" => null,     (if it's missing or any empty value, set as null)
+	 *   "api_refund" => true, (if it's missing or non-bool, set as "true")
+	 *   "line_items" => [     (convert sequential array to associative based on "id")
+	 *     "111" => [
+	 *       "qty" => 222,     (rename "quantity" to "qty")
+	 *       "refund_total" => 333,
+	 *       "refund_tax" => [ (convert sequential array to associative based on "id" and "refund_total)
+	 *         "444" => 555,...
+	 *       ],...
+	 *   ]
+	 * ]
+	 *
+	 * It also calculates the amount if missing and whenever possible, see maybe_calculate_refund_amount_from_line_items.
+	 *
+	 * The conversion is done in a way that if the request is already in the internal format,
+	 * then nothing is changed for compatibility. For example, if the line items array
+	 * is already an associative array or any of its elements
+	 * is missing the "id" key, then the entire array is left unchanged.
+	 * Same for the "refund_tax" array inside each line item.
+	 *
+	 * @param \WP_REST_Request $request The request to adjust.
+	 */
+	public static function adjust_create_refund_request_parameters( \WP_REST_Request &$request ) {
+		if ( empty( $request['reason'] ) ) {
+			$request['reason'] = null;
+		}
+
+		if ( ! is_bool( $request['api_refund'] ) ) {
+			$request['api_refund'] = true;
+		}
+
+		if ( empty( $request['line_items'] ) ) {
+			$request['line_items'] = array();
+		} else {
+			$request['line_items'] = self::adjust_line_items_for_create_refund_request( $request['line_items'] );
+		}
+
+		self::maybe_calculate_refund_amount_from_line_items( $request );
+	}
+
+	/**
+	 * Calculate and set the "amount" parameter in the request based on the amounts found in line items.
+	 * This will ONLY happen if ALL of the following is true:
+	 *
+	 * - The request doesn't have an "amount" parameter already.
+	 * - "line_items" in the request is a non-empty array.
+	 * - All line items have a "refund_total" field with a numeric value.
+	 * - All values inside "refund_tax" in all line items are a numeric value.
+	 *
+	 * The request is assumed to be in internal format already.
+	 *
+	 * @param \WP_REST_Request $request The request to maybe calculate the total amount for.
+	 */
+	private static function maybe_calculate_refund_amount_from_line_items( &$request ) {
+		if ( isset( $request['amount'] ) ) {
+			return;
+		}
+
+		$line_items = $request['line_items'];
+
+		if ( ! is_array( $line_items ) || empty( $line_items ) ) {
+			return;
+		}
+
+		$amount = 0;
+
+		foreach ( $line_items as $item ) {
+			if ( ! isset( $item['refund_total'] ) || ! is_numeric( $item['refund_total'] ) ) {
+				return;
+			}
+
+			$amount += $item['refund_total'];
+
+			if ( ! isset( $item['refund_tax'] ) ) {
+				continue;
+			}
+
+			foreach ( $item['refund_tax'] as $tax ) {
+				if ( ! is_numeric( $tax ) ) {
+					return;
+				}
+				$amount += $tax;
+			}
+		}
+
+		$request['amount'] = strval( $amount );
+	}
+
+	/**
+	 * Convert the line items of a refund request to internal format (see adjust_create_refund_request_parameters).
+	 *
+	 * @param array $line_items The line items to convert.
+	 * @return array The converted line items.
+	 */
+	private static function adjust_line_items_for_create_refund_request( $line_items ) {
+		if ( ! is_array( $line_items ) || empty( $line_items ) || self::is_associative( $line_items ) ) {
+			return $line_items;
+		}
+
+		$new_array = array();
+		foreach ( $line_items as $item ) {
+			if ( ! isset( $item['id'] ) ) {
+				return $line_items;
+			}
+
+			if ( isset( $item['quantity'] ) && ! isset( $item['qty'] ) ) {
+				$item['qty'] = $item['quantity'];
+			}
+			unset( $item['quantity'] );
+
+			if ( isset( $item['refund_tax'] ) ) {
+				$item['refund_tax'] = self::adjust_taxes_for_create_refund_request_line_item( $item['refund_tax'] );
+			}
+
+			$id               = $item['id'];
+			$new_array[ $id ] = $item;
+
+			unset( $new_array[ $id ]['id'] );
+		}
+
+		return $new_array;
+	}
+
+	/**
+	 * Adjust the taxes array from a line item in a refund request, see adjust_create_refund_parameters.
+	 *
+	 * @param array $taxes_array The array to adjust.
+	 * @return array The adjusted array.
+	 */
+	private static function adjust_taxes_for_create_refund_request_line_item( $taxes_array ) {
+		if ( ! is_array( $taxes_array ) || empty( $taxes_array ) || self::is_associative( $taxes_array ) ) {
+			return $taxes_array;
+		}
+
+		$new_array = array();
+		foreach ( $taxes_array as $item ) {
+			if ( ! isset( $item['id'] ) || ! isset( $item['refund_total'] ) ) {
+				return $taxes_array;
+			}
+
+			$id               = $item['id'];
+			$refund_total     = $item['refund_total'];
+			$new_array[ $id ] = $refund_total;
+		}
+
+		return $new_array;
+	}
+
+	/**
+	 * Is an array sequential or associative?
+	 *
+	 * @param array $array The array to check.
+	 * @return bool True if the array is associative, false if it's sequential.
+	 */
+	private static function is_associative( array $array ) {
+		return array_keys( $array ) !== range( 0, count( $array ) - 1 );
+	}
+}

--- a/tests/php/src/Internal/RestApiUtilTest.php
+++ b/tests/php/src/Internal/RestApiUtilTest.php
@@ -1,0 +1,283 @@
+<?php
+
+namespace Automattic\WooCommerce\Tests\Internal;
+
+use Automattic\WooCommerce\Internal\RestApiUtil;
+
+/**
+ * Tests for the RestApiUtil class.
+ * @package Automattic\WooCommerce\Tests\Internal
+ */
+class RestApiUtilTest extends \WC_Unit_Test_Case {
+
+	/**
+	 * @testdox 'adjust_create_refund_request_parameters' adjust the 'reason' parameter to null if it's somehow empty.
+	 *
+	 * @testWith ["", null]
+	 *           ["none", null]
+	 *           ["foo", "foo"]
+	 *
+	 * @param string $input_reason The value of 'reason' to test.
+	 * @param string $expected_output_reason The expected converted value of 'reason'.
+	 */
+	public function test_adjust_create_refund_request_parameters_adjusts_reason( $input_reason, $expected_output_reason ) {
+		$request = new \WP_REST_Request();
+		if ( 'none' !== $input_reason ) {
+			$request['reason'] = $input_reason;
+		}
+
+		RestApiUtil::adjust_create_refund_request_parameters( $request );
+
+		$this->assertEquals( $expected_output_reason, $request['reason'] );
+	}
+
+	/**
+	 * @testdox 'adjust_create_refund_request_parameters' adjust the 'api_refund' parameter if it's missing or non-boolean.
+	 *
+	 * @testWith ["none", true]
+	 *           ["foobar", true]
+	 *           [0, true]
+	 *           [true, true]
+	 *           [false, false]
+	 *
+	 * @param mixed $input_api_refund The value of 'api_refund' to test.
+	 * @param bool  $expected_output_api_refund The expected adjusted value of 'api_refund'.
+	 */
+	public function test_adjust_create_refund_request_parameters_adjusts_api_refund( $input_api_refund, $expected_output_api_refund ) {
+		$request = new \WP_REST_Request();
+		if ( 'none' !== $input_api_refund ) {
+			$request['api_refund'] = $input_api_refund;
+		}
+
+		RestApiUtil::adjust_create_refund_request_parameters( $request );
+
+		$this->assertEquals( $expected_output_api_refund, $request['api_refund'] );
+	}
+
+	/**
+	 * @testdox 'adjust_create_refund_request_parameters' adjust the 'line items' array to be associative, and converts the 'quantity' parameters to 'qty'.
+	 */
+	public function test_adjust_create_refund_request_parameters_adjusts_line_items_and_their_quantities() {
+		$line_items = array(
+			array(
+				'id'       => '1',
+				'quantity' => 10,
+				'qty'      => 20,
+			),
+			array(
+				'id'       => '2',
+				'quantity' => 30,
+			),
+			array(
+				'id'  => '3',
+				'qty' => 40,
+			),
+		);
+
+		$request               = new \WP_REST_Request();
+		$request['line_items'] = $line_items;
+
+		RestApiUtil::adjust_create_refund_request_parameters( $request );
+
+		$expected = array(
+			'1' => array(
+				'qty' => 20,
+			),
+			'2' => array(
+				'qty' => 30,
+			),
+			'3' => array(
+				'qty' => 40,
+			),
+		);
+
+		$this->assertEquals( $expected, $request['line_items'] );
+	}
+
+	/**
+	 * @testdox 'adjust_create_refund_request_parameters' adjusts the line item taxes to be associative arrays.
+	 */
+	public function test_adjust_create_refund_request_parameters_adjusts_line_item_taxes() {
+		$line_items = array(
+			array(
+				'id'         => '1',
+				'refund_tax' => array(
+					array(
+						'id'           => '2',
+						'refund_total' => 10,
+					),
+					array(
+						'id'           => '3',
+						'refund_total' => 20,
+					),
+				),
+			),
+		);
+
+		$request               = new \WP_REST_Request();
+		$request['line_items'] = $line_items;
+
+		RestApiUtil::adjust_create_refund_request_parameters( $request );
+
+		$expected = array(
+			'1' => array(
+				'refund_tax' => array(
+					'2' => 10,
+					'3' => 20,
+				),
+			),
+		);
+
+		$this->assertEquals( $expected, $request['line_items'] );
+	}
+
+	/**
+	 * @testdox 'adjust_create_refund_request_parameters' adjusts nothing if the input is already in internal format.
+	 */
+	public function test_adjust_create_refund_request_parameters_does_nothing_on_line_items_if_input_is_in_internal_format() {
+		$line_items = array(
+			'1' => array(
+				'qty'        => 2,
+				'refund_tax' => array(
+					'2' => 10,
+					'3' => 20,
+				),
+			),
+		);
+
+		$request               = new \WP_REST_Request();
+		$request['line_items'] = $line_items;
+
+		RestApiUtil::adjust_create_refund_request_parameters( $request );
+
+		$this->assertEquals( $line_items, $request['line_items'] );
+	}
+
+	/**
+	 * @testdox 'adjust_create_refund_request_parameters' calculates 'amount' if it's missing and all the partial amounts data is valid.
+	 */
+	public function test_adjust_create_refund_request_parameters_calculates_amount_if_missing() {
+		$line_items = array(
+			'1' => array(
+				'refund_total' => 10,
+				'refund_tax'   => array(
+					'2' => 20,
+					'3' => 30,
+				),
+			),
+			'2' => array(
+				'refund_total' => 40,
+			),
+		);
+
+		$request               = new \WP_REST_Request();
+		$request['line_items'] = $line_items;
+
+		RestApiUtil::adjust_create_refund_request_parameters( $request );
+
+		$expected = strval( 10 + 20 + 30 + 40 );
+		$this->assertEquals( $expected, $request['amount'] );
+	}
+
+	/**
+	 * @testdox 'adjust_create_refund_request_parameters' doesn't change 'amount' if it's already present.
+	 */
+	public function test_adjust_create_refund_request_parameters_does_not_change_amount_if_present() {
+		$line_items = array(
+			'1' => array(
+				'refund_total' => 10,
+				'refund_tax'   => array(
+					'2' => 20,
+					'3' => 30,
+				),
+			),
+		);
+
+		$request               = new \WP_REST_Request();
+		$request['amount']     = '999';
+		$request['line_items'] = $line_items;
+
+		RestApiUtil::adjust_create_refund_request_parameters( $request );
+
+		$this->assertEquals( '999', $request['amount'] );
+	}
+
+	/**
+	 * Data provider for data_for_test_adjust_create_refund_request_parameters_does_not_change_amount_if_invalid_data.
+	 *
+	 * @return array Data for the tests.
+	 */
+	public function data_for_test_adjust_create_refund_request_parameters_does_not_change_amount_if_invalid_data() {
+		return array(
+			// No line items.
+			array(
+				array(),
+			),
+
+			// Non-array line items.
+			array(
+				'Foobar',
+			),
+
+			// Missing refund_total in line item.
+			array(
+				array(
+					'1' => array(
+						'refund_tax' => array(
+							'2' => 20,
+							'3' => 30,
+						),
+					),
+					'2' => array(
+						'refund_total' => 10,
+					),
+				),
+			),
+
+			// Non-numeric refund_total in line item.
+			array(
+				array(
+					'1' => array(
+						'refund_total' => 'foobar',
+						'refund_tax'   => array(
+							'2' => 20,
+							'3' => 30,
+						),
+					),
+					'2' => array(
+						'refund_total' => 10,
+					),
+				),
+			),
+
+			// Non-numeric tax amount.
+			array(
+				'1' => array(
+					'refund_total' => 10,
+					'refund_tax'   => array(
+						'2' => 'Foobar',
+					),
+				),
+				'2' => array(
+					'refund_total' => 10,
+				),
+			),
+		);
+	}
+
+	/**
+	 * @testdox 'adjust_create_refund_request_parameters' doesn't set 'amount' if some partial amounts data is missing or invalid.
+	 *
+	 * @dataProvider data_for_test_adjust_create_refund_request_parameters_does_not_change_amount_if_invalid_data
+	 *
+	 * @param array $line_items The line items array to test.
+	 */
+	public function test_adjust_create_refund_request_parameters_does_not_change_amount_if_invalid_data( $line_items ) {
+		$request               = new \WP_REST_Request();
+		$request['line_items'] = $line_items;
+
+		RestApiUtil::adjust_create_refund_request_parameters( $request );
+
+		$this->assertFalse( isset( $request['amount'] ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Companion pull request for the documentation: https://github.com/woocommerce/woocommerce-rest-api-docs/pull/191

The REST API for creating a refund is currently pretty inconsistent and [not aligned with what's documented](https://github.com/woocommerce/woocommerce/issues/27376#issuecomment-652421974).  This pull request adjusts the request parameters processing so that:

- It allows the list of line items to process to be a non-associative array where each item is identified by an `id` field.
- Same for the taxes inside line items, the amount to refund can be specified in a `refund_total` key as in the case of line items.
- Allows `quantity` keys as synonyms of `qty`.

Also, as an extra improvement, it automatically calculates the `amount` field as the sum of all the `refund_total` values, but only if the field if missing in the request and all line item and tax items have effectively a valid value for `refund_total`.
line items and taxes have a valid `refund_total` key.

Those changes are backwards compatible: the "old way" of creating refunds (by using associative arrays where the keys are the line item/tax ids, and by using `qty`) still work.

Closes https://github.com/woocommerce/woocommerce/issues/27376.

### How to test the changes in this Pull Request:

1. Temporarily add this at the ned of your `woocommerce.php` file, this way you won't have to bother about REST API authentication:

```php
add_filter('woocommerce_rest_check_permissions', function() {return true;}, 10, 0 );
```

(note that this will cause a bunch of unit tests to fail)

2. As a shopper or in the admin area create an order for two different products, with at least two units of each. Make sure to include taxes and shipping costs.

3. Get the line items and taxes ids for the order. The easiest way is to run this in the console:

```bash
curl localhost/wp-json/wc/v3/orders/<order number> | jq --sort-keys .
```

(The `jq` part is optional, it will just pretty-print the json; install with `apt-get install jq`)

Take note of the line item ids (`line_items`,  `shipping_lines`) and the tax ids from the received json:

```json
{
"line_items": [
    {
      "id": 111,
      "taxes": [
        {
          "id": 222,
        }
      ]
    }
  ],
"shipping_lines": [
    {
      "id": 333,
      "taxes": [
        {
          "id": 444,
        }
      ]
    }
  ]
}
```

4. Run the following to create a refund for one unit of each item, for a value of 1 on each case, including 1 for each tax (adjust the line item and tax ids as appropriate):

```bash
curl -X POST localhost/wp-json/wc/v3/orders/<order id>/refunds \
    -H "Content-Type: application/json" \
    -d '{
"api_refund": false,
"reason": "test",
"line_items": [
{
    "id": "<line item 1 id>",
    "quantity": 1,
    "refund_total": 1,
    "refund_tax": [
         {
        "id": "<tax of line item 1 id>",
        "refund_total": 1
        }  
    ]
},
{
    "id": "<line item 2 id>",
    "quantity": 1,
    "refund_total": 1,
    "refund_tax": [
         {
        "id": "<tax of line item 2 id>",
        "refund_total": 1
         }  
    ]
},
{
    "id": "<shipping line item id>",
    "quantity": 0,
    "refund_total": 1,
    "refund_tax": [
         {
        "id": "<tax of shipping line item id>",
        "refund_total": 1
        }  
    ]
}
]}'
```

5. Verify that the response is a json with information about the newly created refund. Load the order in admin and verify that each line item got a refund of 1 item for a value of 1, and that each tax got a refund for a value of 1 as well; also verify that the total refunded amount is correct (if you had two line items, both with taxes, and the shipping had taxes too, the total amount refunded should be 6).


### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Make the parameters of the refund creation REST API behave as documented.
