### PR TITLE
Remove trailing colon when checkbox is before label

### DIFF
--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -86,15 +86,15 @@ defined( 'ABSPATH' ) || exit;
 			?>
 			<p class="form-row form-row-full options">
 				<label>
-					<?php esc_html_e( 'Enabled', 'woocommerce' ); ?>:
+					<?php esc_html_e( 'Enabled', 'woocommerce' ); ?>
 					<input type="checkbox" class="checkbox" name="variable_enabled[<?php echo esc_attr( $loop ); ?>]" <?php checked( in_array( $variation_object->get_status( 'edit' ), array( 'publish', false ), true ), true ); ?> />
 				</label>
 				<label class="tips" data-tip="<?php esc_attr_e( 'Enable this option if access is given to a downloadable file upon purchase of a product', 'woocommerce' ); ?>">
-					<?php esc_html_e( 'Downloadable', 'woocommerce' ); ?>:
+					<?php esc_html_e( 'Downloadable', 'woocommerce' ); ?>
 					<input type="checkbox" class="checkbox variable_is_downloadable" name="variable_is_downloadable[<?php echo esc_attr( $loop ); ?>]" <?php checked( $variation_object->get_downloadable( 'edit' ), true ); ?> />
 				</label>
 				<label class="tips" data-tip="<?php esc_attr_e( 'Enable this option if a product is not shipped or there is no shipping cost', 'woocommerce' ); ?>">
-					<?php esc_html_e( 'Virtual', 'woocommerce' ); ?>:
+					<?php esc_html_e( 'Virtual', 'woocommerce' ); ?>
 					<input type="checkbox" class="checkbox variable_is_virtual" name="variable_is_virtual[<?php echo esc_attr( $loop ); ?>]" <?php checked( $variation_object->get_virtual( 'edit' ), true ); ?> />
 				</label>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Trailing colon is not necessary when checkbox is before label.

![variations](https://user-images.githubusercontent.com/368084/112218404-e6708100-8be0-11eb-9855-273c7277284a.jpg)


### How to test the changes in this Pull Request:

1. Edit a variable product.
2. Go to Variations tab.
3. Edit a variation.

### Changelog entry

> Dev - Remove trailing colon when checkbox is before label