### PR TITLE
Update the persistent cart after it's loaded on log in

### DIFF
--- a/includes/class-wc-cart-session.php
+++ b/includes/class-wc-cart-session.php
@@ -175,6 +175,10 @@ final class WC_Cart_Session {
 		if ( $update_cart_session || is_null( WC()->session->get( 'cart_totals', null ) ) ) {
 			WC()->session->set( 'cart', $this->get_cart_for_session() );
 			$this->cart->calculate_totals();
+
+			if ( $merge_saved_cart ) {
+				$this->persistent_cart_update();
+			}
 		}
 
 		// If this is a re-order, redirect to the cart page to get rid of the `order_again` query string.


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

After loading the user's saved cart on login, update the persistent cart with changes to the cart that might have occurred due to product purchase-ability. 

There exists an issue when your persistent cart contains invalid or non-purchasable. When you log in, WC will load the cart with the contents from the previous session. If the product isn't purchasable any more it won't be added to the cart and the following notice will be displayed, however, the saved persistent cart isn't updated unless you edit your cart in some way (remove, add, restore items etc). This means each time you log in, WC will try to reload the invalid product displaying the same notice each time. 

This PR fixes that by making sure to update the persistent cart after it is loaded and the products are validated and notices are displayed. 

![image](https://user-images.githubusercontent.com/8490476/112795726-461ccf80-90ac-11eb-80bb-61ba582f69d7.png)


<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. While logged into a customer account (admin accounts won't work). Add a standard simple product to your cart.
2. Log out.
2. While logged in as admin, edit the product and set its status to draft. (https://d.pr/i/2WK27E) 
3. Log back into the customers' account. 
     - On `trunk` you'll be presented with this notice https://d.pr/i/5DCUEN. If you continue to log in and out, you will always receive [this message](https://d.pr/i/5DCUEN) each time. 
     - On this branch, when you log in, you will get the notice but subsequent logins won't display the notice.

While it's pretty unlikely or rare that merchants would change the status of their products, it's this function call ([`$product->is_purchasable()`)](https://github.com/woocommerce/woocommerce/blob/5.1.0/includes/class-wc-cart-session.php#L131) which is filtered to allow third-party plugins to determine whether a product is purchasable. WC Subscriptions uses this function's filter for one of our product features and so it's more common and wide-ranging than the changing product statuses.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Update the persistent cart after it's loaded on customer login. Fixes an issue whereby unavailable products would be validated on every login.