### PR TITLE
Bump version for template closes #29595

### DIFF
--- a/templates/single-product/add-to-cart/grouped.php
+++ b/templates/single-product/add-to-cart/grouped.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 4.0.0
+ * @version 4.8.0
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
Closes #29595 

Just bumping the template version since it was missed the last time changes were made.

### Changelog entry

> Fix - Bump the version of the "Grouped product add to cart" template to 4.8.0 (was still at 4.0.0 by mistake)