### PR TITLE
Don't show the "WooCommerce Setup" widget in dashboard if WC Admin is disabled

### DIFF
--- a/includes/admin/class-wc-admin-dashboard-setup.php
+++ b/includes/admin/class-wc-admin-dashboard-setup.php
@@ -162,7 +162,9 @@ if ( ! class_exists( 'WC_Admin_Dashboard_Setup', false ) ) :
 		 * @return bool
 		 */
 		private function should_display_widget() {
-			return 'yes' !== get_option( 'woocommerce_task_list_complete' ) && 'yes' !== get_option( 'woocommerce_task_list_hidden' );
+			return WC()->is_wc_admin_active() &&
+				'yes' !== get_option( 'woocommerce_task_list_complete' ) &&
+				'yes' !== get_option( 'woocommerce_task_list_hidden' );
 		}
 
 		/**

--- a/includes/admin/class-wc-admin-dashboard.php
+++ b/includes/admin/class-wc-admin-dashboard.php
@@ -63,6 +63,10 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 		 * @return bool
 		 */
 		private function should_display_widget() {
+			if ( ! WC()->is_wc_admin_active() ) {
+				return false;
+			}
+
 			$has_permission           = current_user_can( 'view_woocommerce_reports' ) || current_user_can( 'manage_woocommerce' ) || current_user_can( 'publish_shop_orders' );
 			$task_completed_or_hidden = 'yes' === get_option( 'woocommerce_task_list_complete' ) || 'yes' === get_option( 'woocommerce_task_list_hidden' );
 			return $task_completed_or_hidden && $has_permission;
@@ -127,11 +131,11 @@ if ( ! class_exists( 'WC_Admin_Dashboard', false ) ) :
 
 			$reports = new WC_Admin_Report();
 
-			$net_sales_link = 'admin.php?page=wc-reports&tab=orders&range=month';
+			$net_sales_link  = 'admin.php?page=wc-reports&tab=orders&range=month';
 			$top_seller_link = 'admin.php?page=wc-reports&tab=orders&report=sales_by_product&range=month&product_ids=';
-			$report_data = $is_wc_admin_disabled ? $this->get_sales_report_data() : $this->get_wc_admin_performance_data();
+			$report_data     = $is_wc_admin_disabled ? $this->get_sales_report_data() : $this->get_wc_admin_performance_data();
 			if ( ! $is_wc_admin_disabled ) {
-				$net_sales_link = 'admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue&chart=net_revenue&orderby=net_revenue&period=month&compare=previous_period';
+				$net_sales_link  = 'admin.php?page=wc-admin&path=%2Fanalytics%2Frevenue&chart=net_revenue&orderby=net_revenue&period=month&compare=previous_period';
 				$top_seller_link = 'admin.php?page=wc-admin&filter=single_product&path=%2Fanalytics%2Fproducts&products=';
 			}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When the WooCommerce Admin component is disabled it doesn't make much sense to display the "WooCommerce Setup" widget, as clicking its "Start selling" button will produce an error; additionally, the entire dashboard will crash if the package is disabled (e.g. via the `woocommerce_admin_disabled` filter). So this pull request hides the widget when the package is disabled.

Closes #29567.

### How to test the changes in this Pull Request:

1. Make sure that you see the "WooCommerce Setup" widget in the dashboard (if you don't, delete the `woocommerce_task_list_complete` and `woocommerce_task_list_hidden` options).
2. Disable the admin package programmatically with `add_filter( 'woocommerce_admin_disabled', '__return_true' );` and reload the dashboard.

Without this fix (and in WooCommerce 5.2 RC 2) you'll get a "Call to undefined function wc_admin_url()" error, with this fix the dashboard will load and will not display the "WooCommerce Setup" widget.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Error when loading the admin dashboard while the admin package was disabled.
