### PR TITLE
Fix: can't grant permission to downloadable product from order.

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -805,7 +805,7 @@ class WC_AJAX {
 
 			if ( ! empty( $files ) ) {
 				foreach ( $files as $download_id => $file ) {
-					$inserted_id = wc_downloadable_file_permission( $download_id, $product->get_id(), $order, $item->get_quantity(), $item );
+					$inserted_id = wc_downloadable_file_permission( $download_id, $product_id, $order );
 					if ( $inserted_id ) {
 						$download = new WC_Customer_Download( $inserted_id );
 						$loop ++;


### PR DESCRIPTION
**NOTE:** This pull request targets the `release/5.2` branch and **that's on purpose**, details below.

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/23188 added a bug (unable to grant download permissions from order details) that was fixed in https://github.com/woocommerce/woocommerce/pull/29631. So far so good. The problem: the original PR was included in WooCommerce 5.2.0 even though it had the 5.3 milestone, and the fix was included in 5.2.0 too. The fix release 5.2.1 excluded the original PR but not the fix PR, which then became a bug PR in itself.

This pull request fixes the problem (by undoing the fix PR) but only in the 5.2 release branch, since `trunk` already contains both the original and the fix PR and works fine.

Closes #29679.

### How to test the changes in this Pull Request:

1. Create an order for a downloadable product.
2. Open the order details in the admin area, and revoke access to the download for the user ("Revoke access" button in the "Downloadable product permissions" box)
3. Try to grant access to the same product again. Without this fix the request fails with a 500 (you need to look at the network requests to see that, the UI freezes in a waiting loop). With this fix the request succeeds and the permission is successfully granted.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Can't grant permission for download from order details page.
