### PR TITLE
Add a GitHub action for automatic assignment of a milestone to merged PRs

### DIFF
--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -21,7 +21,7 @@ jobs:
         --location $GITHUB_API_URL/repos/${{ github.repository }}/contents/.github/workflows/scripts/assign-milestone-to-merged-pr.php
       env:
         GITHUB_API_URL: ${{ env.GITHUB_API_URL }}
-    - name: Install PHP
+    - name: "Install PHP"
       uses: shivammathur/setup-php@v2
       with:
         php-version: '7.4'

--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -1,0 +1,32 @@
+name: "Pull request post-merge processing"
+on: 
+  pull_request:
+    types: [closed]
+
+jobs:
+  assign-milestone:
+    name: "Assign milestone to merged pull request"
+    if: github.event.pull_request.merged == true && ! github.event.pull_request.milestone
+    runs-on: ubuntu-latest
+    steps:
+    - name: "Get the milestone changer script"
+      run: |
+        curl \
+        --silent \
+        --fail \
+        --header 'Authorization: bearer ${{ secrets.GITHUB_TOKEN }}' \
+        --header 'User-Agent: GitHub action to set the milestone for a pull request' \
+        --header 'Accept: application/vnd.github.v3.raw' \
+        --remote-name \
+        --location $GITHUB_API_URL/repos/${{ github.repository }}/contents/.github/workflows/scripts/assign-milestone-to-merged-pr.php
+      env:
+        GITHUB_API_URL: ${{ env.GITHUB_API_URL }}
+    - name: Install PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: '7.4'
+    - name: "Run the milestone changer script"
+      run: php assign-milestone-to-merged-pr.php
+      env:
+        PULL_REQUEST_ID: ${{ github.event.pull_request.node_id }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scripts/assign-milestone-to-merged-pr.php
+++ b/.github/workflows/scripts/assign-milestone-to-merged-pr.php
@@ -1,0 +1,144 @@
+<?php
+/**
+ * Script to automatically assign a milestone to a pull request when it's merged.
+ *
+ * @package WooCommerce/GithubActions
+ */
+
+// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions
+
+global $repo_owner, $repo_name, $github_token, $graphql_api_url;
+
+/**
+ * Grab/process input.
+ */
+
+$repo_parts = explode( '/', getenv( 'GITHUB_REPOSITORY' ) );
+$repo_owner = $repo_parts[0];
+$repo_name  = $repo_parts[1];
+
+$pr_id           = getenv( 'PULL_REQUEST_ID' );
+$github_token    = getenv( 'GITHUB_TOKEN' );
+$graphql_api_url = getenv( 'GITHUB_GRAPHQL_URL' );
+
+/**
+ * Select the milestone to be added:
+ *
+ * 1. Get the first 10 milestones sorted by creation date descending.
+ *    (we'll never have more than 2 or 3 active milestones but let's get 10 to be sure).
+ * 2. Discard those not open or whose title is not a proper version number ("X.Y.Z").
+ * 3. Sort descending using version_compare.
+ * 4. Get the oldest one that does not have a corresponding "release/X.Y" branch.
+ */
+
+echo "Getting the list of milestones...\n";
+
+$query      = "
+  repository(owner:\"$repo_owner\", name:\"$repo_name\") {
+    milestones(first: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
+      nodes {
+        id
+        title
+        state
+      }
+    }
+  }
+";
+$json       = do_graphql_api_request( $query );
+$milestones = $json['data']['repository']['milestones']['nodes'];
+$milestones = array_map(
+	function( $x ) {
+		return 'OPEN' === $x['state'] && 1 === preg_match( '/^\d+\.\d+\.\d+$/D', $x['title'] ) ? $x : null;
+	},
+	$milestones
+);
+$milestones = array_filter( $milestones );
+usort(
+	$milestones,
+	function( $a, $b ) {
+		return version_compare( $b['title'], $a['title'] );
+	}
+);
+
+echo 'Latest open milestone: ' . $milestones[0]['title'] . "\n";
+
+$chosen_milestone = null;
+foreach ( $milestones as $milestone ) {
+	$milestone_title_parts    = explode( '.', $milestone['title'] );
+	$milestone_release_branch = 'release/' . $milestone_title_parts[0] . '.' . $milestone_title_parts[1];
+
+	$query  = "
+    repository(owner:\"$repo_owner\", name:\"$repo_name\") {
+      ref(qualifiedName: \"refs/heads/$milestone_release_branch\") {
+        id
+      }
+    }
+  ";
+	$result = do_graphql_api_request( $query );
+
+	if ( is_null( $result['data']['repository']['ref'] ) ) {
+		$chosen_milestone = $milestone;
+	} else {
+		break;
+	}
+}
+
+// If all the milestones have a release branch, just take the newest one.
+if ( is_null( $chosen_milestone ) ) {
+	$chosen_milestone = $milestones[0];
+}
+
+echo 'Milestone that will be assigned: ' . $chosen_milestone['title'] . "\n";
+
+if ( getenv( 'DRY_RUN' ) ) {
+	echo "Dry run, skipping the actual milestone assignment\n";
+	return;
+}
+
+/*
+ * Assign the milestone to the pull request.
+ */
+
+echo "Assigning the milestone to the pull request...\n";
+
+$milestone_id = $chosen_milestone['id'];
+$mutation     = "
+  updatePullRequest(input: {pullRequestId: \"$pr_id\", milestoneId: \"$milestone_id\"}) {
+    clientMutationId
+  }
+";
+
+do_graphql_api_request( $mutation, true );
+
+/**
+ * Function to query the GitHub GraphQL API.
+ *
+ * @param string $body The GraphQL-formatted request body, without "query" or "mutation" wrapper.
+ * @param bool   $is_mutation True if the request is a mutation, false if it's a query.
+ * @return array The json-decoded response.
+ */
+function do_graphql_api_request( $body, $is_mutation = false ) {
+	global $github_token, $graphql_api_url;
+
+	$keyword = $is_mutation ? 'mutation' : 'query';
+	$data    = array( 'query' => "$keyword { $body }" );
+	$context = stream_context_create(
+		array(
+			'http' => array(
+				'method'  => 'POST',
+				'header'  => array(
+					'Accept: application/json',
+					'Content-Type: application/json',
+					'User-Agent: GitHub action to set the milestone for a pull request',
+					'Authorization: bearer ' . $github_token,
+				),
+				'content' => json_encode( $data ),
+			),
+		)
+	);
+
+	$result = file_get_contents( $graphql_api_url, false, $context );
+	return json_decode( $result, true );
+}
+
+// phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions

--- a/.github/workflows/scripts/assign-milestone-to-merged-pr.php
+++ b/.github/workflows/scripts/assign-milestone-to-merged-pr.php
@@ -35,7 +35,7 @@ echo "Getting the list of milestones...\n";
 
 $query      = "
   repository(owner:\"$repo_owner\", name:\"$repo_name\") {
-    milestones(first: 10, orderBy: {field: CREATED_AT, direction: DESC}) {
+    milestones(first: 10, states: [OPEN], orderBy: {field: CREATED_AT, direction: DESC}) {
       nodes {
         id
         title
@@ -48,7 +48,7 @@ $json       = do_graphql_api_request( $query );
 $milestones = $json['data']['repository']['milestones']['nodes'];
 $milestones = array_map(
 	function( $x ) {
-		return 'OPEN' === $x['state'] && 1 === preg_match( '/^\d+\.\d+\.\d+$/D', $x['title'] ) ? $x : null;
+		return 1 === preg_match( '/^\d+\.\d+\.\d+$/D', $x['title'] ) ? $x : null;
 	},
 	$milestones
 );


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add a GitHub action that will assign a milestone to any pull request as soon as it's merged, except when the pull request had already a milestone assigned.

The milestone to assign is chosen as follows:

1. List all the open milestones with a title of "X.Y.Z".
2. Sort them descending using `version_compare`.
3. `foreach` them in order, and take the last one not having a corresponding release branch (`release/X.Y`)

For example: if milestones 5.4.0, 5.3.0, 5.2.0 and 5.1.0 exist, and only 5.2.0 has a release branch (`release/5.2`), then the assigned milestone will be 5.3.0.

### How to test the changes in this Pull Request:

Create a sandbox repository and copy the files in this pull request to it using the same directory structure. Then create some milestones (with and without a proper name, open and closed) and some corresponding release branches, create and merge pull requests, and verify that it's working as expected.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

N/A