### PR TITLE
Trigger country field change on address change click

### DIFF
--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -180,6 +180,7 @@ jQuery( function( $ ) {
 		 */
 		toggle_shipping: function() {
 			$( '.shipping-calculator-form' ).slideToggle( 'slow' );
+			$( 'select.country_to_state, input.country_to_state' ).trigger( 'change' );
 			$( document.body ).trigger( 'country_to_state_changed' ); // Trigger select2 to load.
 			return false;
 		},


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Trigger country field change on address change click to resolve irrelevant post code field showing

Closes #29261 


### How to test the changes in this Pull Request:
1. Add a product to the cart.
2. Click `Calculate shipping` under `Cart totals` on the Cart page.
3. Change country to Bahamas. ( This will hide the postcode field )
4. Click `Update`
5. Click on `Change address` and see that the postcode field does not render.

### Changelog entry

> Fix - Cart page calculate shipping fields not showing correct fields based on location.
