### PR TITLE
fix typo in stalebot parameter name

### DIFF
--- a/.github/workflows/stalebot.yml
+++ b/.github/workflows/stalebot.yml
@@ -15,6 +15,6 @@ jobs:
           days-before-issue-stale: 7
           days-before-issue-close: 7
           days-before-pr-close: -1
-          only-issue-label: 'needs feedback'
+          only-issue-labels: 'needs feedback'
           close-issue-label: "category: can't reproduce"
           debug-only: true


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR fixes a warning logged in the stalebot dry run:
```
Unexpected input(s) 'only-issue-label', valid inputs are ['repo-token', 'stale-issue-message', 'stale-pr-message', 'close-issue-message', 'close-pr-message', 'days-before-stale', 'days-before-issue-stale', 'days-before-pr-stale', 'days-before-close', 'days-before-issue-close', 'days-before-pr-close', 'stale-issue-label', 'close-issue-label', 'exempt-issue-labels', 'stale-pr-label', 'close-pr-label', 'exempt-pr-labels', 'exempt-milestones', 'exempt-issue-milestones', 'exempt-pr-milestones', 'exempt-all-milestones', 'exempt-all-issue-milestones', 'exempt-all-pr-milestones', 'only-labels', 'any-of-labels', 'only-issue-labels', 'only-pr-labels', 'operations-per-run', 'remove-stale-when-updated', 'debug-only', 'ascending', 'skip-stale-pr-message', 'skip-stale-issue-message', 'delete-branch', 'start-date', 'exempt-assignees', 'exempt-issue-assignees', 'exempt-pr-assignees', 'exempt-all-assignees', 'exempt-all-issue-assignees', 'exempt-all-pr-assignees', 'enable-statistics']
```

The correct parameter name is plural `only-issue-labels`.
Closes # .

### How to test the changes in this Pull Request:

1. The action is set to do a dry run and can only be tested after being merged.
2. Review the parameter name change and compare to the info in the warning above

### Changelog entry

N/A
