### PR TITLE
Add tracking to WooCommerce Status widget

### DIFF
--- a/assets/js/admin/wc-status-widget.js
+++ b/assets/js/admin/wc-status-widget.js
@@ -1,32 +1,32 @@
 /*global jQuery */
 (function( $ ) {
-    var recordEvent = function( link ) {
-        window.wcTracks.recordEvent( 'status_widget_click' , {
-            link: link
-        } );
-    };
+	var recordEvent = function( link ) {
+		window.wcTracks.recordEvent( 'status_widget_click', {
+			link: link
+		} );
+	};
 
-    $( '.sales-this-month a' ).on( 'click' , function() {
-        recordEvent( 'net-sales' );
-    });
+	$( '.sales-this-month a' ).on( 'click', function() {
+		recordEvent( 'net-sales' );
+	});
 
 	$( '.best-seller-this-month a' ).on( 'click', function() {
 		recordEvent( 'best-seller-this-month' );
 	});
 
-    $( '.processing-orders a' ).on( 'click' , function() {
-        recordEvent( 'orders-processing' );
-    });
+	$( '.processing-orders a' ).on( 'click', function() {
+		recordEvent( 'orders-processing' );
+	});
 
-    $( '.on-hold-orders a' ).on( 'click' , function() {
-        recordEvent( 'orders-on-hold' );
-    });
+	$( '.on-hold-orders a' ).on( 'click', function() {
+		recordEvent( 'orders-on-hold' );
+	});
 
-    $( '.low-in-stock a' ).on( 'click' , function() {
-       recordEvent( 'low-stock' );
-    });
+	$( '.low-in-stock a' ).on( 'click', function() {
+	   recordEvent( 'low-stock' );
+	});
 
-    $( '.out-of-stock a' ).on( 'click' , function() {
-        recordEvent( 'out-of-stock' );
-    });
+	$( '.out-of-stock a' ).on( 'click', function() {
+		recordEvent( 'out-of-stock' );
+	});
 })( jQuery );

--- a/assets/js/admin/wc-status-widget.js
+++ b/assets/js/admin/wc-status-widget.js
@@ -1,0 +1,28 @@
+/*global jQuery */
+(function( $ ) {
+    var recordEvent = function( link ) {
+        window.wcTracks.recordEvent( 'status_widget_click' , {
+            link: link
+        } );
+    };
+
+    $( '.sales-this-month a' ).on( 'click' , function(e) {
+        recordEvent( 'net-sales' );
+    });
+
+    $( '.processing-orders a' ).on( 'click' , function() {
+        recordEvent( 'orders-processing' );
+    });
+
+    $( '.on-hold-orders a' ).on( 'click' , function() {
+        recordEvent( 'orders-on-hold' );
+    });
+
+    $( '.low-in-stock a' ).on( 'click' , function() {
+       recordEvent( 'low-stock' );
+    });
+
+    $( '.out-of-stock a' ).on( 'click' , function() {
+        recordEvent( 'out-of-stock' );
+    });
+})( jQuery );

--- a/assets/js/admin/wc-status-widget.js
+++ b/assets/js/admin/wc-status-widget.js
@@ -10,6 +10,10 @@
         recordEvent( 'net-sales' );
     });
 
+	$( '.best-seller-this-month a' ).on( 'click', function() {
+		recordEvent( 'best-seller-this-month' );
+	});
+
     $( '.processing-orders a' ).on( 'click' , function() {
         recordEvent( 'orders-processing' );
     });

--- a/assets/js/admin/wc-status-widget.js
+++ b/assets/js/admin/wc-status-widget.js
@@ -6,7 +6,7 @@
         } );
     };
 
-    $( '.sales-this-month a' ).on( 'click' , function(e) {
+    $( '.sales-this-month a' ).on( 'click' , function() {
         recordEvent( 'net-sales' );
     });
 

--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -105,6 +105,11 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 		 * Show status widget.
 		 */
 		public function status_widget() {
+			$suffix  = Constants::is_true( 'SCRIPT_DEBUG' ) ? '' : '.min';
+			$version = Constants::get_constant( 'WC_VERSION' );
+
+			wp_enqueue_script( 'wc-status-widget', WC()->plugin_url() . '/assets/js/admin/wc-status-widget' . $suffix . '.js', array( 'jquery' ), $version, true );
+
 			include_once dirname( __FILE__ ) . '/reports/class-wc-admin-report.php';
 
 			$reports = new WC_Admin_Report();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR adds tracks event when a user clicks on the links of the WooCommerce Status widget.

Event name: wcadmin_status_widget_click
Prop: link which will be one of: net-sales, orders-processing, orders-on-hold, low-stock, out-of-stock

Closes #28566

### How to test the changes in this Pull Request:

1. Make sure `woocommerce_allow_tracking` is set to `yes` in your options table.
2. Navigate to WordPress dashboard.
3. Open your browser inspector -> Network -> and click 'Preserve log' so that you can see the event on the page refresh.
4. Click each link on the status widget and confirm the event name and `link` prop.
5. You can search for `t.gif` in the `Network` tab to check the event.


Event name for each link (in red)
![event](https://user-images.githubusercontent.com/4723145/107704013-6fef7380-6c71-11eb-92e3-2b0cf1e65af2.jpg)

### Changelog entry

> Dev - Add tracks event when a user clicks on the links of the WooCommerce Status widget.