### PR TITLE
Make rounding more accurate when prices are entered more than 2dp

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -189,7 +189,10 @@ if ( wc_tax_enabled() ) {
 					<td class="label"><?php echo esc_html( $tax_total->label ); ?>:</td>
 					<td width="1%"></td>
 					<td class="total">
-						<?php echo wc_price( wc_round_tax_total( $tax_total->amount ), array( 'currency' => $order->get_currency() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php
+							// We use wc_round_tax_total here because tax may need to be round up or round down depending upon settings, whereas wc_price alone will always round it down.
+							echo wc_price( wc_round_tax_total( $tax_total->amount ), array( 'currency' => $order->get_currency() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+						?>
 					</td>
 				</tr>
 			<?php endforeach; ?>

--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -189,7 +189,7 @@ if ( wc_tax_enabled() ) {
 					<td class="label"><?php echo esc_html( $tax_total->label ); ?>:</td>
 					<td width="1%"></td>
 					<td class="total">
-						<?php echo wc_price( $tax_total->amount, array( 'currency' => $order->get_currency() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+						<?php echo wc_price( wc_round_tax_total( $tax_total->amount ), array( 'currency' => $order->get_currency() ) ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
 					</td>
 				</tr>
 			<?php endforeach; ?>

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -750,8 +750,8 @@ final class WC_Cart_Totals {
 
 		$items_subtotal = $this->get_rounded_items_total( $this->get_values_for_total( 'subtotal' ) );
 
-		$this->set_total( 'items_subtotal', NumberUtil::round( $items_subtotal ) );
-		$this->set_total( 'items_subtotal_tax', wc_round_tax_total( array_sum( $merged_subtotal_taxes ), 0 ) );
+		$this->set_total( 'items_subtotal', $items_subtotal );
+		$this->set_total( 'items_subtotal_tax', array_sum( $merged_subtotal_taxes ), 0 );
 
 		$this->cart->set_subtotal( $this->get_total( 'items_subtotal' ) );
 		$this->cart->set_subtotal_tax( $this->get_total( 'items_subtotal_tax' ) );

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -788,7 +788,7 @@ final class WC_Cart_Totals {
 
 					if ( $item->product->is_taxable() ) {
 						// Item subtotals were sent, so set 3rd param.
-						$item_tax = wc_round_tax_total( array_sum( WC_Tax::calc_tax( $coupon_discount, $item->tax_rates, $item->price_includes_tax ) ), 0 );
+						$item_tax = array_sum( WC_Tax::calc_tax( $coupon_discount, $item->tax_rates, $item->price_includes_tax ) );
 
 						// Sum total tax.
 						$coupon_discount_tax_amounts[ $coupon_code ] += $item_tax;

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -862,7 +862,10 @@ final class WC_Cart_Totals {
 	 */
 	protected function calculate_totals() {
 		$this->set_total( 'total', NumberUtil::round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + array_sum( $this->get_merged_taxes( true ) ), 0 ) );
-		$this->cart->set_total_tax( array_sum( $this->get_merged_taxes( false ) ) );
+		$items_tax = array_sum( $this->get_merged_taxes( false, array( 'items' ) ) );
+		// Shipping and fee taxes are rounded because they were entered excluding taxes.
+		$shipping_and_fee_taxes = NumberUtil::round( array_sum( $this->get_merged_taxes( false, array( 'fees', 'shipping' ) ) ), wc_get_price_decimals() );
+		$this->cart->set_total_tax( $items_tax + $shipping_and_fee_taxes );
 
 		// Allow plugins to hook and alter totals before final total is calculated.
 		if ( has_action( 'woocommerce_calculate_totals' ) ) {

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -750,6 +750,7 @@ final class WC_Cart_Totals {
 
 		$items_subtotal = $this->get_rounded_items_total( $this->get_values_for_total( 'subtotal' ) );
 
+		// Prices are not rounded here because they should already be rounded based on settings in `get_rounded_items_total` and in `round_line_tax` method calls.
 		$this->set_total( 'items_subtotal', $items_subtotal );
 		$this->set_total( 'items_subtotal_tax', array_sum( $merged_subtotal_taxes ), 0 );
 
@@ -863,7 +864,7 @@ final class WC_Cart_Totals {
 	protected function calculate_totals() {
 		$this->set_total( 'total', NumberUtil::round( $this->get_total( 'items_total', true ) + $this->get_total( 'fees_total', true ) + $this->get_total( 'shipping_total', true ) + array_sum( $this->get_merged_taxes( true ) ), 0 ) );
 		$items_tax = array_sum( $this->get_merged_taxes( false, array( 'items' ) ) );
-		// Shipping and fee taxes are rounded because they were entered excluding taxes.
+		// Shipping and fee taxes are rounded seperately because they were entered excluding taxes (as opposed to item prices, which may or may not be including taxes depending upon settings).
 		$shipping_and_fee_taxes = NumberUtil::round( array_sum( $this->get_merged_taxes( false, array( 'fees', 'shipping' ) ) ), wc_get_price_decimals() );
 		$this->cart->set_total_tax( $items_tax + $shipping_and_fee_taxes );
 

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -430,7 +430,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_subtotal( $value ) {
-		$this->totals['subtotal'] = wc_format_decimal( $value, wc_get_price_decimals() );
+		$this->totals['subtotal'] = $value;
 	}
 
 	/**
@@ -470,7 +470,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_shipping_total( $value ) {
-		$this->totals['shipping_total'] = wc_format_decimal( $value, wc_get_price_decimals() );
+		$this->totals['shipping_total'] = $value;
 	}
 
 	/**
@@ -490,7 +490,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_cart_contents_total( $value ) {
-		$this->totals['cart_contents_total'] = wc_format_decimal( $value, wc_get_price_decimals() );
+		$this->totals['cart_contents_total'] = $value;
 	}
 
 	/**
@@ -531,7 +531,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_fee_total( $value ) {
-		$this->totals['fee_total'] = wc_format_decimal( $value, wc_get_price_decimals() );
+		$this->totals['fee_total'] = $value;
 	}
 
 	/**

--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -430,7 +430,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_subtotal( $value ) {
-		$this->totals['subtotal'] = $value;
+		$this->totals['subtotal'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -470,7 +470,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_shipping_total( $value ) {
-		$this->totals['shipping_total'] = $value;
+		$this->totals['shipping_total'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -490,7 +490,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_cart_contents_total( $value ) {
-		$this->totals['cart_contents_total'] = $value;
+		$this->totals['cart_contents_total'] = wc_format_decimal( $value );
 	}
 
 	/**
@@ -531,7 +531,7 @@ class WC_Cart extends WC_Legacy_Cart {
 	 * @param string $value Value to set.
 	 */
 	public function set_fee_total( $value ) {
-		$this->totals['fee_total'] = $value;
+		$this->totals['fee_total'] = wc_format_decimal( $value );
 	}
 
 	/**

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1821,7 +1821,7 @@ function wc_get_tax_rounding_mode() {
 	$constant = WC_TAX_ROUNDING_MODE;
 
 	if ( 'auto' === $constant ) {
-		return 'yes' === get_option( 'woocommerce_prices_include_tax', 'no' ) ? 2 : 1;
+		return 'yes' === get_option( 'woocommerce_prices_include_tax', 'no' ) ? PHP_ROUND_HALF_DOWN : PHP_ROUND_HALF_UP;
 	}
 
 	return intval( $constant );
@@ -2413,7 +2413,7 @@ function wc_round_discount( $value, $precision ) {
 		return NumberUtil::round( $value, $precision, WC_DISCOUNT_ROUNDING_MODE ); // phpcs:ignore PHPCompatibility.FunctionUse.NewFunctionParameters.round_modeFound
 	}
 
-	if ( 2 === WC_DISCOUNT_ROUNDING_MODE ) {
+	if ( PHP_ROUND_HALF_DOWN === WC_DISCOUNT_ROUNDING_MODE ) {
 		return wc_legacy_round_half_down( $value, $precision );
 	}
 

--- a/tests/legacy/unit-tests/cart/cart.php
+++ b/tests/legacy/unit-tests/cart/cart.php
@@ -73,9 +73,8 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 
 		$this->assertEquals( '13.58', WC()->cart->get_total( 'edit' ) );
 		$this->assertEquals( 0.66, WC()->cart->get_total_tax() );
-		$this->assertEquals( 4.17, WC()->cart->get_discount_total() );
-		$this->assertEquals( 0.83, WC()->cart->get_discount_tax() );
-
+		$this->assertEquals( 0.83, wc_round_tax_total( WC()->cart->get_discount_tax() ) );
+		$this->assertEquals( 4.17, \Automattic\WooCommerce\Utilities\NumberUtil::round( WC()->cart->get_discount_total(), 2 ) );
 	}
 
 	/**

--- a/tests/legacy/unit-tests/cart/cart.php
+++ b/tests/legacy/unit-tests/cart/cart.php
@@ -73,8 +73,8 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 
 		$this->assertEquals( '13.58', WC()->cart->get_total( 'edit' ) );
 		$this->assertEquals( 0.66, WC()->cart->get_total_tax() );
-		$this->assertEquals( 0.83, wc_round_tax_total( WC()->cart->get_discount_tax() ) );
-		$this->assertEquals( 4.17, \Automattic\WooCommerce\Utilities\NumberUtil::round( WC()->cart->get_discount_total(), 2 ) );
+		$this->assertEquals( 0.83, wc_format_decimal( WC()->cart->get_discount_tax(), 2 ) );
+		$this->assertEquals( 4.17, wc_format_decimal( WC()->cart->get_discount_total(), 2 ) );
 	}
 
 	/**

--- a/tests/legacy/unit-tests/cart/cart.php
+++ b/tests/legacy/unit-tests/cart/cart.php
@@ -301,7 +301,7 @@ class WC_Tests_Cart extends WC_Unit_Test_Case {
 
 		WC()->cart->add_to_cart( $product->get_id(), 1 );
 		WC()->cart->calculate_totals();
-		$this->assertEquals( 599, WC()->cart->subtotal );
+		$this->assertEquals( 599, wc_format_decimal( WC()->cart->subtotal, wc_get_price_decimals() ) );
 		$this->assertEquals( 599, WC()->cart->total );
 	}
 

--- a/tests/legacy/unit-tests/util/deprecated-hooks.php
+++ b/tests/legacy/unit-tests/util/deprecated-hooks.php
@@ -105,6 +105,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 		$args     = array( false );
 		$return   = -1;
 
+		$this->setExpectedDeprecated( 'wc_old_hook' );
 		add_filter( $old_hook, array( $this, 'toggle_value' ) );
 
 		$result = $this->handlers['filters']->handle_deprecated_hook( $new_hook, $old_hook, $args, $return );
@@ -123,6 +124,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 		$args       = array( &$test_value );
 		$return     = -1;
 
+		$this->setExpectedDeprecated( 'wc_old_hook' );
 		add_filter( $old_hook, array( $this, 'toggle_value_by_ref' ) );
 
 		$this->handlers['actions']->handle_deprecated_hook( $new_hook, $old_hook, $args, $return );
@@ -137,6 +139,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	public function test_filter_handler() {
 		$test_width = 1;
 
+		$this->setExpectedDeprecated( 'woocommerce_product_width' );
 		add_filter( 'woocommerce_product_width', array( $this, 'toggle_value' ) );
 
 		$new_width = apply_filters( 'woocommerce_product_get_width', $test_width );
@@ -175,6 +178,9 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	public function test_created_actions_deprecation() {
 		add_filter( 'woocommerce_payment_token_created', '__return_true' );
 		add_filter( 'woocommerce_create_product_variation', '__return_true' );
+
+		$this->setExpectedDeprecated( 'woocommerce_payment_token_created' );
+		$this->setExpectedDeprecated( 'woocommerce_create_product_variation' );
 
 		$token = WC_Helper_Payment_Token::create_stub_token( __FUNCTION__ );
 		$token->save();

--- a/tests/legacy/unit-tests/util/deprecated-hooks.php
+++ b/tests/legacy/unit-tests/util/deprecated-hooks.php
@@ -1,44 +1,58 @@
 <?php
-
 /**
  * Classes WC_Deprecated_Filter_Hooks & WC_Deprecated_Action_Hooks.
  * @package WooCommerce\Tests\Util
  * @since 3.0
  */
+
+/**
+ * Class WC_Tests_Deprecated_Hooks.
+ */
 class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 
+	/**
+	 * @var array Deprecated hook handlers.
+	 */
 	protected $handlers = array();
 
 	/**
 	 * Generic toggle value function that can be hooked to a filter for testing.
-	 * @param bool/int $value
-	 * @return bool/int
+	 *
+	 * @param bool/int $value Value to change.
+	 *
+	 * @return bool/int Changed value.
 	 */
-	function toggle_value( $value ) {
+	public function toggle_value( $value ) {
 		return ! $value;
 	}
 
 	/**
 	 * Generic toggle value function that can be hooked to an action for testing.
-	 * @param bool/int $value
+	 *
+	 * @param bool/int $value Value to change.
 	 */
-	function toggle_value_by_ref( &$value ) {
+	public function toggle_value_by_ref( &$value ) {
 		$value = ! $value;
 	}
 
 	/**
 	 * Generic meta setting function that can be hooked to an action for testing.
-	 * @param int $item1_id
-	 * @param int $item2_id (default: false)
+	 *
+	 * @param int $item1_id Post ID.
+	 * @param int $item2_id Post ID.
 	 */
-	function set_meta( $item1_id, $item2_id = false ) {
+	public function set_meta( $item1_id, $item2_id = false ) {
 		update_post_meta( $item1_id, 'wc_deprecated_hook_test_item1_meta', 1 );
 		if ( $item2_id ) {
 			update_post_meta( $item2_id, 'wc_deprecated_hook_test_item2_meta', 2 );
 		}
 	}
 
-	function setUp() {
+	/**
+	 * Disable deprecation error trigger for this class.
+	 */
+	public function setUp() {
+		parent::setUp();
 		add_filter( 'deprecated_function_trigger_error', '__return_false' );
 		add_filter( 'deprecated_hook_trigger_error', '__return_false' );
 		$this->handlers = WC()->deprecated_hook_handlers;
@@ -49,7 +63,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0
 	 */
-	function test_deprecated_hook_handlers_exist() {
+	public function test_deprecated_hook_handlers_exist() {
 		$this->assertArrayHasKey( 'filters', $this->handlers );
 		$this->assertInstanceOf( 'WC_Deprecated_Filter_Hooks', $this->handlers['filters'] );
 
@@ -62,7 +76,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0
 	 */
-	function test_get_old_hooks() {
+	public function test_get_old_hooks() {
 		$old_filters = $this->handlers['filters']->get_old_hooks( 'woocommerce_structured_data_order' );
 		$old_actions = $this->handlers['actions']->get_old_hooks( 'woocommerce_new_order_item' );
 
@@ -75,7 +89,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0
 	 */
-	function test_hook_in() {
+	public function test_hook_in() {
 		$this->assertTrue( (bool) has_filter( 'woocommerce_structured_data_order', array( $this->handlers['filters'], 'maybe_handle_deprecated_hook' ) ) );
 		$this->assertTrue( (bool) has_action( 'woocommerce_new_order_item', array( $this->handlers['actions'], 'maybe_handle_deprecated_hook' ) ) );
 	}
@@ -85,7 +99,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0
 	 */
-	function test_handle_deprecated_hook_filter() {
+	public function test_handle_deprecated_hook_filter() {
 		$new_hook = 'wc_new_hook';
 		$old_hook = 'wc_old_hook';
 		$args     = array( false );
@@ -102,7 +116,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0
 	 */
-	function test_handle_deprecated_hook_action() {
+	public function test_handle_deprecated_hook_action() {
 		$new_hook   = 'wc_new_hook';
 		$old_hook   = 'wc_old_hook';
 		$test_value = false;
@@ -120,7 +134,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0
 	 */
-	function test_filter_handler() {
+	public function test_filter_handler() {
 		$test_width = 1;
 
 		add_filter( 'woocommerce_product_width', array( $this, 'toggle_value' ) );
@@ -134,7 +148,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0
 	 */
-	function test_action_handler() {
+	public function test_action_handler() {
 		$test_product  = WC_Helper_Product::create_simple_product();
 		$test_order    = WC_Helper_Order::create_order( 1, $test_product );
 		$test_order_id = $test_order->get_id();
@@ -142,6 +156,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 		$test_item     = reset( $test_items );
 		$test_item_id  = $test_item->get_id();
 
+		$this->setExpectedDeprecated( 'woocommerce_order_edit_product' );
 		add_action( 'woocommerce_order_edit_product', array( $this, 'set_meta' ), 10, 2 );
 		do_action( 'woocommerce_update_order_item', $test_item_id, $test_item, $test_order_id );
 
@@ -157,7 +172,7 @@ class WC_Tests_Deprecated_Hooks extends WC_Unit_Test_Case {
 	 *
 	 * @since 3.0
 	 */
-	function test_created_actions_deprecation() {
+	public function test_created_actions_deprecation() {
 		add_filter( 'woocommerce_payment_token_created', '__return_true' );
 		add_filter( 'woocommerce_create_product_variation', '__return_true' );
 

--- a/tests/php/includes/class-wc-cart-totals-test.php
+++ b/tests/php/includes/class-wc-cart-totals-test.php
@@ -1,0 +1,80 @@
+<?php
+
+/**
+ * Class WC_Cart_Totals_Tests. Tests for WC_Cart_Total class.
+ */
+class WC_Cart_Totals_Tests extends WC_Unit_Test_Case {
+
+	/**
+	 * Tests whether discount tax is rounded properly in cart.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/23916.
+	 */
+	public function test_discount_tax_rounding() {
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+
+		WC()->cart->empty_cart();
+
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '27.0000',
+			'tax_rate_name'     => 'TAX27',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '0',
+			'tax_rate_order'    => '1',
+		);
+
+		WC_Tax::_insert_tax_rate( $tax_rate );
+		$product_240  = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 240 ) );
+		$product_1250 = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 1250 ) );
+		$product_1990 = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 1990 ) );
+		$product_3390 = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 3390 ) );
+		$product_6200 = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 6200 ) );
+		$coupon = WC_Helper_Coupon::create_coupon( 'flat2000', array( 'coupon_amount' => 2000 ) );
+
+		WC()->cart->add_to_cart( $product_240->get_id(), 1 );
+		WC()->cart->add_to_cart( $product_1250->get_id(), 1 );
+		WC()->cart->add_to_cart( $product_1990->get_id(), 1 );
+		WC()->cart->add_to_cart( $product_3390->get_id(), 1 );
+		WC()->cart->add_to_cart( $product_6200->get_id(), 1 );
+		WC()->cart->apply_coupon( $coupon->get_code() );
+
+		$this->assert_discount_tax_rounding_when_rounding_at_subtotal();
+		$this->assert_discount_tax_rounding_when_rounding_at_line();
+	}
+
+	/**
+	 * Helper method for assertions when prices are rounded at line.
+	 */
+	private function assert_discount_tax_rounding_when_rounding_at_line() {
+		update_option( 'woocommerce_tax_round_at_subtotal', 'no' );
+		$decimal_precision = wc_get_price_decimals();
+		update_option( 'woocommerce_price_num_decimals', 0 );
+
+		WC()->cart->calculate_totals();
+		update_option( 'woocommerce_price_num_decimals', $decimal_precision );
+
+		$this->assertEquals( '1575', wc_format_decimal( WC()->cart->get_discount_total(), 0 ) );
+		$this->assertEquals( '425', wc_format_decimal( WC()->cart->get_discount_tax(), 0 ) );
+		$this->assertEquals( '11070', wc_format_decimal( WC()->cart->get_total(), 0 ) );
+	}
+
+	/**
+	 * Helper method for assertions when prices are rounded at line.
+	 */
+	private function assert_discount_tax_rounding_when_rounding_at_subtotal() {
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+		$decimal_precision = wc_get_price_decimals();
+		update_option( 'woocommerce_price_num_decimals', 0 );
+
+		WC()->cart->calculate_totals();
+
+		$this->assertEquals( '1575', wc_format_decimal( WC()->cart->get_discount_total(), 0 ) );
+		$this->assertEquals( '425', wc_format_decimal( WC()->cart->get_discount_tax(), 0 ) );
+		$this->assertEquals( '11070', wc_format_decimal( WC()->cart->get_total(), 0 ) );
+	}
+
+}

--- a/tests/php/includes/class-wc-cart-totals-test.php
+++ b/tests/php/includes/class-wc-cart-totals-test.php
@@ -71,10 +71,49 @@ class WC_Cart_Totals_Tests extends WC_Unit_Test_Case {
 		update_option( 'woocommerce_price_num_decimals', 0 );
 
 		WC()->cart->calculate_totals();
+		update_option( 'woocommerce_price_num_decimals', $decimal_precision );
 
 		$this->assertEquals( '1575', wc_format_decimal( WC()->cart->get_discount_total(), 0 ) );
 		$this->assertEquals( '425', wc_format_decimal( WC()->cart->get_discount_tax(), 0 ) );
 		$this->assertEquals( '11070', wc_format_decimal( WC()->cart->get_total(), 0 ) );
 	}
 
+	/**
+	 * Tests whether subtotal is properly rounded, when prices entered have higher precision than displayed.
+	 *
+	 * @link https://github.com/woocommerce/woocommerce/issues/28292.
+	 */
+	public function test_subtotal_rounding_with_changing_precision() {
+		update_option( 'woocommerce_prices_include_tax', 'yes' );
+		update_option( 'woocommerce_calc_taxes', 'yes' );
+		update_option( 'woocommerce_tax_round_at_subtotal', 'yes' );
+		$decimal_precision = wc_get_price_decimals();
+		update_option( 'woocommerce_price_num_decimals', 0 );
+
+		WC()->cart->empty_cart();
+
+		$tax_rate = array(
+			'tax_rate_country'  => '',
+			'tax_rate_state'    => '',
+			'tax_rate'          => '23.0000',
+			'tax_rate_name'     => 'TAX23',
+			'tax_rate_priority' => '1',
+			'tax_rate_compound' => '0',
+			'tax_rate_shipping' => '0',
+			'tax_rate_order'    => '1',
+		);
+
+		WC_Tax::_insert_tax_rate( $tax_rate );
+		$product_301_90909 = WC_Helper_Product::create_simple_product( true, array( 'regular_price' => 301.90909 ) );
+
+		WC()->cart->add_to_cart( $product_301_90909->get_id() );
+		WC()->cart->calculate_totals();
+		update_option( 'woocommerce_price_num_decimals', $decimal_precision );
+
+		// Notice how subtotal + tax does not equate to total here.
+		// This is feature of round at subtotal property, where since we are not rounding, displayed components of price may not add up to displayed total price.
+		$this->assertEquals( '245', wc_format_decimal( WC()->cart->get_subtotal(), 0 ) );
+		$this->assertEquals( '302', wc_format_decimal( WC()->cart->get_total(), 0 ) );
+		$this->assertEquals( '56', wc_format_decimal( WC()->cart->get_total_tax(), 0 ) );
+	}
 }

--- a/tests/php/includes/class-wc-cart-totals-test.php
+++ b/tests/php/includes/class-wc-cart-totals-test.php
@@ -59,7 +59,7 @@ class WC_Cart_Totals_Tests extends WC_Unit_Test_Case {
 
 		$this->assertEquals( '1575', wc_format_decimal( WC()->cart->get_discount_total(), 0 ) );
 		$this->assertEquals( '425', wc_format_decimal( WC()->cart->get_discount_tax(), 0 ) );
-		$this->assertEquals( '11070', wc_format_decimal( WC()->cart->get_total(), 0 ) );
+		$this->assertEquals( '11070', wc_format_decimal( WC()->cart->get_total( 'edit' ), 0 ) );
 	}
 
 	/**
@@ -75,7 +75,7 @@ class WC_Cart_Totals_Tests extends WC_Unit_Test_Case {
 
 		$this->assertEquals( '1575', wc_format_decimal( WC()->cart->get_discount_total(), 0 ) );
 		$this->assertEquals( '425', wc_format_decimal( WC()->cart->get_discount_tax(), 0 ) );
-		$this->assertEquals( '11070', wc_format_decimal( WC()->cart->get_total(), 0 ) );
+		$this->assertEquals( '11070', wc_format_decimal( WC()->cart->get_total( 'edit' ), 0 ) );
 	}
 
 	/**
@@ -113,7 +113,7 @@ class WC_Cart_Totals_Tests extends WC_Unit_Test_Case {
 		// Notice how subtotal + tax does not equate to total here.
 		// This is feature of round at subtotal property, where since we are not rounding, displayed components of price may not add up to displayed total price.
 		$this->assertEquals( '245', wc_format_decimal( WC()->cart->get_subtotal(), 0 ) );
-		$this->assertEquals( '302', wc_format_decimal( WC()->cart->get_total(), 0 ) );
+		$this->assertEquals( '302', wc_format_decimal( WC()->cart->get_total( 'edit' ), 0 ) );
 		$this->assertEquals( '56', wc_format_decimal( WC()->cart->get_total_tax(), 0 ) );
 	}
 

--- a/tests/php/includes/class-wc-checkout-test.php
+++ b/tests/php/includes/class-wc-checkout-test.php
@@ -32,6 +32,8 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 			}
 		};
 		// phpcs:enable Generic.CodeAnalysis, Squiz.Commenting
+
+		WC()->cart->empty_cart();
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR introduces the following changes:

1. Remove rounding from many places, where the values would be already rounded depending upon settings. I have added inline comments when applicable, but feel free to point in case anything can be explained more.
2. Added tax rounding before displaying the prices to the user.
3. Unit tests for the above changes.
4. Fixed some older unit tests as they were failing new tests when all tests are run.

Closes #24184 #28292.

### How to test the changes in this Pull Request:

I have tried to cover most things via unit tests but some example configurations to verify

From [24184 first comment](https://github.com/woocommerce/woocommerce/issues/24184#issue-469311323)
1. Set the rounding to subtotal level, and price entered exclusive taxes from WooCommerce > Settings > Tax.
2. Add a tax rate of 20%.
3. Add a product for price 30.825. Add it to cart.
4. Checkout the cart and check that prices are 36.99 with this patch. Without this patch they would be 37.

From #28292
1. Set the rounding to subtotal level, and price entered inclusive taxes from WooCommerce > Settings > Tax.
2. Add a tax rate of 23%.
3. Set the decimals displayed to `0` from WooCommerce > Settings > General
4. Add a product for 301.90909. Add it to cart.
5. Checkout the cart and check that prices everywhere is 302. Without this patch they would be 301.

**Edit: Updated testing instruction with correct configuration of inclusive/exclusive setting.**

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Removed rounding at several places to better support precision when prices are entered more than 2dp.
