### PR TITLE
Change the help text in email settings to include debugging steps.

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -51,7 +51,9 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			array(
 				array(
 					'title' => __( 'Email notifications', 'woocommerce' ),
-					'desc'  => __( 'Email notifications sent from WooCommerce are listed below. Click on an email to configure it.', 'woocommerce' ),
+					'desc'  => __( 'Email notifications sent from WooCommerce are listed below. Click on an email to configure it.
+					
+					To ensure your store’s notifications arrive in your and your customers’ inboxes, we recommend connecting your email address to your domain and setting up a dedicated SMTP server. If something doesn’t seem to be sending correctly, <a href="https://wordpress.org/plugins/wp-mail-logging/">install the WP Mail Logging Plugin</a>. <a href="https://docs.woocommerce.com/document/email-faq/">Learn more and see troubleshooting steps here</a>.', 'woocommerce' ),
 					'type'  => 'title',
 					'id'    => 'email_notification_settings',
 				),

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -46,14 +46,19 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	 * @return array
 	 */
 	public function get_settings() {
+		$desc_help_text = sprintf(
+		/* translators: %1$s: Link to WP Mail Logging plugin, %2$s: Link to Email FAQ support page. */
+			__( 'To ensure your store’s notifications arrive in your and your customers’ inboxes, we recommend connecting your email address to your domain and setting up a dedicated SMTP server. If something doesn’t seem to be sending correctly, install the <a href="%1$s">WP Mail Logging Plugin</a> or check the <a href="%2$s">Email FAQ page</a>.', 'woocommerce' ),
+			'https://wordpress.org/plugins/wp-mail-logging/',
+			'https://docs.woocommerce.com/document/email-faq'
+		);
 		$settings = apply_filters(
 			'woocommerce_email_settings',
 			array(
 				array(
 					'title' => __( 'Email notifications', 'woocommerce' ),
-					'desc'  => __( 'Email notifications sent from WooCommerce are listed below. Click on an email to configure it.
-					
-					To ensure your store’s notifications arrive in your and your customers’ inboxes, we recommend connecting your email address to your domain and setting up a dedicated SMTP server. If something doesn’t seem to be sending correctly, <a href="https://wordpress.org/plugins/wp-mail-logging/">install the WP Mail Logging Plugin</a>. <a href="https://docs.woocommerce.com/document/email-faq/">Learn more and see troubleshooting steps here</a>.', 'woocommerce' ),
+					/* translators: %s: help description with link to WP Mail logging and support page. */
+					'desc'  => sprintf( __( 'Email notifications sent from WooCommerce are listed below. Click on an email to configure it.<br>%s', 'woocommerce' ), $desc_help_text ),
 					'type'  => 'title',
 					'id'    => 'email_notification_settings',
 				),

--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -48,7 +48,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 	public function get_settings() {
 		$desc_help_text = sprintf(
 		/* translators: %1$s: Link to WP Mail Logging plugin, %2$s: Link to Email FAQ support page. */
-			__( 'To ensure your store’s notifications arrive in your and your customers’ inboxes, we recommend connecting your email address to your domain and setting up a dedicated SMTP server. If something doesn’t seem to be sending correctly, install the <a href="%1$s">WP Mail Logging Plugin</a> or check the <a href="%2$s">Email FAQ page</a>.', 'woocommerce' ),
+			__( 'To ensure your store&rsquo;s notifications arrive in your and your customers&rsquo; inboxes, we recommend connecting your email address to your domain and setting up a dedicated SMTP server. If something doesn&rsquo;t seem to be sending correctly, install the <a href="%1$s">WP Mail Logging Plugin</a> or check the <a href="%2$s">Email FAQ page</a>.', 'woocommerce' ),
 			'https://wordpress.org/plugins/wp-mail-logging/',
 			'https://docs.woocommerce.com/document/email-faq'
 		);


### PR DESCRIPTION
This PR is migrated over from https://github.com/Automattic/woocommerce-1/pull/1

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

From https://github.com/Automattic/woocommerce-1/pull/1

This entry adds an explanation of how to ensure the WooCommerce core store emails are sent and received correctly, and what to do if there's something wrong. Here's the text:


### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Go to `wp-admin/admin.php?page=wc-settings&tab=email` page on your site.
2. Make sure the new text is rendered and displayed correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> * Tweak - Change email settings help text to include troubleshooting steps.
