### PR TITLE
Stop nightly builds in forks.

### DIFF
--- a/.github/workflows/nightly-builds.yml
+++ b/.github/workflows/nightly-builds.yml
@@ -4,6 +4,7 @@ on:
     - cron: '0 0 * * *' # Run at 12 AM UTC.
 jobs:
   build:
+    if: github.repository_owner == 'woocommerce'
     name: Nightly builds
     strategy:
       fail-fast: false


### PR DESCRIPTION
Nightly builds workflow requires a GitHub release ID that doesn't exists in forks, making it to always fail.

Here a broken run for e.g.: https://github.com/claudiosanches/woocommerce/actions/runs/655835693

### Changelog entry

N/A