### PR TITLE
Fix E2E shorthand script to allow for directories with spaces

### DIFF
--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Fixed
+
+- Update `wc-e2e` script to fix an issue with directories with a space in their name
+
 # 0.2.0
 
 ## Fixed

--- a/tests/e2e/env/bin/wc-e2e.sh
+++ b/tests/e2e/env/bin/wc-e2e.sh
@@ -30,8 +30,8 @@ TESTRESULT=0
 
 # Use the script symlink to find and change directory to the root of the package
 SCRIPTPATH=$(dirname "$0")
-REALPATH=$(readlink $0)
-cd $SCRIPTPATH/$(dirname "$REALPATH")/..
+REALPATH=$(readlink "$0")
+cd "$SCRIPTPATH/$(dirname "$REALPATH")/.."
 
 # Run scripts
 case $1 in
@@ -65,6 +65,6 @@ case $1 in
 esac
 
 # Restore working path
-cd $OLDPATH
+cd "$OLDPATH"
 
 exit $TESTRESULT


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR updates the `wc-e2e` script introduced in #28596 to work when WooCommerce is checked out in a directory with spaces in its name.

### How to test the changes in this Pull Request:

1. Create a directory with spaces in its name and clone WooCommerce in that directory.
2. Checkout `trunk`, and try running `e2e` tests following the [instructions in the README](https://github.com/woocommerce/woocommerce/blob/trunk/tests/e2e/README.md#running-tests).
3. When you get to the `npx wc-e2e docker:up` step, the script will fail with a message about the directory not existing.
4. Checkout this branch, and repeat the `npx wc-e2e docker:up` attempt. The docker container should be started.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A
