### PR TITLE
add contributor feedback label action

### DIFF
--- a/.github/workflows/update-feedback-labels.yml
+++ b/.github/workflows/update-feedback-labels.yml
@@ -3,7 +3,11 @@ on: 'issue_comment'
 
 jobs:
   feedback:
-    if: github.event.issue && contains(github.event.issue.labels.*.name, 'needs feedback')
+    if: |
+      github.actor != 'github-actions' &&
+      github.event.issue &&
+      github.event.issue.state == 'open' &&
+      contains(github.event.issue.labels.*.name, 'needs feedback')
     runs-on: ubuntu-latest
     steps:
     - name: Add has feedback

--- a/.github/workflows/update-feedback-labels.yml
+++ b/.github/workflows/update-feedback-labels.yml
@@ -1,0 +1,18 @@
+name: 'Update contributor feedback labels on comment'
+on: 'issue_comment'
+
+jobs:
+  feedback:
+    if: github.event.issue && contains(github.event.issue.labels.*.name, 'needs feedback')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Add has feedback
+      uses: actions-ecosystem/action-add-labels@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        labels: 'has feedback'
+    - name: remove needs feedback
+      uses: actions-ecosystem/action-remove-labels@v1
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        labels: 'needs feedback'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a Github action that removes the `needs feedback` label and adds `has feedback` when a comment is added to the issue.

### How to test the changes in this Pull Request:

1. Compare the action in this branch to https://github.com/rrennick/rons-test-repo/blob/master/.github/workflows/update-feedback-labels.yml 
2. Create an issue in that repo with the label `needs feedback`
3. Add a comment to the issue
4. Wait for a minute or two for the action to run
5. You should see the activity added to the issue

<img width="929" alt="Screen Shot 2021-03-26 at 4 38 24 PM" src="https://user-images.githubusercontent.com/343847/112684414-c5629700-8e51-11eb-9c8d-5906db4697a8.png">

6. Experiment with other labels and commenting to verify that the action only updates the issue when it has `needs feedback`

### Changelog entry

N/A
