### PR TITLE
Fix flaky issues with e2e product filter, search, sort test

### DIFF
--- a/tests/e2e/core-tests/specs/shopper/front-end-product-browse-search-sort.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-product-browse-search-sort.test.js
@@ -21,8 +21,8 @@ const {
 const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );
 const singleProductPrice = config.has('products.simple.price') ? config.get('products.simple.price') : '9.99';
-const singleProductPrice2 = config.has('products.simple.price') ? config.get('products.simple.price') : '19.99';
-const singleProductPrice3 = config.has('products.simple.price') ? config.get('products.simple.price') : '29.99';
+const singleProductPrice2 = config.has('products.simple.price') ? '1' + singleProductPrice : '19.99';
+const singleProductPrice3 = config.has('products.simple.price') ? '2' + singleProductPrice : '29.99';
 const clothing = 'Clothing';
 const audio = 'Audio';
 const hardware = 'Hardware';
@@ -31,34 +31,32 @@ const productTitle = 'li.first > a > h2.woocommerce-loop-product__title';
 const runProductBrowseSearchSortTest = () => {
 	describe('Search, browse by categories and sort items in the shop', () => {
 		beforeAll(async () => {
-			await merchant.login();
-			// Create 1st product with Clothing category 
+			// Create 1st product with Clothing category
 			await createSimpleProductWithCategory(simpleProductName + ' 1', singleProductPrice, clothing);
-			// Create 2nd product with Audio category 
+			// Create 2nd product with Audio category
 			await createSimpleProductWithCategory(simpleProductName + ' 2', singleProductPrice2, audio);
-			// Create 3rd product with Hardware category 
+			// Create 3rd product with Hardware category
 			await createSimpleProductWithCategory(simpleProductName + ' 3', singleProductPrice3, hardware);
-			await merchant.logout();
 		});
 
 		it('should let user search the store', async () => {
 			await shopper.goToShop();
 			await shopper.searchForProduct(simpleProductName + ' 1');
+			page.waitForNavigation({waitUntil: 'networkidle0'});
 		});
 
 		it('should let user browse products by categories', async () => {
 			// Browse through Clothing category link
 			await Promise.all([
-				page.waitForNavigation({waitUntil: 'networkidle0'}),
 				page.click('span.posted_in > a', {text: clothing}),
+				page.waitForNavigation({waitUntil: 'networkidle0'}),
 			]);
-			await uiUnblocked();
 
 			// Verify Clothing category page
 			await page.waitForSelector(productTitle);
 			await expect(page).toMatchElement(productTitle, {text: simpleProductName + ' 1'});
 			await expect(page).toClick(productTitle, {text: simpleProductName + ' 1'});
-			await uiUnblocked();
+			page.waitForNavigation({waitUntil: 'networkidle0'});
 			await page.waitForSelector('h1.entry-title');
 			await expect(page).toMatchElement('h1.entry-title', simpleProductName + ' 1');
 		});

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -192,34 +192,18 @@ const createSimpleProduct = async () => {
  * @param categoryName Product's category which can be changed when writing a test
  */
 const createSimpleProductWithCategory = async ( productName, productPrice, categoryName ) => {
-	// Go to "add product" page
-	await merchant.openNewProduct();
+	const product = await factories.products.simple.create( {
+		name: productName,
+		regularPrice: productPrice,
+		categories: [
+			{
+				name: categoryName,
+			}
+		],
+		isVirtual: true,
+	} );
 
-	// Add title and regular price
-	await expect(page).toFill('#title', productName);
-	await expect(page).toClick('#_virtual');
-	await clickTab('General');
-	await expect(page).toFill('#_regular_price', productPrice);
-
-	// Try to select the existing category if present already, otherwise add a new and select it
-	try {
-		const [checkbox] = await page.$x('//label[contains(text(), "'+categoryName+'")]');
-		await checkbox.click();
-	} catch (error) {
-		await expect(page).toClick('#product_cat-add-toggle');
-		await expect(page).toFill('#newproduct_cat', categoryName);
-		await expect(page).toClick('#product_cat-add-submit');
-	}
-
-	// Publish the product
-	await expect(page).toClick('#publish');
-	await uiUnblocked();
-	await page.waitForSelector('.updated.notice', {text:'Product published.'});
-
-	// Get the product ID
-	const variablePostId = await page.$('#post_ID');
-	let variablePostIdValue = (await(await variablePostId.getProperty('value')).jsonValue());
-	return variablePostIdValue;
+	return product.id;
 };
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses the following issues that could cause the test to fail intermittently:

- Updates `createSimpleProductWithCategory()` to use the API to create the products. Screenshots from #29305 showed the shop with no products indicating there were flakiness issues creating the products.
- Updates the price logic to ensure the product order by price.
- Replaces `uiUnblocked()` with `waitForNavigation()`. `blockUI` isn't used when a click on the front end loads a page.

### How to test the changes in this Pull Request:

1. Verify CI runs
2. Run E2E tests locally

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

N/A
