### PR TITLE
Modify wc_get_low_stock_amount function to always return a number

### DIFF
--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -411,5 +411,5 @@ function wc_get_low_stock_amount( WC_Product $product ) {
 		$low_stock_amount = get_option( 'woocommerce_notify_low_stock_amount', 2 );
 	}
 
-	return $low_stock_amount;
+	return intval( $low_stock_amount );
 }

--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -411,5 +411,5 @@ function wc_get_low_stock_amount( WC_Product $product ) {
 		$low_stock_amount = get_option( 'woocommerce_notify_low_stock_amount', 2 );
 	}
 
-	return intval( $low_stock_amount );
+	return (int) $low_stock_amount;
 }

--- a/includes/wc-stock-functions.php
+++ b/includes/wc-stock-functions.php
@@ -403,7 +403,7 @@ function wc_get_low_stock_amount( WC_Product $product ) {
 	$low_stock_amount = $product->get_low_stock_amount();
 
 	if ( '' === $low_stock_amount && $product->is_type( 'variation' ) ) {
-		$product = wc_get_product( $product->get_parent_id() );
+		$product          = wc_get_product( $product->get_parent_id() );
 		$low_stock_amount = $product->get_low_stock_amount();
 	}
 

--- a/tests/legacy/framework/class-wc-unit-test-case.php
+++ b/tests/legacy/framework/class-wc-unit-test-case.php
@@ -7,6 +7,7 @@
 
 use Automattic\WooCommerce\Proxies\LegacyProxy;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\CodeHacker;
+use PHPUnit\Framework\Constraint\IsType;
 
 /**
  * WC Unit Test Case.
@@ -248,13 +249,14 @@ class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 	}
 
 	/**
-	 * Check if a value is of integer type.
-	 * This function is already built-in in PHPUnit 8 so this one can be removed once we upgrade to that version of newer.
+	 * Asserts that a variable is of type int.
+	 * TODO: After upgrading to PHPUnit 8 or newer, remove this method and replace calls with PHPUnit's built-in 'assertIsInt'.
 	 *
-	 * @param mixed $value The value to check.
+	 * @param mixed $actual The value to check.
+	 * @param mixed $message Error message to use if the assertion fails.
 	 * @return bool mixed True if the value is of integer type, false otherwise.
 	 */
-	protected function assertIsInt( $value ) {
-		return $this->assertInternalType( 'int', $value );
+	public static function assertIsInteger( $actual, $message = '' ) {
+		return self::assertInternalType( 'int', $actual, $message );
 	}
 }

--- a/tests/legacy/framework/class-wc-unit-test-case.php
+++ b/tests/legacy/framework/class-wc-unit-test-case.php
@@ -246,4 +246,15 @@ class WC_Unit_Test_Case extends WP_HTTP_TestCase {
 	public function register_legacy_proxy_class_mocks( array $mocks ) {
 		wc_get_container()->get( LegacyProxy::class )->register_class_mocks( $mocks );
 	}
+
+	/**
+	 * Check if a value is of integer type.
+	 * This function is already built-in in PHPUnit 8 so this one can be removed once we upgrade to that version of newer.
+	 *
+	 * @param mixed $value The value to check.
+	 * @return bool mixed True if the value is of integer type, false otherwise.
+	 */
+	protected function assertIsInt( $value ) {
+		return $this->assertInternalType( 'int', $value );
+	}
 }

--- a/tests/php/includes/wc-stock-functions-tests.php
+++ b/tests/php/includes/wc-stock-functions-tests.php
@@ -228,8 +228,8 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$product = WC_Helper_Product::create_simple_product(
 			true,
 			array(
-				'manage_stock'     => true,
-				'stock_quantity'   => 10,
+				'manage_stock'   => true,
+				'stock_quantity' => 10,
 			)
 		);
 
@@ -254,7 +254,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 
 		// Set the variation low stock amount.
 		$variations = $variable_product->get_available_variations( 'objects' );
-		$var1 = $variations[0];
+		$var1       = $variations[0];
 		$var1->set_manage_stock( true );
 		$var1->set_low_stock_amount( $variation_low_stock_amount );
 		$var1->save();
@@ -292,7 +292,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 
 		// Set the variation low stock amount.
 		$variations = $variable_product->get_available_variations( 'objects' );
-		$var1 = $variations[0];
+		$var1       = $variations[0];
 		$var1->set_manage_stock( true );
 		$var1->set_low_stock_amount( $variation_low_stock_amount );
 		$var1->save();
@@ -319,7 +319,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 
 		// Don't set the variation low stock amount.
 		$variations = $variable_product->get_available_variations( 'objects' );
-		$var1 = $variations[0];
+		$var1       = $variations[0];
 
 		$this->assertEquals( $parent_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
 	}
@@ -340,7 +340,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 
 		// Don't set the variation low stock amount.
 		$variations = $variable_product->get_available_variations( 'objects' );
-		$var1 = $variations[0];
+		$var1       = $variations[0];
 		$var1->set_manage_stock( false );
 
 		$this->assertEquals( $site_wide_low_stock_amount, wc_get_low_stock_amount( $var1 ) );

--- a/tests/php/includes/wc-stock-functions-tests.php
+++ b/tests/php/includes/wc-stock-functions-tests.php
@@ -193,6 +193,17 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Assert that a value is equal to another one and is of integer type.
+	 *
+	 * @param mixed $expected The value $actual must be equal to.
+	 * @param mixed $actual The value to check for equality to $expected and for type.
+	 */
+	private function assertIsIntAndEquals( $expected, $actual ) {
+		$this->assertEquals( $expected, $actual );
+		$this->assertIsInt( $actual );
+	}
+
+	/**
 	 * Test wc_get_low_stock_amount with a simple product which has low stock amount set.
 	 */
 	public function test_wc_get_low_stock_amount_simple_set() {
@@ -200,7 +211,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$site_wide_low_stock_amount = 3;
 
 		// Set the store-wide default.
-		update_option( 'woocommerce_notify_low_stock_amount', $site_wide_low_stock_amount );
+		update_option( 'woocommerce_notify_low_stock_amount', strval( $site_wide_low_stock_amount ) );
 
 		// Simple product, set low stock amount.
 		$product = WC_Helper_Product::create_simple_product(
@@ -212,7 +223,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertEquals( $product_low_stock_amount, wc_get_low_stock_amount( $product ) );
+		$this->assertIsIntAndEquals( $product_low_stock_amount, wc_get_low_stock_amount( $product ) );
 	}
 
 	/**
@@ -222,7 +233,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$site_wide_low_stock_amount = 3;
 
 		// Set the store-wide default.
-		update_option( 'woocommerce_notify_low_stock_amount', $site_wide_low_stock_amount );
+		update_option( 'woocommerce_notify_low_stock_amount', strval( $site_wide_low_stock_amount ) );
 
 		// Simple product, don't set low stock amount.
 		$product = WC_Helper_Product::create_simple_product(
@@ -233,7 +244,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 			)
 		);
 
-		$this->assertEquals( $site_wide_low_stock_amount, wc_get_low_stock_amount( $product ) );
+		$this->assertIsIntAndEquals( $site_wide_low_stock_amount, wc_get_low_stock_amount( $product ) );
 	}
 
 	/**
@@ -245,7 +256,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$variation_low_stock_amount = 7;
 
 		// Set the store-wide default.
-		update_option( 'woocommerce_notify_low_stock_amount', $site_wide_low_stock_amount );
+		update_option( 'woocommerce_notify_low_stock_amount', strval( $site_wide_low_stock_amount ) );
 
 		// Parent low stock amount NOT set.
 		$variable_product = WC_Helper_Product::create_variation_product();
@@ -259,17 +270,17 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$var1->set_low_stock_amount( $variation_low_stock_amount );
 		$var1->save();
 
-		$this->assertEquals( $variation_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
+		$this->assertIsIntAndEquals( $variation_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
 
 		// Even after turning on manage stock on the parent, but with no value.
 		$variable_product->set_manage_stock( true );
 		$variable_product->save();
-		$this->assertEquals( $variation_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
+		$this->assertIsIntAndEquals( $variation_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
 
 		// Ans also after turning the manage stock off again on the parent.
 		$variable_product->set_manage_stock( false );
 		$variable_product->save();
-		$this->assertEquals( $variation_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
+		$this->assertIsIntAndEquals( $variation_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
 	}
 
 	/**
@@ -282,7 +293,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$variation_low_stock_amount = 7;
 
 		// Set the store-wide default.
-		update_option( 'woocommerce_notify_low_stock_amount', $site_wide_low_stock_amount );
+		update_option( 'woocommerce_notify_low_stock_amount', strval( $site_wide_low_stock_amount ) );
 
 		// Set the parent low stock amount.
 		$variable_product = WC_Helper_Product::create_variation_product();
@@ -297,7 +308,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$var1->set_low_stock_amount( $variation_low_stock_amount );
 		$var1->save();
 
-		$this->assertEquals( $variation_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
+		$this->assertIsIntAndEquals( $variation_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
 	}
 
 	/**
@@ -309,7 +320,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$parent_low_stock_amount    = 5;
 
 		// Set the store-wide default.
-		update_option( 'woocommerce_notify_low_stock_amount', $site_wide_low_stock_amount );
+		update_option( 'woocommerce_notify_low_stock_amount', strval( $site_wide_low_stock_amount ) );
 
 		// Set the parent low stock amount.
 		$variable_product = WC_Helper_Product::create_variation_product();
@@ -321,7 +332,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$variations = $variable_product->get_available_variations( 'objects' );
 		$var1       = $variations[0];
 
-		$this->assertEquals( $parent_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
+		$this->assertIsIntAndEquals( $parent_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
 	}
 
 	/**
@@ -332,7 +343,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$site_wide_low_stock_amount = 3;
 
 		// Set the store-wide default.
-		update_option( 'woocommerce_notify_low_stock_amount', $site_wide_low_stock_amount );
+		update_option( 'woocommerce_notify_low_stock_amount', strval( $site_wide_low_stock_amount ) );
 
 		// Set the parent low stock amount.
 		$variable_product = WC_Helper_Product::create_variation_product();
@@ -343,7 +354,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 		$var1       = $variations[0];
 		$var1->set_manage_stock( false );
 
-		$this->assertEquals( $site_wide_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
+		$this->assertIsIntAndEquals( $site_wide_low_stock_amount, wc_get_low_stock_amount( $var1 ) );
 	}
 
 }

--- a/tests/php/includes/wc-stock-functions-tests.php
+++ b/tests/php/includes/wc-stock-functions-tests.php
@@ -200,7 +200,7 @@ class WC_Stock_Functions_Tests extends \WC_Unit_Test_Case {
 	 */
 	private function assertIsIntAndEquals( $expected, $actual ) {
 		$this->assertEquals( $expected, $actual );
-		$this->assertIsInt( $actual );
+		self::assertIsInteger( $actual );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `wc_get_low_stock_amount` function is documented as returning an `int`, but when a product didn't have an explicit low stock amount configured the default value from the `woocommerce_notify_low_stock_amount` was returned verbatim, and that value is stored as a string. This pull request makes sure that the function always returns a number.

Also the related unit tests are updated so that they set the value of the `woocommerce_notify_low_stock_amount` option as a string, which is what actually happens in WooCommerce; and now they also verify that the function returns a number.

Closes #29525.

### How to test the changes in this Pull Request:

The easiest way to test this is by using the wp cli tool.

1. Create/edit a product so that it has "Enable stock management at product level" set and "Low stock threshold" unset:

![image](https://user-images.githubusercontent.com/937723/115363338-a93ce600-a1c2-11eb-880a-20932ddf900e.png)

2. Take note of the product id, it's in the product edit page url (`?post=...`) or in the products list (`ID: ...` when you hover the product row).

3. Run this in a console: 

```php
wp eval 'echo gettype(wc_get_low_stock_amount(wc_get_product(<product id>)));'
```

Without the fix you'll get `string`, with the fix you'll get `integer`.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - wc_get_low_stock_amount was returning a string, not an integer, for products not having an explicit low stock value set.
