### PR TITLE
Avoiding initialization of form_fields in frontend

### DIFF
--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -64,6 +64,15 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 	 * Initialise Gateway Settings Form Fields.
 	 */
 	public function init_form_fields() {
+
+		if ( ! is_admin() || defined('DOING_AJAX') ) {
+
+			// Don't initialize form fields if we are not in the backend, as this initialization slows down the site.
+			$this->form_fields = array();
+			return;
+
+		}
+
 		$this->form_fields = array(
 			'enabled'            => array(
 				'title'       => __( 'Enable/Disable', 'woocommerce' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29166 .

### How to test the changes in this Pull Request:

This change optimizes the initialization of the COD_Gateway class when not accessing the backend.
Everything should keep working as it does.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
Optimizing COD_Gateway initialization, potentially speeding up sites with several shipping methods and zones.
