### PR TITLE
Initialize the session during API requests.

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -602,6 +602,8 @@ final class WooCommerce {
 		// Classes/actions loaded for the frontend and for ajax requests.
 		if ( $this->is_request( 'frontend' ) ) {
 			wc_load_cart();
+		} else if( $this->is_rest_api_request() ) {
+			WC()->initialize_session();
 		}
 
 		$this->load_webhooks();


### PR DESCRIPTION
Provides a more efficient way of solving #28364 than initializing the whole cart, but makes the main WooCommerce initializer more complicated.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Initializes the WooCommerce session during REST API requests.
This is a more efficient version of #29443, but it complicates the main WooCommerce class initializer a bit more.

Closes #28364

### How to test the changes in this Pull Request:

Use the test procedure from #25971. You should be logged out during testing, and a new session is best.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?


### Changelog entry

> Initialize WooCommerce session during REST API calls.
