### PR TITLE
Update UID only for WooCommerce cookies

### DIFF
--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -75,7 +75,7 @@ class WC_Session_Handler extends WC_Session {
 		add_action( 'wp_logout', array( $this, 'destroy_session' ) );
 
 		if ( ! is_user_logged_in() ) {
-			add_filter( 'nonce_user_logged_out', array( $this, 'nonce_user_logged_out' ), 10, 2 );
+			add_filter( 'nonce_user_logged_out', array( $this, 'maybe_update_nonce_user_logged_out' ), 10, 2 );
 		}
 	}
 
@@ -288,11 +288,24 @@ class WC_Session_Handler extends WC_Session {
 	/**
 	 * When a user is logged out, ensure they have a unique nonce by using the customer/session ID.
 	 *
+	 * @deprecated 5.3.0
+	 * @param int $uid User ID.
+	 * @return int|string
+	 */
+	public function nonce_user_logged_out( $uid ) {
+		return $this->has_session() && $this->_customer_id ? $this->_customer_id : $uid;
+	}
+
+	/**
+	 * When a user is logged out, ensure they have a unique nonce to manage cart and more using the customer/session ID.
+	 * This filter runs everything `wp_verify_nonce()` and `wp_create_nonce()` gets called.
+	 *
+	 * @since 5.3.0
 	 * @param int    $uid    User ID.
 	 * @param string $action The nonce action.
 	 * @return int|string
 	 */
-	public function nonce_user_logged_out( $uid, $action ) {
+	public function maybe_update_nonce_user_logged_out( $uid, $action ) {
 		if ( Automattic\WooCommerce\Utilities\StringUtil::starts_with( $action, 'woocommerce' ) ) {
 			return $this->has_session() && $this->_customer_id ? $this->_customer_id : $uid;
 		}

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -312,6 +312,8 @@ class WC_Session_Handler extends WC_Session {
 	 * @return int|string
 	 */
 	public function nonce_user_logged_out( $uid ) {
+		wc_deprecated_function( 'WC_Session_Handler::nonce_user_logged_out', '5.3', 'WC_Session_Handler::maybe_update_nonce_user_logged_out' );
+
 		return $this->has_session() && $this->_customer_id ? $this->_customer_id : $uid;
 	}
 

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -188,6 +188,25 @@ class WC_Session_Handler extends WC_Session {
 	}
 
 	/**
+	 * Get session unique ID for quests if session is initialized or user ID if logged in.
+	 * Introduced to help with unit tests.
+	 *
+	 * @since 5.3.0
+	 * @return string
+	 */
+	public function get_customer_unique_id() {
+		$customer_id = '';
+
+		if ( $this->has_session() && $this->_customer_id ) {
+			$customer_id = $this->_customer_id;
+		} elseif ( is_user_logged_in() ) {
+			$customer_id = (string) get_current_user_id();
+		}
+
+		return $customer_id;
+	}
+
+	/**
 	 * Get the session cookie, if set. Otherwise return false.
 	 *
 	 * Session cookies without a customer ID are invalid.

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -188,7 +188,7 @@ class WC_Session_Handler extends WC_Session {
 	}
 
 	/**
-	 * Get session unique ID for quests if session is initialized or user ID if logged in.
+	 * Get session unique ID for requests if session is initialized or user ID if logged in.
 	 * Introduced to help with unit tests.
 	 *
 	 * @since 5.3.0

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -75,7 +75,7 @@ class WC_Session_Handler extends WC_Session {
 		add_action( 'wp_logout', array( $this, 'destroy_session' ) );
 
 		if ( ! is_user_logged_in() ) {
-			add_filter( 'nonce_user_logged_out', array( $this, 'nonce_user_logged_out' ) );
+			add_filter( 'nonce_user_logged_out', array( $this, 'nonce_user_logged_out' ), 10, 2 );
 		}
 	}
 
@@ -288,11 +288,16 @@ class WC_Session_Handler extends WC_Session {
 	/**
 	 * When a user is logged out, ensure they have a unique nonce by using the customer/session ID.
 	 *
-	 * @param int $uid User ID.
-	 * @return string
+	 * @param int    $uid    User ID.
+	 * @param string $action The nonce action.
+	 * @return int|string
 	 */
-	public function nonce_user_logged_out( $uid ) {
-		return $this->has_session() && $this->_customer_id ? $this->_customer_id : $uid;
+	public function nonce_user_logged_out( $uid, $action ) {
+		if ( Automattic\WooCommerce\Utilities\StringUtil::starts_with( $action, 'woocommerce' ) ) {
+			return $this->has_session() && $this->_customer_id ? $this->_customer_id : $uid;
+		}
+
+		return $uid;
 	}
 
 	/**

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -195,11 +195,9 @@ class WC_Session_Handler extends WC_Session {
 	 * @return string
 	 */
 	public function get_customer_unique_id() {
-		$customer_id = '';
+		$customer_id = $this->has_session() && $this->_customer_id ? $this->_customer_id : '';
 
-		if ( $this->has_session() && $this->_customer_id ) {
-			$customer_id = $this->_customer_id;
-		} elseif ( is_user_logged_in() ) {
+		if ( is_user_logged_in() ) {
 			$customer_id = (string) get_current_user_id();
 		}
 

--- a/includes/class-wc-session-handler.php
+++ b/includes/class-wc-session-handler.php
@@ -195,9 +195,11 @@ class WC_Session_Handler extends WC_Session {
 	 * @return string
 	 */
 	public function get_customer_unique_id() {
-		$customer_id = $this->has_session() && $this->_customer_id ? $this->_customer_id : '';
+		$customer_id = '';
 
-		if ( is_user_logged_in() ) {
+		if ( $this->has_session() && $this->_customer_id ) {
+			$customer_id = $this->_customer_id;
+		} elseif ( is_user_logged_in() ) {
 			$customer_id = (string) get_current_user_id();
 		}
 

--- a/tests/legacy/unit-tests/session/class-wc-tests-session-handler.php
+++ b/tests/legacy/unit-tests/session/class-wc-tests-session-handler.php
@@ -10,6 +10,9 @@
  */
 class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 
+	/**
+	 * Setup.
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -17,6 +20,9 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 		$this->create_session();
 	}
 
+	/**
+	 * @testdox Test that save data should insert new row.
+	 */
 	public function test_save_data_should_insert_new_row() {
 		$current_session_data = $this->get_session_from_db( $this->session_key );
 		// delete session to make sure a new row is created in the DB.
@@ -35,6 +41,9 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 		$this->assertEquals( array( 'cart' => 'new cart' ), wp_cache_get( $this->cache_prefix . $this->session_key, WC_SESSION_CACHE_GROUP ) );
 	}
 
+	/**
+	 * @testdox Test that save data should replace existing row.
+	 */
 	public function test_save_data_should_replace_existing_row() {
 		$current_session_data = $this->get_session_from_db( $this->session_key );
 
@@ -49,23 +58,35 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 		$this->assertTrue( is_numeric( $updated_session_data->session_expiry ) );
 	}
 
+	/**
+	 * @testdox Test that get_setting() should use cache.
+	 */
 	public function test_get_session_should_use_cache() {
 		$session = $this->handler->get_session( $this->session_key );
 		$this->assertEquals( array( 'cart' => 'fake cart' ), $session );
 	}
 
+	/**
+	 * @testdox Test that get_setting() shouldn't use cache.
+	 */
 	public function test_get_session_should_not_use_cache() {
 		wp_cache_delete( $this->cache_prefix . $this->session_key, WC_SESSION_CACHE_GROUP );
 		$session = $this->handler->get_session( $this->session_key );
 		$this->assertEquals( array( 'cart' => 'fake cart' ), $session );
 	}
 
+	/**
+	 * @testdox Test that get_setting() should return default value.
+	 */
 	public function test_get_session_should_return_default_value() {
 		$default_session = array( 'session' => 'default' );
 		$session         = $this->handler->get_session( 'non-existent key', $default_session );
 		$this->assertEquals( $default_session, $session );
 	}
 
+	/**
+	 * @testdox Test delete_session().
+	 */
 	public function test_delete_session() {
 		global $wpdb;
 
@@ -82,6 +103,9 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 		$this->assertNull( $session_id );
 	}
 
+	/**
+	 * @testdox Test update_session_timestamp().
+	 */
 	public function test_update_session_timestamp() {
 		global $wpdb;
 
@@ -99,6 +123,14 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox Test that nonce of user logged out is only changed by WooCommerce.
+	 */
+	public function test_maybe_update_nonce_user_logged_out() {
+		$this->assertEquals( 1, $this->handler->maybe_update_nonce_user_logged_out( 1, 'wp_rest' ) );
+		$this->assertEquals( $this->handler->get_customer_unique_id(), $this->handler->maybe_update_nonce_user_logged_out( 1, 'woocommerce-something' ) );
+	}
+
+	/**
 	 * Helper function to create a WC session and save it to the DB.
 	 */
 	protected function create_session() {
@@ -113,7 +145,7 @@ class WC_Tests_Session_Handler extends WC_Unit_Test_Case {
 	/**
 	 * Helper function to get session data from DB.
 	 *
-	 * @param string $session_key
+	 * @param string $session_key Session key.
 	 * @return stdClass
 	 */
 	protected function get_session_from_db( $session_key ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We need to filter into `nonce_user_logged_out` to prevent CSRF attacks for unregistered users, but we introduced some issues since changing this nonce will also invalidate all cookies because it relies in the customer UID.
This PR proposes to only change WooCommerce's cookies, so it doesn't affect 3rd party integrations, unless they are incorrectly using `woocommerce` as a prefix for any cookie or nonce.

Closes #23682.

### How to test the changes in this Pull Request:

I created a plugin to help test how nonces behave: https://gist.github.com/claudiosanches/71e4a1282599509720d72927d10a94ee
But you can also test and follow the same steps in #28364 to test with " WordPress Popular Posts".

1. Install and enable our test plugin: https://gist.github.com/claudiosanches/71e4a1282599509720d72927d10a94ee
2. Set the "Test nonce behavior" widget to any sidebar of your theme (just make sure you can access in WooCommerce's catalog page, you may have to change to a theme like Twenty Twenty-One or Storefront, I have tested with both just in case too).
3. Go to `/wp-admin/admin.php?page=wc-settings&tab=products` and "Enable AJAX add to cart buttons on archives".
4. Open a new incognito window in your browser and starts go your store's catalog page.
5. By clicking in `Test Request` it will display `true` in the bottom of the widget because a of successful request.
6. Now add any product to the cart, and note that is still working the `Test Request` button.
7. Refresh your catalog page and click in `Test Request` again, you'll see now an authentication error from the REST API, go to any page and check that `Test Request` returns the same error every time now.
8. Close your incognito window, apply this patch and start again from step 3.
9. Note that now our `Test Request` works as expected and always returns true, even after completing a checkout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Prevent cart to reset all nonce in front-end.
