### PR TITLE
Merge 28936 - Add woocommerce_ajax_order_items_removed hook

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1302,7 +1302,7 @@ class WC_AJAX {
 			/**
 			 * Fires after order items are removed.
 			 *
-			 * @since 4.9.0
+			 * @since 5.1.0
 			 *
 			 * @param int $item_id WC item ID.
 			 * @param WC_Order_Item|false $item As returned by $order->get_item( $item_id ).

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1273,7 +1273,6 @@ class WC_AJAX {
 			}
 
 			if ( ! empty( $order_item_ids ) ) {
-				$order_notes = array();
 
 				foreach ( $order_item_ids as $item_id ) {
 					$item_id = absint( $item_id );

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1300,6 +1300,8 @@ class WC_AJAX {
 			$order->calculate_taxes( $calculate_tax_args );
 			$order->calculate_totals( false );
 
+			do_action( 'woocommerce_ajax_order_items_removed', $item_id, $item, $changed_stock, $order );
+
 			// Get HTML to return.
 			ob_start();
 			include __DIR__ . '/admin/meta-boxes/views/html-order-items.php';

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1299,6 +1299,16 @@ class WC_AJAX {
 			$order->calculate_taxes( $calculate_tax_args );
 			$order->calculate_totals( false );
 
+			/**
+			 * Fires after order items are removed.
+			 *
+			 * @since 4.9.0
+			 *
+			 * @param int $item_id WC item ID.
+			 * @param WC_Order_Item|false $item As returned by $order->get_item( $item_id ).
+			 * @param bool|array|WP_Error $changed_store Result of wc_maybe_adjust_line_item_product_stock().
+			 * @param bool|WC_Order|WC_Order_Refund $order As returned by wc_get_order().
+			 */
 			do_action( 'woocommerce_ajax_order_items_removed', $item_id, $item, $changed_stock, $order );
 
 			// Get HTML to return.

--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1302,7 +1302,7 @@ class WC_AJAX {
 			/**
 			 * Fires after order items are removed.
 			 *
-			 * @since 5.1.0
+			 * @since 5.2.0
 			 *
 			 * @param int $item_id WC item ID.
 			 * @param WC_Order_Item|false $item As returned by $order->get_item( $item_id ).


### PR DESCRIPTION
Just merging #28936 to trunk and fixing docblock.

Description from the original pull request:

### Changes proposed in this Pull Request:

The purpose of this PR is to address the request of Issue #26857 "Add action for after remove_order_item"

Note: It also cleans up a stray line of code that my IDE recognized as not used. 

### Changelog entry

> Dev - Added `woocommerce_ajax_order_items_removed` hook.