### PR TITLE
Bump woocommerce-admin package to 2.1.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "2.1.3",
+    "woocommerce/woocommerce-admin": "2.1.4",
     "woocommerce/woocommerce-blocks": "4.7.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dc5e21e29d4fb70bba776d20112c74f0",
+    "content-hash": "d0a0153dda851ca2c8e79bed1813ba5f",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -523,16 +523,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.1.3",
+            "version": "2.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "60f4297838569341ae88738a4a8a8090889faaac"
+                "reference": "f992b8c8664e72b00ee7283ba1d34e74e4b67ab0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/60f4297838569341ae88738a4a8a8090889faaac",
-                "reference": "60f4297838569341ae88738a4a8a8090889faaac",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/f992b8c8664e72b00ee7283ba1d34e74e4b67ab0",
+                "reference": "f992b8c8664e72b00ee7283ba1d34e74e4b67ab0",
                 "shasum": ""
             },
             "require": {
@@ -566,9 +566,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.1.3"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.1.4"
             },
-            "time": "2021-03-15T04:42:40+00:00"
+            "time": "2021-03-29T11:59:33+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
This bumps `woocommerce/woocommerce-admin` in Composer to the latest published package for 2.1.x.

## Testing Instructions

The previous testing instructions may be used. See the [Release Testing Instructions WooCommerce Admin 2.1.3 ](https://github.com/woocommerce/woocommerce-admin/wiki/Release-Testing-Instructions-WooCommerce-Admin-2.1.3) wiki page. 

## Changelog

```
== 2.1.4 3/29/2021  ==

- Fix: Adding New Zealand and Ireland to selective bundle option, previously missed. #6649
```

### Changelog entry

> Update - WooCommerce Admin package 2.1.4.