### PR TITLE
Remove node_modules caching to prevent dir related errors.

### DIFF
--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -24,7 +24,7 @@ jobs:
 
   e2e-tests-run:
     name: Runs E2E tests.
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     needs: [ build ]
     steps:
 

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -21,38 +21,11 @@ jobs:
           name: woocommerce
           path: ${{ steps.build.outputs.zip_path }}
           retention-days: 7
-  
-  e2e-tests-cache:
-    name: Set e2e caches for running tests
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout code.
-        uses: actions/checkout@v2
-        
-      - name: Load Node.js.
-        uses: actions/setup-node@v2
-        with:
-          node-version: '12'
-      
-      # From https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action
-      - name: Cache node modules
-        uses: actions/cache@v2
-        id: cache_node_modules
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ./node_modules
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('package-lock.json') }}
-          restore-keys: |
-            ${{ runner.os }}-build-${{ env.cache-name }}-
 
-      - name: Run npm install, and cache if they aren't.
-        run: npm install
-    
   e2e-tests-run:
     name: Runs E2E tests.
     runs-on: ubuntu-latest
-    needs: [ build, e2e-tests-cache ]
+    needs: [ build ]
     steps:
 
       - name: Create dirs.
@@ -66,20 +39,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: package/woocommerce
-  
-      # From https://docs.github.com/en/actions/guides/caching-dependencies-to-speed-up-workflows#using-the-cache-action
-      - name: Cache node modules
-        uses: actions/cache@v2
-        id: cache_node_modules
-        env:
-          cache-name: cache-node-modules
-        with:
-          path: ./node_modules
-          key: ${{ runner.os }}-build-${{ hashFiles('package-lock.json') }}
-          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
-
-      - name: Restore node modules from cache, if available.
-        run: mv ./node_modules package/woocommerce/node_modules
 
       - name: Run npm install.
         working-directory: package/woocommerce

--- a/.github/workflows/pr-build-and-e2e-tests.yml
+++ b/.github/workflows/pr-build-and-e2e-tests.yml
@@ -87,6 +87,8 @@ jobs:
 
       - name: Load docker images and start containers.
         working-directory: package/woocommerce
+        env:
+          WP_VERSION: 5.6.2
         run: npx wc-e2e docker:up
 
       - name: Move current directory to code. We will install zip file in this dir later.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR makes 3 changes to address the failures in the build process for E2E tests in Github CI:

- Remove the node_modules cache - multiple copies of the same npm package can be implemented with symlinks. Based on the build errors it looks like the source link can be inconsistent between `npm install`s. We are temporarily disabling caching until this can be investigated.
- Pin Ubuntu to 18.04 due to port 8084 being used in [Github CI in Ubuntu 20.04](https://github.com/actions/virtual-environments/issues/2821)
- Pin WordPress to 5.6.2 due to changes in docker-compose for 5.7 as reported in #29346

### How to test the changes in this Pull Request:

1. E2E run in Github CI is successful

### Changelog entry

N/A