### PR TITLE
Remove compatibility checks for major version

### DIFF
--- a/includes/admin/plugin-updates/class-wc-updates-screen-updates.php
+++ b/includes/admin/plugin-updates/class-wc-updates-screen-updates.php
@@ -6,6 +6,8 @@
  * @version     3.2.0
  */
 
+use Automattic\Jetpack\Constants;
+
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
@@ -37,8 +39,13 @@ class WC_Updates_Screen_Updates extends WC_Plugin_Updates {
 			return;
 		}
 
+		$version_type = Constants::get_constant( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE' );
+		if ( ! is_string( $version_type ) ) {
+			$version_type = 'none';
+		}
+
 		$this->new_version            = wc_clean( $updateable_plugins['woocommerce/woocommerce.php']->update->new_version );
-		$this->major_untested_plugins = $this->get_untested_plugins( $this->new_version, 'major' );
+		$this->major_untested_plugins = $this->get_untested_plugins( $this->new_version, $version_type );
 
 		if ( ! empty( $this->major_untested_plugins ) ) {
 			echo $this->get_extensions_modal_warning(); // phpcs:ignore WordPress.XSS.EscapeOutput.OutputNotEscaped

--- a/includes/admin/views/html-admin-page-status-report.php
+++ b/includes/admin/views/html-admin-page-status-report.php
@@ -5,15 +5,11 @@
  * @package WooCommerce
  */
 
+use Automattic\Jetpack\Constants;
+
 defined( 'ABSPATH' ) || exit;
 
 global $wpdb;
-
-if ( ! defined( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE' ) ) {
-	// Define if we're checking against major or minor versions.
-	// Since 5.0 all versions are backwards compatible, so there's no more check.
-	define( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE', 'none' );
-}
 
 $report             = wc()->api->get_endpoint_data( '/wc/v3/system_status' );
 $environment        = $report['environment'];
@@ -27,7 +23,7 @@ $security           = $report['security'];
 $settings           = $report['settings'];
 $wp_pages           = $report['pages'];
 $plugin_updates     = new WC_Plugin_Updates();
-$untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE );
+$untested_plugins   = $plugin_updates->get_untested_plugins( WC()->version, Constants::get_constant( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE' ) );
 ?>
 <div class="updated woocommerce-message inline">
 	<p>

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -249,6 +249,18 @@ final class WooCommerce {
 		$this->define( 'WC_NOTICE_MIN_PHP_VERSION', '7.2' );
 		$this->define( 'WC_NOTICE_MIN_WP_VERSION', '5.2' );
 		$this->define( 'WC_PHP_MIN_REQUIREMENTS_NOTICE', 'wp_php_min_requirements_' . WC_NOTICE_MIN_PHP_VERSION . '_' . WC_NOTICE_MIN_WP_VERSION );
+		/** Define if we're checking against major, minor or no versions in the following places:
+		 *   - plugin screen in WP Admin (displaying extra warning when updating to new major versions)
+		 *   - System Status Report ('Installed version not tested with active version of WooCommerce' warning)
+		 *   - core update screen in WP Admin (displaying extra warning when updating to new major versions)
+		 *   - enable/disable automated updates in the plugin screen in WP Admin (if there are any plugins
+		 *      that don't declare compatibility, the auto-update is disabled)
+		 *
+		 * We dropped SemVer before WC 5.0, so all versions are backwards compatible now, thus no more check needed.
+		 * The SSR in the name is preserved for bw compatibility, as this was initially used in System Status Report.
+		 */
+		$this->define( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE', 'none' );
+
 	}
 
 	/**

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -2255,7 +2255,11 @@ function wc_prevent_dangerous_auto_updates( $should_update, $plugin ) {
 
 	$new_version      = wc_clean( $plugin->new_version );
 	$plugin_updates   = new WC_Plugin_Updates();
-	$untested_plugins = $plugin_updates->get_untested_plugins( $new_version, 'major' );
+	$version_type = Constants::get_constant( 'WC_SSR_PLUGIN_UPDATE_RELEASE_VERSION_TYPE' );
+	if ( ! is_string( $version_type ) ) {
+		$version_type = 'none';
+	}
+	$untested_plugins = $plugin_updates->get_untested_plugins( $new_version, $version_type );
 	if ( ! empty( $untested_plugins ) ) {
 		return false;
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In addition to #28840, there are other places where we make use of compatibility check with major versions. I've discovered 2:
- update through /wp-admin/update-core.php
- force disabling auto-updates if there are any extensions that haven't declared their compatibility with WC 5.0

This change updates both places to be in line with the changes done in #28840 and double closes https://github.com/woocommerce/woocommerce/issues/28806.


### How to test the changes in this Pull Request:

1. Install one of the extensions that haven't declared compatibility with WC 5, e.g. Bookings
2. Go to /wp-admin/plugins.php
3. You should see Auto updates disabled on the right side of WC core.
4. Set WC core version to something below 5.0 (e.g 4.9.0 in woocommerce.php comment at the top and in class-woocommerce.php).
5. Go to /wp-admin/update-core.php, select WooCommerce in the list of plugins and hit update, you should see a warning as in the picture below.
6. Apply this branch.
7. Go to /wp-admin/plugins.php
3. It should be possible to enable auto-updates for WC core.
4. Go to /wp-admin/update-core.php, select WooCommerce in the list of plugins and hit update, no more warnings should stop you from updating. 

![Screenshot 2021-02-23 at 13 22 08](https://user-images.githubusercontent.com/2207451/108844785-d616b780-75dc-11eb-9ee8-cdeec23dda9d.png)


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enhancement - Clean up of major version update compatibility warnings.
