### PR TITLE
add smoke test daily log in

### DIFF
--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -1,0 +1,38 @@
+name: Smoke test daily
+on:
+  schedule:
+    - cron: '3 25 * * *'
+jobs:
+  login-run:
+    name: Log into smoke test site.
+    runs-on: ubuntu-18.04
+    steps:
+
+      - name: Create dirs.
+        run: |
+              mkdir -p code/woocommerce
+              mkdir -p package/woocommerce
+              mkdir -p tmp/woocommerce
+              mkdir -p node_modules
+
+      - name: Checkout code.
+        uses: actions/checkout@v2
+        with:
+          path: package/woocommerce
+
+      - name: Run npm install.
+        working-directory: package/woocommerce
+        run: npm install
+
+      - name: Move current directory to code. We will install zip file in this dir later.
+        run: mv ./package/woocommerce/* ./code/woocommerce
+
+      - name: Run login test.
+        working-directory: code/woocommerce
+        env:
+          SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_URL }}
+          SMOKE_TEST_ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
+          SMOKE_TEST_ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
+          SMOKE_TEST_CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
+          SMOKE_TEST_CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
+        run: npx wc-e2e test:e2e ./tests/e2e/specs/activate-and-setup/test-activation.js

--- a/tests/e2e/env/config/custom-environment-variables.json
+++ b/tests/e2e/env/config/custom-environment-variables.json
@@ -1,0 +1,13 @@
+{
+  "url": "SMOKE_TEST_URL",
+  "users": {
+    "admin": {
+      "username": "SMOKE_TEST_ADMIN_USER",
+      "password": "SMOKE_TEST_ADMIN_PASSWORD"
+    },
+    "customer": {
+      "username": "SMOKE_TEST_CUSTOMER_USER",
+      "password": "SMOKE_TEST_CUSTOMER_PASSWORD"
+    }
+  }
+}

--- a/tests/e2e/env/utils/test-config.js
+++ b/tests/e2e/env/utils/test-config.js
@@ -19,10 +19,30 @@ if ( fs.existsSync( localTestConfigFile ) ) {
 	);
 }
 
+/**
+ * Get test container configuration.
+ * @returns {any}
+ */
 const getTestConfig = () => {
 	const rawTestConfig = fs.readFileSync( testConfigFile );
+	const config = require( 'config' );
+	const url = config.get( 'url' );
+	const users = config.get( 'users' );
 
+	// Support for environment variable overrides.
 	let testConfig = JSON.parse( rawTestConfig );
+	if ( url ) {
+		testConfig.url = url;
+	}
+	if ( users ) {
+		if ( users.admin ) {
+			testConfig.users.admin = users.admin;
+		}
+		if ( users.customer ) {
+			testConfig.users.customer = users.customer;
+		}
+	}
+
 	let testPort = testConfig.url.match( /[0-9]+/ );
 	testConfig.baseUrl = testConfig.url.substr( 0, testConfig.url.length - 1 );
 	if ( Array.isArray( testPort ) ) {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds introductory functionality for smoke testing support
- support for test container environment variable overrides for test container configuration which allows running tests against public facing sites
  - SMOKE_TEST_URL
  - SMOKE_TEST_ADMIN_USER
  - SMOKE_TEST_ADMIN_PASSWORD
  - SMOKE_TEST_CUSTOMER_USER
  - SMOKE_TEST_CUSTOMER_PASSWORD
- Github action to log into the site daily. This is the first part of running smoke tests against nightly builds.

See #28485 .

### How to test the changes in this Pull Request:

1. The Github action can't be tested until it is merged
2. Run `npm run build:packages` in this branch
3. Test each of the environment variables. Eg. run tests against a url different from the url in `tests/e2e/config/default.json`
```
SMOKE_TEST_URL="https://example.com" npx wc-e2e test:e2e-dev
```
4. Use `dev` mode for testing to verify the environment variables are being used by the test runner

### Changelog entry

N/A