### PR TITLE
Prevent saved changes message when leaving page closes #29359

### DIFF
--- a/assets/js/admin/wc-shipping-zone-methods.js
+++ b/assets/js/admin/wc-shipping-zone-methods.js
@@ -62,6 +62,7 @@
 							shippingMethod.trigger( 'change:methods' );
 							shippingMethod.changes = {};
 							shippingMethod.trigger( 'saved:methods' );
+							window.onbeforeunload = null;
 						} else {
 							window.alert( data.strings.save_failed );
 						}

--- a/assets/js/admin/wc-shipping-zone-methods.js
+++ b/assets/js/admin/wc-shipping-zone-methods.js
@@ -62,6 +62,8 @@
 							shippingMethod.trigger( 'change:methods' );
 							shippingMethod.changes = {};
 							shippingMethod.trigger( 'saved:methods' );
+
+							// Overrides the onbeforeunload callback added by settings.js.
 							window.onbeforeunload = null;
 						} else {
 							window.alert( data.strings.save_failed );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29359

### How to test the changes in this Pull Request:

1. Go to woocommerce->settings->shipping and add a shipping zone with a shipping method.
2. After seeing the "Save Changes" button disables, try to navigate away from this page.
3. Ensure you're not seeing any save changes message pop up from the browser.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Unneeded browser popup message of unsaved changes when adding a shipping zone with a shipping method.
