### PR TITLE
Bump WooCommerce Admin version to 2.2.2-rc.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "2.2.1",
+    "woocommerce/woocommerce-admin": "2.2.2-rc.1",
     "woocommerce/woocommerce-blocks": "4.9.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "11158f53934e897bd84be190a184ec87",
+    "content-hash": "be33d948ed1d2ee3a7a23ef657f3148d",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -86,16 +86,16 @@
         },
         {
             "name": "composer/installers",
-            "version": "v1.10.0",
+            "version": "v1.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/installers.git",
-                "reference": "1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d"
+                "reference": "ae03311f45dfe194412081526be2e003960df74b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/installers/zipball/1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d",
-                "reference": "1a0357fccad9d1cc1ea0c9a05b8847fbccccb78d",
+                "url": "https://api.github.com/repos/composer/installers/zipball/ae03311f45dfe194412081526be2e003960df74b",
+                "reference": "ae03311f45dfe194412081526be2e003960df74b",
                 "shasum": ""
             },
             "require": {
@@ -189,6 +189,7 @@
                 "majima",
                 "mako",
                 "mediawiki",
+                "miaoxing",
                 "modulework",
                 "modx",
                 "moodle",
@@ -206,6 +207,7 @@
                 "sydes",
                 "sylius",
                 "symfony",
+                "tastyigniter",
                 "typo3",
                 "wordpress",
                 "yawik",
@@ -226,7 +228,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-14T11:07:16+00:00"
+            "time": "2021-04-28T06:42:17+00:00"
         },
         {
             "name": "maxmind-db/reader",
@@ -501,16 +503,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.2.1",
+            "version": "2.2.2-rc.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "78cc9c5ef7de5be5bd0f9208483e5ae97422be9a"
+                "reference": "0d305d1716481a0cc2010ec7b0a608a2d3c8ebe4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/78cc9c5ef7de5be5bd0f9208483e5ae97422be9a",
-                "reference": "78cc9c5ef7de5be5bd0f9208483e5ae97422be9a",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0d305d1716481a0cc2010ec7b0a608a2d3c8ebe4",
+                "reference": "0d305d1716481a0cc2010ec7b0a608a2d3c8ebe4",
                 "shasum": ""
             },
             "require": {
@@ -542,7 +544,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2021-04-02T19:30:03+00:00"
+            "time": "2021-04-28T19:39:33+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -589,10 +591,6 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "support": {
-                "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v4.9.1"
-            },
             "time": "2021-04-13T16:11:16+00:00"
         }
     ],


### PR DESCRIPTION
This bumps `woocommerce/woocommerce-admin` in Composer to the latest published package, version `2.2.2-rc.1`
 
## Testing Instructions
 
### Disable the continue btn when plugins are being installed/activated #6838

1. In OBW fill out store details with a USA address 
2. Click Continue and select Fashion, apparel, and accessories, 
3. Click Continue, and select Physical products, and continue.
4. The business details tab should show a Business details tab, and a Free features tab (disabled at first)
5. Select 1-10 for the first dropdown, and No for the second, and click Continue.
6. Make sure the "Add recommended business features to my site is ticked
7. Click Continue, before the page redirects click Continue again
8. Confirm no error has been recorded in your browser console.
 
## Changelog
 
```
- Fix: Disable the continue btn on OBW when requested are being made #6838
- Tweak: Revert WCPay international support for bundled package #6901
- Tweak: Store profiler - Changed MailPoet's title and description #6886
- Tweak: Update PayU logo #6829
```
 
### Changelog entry
 
> Update - WooCommerce Admin package 2.2.2