### PR TITLE
Move "Add comment" task to a new job

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -22,9 +22,14 @@ jobs:
           path: ${{ steps.build.outputs.zip_path }}
           retention-days: 7
 
-      - name: Add comment
+  add-comment:
+    if: github.repository_owner == 'woocommerce'
+    name: Add comment
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Comment to PR
         uses: actions/github-script@v3
-        if: github.repository_owner == 'woocommerce'
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -34,7 +39,7 @@ jobs:
               repo: context.repo.repo,
               body: ':package: Artifacts ready for [download](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})!'
             })
-  
+
   e2e-tests-cache:
     name: Set e2e caches for running tests
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -35,8 +35,8 @@ jobs:
           script: |
             github.issues.createComment({
               issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
+              owner: 'woocommerce',
+              repo: 'woocommerce',
               body: ':package: Artifacts ready for [download](https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }})!'
             })
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR moves "Add comment" task from build job to a new job where we can skip in forks.

I made a test in a fork and you can it working:

- https://github.com/claudiosanches/woocommerce/actions/runs/611086007
- https://github.com/claudiosanches/woocommerce/runs/2005595413?check_suite_focus=true

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
