### PR TITLE
Disable comment workflow since it fails on fork.

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -21,19 +21,6 @@ jobs:
           name: woocommerce
           path: ${{ steps.build.outputs.zip_path }}
           retention-days: 7
-
-      - name: Add comment
-        uses: actions/github-script@v3
-        if: github.repository_owner == 'woocommerce'
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            github.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: ':package: Artifacts ready for [download](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})!'
-            })
   
   e2e-tests-cache:
     name: Set e2e caches for running tests


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Currently, our e2e tests fail on forks with error: "Error: Unhandled error: HttpError: Resource not accessible by integration
". I tried adding a conditional so that it does not run on the fork, but there does not seem to be a way around this. This PR disables it for now.

### How to test the changes in this Pull Request:

1. Make sure tests pass, specifically e2e.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A