### PR TITLE
Attempt to fix flakiness in shipping test

### DIFF
--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -467,7 +467,7 @@ const createCoupon = async ( couponAmount = '5', discountType = 'Fixed cart disc
  */
 const addShippingZoneAndMethod = async ( zoneName, zoneLocation = 'United States (US)', zipCode = ' ', zoneMethod = 'flat_rate' ) => {
 	await merchant.openNewShipping();
-	
+
 	// Fill shipping zone name
 	await page.waitForSelector('input#zone_name');
 	await expect(page).toFill('input#zone_name', zoneName);
@@ -475,9 +475,9 @@ const addShippingZoneAndMethod = async ( zoneName, zoneLocation = 'United States
 	// Select shipping zone location
 	// (.toSelect is not best option here because a lot of &nbsp are present in country/state names)
 	await expect(page).toFill('#zone_locations', zoneLocation);
-	await page.waitFor(1000); // avoiding flakiness
+	await uiUnblocked();
 	await page.keyboard.press('Tab');
-	await page.waitFor(1000); // avoiding flakiness
+	await uiUnblocked();
 	await page.keyboard.press('Enter');
 
 	// Fill shipping zone postcode if needed otherwise just put empty space
@@ -488,15 +488,14 @@ const addShippingZoneAndMethod = async ( zoneName, zoneLocation = 'United States
 	await expect(page).toClick('button#submit');
 
 	// Add shipping zone method
-	await page.waitFor(2000); // avoiding flakiness
+	await uiUnblocked();
 	await expect(page).toClick('button.wc-shipping-zone-add-method', {text:'Add shipping method'});
-	await page.waitFor(2000); // avoiding flakiness
-	await page.waitForSelector('.wc-shipping-zone-method-description');
+	await page.waitForSelector('.wc-shipping-zone-method-selector');
 	await expect(page).toSelect('select[name="add_method_id"]', zoneMethod);
-	await page.waitFor(1000); // avoiding flakiness
+	await uiUnblocked();
 	await expect(page).toClick('button#btn-ok');
 	await page.waitForSelector('#zone_locations');
-	await page.waitFor(1000); // avoiding flakiness
+	await uiUnblocked();
 };
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the shipping zones test for the following

- Work around Delete and Edit action links not being visible
- delete all shipping zones at beginning of test
- use unBlockUI instead of page wait
- ensure clicking method edit OK button

PR where this test failed was https://github.com/woocommerce/woocommerce/pull/29283

### How to test the changes in this Pull Request:

1. Verify CI run
2. Run full test suite locally
3. Rerun the shipping zones test `npx wc-e2e test:e2e tests/e2e/specs/wp-admin/test-add-shipping-zones.js`
4. Verify that the shipping zones only has the 3 zones created during the test

### Changelog entry

N/A