### PR TITLE
Adding a new Slackbot notification for failed E2E tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12021,6 +12021,14 @@
             "@types/node": "*"
           }
         },
+        "@types/form-data": {
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/@types/form-data/-/form-data-2.2.1.tgz",
+          "integrity": "sha512-JAMFhOaHIciYVh8fb5/83nmuO/AHwmto+Hq7a9y8FzLDcC1KCU344XDOMEmahnrTFlHjgh4L0WJFczNIX2GxnQ==",
+          "requires": {
+            "@types/node": "*"
+          }
+        },
         "@types/is-stream": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/@types/is-stream/-/is-stream-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -139,5 +139,12 @@
         "@wordpress/e2e-test-utils"
       ]
     }
+  },
+  "dependencies": {
+    "@slack/web-api": "^5.0.1",
+    "acorn": "^6.1.1",
+    "expect-puppeteer": "^4.1",
+    "mkdirp": "latest",
+    "rrule": "^2.6.0"
   }
 }

--- a/tests/e2e/jest.test.failure.js
+++ b/tests/e2e/jest.test.failure.js
@@ -1,0 +1,53 @@
+/** @format */
+
+import {
+	sendFailedTestScreenshotToSlack,
+	sendFailedTestMessageToSlack
+} from "./lib/reporter/slack-reporter";
+
+const path = require( 'path' );
+const mkdirp = require( 'mkdirp' );
+
+/**
+ * Override the test case method so we can take screenshots of assertion failures.
+ *
+ * See: https://github.com/smooth-code/jest-puppeteer/issues/131#issuecomment-469439666
+ */
+let currentBlock;
+
+global.describe = ( name, func ) => {
+	currentBlock = name;
+
+	try {
+		func();
+	} catch ( e ) {
+		throw e;
+	}
+};
+
+global.it = async ( name, func ) => {
+	return await test( name, async () => {
+		try {
+			await func();
+		} catch ( e ) {
+			const savePath = './tests/e2e/screenshots';
+			const fileName = `${ currentBlock } - ${ name }.png`;
+			const testNameForTravisMessage = `${ currentBlock } - ${ name }`;
+			const filePath = path.join(
+				savePath,
+				fileName.replace( /[^a-z0-9.-]+/gi, '-' )
+			);
+			mkdirp.sync( savePath );
+
+			await page.screenshot( {
+				path: filePath,
+				fullPage: true,
+			} );
+
+			await sendFailedTestMessageToSlack( testNameForTravisMessage );
+			await sendFailedTestScreenshotToSlack( filePath );
+
+			throw e;
+		}
+	} );
+};

--- a/tests/e2e/lib/reporter/slack-reporter.js
+++ b/tests/e2e/lib/reporter/slack-reporter.js
@@ -1,0 +1,68 @@
+const { createReadStream } = require( 'fs' );
+const { WebClient, ErrorCode } = require( '@slack/web-api' );
+
+// Read a token from the environment variables
+const slackToken = process.env.SLACK_TOKEN;
+
+// Slack channel where the messages and screenshots will be sent to upon test failing
+const slackChannel = process.env.SLACK_CHANNEL;
+
+// if the current job is a pull request, the name of the branch from which the PR originated
+// if the current job is a push build, this variable is empty ("")
+const travisPullRequestBranch = process.env.TRAVIS_PULL_REQUEST_BRANCH;
+
+// The commit that the current build is testing
+const travisCommit = process.env.TRAVIS_COMMIT;
+
+// URL to the build log
+const travisBuildWebLog = process.env.TRAVIS_BUILD_WEB_URL;
+
+// Initialize
+const web = new WebClient( slackToken );
+
+// A file name is required for the upload
+const filename = 'screenshot_of_failed_test_on_Travis.jpeg';
+
+export async function sendFailedTestMessageToSlack( testName ) {
+
+	try {
+		// For details, see: https://api.slack.com/methods/chat.postMessage
+		await web.chat.postMessage({
+			text: `Test failed on Travis on *${ travisPullRequestBranch }* branch. \n 
+            The commit this build is testing is *${ travisCommit }*. \n 
+            The name of the test that failed: *${ testName }*. \n 
+            See screenshot of the failed test below. *Build log* could be found here: ${ travisBuildWebLog }`,
+			channel: slackChannel,
+		});
+	} catch ( error ) {
+		// Check the code property and log the response
+		if ( error.code === ErrorCode.PlatformError || error.code === ErrorCode.RequestError ||
+			error.code === ErrorCode.RateLimitedError || error.code === ErrorCode.HTTPError ) {
+			console.log( error.data );
+		} else {
+			// Some other error, oh no!
+			console.log( 'The error occurred does not match an error we are checking for in this block.' );
+		}
+	}
+}
+
+export async function sendFailedTestScreenshotToSlack( screenshotOfFailedTest ) {
+
+	try {
+		// For details, see: https://api.slack.com/methods/files.upload
+		await web.files.upload({
+			filename,
+			file: createReadStream(screenshotOfFailedTest),
+			channels: slackChannel,
+		});
+	} catch ( error ) {
+		// Check the code property and log the response
+		if ( error.code === ErrorCode.PlatformError || error.code === ErrorCode.RequestError ||
+			error.code === ErrorCode.RateLimitedError || error.code === ErrorCode.HTTPError ) {
+			console.log( error.data );
+		} else {
+			// Some other error, oh no!
+			console.log( 'The error occurred does not match an error we are checking for in this block.' );
+		}
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.
2.
3.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
