### PR TITLE
Only use customInitFile in e2e-environment if it's a string

### DIFF
--- a/tests/e2e/env/bin/docker-compose.js
+++ b/tests/e2e/env/bin/docker-compose.js
@@ -34,7 +34,7 @@ const envVars = getAdminConfig();
 if ( appPath ) {
     if ( 'up' === command ) {
         // Look for an initialization script in the dependent app.
-        if ( customInitFile ) {
+        if ( customInitFile && typeof customInitFile === 'string' ) {
             const possibleInitFile = customInitFile;
             customInitFile = path.resolve( possibleInitFile );
             if ( ! fs.existsSync( customInitFile ) ) {


### PR DESCRIPTION
Re-opened using a branch, originally #29134

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

In WSL2 (with Ubuntu) the second argument of a command passed to wc-e2e appears to be an instance of `Command` and can not be used with `path.resolve`. This change ensures that any argument passed to `path.resolve` must be a string.

This change should be completely harmless, and should not break any existing usage of this `npx wc-e2e docker:up`.

For reference, the error encountered is:

```
node:internal/validators:129
    throw new ERR_INVALID_ARG_TYPE(name, 'string', value);
    ^

TypeError [ERR_INVALID_ARG_TYPE]: The "path" argument must be of type string. Received an instance of Command
    at new NodeError (node:internal/errors:329:5)
    at validateString (node:internal/validators:129:11)
    at Object.resolve (node:path:1019:7)
    at Object.<anonymous> (/home/marcuz/projects/woocommerce/wp-content/plugins/my-plugin/node_modules/@woocommerce/e2e-environment/bin/docker-compose.js:39:35)
    at Module._compile (node:internal/modules/cjs/loader:1108:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1137:10)
    at Module.load (node:internal/modules/cjs/loader:973:32)
    at Function.Module._load (node:internal/modules/cjs/loader:813:14)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:76:12)
    at node:internal/main/run_main_module:17:47 {
  code: 'ERR_INVALID_ARG_TYPE'
```

### Changelog entry

> Dev - Fix usage of docker-compose (wc-e2e) commands in e2e tests when running them within WSL2.
