### PR TITLE
Throw an error if a coupon item ID (readonly) is specified during an order update | #27290

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -45,16 +45,18 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 
 		foreach ( $request['coupon_lines'] as $item ) {
 			if ( is_array( $item ) ) {
-				if ( empty( $item['id'] ) ) {
-					if ( empty( $item['code'] ) ) {
-						throw new WC_REST_Exception( 'woocommerce_rest_invalid_coupon', __( 'Coupon code is required.', 'woocommerce' ), 400 );
-					}
+				if ( ! empty( $item['id'] ) ) {
+					throw new WC_REST_Exception( 'woocommerce_rest_coupon_item_id_readonly', __( 'Coupon item ID is readonly.', 'woocommerce' ), 400 );
+				}
 
-					$results = $order->apply_coupon( wc_clean( $item['code'] ) );
+				if ( empty( $item['code'] ) ) {
+					throw new WC_REST_Exception( 'woocommerce_rest_invalid_coupon', __( 'Coupon code is required.', 'woocommerce' ), 400 );
+				}
 
-					if ( is_wp_error( $results ) ) {
-						throw new WC_REST_Exception( 'woocommerce_rest_' . $results->get_error_code(), $results->get_error_message(), 400 );
-					}
+				$results = $order->apply_coupon( wc_clean( $item['code'] ) );
+
+				if ( is_wp_error( $results ) ) {
+					throw new WC_REST_Exception( 'woocommerce_rest_' . $results->get_error_code(), $results->get_error_message(), 400 );
 				}
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently, if an order is updated via the REST API (see full steps to replicate in #27290), _and_ if coupons are specified, _and_ if one or more of those coupon objects contain an `id` property, then:

* The order is updated, and a `200 OK` response comes back.
* All coupons that were previously applied to the order will have been dropped, and the coupon specified in the request will not have been added.

The coupon lines are being rejected in the above case because the `id` field is readonly [(see here)](https://woocommerce.github.io/woocommerce-rest-api-docs/?php#order-coupon-lines-properties). However, as discussed in the linked issue, in a situation like this it would be preferable to bail out so that:

* A suitable error message is returned (with a `400 Bad Request` status)
* The order is not modified at all.

Closes #27290.

### How to test the changes in this Pull Request:

To see the problem using the [latest production code (5.0)](https://github.com/woocommerce/woocommerce/releases/tag/5.0.0) first of all:

1. Generate an order with a coupon applied.
2. Via a `PUT` request, try updating the order and apply another (or the same) coupon—be sure to include an `id` field for each coupon in the `coupon_lines` array.
3. Notice a `200 OK` response comes back but that _all coupons have been removed (unexpected!)_ :grimacing: 

Using this changeset:

1. Repeat the above.
2. Notice the response is a `400 Bad Request` and that the order itself is unchanged _(much clearer!)_ :slightly_smiling_face: 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

:memo: This change makes us stricter when it comes to handling situations where a coupon ID is set, _but nothing is changed if other readonly coupon fields are specified._ For example, with this change in place, if we update an order and specify one of the coupon lines as follows:

```json
{
    "id": 123,
    "code": "big-discount"
}
```

Then we get a `400 Bad Request`. However, the following will result in a `200 OK`, even though the `discount` field—just like the `id` field—is also readonly.

```json
{
    "id": 123,
    "discount": "500"
}
```

Arguably, we should also be strict about this _but it also feels like it is less critical_ and so we could follow-up with a future change to further tighten things, but still ship this more important incremental change in the meantime.

### Changelog entry

> Fix - If `coupon_lines` are specified within a REST API order update, return an error if coupon item IDs are also specified.


