### PR TITLE
README: Better instructions for running tests db

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -5,18 +5,31 @@ This document discusses unit tests. See [the e2e README](https://github.com/wooc
 
 ## Table of contents
 
-- [WooCommerce Unit Tests](#woocommerce-unit-tests)
+- [WooCommerce Tests](#woocommerce-tests)
+  - [Table of contents](#table-of-contents)
   - [Initial Setup](#initial-setup)
+    - [MySQL database](#mysql-database)
+    - [Setup instructions](#setup-instructions)
   - [Running Tests](#running-tests)
+    - [Running tests in PHP 8](#running-tests-in-php-8)
   - [Writing Tests](#writing-tests)
   - [Automated Tests](#automated-tests)
   - [Code Coverage](#code-coverage)
-- [WooCommerce E2E Tests](#woocommerce-e2e-tests)
 
 
 ## Initial Setup
 
-From the WooCommerce root directory (if you are using VVV you might need to `vagrant ssh` first), run the following:
+### MySQL database
+
+To run the tests, you need to create a test database. You can:
+- Access a database on a server
+- Connect to your local database on your machine
+- Use a solution like VVV - if you are using VVV you might need to `vagrant ssh` first
+- Run a throwaway database in docker with this one-liner: `docker run --rm --name woocommerce_test_db -p 3306:3306 -e MYSQL_ROOT_PASSWORD=woocommerce_test_password -d mysql:5.7.33`. ( Use `tests/bin/install.sh woocommerce_tests root woocommerce_test_password 0.0.0.0` in next step) 
+
+### Setup instructions
+
+Once you have database, from the WooCommerce root directory run the following:
 
 1. Install [PHPUnit](http://phpunit.de/) via Composer by running:
     ```


### PR DESCRIPTION
No functional changes

This PR:
-  introduces a one-liner to README which helps to set up test DB.
- Updates TOC in the tests/README.md

## Motivation

I literally have no SQL access anywhere and had to figure out for myself to test my changes from other PR.
This will help contributors start with running tests quicker.

## Testing

Well, you can follow instructions and run tests in the container

## FAQ

Why MySQL:5.7 and not 8?

Because that's the tag supported by https://hub.docker.com/_/mysql .
On MySQL 8 tests fail with:

```
PHP Warning:  mysqli_real_connect(): The server requested authentication method unknown to the client [caching_sha2_password] in /private/var/folders/w0/l70qdn591rb954_1_rj7dt1r0000gn/T/wordpress/wp-includes/wp-db.php on line 1653
```

### Changelog entry

N/A