### PR TITLE
Enhance woocommerce_logger_log_message filter

### DIFF
--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -143,13 +143,13 @@ class WC_Logger implements WC_Logger_Interface {
 
 			foreach ( $this->handlers as $handler ) {
 				/**
-				 * Filter the logging message. Returning null will prevent logging from occuring since 5.2.
+				 * Filter the logging message. Returning null will prevent logging from occuring since 5.3.
 				 *
 				 * @since 3.1
 				 * @param string $message Log message.
 				 * @param string $level   One of: emergency, alert, critical, error, warning, notice, info, or debug.
 				 * @param array  $context Additional information for log handlers.
-				 * @param object $handler The handler object, such as WC_Log_Handler_File. Available since 5.2.
+				 * @param object $handler The handler object, such as WC_Log_Handler_File. Available since 5.3.
 				 */
 				$message = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context, $handler );
 

--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -142,6 +142,15 @@ class WC_Logger implements WC_Logger_Interface {
 			$timestamp = time();
 
 			foreach ( $this->handlers as $handler ) {
+				/**
+				 * Filter the logging message. Returning null will prevent logging from occuring since 5.2.
+				 *
+				 * @since 3.1
+				 * @param string $message Log message.
+				 * @param string $level   One of: emergency, alert, critical, error, warning, notice, info, or debug.
+				 * @param array  $context Additional information for log handlers.
+				 * @param object $handler The handler object, such as WC_Log_Handler_File. Available since 5.2.
+				 */
 				$message = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context, $handler );
 
 				if ( null !== $message ) {

--- a/includes/class-wc-logger.php
+++ b/includes/class-wc-logger.php
@@ -139,11 +139,14 @@ class WC_Logger implements WC_Logger_Interface {
 		}
 
 		if ( $this->should_handle( $level ) ) {
-			$timestamp = current_time( 'timestamp', 1 );
-			$message   = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context );
+			$timestamp = time();
 
 			foreach ( $this->handlers as $handler ) {
-				$handler->handle( $timestamp, $level, $message, $context );
+				$message = apply_filters( 'woocommerce_logger_log_message', $message, $level, $context, $handler );
+
+				if ( null !== $message ) {
+					$handler->handle( $timestamp, $level, $message, $context );
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

1) Passes the current `$handler` into the filter.
2) Allow an early abort if the `$message` is null.

For a quick explanation on the use case, when using the DB Handler in particular it's advantageous for performance to limit how much is logged. This will allow for "muting" based on certain sources or particular messages.

The only downside here is that if multiple handlers are used - then the filter will now be running more than once. But that's both quite minimal, rare to be using more than one handler, and worth the tradeoff IMO for being able to also filter according to a particular handler (opposed to adding filters into each individual handler class).

The `time()` change was just to appease a pre-commit hook phpcs rule. Nothing functionally changes there.

### How to test the changes in this Pull Request:

1. Pretty self-explanatory, can just make sure the filtering still works I suppose :)

### Changelog entry

> Enhancement - Pass `$handler`, and prevent logging from `woocommerce_logger_log_message` filter when the message is null.
