### PR TITLE
Fix/28759 billing shipping addresses

### DIFF
--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -243,6 +243,25 @@ class WC_Customer extends WC_Legacy_Customer {
 	}
 
 	/**
+	 * Indicates if the customer has a non-empty shipping address.
+	 *
+	 * Note that this does not indicate if the customer's shipping address
+	 * is complete, only that one or more fields are populated.
+	 *
+	 * @return bool
+	 */
+	public function has_shipping_address() {
+		foreach ( $this->get_shipping() as $address_field ) {
+			// Trim guards against a case where a subset of saved shipping address fields contain whitespace.
+			if ( strlen( trim( $address_field ) ) > 0 ) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get if customer is VAT exempt?
 	 *
 	 * @since 3.0.0

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -248,6 +248,8 @@ class WC_Customer extends WC_Legacy_Customer {
 	 * Note that this does not indicate if the customer's shipping address
 	 * is complete, only that one or more fields are populated.
 	 *
+	 * @since 5.3.0
+	 *
 	 * @return bool
 	 */
 	public function has_shipping_address() {

--- a/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/includes/data-stores/class-wc-customer-data-store-session.php
@@ -126,12 +126,13 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 	protected function set_defaults( &$customer ) {
 		try {
 			$default = wc_get_customer_default_location();
+			$has_shipping_address = $customer->has_shipping_address();
 
 			if ( ! $customer->get_billing_country() ) {
 				$customer->set_billing_country( $default['country'] );
 			}
 
-			if ( ! $customer->get_shipping_country() ) {
+			if ( ! $customer->get_shipping_country() && ! $has_shipping_address ) {
 				$customer->set_shipping_country( $customer->get_billing_country() );
 			}
 
@@ -139,7 +140,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 				$customer->set_billing_state( $default['state'] );
 			}
 
-			if ( ! $customer->get_shipping_state() ) {
+			if ( ! $customer->get_shipping_state() && ! $has_shipping_address ) {
 				$customer->set_shipping_state( $customer->get_billing_state() );
 			}
 

--- a/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
+++ b/tests/php/includes/data-stores/class-wc-customer-data-store-session-test.php
@@ -1,0 +1,114 @@
+<?php
+
+/**
+ * Tests relating to the WC_Customer_Data_Store_Session class.
+ */
+class WC_Customer_Data_Store_Session_Test extends WC_Unit_Test_Case {
+	/**
+	 * Ensure that the country and state shipping address fields only inherit
+	 * the corresponding billing address values if a shipping address is not set.
+	 *
+	 * @see https://github.com/woocommerce/woocommerce/issues/28759
+	 * @dataProvider provide_customers_with_different_addresses
+	 *
+	 * @param WC_Customer $customer               The customer object being tested.
+	 * @param bool        $states_should_match    If the billing and shipping states should match.
+	 * @param bool        $countries_should_match If the billing and shipping countries should match.
+	 */
+	public function test_setting_default_address_fields( WC_Customer $customer, bool $states_should_match, bool $countries_should_match ) {
+		$session_data = new WC_Customer_Data_Store_Session();
+		$session_data->read( $customer );
+
+		if ( $states_should_match ) {
+			$this->assertEquals( $customer->get_shipping_state(), $customer->get_billing_state() );
+		} else {
+			$this->assertNotEquals( $customer->get_shipping_state(), $customer->get_billing_state() );
+		}
+
+		if ( $countries_should_match ) {
+			$this->assertEquals( $customer->get_shipping_country(), $customer->get_billing_country() );
+		} else {
+			$this->assertNotEquals( $customer->get_shipping_country(), $customer->get_billing_country() );
+		}
+	}
+
+	/**
+	 * Customer objects with a mixture of billing and shipping addresses.
+	 *
+	 * Each inner dataset is organized as follows:
+	 *
+	 *     [
+	 *         (WC_Customer) $customer_object,
+	 *         (bool) $states_should_match,
+	 *         (bool) $countries_should_match,
+	 *     ]
+	 *
+	 * @return array[]
+	 */
+	public function provide_customers_with_different_addresses() {
+		$has_billing_address_only = new WC_Customer();
+		$has_billing_address_only->set_email( 'wc-customer-test-01@test.user' );
+		$has_billing_address_only->set_billing_address( '1234 Quality Lane' );
+		$has_billing_address_only->set_billing_city( 'Testville' );
+		$has_billing_address_only->set_billing_country( 'US' );
+		$has_billing_address_only->set_billing_state( 'CA' );
+		$has_billing_address_only->set_billing_postcode( '90123' );
+		$has_billing_address_only->save();
+
+		$separate_billing_and_shipping_state_and_country = new WC_Customer();
+		$separate_billing_and_shipping_state_and_country->set_email( 'wc-customer-test-02@test.user' );
+		$separate_billing_and_shipping_state_and_country->set_billing_address( '4567 Scenario Street' );
+		$separate_billing_and_shipping_state_and_country->set_billing_city( 'Unitly' );
+		$separate_billing_and_shipping_state_and_country->set_billing_country( 'UK' );
+		$separate_billing_and_shipping_state_and_country->set_billing_state( 'Computershire' );
+		$separate_billing_and_shipping_state_and_country->set_billing_postcode( 'ZX1 2PQ' );
+		$separate_billing_and_shipping_state_and_country->set_shipping_address( '8901 Situation Court' );
+		$separate_billing_and_shipping_state_and_country->set_shipping_city( 'Endtoendly' );
+		$separate_billing_and_shipping_state_and_country->set_shipping_country( 'CA' );
+		$separate_billing_and_shipping_state_and_country->set_shipping_state( 'BC' );
+		$separate_billing_and_shipping_state_and_country->set_shipping_postcode( 'A1B 2C3' );
+		$separate_billing_and_shipping_state_and_country->save();
+
+		$separate_billing_state_same_country = new WC_Customer();
+		$separate_billing_state_same_country->set_email( 'wc-customer-test-03@test.user' );
+		$separate_billing_state_same_country->set_billing_address( '4567 Scenario Street' );
+		$separate_billing_state_same_country->set_billing_city( 'Unitly' );
+		$separate_billing_state_same_country->set_billing_country( 'UK' );
+		$separate_billing_state_same_country->set_billing_state( 'Computershire' );
+		$separate_billing_state_same_country->set_billing_postcode( 'ZX1 2PQ' );
+		$separate_billing_state_same_country->set_shipping_address( '8901 Situation Court' );
+		$separate_billing_state_same_country->set_shipping_city( 'Endtoendly' );
+		$separate_billing_state_same_country->set_shipping_country( 'UK' );
+		$separate_billing_state_same_country->set_shipping_state( 'Byteshire' );
+		$separate_billing_state_same_country->set_shipping_postcode( 'RS1 2TU' );
+		$separate_billing_state_same_country->save();
+
+		$shipping_address_is_effectively_empty = new WC_Customer();
+		$shipping_address_is_effectively_empty->set_email( 'wc-customer-test-04@test.user' );
+		$shipping_address_is_effectively_empty->set_shipping_address( ' ' );
+		$shipping_address_is_effectively_empty->save();
+
+		return array(
+			'has_billing_address_only' => array(
+				$has_billing_address_only,
+				true,
+				true,
+			),
+			'separate_billing_and_shipping_state_and_country' => array(
+				$separate_billing_and_shipping_state_and_country,
+				false,
+				false,
+			),
+			'separate_billing_state_same_country' => array(
+				$separate_billing_state_same_country,
+				false,
+				true,
+			),
+			'shipping_address_is_effectively_empty' => array(
+				$shipping_address_is_effectively_empty,
+				true,
+				true,
+			),
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

In some countries the state (county) field is optional—the UK is one such example. That means we might have a saved billing address _with_ a county, and a saved shipping address _without_ (or similar). 

In these cases we should not copy the billing state/county to the shipping state/county: that action is really only appropriate if we don't already have a shipping address. Note that this problem also applies to the country field (though, it is easiest to see in relation to the state/county field).

Closes #28759.

### How to test the changes in this Pull Request:

1. Start by confirming you can see the original problem (checkout [current trunk code](https://github.com/woocommerce/woocommerce/commit/855f48d53b9a83c109891340b2b71bf9772db89f), or else the `5.1.0` tag).
    1. Create a customer account and ensure shipping is set up.
    2. Add and save billing and shipping address, supplying a county for the billing address but not for the shipping address.
    3. Now purchase a product (it's easiest to see if you buy a simple physical product).
    4. Note that the shipping address appearing on the cart page includes the billing county.
2. Now checkout this branch.
    1. Start by clearing/deleting the user session† and logging back in, otherwise the shipping address will be inherited from the first test (complete with inappropriately added state/county). 
    2. Then, simply repeat the test. The billing county is not copied over to the shipping address.

† _If you have your own snippet to kill the user session and dump the cart contents that's probably fine, or you could try using [this snippet](https://gist.github.com/barryhughes/d17134dc83dd216555115182879da5f4) (updating the user ID, and if necessary the table prefix, accordingly) then flushing the cache._

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - If we have a non-empty shipping address then do not overwrite the state or country fields with billing address data.
