### PR TITLE
Fix for issue #27553 - REST API v3 not supporting settings type `order` and `class` for settings type on shipping zone methods

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zone-methods-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zone-methods-controller.php
@@ -31,10 +31,10 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zone_Met
 	 * @return array
 	 */
 	public function get_item_schema() {
-		// Get parent schema to append additional supported settings types for shipping zone method
+		// Get parent schema to append additional supported settings types for shipping zone method.
 		$schema = parent::get_item_schema();
 
-		//append additional settings supported types (class, order)
+		// Append additional settings supported types (class, order).
 		$schema['properties']['settings']['properties']['type']['enum'][] = 'class';
 		$schema['properties']['settings']['properties']['type']['enum'][] = 'order';
 

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zone-methods-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-shipping-zone-methods-controller.php
@@ -24,4 +24,20 @@ class WC_REST_Shipping_Zone_Methods_Controller extends WC_REST_Shipping_Zone_Met
 	 * @var string
 	 */
 	protected $namespace = 'wc/v3';
+
+	/**
+	 * Get the settings schema, conforming to JSON Schema.
+	 *
+	 * @return array
+	 */
+	public function get_item_schema() {
+		// Get parent schema to append additional supported settings types for shipping zone method
+		$schema = parent::get_item_schema();
+
+		//append additional settings supported types (class, order)
+		$schema['properties']['settings']['properties']['type']['enum'][] = 'class';
+		$schema['properties']['settings']['properties']['type']['enum'][] = 'order';
+
+		return $this->add_additional_fields_schema( $schema );
+	}
 }


### PR DESCRIPTION
REST API v3 shipping method zone endpoint input payload not allowing settings type to be of type `class` or `order`. Added missing item schema.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #27553 .

### How to test the changes in this Pull Request:

1. From a fresh wp install, install WooCommerce
2. Create a REST API consumer key and secret
3. Add a shipping zone
4. Add a flat rate shipping method under the newly added zone
5. Add at least one shipping class
6. Use the REST API v3 GET endpoint for shipping method zones to retrieve and check the current values (`wp-json/wc/v3/shipping/zones/*/method/*`).
7. Use the REST API v3 PUT endpoint for shipping method zones to update the current values (`wp-json/wc/v3/shipping/zones/*/method/*`) using payload: ``` { "settings": { "type": "order" } }```. Supports `type` with value `order` or `class`
8. Use the same retrieve endpoint from step 6 to verify the changes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Updated `include/rest-api/Controllers/Version3/class-wc-rest-shipping-zone-methods-controller.php` to include a item schema function which appends support for `order` and `class` type values
