### PR TITLE
Merchant email notes now are turned off by default

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -203,7 +203,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'id'            => 'woocommerce_merchant_email_notifications',
 					'type'          => 'checkbox',
 					'checkboxgroup' => 'start',
-					'default'       => 'yes',
+					'default'       => 'no',
 					'autoload'      => false,
 				),
 


### PR DESCRIPTION
This PR turns off the merchant email notes by default.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
As we were receiving some spam reports and also there is an issue with tracking, the email notifications will be turned off by default.

That is going to give us more time to assess and fix the issues.

### How to test the changes in this Pull Request:
1. Confirm that `woocommerce_merchant_email_notifications` was not set before. You can do it with a SQL statement like:
```
DELETE FROM `wp_options` WHERE `wp_options`.`option_name` = 'woocommerce_merchant_email_notifications';
```
or with wp-cli:
```
wp option delete 'woocommerce_merchant_email_notifications';
```

2. Go to `WooCommerce` > `Settings` > `Emails`.
3. Verify the checkbox next to `Enable email insights` is unchecked.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> FIX - "Store management insights" option now is turned off by default.
