### PR TITLE
Fix typos in docs

### DIFF
--- a/includes/abstracts/abstract-wc-payment-token.php
+++ b/includes/abstracts/abstract-wc-payment-token.php
@@ -2,7 +2,7 @@
 /**
  * Abstract payment tokens
  *
- * Generic payment tokens functionality which can be extended by idividual types of payment tokens.
+ * Generic payment tokens functionality which can be extended by individual types of payment tokens.
  *
  * @class WC_Payment_Token
  * @package WooCommerce\Abstracts

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -907,7 +907,7 @@ class WC_Order extends WC_Abstract_Order {
 		$address     = WC()->countries->get_formatted_address( $raw_address );
 
 		/**
-		 * Filter orders formatterd billing address.
+		 * Filter orders formatted billing address.
 		 *
 		 * @since 3.8.0
 		 * @param string   $address     Formatted billing address string.
@@ -933,7 +933,7 @@ class WC_Order extends WC_Abstract_Order {
 		}
 
 		/**
-		 * Filter orders formatterd shipping address.
+		 * Filter orders formatted shipping address.
 		 *
 		 * @since 3.8.0
 		 * @param string   $address     Formatted billing address string.

--- a/tests/legacy/unit-tests/checkout/checkout.php
+++ b/tests/legacy/unit-tests/checkout/checkout.php
@@ -141,7 +141,7 @@ class WC_Tests_Checkout extends WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test usage limit for guest users uasge limit per user is set.
+	 * Test usage limit for guest users usage limit per user is set.
 	 *
 	 * @throws Exception When unable to create order.
 	 */

--- a/tests/legacy/unit-tests/widgets/class-dummy-widget.php
+++ b/tests/legacy/unit-tests/widgets/class-dummy-widget.php
@@ -18,7 +18,7 @@ class Dummy_Widget extends WC_Widget {
 	 * Output widget.
 	 *
 	 * @param mixed     $args Arguments.
-	 * @param WP_Widget $instance Intance of WP_Widget.
+	 * @param WP_Widget $instance Instance of WP_Widget.
 	 * @return void
 	 */
 	public function widget( $args, $instance ) {

--- a/tests/php/includes/wc-stock-functions-tests.php
+++ b/tests/php/includes/wc-stock-functions-tests.php
@@ -85,7 +85,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test inventory count after order status transtions which reduces stock to another status which also reduces stock.
+	 * Test inventory count after order status transitions which reduces stock to another status which also reduces stock.
 	 * Stock should have reduced once already, and should not reduce again.
 	 */
 	public function test_status_transition_stock_reduce_to_stock_reduce() {
@@ -97,7 +97,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test inventory count after order status transtions which reduces stock to another status which restores stock.
+	 * Test inventory count after order status transitions which reduces stock to another status which restores stock.
 	 * Should should have already reduced once, and will increase again after transitioning.
 	 */
 	public function test_status_transition_stock_reduce_to_stock_restore() {
@@ -109,7 +109,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test inventory count after order status transtions which reduces stock to another status which don't affect inventory.
+	 * Test inventory count after order status transitions which reduces stock to another status which don't affect inventory.
 	 * Stock should have already reduced, and will not change on transitioning.
 	 */
 	public function test_status_transition_stock_reduce_to_stock_no_effect() {
@@ -133,7 +133,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test inventory count after order status transtions which restores stock to another status which also restores stock.
+	 * Test inventory count after order status transitions which restores stock to another status which also restores stock.
 	 * Stock should not have reduced, and will remain the same even after transition (i.e. should not be restocked again).
 	 */
 	public function test_status_transition_stock_restore_to_stock_restore() {
@@ -145,7 +145,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test inventory count after order status transtions which restores stock to another status which don't affect inventory.
+	 * Test inventory count after order status transitions which restores stock to another status which don't affect inventory.
 	 * Stock should not have reduced, and will remain the same even after transition.
 	 */
 	public function test_status_transition_stock_restore_to_stock_no_effect() {
@@ -157,7 +157,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test inventory count after order status transtions which don't affect inventory stock to another status which reduces stock.
+	 * Test inventory count after order status transitions which don't affect inventory stock to another status which reduces stock.
 	 * Stock would not have been affected, but will reduce after transition.
 	 */
 	public function test_status_transition_stock_no_effect_to_stock_reduce() {
@@ -169,7 +169,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test inventory count after order status transtions which don't affect inventory stock to another status which restores stock.
+	 * Test inventory count after order status transitions which don't affect inventory stock to another status which restores stock.
 	 * Stock would not have been affected, and will not be restored after transition (since it was not reduced to begin with).
 	 */
 	public function test_status_transition_stock_no_effect_to_stock_restore() {
@@ -181,7 +181,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
-	 * Test inventory count after order status transtions which don't affect inventory stock to another status which also don't affect inventory.
+	 * Test inventory count after order status transitions which don't affect inventory stock to another status which also don't affect inventory.
 	 * Stock levels will not change before or after the transition.
 	 */
 	public function test_status_transition_stock_no_effect_to_stock_no_effect() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix typos in docblocks

### Changelog entry

> Dev - Fix miscellaneous typos in docblocks.