### PR TITLE
Remove legacy code in shipping handling

### DIFF
--- a/includes/wc-cart-functions.php
+++ b/includes/wc-cart-functions.php
@@ -411,23 +411,12 @@ function wc_get_chosen_shipping_method_for_package( $key, $package ) {
 	$chosen_method  = isset( $chosen_methods[ $key ] ) ? $chosen_methods[ $key ] : false;
 	$changed        = wc_shipping_methods_have_changed( $key, $package );
 
-	// This is deprecated but here for BW compat. TODO: Remove in 4.0.0.
-	$method_counts = WC()->session->get( 'shipping_method_counts' );
-
-	if ( ! empty( $method_counts[ $key ] ) ) {
-		$method_count = absint( $method_counts[ $key ] );
-	} else {
-		$method_count = 0;
-	}
-
 	// If not set, not available, or available methods have changed, set to the DEFAULT option.
-	if ( ! $chosen_method || $changed || ! isset( $package['rates'][ $chosen_method ] ) || count( $package['rates'] ) !== $method_count ) {
+	if ( ! $chosen_method || $changed || ! isset( $package['rates'][ $chosen_method ] ) ) {
 		$chosen_method          = wc_get_default_shipping_method_for_package( $key, $package, $chosen_method );
 		$chosen_methods[ $key ] = $chosen_method;
-		$method_counts[ $key ]  = count( $package['rates'] );
 
 		WC()->session->set( 'chosen_shipping_methods', $chosen_methods );
-		WC()->session->set( 'shipping_method_counts', $method_counts );
 
 		do_action( 'woocommerce_shipping_method_chosen', $chosen_method );
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:
This PR removes a legacy code that was added 4 years ago and should have been deleted by Woo 4.0.0

https://github.com/woocommerce/woocommerce/commit/f1f3a6fbc0d63f3da8d4ec053253fc6804785b26

This was discovered as a bug when we were integrating WooCommerce Subscriptions with WooCommerce Blocks, removing it fixes the issue.
### How to test the changes in this Pull Request:

1. Smoke test shipping methods selection in Cart and Checkout.
2. Smoke test using free shipping method with amount or coupon and make sure selection and totals are correct.


### Changelog entry

> Remove legacy code in getting selected shipping method.
