### PR TITLE
Remove duplicate notices from cart during ajax updates

### DIFF
--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -76,7 +76,7 @@ jQuery( function( $ ) {
 			}
 		} );
 
-		return notices;
+		return new_notices;
 	};
 
 	/**

--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -58,6 +58,28 @@ jQuery( function( $ ) {
 	};
 
 	/**
+	 * Removes duplicate notices.
+	 *
+	 * @param {JQuery Object} notices
+	 */
+	var remove_duplicate_notices = function( notices ) {
+		var seen = [];
+		var new_notices = notices;
+
+		notices.each( function( index ) {
+			var text = $( this ).text();
+
+			if ( 'undefined' === typeof seen[ text ] ) {
+				seen[ text ] = true;
+			} else {
+				new_notices.splice( index, 1 );
+			}
+		} );
+
+		return notices;
+	};
+
+	/**
 	 * Update the .woocommerce div with a string of html.
 	 *
 	 * @param {String} html_str The HTML string with which to replace the div.
@@ -67,7 +89,7 @@ jQuery( function( $ ) {
 		var $html       = $.parseHTML( html_str );
 		var $new_form   = $( '.woocommerce-cart-form', $html );
 		var $new_totals = $( '.cart_totals', $html );
-		var $notices    = $( '.woocommerce-error, .woocommerce-message, .woocommerce-info', $html );
+		var $notices    = remove_duplicate_notices( $( '.woocommerce-error, .woocommerce-message, .woocommerce-info', $html ) );
 
 		// No form, cannot do this.
 		if ( $( '.woocommerce-cart-form' ).length === 0 ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Created a new function to handle duplicate notices. While this was to address the shipping debug notices, it will also work in general to remove any duplicate notices.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #28914 

### How to test the changes in this Pull Request:

1. Setup shipping with a valid zone/method.
2. Enable shipping debug mode by going to woocommerce->settings->shipping->shipping options
2. Add several items to the cart and navigate there
3. You should see the shipping debug message/notice of what zone location was detected.
4. Try deleting an item from the cart with the `X` button. After the AJAX process and the item is removed, ensure you are not seeing duplicate shipping debug message/notice.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Cart duplicate debug shipping notices in certain situations.
