### PR TITLE
Remove all coupons before each test run, and clear cart

### DIFF
--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -1,4 +1,4 @@
-import { SimpleProduct } from '@woocommerce/api';
+import { SimpleProduct, Coupon } from '@woocommerce/api';
 import {
 	visitAdminPage,
 	switchUserToTest,
@@ -56,12 +56,32 @@ async function deleteAllProducts() {
 	}
 }
 
+/**
+ * Use api package to delete coupons.
+ *
+ * @return {Promise} Promise resolving once coupons have been trashed.
+ */
+async function deleteAllCoupons() {
+	const repository = Coupon.restRepository( factories.api.withDefaultPermalinks );
+	let coupons;
+
+	coupons = await repository.list();
+
+	while ( coupons.length > 0 ) {
+		for (let c = 0; c < coupons.length; c++ ) {
+			await repository.delete( coupons[ c ].id );
+		}
+		coupons = await repository.list();
+	}
+}
+
 // Before every test suite run, delete all content created by the test. This ensures
 // other posts/comments/etc. aren't dirtying tests and tests don't depend on
 // each other's side-effects.
 beforeAll( async () => {
 	await trashExistingPosts();
 	await deleteAllProducts();
+	await deleteAllCoupons();
 	await clearLocalStorage();
 	await setBrowserViewport( 'large' );
 } );

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
@@ -34,6 +34,7 @@ const runCartApplyCouponsTest = () => {
 			couponPercentage = await createCoupon('50', 'Percentage discount');
 			couponFixedProduct = await createCoupon('5', 'Fixed product discount');
 			await merchant.logout();
+			await shopper.emptyCart();
 			await shopper.goToShop();
 			await shopper.addToCartFromShopPage('Simple product');
 			await uiUnblocked();

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -34,6 +34,7 @@ const runCheckoutApplyCouponsTest = () => {
 			couponPercentage = await createCoupon('50', 'Percentage discount');
 			couponFixedProduct = await createCoupon('5', 'Fixed product discount');
 			await merchant.logout();
+			await shopper.emptyCart();
 			await shopper.goToShop();
 			await shopper.addToCartFromShopPage('Simple product');
 			await uiUnblocked();

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+- `emptyCart()` Shopper flow helper that empties the cart
+
 # 0.1.4
 
 ## Fixed

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -78,7 +78,8 @@ describe( 'Cart page', () => {
 | `productIsInCheckout` | `productTitle, quantity, total, cartSubtotal` | Verify product is in cart on checkout page |
 | `removeFromCart` | `productTitle` | Remove a product from the cart on the cart page |
 | `setCartQuantity` | `productTitle, quantityValue` | Change the quantity of a product on the cart page |
-| `searchForProduct` | Searching for a product name and landing on its detail page |
+| `searchForProduct` | | Searching for a product name and landing on its detail page |
+|  `emptyCart` | | Removes any products and coupons that are the cart |
 
 ### Page Utilities
 

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -79,7 +79,7 @@ describe( 'Cart page', () => {
 | `removeFromCart` | `productTitle` | Remove a product from the cart on the cart page |
 | `setCartQuantity` | `productTitle, quantityValue` | Change the quantity of a product on the cart page |
 | `searchForProduct` | | Searching for a product name and landing on its detail page |
-|  `emptyCart` | | Removes any products and coupons that are the cart |
+|  `emptyCart` | | Removes any products and coupons that are in the cart |
 
 ### Page Utilities
 

--- a/tests/e2e/utils/src/flows/shopper.js
+++ b/tests/e2e/utils/src/flows/shopper.js
@@ -149,7 +149,7 @@ const shopper = {
 		// Remove coupons if they exist
 		if ( await page.$( '.woocommerce-remove-coupon' ) !== null ) {
 			await page.click( '.woocommerce-remove-coupon' );
-			await uiUnblocked()
+			await uiUnblocked();
 		}
 
 		await page.waitForSelector('.woocommerce-info');

--- a/tests/e2e/utils/src/flows/shopper.js
+++ b/tests/e2e/utils/src/flows/shopper.js
@@ -24,6 +24,8 @@ const {
 	SHOP_PRODUCT_PAGE
 } = require( './constants' );
 
+const { uiUnblocked } = require( '../page-utils' );
+
 const gotoMyAccount = async () => {
 	await page.goto( SHOP_MY_ACCOUNT_PAGE, {
 		waitUntil: 'networkidle0',
@@ -125,6 +127,33 @@ const shopper = {
 
 		const [removeButton] = await page.$x(removeItemXPath);
 		await removeButton.click();
+	},
+
+	emptyCart: async () => {
+		await page.goto( SHOP_CART_PAGE, {
+			waitUntil: 'networkidle0',
+		} );
+
+		// Remove products if they exist
+		if ( await page.$( '.remove' ) !== null ) {
+			products = await page.$( '.remove' );
+			while ( products.length > 0 ) {
+				for (let p = 0; p < products.length; p++ ) {
+					await page.click( p );
+					await uiUnblocked();
+				}
+				products = await page.$( '.remove' );
+			}
+		}
+
+		// Remove coupons if they exist
+		if ( await page.$( '.woocommerce-remove-coupon' ) !== null ) {
+			await page.click( '.woocommerce-remove-coupon' );
+			await uiUnblocked()
+		}
+
+		await page.waitForSelector('.woocommerce-info');
+		await expect( page ).toMatchElement( '.woocommerce-info', { text: 'Your cart is currently empty.' } );
 	},
 
 	setCartQuantity: async ( productTitle, quantityValue ) => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes https://github.com/woocommerce/woocommerce/issues/29437.

### How to test the changes in this Pull Request:

1. Spin up the e2e Docker environment with `npx wc-e2e docker:up`
2. Login at `http://localhost:8084/wp-login.php` and create some coupons
3. Open the coupons page and note the coupons you created, for example:

<img width="1364" alt="Screen Shot 2021-03-30 at 3 09 37 PM" src="https://user-images.githubusercontent.com/71906536/113063026-e25cda00-9171-11eb-9255-49fe4143e808.png">

4. Run either a single test or the entire e2e test suite
5. Once the test starts, refresh the page and verify the coupons are no more:

<img width="1362" alt="Screen Shot 2021-03-30 at 3 10 00 PM" src="https://user-images.githubusercontent.com/71906536/113063069-ee489c00-9171-11eb-96cf-2fcfca960101.png">

6. Make sure the tests run and pass locally as well as in CI

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

n/a