### PR TITLE
IE 11 compatibility for the site tracking enable function

### DIFF
--- a/includes/tracks/class-wc-site-tracking.php
+++ b/includes/tracks/class-wc-site-tracking.php
@@ -104,7 +104,7 @@ class WC_Site_Tracking {
 
 		?>
 		<script type="text/javascript">
-			window.wcTracks.enable = function( callback = null ) {
+			window.wcTracks.enable = function( callback ) {
 				window.wcTracks.isEnabled = true;
 
 				var scriptUrl = '<?php echo esc_url( $woo_tracks_script ); ?>';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The `wc.wcTracks.enable` JS function is added to the footer of every admin page ([source](https://github.com/woocommerce/woocommerce/blob/23710744c01ded649d6a94a4eaea8745e543159f/includes/tracks/class-wc-site-tracking.php#L148)). That function is included in the page directly, without any transpilation. Thus, it must use valid ES5 syntax to work on any supported browser. It mostly does, except for the function's [parameter default value](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Default_parameters#browser_compatibility). This PR fixes that.

This may be one of the reasons why IE11 usage seems so low :)

### How to test the changes in this Pull Request:

- Opt out of tracking in the Onboarding wizard, or disable tracking using a filter.
- Go to any admin page using IE11.
- Open the IE11 dev tools (press `F12` or open them from the settings menu).
- On `trunk` you should see a Syntax Error in the console, on this PR you won't see it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix console error on IE11 when opening admin pages.
