### PR TITLE
Fix logic for including the "payments" task in onboarding wizard

### DIFF
--- a/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/includes/admin/class-wc-admin-dashboard-setup.php
@@ -178,7 +178,7 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 			}
 
 			// payments can't be used when woocommerce-payments exists and country is US.
-			if ( $is_woo_payment_installed || 'US' === $country ) {
+			if ( $is_woo_payment_installed && 'US' === $country ) {
 				unset( $this->tasks['payments'] );
 			}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The logic for the payments section in the onboarding wizard should be "if Woo payments is installed and the country
is US then remove the payments task", but the check was mistakenly being set to "or" so the task was removed whenever the country was US. This caused an invalid value in the count of completed onboarding tasks in the dashboard.

Closes #29483.

### How to test the changes in this Pull Request:

See  https://github.com/woocommerce/woocommerce/issues/29483. Make sure that you test with an US-based shop and with a shop in another country.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Wrong logic for including or excluding the payments step in the list of completed tasks in the onboarding wizard.
