### PR TITLE
Fixed return type of $type in docblock

### DIFF
--- a/includes/shortcodes/class-wc-shortcode-products.php
+++ b/includes/shortcodes/class-wc-shortcode-products.php
@@ -84,7 +84,7 @@ class WC_Shortcode_Products {
 	 * Get shortcode type.
 	 *
 	 * @since  3.2.0
-	 * @return array
+	 * @return string
 	 */
 	public function get_type() {
 		return $this->type;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Just updating the return type of `WC_Shortcode_Products::get_type()` method to ensure IDE helps me out typos.

### Changelog entry

- Fixed return type of `WC_Shortcode_Products::get_type()`
