### PR TITLE
Correctly close <option>-tag in admin products/orders list table

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -15,7 +15,7 @@ if ( class_exists( 'WC_Admin_List_Table_Orders', false ) ) {
 }
 
 if ( ! class_exists( 'WC_Admin_List_Table', false ) ) {
-	include_once __DIR__  . '/abstract-class-wc-admin-list-table.php';
+	include_once __DIR__ . '/abstract-class-wc-admin-list-table.php';
 }
 
 /**

--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -765,7 +765,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		}
 		?>
 		<select class="wc-customer-search" name="_customer_user" data-placeholder="<?php esc_attr_e( 'Filter by registered customer', 'woocommerce' ); ?>" data-allow_clear="true">
-			<option value="<?php echo esc_attr( $user_id ); ?>" selected="selected"><?php echo htmlspecialchars( wp_kses_post( $user_string ) ); // htmlspecialchars to prevent XSS when rendered by selectWoo. ?><option>
+			<option value="<?php echo esc_attr( $user_id ); ?>" selected="selected"><?php echo htmlspecialchars( wp_kses_post( $user_string ) ); // htmlspecialchars to prevent XSS when rendered by selectWoo. ?></option>
 		</select>
 		<?php
 	}

--- a/includes/admin/list-tables/class-wc-admin-list-table-products.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-products.php
@@ -337,7 +337,7 @@ class WC_Admin_List_Table_Products extends WC_Admin_List_Table {
 			?>
 			<select class="wc-category-search" name="product_cat" data-placeholder="<?php esc_attr_e( 'Filter by category', 'woocommerce' ); ?>" data-allow_clear="true">
 				<?php if ( $current_category_slug && $current_category ) : ?>
-					<option value="<?php echo esc_attr( $current_category_slug ); ?>" selected="selected"><?php echo esc_html( htmlspecialchars( wp_kses_post( $current_category->name ) ) ); ?><option>
+					<option value="<?php echo esc_attr( $current_category_slug ); ?>" selected="selected"><?php echo esc_html( htmlspecialchars( wp_kses_post( $current_category->name ) ) ); ?></option>
 				<?php endif; ?>
 			</select>
 			<?php


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Fix the same minor syntax error in two files.
An `<option>`-tag was closed with an opening `<option>` tag instead of the closing one `</option>`.

Note: 
If those were supposed to be two separate `<option>`-tags like this syntax:
```html 
<select name="...">
  <option>Option A
  <option>Option B
  <option>Option C
  ...
</select>
```
Then I would move the second tag into a new line.

### How to test the changes in this Pull Request:

#### For developers
1. Open the WordPress backend (without the changes applied) and navigate to the order overview (`/wp-admin/edit.php?post_type=shop_order`).
2. Check the source code to see the invalid `<option>`-tag
```html
<select class="wc-customer-search" name="_customer_user" data-placeholder="Filter by registered customer" data-allow_clear="true">
  <option value="" selected="selected"><option>
                                       ^^^^^^^^
</select>
```
Note: Most modern browsers parse this as:
```html
<select class="wc-customer-search" name="_customer_user" data-placeholder="Filter by registered customer" data-allow_clear="true">
  <option value="" selected="selected"></option>
  <option></option>
</select>
```
3. With the patch applied reopen the same page in the backend. The matching <`\`option>-tag will now be added correctly.
```html
<select class="wc-customer-search" name="_customer_user" data-placeholder="Filter by registered customer" data-allow_clear="true">
  <option value="" selected="selected"></option>
                                       ^^^^^^^^^
</select>
```
4. Repeat the same procedure for the products overview (`/wp-admin/edit.php?post_type=product`)
```html
<select name="stock_status">...</select>
```

#### For non developers

I. Steps for the orders customer filter:
1. Open the WordPress backend and navigate to WooCommerce > Orders
2. Click the "Filter by registered customer" filter in the filters list above the list.
3. Type a valid username and wait until the matching entries have been loaded.
4. Choose one of the options.
5. Press the "Filter" button to apply your selection.
6. Check the order list and check if it was filtered correctly.

II. Steps for the products category filter:
1. Open the WordPress backend and navigate to Products > All products
2. Click the "Filter by category" filter in the filters list above the list.
4. Choose one of the options.
5. Press the "Filter" button to apply your selection.
6. Check the product list and check if it was filtered correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix syntax error in the admin (products/orders) list table
