### PR TITLE
Update code reference after release build is done

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -21,3 +21,17 @@ jobs:
           asset_path: ${{ steps.build.outputs.zip_path }}
           asset_name: woocommerce.zip
           asset_content_type: application/zip
+  update-code-reference:
+    if: github.event.release.prerelease == false && github.event.release.draft == false && github.repository_owner == 'woocommerce'
+    name: Update Code Reference
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Invoke Code Reference build and deploy workflow
+        uses: aurelien-baudet/workflow-dispatch@v2
+        with:
+          workflow: GitHub Pages deploy
+          repo: woocommerce/code-reference
+          token: ${{ secrets.CUSTOM_GH_TOKEN }}
+          ref: refs/heads/trunk
+          inputs: '{ "version": "${{ github.event.release.tag_name }}" }'


### PR DESCRIPTION
This PR introduces a new step to our release build workflow, if isn't a prerelease or a draft it will trigger a build and deploy workflow in Code Reference's repository.

It's possible to see an example in https://github.com/woocommerce/code-reference/actions/runs/648263884

Note that it will be handed by a `workflow_dispatch` event in the code reference repository, so it will list all runs as a "manual" run, also it's required a personal token that I generated, [it's required a personal token since `GITHUB_TOKEN` doesn't work for  `workflow_dispatch` events](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#triggering-new-workflows-using-a-personal-access-token), so my username will be used to trigger all deployments of our code reference.