### PR TITLE
PayPal settings title - capitalisation fix for consistency

### DIFF
--- a/includes/gateways/paypal/includes/settings-paypal.php
+++ b/includes/gateways/paypal/includes/settings-paypal.php
@@ -58,7 +58,7 @@ return array(
 		'description' => sprintf( __( 'Log PayPal events, such as IPN requests, inside %s Note: this may log personal information. We recommend using this for debugging purposes only and deleting the logs when finished.', 'woocommerce' ), '<code>' . WC_Log_Handler_File::get_log_file_path( 'paypal' ) . '</code>' ),
 	),
 	'ipn_notification'      => array(
-		'title'       => __( 'IPN Email Notifications', 'woocommerce' ),
+		'title'       => __( 'IPN email notifications', 'woocommerce' ),
 		'type'        => 'checkbox',
 		'label'       => __( 'Enable IPN email notifications', 'woocommerce' ),
 		'default'     => 'yes',


### PR DESCRIPTION
Makes IPN email notifications title consistent with the other titles (no capital letter starts on new words)

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Updated option title from: "IPN Email Notifications" to "IPN email notifications" to be consistent with the other option titles on this PayPal settings page.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. View PayPal settings before and after.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Modified PayPal settings title - capitalisation fix for consistency
