### PR TITLE
Bump woocommerce/woocommerce-admin to 2.1.0-beta.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "2.0.1",
+    "woocommerce/woocommerce-admin": "2.1.0-beta.1",
     "woocommerce/woocommerce-blocks": "4.4.3"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95f29b23c1baa50f079597378d1673f1",
+    "content-hash": "d68cd83500f9c84fdd5624a61bed3149",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -497,16 +497,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.0.1",
+            "version": "2.1.0-beta.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "b7e89c48479348847fc97ae8be8c27d068106d04"
+                "reference": "cc598f4091df9b26cd5b45d569267d69cd61f936"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/b7e89c48479348847fc97ae8be8c27d068106d04",
-                "reference": "b7e89c48479348847fc97ae8be8c27d068106d04",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/cc598f4091df9b26cd5b45d569267d69cd61f936",
+                "reference": "cc598f4091df9b26cd5b45d569267d69cd61f936",
                 "shasum": ""
             },
             "require": {
@@ -538,7 +538,11 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2021-02-12T01:19:48+00:00"
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.1.0-beta.1"
+            },
+            "time": "2021-02-23T02:58:25+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -648,5 +652,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
This bumps Woocommerce Admin to the latest published package, version `2.1.0-beta.1`.

## Testing Instructions

Testing instructions are available from our [Release Testing Instructions WooCommerce Admin 2.1 ](https://github.com/woocommerce/woocommerce-admin/wiki/Release-Testing-Instructions-WooCommerce-Admin-2.1)wiki page.

## Changelog

```
- Dev: Allow highlight tooltip to use body tag as parent. #6309
- Dev: Remove Google fonts and material icons. #6343
- Add: Remove CES actions for adding and editing a product and editing an order #6355
- Dev: Add filter to allow enabling the WP toolbar within the new navigation. #6371
- Dev: Add unit tests to Navigation's Container component. #6344
- Fix: Enqueue scripts called incorrectly in php unit tests #6358
- Fix: Removed @woocommerce/components/card from OBW #6374
- Fix: Email notes now are turned off by default #6324
- Add: CES track settings tab on updating settings #6368
- Fix: Top bar slightly overlaps wp-admin navigation on mobile #6292
- Fix: Hide tooltip in welcome modal #6142
- Fix: update single column home screen width to 680px #6297
- Fix: Recommended Payment Banner missing in Safari #6375
- Tweak: Order and styles updates to nav footer #6373
- Enhancement: Move capability checks to client #6365
- Tweak: Enqueue beta features scripts on enqueue_scripts action instead of filter  #6358
- Enhancement: Navigation: Add test to container component #6344
- Fix: Empty nav menu #6366
- Enhancement: override wpbody styles when nav present #6354
- Fix: Check if tax was successfully added before displaying notice #6229
- Fix: Update timing of InboxPanel state changes for the unread indicator #6246
- Tweak: Set `is_deleted` from the database when instantiating a `Note` #6322
- Tweak: New Settings: Turn off in dev mode #6348
- Add: Favorites tooltip to the navigation #6312
- Fix: Display" option fails to collapse upon invoking "Help" option #6233
- Enhancement: Move favorited menu items to primary menu #6290
- Dev: Use box sizing and padding to fix nav and admin menu styling #6335
- Tweak: Update inline documentation for navigation Screen class #6173
- Tweak: Remove categories without menu items #6329
- Add: Core settings redirection to new settings pages #6091
- Add: Settings feature and pages #6089
- Add: Settings client pages #6092
- Add: Favoriting extensions client UI #6287
- Dev: Refactor head and body heights #6247
- Fix: Removal of core settings pages #6328
- Dev: Fix the react state update error on homescreen. #6320
- Tweak: Navigation: Migrate methods to `admin_menu` hook #6319
- Tweak: Move admin menu manipulation from admin_head to admin_menu #6310
- Tweak: Updates to copy and punctuation to be more conversational and consistent. #6298
- Dev: Change `siteUrl` to `homeUrl` on navigation site title #6240
- Dev: Add navigation favorites data store #6275
- Add: Add navigation intro modal. #6367
- Fix: Reset Navigation submenu before making Flyout #6396
```