### PR TITLE
Update woocommerce-admin package to 2.0.1

### DIFF
--- a/bin/composer/mozart/composer.lock
+++ b/bin/composer/mozart/composer.lock
@@ -13,12 +13,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/coenjacobs/mozart.git",
-                "reference": "782a9282a7097ae38ddb7600388885059de10ea1"
+                "reference": "3b1243ca8505fa6436569800dc34269178930f39"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/coenjacobs/mozart/zipball/782a9282a7097ae38ddb7600388885059de10ea1",
-                "reference": "782a9282a7097ae38ddb7600388885059de10ea1",
+                "url": "https://api.github.com/repos/coenjacobs/mozart/zipball/3b1243ca8505fa6436569800dc34269178930f39",
+                "reference": "3b1243ca8505fa6436569800dc34269178930f39",
                 "shasum": ""
             },
             "require": {
@@ -59,7 +59,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-02-03T20:37:56+00:00"
+            "time": "2021-02-04T20:20:50+00:00"
         },
         {
             "name": "league/flysystem",

--- a/bin/composer/phpcs/composer.lock
+++ b/bin/composer/phpcs/composer.lock
@@ -282,6 +282,11 @@
                 "phpcs",
                 "standards"
             ],
+            "support": {
+                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
+                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
+                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
+            },
             "time": "2020-10-23T02:01:07+00:00"
         },
         {

--- a/bin/composer/wp/composer.lock
+++ b/bin/composer/wp/composer.lock
@@ -382,10 +382,6 @@
             ],
             "description": "Provides internationalization tools for WordPress projects.",
             "homepage": "https://github.com/wp-cli/i18n-command",
-            "support": {
-                "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/v2.2.6"
-            },
             "time": "2020-12-07T19:28:27+00:00"
         },
         {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "1.9.0",
+    "woocommerce/woocommerce-admin": "2.0.0",
     "woocommerce/woocommerce-blocks": "4.0.0"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "2.0.0",
+    "woocommerce/woocommerce-admin": "2.0.1",
     "woocommerce/woocommerce-blocks": "4.0.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c5ebe496c9f97d9748856d33070681e0",
+    "content-hash": "c05d57eb7794cc7a3ae61257ea751c52",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -44,9 +44,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.9.1"
-            },
             "time": "2021-02-05T19:07:06+00:00"
         },
         {
@@ -282,10 +279,6 @@
                 "geolocation",
                 "maxmind"
             ],
-            "support": {
-                "issues": "https://github.com/maxmind/MaxMind-DB-Reader-php/issues",
-                "source": "https://github.com/maxmind/MaxMind-DB-Reader-php/tree/v1.6.0"
-            },
             "time": "2019-12-19T22:59:03+00:00"
         },
         {
@@ -360,10 +353,6 @@
                 "email",
                 "pre-processing"
             ],
-            "support": {
-                "issues": "https://github.com/MyIntervals/emogrifier/issues",
-                "source": "https://github.com/MyIntervals/emogrifier"
-            },
             "time": "2019-12-26T19:37:31+00:00"
         },
         {
@@ -413,10 +402,6 @@
                 "container-interop",
                 "psr"
             ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
-            },
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
@@ -508,30 +493,26 @@
             ],
             "description": "Action Scheduler for WordPress and WooCommerce",
             "homepage": "https://actionscheduler.org/",
-            "support": {
-                "issues": "https://github.com/woocommerce/action-scheduler/issues",
-                "source": "https://github.com/woocommerce/action-scheduler/tree/master"
-            },
             "time": "2020-05-12T16:22:33+00:00"
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "1.9.0",
+            "version": "2.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "cb2fa7ad034200acba6ee3ef0f332453d2533144"
+                "reference": "b7e89c48479348847fc97ae8be8c27d068106d04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/cb2fa7ad034200acba6ee3ef0f332453d2533144",
-                "reference": "cb2fa7ad034200acba6ee3ef0f332453d2533144",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/b7e89c48479348847fc97ae8be8c27d068106d04",
+                "reference": "b7e89c48479348847fc97ae8be8c27d068106d04",
                 "shasum": ""
             },
             "require": {
-                "automattic/jetpack-autoloader": "^2.2.0",
+                "automattic/jetpack-autoloader": "^2.9.1",
                 "composer/installers": "^1.9.0",
-                "php": ">=5.6|>=7.0"
+                "php": ">=7.0"
             },
             "require-dev": {
                 "phpunit/phpunit": "7.5.20",
@@ -557,7 +538,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2021-01-28T00:59:01+00:00"
+            "time": "2021-02-12T01:19:48+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -604,10 +585,6 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "support": {
-                "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v4.0.0"
-            },
             "time": "2020-12-08T13:17:01+00:00"
         }
     ],
@@ -671,5 +648,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This branch brings in the latest published package of `woocommerce-admin` - version 2.0.0

While preparing this branch, I received the following message when running `composer update`

```
➜  woocommerce git:(update/woocommerce-admin/2.0) composer update
A script named bin would override a Composer command and has been skipped
Loading composer repositories with package information
Warning from https://repo.packagist.org: You are using an outdated version of Composer. Composer 2.0 is now available and you should upgrade. See https://getcomposer.org/2
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - Installation request for woocommerce/woocommerce-admin 2.0.0 -> satisfiable by woocommerce/woocommerce-admin[2.0.0].
    - woocommerce/woocommerce-admin 2.0.0 requires automattic/jetpack-autoloader 2.7.1 -> satisfiable by automattic/jetpack-autoloader[v2.7.1] but these conflict with your requirements or minimum-stability.
```

Since wc-admin is also running the same version of the Autoloader, I'm not certain why this message is shown, but figured I would share it here and see if anyone had any ideas.

As such - **I have yet to run composer update** in this branch, and that needs to happen prior to merging this in to ensure the latest package of wc-admin is included.

## Testing Instructions

@becdetat has added the testing instructions to the [5.1 wiki](https://github.com/woocommerce/woocommerce/wiki/Release-Testing-Instructions-WooCommerce-5.1#woocommerce-admin-200)

## Changelog

```
- Tweak: Bump minimum supported version of PHP to 7.0. #6046
- Fix: allow for more terms to be shown for product attributes in the Analytics orders report. #5868
- Tweak: update the content and timing of the NeedSomeInspiration note. #6076
- Fix: Add support for a floating-point number as a SummaryNumber's delta. #5926
- Add: new inbox message - Getting started in Ecommerce - watch this webinar. #6086
- Add: Remote inbox notifications contains comparison and fix product rule. #6073
- Update: store deprecation welcome modal support doc link #6094
- Enhancement: Allowing users to create products by selecting a template. #5892
- Dev: Add wait script for mysql to be ready for phpunit tests in docker. #6185
- Update: Homescreen layout, moving Inbox panel for better interaction. #6122
- Dev: Remove old debug code for connecting to Calypso / Wordpress.com. #6097
- Tweak: Adjust the Marketing note not to show until store is at least 5 days. #6083
- Add: Task list payments - include Mollie as an option. #6257
- Tweak: Refactored extended task list. #6081
- Fix: Fixed the Add First Product email note checks. #6260
- Fix: Onboarding - Fixed "Business Details" error. #6271
- Enhancement: Use the new Paypal payments plugin for onboarding. #6261
- Fix: Show management links when only main task list is hidden. #6291
- Dev: Allow highlight tooltip to use body tag as parent. #6309
```
