### PR TITLE
Update wc-stock-functions.php

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -141,7 +141,6 @@ function wc_maybe_increase_stock_levels( $order_id ) {
 	$order->get_data_store()->set_stock_reduced( $order_id, false );
 }
 add_action( 'woocommerce_order_status_cancelled', 'wc_maybe_increase_stock_levels' );
-add_action( 'woocommerce_order_status_pending', 'wc_maybe_increase_stock_levels' );
 
 /**
  * Reduce stock levels for items within an order, if stock has not already been reduced for the items.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This  pull request is related to issue #29633 and fixes the stock reservation error.
The point of the problem is that product stock has to be reserved when change order status to pending payment.
If a user changes order status from on hold to pending payment stock increases that allows other consumer to place an order with the reserved product which is as I suppose unexpected behavior.
The solution is simple - just remove `add_action( 'woocommerce_order_status_pending', 'wc_maybe_increase_stock_levels' );` line  from includes/wc-stock-functions.php which I consider redundant

### How to test the changes in this Pull Request:

1. Add a product to the cart which have just 1 unit in stock.
2. Create an order, and use bank transfer payment method.
3. After the order is processed, change the order status from on-hold to pending payment.
4. Open another session in Incognito mode, find the same product of the previous order.
5. You will see that the product is out of stock which is expected

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

`add_action( 'woocommerce_order_status_pending', 'wc_maybe_increase_stock_levels' );` removed from wc-stock-functions.php