### PR TITLE
Fix for e2e flakiness in onboarding wizard

### DIFF
--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -6,7 +6,14 @@
  * Internal dependencies
  */
 import { merchant } from './flows';
-import { clickTab, uiUnblocked, verifyCheckboxIsUnset, evalAndClick, selectOptionInSelect2, setCheckbox } from './page-utils';
+import {
+	clickTab,
+	uiUnblocked,
+	verifyCheckboxIsUnset,
+	selectOptionInSelect2,
+	setCheckbox,
+	unsetCheckbox
+} from './page-utils';
 import factories from './factories';
 
 const config = require( 'config' );
@@ -143,7 +150,8 @@ const completeOnboardingWizard = async () => {
 	await waitAndClickPrimary( false );
 
 	// Skip installing extensions
-	await evalAndClick( '.components-checkbox-control__input' );
+	await unsetCheckbox( '.components-checkbox-control__input' );
+	await verifyCheckboxIsUnset( '.components-checkbox-control__input' );
 	await waitAndClickPrimary();
 
 	// Theme section


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

This PR updates the `completeOnboardingWizard()` workflow to use checkbox-specific page utils on the extension install step to:
* set the checkbox;
* verify the checkbox is set

This would fail previously as we would try and continue with the setup by attempting to continue and install the extensions, throwing a `There was a problem updating your business details` error:

![screenshot_of_failed_test](https://user-images.githubusercontent.com/71906536/113207551-f9610200-922d-11eb-893d-79b0dc3524db.png)

So the changes proposed here will use the specific checkbox checks to avoid potentially missing unchecking the checkbox and continuing on.

### How to test the changes in this Pull Request:

1. Run the full suite on `trunk` and note failures in the onboarding step. Typically these will look like this:

```
   ● Store owner can go through store Onboarding › can start and complete onboarding when visiting the site for the first time.

    : Timeout - Async callback was not invoked within the 30000ms timeout specified by jest.setTimeout.Timeout - Async callback was not invoked within the 30000ms timeout specified by jest.setTimeout.Error:

      at new Spec (node_modules/jest/node_modules/jest-jasmine2/build/jasmine/Spec.js:116:22)
      at _callee2$ (../../../../../package/woocommerce/tests/e2e/env/src/setup/jest.failure.js:63:10)
      at tryCatch (../utils/node_modules/regenerator-runtime/runtime.js:63:40)
      at Generator.invoke [as _invoke] (../utils/node_modules/regenerator-runtime/runtime.js:293:22)
      at Generator.next (../utils/node_modules/regenerator-runtime/runtime.js:118:21)
```

> You can also see an example PR where this was failing [here](https://github.com/woocommerce/woocommerce/runs/2238363566?check_suite_focus=true).

2. Switch to this branch. It may help to tear down your docker environment entirely, run a `docker system prune -a` and spin everything back up again to ensure you're starting fresh.
3. Run the full e2e test suite with `npx wc-e2e test:e2e`
4. Verify the suite passes and specifically the onboarding flows pass:

<img width="668" alt="Screen Shot 2021-03-31 at 2 21 52 PM" src="https://user-images.githubusercontent.com/71906536/113207281-ab4bfe80-922d-11eb-9da9-e8c4ea726b4c.png">

5. Verify the CI tests pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

n/a
