### PR TITLE
Add external product support to api package

### DIFF
--- a/tests/e2e/api/CHANGELOG.md
+++ b/tests/e2e/api/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 # 0.1.1
 
+## Added
+
+- Support for the external product type.
+
 ## Breaking Changes
 
 - The `HTTPClientFactory` API was changed to make it easier to configure instances with

--- a/tests/e2e/api/src/models/products/abstract/common.ts
+++ b/tests/e2e/api/src/models/products/abstract/common.ts
@@ -1,4 +1,4 @@
-import { Model } from '../../model';
+import { Model, ModelID } from '../../model';
 import { MetaData, PostStatus } from '../../shared-types';
 import {
 	CatalogVisibility,
@@ -12,6 +12,14 @@ import {
  * The common parameters that all products can use in search.
  */
 export type ProductSearchParams = { search: string };
+
+/**
+ * A common URL builder.
+ *
+ * @param {ModelID} id the id of the product.
+ * @return {string} RESTful Url.
+ */
+export const buildProductURL = ( id: ModelID ) => '/wc/v3/products/' + id;
 
 /**
  * The base for all product types.

--- a/tests/e2e/api/src/models/products/abstract/external.ts
+++ b/tests/e2e/api/src/models/products/abstract/external.ts
@@ -1,0 +1,22 @@
+import { Model } from '../../model';
+
+/**
+ * The base for external products.
+ */
+abstract class AbstractProductExternal extends Model {
+	/**
+	 * The product's button text.
+	 *
+	 * @type {string}
+	 */
+	public readonly buttonText: string = ''
+
+	/**
+	 * The product's external URL.
+	 *
+	 * @type {string}
+	 */
+	public readonly externalUrl: string = ''
+}
+
+export interface IProductExternal extends AbstractProductExternal {}

--- a/tests/e2e/api/src/models/products/abstract/index.ts
+++ b/tests/e2e/api/src/models/products/abstract/index.ts
@@ -1,6 +1,7 @@
 export * from './common';
 export * from './cross-sell';
 export * from './delivery';
+export * from './external';
 export * from './inventory';
 export * from './sales-tax';
 export * from './shipping';

--- a/tests/e2e/api/src/models/products/external-product.ts
+++ b/tests/e2e/api/src/models/products/external-product.ts
@@ -39,7 +39,7 @@ export type ExternalProductRepositoryParams =
 	ModelRepositoryParams< ExternalProduct, never, ProductSearchParams, ExternalProductUpdateParams >;
 
 /**
- * An interface for listing simple products using the repository.
+ * An interface for listing external products using the repository.
  *
  * @typedef ListsExternalProducts
  * @alias ListsModels.<ExternalProduct>
@@ -47,7 +47,7 @@ export type ExternalProductRepositoryParams =
 export type ListsExternalProducts = ListsModels< ExternalProductRepositoryParams >;
 
 /**
- * An interface for creating simple products using the repository.
+ * An interface for external simple products using the repository.
  *
  * @typedef CreatesExternalProducts
  * @alias CreatesModels.<ExternalProduct>
@@ -55,7 +55,7 @@ export type ListsExternalProducts = ListsModels< ExternalProductRepositoryParams
 export type CreatesExternalProducts = CreatesModels< ExternalProductRepositoryParams >;
 
 /**
- * An interface for reading simple products using the repository.
+ * An interface for reading external products using the repository.
  *
  * @typedef ReadsExternalProducts
  * @alias ReadsModels.<ExternalProduct>
@@ -63,7 +63,7 @@ export type CreatesExternalProducts = CreatesModels< ExternalProductRepositoryPa
 export type ReadsExternalProducts = ReadsModels< ExternalProductRepositoryParams >;
 
 /**
- * An interface for updating simple products using the repository.
+ * An interface for updating external products using the repository.
  *
  * @typedef UpdatesExternalProducts
  * @alias UpdatesModels.<ExternalProduct>
@@ -71,7 +71,7 @@ export type ReadsExternalProducts = ReadsModels< ExternalProductRepositoryParams
 export type UpdatesExternalProducts = UpdatesModels< ExternalProductRepositoryParams >;
 
 /**
- * An interface for deleting simple products using the repository.
+ * An interface for deleting external products using the repository.
  *
  * @typedef DeletesExternalProducts
  * @alias DeletesModels.<ExternalProduct>
@@ -79,7 +79,7 @@ export type UpdatesExternalProducts = UpdatesModels< ExternalProductRepositoryPa
 export type DeletesExternalProducts = DeletesModels< ExternalProductRepositoryParams >;
 
 /**
- * The base for the simple product object.
+ * The base for the external product object.
  */
 export class ExternalProduct extends AbstractProduct implements
 	IProductCommon,

--- a/tests/e2e/api/src/models/products/external-product.ts
+++ b/tests/e2e/api/src/models/products/external-product.ts
@@ -1,0 +1,124 @@
+import {
+	AbstractProduct,
+	IProductCommon,
+	IProductExternal,
+	IProductSalesTax,
+	IProductUpSells,
+	ProductSearchParams,
+} from './abstract';
+import {
+	ProductCommonUpdateParams,
+	ProductExternalUpdateParams,
+	ProductSalesTaxUpdateParams,
+	ProductUpSellUpdateParams,
+	Taxability,
+} from './shared';
+import { HTTPClient } from '../../http';
+import { externalProductRESTRepository } from '../../repositories';
+import {
+	CreatesModels,
+	DeletesModels,
+	ListsModels,
+	ModelRepositoryParams,
+	ReadsModels,
+	UpdatesModels,
+} from '../../framework';
+
+/**
+ * The parameters that external products can update.
+ */
+type ExternalProductUpdateParams = ProductCommonUpdateParams
+	& ProductExternalUpdateParams
+	& ProductSalesTaxUpdateParams
+	& ProductUpSellUpdateParams;
+/**
+ * The parameters embedded in this generic can be used in the ModelRepository in order to give
+ * type-safety in an incredibly granular way.
+ */
+export type ExternalProductRepositoryParams =
+	ModelRepositoryParams< ExternalProduct, never, ProductSearchParams, ExternalProductUpdateParams >;
+
+/**
+ * An interface for listing simple products using the repository.
+ *
+ * @typedef ListsExternalProducts
+ * @alias ListsModels.<ExternalProduct>
+ */
+export type ListsExternalProducts = ListsModels< ExternalProductRepositoryParams >;
+
+/**
+ * An interface for creating simple products using the repository.
+ *
+ * @typedef CreatesExternalProducts
+ * @alias CreatesModels.<ExternalProduct>
+ */
+export type CreatesExternalProducts = CreatesModels< ExternalProductRepositoryParams >;
+
+/**
+ * An interface for reading simple products using the repository.
+ *
+ * @typedef ReadsExternalProducts
+ * @alias ReadsModels.<ExternalProduct>
+ */
+export type ReadsExternalProducts = ReadsModels< ExternalProductRepositoryParams >;
+
+/**
+ * An interface for updating simple products using the repository.
+ *
+ * @typedef UpdatesExternalProducts
+ * @alias UpdatesModels.<ExternalProduct>
+ */
+export type UpdatesExternalProducts = UpdatesModels< ExternalProductRepositoryParams >;
+
+/**
+ * An interface for deleting simple products using the repository.
+ *
+ * @typedef DeletesExternalProducts
+ * @alias DeletesModels.<ExternalProduct>
+ */
+export type DeletesExternalProducts = DeletesModels< ExternalProductRepositoryParams >;
+
+/**
+ * The base for the simple product object.
+ */
+export class ExternalProduct extends AbstractProduct implements
+	IProductCommon,
+	IProductExternal,
+	IProductSalesTax,
+	IProductUpSells {
+	/**
+	 * @see ./abstracts/external.ts
+	 */
+	public readonly buttonText: string = ''
+	public readonly externalUrl: string = ''
+
+	/**
+	 * @see ./abstracts/upsell.ts
+	 */
+	public readonly upSellIds: Array<number> = [];
+
+	/**
+	 * @see ./abstracts/sales-tax.ts
+	 */
+	public readonly taxStatus: Taxability = Taxability.ProductAndShipping;
+	public readonly taxClass: string = '';
+
+	/**
+	 * Creates a new simple product instance with the given properties
+	 *
+	 * @param {Object} properties The properties to set in the object.
+	 */
+	public constructor( properties?: Partial< ExternalProduct > ) {
+		super();
+		Object.assign( this, properties );
+	}
+
+	/**
+	 * Creates a model repository configured for communicating via the REST API.
+	 *
+	 * @param {HTTPClient} httpClient The client for communicating via HTTP.
+	 */
+	public static restRepository( httpClient: HTTPClient ): ReturnType< typeof externalProductRESTRepository > {
+		return externalProductRESTRepository( httpClient );
+	}
+}

--- a/tests/e2e/api/src/models/products/index.ts
+++ b/tests/e2e/api/src/models/products/index.ts
@@ -1,3 +1,4 @@
 export * from './abstract';
 export * from './shared';
 export * from './simple-product';
+export * from './external-product';

--- a/tests/e2e/api/src/models/products/shared/types.ts
+++ b/tests/e2e/api/src/models/products/shared/types.ts
@@ -30,7 +30,7 @@ export type ProductUpSellUpdateParams = 'upSellIds';
 /**
  * Properties exclusive to the External product type.
  */
-export type ProductExternalTypeUpdateParams = 'buttonText' | 'externalUrl';
+export type ProductExternalUpdateParams = 'buttonText' | 'externalUrl';
 
 /**
  * Properties exclusive to the Grouped product type.

--- a/tests/e2e/api/src/repositories/rest/products/external-product.ts
+++ b/tests/e2e/api/src/repositories/rest/products/external-product.ts
@@ -1,8 +1,8 @@
 import { HTTPClient } from '../../../http';
 import { ModelRepository } from '../../../framework';
 import {
+	buildProductURL,
 	ExternalProduct,
-	ModelID,
 	CreatesExternalProducts,
 	DeletesExternalProducts,
 	ListsExternalProducts,
@@ -41,8 +41,6 @@ export function externalProductRESTRepository( httpClient: HTTPClient ): ListsEx
 	& ReadsExternalProducts
 	& UpdatesExternalProducts
 	& DeletesExternalProducts {
-	const buildURL = ( id: ModelID ) => '/wc/v3/products/' + id;
-
 	const external = createProductExternalTransformation();
 	const salesTax = createProductSalesTaxTransformation();
 	const upsells = createProductUpSellsTransformation();
@@ -57,8 +55,8 @@ export function externalProductRESTRepository( httpClient: HTTPClient ): ListsEx
 	return new ModelRepository(
 		restList< ExternalProductRepositoryParams >( () => '/wc/v3/products', ExternalProduct, httpClient, transformer ),
 		restCreate< ExternalProductRepositoryParams >( () => '/wc/v3/products', ExternalProduct, httpClient, transformer ),
-		restRead< ExternalProductRepositoryParams >( buildURL, ExternalProduct, httpClient, transformer ),
-		restUpdate< ExternalProductRepositoryParams >( buildURL, ExternalProduct, httpClient, transformer ),
-		restDelete< ExternalProductRepositoryParams >( buildURL, httpClient ),
+		restRead< ExternalProductRepositoryParams >( buildProductURL, ExternalProduct, httpClient, transformer ),
+		restUpdate< ExternalProductRepositoryParams >( buildProductURL, ExternalProduct, httpClient, transformer ),
+		restDelete< ExternalProductRepositoryParams >( buildProductURL, httpClient ),
 	);
 }

--- a/tests/e2e/api/src/repositories/rest/products/external-product.ts
+++ b/tests/e2e/api/src/repositories/rest/products/external-product.ts
@@ -1,0 +1,64 @@
+import { HTTPClient } from '../../../http';
+import { ModelRepository } from '../../../framework';
+import {
+	ExternalProduct,
+	ModelID,
+	CreatesExternalProducts,
+	DeletesExternalProducts,
+	ListsExternalProducts,
+	ReadsExternalProducts,
+	ExternalProductRepositoryParams,
+	UpdatesExternalProducts,
+} from '../../../models';
+import {
+	createProductTransformer,
+	createProductExternalTransformation,
+	createProductSalesTaxTransformation,
+	createProductUpSellsTransformation,
+} from './shared';
+import {
+	restCreate,
+	restDelete,
+	restList,
+	restRead,
+	restUpdate,
+} from '../shared';
+
+/**
+ * Creates a new ModelRepository instance for interacting with models via the REST API.
+ *
+ * @param {HTTPClient} httpClient The HTTP client for the REST requests to be made using.
+ * @return {
+ * 	ListsExternalProducts|
+ * 	CreatesExternalProducts|
+ * 	ReadsExternalProducts|
+ * 	UpdatesExternalProducts|
+ * 	DeletesExternalProducts
+ * } The created repository.
+ */
+export function externalProductRESTRepository( httpClient: HTTPClient ): ListsExternalProducts
+	& CreatesExternalProducts
+	& ReadsExternalProducts
+	& UpdatesExternalProducts
+	& DeletesExternalProducts {
+	const buildURL = ( id: ModelID ) => '/wc/v3/products/' + id;
+
+	const external = createProductExternalTransformation();
+	const salesTax = createProductSalesTaxTransformation();
+	const upsells = createProductUpSellsTransformation();
+	const transformations = [
+		...external,
+		...salesTax,
+		...upsells,
+	];
+
+	const transformer = createProductTransformer<ExternalProduct>( 'external', transformations );
+
+	return new ModelRepository(
+		restList< ExternalProductRepositoryParams >( () => '/wc/v3/products', ExternalProduct, httpClient, transformer ),
+		restCreate< ExternalProductRepositoryParams >( () => '/wc/v3/products', ExternalProduct, httpClient, transformer ),
+		restRead< ExternalProductRepositoryParams >( buildURL, ExternalProduct, httpClient, transformer ),
+		restUpdate< ExternalProductRepositoryParams >( buildURL, ExternalProduct, httpClient, transformer ),
+		restDelete< ExternalProductRepositoryParams >( buildURL, httpClient ),
+	);
+}

--- a/tests/e2e/api/src/repositories/rest/products/index.ts
+++ b/tests/e2e/api/src/repositories/rest/products/index.ts
@@ -1,7 +1,9 @@
 import { createProductTransformer } from './shared';
 import { simpleProductRESTRepository } from './simple-product';
+import { externalProductRESTRepository } from './external-product';
 
 export {
 	createProductTransformer,
+	externalProductRESTRepository,
 	simpleProductRESTRepository,
 };

--- a/tests/e2e/api/src/repositories/rest/products/shared.ts
+++ b/tests/e2e/api/src/repositories/rest/products/shared.ts
@@ -189,6 +189,9 @@ export function createProductTransformer< T extends AbstractProduct >(
 	return new ModelTransformer( transformations );
 }
 
+/**
+ * Create a transformer for the product cross sells property.
+ */
 export function createProductCrossSellsTransformation(): ModelTransformation[] {
 	const transformations = [
 		new PropertyTypeTransformation(
@@ -206,6 +209,9 @@ export function createProductCrossSellsTransformation(): ModelTransformation[] {
 	return transformations;
 }
 
+/**
+ * Create a transformer for the product upsells property.
+ */
 export function createProductUpSellsTransformation(): ModelTransformation[] {
 	const transformations = [
 		new PropertyTypeTransformation(
@@ -223,6 +229,9 @@ export function createProductUpSellsTransformation(): ModelTransformation[] {
 	return transformations;
 }
 
+/**
+ * Create a transformer for product delivery properties.
+ */
 export function createProductDeliveryTransformation(): ModelTransformation[] {
 	const transformations = [
 		new ModelTransformerTransformation( 'downloads', ProductDownload, createProductDownloadTransformer() ),
@@ -249,6 +258,9 @@ export function createProductDeliveryTransformation(): ModelTransformation[] {
 	return transformations;
 }
 
+/**
+ * Create a transformer for product inventory properties.
+ */
 export function createProductInventoryTransformation(): ModelTransformation[] {
 	const transformations = [
 		new PropertyTypeTransformation(
@@ -278,6 +290,9 @@ export function createProductInventoryTransformation(): ModelTransformation[] {
 	return transformations;
 }
 
+/**
+ * Create a transformer for product sales tax properties.
+ */
 export function createProductSalesTaxTransformation(): ModelTransformation[] {
 	const transformations = [
 		new PropertyTypeTransformation(
@@ -297,6 +312,9 @@ export function createProductSalesTaxTransformation(): ModelTransformation[] {
 	return transformations;
 }
 
+/**
+ * Create a transformer for product shipping properties.
+ */
 export function createProductShippingTransformation(): ModelTransformation[] {
 	const transformations = [
 		new CustomTransformation(

--- a/tests/e2e/api/src/repositories/rest/products/shared.ts
+++ b/tests/e2e/api/src/repositories/rest/products/shared.ts
@@ -14,6 +14,7 @@ import {
 	AbstractProduct,
 	IProductCrossSells,
 	IProductDelivery,
+	IProductExternal,
 	IProductInventory,
 	IProductSalesTax,
 	IProductShipping,
@@ -348,3 +349,26 @@ export function createProductShippingTransformation(): ModelTransformation[] {
 
 	return transformations;
 }
+
+/**
+ * Transformer for the properties unique to the external product type.
+ */
+export function createProductExternalTransformation(): ModelTransformation[] {
+	const transformations = [
+		new PropertyTypeTransformation(
+			{
+				buttonText: PropertyType.String,
+				externalUrl: PropertyType.String,
+			},
+		),
+		new KeyChangeTransformation< IProductExternal >(
+			{
+				buttonText: 'button_text',
+				externalUrl: 'external_url',
+			},
+		),
+	];
+
+	return transformations;
+}
+

--- a/tests/e2e/api/src/repositories/rest/products/simple-product.ts
+++ b/tests/e2e/api/src/repositories/rest/products/simple-product.ts
@@ -2,7 +2,7 @@ import { HTTPClient } from '../../../http';
 import { ModelRepository } from '../../../framework';
 import {
 	SimpleProduct,
-	ModelID,
+	buildProductURL,
 	CreatesSimpleProducts,
 	DeletesSimpleProducts,
 	ListsSimpleProducts,
@@ -44,8 +44,6 @@ export function simpleProductRESTRepository( httpClient: HTTPClient ): ListsSimp
 	& ReadsSimpleProducts
 	& UpdatesSimpleProducts
 	& DeletesSimpleProducts {
-	const buildURL = ( id: ModelID ) => '/wc/v3/products/' + id;
-
 	const crossSells = createProductCrossSellsTransformation();
 	const delivery = createProductDeliveryTransformation();
 	const inventory = createProductInventoryTransformation();
@@ -66,8 +64,8 @@ export function simpleProductRESTRepository( httpClient: HTTPClient ): ListsSimp
 	return new ModelRepository(
 		restList< SimpleProductRepositoryParams >( () => '/wc/v3/products', SimpleProduct, httpClient, transformer ),
 		restCreate< SimpleProductRepositoryParams >( () => '/wc/v3/products', SimpleProduct, httpClient, transformer ),
-		restRead< SimpleProductRepositoryParams >( buildURL, SimpleProduct, httpClient, transformer ),
-		restUpdate< SimpleProductRepositoryParams >( buildURL, SimpleProduct, httpClient, transformer ),
-		restDelete< SimpleProductRepositoryParams >( buildURL, httpClient ),
+		restRead< SimpleProductRepositoryParams >( buildProductURL, SimpleProduct, httpClient, transformer ),
+		restUpdate< SimpleProductRepositoryParams >( buildProductURL, SimpleProduct, httpClient, transformer ),
+		restDelete< SimpleProductRepositoryParams >( buildProductURL, httpClient ),
 	);
 }

--- a/tests/e2e/config/default.json
+++ b/tests/e2e/config/default.json
@@ -17,6 +17,12 @@
     },
     "variable": {
       "name": "Variable Product with Three Variations"
+    },
+    "external": {
+      "name": "External product",
+      "regularPrice": "24.99",
+      "buttonText": "Buy now",
+      "externalUrl": "https://wordpress.org/plugins/woocommerce"
     }
   },
   "addresses": {

--- a/tests/e2e/core-tests/specs/api/external-product.js
+++ b/tests/e2e/core-tests/specs/api/external-product.js
@@ -50,7 +50,6 @@ const runExternalProductAPITest = () => {
 				button_text: defaultExternalProduct.buttonText,
 				external_url: defaultExternalProduct.externalUrl,
 				price: defaultExternalProduct.regularPrice,
-				sale_price: '',
 			};
 
 			// Read product directly from api.
@@ -64,7 +63,6 @@ const runExternalProductAPITest = () => {
 				...defaultExternalProduct,
 				id: product.id,
 				price: defaultExternalProduct.regularPrice,
-				salePrice: ''
 			};
 
 			// Read product via the repository.

--- a/tests/e2e/core-tests/specs/api/external-product.js
+++ b/tests/e2e/core-tests/specs/api/external-product.js
@@ -1,0 +1,77 @@
+/* eslint-disable jest/no-export, jest/no-disabled-tests */
+/**
+ * Internal dependencies
+ */
+const { HTTPClientFactory, ExternalProduct } = require( '@woocommerce/api' );
+
+/**
+ * External dependencies
+ */
+const config = require( 'config' );
+const {
+	it,
+	describe,
+	beforeAll,
+} = require( '@jest/globals' );
+
+/**
+ * Create an external product and retrieve via the API.
+ */
+const runExternalProductAPITest = () => {
+	// @todo: add a call to ensure pretty permalinks are enabled once settings api is in use.
+	describe('REST API > External Product', () => {
+		let client;
+		let defaultExternalProduct;
+		let product;
+		let repository;
+
+		beforeAll(async () => {
+			defaultExternalProduct = config.get( 'products.external' );
+			const admin = config.get( 'users.admin' );
+			const url = config.get( 'url' );
+
+			client = HTTPClientFactory.build( url )
+				.withBasicAuth( admin.username, admin.password )
+				.withIndexPermalinks()
+				.create();
+		} );
+
+		it('can create an external product', async () => {
+			repository = ExternalProduct.restRepository( client );
+
+			// Check properties of product in the create product response.
+			product = await repository.create( defaultExternalProduct );
+			expect( product ).toEqual( expect.objectContaining( defaultExternalProduct ) );
+		});
+
+		it('can retrieve a raw external product', async () => {
+			const rawProperties = {
+				id: product.id,
+				button_text: defaultExternalProduct.buttonText,
+				external_url: defaultExternalProduct.externalUrl,
+				price: defaultExternalProduct.regularPrice,
+				sale_price: '',
+			};
+
+			// Read product directly from api.
+			const response = await client.get( `/wc/v3/products/${product.id}` );
+			expect( response.statusCode ).toBe( 200 );
+			expect( response.data ).toEqual( expect.objectContaining( rawProperties ) );
+		});
+
+		it('can retrieve a transformed external product', async () => {
+			const transformedProperties = {
+				...defaultExternalProduct,
+				id: product.id,
+				price: defaultExternalProduct.regularPrice,
+				salePrice: ''
+			};
+
+			// Read product via the repository.
+			const transformed = await repository.read( product.id );
+			expect( transformed ).toEqual( expect.objectContaining( transformedProperties ) );
+		});
+	});
+};
+
+module.exports = runExternalProductAPITest;

--- a/tests/e2e/core-tests/specs/index.js
+++ b/tests/e2e/core-tests/specs/index.js
@@ -8,6 +8,9 @@ const runActivationTest = require( './activate-and-setup/activate.test' );
 const { runOnboardingFlowTest, runTaskListTest } = require( './activate-and-setup/onboarding-tasklist.test' );
 const runInitialStoreSettingsTest = require( './activate-and-setup/setup.test' );
 
+// REST API tests
+const runExternalProductAPITest = require( './api/external-product' );
+
 // Shopper tests
 const runCartApplyCouponsTest = require( './shopper/front-end-cart-coupons.test');
 const runCartPageTest = require( './shopper/front-end-cart.test' );
@@ -68,6 +71,7 @@ module.exports = {
 	runTaskListTest,
 	runInitialStoreSettingsTest,
 	runSetupOnboardingTests,
+	runExternalProductAPITest,
 	runCartApplyCouponsTest,
 	runCartPageTest,
 	runCheckoutApplyCouponsTest,

--- a/tests/e2e/specs/rest-api/external-product.test.js
+++ b/tests/e2e/specs/rest-api/external-product.test.js
@@ -1,0 +1,6 @@
+/*
+ * Internal dependencies
+ */
+const { runExternalProductAPITest } = require( '@woocommerce/e2e-core-tests' );
+
+runExternalProductAPITest();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds support for the external product type to the `api` package. It includes a E2E test to verify the properties specific to the external product type

Closes #28885 .

### How to test the changes in this Pull Request:

1. Check CI test runs.
2. Run tests locally and note the `REST API > External Product` section
3. Edit the `external` product in `tests/e2e/config/default.json` and add any of the [common product properties](https://github.com/woocommerce/woocommerce/blob/master/tests/e2e/api/src/models/products/abstract/common.ts#L19) except don't put the product `on sale`.
4. Manually run the api test `npx wc-e2e test:e2e tests/e2e/specs/rest-api/external-product.test.js`.
5. Repeat 3 & 4 with a few combinations. Check the dashboard after each test to verify the product was created correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A
