### PR TITLE
Load cart during REST API requests.

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -600,7 +600,7 @@ final class WooCommerce {
 		$this->deprecated_hook_handlers['filters'] = new WC_Deprecated_Filter_Hooks();
 
 		// Classes/actions loaded for the frontend and for ajax requests.
-		if ( $this->is_request( 'frontend' ) ) {
+		if ( $this->is_request( 'frontend' ) || $this->is_rest_api_request() ) {
 			wc_load_cart();
 		}
 


### PR DESCRIPTION
A simple way to fix #28364.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This calls `wc_load_cart()` during REST API requests, which initializes the session and makes it so that WooCommerce filters the UID used to generate nonces. This prevents API requests from returning 403 like in #28364.

Closes #28364

### How to test the changes in this Pull Request:

Use the test procedure in #25971.
You should not be logged in when running the test, and it's best if you have a new session.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? N/A (I think?)
* [ ] Have you successfully run tests with your changes locally? N/A if there are no tests.

### Changelog entry

> Initialize session & cart during REST API requests.
