### PR TITLE
Make select2 dropdown text visible in dark mode closes #29323

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -348,6 +348,12 @@ a.button {
 .woocommerce,
 .woocommerce-page {
 
+	&.is-dark-theme {
+		.select2-dropdown {
+			color: var(--global--color-dark-gray);
+		}
+	}
+
 	table.shop_table {
 
 		td,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29323

### How to test the changes in this Pull Request:

**NOTE**: You need to first `grunt assets`

1. Enable Twenty Twenty One theme.
2. Go to Customizer->Colors & Dark Mode and enable dark mode.
3. Check the Select2 dropdown fields on cart, checkout, my account (edit address) pages.
4. Ensure when in dark mode, the text is showing correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry
 
> Fix - Text not visible in the dropdown fields in Twenty Twenty One theme when in dark mode.
