### PR TITLE
Fix the REST API entry point to add coupons to an order.

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-orders-controller.php
@@ -38,10 +38,10 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 			return false;
 		}
 
-		// Validate input and at the same time generate the coupon objects to apply.
+		// Validate input and at the same time store the processed coupon codes to apply.
 
-		$coupons   = array();
-		$discounts = new WC_Discounts( $order );
+		$coupon_codes = array();
+		$discounts    = new WC_Discounts( $order );
 
 		$current_order_coupons      = array_values( $order->get_coupons() );
 		$current_order_coupon_codes = array_map(
@@ -71,7 +71,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 				}
 			}
 
-			$coupons[] = $coupon;
+			$coupon_codes[] = $coupon_code;
 		}
 
 		// Remove all coupons first to ensure calculation is correct.
@@ -80,7 +80,7 @@ class WC_REST_Orders_Controller extends WC_REST_Orders_V2_Controller {
 		}
 
 		// Apply the coupons.
-		foreach ( $coupons as $new_coupon ) {
+		foreach ( $coupon_codes as $new_coupon ) {
 			$results = $order->apply_coupon( $new_coupon );
 
 			if ( is_wp_error( $results ) ) {

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -6,6 +6,9 @@
  * @since 3.5.0
  */
 
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper;
+use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
+
 /**
  * Class WC_Tests_API_Orders
  */
@@ -51,7 +54,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 
 		// Create 10 orders.
 		for ( $i = 0; $i < 10; $i++ ) {
-			$this->orders[] = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
+			$this->orders[] = OrderHelper::create_order( $this->user );
 		}
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders' ) );
@@ -67,8 +70,8 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_get_items_ordered_by_modified() {
 		wp_set_current_user( $this->user );
 
-		$order1 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
-		$order2 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( $this->user );
+		$order1 = OrderHelper::create_order( $this->user );
+		$order2 = OrderHelper::create_order( $this->user );
 
 		$order1->set_status( 'completed' );
 		$order1->save();
@@ -80,7 +83,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$request->set_query_params(
 			array(
 				'orderby' => 'modified',
-				'order' => 'asc',
+				'order'   => 'asc',
 			)
 		);
 		$response = $this->server->dispatch( $request );
@@ -90,7 +93,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$request->set_query_params(
 			array(
 				'orderby' => 'modified',
-				'order' => 'desc',
+				'order'   => 'desc',
 			)
 		);
 		$response = $this->server->dispatch( $request );
@@ -105,7 +108,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_items_without_permission() {
 		wp_set_current_user( 0 );
-		$this->orders[] = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$this->orders[] = OrderHelper::create_order();
 		$response       = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders' ) );
 		$this->assertEquals( 401, $response->get_status() );
 	}
@@ -116,7 +119,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_item() {
 		wp_set_current_user( $this->user );
-		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order = OrderHelper::create_order();
 		$order->add_meta_data( 'key', 'value' );
 		$order->add_meta_data( 'key2', 'value2' );
 		$order->save();
@@ -140,7 +143,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_item_without_permission() {
 		wp_set_current_user( 0 );
-		$order          = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order          = OrderHelper::create_order();
 		$this->orders[] = $order;
 		$response       = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() ) );
 		$this->assertEquals( 401, $response->get_status() );
@@ -152,18 +155,18 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_get_item_with_line_items_meta_data() {
 		wp_set_current_user( $this->user );
 
-		$attribute_name = 'Site Level Type';
-		$site_level_attribute_id = wc_create_attribute( array( 'name' => $attribute_name ) );
+		$attribute_name            = 'Site Level Type';
+		$site_level_attribute_id   = wc_create_attribute( array( 'name' => $attribute_name ) );
 		$site_level_attribute_slug = wc_attribute_taxonomy_name_by_id( $site_level_attribute_id );
 
 		// Register the attribute so that wp_insert_term will be successful.
 		register_taxonomy( $site_level_attribute_slug, array( 'product' ), array() );
 
-		$term_name = 'Site Level Value - Wood';
+		$term_name                        = 'Site Level Value - Wood';
 		$site_level_term_insertion_result = wp_insert_term( $term_name, $site_level_attribute_slug );
-		$site_level_term = get_term( $site_level_term_insertion_result['term_id'] );
+		$site_level_term                  = get_term( $site_level_term_insertion_result['term_id'] );
 
-		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
+		$product   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
 		$variation = wc_get_product( $product->get_children()[0] );
 
 		$line_item = new WC_Order_Item_Product();
@@ -172,12 +175,12 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 			array( 'variation' => array( "attribute_{$site_level_attribute_slug}" => $site_level_term->slug ) )
 		);
 
-		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order = OrderHelper::create_order();
 		$order->add_item( $line_item );
 		$order->save();
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( $order->get_id(), $data['id'] );
@@ -205,18 +208,18 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_get_item_with_variation_parent_name() {
 		wp_set_current_user( $this->user );
 
-		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
+		$product   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_variation_product();
 		$variation = wc_get_product( $product->get_children()[0] );
 
 		$line_item = new WC_Order_Item_Product();
 		$line_item->set_product( $variation );
 
-		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order = OrderHelper::create_order();
 		$order->add_item( $line_item );
 		$order->save();
 
 		$response = $this->server->dispatch( new WP_REST_Request( 'GET', '/wc/v3/orders/' . $order->get_id() ) );
-		$data = $response->get_data();
+		$data     = $response->get_data();
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( $order->get_id(), $data['id'] );
@@ -248,7 +251,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_get_item_refund_id() {
 		wp_set_current_user( $this->user );
-		$order    = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order    = OrderHelper::create_order();
 		$refund   = wc_create_refund(
 			array(
 				'order_id' => $order->get_id(),
@@ -352,7 +355,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 1, count( $data['line_items'] ) );
 		$this->assertEquals( 1, count( $data['shipping_lines'] ) );
 
-		$shipping = current( $order->get_items( 'shipping' ) );
+		$shipping               = current( $order->get_items( 'shipping' ) );
 		$expected_shipping_line = array(
 			'id'           => $shipping->get_id(),
 			'method_title' => $shipping->get_method_title(),
@@ -542,7 +545,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_order() {
 		wp_set_current_user( $this->user );
-		$order   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order   = OrderHelper::create_order();
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
 		$request->set_body_params(
 			array(
@@ -569,7 +572,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_order_remove_items() {
 		wp_set_current_user( $this->user );
-		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order = OrderHelper::create_order();
 		$fee   = new WC_Order_Item_Fee();
 		$fee->set_props(
 			array(
@@ -610,7 +613,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_update_order_after_delete_product() {
 		wp_set_current_user( $this->user );
 		$product = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
-		$order   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order( 1, $product );
+		$order   = OrderHelper::create_order( 1, $product );
 		$product->delete( true );
 
 		$request    = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
@@ -621,8 +624,8 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 			array(
 				'line_items' => array(
 					array(
-						'id' => $item->get_id(),
-						'quantity'   => 10,
+						'id'       => $item->get_id(),
+						'quantity' => 10,
 					),
 				),
 			)
@@ -653,55 +656,273 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
+	 * Data provider for test_update_order_add_coupons.
+	 *
+	 * @return array Data for test_update_order_add_coupons.
+	 */
+	public function data_provider_for_test_update_order_add_coupons() {
+		return array(
+
+			// Successful case, no previous coupon, it gets created.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => array(
+						array(
+							'code' => 'fake-coupon-2',
+						),
+					),
+				),
+				'order_has_coupon_before_request'          => false,
+				'expected_request_result'                  => array(
+					'code' => 200,
+				),
+				'expected_order_coupon_code_after_request' => 'fake-coupon-2',
+			),
+
+			// Successful case with previous coupon, it gets replaced.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => array(
+						array(
+							'code' => 'fake-coupon-2',
+						),
+					),
+				),
+				'order_has_coupon_before_request'          => true,
+				'expected_request_result'                  => array(
+					'code' => 200,
+				),
+				'expected_order_coupon_code_after_request' => 'fake-coupon-2',
+			),
+
+			// Bad request: invalid coupon name, no previous coupon, it doesn't get added.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => array(
+						array(
+							'code' => 'not-existing-coupon',
+						),
+					),
+				),
+				'order_has_coupon_before_request'          => false,
+				'expected_request_result'                  => array(
+					'code'    => 400,
+					'message' => 'Coupon "not-existing-coupon" does not exist!',
+				),
+				'expected_order_coupon_code_after_request' => null,
+			),
+
+			// Bad request: invalid coupon name, coupon existed, it's kept.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => array(
+						array(
+							'code' => 'not-existing-coupon',
+						),
+					),
+				),
+				'order_has_coupon_before_request'          => true,
+				'expected_request_result'                  => array(
+					'code'    => 400,
+					'message' => 'Coupon "not-existing-coupon" does not exist!',
+				),
+				'expected_order_coupon_code_after_request' => 'fake-coupon',
+			),
+
+			// Bad request: has coupon id, no previous coupon, it doesn't get added.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => array(
+						array(
+							'id'   => '1234',
+							'code' => 'fake-coupon-2',
+						),
+					),
+				),
+				'order_has_coupon_before_request'          => false,
+				'expected_request_result'                  => array(
+					'code'    => 400,
+					'message' => 'Coupon item ID is readonly.',
+				),
+				'expected_order_coupon_code_after_request' => null,
+			),
+
+			// Bad request: has coupon id, previous coupon existed, it's kept.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => array(
+						array(
+							'id'   => '1234',
+							'code' => 'fake-coupon-2',
+						),
+					),
+				),
+				'order_has_coupon_before_request'          => true,
+				'expected_request_result'                  => array(
+					'code'    => 400,
+					'message' => 'Coupon item ID is readonly.',
+				),
+				'expected_order_coupon_code_after_request' => 'fake-coupon',
+			),
+
+			// Bad request: no coupon code, no previous coupon, it doesn't get added.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => array(
+						array(),
+					),
+				),
+				'order_has_coupon_before_request'          => false,
+				'expected_request_result'                  => array(
+					'code'    => 400,
+					'message' => 'Coupon code is required.',
+				),
+				'expected_order_coupon_code_after_request' => null,
+			),
+
+			// Bad request: no coupon code, previous coupon existed, it's kept.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => array(
+						array(),
+					),
+				),
+				'order_has_coupon_before_request'          => true,
+				'expected_request_result'                  => array(
+					'code'    => 400,
+					'message' => 'Coupon code is required.',
+				),
+				'expected_order_coupon_code_after_request' => 'fake-coupon',
+			),
+
+			// Bad request: invalid input ('coupon_lines' is not an array), no previous coupon, it doesn't get added.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => 1234,
+				),
+				'order_has_coupon_before_request'          => false,
+				'expected_request_result'                  => array(
+					'code'    => 400,
+					'message' => 'Invalid parameter(s): coupon_lines',
+				),
+				'expected_order_coupon_code_after_request' => null,
+			),
+
+			// Bad request: invalid input ('coupon_lines' is not an array), previous coupon existed, it's kept.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => 1234,
+				),
+				'order_has_coupon_before_request'          => true,
+				'expected_request_result'                  => array(
+					'code'    => 400,
+					'message' => 'Invalid parameter(s): coupon_lines',
+				),
+				'expected_order_coupon_code_after_request' => 'fake-coupon',
+			),
+
+			// Bad request: invalid input ('coupon_lines' has non-array elements), no previous coupon, it doesn't get added.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => array( 1234 ),
+				),
+				'order_has_coupon_before_request'          => false,
+				'expected_request_result'                  => array(
+					'code'    => 400,
+					'message' => 'Invalid parameter(s): coupon_lines',
+				),
+				'expected_order_coupon_code_after_request' => null,
+			),
+
+			// Bad request: invalid input ('coupon_lines' has non-array elements), previous coupon existed, it's kept.
+			array(
+				'request_body'                             => array(
+					'coupon_lines' => array( 1234 ),
+				),
+				'order_has_coupon_before_request'          => true,
+				'expected_request_result'                  => array(
+					'code'    => 400,
+					'message' => 'Invalid parameter(s): coupon_lines',
+				),
+				'expected_order_coupon_code_after_request' => 'fake-coupon',
+			),
+		);
+	}
+
+
+	/**
 	 * Tests updating an order and adding a coupon.
+	 *
+	 * @dataProvider data_provider_for_test_update_order_add_coupons
+	 *
+	 * @param array  $request_body The body for the API request.
+	 * @param bool   $order_has_coupon_before_request If true, the order will have 'fake-coupon' applied before the API request.
+	 * @param array  $expected_request_result Expected result from the API request, with 'code' and optionally 'message'.
+	 * @param string $expected_order_coupon_code_after_request Code of the expected applied coupon after the API request, null if it shouldn't have a coupon applied.
 	 *
 	 * @since 3.5.0
 	 */
-	public function test_update_order_add_coupons() {
+	public function test_update_order_add_coupons( $request_body, $order_has_coupon_before_request, $expected_request_result, $expected_order_coupon_code_after_request ) {
 		wp_set_current_user( $this->user );
 
-		$order      = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
-		$order_item = current( $order->get_items() );
-		$coupon     = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'fake-coupon' );
+		// Create order and coupons.
+
+		$order                 = OrderHelper::create_order();
+		$original_order_amount = $order->get_total();
+
+		$coupons = array();
+
+		$coupon = CouponHelper::create_coupon( 'fake-coupon' );
 		$coupon->set_amount( 5 );
 		$coupon->save();
+		$coupons['fake-coupon'] = $coupon;
 
-		// Let's try a well-formed request first of all.
+		$coupon = CouponHelper::create_coupon( 'fake-coupon-2' );
+		$coupon->set_amount( 10 );
+		$coupon->save();
+		$coupons['fake-coupon-2'] = $coupon;
+
+		if ( $order_has_coupon_before_request ) {
+			$order->apply_coupon( $coupons['fake-coupon'] );
+		}
+
+		// Perform the request.
+
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
-		$request->set_body_params(
-			array(
-				'coupon_lines' => array(
-					array(
-						'code' => 'fake-coupon',
-					),
-				),
-			)
-		);
+		$request->set_body_params( $request_body );
 		$response = $this->server->dispatch( $request );
 		$data     = $response->get_data();
 
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertCount( 1, $data['coupon_lines'] );
-		$this->assertEquals( '45.00', $data['total'] );
+		// Check the response and the actual order data after the operation.
 
-		// Let's repeat, but this time we'll specify the item ID for the coupon: this is
-		// a readonly property and we expect the request to fail as a result.
-		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
-		$request->set_body_params(
-			array(
-				'coupon_lines' => array(
-					array(
-						'id' => 123,
-						'code' => 'fake-coupon',
-					),
-				),
-			)
-		);
-		$response = $this->server->dispatch( $request );
-		$data     = $response->get_data();
+		$this->assertEquals( $expected_request_result['code'], $response->get_status() );
 
-		$this->assertEquals( 400, $response->get_status() );
-		$this->assertEquals( 'woocommerce_rest_coupon_item_id_readonly', $data['code'] );
+		$order         = wc_get_order( $order->get_id() );
+		$order_coupons = array_values( $order->get_coupons() );
+		if ( is_null( $expected_order_coupon_code_after_request ) ) {
+			$expected_coupon       = null;
+			$expected_order_amount = $original_order_amount;
+		} else {
+			$expected_coupon       = $coupons[ $expected_order_coupon_code_after_request ];
+			$expected_order_amount = number_format( 50 - $expected_coupon->get_amount(), 2 );
+		}
+
+		$is_ok_status = $response->get_status() < 300;
+		if ( $is_ok_status ) {
+			$this->assertEquals( $expected_order_amount, $data['total'] );
+			$this->assertCount( 1, $data['coupon_lines'] );
+		} else {
+			$this->assertEquals( $expected_request_result['message'], $data['message'] );
+		}
+
+		if ( is_null( $expected_order_coupon_code_after_request ) ) {
+			$this->assertEquals( '50.00', $order->get_total() );
+			$this->assertCount( 0, $order_coupons );
+		} else {
+			$this->assertEquals( number_format( $expected_order_amount, 2 ), $order->get_total() );
+			$this->assertCount( 1, $order_coupons );
+			$this->assertEquals( $expected_coupon->get_code(), $order_coupons[0]->get_code() );
+		}
 	}
 
 	/**
@@ -711,9 +932,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_order_remove_coupons() {
 		wp_set_current_user( $this->user );
-		$order      = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order      = OrderHelper::create_order();
 		$order_item = current( $order->get_items() );
-		$coupon     = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'fake-coupon' );
+		$coupon     = CouponHelper::create_coupon( 'fake-coupon' );
 		$coupon->set_amount( 5 );
 		$coupon->save();
 
@@ -723,7 +944,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		// Check that the coupon is applied.
 		$this->assertEquals( '45.00', $order->get_total() );
 
-		$request     = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
+		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
 
 		$request->set_body_params(
 			array(
@@ -752,7 +973,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_invalid_coupon() {
 		wp_set_current_user( $this->user );
-		$order   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order   = OrderHelper::create_order();
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
 
 		$request->set_body_params(
@@ -779,7 +1000,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_update_order_without_permission() {
 		wp_set_current_user( 0 );
-		$order   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order   = OrderHelper::create_order();
 		$request = new WP_REST_Request( 'PUT', '/wc/v3/orders/' . $order->get_id() );
 		$request->set_body_params(
 			array(
@@ -822,7 +1043,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_order() {
 		wp_set_current_user( $this->user );
-		$order   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order   = OrderHelper::create_order();
 		$request = new WP_REST_Request( 'DELETE', '/wc/v3/orders/' . $order->get_id() );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
@@ -837,7 +1058,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_delete_order_without_permission() {
 		wp_set_current_user( 0 );
-		$order   = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order   = OrderHelper::create_order();
 		$request = new WP_REST_Request( 'DELETE', '/wc/v3/orders/' . $order->get_id() );
 		$request->set_param( 'force', true );
 		$response = $this->server->dispatch( $request );
@@ -865,9 +1086,9 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	public function test_orders_batch() {
 		wp_set_current_user( $this->user );
 
-		$order1 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
-		$order2 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
-		$order3 = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order1 = OrderHelper::create_order();
+		$order2 = OrderHelper::create_order();
+		$order3 = OrderHelper::create_order();
 
 		$request = new WP_REST_Request( 'POST', '/wc/v3/orders/batch' );
 		$request->set_body_params(
@@ -904,7 +1125,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_order_schema() {
 		wp_set_current_user( $this->user );
-		$order      = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
+		$order      = OrderHelper::create_order();
 		$request    = new WP_REST_Request( 'OPTIONS', '/wc/v3/orders/' . $order->get_id() );
 		$response   = $this->server->dispatch( $request );
 		$data       = $response->get_data();
@@ -919,8 +1140,8 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	 */
 	public function test_order_line_items_schema() {
 		wp_set_current_user( $this->user );
-		$order = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper::create_order();
-		$request = new WP_REST_Request( 'OPTIONS', '/wc/v3/orders/' . $order->get_id() );
+		$order    = OrderHelper::create_order();
+		$request  = new WP_REST_Request( 'OPTIONS', '/wc/v3/orders/' . $order->get_id() );
 		$response = $this->server->dispatch( $request );
 
 		$data = $response->get_data();


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

After https://github.com/woocommerce/woocommerce/pull/29146 is applied a request for updating the coupons for an order having an invalid input does indeed return a proper error, but the previously existing coupons are still removed from the order. This happens because the existing coupons are removed first, and then the input validation happens.

This PR fixes that:

* Checks that the coupon data in the input has no `id` field and has a `code` field _before_ removing the existing coupons.
* Additionally, a new check is added: the coupon must be valid itself (valid code, not expired, etc); this also happens before the input validation happens.

Also, a couple of redundant checks are removed (is `coupon_lines` and array? Does it contain arrays only?); these cases are already verified by the REST API engine by looking at the schema.

Closes #27290 (again).

### How to test the changes in this Pull Request:

1. Temporarily add this at the ned of your woocommerce.php file, this way you won't have to bother about REST API authentication: `add_filter('woocommerce_rest_check_permissions', function() {return true;}, 10, 0 );` (note that this will cause a bunch of unit tests to fail)
2. Have the id of an order with no coupons and in "Pending payment" status at hand.
3. Try to add an invalid coupon (has `id`, has no `code`, bad coupon code, malformed input) via REST API, verify that in all cases you gent a proper 400 error and the order still doesn't have any coupon applied:

```bash
curl -X PUT "http://localhost/wp-json/wc/v3/orders/<order id>" -H "Content-Type: application/json" -d '{ "coupon_lines": [{ "id": 1234, "code": "the-coupon" }] }'
curl -X PUT "http://localhost/wp-json/wc/v3/orders/<order id>" -H "Content-Type: application/json" -d '{ "coupon_lines": [{ "discount": "30" }] }'
curl -X PUT "http://localhost/wp-json/wc/v3/orders/<order id>" -H "Content-Type: application/json" -d '{ "coupon_lines": [{ "code": "BAD-COUPON-CODE" }] }'
curl -X PUT "http://localhost/wp-json/wc/v3/orders/<order id>" -H "Content-Type: application/json" -d '{ "coupon_lines": "NOT-AN-ARRAY" }'
```

4. Manually add a coupon to the order (via order details in admin), repeat the above invalid requests and verify that the coupon has not been removed from the order.

5. Do a valid request to add a different coupon and verify that it replaces the coupon you had previously added:

```bash
curl -X PUT "http://localhost:8034/wp-json/wc/v3/orders/<order id>" -H "Content-Type: application/json" -d '{ "coupon_lines": [{ "code": "another-coupon"}] }'
```

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Don't remove existing coupons from order when an invalid REST API request for updating coupons is submitted
