### PR TITLE
Fix/remove core test import

### DIFF
--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+# 0.1.3
+
+## Fixed
+
+- removed use of ES6 `import`
 
 # 0.1.2
 

--- a/tests/e2e/core-tests/package.json
+++ b/tests/e2e/core-tests/package.json
@@ -15,7 +15,7 @@
   },
   "peerDependencies": {
     "@woocommerce/api": "^0.1.2",
-    "@woocommerce/e2e-utils": "^0.1.3"
+    "@woocommerce/e2e-utils": "^0.1.4"
   },
   "publishConfig": {
     "access": "public"

--- a/tests/e2e/core-tests/package.json
+++ b/tests/e2e/core-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/e2e-core-tests",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "End-To-End (E2E) tests for WooCommerce",
   "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/core-tests/README.md",
   "repository": {

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
@@ -1,5 +1,5 @@
 /* eslint-disable jest/no-export, jest/no-disabled-tests, jest/no-standalone-expect */
-import {createSimpleProduct} from "@woocommerce/e2e-utils";
+const { createSimpleProduct } = require( '@woocommerce/e2e-utils' );
 
 /**
  * Internal dependencies

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+# 0.1.4
+
+## Fixed
+
+- build issue with faker import
 
 # 0.1.3
 

--- a/tests/e2e/utils/package.json
+++ b/tests/e2e/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/e2e-utils",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "End-To-End (E2E) test utils for WooCommerce",
   "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e-utils/README.md",
   "repository": {

--- a/tests/e2e/utils/src/factories/simple-product.js
+++ b/tests/e2e/utils/src/factories/simple-product.js
@@ -1,5 +1,5 @@
 import { SimpleProduct } from '@woocommerce/api';
-import faker from 'faker/locale/en';
+const faker = require( 'faker/locale/en' );
 import { Factory } from 'fishery';
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Relies on #29440. Core tests work in this repository with `import` statements because the test files are in this repository and babel will dynamically build for them. When the tests are installed as a package they are not dynamically built. 

This PR updates an `import` that slipped through to use `require()` eliminating the need for the dynamic build. I found this testing the published package so this also bumps the package version to allow publishing a functional package.

### How to test the changes in this Pull Request:

1. Verify CI run.
2. Create a test repository using the [E2E Boiler plate](https://github.com/woocommerce/woocommerce-e2e-boilerplate)
3. Copy `tests/e2e/config` and `specs` from this repository to your test repo
4. Run E2E tests - This should error
```
     1 | import { SimpleProduct } from '@woocommerce/api';
    > 2 | import faker from 'faker/locale/en';
        | ^
      3 | import { Factory } from 'fishery';
      4 |
      5 | /**
```
5. Build the packages in this branch `npm run build:packages`
6. Copy `tests/e2e/utils/*` to `node_modules/@woocommerce/e2e-utils` . eg.
```
cp -r woocommerce/tests/e2e/utils/* woocommerce-boiler-plate/node_modules/@woocommerce/e2e-utils
```
7. Repeat step 4 - This should error
```
    import {createSimpleProduct} from "@woocommerce/e2e-utils";
    ^^^^^^

    SyntaxError: Cannot use import statement outside a module
```
8. Copy `tests/e2e/core-tests/specs` to `node_modules/@woocommerce/e2e-core-tests/specs` 
9. Repeat step 4 - tests should run

If these results are reproducible then I will publish `e2e-utils` then we can re-run the test **skipping steps 4-6**. When those results are reproduced I'll publish the core test package.

### Changelog entry

N/A
