### PR TITLE
Update WooCommerce Blocks package to 4.9.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "2.1.5",
-    "woocommerce/woocommerce-blocks": "4.7.2"
+    "woocommerce/woocommerce-blocks": "4.9.1"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4"

--- a/composer.lock
+++ b/composer.lock
@@ -579,16 +579,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v4.7.2",
+            "version": "v4.9.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "942e58553b1a299ad04842e7f0d7465d9e029ac3"
+                "reference": "62f32bfb45dfcb2ba3ca349a6ed0a8cf48ddefce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/942e58553b1a299ad04842e7f0d7465d9e029ac3",
-                "reference": "942e58553b1a299ad04842e7f0d7465d9e029ac3",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/62f32bfb45dfcb2ba3ca349a6ed0a8cf48ddefce",
+                "reference": "62f32bfb45dfcb2ba3ca349a6ed0a8cf48ddefce",
                 "shasum": ""
             },
             "require": {
@@ -624,9 +624,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v4.7.2"
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v4.9.1"
             },
-            "time": "2021-04-13T16:06:16+00:00"
+            "time": "2021-04-13T16:11:16+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 4.9.1. It includes changes from WooCommerce Blocks 4.8.0 and 4.9.0 and intended to target WooCommerce 5.3.0 for release.

The changes from 4.9.1 are already included in WooCommerce 5.2.1 as part of WC Blocks 4.7.2. 

Details from all the different releases included in this pull:

### Blocks 4.8.0

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4018)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/480.md)
* [Release post](https://developer.woocommerce.com/2021/04/01/woocommerce-blocks-4-8-0-release-notes/)

### Blocks 4.9.0

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4053)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/490.md)
* [Release post](https://developer.woocommerce.com/2021/04/12/woocommerce-blocks-4-9-0-release-notes/)

### Blocks 4.9.1

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4058)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/a074162193ff8cf2dde019272e070963db4acd83/docs/testing/releases/491.md)
* [Release post](https://developer.woocommerce.com/2021/04/13/woocommerce-blocks-4-9-1-release-notes/)

### Changelog entry

> #### Enhancements
> 
> - Added compatibility with the Google Analytics Integration in WooCommerce Blocks. ([4020](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4020))
> 
> #### Bug Fixes
> 
> - Fix button alignment in Featured Product and Featured Category blocks. ([4028](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4028))
> 
> #### Technical debt
> 
> - Removed legacy handling for SSR blocks that rendered shortcodes. ([4010](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4010))
