### PR TITLE
Fix sale tag misaligned on product archive when columns are less than…

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -385,6 +385,7 @@ ul.products {
 		.woocommerce-loop-product__link {
 			display: block;
 			text-decoration: none;
+			position: relative;
 		}
 
 		.woocommerce-loop-product__title {


### PR DESCRIPTION
… 3 closes #29343

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Added CSS relative positioning to the anchor tag to allow absolute items to aligned correctly.

Closes #29343

### How to test the changes in this Pull Request:

1. Use Twenty Twenty One theme.
2. Go to Appearances->Customize.
3. Select WooCommerce->Product catalog option.
4. Set the Products per row value to "1".
5. Observe that "Sale" badge appears misaligned to the far right.
6. Checkout this PR and perform the same steps.
7. Ensure the "Sale" badge is correctly aligned to the right top corner of the product image.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - "Sale" badge misaligned on products when displaying 1 item per row.
