### PR TITLE
Fix: Product categories widget item count not always showing the correct number

### DIFF
--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -64,6 +64,12 @@ class WC_Settings_Products extends WC_Settings_Page {
 		$settings = $this->get_settings( $current_section );
 		WC_Admin_Settings::save_fields( $settings );
 
+		/*
+		 * Product->Inventory has a setting `Out of stock visibility`.
+		 * Because of this, we need to recount the terms to keep them in-sync.
+		 */
+		wc_recount_all_terms();
+
 		if ( $current_section ) {
 			do_action( 'woocommerce_update_options_' . $this->id . '_' . $current_section );
 		}

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -711,40 +711,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			wp_set_post_terms( $product->get_id(), array( $product->get_shipping_class_id( 'edit' ) ), 'product_shipping_class', false );
 		}
 
-		/**
-		 * Filter to allow/prevent recounting of terms as it could be expensive.
-		 * A likely scenario for this is when bulk importing products. We could
-		 * then prevent it from recounting per product but instead recount it once
-		 * when import is done. Of course this means the import logic has to support this.
-		 *
-		 * @since 5.2
-		 * @param bool
-		 */
-		if ( apply_filters( 'woocommerce_product_update_recount_terms', '__return_true' ) ) {
-			$product_terms = get_the_terms( $product->get_id(), 'product_cat' );
-
-			if ( $product_terms ) {
-				$product_cats = array();
-
-				foreach ( $product_terms as $term ) {
-					$product_cats[ $term->term_id ] = $term->parent;
-				}
-
-				_wc_term_recount( $product_cats, get_taxonomy( 'product_cat' ), false, false );
-			}
-
-			$product_terms = get_the_terms( $product->get_id(), 'product_tag' );
-
-			if ( $product_terms ) {
-				$product_tags = array();
-
-				foreach ( $product_terms as $term ) {
-					$product_tags[ $term->term_id ] = $term->parent;
-				}
-
-				_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), false, false );
-			}
-		}
+		_wc_recount_terms_by_product( $product->get_id() );
 	}
 
 	/**

--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -710,6 +710,41 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 		if ( $force || array_key_exists( 'shipping_class_id', $changes ) ) {
 			wp_set_post_terms( $product->get_id(), array( $product->get_shipping_class_id( 'edit' ) ), 'product_shipping_class', false );
 		}
+
+		/**
+		 * Filter to allow/prevent recounting of terms as it could be expensive.
+		 * A likely scenario for this is when bulk importing products. We could
+		 * then prevent it from recounting per product but instead recount it once
+		 * when import is done. Of course this means the import logic has to support this.
+		 *
+		 * @since 5.2
+		 * @param bool
+		 */
+		if ( apply_filters( 'woocommerce_product_update_recount_terms', '__return_true' ) ) {
+			$product_terms = get_the_terms( $product->get_id(), 'product_cat' );
+
+			if ( $product_terms ) {
+				$product_cats = array();
+
+				foreach ( $product_terms as $term ) {
+					$product_cats[ $term->term_id ] = $term->parent;
+				}
+
+				_wc_term_recount( $product_cats, get_taxonomy( 'product_cat' ), false, false );
+			}
+
+			$product_terms = get_the_terms( $product->get_id(), 'product_tag' );
+
+			if ( $product_terms ) {
+				$product_tags = array();
+
+				foreach ( $product_terms as $term ) {
+					$product_tags[ $term->term_id ] = $term->parent;
+				}
+
+				_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), false, false );
+			}
+		}
 	}
 
 	/**

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-system-status-tools-v2-controller.php
@@ -504,22 +504,7 @@ class WC_REST_System_Status_Tools_V2_Controller extends WC_REST_Controller {
 				break;
 
 			case 'recount_terms':
-				$product_cats = get_terms(
-					'product_cat',
-					array(
-						'hide_empty' => false,
-						'fields'     => 'id=>parent',
-					)
-				);
-				_wc_term_recount( $product_cats, get_taxonomy( 'product_cat' ), true, false );
-				$product_tags = get_terms(
-					'product_tag',
-					array(
-						'hide_empty' => false,
-						'fields'     => 'id=>parent',
-					)
-				);
-				_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), true, false );
+				wc_recount_all_terms();
 				$message = __( 'Terms successfully recounted', 'woocommerce' );
 				break;
 

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -636,3 +636,28 @@ function wc_get_product_visibility_term_ids() {
 		)
 	);
 }
+
+/**
+ * Recounts all terms.
+ *
+ * @since 5.2
+ * @return void
+ */
+function wc_recount_all_terms() {
+	$product_cats = get_terms(
+		'product_cat',
+		array(
+			'hide_empty' => false,
+			'fields'     => 'id=>parent',
+		)
+	);
+	_wc_term_recount( $product_cats, get_taxonomy( 'product_cat' ), true, false );
+	$product_tags = get_terms(
+		'product_tag',
+		array(
+			'hide_empty' => false,
+			'fields'     => 'id=>parent',
+		)
+	);
+	_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), true, false );
+}

--- a/includes/wc-term-functions.php
+++ b/includes/wc-term-functions.php
@@ -392,6 +392,19 @@ function wc_set_term_order( $term_id, $index, $taxonomy, $recursive = false ) {
 function _wc_term_recount( $terms, $taxonomy, $callback = true, $terms_are_term_taxonomy_ids = true ) {
 	global $wpdb;
 
+	/**
+	 * Filter to allow/prevent recounting of terms as it could be expensive.
+	 * A likely scenario for this is when bulk importing products. We could
+	 * then prevent it from recounting per product but instead recount it once
+	 * when import is done. Of course this means the import logic has to support this.
+	 *
+	 * @since 5.2
+	 * @param bool
+	 */
+	if ( ! apply_filters( 'woocommerce_product_recount_terms', '__return_true' ) ) {
+		return;
+	}
+
 	// Standard callback.
 	if ( $callback ) {
 		_update_post_term_count( $terms, $taxonomy );
@@ -492,29 +505,7 @@ function wc_recount_after_stock_change( $product_id ) {
 		return;
 	}
 
-	$product_terms = get_the_terms( $product_id, 'product_cat' );
-
-	if ( $product_terms ) {
-		$product_cats = array();
-
-		foreach ( $product_terms as $term ) {
-			$product_cats[ $term->term_id ] = $term->parent;
-		}
-
-		_wc_term_recount( $product_cats, get_taxonomy( 'product_cat' ), false, false );
-	}
-
-	$product_terms = get_the_terms( $product_id, 'product_tag' );
-
-	if ( $product_terms ) {
-		$product_tags = array();
-
-		foreach ( $product_terms as $term ) {
-			$product_tags[ $term->term_id ] = $term->parent;
-		}
-
-		_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), false, false );
-	}
+	_wc_recount_terms_by_product( $product_id );
 }
 add_action( 'woocommerce_product_set_stock_status', 'wc_recount_after_stock_change' );
 
@@ -660,4 +651,41 @@ function wc_recount_all_terms() {
 		)
 	);
 	_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), true, false );
+}
+
+/**
+ * Recounts terms by product.
+ *
+ * @since 5.2
+ * @param int $product_id The ID of the product.
+ * @return void
+ */
+function _wc_recount_terms_by_product( $product_id = '' ) {
+	if ( empty( $product_id ) ) {
+		return;
+	}
+
+	$product_terms = get_the_terms( $product_id, 'product_cat' );
+
+	if ( $product_terms ) {
+		$product_cats = array();
+
+		foreach ( $product_terms as $term ) {
+			$product_cats[ $term->term_id ] = $term->parent;
+		}
+
+		_wc_term_recount( $product_cats, get_taxonomy( 'product_cat' ), false, false );
+	}
+
+	$product_terms = get_the_terms( $product_id, 'product_tag' );
+
+	if ( $product_terms ) {
+		$product_tags = array();
+
+		foreach ( $product_terms as $term ) {
+			$product_tags[ $term->term_id ] = $term->parent;
+		}
+
+		_wc_term_recount( $product_tags, get_taxonomy( 'product_tag' ), false, false );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/master/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #25375

### How to test the changes in this Pull Request:

1. Add the Product Categories widget to your site. Enable show counts option.
2. Make sure to have a hand full of products that belong to a category that is listed in that widget.
3. For couple of the products, set the stock level to out of stock and save the product.
4. Go back to the frontend shop page and ensure the widget shows the product count correctly.
5. Go to your woocommerce->settings->products->inventory and set `Hide out of stock items from the catalog` to enabled.
6. Go back to the frontend shop page and ensure the widget shows the product count correctly. Should show less than in step 5 as now it suppose to hide the product from catalog if it is out of stock.
7. Disable `Hide out of stock items from the catalog` setting and save.
8. Go back to the frontend shop page and ensure the widget shows the product count correctly.
9. Test the added filter by using the code snippet `add_filter( 'woocommerce_product_recount_terms', '__return_false' );`.
10. Test steps 1 to 8 and observe that the count is no longer refreshed because the filter prevents the recount.

### Other information:

Simple PR to just flush the caches during the product save operation and product settings page.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Product categories widget item count not always showing the correct number.
> Add - Filter `woocommerce_product_recount_terms` to allow/prevent recounting of product terms.

