### PR TITLE
add stalebot action with dry run enabled

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -1,0 +1,20 @@
+name: 'Close stale needs-feedback issues'
+on:
+  schedule:
+    - cron: '0 21 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+          stale-issue-message: "As a part of this repository’s maintenance, this issue is being marked as stale due to inactivity. Please feel free to comment on it in case we missed something.\n\n###### After 7 days with no activity this issue will be automatically be closed."
+          close-issue-message: 'This issue was closed because it has been 14 days with no activity.'
+          days-before-issue-stale: 7
+          days-before-issue-close: 7
+          days-before-pr-close: -1
+          only-issue-label: 'needs feedback'
+          close-issue-label: "category: can't reproduce"
+          debug-only: true


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a stalebot action with `dry-run` enabled. It should not update any issues when merged. Once the run log verifies that it is properly configured the `dry-run` parameter can be removed.

Closes #29507 .

### How to test the changes in this Pull Request:

1. Review the action configuration

### Changelog entry

N/A
