### PR TITLE
Pass checkout submit result to triggered handler

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -525,7 +525,7 @@ jQuery( function( $ ) {
 						wc_checkout_form.detachUnloadEventsOnSubmit();
 
 						try {
-							if ( 'success' === result.result && $form.triggerHandler( 'checkout_place_order_success' ) !== false ) {
+							if ( 'success' === result.result && $form.triggerHandler( 'checkout_place_order_success', result ) !== false ) {
 								if ( -1 === result.redirect.indexOf( 'https://' ) || -1 === result.redirect.indexOf( 'http://' ) ) {
 									window.location = result.redirect;
 								} else {

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -972,6 +972,8 @@ class WC_Checkout {
 
 		// Redirect to success/confirmation/payment page.
 		if ( isset( $result['result'] ) && 'success' === $result['result'] ) {
+			$result['order_id'] = $order_id;
+
 			$result = apply_filters( 'woocommerce_payment_successful_result', $result, $order_id );
 
 			if ( ! is_ajax() ) {

--- a/includes/class-wc-form-handler.php
+++ b/includes/class-wc-form-handler.php
@@ -440,6 +440,8 @@ class WC_Form_Handler {
 
 							// Redirect to success/confirmation/payment page.
 							if ( isset( $result['result'] ) && 'success' === $result['result'] ) {
+								$result['order_id'] = $order_id;
+
 								$result = apply_filters( 'woocommerce_payment_successful_result', $result, $order_id );
 
 								wp_redirect( $result['redirect'] ); //phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Continuation of #25289.

I need to send data to GTM right after submitting checkout form. In conjunction with `woocommerce_payment_successful_result` filter I will be able to return `order_id` to front and use it for my purposes.

### How to test the changes in this Pull Request:

1. Submit this part of code into console while being on checkout page: 
```js
( function( $ ) {
    $( 'form.woocommerce-checkout' ).on( 'checkout_place_order_success', function( event, result ) {
        console.log( result );

        return false; // to prevent submitting form.
    });
} )( jQuery );
```
2. Submit checkout form
3. Observe data in JS console

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Add - `result` return array to the checkout_place_order_success callback to allow 3rd party to manipulate results.
