### PR TITLE
Don't verify empty country codes on checkout

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -747,7 +747,7 @@ class WC_Checkout {
 				$field_label = isset( $field['label'] ) ? $field['label'] : '';
 
 				if ( $validate_fieldset &&
-					( isset( $field['type'] ) && 'country' === $field['type'] ) &&
+					( isset( $field['type'] ) && 'country' === $field['type'] && '' !== $data[ $key ] ) &&
 					! WC()->countries->country_exists( $data[ $key ] ) ) {
 						/* translators: ISO 3166-1 alpha-2 country code */
 						$errors->add( $key . '_validation', sprintf( __( "'%s' is not a valid country code.", 'woocommerce' ), $data[ $key ] ) );

--- a/tests/php/includes/class-wc-checkout-test.php
+++ b/tests/php/includes/class-wc-checkout-test.php
@@ -94,6 +94,30 @@ class WC_Checkout_Test extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * @testdox 'validate_posted_data' doesn't add errors for empty billing/shipping countries.
+	 *
+	 * @testWith [true]
+	 *           [false]
+	 *
+	 * @param bool $ship_to_different_address True to simulate shipping to a different address than the billing address.
+	 */
+	public function test_validate_posted_data_does_not_add_error_for_empty_country( $ship_to_different_address ) {
+		$_POST = array(
+			'billing_country'           => '',
+			'shipping_country'          => '',
+			'ship_to_different_address' => $ship_to_different_address,
+		);
+		$data  = $_POST; // phpcs:ignore WordPress.Security.NonceVerification.Missing
+
+		$errors = new WP_Error();
+
+		$this->sut->validate_posted_data( $data, $errors );
+
+		$this->assertEmpty( $errors->get_error_message( 'billing_country_validation' ) );
+		$this->assertEmpty( $errors->get_error_message( 'shipping_country_validation' ) );
+	}
+
+	/**
 	 * @testdox 'validate_checkout' adds a "We don't ship to country X" error but only if the country exists.
 	 *
 	 * @testWith [ "XX", false ]


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/28849 introduced a verification of the posted country code on checkout, so an invalid code will throw an error. However there are cases when an empty code is legitimately received, for example when using Paypal checkout directly from the product page and the customer doesn't have an address in his Paypal profile. We are already skipping verification of other fields when they are empty (e.g. phone, email) so this change is consistent with the existing code.

Closes #29545 (again) and https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout/issues/858.

### How to test the changes in this Pull Request:

1. Install [the PayPal checkout plugin](https://github.com/woocommerce/woocommerce-gateway-paypal-express-checkout) and configure it for a sandbox environment according to the instructions.
2. Open `includes/class-wc-gateway-ppec-checkout-handler.php` in the plugin and find this line (`get_mapped_billing_address` method):

```
'country'    => $checkout_details->payer_details->billing_address ? $checkout_details->payer_details->billing_address->getCountry() : $checkout_details->payer_details->country,
```

Replace it with `'country' => ''`. This is needed to simulate a PayPal user with no country configured (which is not possible to do directly when using sandbox accounts).

3. Open the product page of a virtual product (so there's no shipping address involved), and pay from there by using the PayPal button (use the sandbox personal account credentials).
4. On the checkout page confirm the order. Without this fix (in 5.2 beta or RC) you'll get a `'' is not a valid country code` error, with this fix the order will be created successfully.
5. Open the order details in admin area and verify that everything is correct.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - "'' is not a valid country code" error when no billing/shipping country specified (e.g. when using PayPal checkout)
