### PR TITLE
remove unused product import function from jest setup script

### DIFF
--- a/tests/e2e/env/src/setup/jest.setup.js
+++ b/tests/e2e/env/src/setup/jest.setup.js
@@ -52,37 +52,6 @@ async function setupBrowser() {
 }
 
 /**
- * Navigates to woocommerce import page and imports sample products.
- *
- * @return {Promise} Promise resolving once products have been imported.
- */
-async function importSampleProducts() {
-	await switchUserToAdmin();
-	// Visit Import Products page.
-	await visitAdminPage(
-		'edit.php',
-		'post_type=product&page=product_importer'
-	);
-	await page.click( 'a.woocommerce-importer-toggle-advanced-options' );
-	await page.focus( '#woocommerce-importer-file-url' );
-	// local path for sample data that is included with woo.
-	await page.keyboard.type(
-		'wp-content/plugins/woocommerce/sample-data/sample_products.csv'
-	);
-	await page.click( '.wc-actions .button-next' );
-	await page.waitForSelector( '.wc-importer-mapping-table' );
-	await page.select(
-		'.wc-importer-mapping-table tr:nth-child(29) select',
-		''
-	);
-	await page.click( '.wc-actions .button-next' );
-	await page.waitForXPath(
-		"//*[@class='woocommerce-importer-done' and contains(., 'Import complete! ')]"
-	);
-	await switchUserToTest();
-}
-
-/**
  * Adds an event listener to the page to handle additions of page event
  * handlers, to assure that they are removed at test teardown.
  */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `importSampleProducts` function in `jest.setup.js` is a leftover from porting over the original E2E package POC PR. It isn't exported or used in `jest.setup` so it's dead code. We have a test that imports the products so this function is also redundant.

### How to test the changes in this Pull Request:

1. Verify CI run
2. Note that the coupon tests failure is being addressed in #29737.

### Changelog entry

> N/A
