### PR TITLE
Fix alignment issues with lost password form closes #29325

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -1312,6 +1312,30 @@ a.reset_variations {
 		}
 	}
 
+	&.woocommerce-lost-password {
+		.woocommerce {
+
+			max-width: var(--responsive--alignwide-width) !important;
+			padding: 0 !important;
+			flex-wrap: wrap;
+
+			.woocommerce-notices-wrapper {
+				flex: 1 0 100%;
+			}
+
+			.woocommerce-ResetPassword {
+
+				.woocommerce-form-row--first {
+					float: none;
+				}
+
+				#user_login {
+					margin-bottom: 10px;
+				}
+			}
+		}
+	}
+
 	table.account-orders-table {
 		margin-top: 0;
 		border: 0;

--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -2474,6 +2474,12 @@ a.reset_variations {
 				margin: 1.5rem 0;
 			}
 		}
+
+		.woocommerce-ResetPassword {
+			.woocommerce-form-row--first {
+				float: none;
+			}
+		}
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29325

Note that upon looking into this issue, there was not an easy way to tweak it the way the default theme represents it because the markup HTML within WC is not structured the same way. So I just did the next best thing and make it look "nice".

### How to test the changes in this Pull Request:

**NOTE**: you need to `grunt assets` first.

1. Enable Twenty Twenty theme.
2. Logout and go to the frontend My Accounts->Lost Password page.
3. Ensure the input field and submit button looks nicely and not squish together or misaligned.
4. Do the same tests again but with Twenty Twenty One theme.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Lost password form alignment issues.
