### PR TITLE
Make sure customer note and shipping via text is properly translating

### DIFF
--- a/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/plugins/woocommerce/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -402,7 +402,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 
 										<# if ( data.shipping_via ) { #>
 											<strong><?php esc_html_e( 'Shipping method', 'woocommerce' ); ?></strong>
-											{{ data.shipping_via }}
+											{{{ data.shipping_via }}}
 										<# } #>
 									</div>
 								<# } #>
@@ -410,7 +410,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 								<# if ( data.data.customer_note ) { #>
 									<div class="wc-order-preview-note">
 										<strong><?php esc_html_e( 'Note', 'woocommerce' ); ?></strong>
-										{{ data.data.customer_note }}
+										{{{ data.data.customer_note }}}
 									</div>
 								<# } #>
 							</div>


### PR DESCRIPTION
This fixes issues with translator plugins that don't translate customer notes as an example due to it not being handled properly by WooCommerce

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The changes made are making translator plugins like WP Multilang and others like it able to display proper langauge of the customer note and Shipping Via texts.

### How to test the changes in this Pull Request:

1. Install a plugin like WP Multilang. 
2. Setup 2 languages.
3. Setup an an product with some attributes and variations. 
4. Translate the product and its attributes etc. to the 2 languages
5. Buy the product.
6. Check the Order Preview Template on the order page. 
7. You will se that the languages are proper if the fix is made. Otherwise the langauges wont display properly.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### Changelog entry

Changed {{ data.shipping_via }} to {{{ data.shipping_via }}}
Changed {{ data.data.customer_note }} to {{{ data.data.customer_note }}}
