### PR TITLE
Call "wc_downloadable_file_permission" with the right product id

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -810,7 +810,7 @@ class WC_AJAX {
 
 			if ( ! empty( $files ) ) {
 				foreach ( $files as $download_id => $file ) {
-					$inserted_id = wc_downloadable_file_permission( $download_id, $product_id, $order, $item->get_quantity(), $item );
+					$inserted_id = wc_downloadable_file_permission( $download_id, $product->get_id(), $order, $item->get_quantity(), $item );
 					if ( $inserted_id ) {
 						$download = new WC_Customer_Download( $inserted_id );
 						$loop ++;


### PR DESCRIPTION
With the PR #23188, "$product_id" variable become undefined.

Just want to demonstrate the problem, feel free to close this and reimplement it. I haven't run the test suite at the moment of opening this PR.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### How to test the changes in this Pull Request:

1. Create an order for a downloadable product.
2. Open the order details in the admin area, and revoke access to the download for the user ("Revoke access" button in the "Downloadable product permissions" box)
3. Try to grant access to the same product again. Without this fix the request fails with a 500 (you need to look at the network requests to see that, the UI freezes in a waiting loop). With this fix the request succeeds and the permission is successfully granted.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A (it's a fix for something that had been broken in the RC)
