### PR TITLE
Add a filter for the quantity input field label

### DIFF
--- a/templates/global/quantity-input.php
+++ b/templates/global/quantity-input.php
@@ -26,6 +26,7 @@ if ( $max_value && $min_value === $max_value ) {
 } else {
 	/* translators: %s: Quantity. */
 	$label = ! empty( $args['product_name'] ) ? sprintf( esc_html__( '%s quantity', 'woocommerce' ), wp_strip_all_tags( $args['product_name'] ) ) : esc_html__( 'Quantity', 'woocommerce' );
+	$label = apply_filters( 'woocommerce_quantity_input_label', $label );
 	?>
 	<div class="quantity">
 		<?php do_action( 'woocommerce_before_quantity_input_field' ); ?>


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This change introduces a new filter named `woocommerce_quantity_input_label` that allows the quantity input field to be changed without having to override the entire template.

### Changelog entry

Add filter to modify quantity input label