### PR TITLE
Update cart form quantity and coupon code input style

### DIFF
--- a/plugins/woocommerce/changelog/fix-28791-tt1-cart-input-widths
+++ b/plugins/woocommerce/changelog/fix-28791-tt1-cart-input-widths
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Adjust default sizes for the quantity and coupon input fields within the cart page.

--- a/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
+++ b/plugins/woocommerce/client/legacy/css/twenty-twenty-one.scss
@@ -127,11 +127,13 @@ a.button {
 }
 
 .site-main {
+
 	.woocommerce-breadcrumb {
 		margin-bottom: var(--global--spacing-vertical);
 		font-size: 0.88889em;
 		font-family: $headings;
 	}
+
 	.woocommerce-products-header {
 		margin-top: var(--global--spacing-vertical);
 	}
@@ -2887,6 +2889,8 @@ a.reset_variations {
 
 	.woocommerce-cart-form {
 
+		text-align: center;
+
 		.shop_table_responsive {
 			margin-top: var(--global--spacing-vertical);
 			margin-bottom: var(--global--spacing-vertical);
@@ -2895,8 +2899,9 @@ a.reset_variations {
 				border: none;
 			}
 
-			#coupon_code {
+			input#coupon_code.input-text {
 				min-width: 9rem;
+				width: auto !important;
 			}
 		}
 
@@ -2919,6 +2924,11 @@ a.reset_variations {
 			.attachment-woocommerce_thumbnail {
 				height: auto !important;
 			}
+		}
+
+		input.qty {
+			width: 6em;
+			text-align: center;
 		}
 	}
 


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix #28791 

### How to test the changes in this Pull Request:

1. Go to your WooCommerce cart.
2. Check the quantity and coupon code inputs.

Before
<img width="1262" alt="before" src="https://user-images.githubusercontent.com/56378160/107841368-4ecd7680-6d88-11eb-94f2-d6f003fbf9e5.png">
<img width="345" alt="螢幕快照 2021-02-12 下午11 16 48" src="https://user-images.githubusercontent.com/56378160/107841376-699feb00-6d88-11eb-832e-431a034fd5e4.png">

After
<img width="1257" alt="螢幕快照 2021-02-12 下午11 15 52" src="https://user-images.githubusercontent.com/56378160/107841378-702e6280-6d88-11eb-8079-9dd21bca894b.png">
<img width="414" alt="螢幕快照 2021-02-12 下午11 02 31" src="https://user-images.githubusercontent.com/56378160/107841381-73c1e980-6d88-11eb-88f3-bcd03ed231bc.png">

✍🏼 Note that, since this PR was originally created, there have been other changes in WooCommerce and in Twenty Twenty-One. Currently, the quantity input will generally have a size attribute set and therefore, *in many cases,* you may not discern a difference with that input. You should however notice the coupon code is widened:

<img width="1265" alt="Screenshot 2023-02-16 at 10 25 00" src="https://user-images.githubusercontent.com/3594411/219455575-d8e1b2b3-8e20-4935-8be2-e22e500f4890.png">
