### PR TITLE
Update WooCommerce Blocks package to 4.7.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "2.1.5",
-    "woocommerce/woocommerce-blocks": "4.7.1"
+    "woocommerce/woocommerce-blocks": "4.7.2"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5005eed74baf10300e2895e9b6a4f344",
+    "content-hash": "aaad3b20adf49ba997d4be94865087c6",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -579,16 +579,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v4.7.1",
+            "version": "v4.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "841c49b8626f4eb717056a2d1e3eba6140f45e2c"
+                "reference": "942e58553b1a299ad04842e7f0d7465d9e029ac3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/841c49b8626f4eb717056a2d1e3eba6140f45e2c",
-                "reference": "841c49b8626f4eb717056a2d1e3eba6140f45e2c",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/942e58553b1a299ad04842e7f0d7465d9e029ac3",
+                "reference": "942e58553b1a299ad04842e7f0d7465d9e029ac3",
                 "shasum": ""
             },
             "require": {
@@ -624,9 +624,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v4.7.1"
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v4.7.2"
             },
-            "time": "2021-04-02T11:18:50+00:00"
+            "time": "2021-04-13T16:06:16+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
**Note:** This pull request is a duplicate, [the original one](https://github.com/woocommerce/woocommerce/pull/29659) was mistakenly merged to the `release/5.2` branch.

This pull updates the WooCommerce Blocks plugin to 4.7.2.

Closes https://github.com/woocommerce/woocommerce/issues/29656.

## Blocks 4.7.2

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4060)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/472.md)
* No release post.

## Testing instructions

Verify that you can use the [Elementor](https://elementor.com/) plugin in PHP 8 without errors.

### Changelog entry

> Update - WooCommerce Blocks package 4.7.2.