### PR TITLE
Introduce the filter hook `woocommerce_breadcrumb_is_using_shop_base`

### DIFF
--- a/includes/class-wc-breadcrumb.php
+++ b/includes/class-wc-breadcrumb.php
@@ -93,14 +93,34 @@ class WC_Breadcrumb {
 	 * Prepend the shop page to shop breadcrumbs.
 	 */
 	protected function prepend_shop_page() {
-		$permalinks   = wc_get_permalink_structure();
 		$shop_page_id = wc_get_page_id( 'shop' );
 		$shop_page    = get_post( $shop_page_id );
 
 		// If permalinks contain the shop page in the URI prepend the breadcrumb with shop.
-		if ( $shop_page_id && $shop_page && isset( $permalinks['product_base'] ) && strstr( $permalinks['product_base'], '/' . $shop_page->post_name ) && intval( get_option( 'page_on_front' ) ) !== $shop_page_id ) {
+		if ( $shop_page_id && $shop_page && $this->is_using_shop_base( $shop_page ) && intval( get_option( 'page_on_front' ) ) !== $shop_page_id ) {
 			$this->add_crumb( get_the_title( $shop_page ), get_permalink( $shop_page ) );
 		}
+	}
+
+	/**
+	 * Checks if the permalinks product base is using the shop base.
+	 *
+	 * @param WP_Post $shop_page The shop page.
+	 *
+	 * @return bool
+	 */
+	private function is_using_shop_base( $shop_page ) {
+		$permalinks         = wc_get_permalink_structure();
+		$is_using_shop_base = isset( $permalinks['product_base'] ) && strstr( $permalinks['product_base'], '/' . $shop_page->post_name );
+
+		/**
+		 * Allows to filter the "is using shop base" condition.
+		 *
+		 * @since 5.3.0
+		 *
+		 * @param bool True if using shop base or false otherwise.
+		 */
+		return apply_filters( 'woocommerce_breadcrumb_is_using_shop_base', $is_using_shop_base );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This will allow to override the check if "is using shop base" in the breadcrumb as explained in https://github.com/woocommerce/woocommerce/issues/29618

Closes #29618  .

### How to test the changes in this Pull Request:
Here's a test that allows to insert the "Shop" crumb even if it's not using the shop base in permalinks
1. WC setup completed
2. Go to Settings > Permalinks and use "Default" for "Product permalinks"
3. Add the following code in your theme's `functions.php`:

```php
add_filter( 'woocommerce_breadcrumb_is_using_shop_base', '__return_true' );
```

4. Create a product a product and visit it on the frontend

=> We should see the "Shop" crumb

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Introduced the filter hook `woocommerce_breadcrumb_is_using_shop_base`.
