### PR TITLE
Quick fix, ask if $options is an array

### DIFF
--- a/includes/admin/helper/class-wc-helper-options.php
+++ b/includes/admin/helper/class-wc-helper-options.php
@@ -51,7 +51,7 @@ class WC_Helper_Options {
 	 */
 	public static function get( $key, $default = false ) {
 		$options = get_option( self::$option_name, array() );
-		if ( array_key_exists( $key, $options ) ) {
+		if ( is_array($options) && array_key_exists( $key, $options ) ) {
 			return $options[ $key ];
 		}
 


### PR DESCRIPTION
Ask if $options is an array before ask if $key exists on this array. This prevents some annoying errors found after site cloning when the plugin is installed but options are missing

### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. No need, it is self-explanatory.
2. 
3.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
