### PR TITLE
Add a GitHub action to manually trigger the generation of a release zip file

### DIFF
--- a/.github/workflows/build-release-zip-file.yml
+++ b/.github/workflows/build-release-zip-file.yml
@@ -1,0 +1,30 @@
+name: Build release zip file
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'By default the zip file is generated from the branch the workflow runs from, but you can specify an explicit reference to use instead here (e.g. refs/tags/tag_name). The resulting file will be available as an artifact on the workflow run.'
+        required: false
+        default: ''
+jobs:
+  build:
+    name: Build release zip file
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.inputs.ref || github.ref }}
+      - name: Build the zip file
+        id: build
+        uses: woocommerce/action-build@v2
+      - name: Unzip the file (prevents double zip problem)
+        run: unzip ${{ steps.build.outputs.zip_path }} -d zipfile
+      - name: Upload the zip file as an artifact
+        uses: actions/upload-artifact@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          name: woocommerce
+          path: zipfile
+          retention-days: 7


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add a new GitHub action, intended to be triggered manually (defined with `on: workflow_dispatch`) that allows the generation of a ZIP file from any branch or tag; the generated file remains as an artifact of the workflow run after it completes. With this there's no need to publish a release in GitHub in order to have a release file anymore.

### How to test the changes in this Pull Request:

Create an empty repository and copy the `.github/workflows/build-release-zip-file.yml` file to it. Then change it as follows so that it acts on the WooCommerce repository:

    steps:
      - name: Checkout code
        uses: actions/checkout@v2
        with:
          repository: 'woocommerce/woocommerce' <--- ADD THIS
          ref: ${{ github.event.inputs.ref || github.ref }}
      - name: Build the zip file
        id: build
        uses: woocommerce/action-build@v2
        env:                         <--- ADD THIS
          PLUGIN_SLUG: 'woocommerce' <--- ADD THIS

Go to the _Actions_ tab in the repository page and select _Build release zip file_ on the left. Click the _Run workflow_ button. If you just click the green _Run workflow_ button now it will create a zip file for `trunk` (or for whatever branch you select for the workflow to run on, but of course your testing repo won't have the real WooCommerce branches); to create a zip file for a tag write `refs/tags/tag_name` in the textbox before running the workflow (or for a branch: `refs/heads/branch_name`).

The process will take about 8 minutes, once finished there will be a downloadable artifact. Although it will say it's 26MB, that's the uncompressed size, the file you'll get is actually 8MB.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Add - GitHub action to manually trigger the generation of a release zip file
