### PR TITLE
Bump WooCommerce Admin version to 2.2.2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "2.2.2-rc.1",
+    "woocommerce/woocommerce-admin": "2.2.2",
     "woocommerce/woocommerce-blocks": "4.9.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be33d948ed1d2ee3a7a23ef657f3148d",
+    "content-hash": "a604678b268820c78736d599e1eb6726",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -503,16 +503,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.2.2-rc.1",
+            "version": "2.2.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "0d305d1716481a0cc2010ec7b0a608a2d3c8ebe4"
+                "reference": "161e6afa01a3fb69533cfa2b245a71df7512ec3f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/0d305d1716481a0cc2010ec7b0a608a2d3c8ebe4",
-                "reference": "0d305d1716481a0cc2010ec7b0a608a2d3c8ebe4",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/161e6afa01a3fb69533cfa2b245a71df7512ec3f",
+                "reference": "161e6afa01a3fb69533cfa2b245a71df7512ec3f",
                 "shasum": ""
             },
             "require": {
@@ -544,7 +544,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2021-04-28T19:39:33+00:00"
+            "time": "2021-04-29T14:11:48+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
This bumps `woocommerce/woocommerce-admin` in Composer to the latest published package, version `2.2.2`
 
## Testing Instructions
 
### Disable the continue btn when plugins are being installed/activated #6838

1. In OBW fill out store details with a USA address 
2. Click Continue and select Fashion, apparel, and accessories, 
3. Click Continue, and select Physical products, and continue.
4. The business details tab should show a Business details tab, and a Free features tab (disabled at first)
5. Select 1-10 for the first dropdown, and No for the second, and click Continue.
6. Make sure the "Add recommended business features to my site is ticked
7. Click Continue, before the page redirects click Continue again
8. Confirm no error has been recorded in your browser console.
 
## Changelog
 
```
- Fix: Disable the continue btn on OBW when requested are being made #6838
- Tweak: Revert WCPay international support for bundled package #6901
- Tweak: Store profiler - Changed MailPoet's title and description #6886
- Tweak: Update PayU logo #6829
```
 
### Changelog entry
 
> Update - WooCommerce Admin package 2.2.2