### PR TITLE
Use the same cart item key if set

### DIFF
--- a/includes/class-wc-cart.php
+++ b/includes/class-wc-cart.php
@@ -1123,8 +1123,13 @@ class WC_Cart extends WC_Legacy_Cart {
 			// Load cart item data - may be added by other plugins.
 			$cart_item_data = (array) apply_filters( 'woocommerce_add_cart_item_data', $cart_item_data, $product_id, $variation_id, $quantity );
 
-			// Generate a ID based on product ID, variation ID, variation data, and other cart item data.
-			$cart_id = $this->generate_cart_id( $product_id, $variation_id, $variation, $cart_item_data );
+			// If cart item key is set use it.
+			if( isset( $cart_item_data['cart_item_key'] ) && !empty( $cart_item_data['cart_item_key'] ) ){
+				$cart_id = $cart_item_data['cart_item_key'];
+			}else{
+				// Generate a ID based on product ID, variation ID, variation data, and other cart item data.
+				$cart_id = $this->generate_cart_id( $product_id, $variation_id, $variation, $cart_item_data );
+			}
 
 			// Find the cart item key in the existing cart.
 			$cart_item_key = $this->find_product_in_cart( $cart_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

While adding the product in the cart using the add_to_cart function, if the cart item key is set in the $cart_item_data ( last parameter of the add_to_cart function ) use it else generate it with cart item data.

### How to test the changes in this Pull Request:

1. Pass the cart_item_key parameter in the add_to_Cart function.
2.Add the product to the cart.
3.Same cart item key should be there.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
