### PR TITLE
update onboarding flow modal checks

### DIFF
--- a/tests/e2e/core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
+++ b/tests/e2e/core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
@@ -41,7 +41,6 @@ const runOnboardingFlowTest = () => {
 		}
 
 		it('can start and complete onboarding when visiting the site for the first time.', async () => {
-			await merchant.runSetupWizard();
 			await completeOnboardingWizard();
 		});
 	});
@@ -62,7 +61,6 @@ const runTaskListTest = () => {
 				// Click on "Set up shipping" task to move to the next step
 				const [ setupTaskListItem ] = await page.$x( '//div[contains(text(),"Set up shipping")]' );
 				await setupTaskListItem.click();
-				await page.waitForNavigation({waitUntil: 'networkidle0'});
 
 				// Wait for "Proceed" button to become active
 				await page.waitForSelector('button.is-primary:not(:disabled)');

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
@@ -27,11 +27,11 @@ const runOrderApplyCouponTest = () => {
 	describe('WooCommerce Orders > Apply coupon', () => {
 		beforeAll(async () => {
 			await merchant.login();
+			await createSimpleProduct();
+			couponCode = await createCoupon();
+			orderId = await createSimpleOrder('Pending payment', simpleProductName);
 			await Promise.all([
-				await createSimpleProduct(),
-				couponCode = await createCoupon(),
-				orderId = await createSimpleOrder('Pending payment', simpleProductName),
-				await addProductToOrder(orderId, simpleProductName),
+				addProductToOrder(orderId, simpleProductName),
 
 				// We need to remove any listeners on the `dialog` event otherwise we can't catch the dialog below
 				page.removeAllListeners('dialog'),
@@ -43,7 +43,7 @@ const runOrderApplyCouponTest = () => {
 
 		it('can apply a coupon', async () => {
 			const couponDialog = await expect(page).toDisplayDialog(async () => {
-				await expect(page).toClick('button.add-coupon');
+				await evalAndClick('button.add-coupon');
 			});
 
 			expect(couponDialog.message()).toMatch(couponDialogMessage);

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Added
 
 - `emptyCart()` Shopper flow helper that empties the cart
-- `deleteAllShippingZones` Delete all the existing shipping zones
+- `deleteAllShippingZones()` Delete all the existing shipping zones
 - constants
   - `WP_ADMIN_POST_TYPE`
   - `WP_ADMIN_NEW_POST_TYPE`
@@ -11,6 +11,7 @@
   - `WP_ADMIN_WC_HOME`
   - `IS_RETEST_MODE`
 - `withRestApi` flow containing utility functions that manage data with the rest api
+- `waitForSelectorWithoutThrow` - conditionally wait for a selector without throwing an error
 
 # 0.1.4
 

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -181,6 +181,7 @@ This package provides support for enabling retries in tests:
 | `selectOrderAction` | `action` | Helper method to select an order action in the `Order Actions` postbox |
 | `clickUpdateOrder` | `noticeText`, `waitForSave` | Helper method to click the Update button on the order details page |
 | `deleteAllShippingZones` | | Delete all the existing shipping zones |
+| `waitForSelectorWithoutThrow` | `selector`, `timeoutInSeconds` | conditionally wait for a selector without throwing an error. Default timeout is 5 seconds |
 
 ### Test Utilities
 

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -15,6 +15,7 @@ import {
 	unsetCheckbox,
 	evalAndClick,
 	backboneUnblocked,
+	waitForSelectorWithoutThrow,
 } from './page-utils';
 import factories from './factories';
 
@@ -58,6 +59,7 @@ const waitAndClickPrimary = async ( waitForNetworkIdle = true ) => {
  */
 const completeOnboardingWizard = async () => {
 	// Store Details section
+	await merchant.runSetupWizard();
 
 	// Fill store's address - first line
 	await expect( page ).toFill( '#inspector-text-control-0', config.get( 'addresses.admin.store.addressfirstline' ) );
@@ -84,8 +86,8 @@ const completeOnboardingWizard = async () => {
 	await page.click( 'button.is-primary', { text: 'Continue' } );
 
 	// Wait for usage tracking pop-up window to appear on a new site
-	if ( ! IS_RETEST_MODE ) {
-		await page.waitForSelector('.components-modal__header-heading');
+	const usageTrackingHeader = await page.$('.components-modal__header-heading');
+	if ( usageTrackingHeader ) {
 		await expect(page).toMatchElement(
 			'.components-modal__header-heading', {text: 'Build a better WooCommerce'}
 		);
@@ -163,24 +165,18 @@ const completeOnboardingWizard = async () => {
 	}
 
 	// Wait for homescreen welcome modal to appear
-	await page.waitForSelector( '.woocommerce__welcome-modal__page-content__header' );
-	await expect( page ).toMatchElement(
-		'.woocommerce__welcome-modal__page-content__header', { text: 'Welcome to your WooCommerce store\’s online HQ!' }
-	);
+	let welcomeHeader = await waitForSelectorWithoutThrow( '.woocommerce__welcome-modal__page-content' );
+	if ( ! welcomeHeader ) {
+		return;
+	}
 
-	// Wait for "Next" button to become active
-	await page.waitForSelector( 'button.components-guide__forward-button' );
-	// Click on "Next" button to move to the next step
-	await page.click( 'button.components-guide__forward-button' );
-
-	// Wait for "Next" button to become active
-	await page.waitForSelector( 'button.components-guide__forward-button' );
-	// Click on "Next" button to move to the next step
-	await page.click( 'button.components-guide__forward-button' );
-
+	// Click two Next buttons
+	for ( let b = 0; b < 2; b++ ) {
+		await page.waitForSelector('button.components-guide__forward-button');
+		await page.click('button.components-guide__forward-button');
+	}
 	// Wait for "Let's go" button to become active
 	await page.waitForSelector( 'button.components-guide__finish-button' );
-	// Click on "Let's go" button to move to the next step
 	await page.click( 'button.components-guide__finish-button' );
 };
 

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -14,7 +14,7 @@ import {
 	setCheckbox,
 	unsetCheckbox,
 	evalAndClick,
-	clearAndFillInput,
+	backboneUnblocked,
 } from './page-utils';
 import factories from './factories';
 
@@ -437,7 +437,7 @@ const addProductToOrder = async ( orderId, productName ) => {
 	await expect( page ).toClick( 'li[aria-selected="true"]' );
 	await page.click( '.wc-backbone-modal-content #btn-ok' );
 
-	await uiUnblocked();
+	await backboneUnblocked();
 
 	// Verify the product we added shows as a line item now
 	await expect( page ).toMatchElement( '.wc-order-item-name', { text: productName } );

--- a/tests/e2e/utils/src/flows/merchant.js
+++ b/tests/e2e/utils/src/flows/merchant.js
@@ -62,7 +62,6 @@ const merchant = {
 	},
 
 	openAllOrdersView: async () => {
-		console.log('all orders view url: ' + WP_ADMIN_ALL_ORDERS_VIEW );
 		await page.goto( WP_ADMIN_ALL_ORDERS_VIEW, {
 			waitUntil: 'networkidle0',
 		} );

--- a/tests/e2e/utils/src/flows/merchant.js
+++ b/tests/e2e/utils/src/flows/merchant.js
@@ -62,6 +62,7 @@ const merchant = {
 	},
 
 	openAllOrdersView: async () => {
+		console.log('all orders view url: ' + WP_ADMIN_ALL_ORDERS_VIEW );
 		await page.goto( WP_ADMIN_ALL_ORDERS_VIEW, {
 			waitUntil: 'networkidle0',
 		} );

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -90,6 +90,25 @@ export const backboneUnblocked = async () => {
 };
 
 /**
+ * Conditionally wait for a selector without throwing an error.
+ *
+ * @param selector
+ * @param timeoutInSeconds
+ * @returns {Promise<boolean>}
+ */
+export const waitForSelectorWithoutThrow = async ( selector, timeoutInSeconds = 5 ) => {
+	let selected = await page.$( selector );
+	for ( let s = 0; s < timeoutInSeconds; s++ ) {
+		if ( selected ) {
+			break;
+		}
+		await page.waitFor( 1000 );
+		selected = await page.$( selector );
+	}
+	return Boolean( selected );
+};
+
+/**
  * Publish, verify that item was published. Trash, verify that item was trashed.
  *
  * @param {string} button (Publish)

--- a/tests/e2e/utils/src/page-utils.js
+++ b/tests/e2e/utils/src/page-utils.js
@@ -83,6 +83,13 @@ export const uiUnblocked = async () => {
 };
 
 /**
+ * Wait for backbone blocking to end.
+ */
+export const backboneUnblocked = async () => {
+	await page.waitForFunction( () => ! Boolean( document.querySelector( '.wc-backbone-modal' ) ) );
+};
+
+/**
  * Publish, verify that item was published. Trash, verify that item was trashed.
  *
  * @param {string} button (Publish)


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR depends on #29767.

It introduces the `waitForSelectorWithoutThrow()` utility function to allow for conditional flow in tests without throwing an error. It uses the function to determine whether the onboarding flow modals appear or not. When either of the modals are absent the tests implement an alternate flow that completes the same setup tasks.

It includes a small fix for the order edit coupon test.

Supersedes the initial intent of #29725 . The PR has additional changes that will be implemented as separate PRs and closed once all its changes have been addressed.

### How to test the changes in this Pull Request:

1. Verify CI run.
2.
3.

### Changelog entry

> N/A
