### PR TITLE
Fixed logged-in users are able to access reset password page.

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-my-account.php
+++ b/includes/shortcodes/class-wc-shortcode-my-account.php
@@ -39,7 +39,7 @@ class WC_Shortcode_My_Account {
 			return;
 		}
 
-		if ( ! is_user_logged_in() || isset( $wp->query_vars['lost-password'] ) ) {
+		if ( ! is_user_logged_in() && isset( $wp->query_vars['lost-password'] ) ) {
 			$message = apply_filters( 'woocommerce_my_account_message', '' );
 
 			if ( ! empty( $message ) ) {


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Closes #28956

### How to test the changes in this Pull Request:

1. Log in as a customer.
2. Access the user password reset page.
3. You should not see the form, but be redirected to the user dashboard. But the user can actually access the form.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Logged-in users are now unable to access reset password page.
