### PR TITLE
Only add '(optional)' to the billing_address_2 placeholder | #25510

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -658,10 +658,14 @@ class WC_Countries {
 	 * @return array
 	 */
 	public function get_default_address_fields() {
+		$address_2_label = __( 'Apartment, suite, unit, etc.', 'woocommerce' );
+
+		// If necessary, append '(optional)' to the placeholder: we don't need to worry about the
+		// label, though, as woocommerce_form_field() takes care of that.
 		if ( 'optional' === get_option( 'woocommerce_checkout_address_2_field', 'optional' ) ) {
 			$address_2_placeholder = __( 'Apartment, suite, unit, etc. (optional)', 'woocommerce' );
 		} else {
-			$address_2_placeholder = __( 'Apartment, suite, unit, etc.', 'woocommerce' );
+			$address_2_placeholder = $address_2_label;
 		}
 
 		$fields = array(
@@ -704,6 +708,8 @@ class WC_Countries {
 				'priority'     => 50,
 			),
 			'address_2'  => array(
+				'label'        => esc_attr( $address_2_label ),
+				'label_class'  => array( 'screen-reader-text' ),
 				'placeholder'  => esc_attr( $address_2_placeholder ),
 				'class'        => array( 'form-row-wide', 'address-field' ),
 				'autocomplete' => 'address-line2',

--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -708,7 +708,7 @@ class WC_Countries {
 				'priority'     => 50,
 			),
 			'address_2'  => array(
-				'label'        => esc_attr( $address_2_label ),
+				'label'        => $address_2_label,
 				'label_class'  => array( 'screen-reader-text' ),
 				'placeholder'  => esc_attr( $address_2_placeholder ),
 				'class'        => array( 'form-row-wide', 'address-field' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Billing Address 2 is usually an optional field. To make this clear, as we do with other optional fields, we append the text `(optional)` at the end of the string. Unfortunately, that piece of text was unintentionally being duplicated, please see the screenshot for an example (since the label is also hidden, I captured the page inspector):

![dupe-optional](https://user-images.githubusercontent.com/3594411/107996628-ab51b100-6f95-11eb-82f5-8c814e26427c.png)

_With_ this change in place, the label remains hidden by default and the duplication is resolved:

![dupe-optional-cleaned-up](https://user-images.githubusercontent.com/3594411/107996682-d20fe780-6f95-11eb-87cd-43d6dbd65645.png)

Closes #25510.

### How to test the changes in this Pull Request:

1. Checkout current `master`
2. Visit the checkout page and inspect the markup for Billing Address 2 field.
3. Notice that `(optional)` is repeated (as part of the label text, and again within a span).
4. Checkout this branch.
5. Confirm that:
    * The extra `(optional)` is removed from the _label._
    * That the placeholder text still has `(optional)` at the end.
    * That the label remains hidden.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Avoids duplicating the word '(optional)' in the context of the Billing Address 2 field.
