### PR TITLE
Add filters for quantity input_name & input_value

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1712,8 +1712,8 @@ if ( ! function_exists( 'woocommerce_quantity_input' ) ) {
 
 		$defaults = array(
 			'input_id'     => uniqid( 'quantity_' ),
-			'input_name'   => 'quantity',
-			'input_value'  => '1',
+			'input_name'   => apply_filters( 'woocommerce_quantity_input_name', 'quantity', $product ),
+			'input_value'  => apply_filters( 'woocommerce_quantity_input_value', '1', $product ),
 			'classes'      => apply_filters( 'woocommerce_quantity_input_classes', array( 'input-text', 'qty', 'text' ), $product ),
 			'max_value'    => apply_filters( 'woocommerce_quantity_input_max', -1, $product ),
 			'min_value'    => apply_filters( 'woocommerce_quantity_input_min', 0, $product ),


### PR DESCRIPTION

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds filters for input_name `woocommerce_quantity_input_name` and input_value `woocommerce_quantity_input_value` so that these values can be modified without having to clone the template.

Closes #26748 

### How to test the changes in this Pull Request:

1. Add a new filter `add_filter( 'woocommerce_quantity_input_name', function ( $input, $product ) {  return 'foo'; }, 10, 2 );`
2. Add a new filter `add_filter( 'woocommerce_quantity_input_value', function ( $input, $product ) {  return '4'; }, 10, 2 );`


### Changelog entry

Add two new filters for quantity input name and value