### PR TITLE
Release preparation: 5.2.1

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,5 +1,15 @@
 == Changelog ==
 
+= 5.2.1 2021-04-14 =
+
+**WooCommerce**
+
+* Update - WooCommerce Blocks package 4.7.2. #29660
+
+**WooCommerce Blocks - 4.7.2**
+
+* Fix - Check if Cart and Checkout are registered before removing payment methods. ([4056](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4056))
+
 = 5.2.0 2021-04-13 =
 
 **WooCommerce**

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.5
 Tested up to: 5.7
 Requires PHP: 7.0
-Stable tag: 5.2.0
+Stable tag: 5.2.1
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -159,6 +159,16 @@ If you encounter issues with the shop/category pages after an update, flush the 
 WooCommerce comes with some sample data you can use to see how products look; import sample_products.xml via the [WordPress importer](https://wordpress.org/plugins/wordpress-importer/). You can also use the core [CSV importer](https://docs.woocommerce.com/document/product-csv-importer-exporter/?utm_source=wp%20org%20repo%20listing&utm_content=3.6) or our [CSV Import Suite extension](https://woocommerce.com/products/product-csv-import-suite/?utm_source=wp%20org%20repo%20listing&utm_content=3.6) to import sample_products.csv
 
 == Changelog ==
+
+= 5.2.1 2021-04-14 =
+
+**WooCommerce**
+
+* Update - WooCommerce Blocks package 4.7.2. #29660
+
+**WooCommerce Blocks - 4.7.2**
+
+* Fix - Check if Cart and Checkout are registered before removing payment methods. ([4056](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4056))
 
 = 5.2.0 2021-04-13 =
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

* Add new entries for WooCommerce, Admin and Blocks to `changelog.txt`; and copy them to `readme.txt`
* Set the `stable` tag in `readme.txt` to `5.2.1`

### Important!

After this is merged and cherrypicked into `release/5.2`, that branch needs to get an extra commit that:

* Changes `Version` in `woocommerce.php` to `5.2.1`

Commit: https://github.com/woocommerce/woocommerce/commit/f17f11a50bc3c56caa0fe0bc5dc6067240c408c8