### PR TITLE
Avoid/minimize wc-ajax requests when `geolocation_ajax` is enabled | #26973

### DIFF
--- a/assets/js/frontend/geolocation.js
+++ b/assets/js/frontend/geolocation.js
@@ -31,7 +31,7 @@ jQuery( function( $ ) {
 	 * @returns {boolean}
 	 */
 	function needs_refresh() {
-		return geo_hash && ( new URLSearchParams( window.location.search ) ).get('v') !== geo_hash;
+		return geo_hash && ( new URLSearchParams( window.location.search ) ).get( 'v' ) !== geo_hash;
 	}
 
 	/**

--- a/assets/js/frontend/geolocation.js
+++ b/assets/js/frontend/geolocation.js
@@ -109,7 +109,7 @@ jQuery( function( $ ) {
 			var method = $this.attr( 'method' );
 			var hasField = $this.find( 'input[name="v"]' ).length > 0;
 
-			if (method && 'get' === method.toLowerCase() && ! hasField) {
+			if ( method && 'get' === method.toLowerCase() && ! hasField ) {
 				$this.append( '<input type="hidden" name="v" value="' + geo_hash + '" />' );
 			} else {
 				var href = $this.attr( 'action' );

--- a/assets/js/frontend/geolocation.js
+++ b/assets/js/frontend/geolocation.js
@@ -1,33 +1,90 @@
 /*global wc_geolocation_params */
 jQuery( function( $ ) {
+	/**
+	 * Contains the current geo hash (or false if the hash
+	 * is not set/cannot be determined).
+	 *
+	 * @type {boolean|string}
+	 */
+	var geo_hash = false;
 
-	var this_page = window.location.toString();
+	/**
+	 * Obtains the current geo hash from the `woocommerce_geo_hash` cookie, if set.
+	 *
+	 * @returns {boolean}
+	 */
+	function get_geo_hash() {
+		var geo_hash_cookie = Cookies.get( 'woocommerce_geo_hash' );
 
+		if ( 'string' === typeof geo_hash_cookie && geo_hash_cookie.length ) {
+			geo_hash = geo_hash_cookie;
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
+	 * If we have an active geo hash value but it does not match the `?v=` query var in
+	 * current page URL, that indicates that we need to refresh the page.
+	 *
+	 * @returns {boolean}
+	 */
+	function needs_refresh() {
+		return geo_hash && ( new URLSearchParams( window.location.search ) ).get('v') !== geo_hash;
+	}
+
+	/**
+	 * Appends (or replaces) the geo hash used for links on the current page.
+	 */
 	var $append_hashes = function() {
-		if ( wc_geolocation_params.hash ) {
-			$( 'a[href^="' + wc_geolocation_params.home_url + '"]:not(a[href*="v="]), a[href^="/"]:not(a[href*="v="])' ).each( function() {
-				var $this      = $( this ),
-					href       = $this.attr( 'href' ),
-					href_parts = href.split( '#' );
+		if ( ! geo_hash ) {
+			return;
+		}
 
-				href = href_parts[0];
+		$( 'a[href^="' + wc_geolocation_params.home_url + '"]:not(a[href*="v="]), a[href^="/"]:not(a[href*="v="])' ).each( function() {
+			var $this      = $( this ),
+				href       = $this.attr( 'href' ),
+				href_parts = href.split( '#' );
 
-				if ( href.indexOf( '?' ) > 0 ) {
-					href = href + '&v=' + wc_geolocation_params.hash;
-				} else {
-					href = href + '?v=' + wc_geolocation_params.hash;
-				}
+			href = href_parts[0];
 
-				if ( typeof href_parts[1] !== 'undefined' && href_parts[1] !== null ) {
-					href = href + '#' + href_parts[1];
-				}
+			if ( href.indexOf( '?' ) > 0 ) {
+				href = href + '&v=' + geo_hash;
+			} else {
+				href = href + '?v=' + geo_hash;
+			}
 
-				$this.attr( 'href', href );
-			});
+			if ( typeof href_parts[1] !== 'undefined' && href_parts[1] !== null ) {
+				href = href + '#' + href_parts[1];
+			}
+
+			$this.attr( 'href', href );
+		});
+	};
+
+	var $geolocate_customer = {
+		url: wc_geolocation_params.wc_ajax_url.toString().replace( '%%endpoint%%', 'get_customer_location' ),
+		type: 'GET',
+		success: function( response ) {
+			if ( response.success && response.data.hash && response.data.hash !== geo_hash ) {
+				$geolocation_redirect( response.data.hash );
+			}
 		}
 	};
 
+	/**
+	 * Once we have a new hash, we redirect so a new version of the current page
+	 * (with correct pricing for the current region, etc) is displayed.
+	 *
+	 * @param {string} hash
+	 */
 	var $geolocation_redirect = function( hash ) {
+		// Updates our (cookie-based) cache of the hash value. Expires in 1 hour.
+		Cookies.set( 'woocommerce_geo_hash', hash, { expires: 1 / 24 } );
+
+		var this_page = window.location.toString();
+
 		if ( this_page.indexOf( '?v=' ) > 0 || this_page.indexOf( '&v=' ) > 0 ) {
 			this_page = this_page.replace( /v=[^&]+/, 'v=' + hash );
 		} else if ( this_page.indexOf( '?' ) > 0 ) {
@@ -39,50 +96,50 @@ jQuery( function( $ ) {
 		window.location = this_page;
 	};
 
-	var $geolocate_customer = {
-		url: wc_geolocation_params.wc_ajax_url.toString().replace( '%%endpoint%%', 'get_customer_location' ),
-		type: 'GET',
-		success: function( response ) {
-			if ( response.success && response.data.hash && response.data.hash !== wc_geolocation_params.hash ) {
-				$geolocation_redirect( response.data.hash );
-			}
+	/**
+	 * Updates any forms on the page so they use the current geo hash.
+	 */
+	function update_forms() {
+		if ( ! geo_hash ) {
+			return;
 		}
-	};
 
-	if ( '1' === wc_geolocation_params.is_available ) {
-		$.ajax( $geolocate_customer );
-
-		// Support form elements
-		$( 'form' ).each( function() {
-			var $this  = $( this );
+		$( 'form' ).each( function () {
+			var $this = $( this );
 			var method = $this.attr( 'method' );
-			var hasField = $this.find('input[name="v"]').length > 0;
+			var hasField = $this.find( 'input[name="v"]' ).length > 0;
 
-			if ( method && 'get' === method.toLowerCase() && !hasField ) {
-				$this.append( '<input type="hidden" name="v" value="' + wc_geolocation_params.hash + '" />' );
+			if (method && 'get' === method.toLowerCase() && ! hasField) {
+				$this.append( '<input type="hidden" name="v" value="' + geo_hash + '" />' );
 			} else {
 				var href = $this.attr( 'action' );
 				if ( href ) {
 					if ( href.indexOf( '?' ) > 0 ) {
-						$this.attr( 'action', href + '&v=' + wc_geolocation_params.hash );
+						$this.attr( 'action', href + '&v=' + geo_hash );
 					} else {
-						$this.attr( 'action', href + '?v=' + wc_geolocation_params.hash );
+						$this.attr( 'action', href + '?v=' + geo_hash );
 					}
 				}
 			}
 		});
-
-		// Append hashes on load
-		$append_hashes();
 	}
+
+	// Get the current geo hash. If it doesn't exist, or if it doesn't match the current
+	// page URL, perform a geolocation request.
+	if ( ! get_geo_hash() || needs_refresh() ) {
+		$.ajax( $geolocate_customer );
+	}
+
+	// Page updates.
+	update_forms();
+	$append_hashes();
 
 	$( document.body ).on( 'added_to_cart', function() {
 		$append_hashes();
 	});
-	
+
 	// Enable user to trigger manual append hashes on AJAX operations
 	$( document.body ).on( 'woocommerce_append_geo_hashes', function() {
 		$append_hashes();
 	});
-
 });

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -26,6 +26,7 @@ class WC_Cache_Helper {
 		add_filter( 'nocache_headers', array( __CLASS__, 'additional_nocache_headers' ), 10 );
 		add_action( 'shutdown', array( __CLASS__, 'delete_transients_on_shutdown' ), 10 );
 		add_action( 'template_redirect', array( __CLASS__, 'geolocation_ajax_redirect' ) );
+		add_action( 'wc_ajax_update_order_review', array( __CLASS__, 'update_geolocation_hash' ), 5 );
 		add_action( 'admin_notices', array( __CLASS__, 'notices' ) );
 		add_action( 'delete_version_transients', array( __CLASS__, 'delete_version_transients' ), 10 );
 		add_action( 'wp', array( __CLASS__, 'prevent_caching' ) );
@@ -187,6 +188,24 @@ class WC_Cache_Helper {
 				wp_safe_redirect( esc_url_raw( $redirect_url ), 307 );
 				exit;
 			}
+		}
+	}
+
+	/**
+	 * Updates the `woocommerce_geo_hash` cookie, which is used to help ensure we display
+	 * the correct pricing etc to customers, according to their billing country.
+	 *
+	 * Note that:
+	 *
+	 * A) This only sets the cookie if the default customer address is set to "Geolocate (with
+	 *    Page Caching Support)".
+	 *
+	 * B) It is hooked into the `wc_ajax_update_order_review` action, which has the benefit of
+	 *    ensuring we update the cookie any time the billing country is changed.
+	 */
+	public static function update_geolocation_hash() {
+		if ( 'geolocation_ajax' === get_option( 'woocommerce_default_customer_address' ) ) {
+			wc_setcookie( 'woocommerce_geo_hash', static::geolocation_ajax_get_location_hash(), time() + HOUR_IN_SECONDS );
 		}
 	}
 

--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -398,7 +398,12 @@ class WC_Frontend_Scripts {
 			self::enqueue_script( 'wc-single-product' );
 		}
 
-		if ( 'geolocation_ajax' === get_option( 'woocommerce_default_customer_address' ) ) {
+		// Only enqueue the geolocation script if the Default Current Address is set to "Geolocate
+		// (with Page Caching Support) and outside of the cart, checkout, account and customizer preview.
+		if (
+			'geolocation_ajax' === get_option( 'woocommerce_default_customer_address' )
+			&& ! ( is_cart() || is_account_page() || is_checkout() || is_customize_preview() )
+		) {
 			$ua = strtolower( wc_get_user_agent() ); // Exclude common bots from geolocation by user agent.
 
 			if ( ! strstr( $ua, 'bot' ) && ! strstr( $ua, 'spider' ) && ! strstr( $ua, 'crawl' ) ) {
@@ -473,8 +478,6 @@ class WC_Frontend_Scripts {
 				$params = array(
 					'wc_ajax_url'  => WC_AJAX::get_endpoint( '%%endpoint%%' ),
 					'home_url'     => remove_query_arg( 'lang', home_url() ), // FIX for WPML compatibility.
-					'is_available' => ! ( is_cart() || is_account_page() || is_checkout() || is_customize_preview() ) ? '1' : '0',
-					'hash'         => isset( $_GET['v'] ) ? wc_clean( wp_unslash( $_GET['v'] ) ) : '', // WPCS: input var ok, CSRF ok.
 				);
 				break;
 			case 'wc-single-product':


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Currently, if the Default Customer Address is set to _"Geolocation (with Page Caching Support)"_ (aka `geolocation_ajax`) then we do all of the following things:

* With a few exceptions, such as if the cart or checkout page is being viewed, we send an extra request via ajax to check if the customer's location (as represented by a short hash) has changed.
* If it has changed, we redirect to the same page but we change the value of the `?v=` query var to match the hash.
* This effectively 'bursts' the page cache and ensures customers see appropriate pricing etc according to their current country, but it also means that we are firing off an extra HTTP request on almost every page load.

So, it works well but—as @Konamiman proposed—we could instead cache the value of the hash in a short-lived cookie, which is precisely what this changeset does:

* If the cookie `woocommerce_geo_hash` doesn't exist, then we discover the correct value via an ajax request and set it.
* If the customer's location changes, such as if they alter their billing country during checkout and then continue shopping, we update the cookie.
* Anytime the cookie does not match the `?v=` URL var, we do a refresh.

In essence: we get the same effect and benefits, but we reduce the number of ajax requests. 

Closes #26973.

![26973--fix](https://user-images.githubusercontent.com/3594411/108572898-313c6780-72c8-11eb-9ddc-102fb6def7d0.gif)

### How to test the changes in this Pull Request:

Start by checking out the problem:

1. Checkout the latest production release to see how things currently behave.
2. Open your browser's network tab, observe that with each new page load (while you move around the storefront), there is an extra `wc-ajax=get_customer_location` request.
3. Enter the cart and checkout pages, notice that the `wc-ajax=get_customer_location` requests don't happen on these pages.

Next:

1. Checkout this branch.
2. Repeat the above test; notice that the number of `wc-ajax=get_customer_location` requests has been reduced.
3. Add one or more items and navigate to checkout (but, no need to _actually_ checkout).
4. Change your billing country and then keep on shopping without checking out.
5. Observe that the value of the `?v=` query var has changed accordingly.

:movie_camera: Screencasts

* [Current behaviour](https://d.pr/i/cyTixw) → pay attention to the large number of `wc-ajax=get_customer_location` requests.
* [Revised behaviour](https://d.pr/i/xchl3q) → (also shared above) notice the number of `wc-ajax=get_customer_location` requests is massively reduced, but that the `?v=` query var still 'updates' if the billing country changes.

### Notes

:cookie: **Cookies** → If we accept this change, we should also update [this documentation](https://docs.woocommerce.com/document/woocommerce-cookies/) to cover the existence and role of the new `woocommerce_geo_hash` cookie.

:hammer_and_wrench: **JS Changes** → It may initially look like I changed and introduced more to [frontend/geolocation.js](https://github.com/woocommerce/woocommerce/compare/fix/26973-get-customer-location?expand=1#diff-23ad8c5deb8c3d2c72841277f0b9b3730c0dfebb991e9bf9321326608d5020b9) than actually I did, a lot of that code is the same pre-existing stuff, it's just been relocated or the indentation has changed.

### Changelog entry

> Fix - Reduce the number of ajax calls used when Geolocation (with Page Caching Enabled) mode is enabled.