### PR TITLE
Wrap variables in recent SASS format closes #29119

### DIFF
--- a/assets/css/_variables.scss
+++ b/assets/css/_variables.scss
@@ -22,17 +22,17 @@ $subtext:           #767676 !default;                                  // small,
 
 // export vars as CSS vars
 :root {
-	--woocommerce: $woocommerce;
-	--wc-green: $green;
-	--wc-red: $red;
-	--wc-orange: $orange;
-	--wc-blue: $blue;
-	--wc-primary: $primary;
-	--wc-primary-text: $primarytext;
-	--wc-secondary: $secondary;
-	--wc-secondary-text: $secondarytext;
-	--wc-highlight: $highlight;
-	--wc-highligh-text: $highlightext;
-	--wc-content-bg: $contentbg;
-	--wc-subtext: $subtext;
+	--woocommerce: #{$woocommerce};
+	--wc-green: #{$green};
+	--wc-red: #{$red};
+	--wc-orange: #{$orange};
+	--wc-blue: #{$blue};
+	--wc-primary: #{$primary};
+	--wc-primary-text: #{$primarytext};
+	--wc-secondary: #{$secondary};
+	--wc-secondary-text: #{$secondarytext};
+	--wc-highlight: #{$highlight};
+	--wc-highligh-text: #{$highlightext};
+	--wc-content-bg: #{$contentbg};
+	--wc-subtext: #{$subtext};
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29119

### How to test the changes in this Pull Request:

1. Compile the assets. `grunt assets`
2. Check `woocommerce-layout.css` file.
3. Ensure variables are translated to the correct CSS values. such as `:root{--woocommerce:#a46497...}`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - SASS variables not being compile correctly due to recent SASS version.

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
