### PR TITLE
Prevent displaying coupon form on checkout requiring login

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -2292,12 +2292,14 @@ if ( ! function_exists( 'woocommerce_checkout_coupon_form' ) ) {
 	 * Output the Coupon form for the checkout.
 	 */
 	function woocommerce_checkout_coupon_form() {
-		wc_get_template(
-			'checkout/form-coupon.php',
-			array(
-				'checkout' => WC()->checkout(),
-			)
-		);
+		if ( is_user_logged_in() || WC()->checkout()->is_registration_enabled() || ! WC()->checkout()->is_registration_required() ) {
+			wc_get_template(
+				'checkout/form-coupon.php',
+				array(
+					'checkout' => WC()->checkout(),
+				)
+			);
+		}
 	}
 }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Prevents the coupon form from being displayed on the checkout page if the user isn't logged in, registration is required and you cannot create an account on checkout. 

We received this issue in WC Subscriptions (4019-gh-woocommerce/woocommerce-subscriptions#issuecomment-780209615) but given this is replicable via standard WC settings, I submitted the changes here.

Feedback provided from a customer: 

> I found the coupon reminder confusing given that I couldn't proceed with the checkout until I had an authenticated account. If it's possible, it might make more sense to prevent the coupon reminder from showing until the user is able to proceed with the checkout. That might be a broader issue with the way WC core displays the notice though. 🤔

### How to test the changes in this Pull Request:

1. While logged in, add a product to your cart.
2. Go to the checkout page. 
    - On `master` and this branch you should see the coupon form displayed. https://d.pr/i/HWMJ5a
3. Go to **WooCommerce > Settings > Accounts and Privacy.**
4. Change your settings to match these https://d.pr/i/cvTYw2
     - Disable _Allow customers to place orders without an account_ 
     - Disable _Allow customers to create an account during checkout_
5. Log out (or open your store in a new/private browser).
6. Add a product to your cart.
7. Go to the checkout page
     - On `master` you'll see the coupon form, with no checkout fields. https://d.pr/i/w0JpkG
     - On this branch, the coupon notice isn't displayed. https://d.pr/i/wnfrD8

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

I wasn't 100% sure where to add this logic so let me know if you'd prefer it to be added to the template which displays the form - `templates/checkout/form-coupon.php`.

### Changelog entry

> Fix - Don't display the coupon form on checkouts requiring the customer to be logged in to checkout.