### PR TITLE
Fix wrong taxonomy caching in term and product attributes controllers

### DIFF
--- a/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller.php
@@ -4,8 +4,6 @@
  *
  * Handles requests to the products/attributes endpoint.
  *
- * @author   WooThemes
- * @category API
  * @package WooCommerce\RestApi
  * @since    3.0.0
  */
@@ -54,73 +52,88 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	 * Register the routes for product attributes.
 	 */
 	public function register_routes() {
-		register_rest_route( $this->namespace, '/' . $this->rest_base, array(
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base,
 			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_items' ),
-				'permission_callback' => array( $this, 'get_items_permissions_check' ),
-				'args'                => $this->get_collection_params(),
-			),
-			array(
-				'methods'             => WP_REST_Server::CREATABLE,
-				'callback'            => array( $this, 'create_item' ),
-				'permission_callback' => array( $this, 'create_item_permissions_check' ),
-				'args'                => array_merge( $this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ), array(
-					'name' => array(
-						'description' => __( 'Name for the resource.', 'woocommerce' ),
-						'type'        => 'string',
-						'required'    => true,
-					),
-				) ),
-			),
-			'schema' => array( $this, 'get_public_item_schema' ),
-		));
-
-		register_rest_route( $this->namespace, '/' . $this->rest_base . '/(?P<id>[\d]+)', array(
-			'args' => array(
-				'id' => array(
-					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
-					'type'        => 'integer',
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_items' ),
+					'permission_callback' => array( $this, 'get_items_permissions_check' ),
+					'args'                => $this->get_collection_params(),
 				),
-			),
-			array(
-				'methods'             => WP_REST_Server::READABLE,
-				'callback'            => array( $this, 'get_item' ),
-				'permission_callback' => array( $this, 'get_item_permissions_check' ),
-				'args'                => array(
-					'context'         => $this->get_context_param( array( 'default' => 'view' ) ),
-				),
-			),
-			array(
-				'methods'             => WP_REST_Server::EDITABLE,
-				'callback'            => array( $this, 'update_item' ),
-				'permission_callback' => array( $this, 'update_item_permissions_check' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
-			),
-			array(
-				'methods'             => WP_REST_Server::DELETABLE,
-				'callback'            => array( $this, 'delete_item' ),
-				'permission_callback' => array( $this, 'delete_item_permissions_check' ),
-				'args'                => array(
-					'force' => array(
-						'default'     => true,
-						'type'        => 'boolean',
-						'description' => __( 'Required to be true, as resource does not support trashing.', 'woocommerce' ),
+				array(
+					'methods'             => WP_REST_Server::CREATABLE,
+					'callback'            => array( $this, 'create_item' ),
+					'permission_callback' => array( $this, 'create_item_permissions_check' ),
+					'args'                => array_merge(
+						$this->get_endpoint_args_for_item_schema( WP_REST_Server::CREATABLE ),
+						array(
+							'name' => array(
+								'description' => __( 'Name for the resource.', 'woocommerce' ),
+								'type'        => 'string',
+								'required'    => true,
+							),
+						)
 					),
 				),
-			),
-			'schema' => array( $this, 'get_public_item_schema' ),
-		) );
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
 
-		register_rest_route( $this->namespace, '/' . $this->rest_base . '/batch', array(
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/(?P<id>[\d]+)',
 			array(
-				'methods'             => WP_REST_Server::EDITABLE,
-				'callback'            => array( $this, 'batch_items' ),
-				'permission_callback' => array( $this, 'batch_items_permissions_check' ),
-				'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
-			),
-			'schema' => array( $this, 'get_public_batch_schema' ),
-		) );
+				'args'   => array(
+					'id' => array(
+						'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
+						'type'        => 'integer',
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::READABLE,
+					'callback'            => array( $this, 'get_item' ),
+					'permission_callback' => array( $this, 'get_item_permissions_check' ),
+					'args'                => array(
+						'context' => $this->get_context_param( array( 'default' => 'view' ) ),
+					),
+				),
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'update_item' ),
+					'permission_callback' => array( $this, 'update_item_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				array(
+					'methods'             => WP_REST_Server::DELETABLE,
+					'callback'            => array( $this, 'delete_item' ),
+					'permission_callback' => array( $this, 'delete_item_permissions_check' ),
+					'args'                => array(
+						'force' => array(
+							'default'     => true,
+							'type'        => 'boolean',
+							'description' => __( 'Required to be true, as resource does not support trashing.', 'woocommerce' ),
+						),
+					),
+				),
+				'schema' => array( $this, 'get_public_item_schema' ),
+			)
+		);
+
+		register_rest_route(
+			$this->namespace,
+			'/' . $this->rest_base . '/batch',
+			array(
+				array(
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => array( $this, 'batch_items' ),
+					'permission_callback' => array( $this, 'batch_items_permissions_check' ),
+					'args'                => $this->get_endpoint_args_for_item_schema( WP_REST_Server::EDITABLE ),
+				),
+				'schema' => array( $this, 'get_public_batch_schema' ),
+			)
+		);
 	}
 
 	/**
@@ -223,7 +236,7 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	/**
 	 * Get all attributes.
 	 *
-	 * @param WP_REST_Request $request
+	 * @param WP_REST_Request $request The request to get the attributes from.
 	 * @return array
 	 */
 	public function get_items( $request ) {
@@ -232,7 +245,7 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 		foreach ( $attributes as $attribute_obj ) {
 			$attribute = $this->prepare_item_for_response( $attribute_obj, $request );
 			$attribute = $this->prepare_response_for_collection( $attribute );
-			$data[] = $attribute;
+			$data[]    = $attribute;
 		}
 
 		$response = rest_ensure_response( $data );
@@ -253,13 +266,15 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	public function create_item( $request ) {
 		global $wpdb;
 
-		$id = wc_create_attribute( array(
-			'name'         => $request['name'],
-			'slug'         => wc_sanitize_taxonomy_name( stripslashes( $request['slug'] ) ),
-			'type'         => ! empty( $request['type'] ) ? $request['type'] : 'select',
-			'order_by'     => ! empty( $request['order_by'] ) ? $request['order_by'] : 'menu_order',
-			'has_archives' => true === $request['has_archives'],
-		) );
+		$id = wc_create_attribute(
+			array(
+				'name'         => $request['name'],
+				'slug'         => wc_sanitize_taxonomy_name( stripslashes( $request['slug'] ) ),
+				'type'         => ! empty( $request['type'] ) ? $request['type'] : 'select',
+				'order_by'     => ! empty( $request['order_by'] ) ? $request['order_by'] : 'menu_order',
+				'has_archives' => true === $request['has_archives'],
+			)
+		);
 
 		// Checks for errors.
 		if ( is_wp_error( $id ) ) {
@@ -320,13 +335,16 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 		global $wpdb;
 
 		$id     = (int) $request['id'];
-		$edited = wc_update_attribute( $id, array(
-			'name'         => $request['name'],
-			'slug'         => wc_sanitize_taxonomy_name( stripslashes( $request['slug'] ) ),
-			'type'         => $request['type'],
-			'order_by'     => $request['order_by'],
-			'has_archives' => $request['has_archives'],
-		) );
+		$edited = wc_update_attribute(
+			$id,
+			array(
+				'name'         => $request['name'],
+				'slug'         => wc_sanitize_taxonomy_name( stripslashes( $request['slug'] ) ),
+				'type'         => $request['type'],
+				'order_by'     => $request['order_by'],
+				'has_archives' => $request['has_archives'],
+			)
+		);
 
 		// Checks for errors.
 		if ( is_wp_error( $edited ) ) {
@@ -400,9 +418,9 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	/**
 	 * Prepare a single product attribute output for response.
 	 *
-	 * @param obj $item Term object.
-	 * @param WP_REST_Request $request
-	 * @return WP_REST_Response $response
+	 * @param obj             $item Term object.
+	 * @param WP_REST_Request $request The request to process.
+	 * @return WP_REST_Response
 	 */
 	public function prepare_item_for_response( $item, $request ) {
 		$data = array(
@@ -443,7 +461,7 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	protected function prepare_links( $attribute ) {
 		$base  = '/' . $this->namespace . '/' . $this->rest_base;
 		$links = array(
-			'self' => array(
+			'self'       => array(
 				'href' => rest_url( trailingslashit( $base ) . $attribute->attribute_id ),
 			),
 			'collection' => array(
@@ -461,17 +479,17 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	 */
 	public function get_item_schema() {
 		$schema = array(
-			'$schema'              => 'http://json-schema.org/draft-04/schema#',
-			'title'                => 'product_attribute',
-			'type'                 => 'object',
-			'properties'           => array(
-				'id' => array(
+			'$schema'    => 'http://json-schema.org/draft-04/schema#',
+			'title'      => 'product_attribute',
+			'type'       => 'object',
+			'properties' => array(
+				'id'           => array(
 					'description' => __( 'Unique identifier for the resource.', 'woocommerce' ),
 					'type'        => 'integer',
 					'context'     => array( 'view', 'edit' ),
 					'readonly'    => true,
 				),
-				'name' => array(
+				'name'         => array(
 					'description' => __( 'Attribute name.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
@@ -479,7 +497,7 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 						'sanitize_callback' => 'sanitize_text_field',
 					),
 				),
-				'slug' => array(
+				'slug'         => array(
 					'description' => __( 'An alphanumeric identifier for the resource unique to its type.', 'woocommerce' ),
 					'type'        => 'string',
 					'context'     => array( 'view', 'edit' ),
@@ -487,14 +505,14 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 						'sanitize_callback' => 'sanitize_title',
 					),
 				),
-				'type' => array(
+				'type'         => array(
 					'description' => __( 'Type of attribute.', 'woocommerce' ),
 					'type'        => 'string',
 					'default'     => 'select',
 					'enum'        => array_keys( wc_get_attribute_types() ),
 					'context'     => array( 'view', 'edit' ),
 				),
-				'order_by' => array(
+				'order_by'     => array(
 					'description' => __( 'Default sort order.', 'woocommerce' ),
 					'type'        => 'string',
 					'default'     => 'menu_order',
@@ -519,7 +537,7 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	 * @return array
 	 */
 	public function get_collection_params() {
-		$params = array();
+		$params            = array();
 		$params['context'] = $this->get_context_param( array( 'default' => 'view' ) );
 
 		return $params;
@@ -559,11 +577,16 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	protected function get_attribute( $id ) {
 		global $wpdb;
 
-		$attribute = $wpdb->get_row( $wpdb->prepare( "
+		$attribute = $wpdb->get_row(
+			$wpdb->prepare(
+				"
 			SELECT *
 			FROM {$wpdb->prefix}woocommerce_attribute_taxonomies
 			WHERE attribute_id = %d
-		 ", $id ) );
+		 ",
+				$id
+			)
+		);
 
 		if ( is_wp_error( $attribute ) || is_null( $attribute ) ) {
 			return new WP_Error( 'woocommerce_rest_attribute_invalid', __( 'Resource does not exist.', 'woocommerce' ), array( 'status' => 404 ) );
@@ -576,16 +599,19 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	 * Validate attribute slug.
 	 *
 	 * @deprecated 3.2.0
-	 * @param string $slug
-	 * @param bool $new_data
+	 * @param string $slug The slug to validate.
+	 * @param bool   $new_data If we are creating new data.
 	 * @return bool|WP_Error
 	 */
 	protected function validate_attribute_slug( $slug, $new_data = true ) {
 		if ( strlen( $slug ) >= 28 ) {
+			/* translators: %s: slug being validated */
 			return new WP_Error( 'woocommerce_rest_invalid_product_attribute_slug_too_long', sprintf( __( 'Slug "%s" is too long (28 characters max). Shorten it, please.', 'woocommerce' ), $slug ), array( 'status' => 400 ) );
 		} elseif ( wc_check_if_attribute_name_is_reserved( $slug ) ) {
+			/* translators: %s: slug being validated */
 			return new WP_Error( 'woocommerce_rest_invalid_product_attribute_slug_reserved_name', sprintf( __( 'Slug "%s" is not allowed because it is a reserved term. Change it, please.', 'woocommerce' ), $slug ), array( 'status' => 400 ) );
 		} elseif ( $new_data && taxonomy_exists( wc_attribute_taxonomy_name( $slug ) ) ) {
+			/* translators: %s: slug being validated */
 			return new WP_Error( 'woocommerce_rest_invalid_product_attribute_slug_already_exists', sprintf( __( 'Slug "%s" is already in use. Change it, please.', 'woocommerce' ), $slug ), array( 'status' => 400 ) );
 		}
 

--- a/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller.php
+++ b/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller.php
@@ -44,6 +44,13 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	protected $attribute = '';
 
 	/**
+	 * Cached taxonomies by attribute id.
+	 *
+	 * @var array
+	 */
+	protected $taxonomies_by_id = array();
+
+	/**
 	 * Register the routes for product attributes.
 	 */
 	public function register_routes() {
@@ -525,17 +532,22 @@ class WC_REST_Product_Attributes_V1_Controller extends WC_REST_Controller {
 	 * @return string
 	 */
 	protected function get_taxonomy( $request ) {
-		if ( '' !== $this->attribute ) {
-			return $this->attribute;
+		$attribute_id = $request['id'];
+
+		if ( empty( $attribute_id ) ) {
+			return '';
 		}
 
-		if ( $request['id'] ) {
-			$name = wc_attribute_taxonomy_name_by_id( (int) $request['id'] );
-
-			$this->attribute = $name;
+		if ( isset( $this->taxonomies_by_id[ $attribute_id ] ) ) {
+			return $this->taxonomies_by_id[ $attribute_id ];
 		}
 
-		return $this->attribute;
+		$taxonomy = WC()->call_function( 'wc_attribute_taxonomy_name_by_id', (int) $request['id'] );
+		if ( ! empty( $taxonomy ) ) {
+			$this->taxonomies_by_id[ $attribute_id ] = $taxonomy;
+		}
+
+		return $taxonomy;
 	}
 
 	/**

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller.php
@@ -358,7 +358,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 		$max_pages = ceil( $total_terms / $per_page );
 		$response->header( 'X-WP-TotalPages', (int) $max_pages );
 
-		$base  = str_replace( '(?P<attribute_id>[\d]+)', $request['attribute_id'], $this->rest_base );
+		$base = str_replace( '(?P<attribute_id>[\d]+)', $request['attribute_id'], $this->rest_base );
 		$base = add_query_arg( $request->get_query_params(), rest_url( '/' . $this->namespace . '/' . $base ) );
 		if ( $page > 1 ) {
 			$prev_page = $page - 1;
@@ -700,7 +700,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 
 		$params['context']['default'] = 'view';
 
-		$params['exclude'] = array(
+		$params['exclude']    = array(
 			'description'       => __( 'Ensure result set excludes specific IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -709,7 +709,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['include'] = array(
+		$params['include']    = array(
 			'description'       => __( 'Limit result set to specific ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -763,13 +763,13 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['product'] = array(
+		$params['product']    = array(
 			'description'       => __( 'Limit result set to resources assigned to a specific product.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => null,
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['slug']    = array(
+		$params['slug']       = array(
 			'description'       => __( 'Limit result set to resources with a specific slug.', 'woocommerce' ),
 			'type'              => 'string',
 			'validate_callback' => 'rest_validate_request_arg',
@@ -797,7 +797,7 @@ abstract class WC_REST_Terms_Controller extends WC_REST_Controller {
 
 		$taxonomy = WC()->call_function( 'wc_attribute_taxonomy_name_by_id', (int) $request['attribute_id'] );
 		if ( ! empty( $taxonomy ) ) {
-			$this->taxonomy = $taxonomy;
+			$this->taxonomy                          = $taxonomy;
 			$this->taxonomies_by_id[ $attribute_id ] = $taxonomy;
 		}
 

--- a/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller-tests.php
+++ b/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller-tests.php
@@ -6,14 +6,22 @@
  */
 class WC_REST_Product_Attributes_V1_Controller_Tests extends WC_Unit_Test_Case {
 
+	/**
+	 * Runs before any test.
+	 */
 	public function setUp() {
+		// phpcs:disable Generic.CodeAnalysis, Squiz.Commenting
 		$this->sut = new class() extends WC_REST_Product_Attributes_V1_Controller {
 			public function get_taxonomy( $request ) {
-				  return parent::get_taxonomy( $request );
+				return parent::get_taxonomy( $request );
 			}
 		};
+		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
 	}
 
+	/**
+	 * testdox 'get_taxonomy' returns the proper values when called for different requests.
+	 */
 	public function test_get_taxonomy_returns_the_proper_values_for_different_requests() {
 		$this->register_legacy_proxy_function_mocks(
 			array(

--- a/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller-tests.php
+++ b/tests/php/includes/rest-api/Controllers/Version1/class-wc-rest-product-attributes-v1-controller-tests.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * class WC_REST_Product_Attributes_V1_Controller_Tests.
+ * Product Attributes Controller tests for V1 REST API.
+ */
+class WC_REST_Product_Attributes_V1_Controller_Tests extends WC_Unit_Test_Case {
+
+	public function setUp() {
+		$this->sut = new class() extends WC_REST_Product_Attributes_V1_Controller {
+			public function get_taxonomy( $request ) {
+				  return parent::get_taxonomy( $request );
+			}
+		};
+	}
+
+	public function test_get_taxonomy_returns_the_proper_values_for_different_requests() {
+		$this->register_legacy_proxy_function_mocks(
+			array(
+				'wc_attribute_taxonomy_name_by_id' => function( $attribute_id ) {
+					return 'taxonomy_' . $attribute_id;
+				},
+			)
+		);
+
+		$request = array( 'id' => 1 );
+		$value1  = $this->sut->get_taxonomy( $request );
+
+		$request = array( 'id' => 2 );
+		$value2  = $this->sut->get_taxonomy( $request );
+
+		$this->assertEquals( 'taxonomy_1', $value1 );
+		$this->assertEquals( 'taxonomy_2', $value2 );
+	}
+}
+

--- a/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
+++ b/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
@@ -1,0 +1,36 @@
+<?php
+
+/**
+ * class WC_REST_Products_Controller_Tests.
+ * Terms Controller tests for V3 REST API.
+ */
+class WC_REST_Terms_Controller_Tests extends WC_Unit_Test_Case
+{
+	public function setUp()
+	{
+		$this->sut = new class extends WC_REST_Terms_Controller {
+			public function get_taxonomy( $request ) {
+				return parent::get_taxonomy($request);
+			}
+		};
+	}
+
+	public function test_get_taxonomy_returns_the_proper_values_for_different_requests() {
+		$this->register_legacy_proxy_function_mocks(
+			[
+				'wc_attribute_taxonomy_name_by_id' => function($attribute_id) {
+					return 'taxonomy_' . $attribute_id;
+				}
+			]
+		);
+
+		$request = ['attribute_id' => 1];
+		$value1 = $this->sut->get_taxonomy($request);
+
+		$request = ['attribute_id' => 2];
+		$value2 = $this->sut->get_taxonomy($request);
+
+		$this->assertEquals('taxonomy_1', $value1);
+		$this->assertEquals('taxonomy_2', $value2);
+	}
+}

--- a/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
+++ b/tests/php/includes/rest-api/Controllers/Version3/class-wc-rest-terms-controller-tests.php
@@ -4,33 +4,40 @@
  * class WC_REST_Products_Controller_Tests.
  * Terms Controller tests for V3 REST API.
  */
-class WC_REST_Terms_Controller_Tests extends WC_Unit_Test_Case
-{
-	public function setUp()
-	{
-		$this->sut = new class extends WC_REST_Terms_Controller {
+class WC_REST_Terms_Controller_Tests extends WC_Unit_Test_Case {
+
+	/**
+	 * Runs before any test.
+	 */
+	public function setUp() {
+		// phpcs:disable Generic.CodeAnalysis, Squiz.Commenting
+		$this->sut = new class() extends WC_REST_Terms_Controller {
 			public function get_taxonomy( $request ) {
-				return parent::get_taxonomy($request);
+				return parent::get_taxonomy( $request );
 			}
 		};
+		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
 	}
 
+	/**
+	 * @testdox 'get_taxonomy' returns the proper values when called for different requests.
+	 */
 	public function test_get_taxonomy_returns_the_proper_values_for_different_requests() {
 		$this->register_legacy_proxy_function_mocks(
-			[
-				'wc_attribute_taxonomy_name_by_id' => function($attribute_id) {
+			array(
+				'wc_attribute_taxonomy_name_by_id' => function( $attribute_id ) {
 					return 'taxonomy_' . $attribute_id;
-				}
-			]
+				},
+			)
 		);
 
-		$request = ['attribute_id' => 1];
-		$value1 = $this->sut->get_taxonomy($request);
+		$request = array( 'attribute_id' => 1 );
+		$value1  = $this->sut->get_taxonomy( $request );
 
-		$request = ['attribute_id' => 2];
-		$value2 = $this->sut->get_taxonomy($request);
+		$request = array( 'attribute_id' => 2 );
+		$value2  = $this->sut->get_taxonomy( $request );
 
-		$this->assertEquals('taxonomy_1', $value1);
-		$this->assertEquals('taxonomy_2', $value2);
+		$this->assertEquals( 'taxonomy_1', $value1 );
+		$this->assertEquals( 'taxonomy_2', $value2 );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `WC_REST_Terms_Controller` and `WC_REST_Product_Attributes_V1_Controller` classes have a get_taxonomy method that gets the name of the taxonomy to process from a taxonomy id passed in the request, but once the taxonomy name has been obtained it's cached and sbsequently reused. The problem is that these controller instances are reused if more than one request is processed programmatically, and thus the taxonomy that was cached once is always used even if the new request specifies a
different taxonomy id.

The fix consists of using a dictionary of taxonomy id - taxonomy name instead of one single taxonomy for caching.

In the case of `WC_REST_Terms_Controller` there's a protected `$taxonomy` property that needs to be kept for compatibility, it's now set to the last taxonomy name that has been introduced in the dictionary.

Closes https://github.com/woocommerce/woocommerce/issues/27434.

### How to test the changes in this Pull Request:

Run the code pointed out in [the original issue](https://github.com/woocommerce/woocommerce/issues/27434), (it needs to be run while or after the `wp_loaded` action has been fired), and verify that `$data1` and `$data2` properly contain the terms for each of the requested taxonomies (without the fix both would contain the same values).

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - wrong taxonomy caching in term and product attributes controllers.
