### PR TITLE
New filter: stock check message

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1221,7 +1221,7 @@ class WC_Cart extends WC_Legacy_Cart {
 					$stock_quantity         = $product_data->get_stock_quantity();
 					$stock_quantity_in_cart = $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ];
 
-					$message = printf(
+					$message = sprintf(
 						'<a href="%s" class="button wc-forward">%s</a> %s',
 						wc_get_cart_url(),
 						__( 'View cart', 'woocommerce' ),

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1218,15 +1218,30 @@ class WC_Cart extends WC_Legacy_Cart {
 				$products_qty_in_cart = $this->get_cart_item_quantities();
 
 				if ( isset( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] ) && ! $product_data->has_enough_stock( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ] + $quantity ) ) {
-					throw new Exception(
-						sprintf(
-							'<a href="%s" class="button wc-forward">%s</a> %s',
-							wc_get_cart_url(),
-							__( 'View cart', 'woocommerce' ),
-							/* translators: 1: quantity in stock 2: current quantity */
-							sprintf( __( 'You cannot add that amount to the cart &mdash; we have %1$s in stock and you already have %2$s in your cart.', 'woocommerce' ), wc_format_stock_quantity_for_display( $product_data->get_stock_quantity(), $product_data ), wc_format_stock_quantity_for_display( $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ], $product_data ) )
-						)
+					$stock_quantity         = $product_data->get_stock_quantity();
+					$stock_quantity_in_cart = $products_qty_in_cart[ $product_data->get_stock_managed_by_id() ];
+
+					$message = printf(
+						'<a href="%s" class="button wc-forward">%s</a> %s',
+						wc_get_cart_url(),
+						__( 'View cart', 'woocommerce' ),
+						/* translators: 1: quantity in stock 2: current quantity */
+						sprintf( __( 'You cannot add that amount to the cart &mdash; we have %1$s in stock and you already have %2$s in your cart.', 'woocommerce' ), wc_format_stock_quantity_for_display( $stock_quantity, $product_data ), wc_format_stock_quantity_for_display( $stock_quantity_in_cart, $product_data ) )
 					);
+
+					/**
+					 * Filters message about product not having enough stock accounting for what's already in the cart.
+					 *
+					 * @param string $message Message.
+					 * @param WC_Product $product_data Product data.
+					 * @param int $stock_quantity Quantity remaining.
+					 * @param int $stock_quantity_in_cart
+					 *
+					 * @since 5.0.0
+					 */
+					$message = apply_filters( 'woocommerce_cart_product_not_enough_stock_already_in_cart_message', $message, $product_data, $stock_quantity, $stock_quantity_in_cart );
+
+					throw new Exception( $message );
 				}
 			}
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1237,7 +1237,7 @@ class WC_Cart extends WC_Legacy_Cart {
 					 * @param int $stock_quantity Quantity remaining.
 					 * @param int $stock_quantity_in_cart
 					 *
-					 * @since 5.0.0
+					 * @since 5.3.0
 					 */
 					$message = apply_filters( 'woocommerce_cart_product_not_enough_stock_already_in_cart_message', $message, $product_data, $stock_quantity, $stock_quantity_in_cart );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

Adds a new filter to allow customization of the stock check message error when a product is out of stock, but accounting for what's already in the cart. It mimics the existing `woocommerce_cart_product_not_enough_stock_message` filter.

Without this filter we cannot customize the error message.

### How to test the changes in this Pull Request:

1. Add a product to your cart with one item in stock and can-manage-inventory set to true
2. Repeat

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Add - A new `woocommerce_cart_product_not_enough_stock_already_in_cart_message` filter to allow developers to filter an add-to-cart error when there isn't enough in stock taking into account what's already in the cart.
