### PR TITLE
give cart and checkout coupon tests unique titles

### DIFF
--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
@@ -41,7 +41,7 @@ const runCartApplyCouponsTest = () => {
 			await shopper.goToCart();
 		});
 
-		it('allows customer to apply fixed cart coupon', async () => {
+		it('allows cart to apply fixed cart coupon', async () => {
 			await applyCoupon(couponFixedCart);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
@@ -52,7 +52,7 @@ const runCartApplyCouponsTest = () => {
 			await removeCoupon(couponFixedCart);
 		});
 
-		it('allows customer to apply percentage coupon', async () => {
+		it('allows cart to apply percentage coupon', async () => {
 			await applyCoupon(couponPercentage);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
@@ -63,7 +63,7 @@ const runCartApplyCouponsTest = () => {
 			await removeCoupon(couponPercentage);
 		});
 
-		it('allows customer to apply fixed product coupon', async () => {
+		it('allows cart to apply fixed product coupon', async () => {
 			await applyCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
@@ -74,7 +74,7 @@ const runCartApplyCouponsTest = () => {
 			await removeCoupon(couponFixedProduct);
 		});
 
-		it('prevents customer applying same coupon twice', async () => {
+		it('prevents cart applying same coupon twice', async () => {
 			await applyCoupon(couponFixedCart);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 			await applyCoupon(couponFixedCart);
@@ -84,7 +84,7 @@ const runCartApplyCouponsTest = () => {
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
 		});
 
-		it('allows customer to apply multiple coupons', async () => {
+		it('allows cart to apply multiple coupons', async () => {
 			await applyCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -41,7 +41,7 @@ const runCheckoutApplyCouponsTest = () => {
 			await shopper.goToCheckout();
 		});
 
-		it('allows customer to apply fixed cart coupon', async () => {
+		it('allows checkout to apply fixed cart coupon', async () => {
 			await applyCoupon(couponFixedCart);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
@@ -54,7 +54,7 @@ const runCheckoutApplyCouponsTest = () => {
 			await removeCoupon(couponFixedCart);
 		});
 
-		it('allows customer to apply percentage coupon', async () => {
+		it('allows checkout to apply percentage coupon', async () => {
 			await applyCoupon(couponPercentage);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
@@ -64,7 +64,7 @@ const runCheckoutApplyCouponsTest = () => {
 			await removeCoupon(couponPercentage);
 		});
 
-		it('allows customer to apply fixed product coupon', async () => {
+		it('allows checkout to apply fixed product coupon', async () => {
 			await applyCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
@@ -75,7 +75,7 @@ const runCheckoutApplyCouponsTest = () => {
 			await removeCoupon(couponFixedProduct);
 		});
 
-		it('prevents customer applying same coupon twice', async () => {
+		it('prevents checkout applying same coupon twice', async () => {
 			await applyCoupon(couponFixedCart);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 			await applyCoupon(couponFixedCart);
@@ -85,7 +85,7 @@ const runCheckoutApplyCouponsTest = () => {
 			await expect(page).toMatchElement('.order-total .amount', {text: '$4.99'});
 		});
 
-		it('allows customer to apply multiple coupons', async () => {
+		it('allows checkout to apply multiple coupons', async () => {
 			await applyCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.woocommerce-message', {text: 'Coupon code applied successfully.'});
 
@@ -94,7 +94,7 @@ const runCheckoutApplyCouponsTest = () => {
 			await expect(page).toMatchElement('.order-total .amount', {text: '$0.00'});
 		});
 
-		it('restores cart total when coupons are removed', async () => {
+		it('restores checkout total when coupons are removed', async () => {
 			await removeCoupon(couponFixedCart);
 			await removeCoupon(couponFixedProduct);
 			await expect(page).toMatchElement('.order-total .amount', {text: '$9.99'});


### PR DESCRIPTION
### Changes proposed in this Pull Request:

While working on #29725 I noticed that the cart and checkout coupon tests use the same test titles. This isn't an issue when reviewing the log because the test group identifies which it is. 

However, when looking at the `tests/e2e/screenshots` you have to open the image to determine which test it's for. Also, if the same test fails in both cart and checkout, the second screenshot overwrites the first one.

This PR replaces `customer` in the test title with `cart` and `checkout` respectively.

### How to test the changes in this Pull Request:

1. Run E2E tests (or review the CI log).
2. Confirm that the cart & checkout coupon test titles have unique names.

### Changelog entry

> N/A
