### PR TITLE
Fix placeholder image height in cart closes #29137

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -1482,7 +1482,7 @@ a.reset_variations {
 		}
 	}
 
-	table.cart img, .woocommerce table.cart img, .woocommerce-page #content table.cart img, .woocommerce-page table.cart img {
+	table.cart img.woocommerce-placeholder {
 		height: auto !important;
 	}
 }

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -1481,6 +1481,10 @@ a.reset_variations {
 			border: 1px solid #ddd;
 		}
 	}
+
+	table.cart img, .woocommerce table.cart img, .woocommerce-page #content table.cart img, .woocommerce-page table.cart img {
+		height: auto !important;
+	}
 }
 
 /**
@@ -1871,7 +1875,7 @@ a.reset_variations {
 			}
 		}
 	}
-	
+
 	tfoot {
 		text-align: left;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29137

### How to test the changes in this Pull Request:

**NOTE**: you need to first minify the assets `grunt assets`

1. Enable Twenty Twenty One theme.
2. Add a product to the cart that has no main image.
3. Ensure the placeholder image in the cart is not distorted vertically.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> * Fix - Product placeholder image distorted in the cart using Twenty Twenty One theme. #29137

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
