### PR TITLE
Add missing sectionend in email settings

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -206,7 +206,6 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'default'       => 'no',
 					'autoload'      => false,
 				),
-				
 				array(
 					'type' => 'sectionend',
 					'id'   => 'email_merchant_notes',

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -206,7 +206,11 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'default'       => 'no',
 					'autoload'      => false,
 				),
-
+				
+				array(
+					'type' => 'sectionend',
+					'id'   => 'email_merchant_notes',
+				),
 			)
 		);
 

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -206,6 +206,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'default'       => 'no',
 					'autoload'      => false,
 				),
+
 				array(
 					'type' => 'sectionend',
 					'id'   => 'email_merchant_notes',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changelog entry

- closes the section "Store management insights" in email settings