### PR TITLE
Add new e2e test opening analytics pages

### DIFF
--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -28,6 +28,7 @@
 - Merchant Settings Shipping Zones
 - Shopper Variable product info updates on different variations
 - Merchant order emails flow
+- Merchant analytics page load tests
 
 ## Fixed
 

--- a/tests/e2e/core-tests/README.md
+++ b/tests/e2e/core-tests/README.md
@@ -62,6 +62,7 @@ The functions to access the core tests are:
   - `runTaxSettingsTest` - Merchant can update tax settings
   - `runUpdateGeneralSettingsTest` - Merchant can update general settings
   - `runMerchantOrderEmailsTest` - Merchant can receive order emails and resend emails by Order Actions
+  - `runAnalyticsPageLoadsTest` - Merchant can load and see all pages in Analytics
 
 ### Shopper
 

--- a/tests/e2e/core-tests/specs/index.js
+++ b/tests/e2e/core-tests/specs/index.js
@@ -36,6 +36,7 @@ const runProductSearchTest = require( './merchant/wp-admin-product-search.test' 
 const runMerchantOrdersCustomerPaymentPage = require( './merchant/wp-admin-order-customer-payment-page.test' );
 const runMerchantOrderEmailsTest = require( './merchant/wp-admin-order-emails.test' );
 const runOrderSearchingTest = require( './merchant/wp-admin-order-searching.test' );
+const runAnalyticsPageLoadsTest = require( './merchant/wp-admin-analytics-page-loads.test' );
 
 // REST API tests
 const runExternalProductAPITest = require( './api/external-product.test' );
@@ -79,6 +80,7 @@ const runMerchantTests = () => {
 	runProductEditDetailsTest();
 	runProductSearchTest();
 	runMerchantOrdersCustomerPaymentPage();
+	runAnalyticsPageLoadsTest();
 }
 
 const runApiTests = () => {
@@ -127,4 +129,5 @@ module.exports = {
 	runAddNewShippingZoneTest,
 	runProductBrowseSearchSortTest,
 	runApiTests,
+	runAnalyticsPageLoadsTest,
 };

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-analytics-page-loads.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-analytics-page-loads.test.js
@@ -1,0 +1,105 @@
+/* eslint-disable jest/no-export, jest/no-disabled-tests */
+/**
+ * Internal dependencies
+ */
+ const {
+	merchant,
+} = require( '@woocommerce/e2e-utils' );
+
+/**
+ * External dependencies
+ */
+const {
+	it,
+	describe,
+	beforeAll,
+} = require( '@jest/globals' );
+
+/**
+ * Quick check for page title and no data message.
+ *
+ * @param pageTitle Page title in H1.
+ * @param element Defaults to '.d3-chart__empty-message'
+ * @param elementText Defaults to 'No data for the selected date range'
+ */
+const checkHeadingAndElement = async (
+	pageTitle, element = '.d3-chart__empty-message', elementText = 'No data for the selected date range') => {
+	await expect(page).toMatchElement('h1', {text: pageTitle});
+	await expect(page).toMatchElement(element, elementText);
+ };
+
+const runAnalyticsPageLoadsTest = () => {
+	describe('Analytics > Opening Top Level Pages', () => {
+		beforeAll(async () => {
+			await merchant.login();
+		});
+
+		it('can see Overview page properly', async () => {
+			// Go to "overview" page and verify it
+			await merchant.openAnalyticsPage('overview');
+			await checkHeadingAndElement('Overview');
+		});
+
+		it('can see Products page properly', async () => {
+			// Go to "overview" page and verify it
+			await merchant.openAnalyticsPage('products');
+			await checkHeadingAndElement('Products');
+		});
+
+		it('can see Revenue page properly', async () => {
+			// Go to "overview" page and verify it
+			await merchant.openAnalyticsPage('revenue');
+			await checkHeadingAndElement('Revenue');
+		});
+
+		it('can see Orders page properly', async () => {
+			// Go to "overview" page and verify it
+			await merchant.openAnalyticsPage('orders');
+			await checkHeadingAndElement('Orders');
+		});
+
+		it('can see Variations page properly', async () => {
+			// Go to "overview" page and verify it
+			await merchant.openAnalyticsPage('variations');
+			await checkHeadingAndElement('Variations');
+		});
+
+		it('can see Categories page properly', async () => {
+			// Go to "overview" page and verify it
+			await merchant.openAnalyticsPage('categories');
+			await checkHeadingAndElement('Categories');
+		});
+
+		it('can see Coupons page properly', async () => {
+			// Go to "overview" page and verify it
+			await merchant.openAnalyticsPage('coupons');
+			await checkHeadingAndElement('Coupons');
+		});
+
+		it('can see Taxes page properly', async () => {
+			// Go to "overview" page and verify it
+			await merchant.openAnalyticsPage('taxes');
+			await checkHeadingAndElement('Taxes');
+		});
+
+		it('can see Downloads page properly', async () => {
+			// Go to "overview" page and verify it
+			await merchant.openAnalyticsPage('downloads');
+			await checkHeadingAndElement('Downloads');
+		});
+
+		it('can see Stock page properly', async () => {
+			// Go to "overview" page and verify it
+			await merchant.openAnalyticsPage('stock');
+			await checkHeadingAndElement('Stock', '.woocommerce-table__empty-item', 'No data to display');
+		});
+
+		it('can see Settings page properly', async () => {
+			// Go to "overview" page and verify it
+			await merchant.openAnalyticsPage('settings');
+			await checkHeadingAndElement('Settings', 'h2', 'Analytics Settings');
+		});
+	});
+}
+
+module.exports = runAnalyticsPageLoadsTest;

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-analytics-page-loads.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-analytics-page-loads.test.js
@@ -41,61 +41,61 @@ const runAnalyticsPageLoadsTest = () => {
 		});
 
 		it('can see Products page properly', async () => {
-			// Go to "overview" page and verify it
+			// Go to "products" page and verify it
 			await merchant.openAnalyticsPage('products');
 			await checkHeadingAndElement('Products');
 		});
 
 		it('can see Revenue page properly', async () => {
-			// Go to "overview" page and verify it
+			// Go to "revenue" page and verify it
 			await merchant.openAnalyticsPage('revenue');
 			await checkHeadingAndElement('Revenue');
 		});
 
 		it('can see Orders page properly', async () => {
-			// Go to "overview" page and verify it
+			// Go to "orders" page and verify it
 			await merchant.openAnalyticsPage('orders');
 			await checkHeadingAndElement('Orders');
 		});
 
 		it('can see Variations page properly', async () => {
-			// Go to "overview" page and verify it
+			// Go to "variations" page and verify it
 			await merchant.openAnalyticsPage('variations');
 			await checkHeadingAndElement('Variations');
 		});
 
 		it('can see Categories page properly', async () => {
-			// Go to "overview" page and verify it
+			// Go to "categories" page and verify it
 			await merchant.openAnalyticsPage('categories');
 			await checkHeadingAndElement('Categories');
 		});
 
 		it('can see Coupons page properly', async () => {
-			// Go to "overview" page and verify it
+			// Go to "coupons" page and verify it
 			await merchant.openAnalyticsPage('coupons');
 			await checkHeadingAndElement('Coupons');
 		});
 
 		it('can see Taxes page properly', async () => {
-			// Go to "overview" page and verify it
+			// Go to "taxes" page and verify it
 			await merchant.openAnalyticsPage('taxes');
 			await checkHeadingAndElement('Taxes');
 		});
 
 		it('can see Downloads page properly', async () => {
-			// Go to "overview" page and verify it
+			// Go to "downloads" page and verify it
 			await merchant.openAnalyticsPage('downloads');
 			await checkHeadingAndElement('Downloads');
 		});
 
 		it('can see Stock page properly', async () => {
-			// Go to "overview" page and verify it
+			// Go to "stock" page and verify it
 			await merchant.openAnalyticsPage('stock');
-			await checkHeadingAndElement('Stock', '.woocommerce-table__empty-item', 'No data to display');
+			await checkHeadingAndElement('Stock', '.components-button > span', 'Product / Variation');
 		});
 
 		it('can see Settings page properly', async () => {
-			// Go to "overview" page and verify it
+			// Go to "settings" page and verify it
 			await merchant.openAnalyticsPage('settings');
 			await checkHeadingAndElement('Settings', 'h2', 'Analytics Settings');
 		});

--- a/tests/e2e/specs/wp-admin/test-analytics-page-loads.js
+++ b/tests/e2e/specs/wp-admin/test-analytics-page-loads.js
@@ -1,0 +1,6 @@
+/*
+ * Internal dependencies
+ */
+const { runAnalyticsPageLoadsTest } = require( '@woocommerce/e2e-core-tests' );
+
+runAnalyticsPageLoadsTest();

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -53,6 +53,7 @@ describe( 'Cart page', () => {
 | `runSetupWizard` | | Open the onboarding profiler |
 | `updateOrderStatus` | `orderId, status` | Update the status of an order |
 | `openEmailLog` | | Open the WP Mail Log page |
+| `openAnalyticsPage` | | Open any Analytics page |
 
 ### Shopper `shopper`
 

--- a/tests/e2e/utils/src/flows/constants.js
+++ b/tests/e2e/utils/src/flows/constants.js
@@ -17,6 +17,7 @@ export const WP_ADMIN_NEW_PRODUCT = baseUrl + 'wp-admin/post-new.php?post_type=p
 export const WP_ADMIN_WC_SETTINGS = baseUrl + 'wp-admin/admin.php?page=wc-settings&tab=';
 export const WP_ADMIN_PERMALINK_SETTINGS = baseUrl + 'wp-admin/options-permalink.php';
 export const WP_ADMIN_NEW_SHIPPING_ZONE = baseUrl + 'wp-admin/admin.php?page=wc-settings&tab=shipping&zone_id=new';
+export const WP_ADMIN_ANALYTICS_PAGES = baseUrl + 'wp-admin/admin.php?page=wc-admin&path=%2Fanalytics%2F';
 
 export const SHOP_PAGE = baseUrl + 'shop';
 export const SHOP_PRODUCT_PAGE = baseUrl + '?p=';

--- a/tests/e2e/utils/src/flows/merchant.js
+++ b/tests/e2e/utils/src/flows/merchant.js
@@ -187,14 +187,12 @@ const merchant = {
 
 	openAnalyticsPage: async ( pageName ) => {
 		await page.goto( WP_ADMIN_ANALYTICS_PAGES + pageName, {
-      
-      waitUntil: 'networkidle0',
-    } );
-  },
-  
+			waitUntil: 'networkidle0',
+		} );
+	},
+
 	openAllUsersView: async () => {
 		await page.goto( WP_ADMIN_ALL_USERS_VIEW, {
-
 			waitUntil: 'networkidle0',
 		} );
 	},

--- a/tests/e2e/utils/src/flows/merchant.js
+++ b/tests/e2e/utils/src/flows/merchant.js
@@ -19,7 +19,8 @@ const {
 	WP_ADMIN_PLUGINS,
 	WP_ADMIN_SETUP_WIZARD,
 	WP_ADMIN_WC_SETTINGS,
-	WP_ADMIN_NEW_SHIPPING_ZONE
+	WP_ADMIN_NEW_SHIPPING_ZONE,
+	WP_ADMIN_ANALYTICS_PAGES,
 } = require( './constants' );
 
 const baseUrl = config.get( 'url' );
@@ -179,6 +180,12 @@ const merchant = {
 
 	openEmailLog: async () => {
 		await page.goto( `${baseUrl}wp-admin/tools.php?page=wpml_plugin_log`, {
+			waitUntil: 'networkidle0',
+		} );
+	},
+
+	openAnalyticsPage: async ( pageName ) => {
+		await page.goto( WP_ADMIN_ANALYTICS_PAGES + pageName, {
 			waitUntil: 'networkidle0',
 		} );
 	},


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Added a whole new e2e test
Added a new merchant function openAnalyticsPage

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29331

### How to test the changes in this Pull Request:

- npx wc-e2e test:e2e-dev ./tests/e2e/specs/wp-admin/test-analytics-page-loads.js

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
