### PR TITLE
Return 0 if order isn't available in WC_Payment_Gateway::get_order_total

### DIFF
--- a/includes/abstracts/abstract-wc-payment-gateway.php
+++ b/includes/abstracts/abstract-wc-payment-gateway.php
@@ -262,7 +262,9 @@ abstract class WC_Payment_Gateway extends WC_Settings_API {
 		// Gets order total from "pay for order" page.
 		if ( 0 < $order_id ) {
 			$order = wc_get_order( $order_id );
-			$total = (float) $order->get_total();
+			if ( $order ) {
+				$total = (float) $order->get_total();
+			}
 
 			// Gets order total from cart/checkout.
 		} elseif ( 0 < WC()->cart->total ) {

--- a/includes/gateways/cod/class-wc-gateway-cod.php
+++ b/includes/gateways/cod/class-wc-gateway-cod.php
@@ -132,7 +132,7 @@ class WC_Gateway_COD extends WC_Payment_Gateway {
 			$order    = wc_get_order( $order_id );
 
 			// Test if order needs shipping.
-			if ( 0 < count( $order->get_items() ) ) {
+			if ( $order && 0 < count( $order->get_items() ) ) {
 				foreach ( $order->get_items() as $item ) {
 					$_product = $item->get_product();
 					if ( $_product && $_product->needs_shipping() ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Prevent errors like: https://github.com/woocommerce/woocommerce-gateway-stripe/issues/1104

### How to test the changes in this Pull Request:

1. Install the official Woo Stripe gateway
2. Visit a payment link for a non-existent order

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Return 0 if order isn't available in `WC_Payment_Gateway::get_order_total()`.
