### PR TITLE
Allow local slackbot

### DIFF
--- a/tests/e2e/env/src/slack/reporter.js
+++ b/tests/e2e/env/src/slack/reporter.js
@@ -37,7 +37,11 @@ const initializeSlack = () => {
 		return false;
 	}
 	if ( ! GITHUB_ACTIONS && ! TRAVIS_PULL_REQUEST_BRANCH ) {
-		return false;
+		return {
+			branch: 'local environment',
+			commit: 'latest',
+			webUrl: 'http:://localhost',
+		};
 	}
 	// Build PR info
 	if ( GITHUB_ACTIONS ) {

--- a/tests/e2e/env/src/slack/reporter.js
+++ b/tests/e2e/env/src/slack/reporter.js
@@ -1,5 +1,6 @@
 const { createReadStream } = require( 'fs' );
 const { WebClient, ErrorCode } = require( '@slack/web-api' );
+const { getTestConfig } = require( '../../utils' );
 const {
 	GITHUB_ACTIONS,
 	GITHUB_REF,
@@ -37,10 +38,11 @@ const initializeSlack = () => {
 		return false;
 	}
 	if ( ! GITHUB_ACTIONS && ! TRAVIS_PULL_REQUEST_BRANCH ) {
+		const testConfig = getTestConfig();
 		return {
 			branch: 'local environment',
 			commit: 'latest',
-			webUrl: 'http:://localhost',
+			webUrl: testConfig.url,
 		};
 	}
 	// Build PR info
@@ -84,7 +86,9 @@ export async function sendFailedTestMessageToSlack( testName ) {
 		// Check the code property and log the response
 		if ( error.code === ErrorCode.PlatformError || error.code === ErrorCode.RequestError ||
 			error.code === ErrorCode.RateLimitedError || error.code === ErrorCode.HTTPError ) {
-			console.log( error.data );
+			if ( error.data.error != 'channel_not_found' ) {
+				console.log(error.data);
+			}
 		} else {
 			// Some other error, oh no!
 			console.log(


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR addresses two inconvenience issues with the E2E Slackbot:
- Silence an error being logged when the slackbot joins a channel it has previously joined
- Add support for the slackbot in a local environment to facilitate setting up a new bot

Closes #29532 

### How to test the changes in this Pull Request:

1. Run `npm run build:packages` in this branch
2. Break the first test by commenting out https://github.com/woocommerce/woocommerce/blob/trunk/tests/e2e/core-tests/specs/activate-and-setup/activate.test.js#L24
```
// await merchant.openPlugins();
``` 
3. Run tests locally
```
WC_E2E_SCREENSHOTS=1 E2E_SLACK_TOKEN='{your-token}' E2E_SLACK_CHANNEL='{your-channel}' npx wc-e2e test:e2e
```
4. Monitor the slack channel for screenshot

<img width="723" alt="Screen Shot 2021-03-31 at 10 18 27 AM" src="https://user-images.githubusercontent.com/343847/113150433-74b0bc80-920a-11eb-9f3f-a6c00266b92f.png">

5. Check the test output in the console to verify there are no `channel_not_found` messages logged.


### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
