### PR TITLE
Fix e2e test merchant import products via csv

### DIFF
--- a/tests/e2e/core-tests/specs/merchant/wp-admin-product-import-csv.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-product-import-csv.test.js
@@ -43,8 +43,11 @@ const runImportProductsTest = () => {
 			await merchant.openImportProducts();
 		});
 		it('should show error message if you go without providing CSV file', async () => {
-			// Verify error message if you go without providing CSV file
-			await expect(page).toClick('button[value="Continue"]');
+			// Verify the error message if you go without providing CSV file
+			await Promise.all( [
+				page.click( 'button[value="Continue"]' ),
+				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+			]);
 			await page.waitForSelector('div.error');
 			await expect(page).toMatchElement('div.error > p', errorMessage);
 		});

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-product-import-csv.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-product-import-csv.test.js
@@ -14,7 +14,8 @@ const getCoreTestsRoot = require( '../../core-tests-root' );
  */
 const {
 	it,
-	describe
+	describe,
+	beforeAll,
 } = require( '@jest/globals' );
 
 const path = require( 'path' );

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-product-import-csv.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-product-import-csv.test.js
@@ -40,15 +40,16 @@ const runImportProductsTest = () => {
 		beforeAll(async () => {
 			await merchant.login();
 			await merchant.openAllProductsView();
-		});
-		it('can upload the CSV file and import products', async () => {
 			await merchant.openImportProducts();
-
-			// Verify error message if you go withot provided CSV file
+		});
+		it('should show error message if you go without providing CSV file', async () => {
+			// Verify error message if you go without providing CSV file
 			await expect(page).toClick('button[value="Continue"]');
 			await page.waitForSelector('div.error');
 			await expect(page).toMatchElement('div.error > p', errorMessage);
+		});
 
+		it('can upload the CSV file and import products', async () => {
 			// Put the CSV products file and proceed further
 			const uploader = await page.$("input[type=file]");
 			await uploader.uploadFile(filePath);
@@ -62,7 +63,9 @@ const runImportProductsTest = () => {
 			await page.waitForSelector('section.woocommerce-importer-done', {visible:true, timeout: 60000});
 			await page.waitForSelector('.woocommerce-importer-done');
 			await expect(page).toMatchElement('.woocommerce-importer-done', {text: 'Import complete!'});
+		});
 
+		it('can see and verify the uploaded products', async () => {
 			// Click on view products
 			await page.waitForSelector('div.wc-actions > a.button.button-primary');
 			await expect(page).toClick('div.wc-actions > a.button.button-primary');
@@ -70,7 +73,7 @@ const runImportProductsTest = () => {
 			// Gathering product names
 			await page.waitForSelector('a.row-title');
 			const productTitles = await page.$$eval('a.row-title',
-			 elements => elements.map(item => item.innerHTML));
+			elements => elements.map(item => item.innerHTML));
 
 			// Compare imported product names
 			expect(productTitles.sort()).toEqual(productNames.sort());
@@ -93,7 +96,9 @@ const runImportProductsTest = () => {
 			await page.waitForSelector('section.woocommerce-importer-done', {visible:true, timeout: 60000});
 			await page.waitForSelector('.woocommerce-importer-done');
 			await expect(page).toMatchElement('.woocommerce-importer-done', {text: 'Import complete!'});
+		});
 
+		it('can see and verify the uploaded overrode products', async () => {
 			// Click on view products
 			await page.waitForSelector('div.wc-actions > a.button.button-primary');
 			await expect(page).toClick('div.wc-actions > a.button.button-primary');
@@ -116,6 +121,7 @@ const runImportProductsTest = () => {
 
 			// Move all imported products to trash
 			await moveAllItemsToTrash();
+
 		});
 	});
 };


### PR DESCRIPTION
This is a quick fix for e2e merchant import products via csv test.

Changes in this pull request:

- Added missing `beforeAll`
- Made test more granular and added Promise.All for clicking the Continue button without providing CSV file