### PR TITLE
Feature/add input filters

### DIFF
--- a/includes/admin/wc-meta-box-functions.php
+++ b/includes/admin/wc-meta-box-functions.php
@@ -1,296 +1,284 @@
 <?php
-	/**
-	 * WooCommerce Meta Box Functions
-	 *
-	 * @author      WooThemes
-	 * @category    Core
-	 * @package     WooCommerce\Admin\Functions
-	 * @version     2.3.0
-	 */
-	if ( ! defined( 'ABSPATH' ) ) {
-		exit; // Exit if accessed directly
+/**
+ * WooCommerce Meta Box Functions
+ *
+ * @author      WooThemes
+ * @category    Core
+ * @package     WooCommerce\Admin\Functions
+ * @version     2.3.0
+ */
+if ( ! defined( 'ABSPATH' ) ) {
+	exit; // Exit if accessed directly
+}
+
+/**
+ * Output a text input box.
+ *
+ * @param array $field
+ */
+function woocommerce_wp_text_input( $field ) {
+	global $thepostid, $post;
+
+	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
+	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
+	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
+	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
+	$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
+	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
+	$field['type']          = isset( $field['type'] ) ? $field['type'] : 'text';
+	$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
+	$data_type              = empty( $field['data_type'] ) ? '' : $field['data_type'];
+
+	switch ( $data_type ) {
+		case 'price':
+			$field['class'] .= ' wc_input_price';
+			$field['value']  = wc_format_localized_price( $field['value'] );
+			break;
+		case 'decimal':
+			$field['class'] .= ' wc_input_decimal';
+			$field['value']  = wc_format_localized_decimal( $field['value'] );
+			break;
+		case 'stock':
+			$field['class'] .= ' wc_input_stock';
+			$field['value']  = wc_stock_amount( $field['value'] );
+			break;
+		case 'url':
+			$field['class'] .= ' wc_input_url';
+			$field['value']  = esc_url( $field['value'] );
+			break;
+
+		default:
+			break;
 	}
 
-	/**
-	 * Output a text input box.
-	 *
-	 * @param array $field
-	 */
-	function woocommerce_wp_text_input( $field ) {
-		global $thepostid, $post;
+	// Custom attribute handling
+	$custom_attributes = array();
 
-		$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
-		$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
-		$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
-		$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
-		$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
-		$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
-		$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
-		$field['type']          = isset( $field['type'] ) ? $field['type'] : 'text';
-		$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
-		$data_type              = empty( $field['data_type'] ) ? '' : $field['data_type'];
+	if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
 
-		switch ( $data_type ) {
-			case 'price':
-				$field['class'] .= ' wc_input_price';
-				$field['value']  = wc_format_localized_price( $field['value'] );
-				break;
-			case 'decimal':
-				$field['class'] .= ' wc_input_decimal';
-				$field['value']  = wc_format_localized_decimal( $field['value'] );
-				break;
-			case 'stock':
-				$field['class'] .= ' wc_input_stock';
-				$field['value']  = wc_stock_amount( $field['value'] );
-				break;
-			case 'url':
-				$field['class'] .= ' wc_input_url';
-				$field['value']  = esc_url( $field['value'] );
-				break;
-
-			default:
-				break;
+		foreach ( $field['custom_attributes'] as $attribute => $value ) {
+			$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
 		}
-
-		// Custom attribute handling
-		$custom_attributes = array();
-
-		$field = apply_filters( 'woocommerce_input_text_filter', $field );
-
-		if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
-
-			foreach ( $field['custom_attributes'] as $attribute => $value ) {
-				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
-			}
-		}
-
-		echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
-        <label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
-
-		if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
-			echo wc_help_tip( $field['description'] );
-		}
-
-		echo '<input type="' . esc_attr( $field['type'] ) . '" class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '" name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" ' . implode( ' ', $custom_attributes ) . ' /> ';
-
-		if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
-			echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
-		}
-
-		echo '</p>';
 	}
 
-	/**
-	 * Output a hidden input box.
-	 *
-	 * @param array $field
-	 */
-	function woocommerce_wp_hidden_input( $field ) {
-		global $thepostid, $post;
+	echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
+	<label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
 
-		$thepostid      = empty( $thepostid ) ? $post->ID : $thepostid;
-		$field['value'] = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
-		$field['class'] = isset( $field['class'] ) ? $field['class'] : '';
-
-		$field = apply_filters( 'woocommerce_input_hidden_filter', $field );
-
-		echo '<input type="hidden" class="' . esc_attr( $field['class'] ) . '" name="' . esc_attr( $field['id'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) . '" /> ';
+	if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
+		echo wc_help_tip( $field['description'] );
 	}
 
-	/**
-	 * Output a textarea input box.
-	 *
-	 * @param array $field
-	 */
-	function woocommerce_wp_textarea_input( $field ) {
-		global $thepostid, $post;
+	echo '<input type="' . esc_attr( $field['type'] ) . '" class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '" name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" ' . implode( ' ', $custom_attributes ) . ' /> ';
 
-		$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
-		$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
-		$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
-		$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
-		$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
-		$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
-		$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
-		$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
-		$field['rows']          = isset( $field['rows'] ) ? $field['rows'] : 2;
-		$field['cols']          = isset( $field['cols'] ) ? $field['cols'] : 20;
-
-		// Custom attribute handling
-		$custom_attributes = array();
-
-		$field = apply_filters( 'woocommerce_input_textarea_filter', $field );
-
-		if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
-
-			foreach ( $field['custom_attributes'] as $attribute => $value ) {
-				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
-			}
-		}
-
-		echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
-        <label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
-
-		if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
-			echo wc_help_tip( $field['description'] );
-		}
-
-		echo '<textarea class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '"  name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" rows="' . esc_attr( $field['rows'] ) . '" cols="' . esc_attr( $field['cols'] ) . '" ' . implode( ' ', $custom_attributes ) . '>' . esc_textarea( $field['value'] ) . '</textarea> ';
-
-		if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
-			echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
-		}
-
-		echo '</p>';
+	if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
+		echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
 	}
 
-	/**
-	 * Output a checkbox input box.
-	 *
-	 * @param array $field
-	 */
-	function woocommerce_wp_checkbox( $field ) {
-		global $thepostid, $post;
+	echo '</p>';
+}
 
-		$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
-		$field['class']         = isset( $field['class'] ) ? $field['class'] : 'checkbox';
-		$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
-		$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
-		$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
-		$field['cbvalue']       = isset( $field['cbvalue'] ) ? $field['cbvalue'] : 'yes';
-		$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
-		$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
+/**
+ * Output a hidden input box.
+ *
+ * @param array $field
+ */
+function woocommerce_wp_hidden_input( $field ) {
+	global $thepostid, $post;
 
-		// Custom attribute handling
-		$custom_attributes = array();
+	$thepostid      = empty( $thepostid ) ? $post->ID : $thepostid;
+	$field['value'] = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
+	$field['class'] = isset( $field['class'] ) ? $field['class'] : '';
 
-		$field = apply_filters( 'woocommerce_input_checkbox_filter', $field );
+	echo '<input type="hidden" class="' . esc_attr( $field['class'] ) . '" name="' . esc_attr( $field['id'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) . '" /> ';
+}
 
-		if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
+/**
+ * Output a textarea input box.
+ *
+ * @param array $field
+ */
+function woocommerce_wp_textarea_input( $field ) {
+	global $thepostid, $post;
 
-			foreach ( $field['custom_attributes'] as $attribute => $value ) {
-				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
-			}
+	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
+	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
+	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
+	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
+	$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
+	$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
+	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
+	$field['rows']          = isset( $field['rows'] ) ? $field['rows'] : 2;
+	$field['cols']          = isset( $field['cols'] ) ? $field['cols'] : 20;
+
+	// Custom attribute handling
+	$custom_attributes = array();
+
+	if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
+
+		foreach ( $field['custom_attributes'] as $attribute => $value ) {
+			$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
 		}
-
-		echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
-        <label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
-
-		if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
-			echo wc_help_tip( $field['description'] );
-		}
-
-		echo '<input type="checkbox" class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '" name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['cbvalue'] ) . '" ' . checked( $field['value'], $field['cbvalue'], false ) . '  ' . implode( ' ', $custom_attributes ) . '/> ';
-
-		if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
-			echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
-		}
-
-		echo '</p>';
 	}
 
-	/**
-	 * Output a select input box.
-	 *
-	 * @param array $field Data about the field to render.
-	 */
-	function woocommerce_wp_select( $field ) {
-		global $thepostid, $post;
+	echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
+	<label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
 
-		$thepostid = empty( $thepostid ) ? $post->ID : $thepostid;
-		$field     = wp_parse_args(
-			$field, array(
-				'class'             => 'select short',
-				'style'             => '',
-				'wrapper_class'     => '',
-				'value'             => get_post_meta( $thepostid, $field['id'], true ),
-				'name'              => $field['id'],
-				'desc_tip'          => false,
-				'custom_attributes' => array(),
-			)
-		);
-
-		$field = apply_filters( 'woocommerce_input_select_filter', $field );
-
-		$wrapper_attributes = array(
-			'class' => $field['wrapper_class'] . " form-field {$field['id']}_field",
-		);
-
-		$label_attributes = array(
-			'for' => $field['id'],
-		);
-
-		$field_attributes          = (array) $field['custom_attributes'];
-		$field_attributes['style'] = $field['style'];
-		$field_attributes['id']    = $field['id'];
-		$field_attributes['name']  = $field['name'];
-		$field_attributes['class'] = $field['class'];
-
-		$tooltip     = ! empty( $field['description'] ) && false !== $field['desc_tip'] ? $field['description'] : '';
-		$description = ! empty( $field['description'] ) && false === $field['desc_tip'] ? $field['description'] : '';
-		?>
-		<p <?php echo wc_implode_html_attributes( $wrapper_attributes ); // WPCS: XSS ok. ?>>
-			<label <?php echo wc_implode_html_attributes( $label_attributes ); // WPCS: XSS ok. ?>><?php echo wp_kses_post( $field['label'] ); ?></label>
-			<?php if ( $tooltip ) : ?>
-				<?php echo wc_help_tip( $tooltip ); // WPCS: XSS ok. ?>
-			<?php endif; ?>
-			<select <?php echo wc_implode_html_attributes( $field_attributes ); // WPCS: XSS ok. ?>>
-				<?php
-					foreach ( $field['options'] as $key => $value ) {
-						echo '<option value="' . esc_attr( $key ) . '"' . wc_selected( $key, $field['value'] ) . '>' . esc_html( $value ) . '</option>';
-					}
-				?>
-			</select>
-			<?php if ( $description ) : ?>
-				<span class="description"><?php echo wp_kses_post( $description ); ?></span>
-			<?php endif; ?>
-		</p>
-		<?php
+	if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
+		echo wc_help_tip( $field['description'] );
 	}
 
-	/**
-	 * Output a radio input box.
-	 *
-	 * @param array $field
-	 */
-	function woocommerce_wp_radio( $field ) {
-		global $thepostid, $post;
+	echo '<textarea class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '"  name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" rows="' . esc_attr( $field['rows'] ) . '" cols="' . esc_attr( $field['cols'] ) . '" ' . implode( ' ', $custom_attributes ) . '>' . esc_textarea( $field['value'] ) . '</textarea> ';
 
-		$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
-		$field['class']         = isset( $field['class'] ) ? $field['class'] : 'select short';
-		$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
-		$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
-		$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
-		$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
-		$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
-
-		$field = apply_filters( 'woocommerce_input_radio_filter', $field );
-
-		echo '<fieldset class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '"><legend>' . wp_kses_post( $field['label'] ) . '</legend>';
-
-		if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
-			echo wc_help_tip( $field['description'] );
-		}
-
-		echo '<ul class="wc-radios">';
-
-		foreach ( $field['options'] as $key => $value ) {
-
-			echo '<li><label><input
-                name="' . esc_attr( $field['name'] ) . '"
-                value="' . esc_attr( $key ) . '"
-                type="radio"
-                class="' . esc_attr( $field['class'] ) . '"
-                style="' . esc_attr( $field['style'] ) . '"
-                ' . checked( esc_attr( $field['value'] ), esc_attr( $key ), false ) . '
-                /> ' . esc_html( $value ) . '</label>
-        </li>';
-		}
-		echo '</ul>';
-
-		if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
-			echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
-		}
-
-		echo '</fieldset>';
+	if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
+		echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
 	}
+
+	echo '</p>';
+}
+
+/**
+ * Output a checkbox input box.
+ *
+ * @param array $field
+ */
+function woocommerce_wp_checkbox( $field ) {
+	global $thepostid, $post;
+
+	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'checkbox';
+	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
+	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
+	$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
+	$field['cbvalue']       = isset( $field['cbvalue'] ) ? $field['cbvalue'] : 'yes';
+	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
+	$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
+
+	// Custom attribute handling
+	$custom_attributes = array();
+
+	if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
+
+		foreach ( $field['custom_attributes'] as $attribute => $value ) {
+			$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
+		}
+	}
+
+	echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
+	<label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
+
+	if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
+		echo wc_help_tip( $field['description'] );
+	}
+
+	echo '<input type="checkbox" class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '" name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['cbvalue'] ) . '" ' . checked( $field['value'], $field['cbvalue'], false ) . '  ' . implode( ' ', $custom_attributes ) . '/> ';
+
+	if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
+		echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
+	}
+
+	echo '</p>';
+}
+
+/**
+ * Output a select input box.
+ *
+ * @param array $field Data about the field to render.
+ */
+function woocommerce_wp_select( $field ) {
+	global $thepostid, $post;
+
+	$thepostid = empty( $thepostid ) ? $post->ID : $thepostid;
+	$field     = wp_parse_args(
+		$field, array(
+			'class'             => 'select short',
+			'style'             => '',
+			'wrapper_class'     => '',
+			'value'             => get_post_meta( $thepostid, $field['id'], true ),
+			'name'              => $field['id'],
+			'desc_tip'          => false,
+			'custom_attributes' => array(),
+		)
+	);
+
+	$wrapper_attributes = array(
+		'class' => $field['wrapper_class'] . " form-field {$field['id']}_field",
+	);
+
+	$label_attributes = array(
+		'for' => $field['id'],
+	);
+
+	$field_attributes          = (array) $field['custom_attributes'];
+	$field_attributes['style'] = $field['style'];
+	$field_attributes['id']    = $field['id'];
+	$field_attributes['name']  = $field['name'];
+	$field_attributes['class'] = $field['class'];
+
+	$tooltip     = ! empty( $field['description'] ) && false !== $field['desc_tip'] ? $field['description'] : '';
+	$description = ! empty( $field['description'] ) && false === $field['desc_tip'] ? $field['description'] : '';
+	?>
+	<p <?php echo wc_implode_html_attributes( $wrapper_attributes ); // WPCS: XSS ok. ?>>
+		<label <?php echo wc_implode_html_attributes( $label_attributes ); // WPCS: XSS ok. ?>><?php echo wp_kses_post( $field['label'] ); ?></label>
+		<?php if ( $tooltip ) : ?>
+			<?php echo wc_help_tip( $tooltip ); // WPCS: XSS ok. ?>
+		<?php endif; ?>
+		<select <?php echo wc_implode_html_attributes( $field_attributes ); // WPCS: XSS ok. ?>>
+			<?php
+				foreach ( $field['options'] as $key => $value ) {
+					echo '<option value="' . esc_attr( $key ) . '"' . wc_selected( $key, $field['value'] ) . '>' . esc_html( $value ) . '</option>';
+				}
+			?>
+		</select>
+		<?php if ( $description ) : ?>
+			<span class="description"><?php echo wp_kses_post( $description ); ?></span>
+		<?php endif; ?>
+	</p>
+	<?php
+}
+
+/**
+ * Output a radio input box.
+ *
+ * @param array $field
+ */
+function woocommerce_wp_radio( $field ) {
+	global $thepostid, $post;
+
+	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'select short';
+	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
+	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
+	$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
+	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
+	$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
+
+	echo '<fieldset class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '"><legend>' . wp_kses_post( $field['label'] ) . '</legend>';
+
+	if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
+		echo wc_help_tip( $field['description'] );
+	}
+
+	echo '<ul class="wc-radios">';
+
+	foreach ( $field['options'] as $key => $value ) {
+
+		echo '<li><label><input
+			name="' . esc_attr( $field['name'] ) . '"
+			value="' . esc_attr( $key ) . '"
+			type="radio"
+			class="' . esc_attr( $field['class'] ) . '"
+			style="' . esc_attr( $field['style'] ) . '"
+			' . checked( esc_attr( $field['value'] ), esc_attr( $key ), false ) . '
+			/> ' . esc_html( $value ) . '</label>
+	</li>';
+	}
+	echo '</ul>';
+
+	if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
+		echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
+	}
+
+	echo '</fieldset>';
+}

--- a/includes/admin/wc-meta-box-functions.php
+++ b/includes/admin/wc-meta-box-functions.php
@@ -1,284 +1,294 @@
 <?php
-/**
- * WooCommerce Meta Box Functions
- *
- * @author      WooThemes
- * @category    Core
- * @package     WooCommerce\Admin\Functions
- * @version     2.3.0
- */
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
-}
-
-/**
- * Output a text input box.
- *
- * @param array $field
- */
-function woocommerce_wp_text_input( $field ) {
-	global $thepostid, $post;
-
-	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
-	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
-	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
-	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
-	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
-	$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
-	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
-	$field['type']          = isset( $field['type'] ) ? $field['type'] : 'text';
-	$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
-	$data_type              = empty( $field['data_type'] ) ? '' : $field['data_type'];
-
-	switch ( $data_type ) {
-		case 'price':
-			$field['class'] .= ' wc_input_price';
-			$field['value']  = wc_format_localized_price( $field['value'] );
-			break;
-		case 'decimal':
-			$field['class'] .= ' wc_input_decimal';
-			$field['value']  = wc_format_localized_decimal( $field['value'] );
-			break;
-		case 'stock':
-			$field['class'] .= ' wc_input_stock';
-			$field['value']  = wc_stock_amount( $field['value'] );
-			break;
-		case 'url':
-			$field['class'] .= ' wc_input_url';
-			$field['value']  = esc_url( $field['value'] );
-			break;
-
-		default:
-			break;
+	/**
+	 * WooCommerce Meta Box Functions
+	 *
+	 * @author      WooThemes
+	 * @category    Core
+	 * @package     WooCommerce\Admin\Functions
+	 * @version     2.3.0
+	 */
+	if ( ! defined( 'ABSPATH' ) ) {
+		exit; // Exit if accessed directly
 	}
 
-	// Custom attribute handling
-	$custom_attributes = array();
+	/**
+	 * Output a text input box.
+	 *
+	 * @param array $field
+	 */
+	function woocommerce_wp_text_input( $field ) {
+		global $thepostid, $post;
 
-	if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
+		$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+		$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
+		$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
+		$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
+		$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
+		$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
+		$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
+		$field['type']          = isset( $field['type'] ) ? $field['type'] : 'text';
+		$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
+		$data_type              = empty( $field['data_type'] ) ? '' : $field['data_type'];
 
-		foreach ( $field['custom_attributes'] as $attribute => $value ) {
-			$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
+		switch ( $data_type ) {
+			case 'price':
+				$field['class'] .= ' wc_input_price';
+				$field['value']  = wc_format_localized_price( $field['value'] );
+				break;
+			case 'decimal':
+				$field['class'] .= ' wc_input_decimal';
+				$field['value']  = wc_format_localized_decimal( $field['value'] );
+				break;
+			case 'stock':
+				$field['class'] .= ' wc_input_stock';
+				$field['value']  = wc_stock_amount( $field['value'] );
+				break;
+			case 'url':
+				$field['class'] .= ' wc_input_url';
+				$field['value']  = esc_url( $field['value'] );
+				break;
+
+			default:
+				break;
 		}
-	}
 
-	echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
-		<label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
+		// Custom attribute handling
+		$custom_attributes = array();
 
-	if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
-		echo wc_help_tip( $field['description'] );
-	}
+		if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
 
-	echo '<input type="' . esc_attr( $field['type'] ) . '" class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '" name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" ' . implode( ' ', $custom_attributes ) . ' /> ';
-
-	if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
-		echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
-	}
-
-	echo '</p>';
-}
-
-/**
- * Output a hidden input box.
- *
- * @param array $field
- */
-function woocommerce_wp_hidden_input( $field ) {
-	global $thepostid, $post;
-
-	$thepostid      = empty( $thepostid ) ? $post->ID : $thepostid;
-	$field['value'] = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
-	$field['class'] = isset( $field['class'] ) ? $field['class'] : '';
-
-	echo '<input type="hidden" class="' . esc_attr( $field['class'] ) . '" name="' . esc_attr( $field['id'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) . '" /> ';
-}
-
-/**
- * Output a textarea input box.
- *
- * @param array $field
- */
-function woocommerce_wp_textarea_input( $field ) {
-	global $thepostid, $post;
-
-	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
-	$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
-	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
-	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
-	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
-	$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
-	$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
-	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
-	$field['rows']          = isset( $field['rows'] ) ? $field['rows'] : 2;
-	$field['cols']          = isset( $field['cols'] ) ? $field['cols'] : 20;
-
-	// Custom attribute handling
-	$custom_attributes = array();
-
-	if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
-
-		foreach ( $field['custom_attributes'] as $attribute => $value ) {
-			$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
-		}
-	}
-
-	echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
-		<label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
-
-	if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
-		echo wc_help_tip( $field['description'] );
-	}
-
-	echo '<textarea class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '"  name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" rows="' . esc_attr( $field['rows'] ) . '" cols="' . esc_attr( $field['cols'] ) . '" ' . implode( ' ', $custom_attributes ) . '>' . esc_textarea( $field['value'] ) . '</textarea> ';
-
-	if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
-		echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
-	}
-
-	echo '</p>';
-}
-
-/**
- * Output a checkbox input box.
- *
- * @param array $field
- */
-function woocommerce_wp_checkbox( $field ) {
-	global $thepostid, $post;
-
-	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
-	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'checkbox';
-	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
-	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
-	$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
-	$field['cbvalue']       = isset( $field['cbvalue'] ) ? $field['cbvalue'] : 'yes';
-	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
-	$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
-
-	// Custom attribute handling
-	$custom_attributes = array();
-
-	if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
-
-		foreach ( $field['custom_attributes'] as $attribute => $value ) {
-			$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
-		}
-	}
-
-	echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
-		<label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
-
-	if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
-		echo wc_help_tip( $field['description'] );
-	}
-
-	echo '<input type="checkbox" class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '" name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['cbvalue'] ) . '" ' . checked( $field['value'], $field['cbvalue'], false ) . '  ' . implode( ' ', $custom_attributes ) . '/> ';
-
-	if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
-		echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
-	}
-
-	echo '</p>';
-}
-
-/**
- * Output a select input box.
- *
- * @param array $field Data about the field to render.
- */
-function woocommerce_wp_select( $field ) {
-	global $thepostid, $post;
-
-	$thepostid = empty( $thepostid ) ? $post->ID : $thepostid;
-	$field     = wp_parse_args(
-		$field, array(
-			'class'             => 'select short',
-			'style'             => '',
-			'wrapper_class'     => '',
-			'value'             => get_post_meta( $thepostid, $field['id'], true ),
-			'name'              => $field['id'],
-			'desc_tip'          => false,
-			'custom_attributes' => array(),
-		)
-	);
-
-	$wrapper_attributes = array(
-		'class' => $field['wrapper_class'] . " form-field {$field['id']}_field",
-	);
-
-	$label_attributes = array(
-		'for' => $field['id'],
-	);
-
-	$field_attributes          = (array) $field['custom_attributes'];
-	$field_attributes['style'] = $field['style'];
-	$field_attributes['id']    = $field['id'];
-	$field_attributes['name']  = $field['name'];
-	$field_attributes['class'] = $field['class'];
-
-	$tooltip     = ! empty( $field['description'] ) && false !== $field['desc_tip'] ? $field['description'] : '';
-	$description = ! empty( $field['description'] ) && false === $field['desc_tip'] ? $field['description'] : '';
-	?>
-	<p <?php echo wc_implode_html_attributes( $wrapper_attributes ); // WPCS: XSS ok. ?>>
-		<label <?php echo wc_implode_html_attributes( $label_attributes ); // WPCS: XSS ok. ?>><?php echo wp_kses_post( $field['label'] ); ?></label>
-		<?php if ( $tooltip ) : ?>
-			<?php echo wc_help_tip( $tooltip ); // WPCS: XSS ok. ?>
-		<?php endif; ?>
-		<select <?php echo wc_implode_html_attributes( $field_attributes ); // WPCS: XSS ok. ?>>
-			<?php
-			foreach ( $field['options'] as $key => $value ) {
-				echo '<option value="' . esc_attr( $key ) . '"' . wc_selected( $key, $field['value'] ) . '>' . esc_html( $value ) . '</option>';
+			foreach ( $field['custom_attributes'] as $attribute => $value ) {
+				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
 			}
-			?>
-		</select>
-		<?php if ( $description ) : ?>
-			<span class="description"><?php echo wp_kses_post( $description ); ?></span>
-		<?php endif; ?>
-	</p>
-	<?php
-}
+		}
 
-/**
- * Output a radio input box.
- *
- * @param array $field
- */
-function woocommerce_wp_radio( $field ) {
-	global $thepostid, $post;
+		$field = apply_filters( 'woocommerce_input_text_filter', $field );
 
-	$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
-	$field['class']         = isset( $field['class'] ) ? $field['class'] : 'select short';
-	$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
-	$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
-	$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
-	$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
-	$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
+		echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
+        <label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
 
-	echo '<fieldset class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '"><legend>' . wp_kses_post( $field['label'] ) . '</legend>';
+		if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
+			echo wc_help_tip( $field['description'] );
+		}
 
-	if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
-		echo wc_help_tip( $field['description'] );
+		echo '<input type="' . esc_attr( $field['type'] ) . '" class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '" name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" ' . implode( ' ', $custom_attributes ) . ' /> ';
+
+		if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
+			echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
+		}
+
+		echo '</p>';
 	}
 
-	echo '<ul class="wc-radios">';
+	/**
+	 * Output a hidden input box.
+	 *
+	 * @param array $field
+	 */
+	function woocommerce_wp_hidden_input( $field ) {
+		global $thepostid, $post;
 
-	foreach ( $field['options'] as $key => $value ) {
+		$thepostid      = empty( $thepostid ) ? $post->ID : $thepostid;
+		$field['value'] = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
+		$field['class'] = isset( $field['class'] ) ? $field['class'] : '';
 
-		echo '<li><label><input
-				name="' . esc_attr( $field['name'] ) . '"
-				value="' . esc_attr( $key ) . '"
-				type="radio"
-				class="' . esc_attr( $field['class'] ) . '"
-				style="' . esc_attr( $field['style'] ) . '"
-				' . checked( esc_attr( $field['value'] ), esc_attr( $key ), false ) . '
-				/> ' . esc_html( $value ) . '</label>
-		</li>';
-	}
-	echo '</ul>';
-
-	if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
-		echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
+		echo '<input type="hidden" class="' . esc_attr( $field['class'] ) . '" name="' . esc_attr( $field['id'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) . '" /> ';
 	}
 
-	echo '</fieldset>';
-}
+	/**
+	 * Output a textarea input box.
+	 *
+	 * @param array $field
+	 */
+	function woocommerce_wp_textarea_input( $field ) {
+		global $thepostid, $post;
+
+		$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+		$field['placeholder']   = isset( $field['placeholder'] ) ? $field['placeholder'] : '';
+		$field['class']         = isset( $field['class'] ) ? $field['class'] : 'short';
+		$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
+		$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
+		$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
+		$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
+		$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
+		$field['rows']          = isset( $field['rows'] ) ? $field['rows'] : 2;
+		$field['cols']          = isset( $field['cols'] ) ? $field['cols'] : 20;
+
+		// Custom attribute handling
+		$custom_attributes = array();
+
+		if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
+
+			foreach ( $field['custom_attributes'] as $attribute => $value ) {
+				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
+			}
+		}
+
+		$field = apply_filters( 'woocommerce_input_textarea_filter', $field );
+
+		echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
+        <label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
+
+		if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
+			echo wc_help_tip( $field['description'] );
+		}
+
+		echo '<textarea class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '"  name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" placeholder="' . esc_attr( $field['placeholder'] ) . '" rows="' . esc_attr( $field['rows'] ) . '" cols="' . esc_attr( $field['cols'] ) . '" ' . implode( ' ', $custom_attributes ) . '>' . esc_textarea( $field['value'] ) . '</textarea> ';
+
+		if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
+			echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
+		}
+
+		echo '</p>';
+	}
+
+	/**
+	 * Output a checkbox input box.
+	 *
+	 * @param array $field
+	 */
+	function woocommerce_wp_checkbox( $field ) {
+		global $thepostid, $post;
+
+		$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+		$field['class']         = isset( $field['class'] ) ? $field['class'] : 'checkbox';
+		$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
+		$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
+		$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
+		$field['cbvalue']       = isset( $field['cbvalue'] ) ? $field['cbvalue'] : 'yes';
+		$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
+		$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
+
+		// Custom attribute handling
+		$custom_attributes = array();
+
+		if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
+
+			foreach ( $field['custom_attributes'] as $attribute => $value ) {
+				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
+			}
+		}
+
+		$field = apply_filters( 'woocommerce_input_checkbox_filter', $field );
+
+		echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
+        <label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
+
+		if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
+			echo wc_help_tip( $field['description'] );
+		}
+
+		echo '<input type="checkbox" class="' . esc_attr( $field['class'] ) . '" style="' . esc_attr( $field['style'] ) . '" name="' . esc_attr( $field['name'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['cbvalue'] ) . '" ' . checked( $field['value'], $field['cbvalue'], false ) . '  ' . implode( ' ', $custom_attributes ) . '/> ';
+
+		if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
+			echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
+		}
+
+		echo '</p>';
+	}
+
+	/**
+	 * Output a select input box.
+	 *
+	 * @param array $field Data about the field to render.
+	 */
+	function woocommerce_wp_select( $field ) {
+		global $thepostid, $post;
+
+		$thepostid = empty( $thepostid ) ? $post->ID : $thepostid;
+		$field     = wp_parse_args(
+			$field, array(
+				'class'             => 'select short',
+				'style'             => '',
+				'wrapper_class'     => '',
+				'value'             => get_post_meta( $thepostid, $field['id'], true ),
+				'name'              => $field['id'],
+				'desc_tip'          => false,
+				'custom_attributes' => array(),
+			)
+		);
+
+		$field = apply_filters( 'woocommerce_input_select_filter', $field );
+
+		$wrapper_attributes = array(
+			'class' => $field['wrapper_class'] . " form-field {$field['id']}_field",
+		);
+
+		$label_attributes = array(
+			'for' => $field['id'],
+		);
+
+		$field_attributes          = (array) $field['custom_attributes'];
+		$field_attributes['style'] = $field['style'];
+		$field_attributes['id']    = $field['id'];
+		$field_attributes['name']  = $field['name'];
+		$field_attributes['class'] = $field['class'];
+
+		$tooltip     = ! empty( $field['description'] ) && false !== $field['desc_tip'] ? $field['description'] : '';
+		$description = ! empty( $field['description'] ) && false === $field['desc_tip'] ? $field['description'] : '';
+		?>
+		<p <?php echo wc_implode_html_attributes( $wrapper_attributes ); // WPCS: XSS ok. ?>>
+			<label <?php echo wc_implode_html_attributes( $label_attributes ); // WPCS: XSS ok. ?>><?php echo wp_kses_post( $field['label'] ); ?></label>
+			<?php if ( $tooltip ) : ?>
+				<?php echo wc_help_tip( $tooltip ); // WPCS: XSS ok. ?>
+			<?php endif; ?>
+			<select <?php echo wc_implode_html_attributes( $field_attributes ); // WPCS: XSS ok. ?>>
+				<?php
+					foreach ( $field['options'] as $key => $value ) {
+						echo '<option value="' . esc_attr( $key ) . '"' . wc_selected( $key, $field['value'] ) . '>' . esc_html( $value ) . '</option>';
+					}
+				?>
+			</select>
+			<?php if ( $description ) : ?>
+				<span class="description"><?php echo wp_kses_post( $description ); ?></span>
+			<?php endif; ?>
+		</p>
+		<?php
+	}
+
+	/**
+	 * Output a radio input box.
+	 *
+	 * @param array $field
+	 */
+	function woocommerce_wp_radio( $field ) {
+		global $thepostid, $post;
+
+		$thepostid              = empty( $thepostid ) ? $post->ID : $thepostid;
+		$field['class']         = isset( $field['class'] ) ? $field['class'] : 'select short';
+		$field['style']         = isset( $field['style'] ) ? $field['style'] : '';
+		$field['wrapper_class'] = isset( $field['wrapper_class'] ) ? $field['wrapper_class'] : '';
+		$field['value']         = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
+		$field['name']          = isset( $field['name'] ) ? $field['name'] : $field['id'];
+		$field['desc_tip']      = isset( $field['desc_tip'] ) ? $field['desc_tip'] : false;
+
+		$field = apply_filters( 'woocommerce_input_radio_filter', $field );
+
+		echo '<fieldset class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '"><legend>' . wp_kses_post( $field['label'] ) . '</legend>';
+
+		if ( ! empty( $field['description'] ) && false !== $field['desc_tip'] ) {
+			echo wc_help_tip( $field['description'] );
+		}
+
+		echo '<ul class="wc-radios">';
+
+		foreach ( $field['options'] as $key => $value ) {
+
+			echo '<li><label><input
+                name="' . esc_attr( $field['name'] ) . '"
+                value="' . esc_attr( $key ) . '"
+                type="radio"
+                class="' . esc_attr( $field['class'] ) . '"
+                style="' . esc_attr( $field['style'] ) . '"
+                ' . checked( esc_attr( $field['value'] ), esc_attr( $key ), false ) . '
+                /> ' . esc_html( $value ) . '</label>
+        </li>';
+		}
+		echo '</ul>';
+
+		if ( ! empty( $field['description'] ) && false === $field['desc_tip'] ) {
+			echo '<span class="description">' . wp_kses_post( $field['description'] ) . '</span>';
+		}
+
+		echo '</fieldset>';
+	}

--- a/includes/admin/wc-meta-box-functions.php
+++ b/includes/admin/wc-meta-box-functions.php
@@ -55,6 +55,8 @@ function woocommerce_wp_text_input( $field ) {
 	// Custom attribute handling
 	$custom_attributes = array();
 
+	$field = apply_filters( 'woocommerce_input_text_filter', $field );
+
 	if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
 
 		foreach ( $field['custom_attributes'] as $attribute => $value ) {
@@ -90,6 +92,8 @@ function woocommerce_wp_hidden_input( $field ) {
 	$field['value'] = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
 	$field['class'] = isset( $field['class'] ) ? $field['class'] : '';
 
+	$field = apply_filters( 'woocommerce_input_hidden_filter', $field );
+
 	echo '<input type="hidden" class="' . esc_attr( $field['class'] ) . '" name="' . esc_attr( $field['id'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) . '" /> ';
 }
 
@@ -114,6 +118,8 @@ function woocommerce_wp_textarea_input( $field ) {
 
 	// Custom attribute handling
 	$custom_attributes = array();
+
+	$field = apply_filters( 'woocommerce_input_textarea_filter', $field );
 
 	if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
 
@@ -158,6 +164,8 @@ function woocommerce_wp_checkbox( $field ) {
 	// Custom attribute handling
 	$custom_attributes = array();
 
+	$field = apply_filters( 'woocommerce_input_checkbox_filter', $field );
+
 	if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
 
 		foreach ( $field['custom_attributes'] as $attribute => $value ) {
@@ -201,6 +209,8 @@ function woocommerce_wp_select( $field ) {
 			'custom_attributes' => array(),
 		)
 	);
+
+	$field = apply_filters( 'woocommerce_input_select_filter', $field );
 
 	$wrapper_attributes = array(
 		'class' => $field['wrapper_class'] . " form-field {$field['id']}_field",

--- a/includes/admin/wc-meta-box-functions.php
+++ b/includes/admin/wc-meta-box-functions.php
@@ -55,14 +55,14 @@
 		// Custom attribute handling
 		$custom_attributes = array();
 
+		$field = apply_filters( 'woocommerce_input_text_filter', $field );
+
 		if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
 
 			foreach ( $field['custom_attributes'] as $attribute => $value ) {
 				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
 			}
 		}
-
-		$field = apply_filters( 'woocommerce_input_text_filter', $field );
 
 		echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
         <label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
@@ -92,6 +92,8 @@
 		$field['value'] = isset( $field['value'] ) ? $field['value'] : get_post_meta( $thepostid, $field['id'], true );
 		$field['class'] = isset( $field['class'] ) ? $field['class'] : '';
 
+		$field = apply_filters( 'woocommerce_input_hidden_filter', $field );
+
 		echo '<input type="hidden" class="' . esc_attr( $field['class'] ) . '" name="' . esc_attr( $field['id'] ) . '" id="' . esc_attr( $field['id'] ) . '" value="' . esc_attr( $field['value'] ) . '" /> ';
 	}
 
@@ -117,14 +119,14 @@
 		// Custom attribute handling
 		$custom_attributes = array();
 
+		$field = apply_filters( 'woocommerce_input_textarea_filter', $field );
+
 		if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
 
 			foreach ( $field['custom_attributes'] as $attribute => $value ) {
 				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
 			}
 		}
-
-		$field = apply_filters( 'woocommerce_input_textarea_filter', $field );
 
 		echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
         <label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';
@@ -162,14 +164,14 @@
 		// Custom attribute handling
 		$custom_attributes = array();
 
+		$field = apply_filters( 'woocommerce_input_checkbox_filter', $field );
+
 		if ( ! empty( $field['custom_attributes'] ) && is_array( $field['custom_attributes'] ) ) {
 
 			foreach ( $field['custom_attributes'] as $attribute => $value ) {
 				$custom_attributes[] = esc_attr( $attribute ) . '="' . esc_attr( $value ) . '"';
 			}
 		}
-
-		$field = apply_filters( 'woocommerce_input_checkbox_filter', $field );
 
 		echo '<p class="form-field ' . esc_attr( $field['id'] ) . '_field ' . esc_attr( $field['wrapper_class'] ) . '">
         <label for="' . esc_attr( $field['id'] ) . '">' . wp_kses_post( $field['label'] ) . '</label>';


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I added a filter before woocommerce field options/settings are outputted. This way the user can override any default settings.

Example: I have a customer who's products are managed by API, so he shouldn't edit any info, but he still can since price fields are editable.

By utilising this simple addition, field settings can be set by the user if needed. In my case I want to add the readonly option in price/tax fields.

### How to test the changes in this Pull Request:

Apply one of the following filters:
* woocommerce_input_text_filter
* woocommerce_input_hidden_filter
* woocommerce_input_textarea_filter
* woocommerce_input_checkbox_filter
* woocommerce_input_select_filter
* woocommerce_input_radio_filter

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? No - didn't think it would be necessary for 5 lines of added code
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Added on line 58 in wc-meta-box-functions.php
`$field = apply_filters( 'woocommerce_input_text_filter', $field );`

Added on line 95 in wc-meta-box-functions.php
`$field = apply_filters( 'woocommerce_input_hidden_filter', $field );`

Added on line 122 in wc-meta-box-functions.php
`$field = apply_filters( 'woocommerce_input_textarea_filter', $field );`

Added on line 167 in wc-meta-box-functions.php
`$field = apply_filters( 'woocommerce_input_checkbox_filter', $field );`

Added on line 213 in wc-meta-box-functions.php
`$field = apply_filters( 'woocommerce_input_select_filter', $field );`
