### PR TITLE
Avoids redirect caused by some custom permalink structures.

### DIFF
--- a/includes/widgets/class-wc-widget-layered-nav.php
+++ b/includes/widgets/class-wc-widget-layered-nav.php
@@ -252,7 +252,7 @@ class WC_Widget_Layered_Nav extends WC_Widget {
 			if ( '' === get_option( 'permalink_structure' ) ) {
 				$form_action = remove_query_arg( array( 'page', 'paged' ), add_query_arg( $wp->query_string, '', home_url( $wp->request ) ) );
 			} else {
-				$form_action = preg_replace( '%\/page/[0-9]+%', '', home_url( trailingslashit( $wp->request ) ) );
+				$form_action = preg_replace( '%\/page/[0-9]+%', '', home_url( user_trailingslashit( $wp->request ) ) );
 			}
 
 			echo '<form method="get" action="' . esc_url( $form_action ) . '" class="woocommerce-widget-layered-nav-dropdown">';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29421 .

### How to test the changes in this Pull Request:

Before below make sure to have a permalink custom structure set to something without trailing slashes like /%postname%.

1. Go to a product listing page with a dropdown filter.
2. Click on a category or brand, etc.
3. Make sure to have network tab open filtered by "filter" in the search bar to catch url '/?filter...=...' redirect to just '?filter...=...'. 
4. Look into markup for the filter selected and see what is being output:
`echo '<form method="get" action="' . esc_url( $form_action ) . '" class="woocommerce-widget-layered-nav-dropdown">';`
5. Look into code and see form_action is always resulting in a trailing slash even though permalink does not have one.

### Other information:
Please check issue for screenshots and further explanation.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
> Tweak - Improves performance by avoiding an unnecessary redirect if custom permalink structure does not contain trailing slashes.
