### PR TITLE
add: action hook in toogle gateway enabled

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2996,7 +2996,10 @@ class WC_AJAX {
 
 				/**
 				 * Fires after on/off payment gateway
-				 * Here, $enabled is old status and $is_enabled is new status for the gateway
+				 *
+				 * @param string $gateway_id Gateway ID
+				 * @param bool $enabled Old status
+				 * @param bool $is_enabled Updated status
 				 */
 				do_action( 'woocommerce_after_toggle_gateway_enabled', $gateway_id, $enabled, $is_enabled );
 

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -2992,7 +2992,15 @@ class WC_AJAX {
 					$gateway->update_option( 'enabled', 'no' );
 				}
 
-				wp_send_json_success( ! wc_string_to_bool( $enabled ) );
+				$is_enabled = ! wc_string_to_bool( $enabled );
+
+				/**
+				 * Fires after on/off payment gateway
+				 * Here, $enabled is old status and $is_enabled is new status for the gateway
+				 */
+				do_action( 'woocommerce_after_toggle_gateway_enabled', $gateway_id, $enabled, $is_enabled );
+
+				wp_send_json_success( $is_enabled );
 				wp_die();
 			}
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A hook to be able to make some decisions when payment gateway is enabled or disabled.

### How to test the changes in this Pull Request:

1. add an action for 'woocommerce_after_toggle_gateway_enabled' and do some operations eg: log data to debug log for testing.
2. Now, go to woocommerce settings -> payments tab and enable or disable any gateway by the toggle button.
3. You can see the log in debug log.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> When the payment gateway is enabled/disabled do actions to make some decisions.
