### PR TITLE
fix: use event delegation for wpbody instead tbody

### DIFF
--- a/assets/js/admin/quick-edit.js
+++ b/assets/js/admin/quick-edit.js
@@ -1,9 +1,9 @@
 /*global inlineEditPost, woocommerce_admin, woocommerce_quick_edit */
 jQuery(
 	function( $ ) {
-		$( '#the-list' ).on(
+		$( '#wpbody' ).on(
 			'click',
-			'.editinline',
+			'#the-list .editinline',
 			function() {
 
 				inlineEditPost.revert();
@@ -116,9 +116,9 @@ jQuery(
 			}
 		);
 
-		$( '#the-list' ).on(
+		$( '#wpbody' ).on(
 			'change',
-			'.inline-edit-row input[name="_manage_stock"]',
+			'#the-list .inline-edit-row input[name="_manage_stock"]',
 			function() {
 
 				if ( $( this ).is( ':checked' ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Some plugins offer a feature for a "lazy loading" or "infinite loading" to the WP List Table for posts (including products). Unfortunately, the quick edit does no longer work if the product row got lazy loaded.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? -> *I did not find any tests for this file*
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

Make quick edit of products work with infinite scrolling plugins

Regards,
Matthew 😊