### PR TITLE
check return type on log file fopen

### DIFF
--- a/includes/log-handlers/class-wc-log-handler-file.php
+++ b/includes/log-handlers/class-wc-log-handler-file.php
@@ -146,10 +146,12 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 		if ( $file ) {
 			if ( ! file_exists( $file ) ) {
 				$temphandle = @fopen( $file, 'w+' ); // @codingStandardsIgnoreLine.
-				@fclose( $temphandle ); // @codingStandardsIgnoreLine.
-
-				if ( Constants::is_defined( 'FS_CHMOD_FILE' ) ) {
-					@chmod( $file, FS_CHMOD_FILE ); // @codingStandardsIgnoreLine.
+				if ( is_resource( $temphandle ) ) {
+					@fclose( $temphandle ); // @codingStandardsIgnoreLine.
+	
+					if ( Constants::is_defined( 'FS_CHMOD_FILE' ) ) {
+						@chmod( $file, FS_CHMOD_FILE ); // @codingStandardsIgnoreLine.
+					}
 				}
 			}
 

--- a/includes/log-handlers/class-wc-log-handler-file.php
+++ b/includes/log-handlers/class-wc-log-handler-file.php
@@ -148,7 +148,7 @@ class WC_Log_Handler_File extends WC_Log_Handler {
 				$temphandle = @fopen( $file, 'w+' ); // @codingStandardsIgnoreLine.
 				if ( is_resource( $temphandle ) ) {
 					@fclose( $temphandle ); // @codingStandardsIgnoreLine.
-	
+
 					if ( Constants::is_defined( 'FS_CHMOD_FILE' ) ) {
 						@chmod( $file, FS_CHMOD_FILE ); // @codingStandardsIgnoreLine.
 					}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Adds a check for the return type of `fopen()` to avoid crashes

Closes #29395 .

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Prevent crash when log file can't be opened for writing