### PR TITLE
Validate variation ID while adding products to the cart

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1120,6 +1120,20 @@ class WC_Cart extends WC_Legacy_Cart {
 				}
 			}
 
+			// Validate variation ID.
+			if (
+				0 < $variation_id && // Only check if variation_id exists.
+				(
+					'product_variation' !== get_post_type( $variation_id ) || // Check if doesn't belong to a product variation.
+					wp_get_post_parent_id( $variation_id ) !== $product_id // Check if belongs to the selected variable product.
+				)
+			) {
+				$product = wc_get_product( $product_id );
+
+				/* translators: 1: product link, 2: product name */
+				throw new Exception( sprintf( __( 'The selected product isn\'t a variation of %2$s, please choose product options by visiting <a href="%1$s" title="%2$s">%2$s</a>.', 'woocommerce' ), esc_url( $product->get_permalink() ), esc_html( $product->get_name() ) ) );
+			}
+
 			// Load cart item data - may be added by other plugins.
 			$cart_item_data = (array) apply_filters( 'woocommerce_add_cart_item_data', $cart_item_data, $product_id, $variation_id, $quantity );
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1122,10 +1122,10 @@ class WC_Cart extends WC_Legacy_Cart {
 
 			// Validate variation ID.
 			if (
-				0 < $variation_id && // Only check if variation_id exists.
+				0 < $variation_id && // Only check if there's any variation_id.
 				(
-					'product_variation' !== get_post_type( $variation_id ) || // Check if doesn't belong to a product variation.
-					wp_get_post_parent_id( $variation_id ) !== $product_id // Check if belongs to the selected variable product.
+					! $product_data->is_type( 'variation' ) || // Check if isn't a variation, it suppose to be a variation at this point.
+					$product_data->get_parent_id() !== $product_id // Check if belongs to the selected variable product.
 				)
 			) {
 				$product = wc_get_product( $product_id );

--- a/tests/php/includes/class-wc-cart-test.php
+++ b/tests/php/includes/class-wc-cart-test.php
@@ -62,6 +62,41 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox should throw a notice to the cart if using variation_id
+	 * that doesn't belong to specified variable product.
+	 */
+	public function test_add_variation_to_the_cart_invalid_variation_id() {
+		WC()->cart->empty_cart();
+		WC()->session->set( 'wc_notices', null );
+
+		$variable_product = WC_Helper_Product::create_variation_product();
+		$single_product   = WC_Helper_Product::create_simple_product();
+
+		// Add variation using parent id.
+		WC()->cart->add_to_cart(
+			$variable_product->get_id(),
+			1,
+			$single_product->get_id()
+		);
+		$notices = WC()->session->get( 'wc_notices', array() );
+
+		// Check that the second add to cart call increases the quantity of the existing cart-item.
+		$this->assertCount( 0, WC()->cart->get_cart_contents() );
+		$this->assertEquals( 0, WC()->cart->get_cart_contents_count() );
+
+		// Check that the notices contain an error message about invalid colour and number.
+		$this->assertArrayHasKey( 'error', $notices );
+		$this->assertCount( 1, $notices['error'] );
+		$expected = sprintf( sprintf( 'The selected product isn\'t a variation of %2$s, please choose product options by visiting <a href="%1$s" title="%2$s">%2$s</a>.', esc_url( $variable_product->get_permalink() ), esc_html( $variable_product->get_name() ) ) );
+		$this->assertEquals( $expected, $notices['error'][0]['notice'] );
+
+		// Reset cart.
+		WC()->cart->empty_cart();
+		WC()->customer->set_is_vat_exempt( false );
+		$variable_product->delete( true );
+	}
+
+	/**
 	 * Test show shipping.
 	 */
 	public function test_show_shipping() {

--- a/tests/php/includes/class-wc-cart-test.php
+++ b/tests/php/includes/class-wc-cart-test.php
@@ -46,7 +46,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		);
 		$notices = WC()->session->get( 'wc_notices', array() );
 
-		// Check that the second add to cart call increases the quantity of the existing cart-item.
+		// Check for cart contents.
 		$this->assertCount( 0, WC()->cart->get_cart_contents() );
 		$this->assertEquals( 0, WC()->cart->get_cart_contents_count() );
 
@@ -80,7 +80,7 @@ class WC_Cart_Test extends \WC_Unit_Test_Case {
 		);
 		$notices = WC()->session->get( 'wc_notices', array() );
 
-		// Check that the second add to cart call increases the quantity of the existing cart-item.
+		// Check for cart contents.
 		$this->assertCount( 0, WC()->cart->get_cart_contents() );
 		$this->assertEquals( 0, WC()->cart->get_cart_contents_count() );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Tam found some issues with our "add to cart" feature while using `?add-to-cart=VARIABLE_PRODUCT_ID&variation_id=VARIABLE_PRODUCT_ID`. While investigating this issue I found out that using any variable product ID can skip validation and include the item to the cart.

### How to test the changes in this Pull Request:

1. Try add to a product to the cart with `?add-to-cart=VARIABLE_PRODUCT_ID&variation_id=VARIABLE_PRODUCT_ID`
2. Now try `?add-to-cart=VARIABLE_PRODUCT_ID&variation_id=PRODUCT_ID`
3. And finally `?add-to-cart=VARIABLE_PRODUCT_ID&variation_id=VARIATION_ID_FROM_ANOTHER_VARIABLE_PRODUCT`
4. Apply this patch and try all steps again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Check if `variation_id` if belongs to the parent product while adding products to the cart.