### PR TITLE
gitignore unneeded eslint cache file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ project.properties
 .settings*
 .idea
 .vscode
+.eslintcache
 *.sublime-project
 *.sublime-workspace
 .sublimelinterrc


### PR DESCRIPTION
Just gitignores the `.eslintcache` file as sometimes this file gets created and creates `untracked files` situation in git.