### PR TITLE
Issues/29574 css color variables

### DIFF
--- a/assets/css/_mixins.scss
+++ b/assets/css/_mixins.scss
@@ -286,3 +286,40 @@
 		text-decoration: none !important;
 	}
 }
+
+@function set_value($val, $val2) {
+	@if (type-of($val) == string) {
+		@return calc(#{$val} + #{$val2});
+	} @else {
+		@return $val + $val2;
+	}
+}
+
+@function gen-custom-prop($color, $hue: false, $saturation: false, $luminosity: false, $alpha: false) {
+
+	@if (type_of($color) == string) {
+		@error("Error in _variables.scss: colors needs to be a list like 150, 100%, 50% and not " + $color)
+	}
+
+	$h: nth($color, 1);
+	$s: nth($color, 2);
+	$l: nth($color, 3);
+
+	@if($hue != false) {
+		$h: set_value($h, $hue);
+	}
+
+	@if($saturation != false) {
+		$s: set_value($s, $saturation);
+	}
+
+	@if($luminosity != false) {
+		$l: set_value($l, $luminosity);
+	}
+
+	@if($alpha != false) {
+		@return unquote("hsla(#{$h}, #{$s}, #{$l}, #{$alpha})");
+	}
+
+	@return unquote("hsl(#{$h}, #{$s}, #{$l})");
+}

--- a/assets/css/_variables.scss
+++ b/assets/css/_variables.scss
@@ -32,7 +32,7 @@ $subtext:           #767676 !default;                                  // small,
 	--wc-secondary: #{$secondary};
 	--wc-secondary-text: #{$secondarytext};
 	--wc-highlight: #{$highlight};
-	--wc-highligh-text: #{$highlightext};
+	--wc-highlight-text: #{$highlightext};
 	--wc-content-bg: #{$contentbg};
 	--wc-subtext: #{$subtext};
 }

--- a/assets/css/_variables.scss
+++ b/assets/css/_variables.scss
@@ -8,31 +8,46 @@ $red:           	#a00 !default;
 $orange:        	#ffba00 !default;
 $blue:          	#2ea2cc !default;
 
-$primary:           #a46497 !default;                                  // Primary color for buttons (alt)
-$primarytext:       desaturate(lighten($primary, 50%), 18%) !default;    // Text on primary color bg
+$wc-primary: var(--wc-hue), var(--wc-sat), var(--wc-luma);									// Primary color for buttons (alt)
+$wc-primary-text: var(--wc-hue), calc(var(--wc-sat) - 18%), calc(var(--wc-luma) + 50%);		// Text on primary color bg
 
-$secondary:         desaturate(lighten($primary, 40%), 21%) !default;    // Secondary buttons
-$secondarytext:     desaturate(darken($secondary, 60%), 21%) !default;   // Text on secondary color bg
+$wc-secondary: var(--wc-hue), var(--wc-sat--secondary), calc(var(--wc-luma) + 40%); 		// Secondary buttons
+$wc-secondary-text: var(--wc-hue), var(--wc-sat--secondary), calc(var(--wc-luma) - 20%); 	// Text on secondary color bg
 
-$highlight:         adjust-hue($primary, 150deg) !default;               // Prices, In stock labels, sales flash
-$highlightext:      desaturate(lighten($highlight, 50%), 18%) !default;  // Text on highlight color bg
+$wc-highlight: var(--wc-hue--highlight), var(--wc-sat), var(--wc-luma); 								// Prices, In stock labels, sales flash
+$wc-highlight-text: var(--wc-hue--highlight), calc(var(--wc-sat) - 18%), calc(var(--wc-luma) + 50%); 	// Text on highlight color bg
 
-$contentbg:         #fff !default;                                     // Content BG - Tabs (active state)
-$subtext:           #767676 !default;                                  // small, breadcrumbs etc
 
 // export vars as CSS vars
 :root {
+	// base color values
+	--wc-hue: 312;
+	--wc-hue--highlight: calc(var(--wc-hue) + 150);
+
+	--wc-sat: 26%;
+	--wc-sat--secondary: calc(var(--wc-sat) - 21%);
+
+	--wc-luma: 52%;
+	--wc-luma-white: 100%;
+
+	// WooCommerce base colors
 	--woocommerce: #{$woocommerce};
-	--wc-green: #{$green};
-	--wc-red: #{$red};
-	--wc-orange: #{$orange};
-	--wc-blue: #{$blue};
-	--wc-primary: #{$primary};
-	--wc-primary-text: #{$primarytext};
-	--wc-secondary: #{$secondary};
-	--wc-secondary-text: #{$secondarytext};
-	--wc-highlight: #{$highlight};
-	--wc-highlight-text: #{$highlightext};
-	--wc-content-bg: #{$contentbg};
-	--wc-subtext: #{$subtext};
+	--wc-green: var(--wp--preset--color--vivid-green-cyan, #{$green});
+	--wc-red: var(--wp--preset--color--vivid-red, #{$red});
+	--wc-orange: var(--wp--preset--color--luminous-vivid-amber, #{$orange});
+	--wc-blue: var(--wp--preset--color--pale-cyan-blue, #{$blue});
+	--wc-white: hsl(0,0%,var(--wc-luma-white));
+	--wc-gray: hsl(0,0%,calc(var(--wc-luma-white) * .46));
+	--wc-black: hsl(0,0%,calc(var(--wc-luma-white) * 0));
+
+	// theme colors
+	--wc-primary: hsl(#{$wc-primary});
+	--wc-primary-text: hsl(#{$wc-primary-text});
+	--wc-secondary: hsl(#{$wc-secondary});
+	--wc-secondary-text: hsl(#{$wc-secondary-text});
+	--wc-highlight: hsl(#{$wc-highlight});
+	--wc-highlight-text: hsl(#{$wc-highlight-text});
+
+	--wc-content-bg: var(--wc-white);
+	--wc-subtext: var(--wc-gray);
 }

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -711,7 +711,7 @@ table.wc_status_table {
 		}
 
 		mark.yes {
-			color: $green;
+			color: var( --wc-green );
 		}
 
 		mark.no {
@@ -720,7 +720,7 @@ table.wc_status_table {
 
 		mark.error,
 		.red {
-			color: $red;
+			color: var( --wc-red );
 		}
 
 		ul {
@@ -1025,7 +1025,7 @@ ul.wc_coupon_list {
 				}
 
 				&:hover::before {
-					color: $red;
+					color: var( --wc-red );
 				}
 			}
 		}
@@ -1421,7 +1421,7 @@ ul.wc_coupon_list_block {
 		}
 
 		.refunded-total {
-			color: $red;
+			color: var( --wc-red );
 		}
 
 		.label-highlight {
@@ -1903,7 +1903,7 @@ ul.wc_coupon_list_block {
 					}
 
 					&:hover::before {
-						color: $red;
+						color: var( --wc-red );
 					}
 				}
 
@@ -1914,7 +1914,7 @@ ul.wc_coupon_list_block {
 
 			small.refunded {
 				display: block;
-				color: $red;
+				color: var( --wc-red );
 				white-space: nowrap;
 				margin-top: 0.5em;
 
@@ -1990,7 +1990,7 @@ ul.wc_coupon_list_block {
 			}
 
 			&:hover::before {
-				color: $red;
+				color: var( --wc-red );
 			}
 		}
 	}
@@ -2732,7 +2732,7 @@ ul.order_notes {
 		}
 
 		a.delete_note {
-			color: $red;
+			color: var( --wc-red );
 		}
 
 		.note_content::after {
@@ -2933,7 +2933,7 @@ table.wp-list-table {
 		}
 
 		&.instock {
-			color: $green;
+			color: var( --wc-green );
 		}
 
 		&.outofstock {
@@ -2996,7 +2996,7 @@ table.wp-list-table {
 
 mark.notice {
 	background: #fff;
-	color: $red;
+	color: var( --wc-red );
 	margin: 0 0 0 10px;
 }
 
@@ -3041,7 +3041,7 @@ table.wc_input_table {
 	}
 
 	span.tips {
-		color: $blue;
+		color: var( --wc-blue );
 	}
 
 	th {
@@ -3874,7 +3874,7 @@ img.help_tip {
 .status-enabled::before {
 
 	@include icon( "\e015" );
-	color: $woocommerce;
+	color: var( --woocommerce );
 }
 
 .status-disabled::before {
@@ -4017,7 +4017,7 @@ img.help_tip {
 
 		span.help_tip {
 			cursor: help;
-			color: $blue;
+			color: var( --wc-blue );
 		}
 
 		th {
@@ -4350,7 +4350,7 @@ img.help_tip {
 						}
 
 						&:hover::before {
-							color: $red;
+							color: var( --wc-red );
 						}
 					}
 				}
@@ -4734,7 +4734,7 @@ img.help_tip {
 				&:hover {
 
 					&::before {
-						color: $red;
+						color: var( --wc-red );
 					}
 				}
 			}
@@ -4855,7 +4855,7 @@ img.help_tip {
 		.req {
 			font-weight: 700;
 			font-style: normal;
-			color: $red;
+			color: var( --wc-red );
 		}
 	}
 
@@ -5752,12 +5752,12 @@ img.ui-datepicker-trigger {
 					border-right-width: 0;
 					padding: 10px;
 					margin: 0;
-					color: $blue;
+					color: var( --wc-blue );
 					border-top-width: 0;
 					background-image: linear-gradient(to top, #ececec, #f9f9f9);
 
 					&.section_title:hover {
-						color: $red;
+						color: var( --wc-red );
 					}
 				}
 

--- a/assets/css/dashboard.scss
+++ b/assets/css/dashboard.scss
@@ -171,7 +171,7 @@ ul.woocommerce_stats {
 
 			a::before {
 				content: "\e016";
-				color: $orange;
+				color: var( --wc-orange );
 			}
 		}
 
@@ -179,7 +179,7 @@ ul.woocommerce_stats {
 
 			a::before {
 				content: "\e013";
-				color: $red;
+				color: var( --wc-red );
 			}
 		}
 	}

--- a/assets/css/twenty-nineteen.scss
+++ b/assets/css/twenty-nineteen.scss
@@ -10,7 +10,7 @@ $body: "NonBreakingSpaceOverride", "Hoefler Text", "Baskerville Old Face", Garam
 $body-color: #111;
 :root {
 	--wc-highlight: #0073aa;
-}:
+}
 
 /**
  * Fonts

--- a/assets/css/twenty-nineteen.scss
+++ b/assets/css/twenty-nineteen.scss
@@ -8,7 +8,9 @@ $headings: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen,Ubuntu,Cant
 $body: "NonBreakingSpaceOverride", "Hoefler Text", "Baskerville Old Face", Garamond, "Times New Roman", serif;
 
 $body-color: #111;
-$highlights-color: #0073aa;
+:root {
+	--wc-highlight: #0073aa;
+}:
 
 /**
  * Fonts
@@ -103,7 +105,7 @@ a.button {
 	top: 0;
 	left: 0;
 	display: inline-block;
-	background: $highlights-color;
+	background: var( --wc-highlight );
 	color: #fff;
 	display: inline-block;
 	font-family: $headings;
@@ -169,11 +171,11 @@ a.button {
 }
 
 .woocommerce-info {
-	background: $highlights-color;
+	background: var( --wc-highlight );
 }
 
 .woocommerce-store-notice {
-	background: $highlights-color;
+	background: var( --wc-highlight );
 	color: #fff;
 	padding: 1rem;
 	position: absolute;
@@ -537,8 +539,8 @@ table.variations {
 
 			&.active {
 				a {
-					color: $highlights-color;
-					box-shadow: 0 2px 0 $highlights-color;
+					color: var( --wc-highlight );
+					box-shadow: 0 2px 0 var( --wc-highlight );
 				}
 			}
 		}

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -8,7 +8,9 @@ $headings: -apple-system, blinkmacsystemfont, "Helvetica Neue", helvetica, sans-
 $body: nonbreakingspaceoverride, "Hoefler Text", garamond, "Times New Roman", serif;
 
 $body-color: currentColor;
-$highlights-color: #88a171;
+:root {
+	--wc-highlight: #88a171;
+}:
 
 /**
  * Fonts
@@ -164,7 +166,7 @@ a.button {
 	position: absolute;
 	top: -0.7rem;
 	right: -0.7rem;
-	background: $highlights-color;
+	background: var( --wc-highlight );
 	color: #fff;
 	font-family: $headings;
 	font-size: 1.2rem;
@@ -267,7 +269,7 @@ a.button {
 .woocommerce-info {
 	background: #eee;
 	color: #000;
-	border-top: 2px solid $highlights-color;
+	border-top: 2px solid var( --wc-highlight );
 
 	a {
 		color: #444;
@@ -277,7 +279,7 @@ a.button {
 		}
 
 		&.button {
-			background: $highlights-color;
+			background: var( --wc-highlight );
 			color: #f5efe0;
 		}
 	}
@@ -286,7 +288,7 @@ a.button {
 .woocommerce-store-notice {
 	background: #eee;
 	color: #000;
-	border-top: 2px solid $highlights-color;
+	border-top: 2px solid var( --wc-highlight );
 	padding: 2rem;
 	position: absolute;
 	top: 0;
@@ -498,7 +500,7 @@ a.remove {
 	color: #000;
 
 	&:hover {
-		background: $highlights-color;
+		background: var( --wc-highlight );
 		color: #fff !important;
 	}
 }
@@ -1231,7 +1233,7 @@ a.reset_variations {
 
 				a {
 					text-decoration: underline;
-					color: $highlights-color;
+					color: var( --wc-highlight );
 				}
 			}
 		}
@@ -1753,7 +1755,7 @@ a.reset_variations {
 		.form-row.woocommerce-invalid {
 
 			input.input-text {
-				border: 2px solid $highlights-color;
+				border: 2px solid var( --wc-highlight );
 			}
 		}
 

--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -10,7 +10,7 @@ $body: nonbreakingspaceoverride, "Hoefler Text", garamond, "Times New Roman", se
 $body-color: currentColor;
 :root {
 	--wc-highlight: #88a171;
-}:
+}
 
 /**
  * Fonts

--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -8,7 +8,9 @@ $headings: -apple-system, blinkmacsystemfont, "Helvetica Neue", helvetica, sans-
 $body: nonbreakingspaceoverride, "Hoefler Text", garamond, "Times New Roman", serif;
 
 $body-color: #111;
-$highlights-color: #cd2653;
+:root {
+	--wc-highlight: #cd2653;
+}:
 
 /**
  * Fonts
@@ -157,7 +159,7 @@ a.button {
 	top: 0;
 	left: 0;
 	display: inline-block;
-	background: $highlights-color;
+	background: var( --wc-highlight );
 	color: #fff;
 	font-family: $headings;
 	font-size: 1.7rem;
@@ -245,7 +247,7 @@ a.button {
 .woocommerce-info {
 	background: #eee;
 	color: #000;
-	border-top: 2px solid $highlights-color;
+	border-top: 2px solid var( --wc-highlight );
 
 	a {
 		color: #444;
@@ -255,7 +257,7 @@ a.button {
 		}
 
 		&.button {
-			background: $highlights-color;
+			background: var( --wc-highlight );
 			color: #f5efe0;
 		}
 	}
@@ -264,7 +266,7 @@ a.button {
 .woocommerce-store-notice {
 	background: #eee;
 	color: #000;
-	border-top: 2px solid $highlights-color;
+	border-top: 2px solid var( --wc-highlight );
 	padding: 2rem;
 	position: absolute;
 	top: 0;
@@ -459,7 +461,7 @@ a.remove {
 	color: #000;
 
 	&:hover {
-		background: $highlights-color;
+		background: var( --wc-highlight );
 		color: #fff !important;
 	}
 }
@@ -772,8 +774,8 @@ a.reset_variations {
 			&.active {
 
 				a {
-					color: $highlights-color;
-					box-shadow: 0 2px 0 $highlights-color;
+					color: var( --wc-highlight );
+					box-shadow: 0 2px 0 var( --wc-highlight );
 				}
 			}
 		}
@@ -1170,7 +1172,7 @@ a.reset_variations {
 
 				a {
 					text-decoration: underline;
-					color: $highlights-color;
+					color: var( --wc-highlight );
 				}
 			}
 		}
@@ -1742,7 +1744,7 @@ a.reset_variations {
 		.form-row.woocommerce-invalid {
 
 			input.input-text {
-				border: 2px solid $highlights-color;
+				border: 2px solid var( --wc-highlight );
 			}
 		}
 

--- a/assets/css/twenty-twenty.scss
+++ b/assets/css/twenty-twenty.scss
@@ -10,7 +10,7 @@ $body: nonbreakingspaceoverride, "Hoefler Text", garamond, "Times New Roman", se
 $body-color: #111;
 :root {
 	--wc-highlight: #cd2653;
-}:
+}
 
 /**
  * Fonts

--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -327,7 +327,7 @@ p.demo_store,
 				position: relative;
 
 				li {
-					border: 1px solid darken(var( --wc-secondary ), 10%);
+					border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 					background-color: var( --wc-secondary );
 					display: inline-block;
 					position: relative;
@@ -345,7 +345,7 @@ p.demo_store,
 
 						&:hover {
 							text-decoration: none;
-							color: lighten($secondarytext, 10%);
+							color: #{gen-custom-prop( $wc-secondary-text, false, false, 10% )};
 						}
 					}
 
@@ -370,7 +370,7 @@ p.demo_store,
 
 					&::before,
 					&::after {
-						border: 1px solid darken($secondary, 10%);
+						border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 						position: absolute;
 						bottom: -1px;
 						width: 5px;
@@ -400,7 +400,7 @@ p.demo_store,
 					width: 100%;
 					bottom: 0;
 					left: 0;
-					border-bottom: 1px solid darken(var( --wc-secondary ), 10%);
+					border-bottom: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 					z-index: 1;
 				}
 			}
@@ -453,12 +453,13 @@ p.demo_store,
 				td,
 				th {
 					border: 0;
-					vertical-align: top;
 					line-height: 2em;
+					vertical-align: top;
 				}
 
 				label {
 					font-weight: 700;
+					text-align: left;
 				}
 
 				select {
@@ -533,7 +534,7 @@ p.demo_store,
 		margin: 0;
 		border-radius: 100%;
 		background-color: var( --wc-highlight );
-		color: var( --wc-highlight )ext;
+		color: var( --wc-highlight );
 		font-size: 0.857em;
 		z-index: 9;
 	}
@@ -623,7 +624,7 @@ p.demo_store,
 				font-size: 0.67em;
 				margin: -2px 0 0 0;
 				text-transform: uppercase;
-				color: rgba(desaturate(var( --wc-highlight ), 75%), 0.5);
+				color: #{gen-custom-prop( $wc-highlight, false, -75%, false, .5 )};
 			}
 		}
 	}
@@ -648,12 +649,12 @@ p.demo_store,
 			white-space: nowrap;
 			padding: 0;
 			clear: both;
-			border: 1px solid darken(var( --wc-secondary ), 10%);
+			border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 			border-right: 0;
 			margin: 1px;
 
 			li {
-				border-right: 1px solid darken(var( --wc-secondary ), 10%);
+				border-right: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 				padding: 0;
 				margin: 0;
 				float: left;
@@ -677,7 +678,7 @@ p.demo_store,
 				a:hover,
 				a:focus {
 					background: var( --wc-secondary );
-					color: darken(var( --wc-secondary ), 40%);
+					color: #{gen-custom-prop( $wc-secondary, false, false, -40% )};
 				}
 			}
 		}
@@ -733,7 +734,7 @@ p.demo_store,
 		}
 
 		&:hover {
-			background-color: darken(var( --wc-secondary ), 5%);
+			background-color: #{gen-custom-prop( $wc-secondary, false, false, -5% )};
 			text-decoration: none;
 			background-image: none;
 			color: var( --wc-secondary-text );
@@ -745,7 +746,7 @@ p.demo_store,
 			-webkit-font-smoothing: antialiased;
 
 			&:hover {
-				background-color: darken(var( --wc-primary ), 5%);
+				background-color: #{gen-custom-prop( $wc-primary, false, false, -5% )};
 				color: var( --wc-primary-text );
 			}
 
@@ -857,14 +858,14 @@ p.demo_store,
 						width: 32px;
 						height: auto;
 						background: var( --wc-secondary );
-						border: 1px solid darken(var( --wc-secondary ), 3%);
+						border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -3% )};
 						margin: 0;
 						box-shadow: none;
 					}
 
 					.comment-text {
 						margin: 0 0 0 50px;
-						border: 1px solid darken(var( --wc-secondary ), 3%);
+						border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -3% )};
 						border-radius: 4px;
 						padding: 1em 1em 0;
 
@@ -890,7 +891,7 @@ p.demo_store,
 				}
 
 				#respond {
-					border: 1px solid darken(var( --wc-secondary ), 3%);
+					border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -3% )};
 					border-radius: 4px;
 					padding: 1em 1em 0;
 					margin: 20px 0 0 50px;
@@ -918,7 +919,7 @@ p.demo_store,
 
 		&::before {
 			content: "\73\73\73\73\73";
-			color: darken(var( --wc-secondary ), 10%);
+			color: #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 			float: left;
 			top: 0;
 			left: 0;
@@ -1436,7 +1437,7 @@ p.demo_store,
 	form.login,
 	form.checkout_coupon,
 	form.register {
-		border: 1px solid darken(var( --wc-secondary ), 10%);
+		border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 		padding: 20px;
 		margin: 2em 0;
 		text-align: left;
@@ -1487,7 +1488,7 @@ p.demo_store,
 			text-transform: uppercase;
 			font-size: 0.715em;
 			line-height: 1;
-			border-right: 1px dashed darken(var( --wc-secondary ), 10%);
+			border-right: 1px dashed #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 			padding-right: 2em;
 			margin-left: 0;
 			padding-left: 0;
@@ -1670,7 +1671,7 @@ p.demo_store,
 
 		.price_slider_wrapper .ui-widget-content {
 			border-radius: 1em;
-			background-color: darken(var( --wc-primary ), 30%);
+			background-color: #{gen-custom-prop( $wc-primary, false, false, -30% )};
 			border: 0;
 		}
 
@@ -1758,7 +1759,7 @@ p.demo_store,
 	padding: 1em 2em 1em 3.5em;
 	margin: 0 0 2em;
 	position: relative;
-	background-color: lighten(var( --wc-secondary ), 5%);
+	background-color: #{gen-custom-prop( $wc-secondary, false, false, 5% )};
 	color: var( --wc-secondary-text );
 	border-top: 3px solid var( --wc-primary );
 	list-style: none outside;
@@ -1906,7 +1907,7 @@ p.demo_store,
 		td.actions .coupon .input-text {
 			float: left;
 			box-sizing: border-box;
-			border: 1px solid darken(var( --wc-secondary ), 10%);
+			border: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 			padding: 6px 6px 5px;
 			margin: 0 4px 0 0;
 			outline: 0;
@@ -2053,7 +2054,7 @@ p.demo_store,
 			@include clearfix();
 			text-align: left;
 			padding: 1em;
-			border-bottom: 1px solid darken(var( --wc-secondary ), 10%);
+			border-bottom: 1px solid #{gen-custom-prop( $wc-secondary, false, false, -10% )};
 			margin: 0;
 			list-style: none outside;
 
@@ -2099,25 +2100,25 @@ p.demo_store,
 			font-size: 0.92em;
 			border-radius: 2px;
 			line-height: 1.5;
-			background-color: darken(var( --wc-secondary ), 5%);
+			background-color: #{gen-custom-prop( $wc-secondary, false, false, -5% )};
 			color: var( --wc-secondary-text );
 
 			input.input-text,
 			textarea {
-				border-color: darken(var( --wc-secondary ), 15%);
-				border-top-color: darken(var( --wc-secondary ), 20%);
+				border-color: #{gen-custom-prop( $wc-secondary, false, false, -15% )};
+				border-top-color: #{gen-custom-prop( $wc-secondary, false, false, -20% )};
 			}
 
 			::-webkit-input-placeholder {
-				color: darken(var( --wc-secondary ), 20%);
+				color: #{gen-custom-prop( $wc-secondary, false, false, -20% )};
 			}
 
 			:-moz-placeholder {
-				color: darken(var( --wc-secondary ), 20%);
+				color: #{gen-custom-prop( $wc-secondary, false, false, -20% )};
 			}
 
 			:-ms-input-placeholder {
-				color: darken(var( --wc-secondary ), 20%);
+				color:  #{gen-custom-prop( $wc-secondary, false, false, -20% )};
 			}
 
 			.woocommerce-SavedPaymentMethods {
@@ -2205,7 +2206,7 @@ p.demo_store,
 			&::before {
 				content: "";
 				display: block;
-				border: 1em solid darken(var( --wc-secondary ), 5%); /* arrow size / color */
+				border: 1em solid  #{gen-custom-prop( $wc-secondary, false, false, -5% )}; /* arrow size / color */
 				border-right-color: transparent;
 				border-left-color: transparent;
 				border-top-color: transparent;

--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -26,14 +26,14 @@ p.demo_store,
 	font-size: 1em;
 	padding: 1em 0;
 	text-align: center;
-	background-color: $primary;
-	color: $primarytext;
+	background-color: var( --wc-primary );
+	color: var( --wc-primary )text;
 	z-index: 99998;
 	box-shadow: 0 1px 1em rgba(0, 0, 0, 0.2);
 	display: none;
 
 	a {
-		color: $primarytext;
+		color: var( --wc-primary )text;
 		text-decoration: underline;
 	}
 }
@@ -95,7 +95,7 @@ p.demo_store,
 
 	small.note {
 		display: block;
-		color: $subtext;
+		color: var( --wc-subtext );
 		font-size: 0.857em;
 		margin-top: 10px;
 	}
@@ -106,10 +106,10 @@ p.demo_store,
 		margin: 0 0 1em;
 		padding: 0;
 		font-size: 0.92em;
-		color: $subtext;
+		color: var( --wc-subtext );
 
 		a {
-			color: $subtext;
+			color: var( --wc-subtext );
 		}
 	}
 
@@ -133,7 +133,7 @@ p.demo_store,
 
 		span.price,
 		p.price {
-			color: $highlight;
+			color: var( --wc-highlight );
 			font-size: 1.25em;
 
 			ins {
@@ -153,7 +153,7 @@ p.demo_store,
 		}
 
 		.stock {
-			color: $highlight;
+			color: var( --wc-highlight );
 		}
 
 		.out-of-stock {
@@ -327,8 +327,8 @@ p.demo_store,
 				position: relative;
 
 				li {
-					border: 1px solid darken($secondary, 10%);
-					background-color: $secondary;
+					border: 1px solid darken(var( --wc-secondary ), 10%);
+					background-color: var( --wc-secondary );
 					display: inline-block;
 					position: relative;
 					z-index: 0;
@@ -340,7 +340,7 @@ p.demo_store,
 						display: inline-block;
 						padding: 0.5em 0;
 						font-weight: 700;
-						color: $secondarytext;
+						color: var( --wc-secondary-text );
 						text-decoration: none;
 
 						&:hover {
@@ -350,9 +350,9 @@ p.demo_store,
 					}
 
 					&.active {
-						background: $contentbg;
+						background: var( --wc-content-bg );
 						z-index: 2;
-						border-bottom-color: $contentbg;
+						border-bottom-color: var( --wc-content-bg );
 
 						a {
 							color: inherit;
@@ -360,11 +360,11 @@ p.demo_store,
 						}
 
 						&::before {
-							box-shadow: 2px 2px 0 $contentbg;
+							box-shadow: 2px 2px 0 var( --wc-content-bg );
 						}
 
 						&::after {
-							box-shadow: -2px 2px 0 $contentbg;
+							box-shadow: -2px 2px 0 var( --wc-content-bg );
 						}
 					}
 
@@ -383,14 +383,14 @@ p.demo_store,
 						left: -5px;
 						border-bottom-right-radius: 4px;
 						border-width: 0 1px 1px 0;
-						box-shadow: 2px 2px 0 $secondary;
+						box-shadow: 2px 2px 0 var( --wc-secondary );
 					}
 
 					&::after {
 						right: -5px;
 						border-bottom-left-radius: 4px;
 						border-width: 0 0 1px 1px;
-						box-shadow: -2px 2px 0 $secondary;
+						box-shadow: -2px 2px 0 var( --wc-secondary );
 					}
 				}
 
@@ -400,7 +400,7 @@ p.demo_store,
 					width: 100%;
 					bottom: 0;
 					left: 0;
-					border-bottom: 1px solid darken($secondary, 10%);
+					border-bottom: 1px solid darken(var( --wc-secondary ), 10%);
 					z-index: 1;
 				}
 			}
@@ -532,8 +532,8 @@ p.demo_store,
 		left: -0.5em;
 		margin: 0;
 		border-radius: 100%;
-		background-color: $highlight;
-		color: $highlightext;
+		background-color: var( --wc-highlight );
+		color: var( --wc-highlight )ext;
 		font-size: 0.857em;
 		z-index: 9;
 	}
@@ -601,7 +601,7 @@ p.demo_store,
 		}
 
 		.price {
-			color: $highlight;
+			color: var( --wc-highlight );
 			display: block;
 			font-weight: normal;
 			margin-bottom: 0.5em;
@@ -623,7 +623,7 @@ p.demo_store,
 				font-size: 0.67em;
 				margin: -2px 0 0 0;
 				text-transform: uppercase;
-				color: rgba(desaturate($highlight, 75%), 0.5);
+				color: rgba(desaturate(var( --wc-highlight ), 75%), 0.5);
 			}
 		}
 	}
@@ -648,12 +648,12 @@ p.demo_store,
 			white-space: nowrap;
 			padding: 0;
 			clear: both;
-			border: 1px solid darken($secondary, 10%);
+			border: 1px solid darken(var( --wc-secondary ), 10%);
 			border-right: 0;
 			margin: 1px;
 
 			li {
-				border-right: 1px solid darken($secondary, 10%);
+				border-right: 1px solid darken(var( --wc-secondary ), 10%);
 				padding: 0;
 				margin: 0;
 				float: left;
@@ -676,8 +676,8 @@ p.demo_store,
 				span.current,
 				a:hover,
 				a:focus {
-					background: $secondary;
-					color: darken($secondary, 40%);
+					background: var( --wc-secondary );
+					color: darken(var( --wc-secondary ), 40%);
 				}
 			}
 		}
@@ -701,8 +701,8 @@ p.demo_store,
 		font-weight: 700;
 		border-radius: 3px;
 		left: auto;
-		color: $secondarytext;
-		background-color: $secondary;
+		color: var( --wc-secondary-text );
+		background-color: var( --wc-secondary );
 		border: 0;
 		display: inline-block;
 		background-image: none;
@@ -733,20 +733,20 @@ p.demo_store,
 		}
 
 		&:hover {
-			background-color: darken($secondary, 5%);
+			background-color: darken(var( --wc-secondary ), 5%);
 			text-decoration: none;
 			background-image: none;
-			color: $secondarytext;
+			color: var( --wc-secondary-text );
 		}
 
 		&.alt {
-			background-color: $primary;
-			color: $primarytext;
+			background-color: var( --wc-primary );
+			color: var( --wc-primary )text;
 			-webkit-font-smoothing: antialiased;
 
 			&:hover {
-				background-color: darken($primary, 5%);
-				color: $primarytext;
+				background-color: darken(var( --wc-primary ), 5%);
+				color: var( --wc-primary )text;
 			}
 
 			&.disabled,
@@ -755,8 +755,8 @@ p.demo_store,
 			&.disabled:hover,
 			&:disabled:hover,
 			&:disabled[disabled]:hover {
-				background-color: $primary;
-				color: $primarytext;
+				background-color: var( --wc-primary );
+				color: var( --wc-primary )text;
 			}
 		}
 
@@ -770,7 +770,7 @@ p.demo_store,
 
 			&:hover {
 				color: inherit;
-				background-color: $secondary;
+				background-color: var( --wc-secondary );
 			}
 		}
 	}
@@ -792,13 +792,13 @@ p.demo_store,
 
 		h2 small {
 			float: right;
-			color: $subtext;
+			color: var( --wc-subtext );
 			font-size: 15px;
 			margin: 10px 0 0;
 
 			a {
 				text-decoration: none;
-				color: $subtext;
+				color: var( --wc-subtext );
 			}
 		}
 
@@ -844,7 +844,7 @@ p.demo_store,
 					border: 0;
 
 					.meta {
-						color: $subtext;
+						color: var( --wc-subtext );
 						font-size: 0.75em;
 					}
 
@@ -856,15 +856,15 @@ p.demo_store,
 						padding: 3px;
 						width: 32px;
 						height: auto;
-						background: $secondary;
-						border: 1px solid darken($secondary, 3%);
+						background: var( --wc-secondary );
+						border: 1px solid darken(var( --wc-secondary ), 3%);
 						margin: 0;
 						box-shadow: none;
 					}
 
 					.comment-text {
 						margin: 0 0 0 50px;
-						border: 1px solid darken($secondary, 3%);
+						border: 1px solid darken(var( --wc-secondary ), 3%);
 						border-radius: 4px;
 						padding: 1em 1em 0;
 
@@ -890,7 +890,7 @@ p.demo_store,
 				}
 
 				#respond {
-					border: 1px solid darken($secondary, 3%);
+					border: 1px solid darken(var( --wc-secondary ), 3%);
 					border-radius: 4px;
 					padding: 1em 1em 0;
 					margin: 20px 0 0 50px;
@@ -918,7 +918,7 @@ p.demo_store,
 
 		&::before {
 			content: "\73\73\73\73\73";
-			color: darken($secondary, 10%);
+			color: darken(var( --wc-secondary ), 10%);
 			float: left;
 			top: 0;
 			left: 0;
@@ -1262,7 +1262,7 @@ p.demo_store,
 	.widget_shopping_cart {
 
 		.total {
-			border-top: 3px double $secondary;
+			border-top: 3px double var( --wc-secondary );
 			padding: 4px 0 0;
 
 			strong {
@@ -1401,13 +1401,13 @@ p.demo_store,
 		&.woocommerce-invalid {
 
 			label {
-				color: $red;
+				color: var( --wc-red );
 			}
 
 			.select2-container,
 			input.input-text,
 			select {
-				border-color: $red;
+				border-color: var( --wc-red );
 			}
 		}
 
@@ -1436,7 +1436,7 @@ p.demo_store,
 	form.login,
 	form.checkout_coupon,
 	form.register {
-		border: 1px solid darken($secondary, 10%);
+		border: 1px solid darken(var( --wc-secondary ), 10%);
 		padding: 20px;
 		margin: 2em 0;
 		text-align: left;
@@ -1487,7 +1487,7 @@ p.demo_store,
 			text-transform: uppercase;
 			font-size: 0.715em;
 			line-height: 1;
-			border-right: 1px dashed darken($secondary, 10%);
+			border-right: 1px dashed darken(var( --wc-secondary ), 10%);
 			padding-right: 2em;
 			margin-left: 0;
 			padding-left: 0;
@@ -1581,7 +1581,7 @@ p.demo_store,
 		.woocommerce-widget-layered-nav-list__item--chosen a::before {
 
 			@include iconbefore( "\e013" );
-			color: $red;
+			color: var( --wc-red );
 		}
 	}
 
@@ -1608,7 +1608,7 @@ p.demo_store,
 				&::before {
 
 					@include iconbefore( "\e013" );
-					color: $red;
+					color: var( --wc-red );
 					vertical-align: inherit;
 					margin-right: 0.5em;
 				}
@@ -1648,7 +1648,7 @@ p.demo_store,
 			z-index: 2;
 			width: 1em;
 			height: 1em;
-			background-color: $primary;
+			background-color: var( --wc-primary );
 			border-radius: 1em;
 			cursor: ew-resize;
 			outline: none;
@@ -1665,12 +1665,12 @@ p.demo_store,
 			display: block;
 			border: 0;
 			border-radius: 1em;
-			background-color: $primary;
+			background-color: var( --wc-primary );
 		}
 
 		.price_slider_wrapper .ui-widget-content {
 			border-radius: 1em;
-			background-color: darken($primary, 30%);
+			background-color: darken(var( --wc-primary ), 30%);
 			border: 0;
 		}
 
@@ -1721,7 +1721,7 @@ p.demo_store,
 		li.chosen a::before {
 
 			@include iconbefore( "\e013" );
-			color: $red;
+			color: var( --wc-red );
 		}
 	}
 
@@ -1758,9 +1758,9 @@ p.demo_store,
 	padding: 1em 2em 1em 3.5em;
 	margin: 0 0 2em;
 	position: relative;
-	background-color: lighten($secondary, 5%);
-	color: $secondarytext;
-	border-top: 3px solid $primary;
+	background-color: lighten(var( --wc-secondary ), 5%);
+	color: var( --wc-secondary-text );
+	border-top: 3px solid var( --wc-primary );
 	list-style: none outside;
 
 	@include clearfix();
@@ -1906,7 +1906,7 @@ p.demo_store,
 		td.actions .coupon .input-text {
 			float: left;
 			box-sizing: border-box;
-			border: 1px solid darken($secondary, 10%);
+			border: 1px solid darken(var( --wc-secondary ), 10%);
 			padding: 6px 6px 5px;
 			margin: 0 4px 0 0;
 			outline: 0;
@@ -1952,7 +1952,7 @@ p.demo_store,
 		.cart_totals {
 
 			p small {
-				color: $subtext;
+				color: var( --wc-subtext );
 				font-size: 0.83em;
 			}
 
@@ -1982,7 +1982,7 @@ p.demo_store,
 				}
 
 				small {
-					color: $subtext;
+					color: var( --wc-subtext );
 				}
 
 				select {
@@ -1991,12 +1991,12 @@ p.demo_store,
 			}
 
 			.discount td {
-				color: $highlight;
+				color: var( --wc-highlight );
 			}
 
 			tr td,
 			tr th {
-				border-top: 1px solid $secondary;
+				border-top: 1px solid var( --wc-secondary );
 			}
 
 			.woocommerce-shipping-destination {
@@ -2029,7 +2029,7 @@ p.demo_store,
 
 		.create-account small {
 			font-size: 11px;
-			color: $subtext;
+			color: var( --wc-subtext );
 			font-weight: normal;
 		}
 
@@ -2045,7 +2045,7 @@ p.demo_store,
 	}
 
 	#payment {
-		background: $secondary;
+		background: var( --wc-secondary );
 		border-radius: 5px;
 
 		ul.payment_methods {
@@ -2053,7 +2053,7 @@ p.demo_store,
 			@include clearfix();
 			text-align: left;
 			padding: 1em;
-			border-bottom: 1px solid darken($secondary, 10%);
+			border-bottom: 1px solid darken(var( --wc-secondary ), 10%);
 			margin: 0;
 			list-style: none outside;
 
@@ -2099,25 +2099,25 @@ p.demo_store,
 			font-size: 0.92em;
 			border-radius: 2px;
 			line-height: 1.5;
-			background-color: darken($secondary, 5%);
-			color: $secondarytext;
+			background-color: darken(var( --wc-secondary ), 5%);
+			color: var( --wc-secondary-text );
 
 			input.input-text,
 			textarea {
-				border-color: darken($secondary, 15%);
-				border-top-color: darken($secondary, 20%);
+				border-color: darken(var( --wc-secondary ), 15%);
+				border-top-color: darken(var( --wc-secondary ), 20%);
 			}
 
 			::-webkit-input-placeholder {
-				color: darken($secondary, 20%);
+				color: darken(var( --wc-secondary ), 20%);
 			}
 
 			:-moz-placeholder {
-				color: darken($secondary, 20%);
+				color: darken(var( --wc-secondary ), 20%);
 			}
 
 			:-ms-input-placeholder {
-				color: darken($secondary, 20%);
+				color: darken(var( --wc-secondary ), 20%);
 			}
 
 			.woocommerce-SavedPaymentMethods {
@@ -2190,7 +2190,7 @@ p.demo_store,
 
 			span.help {
 				font-size: 0.857em;
-				color: $subtext;
+				color: var( --wc-subtext );
 				font-weight: normal;
 			}
 
@@ -2205,7 +2205,7 @@ p.demo_store,
 			&::before {
 				content: "";
 				display: block;
-				border: 1em solid darken($secondary, 5%); /* arrow size / color */
+				border: 1em solid darken(var( --wc-secondary ), 5%); /* arrow size / color */
 				border-right-color: transparent;
 				border-left-color: transparent;
 				border-top-color: transparent;

--- a/assets/css/woocommerce.scss
+++ b/assets/css/woocommerce.scss
@@ -27,13 +27,13 @@ p.demo_store,
 	padding: 1em 0;
 	text-align: center;
 	background-color: var( --wc-primary );
-	color: var( --wc-primary )text;
+	color: var( --wc-primary-text );
 	z-index: 99998;
 	box-shadow: 0 1px 1em rgba(0, 0, 0, 0.2);
 	display: none;
 
 	a {
-		color: var( --wc-primary )text;
+		color: var( --wc-primary-text );
 		text-decoration: underline;
 	}
 }
@@ -741,12 +741,12 @@ p.demo_store,
 
 		&.alt {
 			background-color: var( --wc-primary );
-			color: var( --wc-primary )text;
+			color: var( --wc-primary-text );
 			-webkit-font-smoothing: antialiased;
 
 			&:hover {
 				background-color: darken(var( --wc-primary ), 5%);
-				color: var( --wc-primary )text;
+				color: var( --wc-primary-text );
 			}
 
 			&.disabled,
@@ -756,7 +756,7 @@ p.demo_store,
 			&:disabled:hover,
 			&:disabled[disabled]:hover {
 				background-color: var( --wc-primary );
-				color: var( --wc-primary )text;
+				color: var( --wc-primary-text );
 			}
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Replace SCSS color variables with CSS color variables. This will allow a theme to override the CSS root variable and have that change propagate to all the places where that color variable is used.  Currently, overriding the root variable does nothing as the colors are still hard-coded into the CSS when built from the SCSS.

Closes #29574 .

### How to test the changes in this Pull Request:

1. Rebuild the CSS files, 'npm run build:assets`
2. View elements that expect to show the WooCommerce coloring

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
