### PR TITLE
Add new e2e test shopper order email receiving

### DIFF
--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Added
 
 - Support for re-running setup and shopper tests
+- Shopper Order Email Receiving
 
 ## Fixed
 

--- a/tests/e2e/core-tests/README.md
+++ b/tests/e2e/core-tests/README.md
@@ -86,6 +86,7 @@ The functions to access the core tests are:
   - `runCheckoutLoginAccountTest` - Shopper can login to an account during checkout
   - `runMyAccountCreateAccountTest` - Shopper can create an account via my account page
   - `runCartRedirectionTest` - Shopper is redirected to the cart page after adding to cart
+  - `runOrderEmailReceivingTest` - Shopper can receive an email for his order
 
 ### REST API
 

--- a/tests/e2e/core-tests/specs/index.js
+++ b/tests/e2e/core-tests/specs/index.js
@@ -22,6 +22,7 @@ const runVariableProductUpdateTest = require( './shopper/front-end-variable-prod
 const runCheckoutCreateAccountTest = require( './shopper/front-end-checkout-create-account.test' );
 const runCheckoutLoginAccountTest = require( './shopper/front-end-checkout-login-account.test' );
 const runCartRedirectionTest = require( './shopper/front-end-cart-redirection.test' );
+const runOrderEmailReceivingTest = require( './shopper/front-end-order-email-receiving.test' );
 
 // Merchant tests
 const runAddNewShippingZoneTest = require ( './merchant/wp-admin-settings-shipping-zones.test' );
@@ -70,7 +71,8 @@ const runShopperTests = () => {
 	runVariableProductUpdateTest();
 	runCheckoutCreateAccountTest();
 	runCheckoutLoginAccountTest();
-  runCartRedirectionTest();
+	runCartRedirectionTest();
+	runOrderEmailReceivingTest();
 };
 
 const runMerchantTests = () => {
@@ -144,8 +146,9 @@ module.exports = {
 	runAddShippingClassesTest,
 	runAnalyticsPageLoadsTest,
 	runCheckoutCreateAccountTest,
-  runImportProductsTest,
+	runImportProductsTest,
 	runCheckoutLoginAccountTest,
 	runCartRedirectionTest,
 	runMyAccountCreateAccountTest,
+	runOrderEmailReceivingTest,
 };

--- a/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
@@ -7,6 +7,7 @@
 	merchant,
 	createSimpleProduct,
 	uiUnblocked,
+    deleteAllEmailLogs,
 } = require( '@woocommerce/e2e-utils' );
 
 let simplePostIdValue;
@@ -29,6 +30,7 @@ const runOrderEmailReceivingTest = () => {
 	describe('Shopper Order Email Receiving', () => {
 		beforeAll(async () => {
 			await merchant.login();
+            await deleteAllEmailLogs();
 			simplePostIdValue = await createSimpleProduct();
 			await merchant.logout();
 		});

--- a/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
@@ -7,7 +7,7 @@
 	merchant,
 	createSimpleProduct,
 	uiUnblocked,
-    deleteAllEmailLogs,
+	deleteAllEmailLogs,
 } = require( '@woocommerce/e2e-utils' );
 
 let simplePostIdValue;
@@ -30,7 +30,7 @@ const runOrderEmailReceivingTest = () => {
 	describe('Shopper Order Email Receiving', () => {
 		beforeAll(async () => {
 			await merchant.login();
-            await deleteAllEmailLogs();
+			await deleteAllEmailLogs();
 			simplePostIdValue = await createSimpleProduct();
 			await merchant.logout();
 		});

--- a/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
@@ -1,0 +1,57 @@
+/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/expect-expect */
+/**
+ * Internal dependencies
+ */
+ const {
+	shopper,
+	merchant,
+	createSimpleProduct,
+	uiUnblocked,
+} = require( '@woocommerce/e2e-utils' );
+
+let simplePostIdValue;
+let orderId;
+const config = require( 'config' );
+const simpleProductName = config.get( 'products.simple.name' );
+const customerEmail = config.get( 'addresses.customer.billing.email' );
+const storeName = 'WooCommerce Core E2E Test Suite';
+
+/**
+ * External dependencies
+ */
+const {
+	it,
+	describe,
+	beforeAll,
+} = require( '@jest/globals' );
+
+const runOrderEmailReceivingTest = () => {
+	describe('Shopper Order Email Receiving', () => {
+		beforeAll(async () => {
+			await merchant.login();
+			simplePostIdValue = await createSimpleProduct();
+			await merchant.logout();
+		});
+
+		it('should receive order email after purchasing an item', async () => {
+			await shopper.login();
+
+			// Go to the shop and purchase an item
+			await shopper.goToProduct(simplePostIdValue);
+			await shopper.addToCart(simpleProductName);
+			await shopper.goToCheckout();
+			await uiUnblocked();
+			await shopper.placeOrder();
+			// Get order ID from the order received html element on the page
+			orderId = await page.$$eval(".woocommerce-order-overview__order strong", elements => elements.map(item => item.textContent));
+
+			// Verify the new order email has been received
+			await merchant.login();
+			await merchant.openEmailLog();
+			await expect( page ).toMatchElement( '.column-receiver', { text: customerEmail } );
+			await expect( page ).toMatchElement( '.column-subject', { text: `[${storeName}]: New order #${orderId}` } );
+		});
+	});
+};
+
+module.exports = runOrderEmailReceivingTest;

--- a/tests/e2e/specs/front-end/test-order-email-receiving.js
+++ b/tests/e2e/specs/front-end/test-order-email-receiving.js
@@ -1,0 +1,6 @@
+/*
+ * Internal dependencies
+ */
+const { runOrderEmailReceivingTest } = require( '@woocommerce/e2e-core-tests' );
+
+runOrderEmailReceivingTest();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29420

### How to test the changes in this Pull Request:

- npx wc-e2e test:e2e-dev ./tests/e2e/specs/front-end/test-order-email-receiving.js

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
