### PR TITLE
Remove set_backorders logic from external products closes #29696

### DIFF
--- a/includes/admin/class-wc-admin-post-types.php
+++ b/includes/admin/class-wc-admin-post-types.php
@@ -430,7 +430,10 @@ class WC_Admin_Post_Types {
 		// phpcs:enable WordPress.Security.ValidatedSanitizedInput.MissingUnslash, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 
 		$product->set_manage_stock( $manage_stock );
-		$product->set_backorders( $backorders );
+
+		if ( 'external' !== $product->get_type() ) {
+			$product->set_backorders( $backorders );
+		}
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
 			$stock_amount = 'yes' === $manage_stock && isset( $request_data['_stock'] ) && is_numeric( wp_unslash( $request_data['_stock'] ) ) ? wc_stock_amount( wp_unslash( $request_data['_stock'] ) ) : '';
@@ -550,7 +553,10 @@ class WC_Admin_Post_Types {
 		$stock_amount = 'yes' === $manage_stock && ! empty( $request_data['change_stock'] ) && isset( $request_data['_stock'] ) ? wc_stock_amount( $request_data['_stock'] ) : $product->get_stock_quantity();
 
 		$product->set_manage_stock( $manage_stock );
-		$product->set_backorders( $backorders );
+
+		if ( 'external' !== $product->get_type() ) {
+			$product->set_backorders( $backorders );
+		}
 
 		if ( 'yes' === get_option( 'woocommerce_manage_stock' ) ) {
 			$change_stock = absint( $request_data['change_stock'] );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

We're making this change because external products does not support backorders.

Closes #29696 

### How to test the changes in this Pull Request:

1. Create an external product.
2. Go to the product list and check the bulk edit checkbox for the external product.
3. On the `Bulk actions` dropdown select `Edit` then `Apply`
4. Go to `Backorders` dropdown and select any value.
5. Click on `Update`
6. Ensure there are no errors in your logs and the product updated without issues.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Bulk edit on external products causes an error when changing the `Backorders` setting.
