### PR TITLE
Woo mobile: Added product image virtual flag to GET Order API response

### DIFF
--- a/includes/abstracts/abstract-wc-product.php
+++ b/includes/abstracts/abstract-wc-product.php
@@ -1902,6 +1902,29 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 	}
 
 	/**
+	 * Returns the main product image url.
+	 *
+	 * @return string
+	 */
+	public function get_main_image() {
+		$attachment = '';
+		if ( $this->get_image_id() ) {
+			$attachment = wp_get_attachment_image_src( $this->get_image_id(), 'full' );
+		} elseif ( $this->get_parent_id() ) {
+			$parent_product = wc_get_product( $this->get_parent_id() );
+			if ( $parent_product ) {
+				$attachment = $parent_product->get_main_image();
+			}
+		}
+
+		if ( ! $attachment ) {
+			return null;
+		} else {
+			return current( $attachment );
+		}
+	}
+
+	/**
 	 * Returns the product shipping class SLUG.
 	 *
 	 * @return string

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -1418,6 +1418,18 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 								'context'     => array( 'view', 'edit' ),
 								'readonly'    => true,
 							),
+							'image'        => array(
+								'description' => __( 'Product image.', 'woocommerce' ),
+								'type'        => 'string',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
+							'virtual'        => array(
+								'description' => __( 'True the product is a virtual product.', 'woocommerce' ),
+								'type'        => 'boolean',
+								'context'     => array( 'view', 'edit' ),
+								'readonly'    => true,
+							),
 						),
 					),
 				),

--- a/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-orders-v2-controller.php
@@ -166,10 +166,12 @@ class WC_REST_Orders_V2_Controller extends WC_REST_CRUD_Controller {
 			}
 		}
 
-		// Add SKU and PRICE to products.
+		// Add SKU, PRICE, IMAGE and VIRTUAL flag to products.
 		if ( is_callable( array( $item, 'get_product' ) ) ) {
 			$data['sku']   = $item->get_product() ? $item->get_product()->get_sku() : null;
 			$data['price'] = $item->get_quantity() ? $item->get_total() / $item->get_quantity() : 0;
+			$data['image'] = $item->get_product() ? $item->get_product()->get_main_image() : null;
+			$data['virtual'] = $item->get_product() ? $item->get_product()->get_virtual() : false;
 		}
 
 		// Add parent_name if the product is a variation.

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/orders.php
@@ -545,6 +545,8 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 			'sku'          => null,
 			'price'        => 4,
 			'parent_name'  => null,
+			'virtual'  => false,
+			'image'  => null,
 		);
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -785,10 +787,12 @@ class WC_Tests_API_Orders_V2 extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 
 		$line_item_properties = $data['schema']['properties']['line_items']['items']['properties'];
-		$this->assertEquals( 15, count( $line_item_properties ) );
+		$this->assertEquals( 17, count( $line_item_properties ) );
 		$this->assertArrayHasKey( 'id', $line_item_properties );
 		$this->assertArrayHasKey( 'meta_data', $line_item_properties );
 		$this->assertArrayHasKey( 'parent_name', $line_item_properties );
+		$this->assertArrayHasKey( 'image', $line_item_properties );
+		$this->assertArrayHasKey( 'virtual', $line_item_properties );
 
 		$meta_data_item_properties = $line_item_properties['meta_data']['items']['properties'];
 		$this->assertEquals( 5, count( $meta_data_item_properties ) );

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -649,6 +649,8 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 			'sku'          => null,
 			'price'        => 4,
 			'parent_name'  => null,
+			'virtual'  => false,
+			'image'  => null,
 		);
 
 		$this->assertEquals( 200, $response->get_status() );
@@ -1147,10 +1149,12 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$data = $response->get_data();
 
 		$line_item_properties = $data['schema']['properties']['line_items']['items']['properties'];
-		$this->assertEquals( 15, count( $line_item_properties ) );
+		$this->assertEquals( 17, count( $line_item_properties ) );
 		$this->assertArrayHasKey( 'id', $line_item_properties );
 		$this->assertArrayHasKey( 'meta_data', $line_item_properties );
 		$this->assertArrayHasKey( 'parent_name', $line_item_properties );
+		$this->assertArrayHasKey( 'image', $line_item_properties );
+		$this->assertArrayHasKey( 'virtual', $line_item_properties );
 
 		$meta_data_item_properties = $line_item_properties['meta_data']['items']['properties'];
 		$this->assertEquals( 5, count( $meta_data_item_properties ) );


### PR DESCRIPTION
Ref: `p91TBi-4y5`

### Background
The mobile apps use the GET Order API to fetch the details of an order. We use the `line_items` object to display the list of products associated with the order. We are currently making a separate API call to: 
- fetch the image of a product and 
- to know if a product in an order is virtual. We use this field to determine if the shipping section of an order should be displayed. If the order contains only virtual products, then the shipping section is hidden.

The current flow in the app works like this:
- The GET Order API is called.
- We parse the list of `line_items` from the response. 
- Iterate through the list of `line_items`. Check the local database to determine if the product is virtual. If the product is not found in the local database, an API call to the GET Product API endpoint is made.
- Once response is received, we check if the products in an order is virtual. If it is, the shipping section of the order is hidden.
- The products of the order is displayed, along with the image.  

### Solution
As part of initiative to reduce the number of API calls from the app, this PR adds two new fields to the `line_items` object in the GET Order API response. 
- `virtual` - Boolean flag: determines if the `line_item` product is virtual.
- `image` - String field: fetches the main image url of the product.

```
"line_items": [
        {
            "id": 1,
            "name": "T-Shirt",
            "product_id": 21,
            "variation_id": 0,
            "quantity": 1,
            "tax_class": "",
            "subtotal": "18.00",
            "subtotal_tax": "0.00",
            "total": "18.00",
            "total_tax": "0.00",
            "taxes": [],
            "meta_data": [],
            "sku": "woo-tshirt",
            "price": 18,
            "image": "https://one.wordpress.test/wp-content/uploads/2021/03/tshirt-2.jpg",
            "virtual": false,
            "parent_name": null
        }
]
```

### Changes
- Adds a new method to `abstract-wc-product.php` to fetch the main image of a product.
- Adds two new fields to the `line_items` object in `class-wc-rest-orders-v2-controller.php`.
- Adds the two new fields to the existing unit tests in `Version3/orders.php` and `Version2/orders.php`.

### Testing
#### Scenario 1: Order with single image
- As a customer, create an order that includes only 1 physical product (with 1 image). 
- In the API, run GET `/wp-json/wc/v3/orders/{OrderID}`.
- Confirm that the `line_items` has the `virtual` and `image` properties and they are correct.

#### Scenario 2: Order with multiple images (should return the main image of the product)
- As a customer, create an order that includes only 1 physical product (with multiple images). 
- In the API, run GET `/wp-json/wc/v3/orders/{OrderID}`.
- Confirm that the `line_items` has the `virtual` and `image` properties and they are correct.

#### Scenario 3: Order with no image (image field should return null)
- As a customer, create an order that includes only 1 physical product (with multiple images). 
- In the API, run GET `/wp-json/wc/v3/orders/{OrderID}`.
- Confirm that the `line_items` has the `virtual` and `image` properties and they are correct.

#### Scenario 4: Order with variable products (Should return the variation image if the product chosen)
- As a customer, create an order that includes only 1 physical product (with multiple images). 
- In the API, run GET `/wp-json/wc/v3/orders/{OrderID}`.
- Confirm that the `line_items` has the `virtual` and `image` properties and they are correct.

#### Scenario 5: Order with virtual product (virtual flag should return true):
- As a customer, create an order that includes only 1 physical product (with multiple images). 
- In the API, run GET `/wp-json/wc/v3/orders/{OrderID}`.
- Confirm that the `line_items` has the `virtual` and `image` properties and they are correct.

Please do feel free to test any other scenarios that you think might be relevant 😄 