### PR TITLE
return test name when there is no screenshot

### DIFF
--- a/tests/e2e/env/utils/take-screenshot.js
+++ b/tests/e2e/env/utils/take-screenshot.js
@@ -24,7 +24,7 @@ const takeScreenshotFor = async ( message ) => {
 		});
 	} catch ( error ) {
 		return {
-			title: 'no screenshot',
+			title,
 			filePath: '',
 		};
 	}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

We added a screenshot utility in #29672 . When there is no screenshot it returns `no screenshot` for the test title. When this is posted to Slack, you have to go to the CI log to see which test timed out. This PR updates the function to return the test title whether or not a screenshot is saved.

### How to test the changes in this Pull Request:

1. Verify CI run.

### Changelog entry

> N/A
