### PR TITLE
Logout merchant and clear the cart before running tests

### DIFF
--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
@@ -61,6 +61,8 @@ const runCartCalculateShippingTest = () => {
 			await page.select('select[name="add_method_id"]', 'local_pickup');
 			await page.click('button#btn-ok');
 			await page.waitForSelector('#zone_locations');
+			await merchant.logout();
+			await shopper.emptyCart();
 		});
 
 		it('allows customer to calculate Free Shipping if in Germany', async () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR attempts to fix some flakiness seen with the `Cart Calculate Shipping` tests by adding in a logout step for the merchant, and clearing the cart before starting the tests.

### How to test the changes in this Pull Request:

1. Verify the CI tests run and pass
2. Verify the e2e tests run and pass locally

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
