### PR TITLE
Revert replacing wp_redirect with wp_safe_redirect in WC_Checkout::process_order_payment

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -977,7 +977,8 @@ class WC_Checkout {
 			$result = apply_filters( 'woocommerce_payment_successful_result', $result, $order_id );
 
 			if ( ! is_ajax() ) {
-				wp_safe_redirect( $result['redirect'] );
+				// phpcs:ignore WordPress.Security.SafeRedirect.wp_redirect_wp_redirect
+				wp_redirect( $result['redirect'] );
 				exit;
 			}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Reverts the replacement of `wp_redirect` to `wp_safe_redirect` in `WC_Checkout::process_order_payment`. See the linked issue for details.

Closes #29387.

### How to test the changes in this Pull Request:

See the linked issue.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Revert a replacement of `wp_redirect` to `wp_safe_redirect` in `WC_Checkout::process_order_payment` that caused issues in the default PayPal interface.
