### PR TITLE
Set checkout field value with defined default

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -691,19 +691,34 @@ class WC_Checkout {
 				// phpcs:disable WordPress.Security.NonceVerification.Missing
 				switch ( $type ) {
 					case 'checkbox':
-						$value = isset( $_POST[ $key ] ) ? 1 : '';
+						$value = isset( $field['default'] ) && ! empty( $field['default'] ) ? 1 : '';
+						if ( isset( $_POST[ $key ] ) ) {
+							$value = 1;
+						}
 						break;
 					case 'multiselect':
-						$value = isset( $_POST[ $key ] ) ? implode( ', ', wc_clean( wp_unslash( $_POST[ $key ] ) ) ) : '';
+						$value = isset( $field['default'] ) ? implode( ', ', wc_clean( wp_unslash( $_POST[ $key ] ) ) ) : '';
+						if ( isset( $_POST[ $key ] ) ) {
+							$value = implode( ', ', wc_clean( wp_unslash( $_POST[ $key ] ) ) );
+						}
 						break;
 					case 'textarea':
-						$value = isset( $_POST[ $key ] ) ? wc_sanitize_textarea( wp_unslash( $_POST[ $key ] ) ) : '';
+						$value = isset( $field['default'] ) ? wc_sanitize_textarea( wp_unslash( $field['default'] ) ) : '';
+						if ( isset( $_POST[ $key ] ) ) {
+							$value = wc_sanitize_textarea( wp_unslash( $_POST[ $key ] ) );
+						}
 						break;
 					case 'password':
-						$value = isset( $_POST[ $key ] ) ? wp_unslash( $_POST[ $key ] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+						$value = isset( $field['default'] ) ? wp_unslash( $field['default'] ) : '';
+						if ( isset( $_POST[ $key ] ) ) {
+							$value = wp_unslash( $_POST[ $key ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+						}
 						break;
 					default:
-						$value = isset( $_POST[ $key ] ) ? wc_clean( wp_unslash( $_POST[ $key ] ) ) : '';
+						$value = isset( $field['default'] ) ? wc_clean( wp_unslash( $field['default'] ) ) : '';
+						if ( isset( $_POST[ $key ] ) ) {
+							$value = wc_clean( wp_unslash( $_POST[ $key ] ) );
+						}
 						break;
 				}
 				// phpcs:enable WordPress.Security.NonceVerification.Missing


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Fixes https://github.com/woocommerce/woocommerce/issues/29746 and Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/950 

The changes proposed in this PR affects mainly the Cart and Product Pages because the Payment Request button can be used to purchase without filling out check out details:

1. Pre-assigns the "default" value to every checkout field if defined. Otherwise the corresponding value via $_POST will be used.
2. We are keeping the previous default value if no "default" value for the checkout field is defined to keep things as before.

### How to test the changes in this Pull Request:

Here's a script to add all supported fields in `WC_Checkout->get_posted_data()`. We can put this on the current theme's `functions.php`

<details>
<summary>code to add checkout fields</summary>

```php
add_filter('woocommerce_checkout_fields', 'add_foo_fields');

function add_foo_fields($fields) {

	// billing
	$fields['billing']['billing_no_type'] = array(
		'required' => true,
		'label' => 'billing_no_type',
		'default' => 'no_type default value'
	);

	$fields['billing']['billing_checkbox'] = array(
		'type' => 'checkbox',
		'required' => true,
		'label' => 'billing_checkbox',
		'default' => '1'
	);

	// This is ignored because `woocommerce_form_field()` doesn't support this input type
	$fields['billing']['billing_multiselect'] = array(
		'type' => 'multiselect',
		'required' => true,
		'label' => 'billing_multiselect',
		'default' => 'billing_multiselect_default_value',
		'options' => array('foo' => 'foo_label', 'billing_multiselect_default_value' => 'billing_multiselect_default_value_label'),
	);

	$fields['billing']['billing_select'] = array(
		'type' => 'select',
		'required' => true,
		'label' => 'billing_select',
		'default' => 'billing_select_default_value',
		'options' => array('foo' => 'foo_label', 'billing_select_default_value' => 'billing_select_default_value_label'),
	);

	$fields['billing']['billing_textarea'] = array(
		'type' => 'textarea',
		'required' => true,
		'label' => 'billing_textarea',
		'default' => 'billing_textarea default_value',
	);

	$fields['billing']['billing_password'] = array(
		'type' => 'password',
		'required' => true,
		'label' => 'billing_password',
		'default' => 'billing_password default_value',
	);

	$fields['billing']['billing_radio'] = array(
		'type' => 'radio',
		'required' => true,
		'label' => 'billing_radio',
		'default' => 'billing_radio_default_value',
		'options' => array('foo' => 'foo_label', 'billing_radio_default_value' => 'billing_radio_default_value_label'),
	);

	$fields['shipping']['shipping_hidden'] = array(
		'type' => 'hidden',
		'required' => true,
		'label' => 'billing_hidden',
		'default' => 'billing_hidden default_value',
	);

	// shipping
	$fields['shipping']['shipping_no_type'] = array(
		'required' => true,
		'label' => 'billing_no_type',
		'default' => 'no_type default value'
	);

	$fields['shipping']['shipping_checkbox'] = array(
		'type' => 'checkbox',
		'required' => true,
		'label' => 'billing_checkbox',
		'default' => '1'
	);

	// This is ignored because `woocommerce_form_field()` doesn't support this input type
	$fields['shipping']['shipping_multiselect'] = array(
		'type' => 'multiselect',
		'required' => true,
		'label' => 'billing_multiselect',
		'default' => 'billing_multiselect_default_value',
		'options' => array('foo' => 'foo_label', 'billing_multiselect_default_value' => 'billing_multiselect_default_value_label'),
	);

	$fields['shipping']['shipping_select'] = array(
		'type' => 'select',
		'required' => true,
		'label' => 'billing_select',
		'default' => 'billing_select_default_value',
		'options' => array('foo' => 'foo_label', 'billing_select_default_value' => 'billing_select_default_value_label'),
	);

	$fields['shipping']['shipping_textarea'] = array(
		'type' => 'textarea',
		'required' => true,
		'label' => 'billing_textarea',
		'default' => 'billing_textarea default_value',
	);

	$fields['shipping']['shipping_password'] = array(
		'type' => 'password',
		'required' => true,
		'label' => 'billing_password',
		'default' => 'billing_password default_value',
	);

	$fields['shipping']['shipping_radio'] = array(
		'type' => 'radio',
		'required' => true,
		'label' => 'billing_radio',
		'default' => 'billing_radio_default_value',
		'options' => array('foo' => 'foo_label', 'billing_radio_default_value' => 'billing_radio_default_value_label'),
	);

	$fields['shipping']['shipping_hidden'] = array(
		'type' => 'hidden',
		'required' => true,
		'label' => 'billing_hidden',
		'default' => 'billing_hidden default_value',
	);

	return $fields;
}
```

</details>

1. Use the code above to add checkout fields.
2. Add a product to the cart.
3. Purchase using the checkout page. In my case I'm using `woocommerce-gateway-stripe`. So I'm using a test credit card.
4. Fill out missing required information and submit the checkout form.
5. Then we can confirm the fields are being saved with the default value.

<details>
<summary>post meta for newly created order</summary>

```
MariaDB [wordpress-one]> SELECT * FROM `wp_postmeta` WHERE `post_id` = 31 AND (`meta_key` LIKE '_billing_%' OR `meta_key` LIKE '_shipping_%') ORDER BY meta_key;
+---------+---------+-------------------------+------------------------------------------------------------------------------------------------------+
| meta_id | post_id | meta_key                | meta_value                                                                                           |
+---------+---------+-------------------------+------------------------------------------------------------------------------------------------------+
|     931 |      31 | _billing_address_1      | 55 Music Concourse Drive                                                                             |
|     954 |      31 | _billing_address_index  | Alfredo Sumaran  55 Music Concourse Drive  San Francisco AZ 94118 US a.sumaran@gmail.com 19892992222 |
|     959 |      31 | _billing_checkbox       | 1                                                                                                    |
|     932 |      31 | _billing_city           | San Francisco                                                                                        |
|     935 |      31 | _billing_country        | US                                                                                                   |
|     936 |      31 | _billing_email          | a.sumaran@gmail.com                                                                                  |
|     929 |      31 | _billing_first_name     | Alfredo                                                                                              |
|     930 |      31 | _billing_last_name      | Sumaran                                                                                              |
|     960 |      31 | _billing_no_type        | no_type default value                                                                                |
|     957 |      31 | _billing_password       | billing_password default_value                                                                       |
|     937 |      31 | _billing_phone          | 19892992222                                                                                          |
|     934 |      31 | _billing_postcode       | 94118                                                                                                |
|     961 |      31 | _billing_radio          | billing_radio_default_value                                                                          |
|     956 |      31 | _billing_select         | billing_select_default_value                                                                         |
|     933 |      31 | _billing_state          | AZ                                                                                                   |
|     958 |      31 | _billing_textarea       | billing_textarea default_value                                                                       |
|     940 |      31 | _shipping_address_1     | 55 Music Concourse Drive                                                                             |
|     955 |      31 | _shipping_address_index | Alfredo Sumaran  55 Music Concourse Drive  San Francisco AZ 94118 US                                 |
|     966 |      31 | _shipping_checkbox      | 1                                                                                                    |
|     941 |      31 | _shipping_city          | San Francisco                                                                                        |
|     944 |      31 | _shipping_country       | US                                                                                                   |
|     938 |      31 | _shipping_first_name    | Alfredo                                                                                              |
|     968 |      31 | _shipping_hidden        |                                                                                                      |
|     939 |      31 | _shipping_last_name     | Sumaran                                                                                              |
|     965 |      31 | _shipping_multiselect   |                                                                                                      |
|     967 |      31 | _shipping_no_type       | no_type default value                                                                                |
|     963 |      31 | _shipping_password      | billing_password default_value                                                                       |
|     943 |      31 | _shipping_postcode      | 94118                                                                                                |
|     969 |      31 | _shipping_radio         | billing_radio_default_value                                                                          |
|     962 |      31 | _shipping_select        | billing_select_default_value                                                                         |
|     942 |      31 | _shipping_state         | AZ                                                                                                   |
|     964 |      31 | _shipping_textarea      | billing_textarea default_value                                                                       |
+---------+---------+-------------------------+------------------------------------------------------------------------------------------------------+
32 rows in set (0.000 sec)
```

</details>

6. Add a product to the cart
7. Purchase using the Payment Request button in the "Cart" page. For this I'm using the `woocommerce-gateway-plugin` in test mode.
8. No error should be displayed and the payment should be done successfully.
9. Then we can confirm the fields are being saved with the default value.

<details>
<summary>post meta for newly created order using Payment Request button</summary>

```
MariaDB [wordpress-one]> SELECT * FROM `wp_postmeta` WHERE `post_id` = 32 AND (`meta_key` LIKE '_billing_%' OR `meta_key` LIKE '_shipping_%') ORDER BY meta_key;
+---------+---------+-------------------------+----------------------------------------------------------------------------------------------------+
| meta_id | post_id | meta_key                | meta_value                                                                                         |
+---------+---------+-------------------------+----------------------------------------------------------------------------------------------------+
|     997 |      32 | _billing_address_1      | 55 Music Concourse Drive                                                                           |
|    1021 |      32 | _billing_address_index  | Alfredo Sumaran  55 Music Concourse Drive  San Francisco CA 94118 US a.sumaran@gmail.com 989098920 |
|    1026 |      32 | _billing_checkbox       | 1                                                                                                  |
|     998 |      32 | _billing_city           | San Francisco                                                                                      |
|    1001 |      32 | _billing_country        | US                                                                                                 |
|    1002 |      32 | _billing_email          | a.sumaran@gmail.com                                                                                |
|     995 |      32 | _billing_first_name     | Alfredo                                                                                            |
|     996 |      32 | _billing_last_name      | Sumaran                                                                                            |
|    1027 |      32 | _billing_no_type        | no_type default value                                                                              |
|    1024 |      32 | _billing_password       | billing_password default_value                                                                     |
|    1003 |      32 | _billing_phone          | 989098920                                                                                          |
|    1000 |      32 | _billing_postcode       | 94118                                                                                              |
|    1028 |      32 | _billing_radio          | billing_radio_default_value                                                                        |
|    1023 |      32 | _billing_select         | billing_select_default_value                                                                       |
|     999 |      32 | _billing_state          | CA                                                                                                 |
|    1025 |      32 | _billing_textarea       | billing_textarea default_value                                                                     |
|    1007 |      32 | _shipping_address_1     | Bernardo Monteagudo 200                                                                            |
|    1022 |      32 | _shipping_address_index | Alfredo Sumaran Automattic Bernardo Monteagudo 200  Lima LIM LIMA07 PE                             |
|    1032 |      32 | _shipping_checkbox      | 1                                                                                                  |
|    1008 |      32 | _shipping_city          | Lima                                                                                               |
|    1006 |      32 | _shipping_company       | Automattic                                                                                         |
|    1011 |      32 | _shipping_country       | PE                                                                                                 |
|    1004 |      32 | _shipping_first_name    | Alfredo                                                                                            |
|    1034 |      32 | _shipping_hidden        | billing_hidden default_value                                                                       |
|    1005 |      32 | _shipping_last_name     | Sumaran                                                                                            |
|    1033 |      32 | _shipping_no_type       | no_type default value                                                                              |
|    1030 |      32 | _shipping_password      | billing_password default_value                                                                     |
|    1010 |      32 | _shipping_postcode      | LIMA07                                                                                             |
|    1035 |      32 | _shipping_radio         | billing_radio_default_value                                                                        |
|    1029 |      32 | _shipping_select        | billing_select_default_value                                                                       |
|    1009 |      32 | _shipping_state         | LIM                                                                                                |
|    1031 |      32 | _shipping_textarea      | billing_textarea default_value                                                                     |
+---------+---------+-------------------------+----------------------------------------------------------------------------------------------------+
32 rows in set (0.001 sec)
```

</details>



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
