### PR TITLE
Customer billing and shipping getters should return all address data, not just data that changed

### DIFF
--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -449,7 +449,19 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return array
 	 */
 	public function get_billing( $context = 'view' ) {
-		return $this->get_prop( 'billing', $context );
+		$value = null;
+		$prop  = 'billing';
+
+		if ( array_key_exists( $prop, $this->data ) ) {
+			$changes = array_key_exists( $prop, $this->changes ) ? $this->changes[ $prop ] : array();
+			$value   = array_merge( $this->data[ $prop ], $changes );
+
+			if ( 'view' === $context ) {
+				$value = apply_filters( $this->get_hook_prefix() . $prop, $value, $this );
+			}
+		}
+
+		return $value;
 	}
 
 	/**
@@ -580,7 +592,19 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * @return array
 	 */
 	public function get_shipping( $context = 'view' ) {
-		return $this->get_prop( 'shipping', $context );
+		$value = null;
+		$prop  = 'shipping';
+
+		if ( array_key_exists( $prop, $this->data ) ) {
+			$changes = array_key_exists( $prop, $this->changes ) ? $this->changes[ $prop ] : array();
+			$value   = array_merge( $this->data[ $prop ], $changes );
+
+			if ( 'view' === $context ) {
+				$value = apply_filters( $this->get_hook_prefix() . $prop, $value, $this );
+			}
+		}
+
+		return $value;
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When you update some customer billing or shipping data, the `$customer->get_shipping()` and `$customer->get_billing()` getters only return changes.

Example, say you are working with the global customer `wc()->customer`:

```
wc()->customer->get_shipping(); // This gives you the full address (so first name, last name, etc)
wc()->customer->set_shipping_address_1( 'test' ); // This updates then address 1 field of the billing address.
wc()->customer->get_shipping(); // Now this only returns the address_1 field.
```

The solution is to merge the array of changes with the array of address data. 

This was pretty difficult to trace and was part of https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/3975. I will be attempting a workaround for blocks to avoid these getters in the interim.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Updated `$customer->get_shipping()` and `$customer->get_billing()` to return the full address after updating individual fields.
