### PR TITLE
Bump woocommerce-admin version to 2.0.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "2.0.1",
+    "woocommerce/woocommerce-admin": "2.0.2",
     "woocommerce/woocommerce-blocks": "4.4.3"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "95f29b23c1baa50f079597378d1673f1",
+    "content-hash": "f24a600ea103061d766dd7b06c13e8f2",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -44,6 +44,9 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/v2.9.1"
+            },
             "time": "2021-02-05T19:07:06+00:00"
         },
         {
@@ -75,6 +78,9 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for defining constants in a more testable way.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-constants/tree/v1.5.1"
+            },
             "time": "2020-10-28T19:00:31+00:00"
         },
         {
@@ -205,6 +211,10 @@
                 "zend",
                 "zikula"
             ],
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.10.0"
+            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -279,6 +289,10 @@
                 "geolocation",
                 "maxmind"
             ],
+            "support": {
+                "issues": "https://github.com/maxmind/MaxMind-DB-Reader-php/issues",
+                "source": "https://github.com/maxmind/MaxMind-DB-Reader-php/tree/v1.6.0"
+            },
             "time": "2019-12-19T22:59:03+00:00"
         },
         {
@@ -353,6 +367,10 @@
                 "email",
                 "pre-processing"
             ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/emogrifier/issues",
+                "source": "https://github.com/MyIntervals/emogrifier"
+            },
             "time": "2019-12-26T19:37:31+00:00"
         },
         {
@@ -402,6 +420,10 @@
                 "container-interop",
                 "psr"
             ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/master"
+            },
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
@@ -493,20 +515,24 @@
             ],
             "description": "Action Scheduler for WordPress and WooCommerce",
             "homepage": "https://actionscheduler.org/",
+            "support": {
+                "issues": "https://github.com/woocommerce/action-scheduler/issues",
+                "source": "https://github.com/woocommerce/action-scheduler/tree/master"
+            },
             "time": "2020-05-12T16:22:33+00:00"
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.0.1",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "b7e89c48479348847fc97ae8be8c27d068106d04"
+                "reference": "c4ffd90ebc72652f9d1bc8943a56d7723acc5bf4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/b7e89c48479348847fc97ae8be8c27d068106d04",
-                "reference": "b7e89c48479348847fc97ae8be8c27d068106d04",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/c4ffd90ebc72652f9d1bc8943a56d7723acc5bf4",
+                "reference": "c4ffd90ebc72652f9d1bc8943a56d7723acc5bf4",
                 "shasum": ""
             },
             "require": {
@@ -538,7 +564,11 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2021-02-12T01:19:48+00:00"
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.0.2"
+            },
+            "time": "2021-02-25T07:29:24+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -585,6 +615,10 @@
                 "gutenberg",
                 "woocommerce"
             ],
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v4.4.3"
+            },
             "time": "2021-02-11T18:07:48+00:00"
         }
     ],
@@ -633,6 +667,10 @@
                 "isolation",
                 "tool"
             ],
+            "support": {
+                "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/master"
+            },
             "time": "2020-05-03T08:27:20+00:00"
         }
     ],
@@ -648,5 +686,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
This bumps the included version of WooCommerce Admin from 2.0.1 to 2.0.2, which includes the following changes:

- Correct the Klarna slug used when installing the Klarna payment plugin, to correct a UI issue
- refactor the inbox/layout panels to handle outside clicks

The corresponding test instructions will be added to the wiki.