### PR TITLE
Added delete step to API product tests

### DIFF
--- a/tests/e2e/core-tests/specs/api/coupon.test.js
+++ b/tests/e2e/core-tests/specs/api/coupon.test.js
@@ -74,10 +74,10 @@ const runCouponApiTest = () => {
 
 		it('can delete a coupon', async () => {
 			// Delete the coupon
-			const deletedCoupon = await repository.delete( coupon.id );
+			const status = await repository.delete( coupon.id );
 
 			// If the delete is successful, the response comes back truthy
-			expect( deletedCoupon ).toBeTruthy();
+			expect( status ).toBeTruthy();
 		});
 	});
 };

--- a/tests/e2e/core-tests/specs/api/external-product.test.js
+++ b/tests/e2e/core-tests/specs/api/external-product.test.js
@@ -69,6 +69,11 @@ const runExternalProductAPITest = () => {
 			const transformed = await repository.read( product.id );
 			expect( transformed ).toEqual( expect.objectContaining( transformedProperties ) );
 		});
+
+		it('can delete an external product', async () => {
+			const status = repository.delete( product.id );
+			expect( status ).toBeTruthy();
+		});
 	});
 };
 

--- a/tests/e2e/core-tests/specs/api/grouped-product.test.js
+++ b/tests/e2e/core-tests/specs/api/grouped-product.test.js
@@ -71,10 +71,15 @@ const runGroupedProductAPITest = () => {
 			expect( response.data ).toEqual( expect.objectContaining( rawProperties ) );
 		});
 
-		it('can retrieve a transformed external product', async () => {
+		it('can retrieve a transformed grouped product', async () => {
 			// Read product via the repository.
 			const transformed = await repository.read( product.id );
 			expect( transformed ).toEqual( expect.objectContaining( baseGroupedProduct ) );
+		});
+
+		it('can delete a grouped product', async () => {
+			const status = repository.delete( product.id );
+			expect( status ).toBeTruthy();
 		});
 	});
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a delete step to the product API tests that were added.

Closes https://github.com/woocommerce/woocommerce/issues/29266.

### How to test the changes in this Pull Request:

1. Make sure the tests pass both on Travis and locally.
2. Login to the UI and verify the products don't show in the Products > All Products list view.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A
