### PR TITLE
Fix/contributor guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -42,6 +42,7 @@ If you have questions about the process to contribute code or want to discuss de
 - Please avoid modifying the changelog directly or updating the .pot files. These will be updated by the WooCommerce team.
 
 If you are contributing code to the (Javascript-driven) WooCommerce Admin project or to Gutenberg blocks, note that these are developed in external packages.
+
 - [WooCommerce Admin](https://github.com/woocommerce/woocommerce-admin)
 - [Blocks](https://github.com/woocommerce/woocommerce-gutenberg-products-block)
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -41,8 +41,8 @@ If you have questions about the process to contribute code or want to discuss de
 - Make sure to write good and detailed commit messages (see [this post](https://chris.beams.io/posts/git-commit/) for more on this) and follow all the applicable sections of the pull request template.
 - Please avoid modifying the changelog directly or updating the .pot files. These will be updated by the WooCommerce team.
 
-If you are contributing code to the REST API or editor blocks, these are developed in external packages.
-- [WooCommerce REST API package](https://github.com/woocommerce/woocommerce-rest-api)
+If you are contributing code to the (Javascript-driven) WooCommerce Admin project or to Gutenberg blocks, note that these are developed in external packages.
+- [WooCommerce Admin](https://github.com/woocommerce/woocommerce-admin)
 - [Blocks](https://github.com/woocommerce/woocommerce-gutenberg-products-block)
 
 ## Feature Requests 🚀


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Minor change to the contributor guidelines. We currently list two 'external' packages and note that they are developed separately:

* REST API :x: _(which is no longer developed separately)_
* Blocks :heavy_check_mark: _(is still developed separately)_

This change swaps out REST API (now developed as part of WC core) and replaces it with a link to the WC Admin project.

### How to test the changes in this Pull Request:

View modified Markdown.

### Changelog entry

> Tweak - Update the contributor guidelines.
