### PR TITLE
Check for WP Error when uploading products placeholder

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1332,7 +1332,7 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 			'post_content'   => '',
 			'post_status'    => 'inherit',
 		);
-		$attach_id  = wp_insert_attachment( $attachment, $filename );
+		$attach_id = wp_insert_attachment( $attachment, $filename );
 		if ( is_wp_error( $attach_id ) ) {
 			update_option( 'woocommerce_placeholder_image', 0 );
 			return;

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1333,6 +1333,10 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 			'post_status'    => 'inherit',
 		);
 		$attach_id  = wp_insert_attachment( $attachment, $filename );
+		if ( is_wp_error( $attach_id ) ) {
+			update_option( 'woocommerce_placeholder_image', 0 );
+			return;
+		}
 
 		update_option( 'woocommerce_placeholder_image', $attach_id );
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1332,6 +1332,7 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 			'post_content'   => '',
 			'post_status'    => 'inherit',
 		);
+
 		$attach_id = wp_insert_attachment( $attachment, $filename );
 		if ( is_wp_error( $attach_id ) ) {
 			update_option( 'woocommerce_placeholder_image', 0 );


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Adds extra security when uploading the default placeholder for products to avoid any PHP error

### How to test the changes in this Pull Request:

1. Install WooCommerce

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Handle `WP_Error` while creating placeholder image during install.
