### PR TITLE
Make attribute ID unique. Fixes #26832

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3018,7 +3018,7 @@ if ( ! function_exists( 'wc_dropdown_variation_attribute_options' ) ) {
 		$product               = $args['product'];
 		$attribute             = $args['attribute'];
 		$name                  = $args['name'] ? $args['name'] : 'attribute_' . sanitize_title( $attribute );
-		$id                    = $args['id'] ? $args['id'] : sanitize_title( $attribute );
+		$id                    = $args['id'] ? $args['id'] : (!empty($args['product']->get_id() )) ? 'attribute_' .  $args['product']->get_id() . '_' . sanitize_title( $attribute ) : sanitize_title( $attribute );
 		$class                 = $args['class'];
 		$show_option_none      = (bool) $args['show_option_none'];
 		$show_option_none_text = $args['show_option_none'] ? $args['show_option_none'] : __( 'Choose an option', 'woocommerce' ); // We'll do our best to hide the placeholder, but we'll need to show something when resetting options.

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3018,7 +3018,7 @@ if ( ! function_exists( 'wc_dropdown_variation_attribute_options' ) ) {
 		$product               = $args['product'];
 		$attribute             = $args['attribute'];
 		$name                  = $args['name'] ? $args['name'] : 'attribute_' . sanitize_title( $attribute );
-		$id                    = $args['id'] ? $args['id'] : (!empty($args['product']->get_id() )) ? 'attribute_' .  $args['product']->get_id() . '_' . sanitize_title( $attribute ) : sanitize_title( $attribute );
+		$id                    = $args['id'] ? $args['id'] : ( ( ! empty( $args['product']->get_id() ) ) ? 'attribute_' . $args['product']->get_id() . '_' . sanitize_title( $attribute ) : sanitize_title( $attribute ) );
 		$class                 = $args['class'];
 		$show_option_none      = (bool) $args['show_option_none'];
 		$show_option_none_text = $args['show_option_none'] ? $args['show_option_none'] : __( 'Choose an option', 'woocommerce' ); // We'll do our best to hide the placeholder, but we'll need to show something when resetting options.

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -3018,7 +3018,7 @@ if ( ! function_exists( 'wc_dropdown_variation_attribute_options' ) ) {
 		$product               = $args['product'];
 		$attribute             = $args['attribute'];
 		$name                  = $args['name'] ? $args['name'] : 'attribute_' . sanitize_title( $attribute );
-		$id                    = $args['id'] ? $args['id'] : ( ( ! empty( $args['product']->get_id() ) ) ? 'attribute_' . $args['product']->get_id() . '_' . sanitize_title( $attribute ) : sanitize_title( $attribute ) );
+		$id                    = $args['id'] ? $args['id'] : sanitize_title( $attribute );
 		$class                 = $args['class'];
 		$show_option_none      = (bool) $args['show_option_none'];
 		$show_option_none_text = $args['show_option_none'] ? $args['show_option_none'] : __( 'Choose an option', 'woocommerce' ); // We'll do our best to hide the placeholder, but we'll need to show something when resetting options.

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -35,7 +35,7 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 			<tbody>
 				<?php foreach ( $attributes as $attribute_name => $options ) : ?>
 					<tr>
-						<td class="label"><label for="<?php echo esc_attr( sanitize_title( $attribute_name ) ); ?>"><?php echo wc_attribute_label( $attribute_name ); // WPCS: XSS ok. ?></label></td>
+						<td class="label"><label for="<?php echo esc_attr( 'attribute_' . $product->get_id() . '_' . sanitize_title( $attribute_name ) ); ?>"><?php echo wc_attribute_label( $attribute_name ); // WPCS: XSS ok. ?></label></td>
 						<td class="value">
 							<?php
 								wc_dropdown_variation_attribute_options(

--- a/templates/single-product/add-to-cart/variable.php
+++ b/templates/single-product/add-to-cart/variable.php
@@ -34,8 +34,9 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 		<table class="variations" cellspacing="0">
 			<tbody>
 				<?php foreach ( $attributes as $attribute_name => $options ) : ?>
+				<?php $attribute_id =  esc_attr( 'attribute_' . $product->get_id() . '_' . sanitize_title( $attribute_name ) ); ?>
 					<tr>
-						<td class="label"><label for="<?php echo esc_attr( 'attribute_' . $product->get_id() . '_' . sanitize_title( $attribute_name ) ); ?>"><?php echo wc_attribute_label( $attribute_name ); // WPCS: XSS ok. ?></label></td>
+						<td class="label"><label for="<?php echo $attribute_id; ?>"><?php echo wc_attribute_label( $attribute_name ); // WPCS: XSS ok. ?></label></td>
 						<td class="value">
 							<?php
 								wc_dropdown_variation_attribute_options(
@@ -43,6 +44,8 @@ do_action( 'woocommerce_before_add_to_cart_form' ); ?>
 										'options'   => $options,
 										'attribute' => $attribute_name,
 										'product'   => $product,
+										'id'		=> $attribute_id,
+										'class'		=> $attribute_name,
 									)
 								);
 								echo end( $attribute_keys ) === $attribute_name ? wp_kses_post( apply_filters( 'woocommerce_reset_variations_link', '<a class="reset_variations" href="#">' . esc_html__( 'Clear', 'woocommerce' ) . '</a>' ) ) : '';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Make attribute dropdown ID unique by adding phrase "attribute" and product ID. This eliminates risk of accidental duplicate ID. 

Closes #26832

### How to test the changes in this Pull Request:

1. View a variable product and check the attribute ID and label from fields

### Other information:

* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Made attribute dropdown ID unique. May require CSS stylesheet update if theme references attribute dropdown IDs. 
