### PR TITLE
Enable smoke test

### DIFF
--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -4,7 +4,7 @@ on:
     - cron: '25 3 * * *'
 jobs:
   login-run:
-    name: Log into smoke test site.
+    name: Daily smoke test on trunk.
     runs-on: ubuntu-18.04
     steps:
 
@@ -18,21 +18,26 @@ jobs:
       - name: Checkout code.
         uses: actions/checkout@v2
         with:
-          path: package/woocommerce
+          ref: trunk
 
-      - name: Run npm install.
-        working-directory: package/woocommerce
-        run: npm install
-
-      - name: Move current directory to code. We will install zip file in this dir later.
-        run: mv ./package/woocommerce/* ./code/woocommerce
-
-      - name: Run login test.
-        working-directory: code/woocommerce
+      - name: Install prerequisites.
+        run: |
+          npm install
+          composer install --no-dev
+          npm run build:assets
+          npm install jest
+          
+     - name: Run smoke test.
         env:
           SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_URL }}
           SMOKE_TEST_ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}
           SMOKE_TEST_ADMIN_PASSWORD: ${{ secrets.SMOKE_TEST_ADMIN_PASSWORD }}
           SMOKE_TEST_CUSTOMER_USER: ${{ secrets.SMOKE_TEST_CUSTOMER_USER }}
           SMOKE_TEST_CUSTOMER_PASSWORD: ${{ secrets.SMOKE_TEST_CUSTOMER_PASSWORD }}
-        run: npx wc-e2e test:e2e ./tests/e2e/specs/activate-and-setup/test-activation.js
+          WC_E2E_SCREENSHOTS: 1
+          E2E_RETEST: 1
+          E2E_SLACK_TOKEN: ${{ secrets.SMOKE_TEST_SLACK_TOKEN }}
+          E2E_SLACK_CHANNEL: ${{ secrets.SMOKE_TEST_SLACK_CHANNEL }}
+        run: |
+          npx wc-e2e docker:up
+          npx wc-e2e test:e2e

--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -27,7 +27,7 @@ jobs:
           npm run build:assets
           npm install jest
           
-     - name: Run smoke test.
+      - name: Run smoke test.
         env:
           SMOKE_TEST_URL: ${{ secrets.SMOKE_TEST_URL }}
           SMOKE_TEST_ADMIN_USER: ${{ secrets.SMOKE_TEST_ADMIN_USER }}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR depends on #29623. It updates the smoke test daily action to run the full E2E test suite against the smoke test site.

Closes #28485 .

### How to test the changes in this Pull Request:

1. This can only be tested once merged.
2. Review job configuration changes.

### Changelog entry

N/A
