### PR TITLE
Fixed checkout coupons flaky scenario in e2e suite

### DIFF
--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -86,6 +86,8 @@ const runCheckoutApplyCouponsTest = () => {
 		});
 
 		it('allows customer to apply multiple coupons', async () => {
+			await page.reload();
+			await page.waitForSelector('.woocommerce-notices-wrapper');
 			await applyCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -86,8 +86,6 @@ const runCheckoutApplyCouponsTest = () => {
 		});
 
 		it('allows customer to apply multiple coupons', async () => {
-			await page.reload();
-			await page.waitForSelector('.woocommerce-notices-wrapper');
 			await applyCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -236,6 +236,10 @@ export const searchForOrder = async (value, orderId, customerName) => {
  */
 export const applyCoupon = async ( couponCode ) => {
 	try {
+		await Promise.all([
+			page.reload(),
+			page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+		]);
 		await expect(page).toClick('a', {text: 'Click here to enter your code'});
 		await uiUnblocked();
 		await clearAndFillInput('#coupon_code', couponCode);
@@ -255,6 +259,10 @@ export const applyCoupon = async ( couponCode ) => {
  * @returns {Promise<void>}
  */
 export const removeCoupon = async ( couponCode ) => {
+	await Promise.all([
+		page.reload(),
+		page.waitForNavigation( { waitUntil: 'networkidle0' } ),
+	]);
 	await expect(page).toClick('[data-coupon="'+couponCode.toLowerCase()+'"]', {text: '[Remove]'});
 	await uiUnblocked();
 	await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon has been removed.'});


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

- npx wc-e2e test:e2e ./tests/e2e/specs/front-end/test-checkout-coupons.js

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
