### PR TITLE
Remove rounding of taxes displayed in items meta table

### DIFF
--- a/plugins/woocommerce/changelog/fix-tax_data_rounded_on_save
+++ b/plugins/woocommerce/changelog/fix-tax_data_rounded_on_save
@@ -1,0 +1,4 @@
+Significance: patch
+Type: fix
+
+Display the raw 6 decimal place tax data while editing line item

--- a/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/views/html-order-item.php
@@ -141,11 +141,6 @@ $row_class    = apply_filters( 'woocommerce_admin_html_order_item_class', ! empt
 			$tax_item_total    = isset( $tax_data['total'][ $tax_item_id ] ) ? $tax_data['total'][ $tax_item_id ] : '';
 			$tax_item_subtotal = isset( $tax_data['subtotal'][ $tax_item_id ] ) ? $tax_data['subtotal'][ $tax_item_id ] : '';
 
-			if ( '' !== $tax_item_subtotal ) {
-				$round_at_subtotal = 'yes' === get_option( 'woocommerce_tax_round_at_subtotal' );
-				$tax_item_total    = wc_round_tax_total( $tax_item_total, $round_at_subtotal ? wc_get_rounding_precision() : null );
-				$tax_item_subtotal = wc_round_tax_total( $tax_item_subtotal, $round_at_subtotal ? wc_get_rounding_precision() : null );
-			}
 			?>
 			<td class="line_tax" width="1%">
 				<div class="view">


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

When an order is saved via the edit order screen, the `_line_tax_data` line item metadata is updated, removing the 6 decimal place precision and leading to off-by-1 issues for WC Subscriptions. 

WC Subscriptions issue: 3996-gh-woocommerce/woocommerce-subscriptions

### How to test the changes in this Pull Request:

1. Prices include tax
2. Tax calculated on shop base location
3. A 10% tax applies
4. The product price is $80 - https://d.pr/i/8Taq4I
5. Purchase the product - https://d.pr/i/kYgdit
6. Look at the order line item's meta in the database - https://d.pr/i/3kySSY
    - Note the `_line_tax_data` is to 6 decimal place and the line item subtotal is also 6 decimal places.
7. View the admin edit order screen. 
8. Without any changes click save/update.
6. Look at the order line item's meta in the database again - https://d.pr/i/eLjHJr
    - Note the `_line_tax_data` is now 2 decimal place and the line item subtotal is still 6 decimal places.
7. On this branch the tax data isn't changed on order save. 
8. On this branch the tax and line item subtotal number of decimal places also match - https://d.pr/i/X3SUKx
### Other information:

I've probably misunderstood the setting so please let me know if there's another fix for this. The reason I believe this might be the fix is because of what happens when you edit the line item, you see this: 

<img width="467" alt="Screen Shot 2021-04-15 at 3 05 12 pm" src="https://user-images.githubusercontent.com/8490476/114816704-04a25900-9dfc-11eb-8fe3-16ca17777c50.png">

The line item total isn't rounded but the tax is. When saved this leads to the order's total no longer adding up. 
72.727273 + 7.27 = 79.997273 != 80. 

I'm not fully across what the intended outcome of the _Round tax at subtotal level, instead of rounding per line_ setting (https://d.pr/i/jKGciD) is which is why I think I'm probably missing something here. 

The section of code I'm removing was added in https://github.com/woocommerce/woocommerce/commit/7f65a33fe8652338ce55daaa3c8f9e90f51aba4e. If the tax needs to be rounded here, then we need to make sure that only happens when figures are recalculated/changed, and not just changed on saving arbitrarily. At the end of the day, the number of decimals for the tax and subtotal should be the same. 

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Fix: display the raw 6 decimal place tax data while editing line item