### PR TITLE
Handles errors in fault installations of PHP Intl

### DIFF
--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1807,13 +1807,15 @@ function wc_asort_by_locale( &$data, $locale = '' ) {
 			$collator->asort( $data, Collator::SORT_STRING );
 			return $data;
 		} catch ( IntlException $e ) {
-			// Just skip if some error got caused.
-			// It may be caused in installations that doesn't include ICU TZData.
+			/*
+			 * Just skip if some error got caused.
+			 * It may be caused in installations that doesn't include ICU TZData.
+			 */
 			if ( Constants::is_true( 'WP_DEBUG' ) ) {
 				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 					sprintf(
 						/* translators: 1: PHP docs link 2: error message */
-						esc_html__( 'An unexpected error occurred while trying to use PHP Intl Collator class, it may be caused by an incorrect installation of PHP Intl and ICU, and could be fixed by reinstallaing PHP Intl, see more details about PHP Intl installation: %1$s. Error message: %2$s', 'woocommerce' ),
+						__( 'An unexpected error occurred while trying to use PHP Intl Collator class, it may be caused by an incorrect installation of PHP Intl and ICU, and could be fixed by reinstallaing PHP Intl, see more details about PHP Intl installation: %1$s. Error message: %2$s', 'woocommerce' ),
 						'https://www.php.net/manual/en/intl.installation.php',
 						$e->getMessage()
 					)

--- a/includes/wc-core-functions.php
+++ b/includes/wc-core-functions.php
@@ -1814,8 +1814,7 @@ function wc_asort_by_locale( &$data, $locale = '' ) {
 			if ( Constants::is_true( 'WP_DEBUG' ) ) {
 				error_log( // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_error_log
 					sprintf(
-						/* translators: 1: PHP docs link 2: error message */
-						__( 'An unexpected error occurred while trying to use PHP Intl Collator class, it may be caused by an incorrect installation of PHP Intl and ICU, and could be fixed by reinstallaing PHP Intl, see more details about PHP Intl installation: %1$s. Error message: %2$s', 'woocommerce' ),
+						'An unexpected error occurred while trying to use PHP Intl Collator class, it may be caused by an incorrect installation of PHP Intl and ICU, and could be fixed by reinstallaing PHP Intl, see more details about PHP Intl installation: %1$s. Error message: %2$s',
 						'https://www.php.net/manual/en/intl.installation.php',
 						$e->getMessage()
 					)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

PHP Collator class from PHP Intl is used to sort country names in the front-end, it works already as a workaround and used only if supported, but we found out that in some installations PHP Intl could be incomplete and not including ICU TZData.

I couldn't find a way to reproduce the error reported in #28516, and since it requires a fix in the server side, I decided to just skip some `IntlException` exception happens, and if `WP_DEBUG` is enabled it will log the exception message and some tips about this error.

Also note that's possible to complete [disable `wc_asort_by_locale()` and replace with custom sorting](https://github.com/woocommerce/woocommerce/blob/20c8cbee0c99e86700d13de9cf7717dba1d60b08/includes/class-wc-countries.php#L44-L58) with:

```php
add_filter( 'woocommerce_sort_countries', '__return_false' );
add_filter( 'woocommerce_countries', 'some_custom_sorting_function' );
```

Closes #28516.

### How to test the changes in this Pull Request:

Sorry but I couldn't reproduce this error.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Handle errors in fault installations of PHP Intl