### PR TITLE
Remove extra content wrapper

### DIFF
--- a/includes/theme-support/class-wc-twenty-twenty-one.php
+++ b/includes/theme-support/class-wc-twenty-twenty-one.php
@@ -24,9 +24,6 @@ class WC_Twenty_Twenty_One {
 		remove_action( 'woocommerce_before_main_content', 'woocommerce_output_content_wrapper', 10 );
 		remove_action( 'woocommerce_after_main_content', 'woocommerce_output_content_wrapper_end', 10 );
 
-		add_action( 'woocommerce_before_main_content', array( __CLASS__, 'output_content_wrapper' ), 10 );
-		add_action( 'woocommerce_after_main_content', array( __CLASS__, 'output_content_wrapper_end' ), 10 );
-
 		// This theme doesn't have a traditional sidebar.
 		remove_action( 'woocommerce_sidebar', 'woocommerce_get_sidebar', 10 );
 
@@ -34,7 +31,7 @@ class WC_Twenty_Twenty_One {
 		add_filter( 'woocommerce_enqueue_styles', array( __CLASS__, 'enqueue_styles' ) );
 
 		// Enqueue wp-admin compatibility styles.
-		add_action( 'admin_enqueue_scripts', array( __CLASS__ , 'enqueue_admin_styles' ) );
+		add_action( 'admin_enqueue_scripts', array( __CLASS__, 'enqueue_admin_styles' ) );
 
 		// Register theme features.
 		add_theme_support( 'wc-product-gallery-zoom' );
@@ -48,22 +45,6 @@ class WC_Twenty_Twenty_One {
 			)
 		);
 
-	}
-
-	/**
-	 * Open the Twenty Twenty One wrapper.
-	 */
-	public static function output_content_wrapper() {
-		echo '<section id="primary" class="content-area">';
-		echo '<main id="main" class="site-main">';
-	}
-
-	/**
-	 * Close the Twenty Twenty One wrapper.
-	 */
-	public static function output_content_wrapper_end() {
-		echo '</main>';
-		echo '</section>';
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28868 

The outer wrapper `<div id="primary" class="content-area"> <main id="main" class="site-main" role="main">` is from twentytwentyone theme, so remove the extra content wrapper in WooCommerce.

### How to test the changes in this Pull Request:

1. Go to your WooCommerce shop page
2. See there's no double wrapper for primary and main
<img width="469" alt="螢幕快照 2021-02-12 下午6 23 31" src="https://user-images.githubusercontent.com/56378160/107832888-9db2e600-6d5f-11eb-832c-b020639c13e7.png">

### Changelog entry

> Fix - Remove duplicate containers from the single and archive product pages.