### PR TITLE
Check if index value is set before accessing

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -747,7 +747,7 @@ class WC_Checkout {
 				$field_label = isset( $field['label'] ) ? $field['label'] : '';
 
 				if ( $validate_fieldset &&
-					'country' === $field['type'] &&
+					( isset( $field['type'] ) && 'country' === $field['type'] ) &&
 					! WC()->countries->country_exists( $data[ $key ] ) ) {
 						/* translators: ISO 3166-1 alpha-2 country code */
 						$errors->add( $key . '_validation', sprintf( __( "'%s' is not a valid country code.", 'woocommerce' ), $data[ $key ] ) );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds a check if array is set before trying to access.

### How to test the changes in this Pull Request:

1. From master branch setup a shipping method such as flat rate.
2. Add item to cart and go through checkout.
3. You will see in PHP logs `PHP Notice:  Undefined index: type in /srv/www/gitwooplugins/public_html/wp-content/plugins/woocommerce/includes/class-wc-checkout.php on line 750`
4. Switch to this PR. Re-test the steps from above.
5. The PHP notice should no longer produce.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - PHP notice when checking out.
