### PR TITLE
Temporarily pin WP version to 5.6.2

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Load docker images and start containers.
         working-directory: package/woocommerce
+        env:
+          WP_VERSION: 5.6.2
         run: npx wc-e2e docker:up
 
       - name: Move current directory to code. We will install zip file in this dir later.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR pins the test WP version to 5.6.2 in the Github action E2E tests. There are errors with 5.7 which are addressed in #29346 . That PR is generating permission issues with `npm install`. So we will need to investigate that before the afore mentioned PR can be merged.

As a temporary work around this PR will get E2E tests up and running in GH.

### How to test the changes in this Pull Request:

1. Verify E2E runs correctly in the Github E2E test run.

### Changelog entry

N/A
