### PR TITLE
refactor: remove unused while loop from WP CLI update command

### DIFF
--- a/includes/cli/class-wc-cli-update-command.php
+++ b/includes/cli/class-wc-cli-update-command.php
@@ -63,10 +63,6 @@ class WC_CLI_Update_Command {
 
 		foreach ( $callbacks_to_run as $update_callback ) {
 			call_user_func( $update_callback );
-			$result = false;
-			while ( $result ) {
-				$result = (bool) call_user_func( $update_callback );
-			}
 			$update_count ++;
 			$progress->tick();
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

While checking out the code in `wc update` WP CLI command I have noticed that due to 
`$result = false;`
the while loop below won't ever be executed. My guess is that someone wanted to use `do..while` here, but looks like this code can be removed altogheter. If you can think of any use for that, let me know and I'll refactor that to the aforementioned `do..while`.

### How to test the changes in this Pull Request:

1. Run WP CLI `wp wc update` command.
### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

>Refactor - Remove unused while loop in WP CLI WooCommerce database update command.
