### PR TITLE
Add the support to optgroups in single select on Settings API

### DIFF
--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -712,11 +712,11 @@ abstract class WC_Settings_API {
 							<?php if ( is_array( $option_value ) ) : ?>
 								<optgroup label="<?php echo esc_attr( $option_key ); ?>">
 									<?php foreach ( $option_value as $option_key_inner => $option_value_inner ) : ?>
-										<option value="<?php echo esc_attr( $option_key_inner ); ?>" <?php selected( (string) $option_key_inner, $value ); ?>><?php echo esc_html( $option_value_inner ); ?></option>
+										<option value="<?php echo esc_attr( $option_key_inner ); ?>" <?php selected( (string) $option_key_inner, esc_attr( $value ) ); ?>><?php echo esc_html( $option_value_inner ); ?></option>
 									<?php endforeach; ?>
 								</optgroup>
 							<?php else : ?>
-								<option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( (string) $option_key, $value ); ?>><?php echo esc_html( $option_value ); ?></option>
+								<option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( (string) $option_key, esc_attr( $value ) ); ?>><?php echo esc_html( $option_value ); ?></option>
 							<?php endif; ?>
 						<?php endforeach; ?>
 					</select>

--- a/includes/abstracts/abstract-wc-settings-api.php
+++ b/includes/abstracts/abstract-wc-settings-api.php
@@ -696,6 +696,7 @@ abstract class WC_Settings_API {
 		);
 
 		$data = wp_parse_args( $data, $defaults );
+		$value = $this->get_option( $key );
 
 		ob_start();
 		?>
@@ -708,7 +709,15 @@ abstract class WC_Settings_API {
 					<legend class="screen-reader-text"><span><?php echo wp_kses_post( $data['title'] ); ?></span></legend>
 					<select class="select <?php echo esc_attr( $data['class'] ); ?>" name="<?php echo esc_attr( $field_key ); ?>" id="<?php echo esc_attr( $field_key ); ?>" style="<?php echo esc_attr( $data['css'] ); ?>" <?php disabled( $data['disabled'], true ); ?> <?php echo $this->get_custom_attribute_html( $data ); // WPCS: XSS ok. ?>>
 						<?php foreach ( (array) $data['options'] as $option_key => $option_value ) : ?>
-							<option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( (string) $option_key, esc_attr( $this->get_option( $key ) ) ); ?>><?php echo esc_html( $option_value ); ?></option>
+							<?php if ( is_array( $option_value ) ) : ?>
+								<optgroup label="<?php echo esc_attr( $option_key ); ?>">
+									<?php foreach ( $option_value as $option_key_inner => $option_value_inner ) : ?>
+										<option value="<?php echo esc_attr( $option_key_inner ); ?>" <?php selected( (string) $option_key_inner, $value ); ?>><?php echo esc_html( $option_value_inner ); ?></option>
+									<?php endforeach; ?>
+								</optgroup>
+							<?php else : ?>
+								<option value="<?php echo esc_attr( $option_key ); ?>" <?php selected( (string) $option_key, $value ); ?>><?php echo esc_html( $option_value ); ?></option>
+							<?php endif; ?>
 						<?php endforeach; ?>
 					</select>
 					<?php echo $this->get_description_html( $data ); // WPCS: XSS ok. ?>


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Add the optgroups support to single select from Settings API.
The multiselect input already has this feature.

### How to test the changes in this Pull Request:

1. Create a `WC_Shipping_Method` (or any class extends `WC_Settings_API`).
2. In `init_form_fields` method insert the select with options as array of arrays. 
3. Check the created output.

```
'example' => array(
    'type'    => 'select',
    'title'   => 'Example',
    'options' => array(
        'Group 1' => [
            '11' => 'Option 11',
            '12' => 'Option 12',
            '13' => 'Option 13',
        ],
        'Group 2' => [
            '21' => 'Option 21',
            '22' => 'Option 22',
            '23' => 'Option 23',
        ],
    ),
),
```

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Tweak - Add the support to `optgroups` in single select on Settings API.
