### PR TITLE
Set checkout field value with defined default

### DIFF
--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -685,11 +685,13 @@ class WC_Checkout {
 				continue;
 			}
 
+			$is_checkout_page = isset( $_REQUEST['woocommerce-process-checkout-nonce'] );
+
 			foreach ( $fieldset as $key => $field ) {
 				if ( isset( $_POST[ $key ] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Missing
 					$value = wp_unslash( $_POST[ $key ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				} elseif ( isset( $field['default'] ) ) {
-					$value = $field['default'];
+				} elseif ( isset( $field['default'] ) && ! $is_checkout_page ) {
+					$value = '1' === (string) $field['default'] ? 1 : '';
 				} else {
 					$value = '';
 				}

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -696,21 +696,23 @@ class WC_Checkout {
 
 				$type = sanitize_title( isset( $field['type'] ) ? $field['type'] : 'text' );
 
-				switch ( $type ) {
-					case 'checkbox':
-						$value = 1;
-						break;
-					case 'multiselect':
-						$value = implode( ', ', wc_clean( $value ) );
-						break;
-					case 'textarea':
-						$value = wc_sanitize_textarea( $value );
-						break;
-					case 'password':
-						break;
-					default:
-						$value = wc_clean( $value );
-						break;
+				if ( '' !== $value ) {
+					switch ( $type ) {
+						case 'checkbox':
+							$value = 1;
+							break;
+						case 'multiselect':
+							$value = implode( ', ', wc_clean( $value ) );
+							break;
+						case 'textarea':
+							$value = wc_sanitize_textarea( $value );
+							break;
+						case 'password':
+							break;
+						default:
+							$value = wc_clean( $value );
+							break;
+					}
 				}
 
 				$data[ $key ] = apply_filters( 'woocommerce_process_checkout_' . $type . '_field', apply_filters( 'woocommerce_process_checkout_field_' . $key, $value ) );

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -1128,7 +1128,7 @@ class WC_Checkout {
 	 */
 	public function process_checkout() {
 		try {
-			$nonce_value = wc_get_var( $_REQUEST['woocommerce-process-checkout-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // @codingStandardsIgnoreLine.
+			$nonce_value = wc_get_var( $_REQUEST['woocommerce-process-checkout-nonce'], wc_get_var( $_REQUEST['_wpnonce'], '' ) ); // phpcs:ignore
 
 			if ( empty( $nonce_value ) || ! wp_verify_nonce( $nonce_value, 'woocommerce-process_checkout' ) ) {
 				WC()->session->set( 'refresh_totals', true );

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -686,27 +686,32 @@ class WC_Checkout {
 			}
 
 			foreach ( $fieldset as $key => $field ) {
+				if ( isset( $_POST[ $key ] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Missing
+					$value = wp_unslash( $_POST[ $key ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+				} elseif ( isset( $field['default'] ) ) {
+					$value = $field['default'];
+				} else {
+					$value = '';
+				}
+
 				$type = sanitize_title( isset( $field['type'] ) ? $field['type'] : 'text' );
 
-				// phpcs:disable WordPress.Security.NonceVerification.Missing
 				switch ( $type ) {
 					case 'checkbox':
-						$value = isset( $_POST[ $key ] ) ? 1 : '';
+						$value = 1;
 						break;
 					case 'multiselect':
-						$value = isset( $_POST[ $key ] ) ? implode( ', ', wc_clean( wp_unslash( $_POST[ $key ] ) ) ) : '';
+						$value = implode( ', ', wc_clean( $value ) );
 						break;
 					case 'textarea':
-						$value = isset( $_POST[ $key ] ) ? wc_sanitize_textarea( wp_unslash( $_POST[ $key ] ) ) : '';
+						$value = wc_sanitize_textarea( $value );
 						break;
 					case 'password':
-						$value = isset( $_POST[ $key ] ) ? wp_unslash( $_POST[ $key ] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 						break;
 					default:
-						$value = isset( $_POST[ $key ] ) ? wc_clean( wp_unslash( $_POST[ $key ] ) ) : '';
+						$value = wc_clean( $value );
 						break;
 				}
-				// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 				$data[ $key ] = apply_filters( 'woocommerce_process_checkout_' . $type . '_field', apply_filters( 'woocommerce_process_checkout_field_' . $key, $value ) );
 			}

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -679,7 +679,7 @@ class WC_Checkout {
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		$skipped = array();
-		$form_was_shown = isset( $_POST['woocommerce-process-checkout-nonce'] );
+		$form_was_shown = isset( $_POST['woocommerce-process-checkout-nonce'] ); // phpcs:disable WordPress.Security.NonceVerification.Missing
 
 		foreach ( $this->get_checkout_fields() as $fieldset_key => $fieldset ) {
 			if ( $this->maybe_skip_fieldset( $fieldset_key, $data ) ) {

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -688,15 +688,15 @@ class WC_Checkout {
 			$is_checkout_page = isset( $_REQUEST['woocommerce-process-checkout-nonce'] );
 
 			foreach ( $fieldset as $key => $field ) {
-				if ( isset( $_POST[ $key ] ) ) { // phpcs:disable WordPress.Security.NonceVerification.Missing
+				$type = sanitize_title( isset( $field['type'] ) ? $field['type'] : 'text' );
+
+				if ( isset( $_POST[ $key ] ) && '' !== $_POST[ $key ] ) { // phpcs:disable WordPress.Security.NonceVerification.Missing
 					$value = wp_unslash( $_POST[ $key ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				} elseif ( isset( $field['default'] ) && ! $is_checkout_page ) {
-					$value = '1' === (string) $field['default'] ? 1 : '';
+				} elseif ( isset( $field['default'] ) && 'checkbox' !== $type ) {
+					$value = $field['default'];
 				} else {
 					$value = '';
 				}
-
-				$type = sanitize_title( isset( $field['type'] ) ? $field['type'] : 'text' );
 
 				if ( '' !== $value ) {
 					switch ( $type ) {

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -685,14 +685,14 @@ class WC_Checkout {
 				continue;
 			}
 
-			$is_checkout_page = isset( $_REQUEST['woocommerce-process-checkout-nonce'] );
+			$form_was_shown = isset( $_REQUEST['woocommerce-process-checkout-nonce'] );
 
 			foreach ( $fieldset as $key => $field ) {
 				$type = sanitize_title( isset( $field['type'] ) ? $field['type'] : 'text' );
 
 				if ( isset( $_POST[ $key ] ) && '' !== $_POST[ $key ] ) { // phpcs:disable WordPress.Security.NonceVerification.Missing
 					$value = wp_unslash( $_POST[ $key ] ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-				} elseif ( isset( $field['default'] ) && 'checkbox' !== $type ) {
+				} elseif ( isset( $field['default'] ) && 'checkbox' !== $type && ! $form_was_shown ) {
 					$value = $field['default'];
 				} else {
 					$value = '';

--- a/includes/class-wc-checkout.php
+++ b/includes/class-wc-checkout.php
@@ -679,13 +679,13 @@ class WC_Checkout {
 		// phpcs:enable WordPress.Security.NonceVerification.Missing
 
 		$skipped = array();
+		$form_was_shown = isset( $_POST['woocommerce-process-checkout-nonce'] );
+
 		foreach ( $this->get_checkout_fields() as $fieldset_key => $fieldset ) {
 			if ( $this->maybe_skip_fieldset( $fieldset_key, $data ) ) {
 				$skipped[] = $fieldset_key;
 				continue;
 			}
-
-			$form_was_shown = isset( $_REQUEST['woocommerce-process-checkout-nonce'] );
 
 			foreach ( $fieldset as $key => $field ) {
 				$type = sanitize_title( isset( $field['type'] ) ? $field['type'] : 'text' );


### PR DESCRIPTION
### All Submissions:
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
Fixes https://github.com/woocommerce/woocommerce/issues/29746 and Fixes https://github.com/woocommerce/woocommerce-gateway-stripe/issues/950 

The changes proposed in this PR affects mainly the Cart and Product Pages because the Payment Request button can be used to purchase without filling out check out details:

1. Pre-assigns the "default" value to every checkout field if defined. Otherwise the corresponding value via $_POST will be used.
2. We are keeping the previous default value if no "default" value for the checkout field is defined to keep things as before.

### How to test the changes in this Pull Request:

Here's a script to add all supported fields in `WC_Checkout->get_posted_data()`. We can put this on the current theme's `functions.php`

<details>
<summary>code to add checkout fields</summary>

```php
add_filter('woocommerce_checkout_fields', 'add_foo_fields');

function add_foo_fields($fields) {

	// billing
	$fields['billing']['billing_no_type'] = array(
		'required' => true,
		'label' => 'billing_no_type',
		'default' => 'no_type default value'
	);

	$fields['billing']['billing_checkbox'] = array(
		'type' => 'checkbox',
		'required' => true,
		'label' => 'billing_checkbox',
		'default' => '1'
	);

	// This is ignored because `woocommerce_form_field()` doesn't support this input type
	$fields['billing']['billing_multiselect'] = array(
		'type' => 'multiselect',
		'required' => true,
		'label' => 'billing_multiselect',
		'default' => 'billing_multiselect_default_value',
		'options' => array('foo' => 'foo_label', 'billing_multiselect_default_value' => 'billing_multiselect_default_value_label'),
	);

	$fields['billing']['billing_select'] = array(
		'type' => 'select',
		'required' => true,
		'label' => 'billing_select',
		'default' => 'billing_select_default_value',
		'options' => array('foo' => 'foo_label', 'billing_select_default_value' => 'billing_select_default_value_label'),
	);

	$fields['billing']['billing_textarea'] = array(
		'type' => 'textarea',
		'required' => true,
		'label' => 'billing_textarea',
		'default' => 'billing_textarea default_value',
	);

	$fields['billing']['billing_password'] = array(
		'type' => 'password',
		'required' => true,
		'label' => 'billing_password',
		'default' => 'billing_password default_value',
	);

	$fields['billing']['billing_radio'] = array(
		'type' => 'radio',
		'required' => true,
		'label' => 'billing_radio',
		'default' => 'billing_radio_default_value',
		'options' => array('foo' => 'foo_label', 'billing_radio_default_value' => 'billing_radio_default_value_label'),
	);

	$fields['billing']['billing_hidden'] = array(
		'type' => 'hidden',
		'required' => true,
		'label' => 'billing_hidden',
		'default' => 'billing_hidden default_value',
	);

	// shipping
	$fields['shipping']['shipping_no_type'] = array(
		'required' => true,
		'label' => 'billing_no_type',
		'default' => 'no_type default value'
	);

	$fields['shipping']['shipping_checkbox'] = array(
		'type' => 'checkbox',
		'required' => true,
		'label' => 'shipping_checkbox',
		'default' => '1'
	);

	// This is ignored because `woocommerce_form_field()` doesn't support this input type
	$fields['shipping']['shipping_multiselect'] = array(
		'type' => 'multiselect',
		'required' => true,
		'label' => 'shipping_multiselect',
		'default' => 'shipping_multiselect_default_value',
		'options' => array('foo' => 'foo_label', 'shipping_multiselect_default_value' => 'shipping_multiselect_default_value_label'),
	);

	$fields['shipping']['shipping_select'] = array(
		'type' => 'select',
		'required' => true,
		'label' => 'shipping_select',
		'default' => 'shipping_select_default_value',
		'options' => array('foo' => 'foo_label', 'shipping_select_default_value' => 'shipping_select_default_value_label'),
	);

	$fields['shipping']['shipping_textarea'] = array(
		'type' => 'textarea',
		'required' => true,
		'label' => 'shipping_textarea',
		'default' => 'shipping_textarea default_value',
	);

	$fields['shipping']['shipping_password'] = array(
		'type' => 'password',
		'required' => true,
		'label' => 'shipping_password',
		'default' => 'shipping_password default_value',
	);

	$fields['shipping']['shipping_radio'] = array(
		'type' => 'radio',
		'required' => true,
		'label' => 'shipping_radio',
		'default' => 'shipping_radio_default_value',
		'options' => array('foo' => 'foo_label', 'shipping_radio_default_value' => 'shipping_radio_default_value_label'),
	);

	$fields['shipping']['shipping_hidden'] = array(
		'type' => 'hidden',
		'required' => true,
		'label' => 'shipping_hidden',
		'default' => 'shipping_hidden default_value',
	);

	return $fields;
}
```

</details>

1. Use the code above to add checkout fields.
2. Add a product to the cart.
3. Purchase using the checkout page. In my case I'm using `woocommerce-gateway-stripe`. So I'm using a test credit card.
4. Fill out missing required information and submit the checkout form.
5. Then we can confirm the fields are being saved with the default value.

<details>
<summary>post meta for newly created order</summary>

```
MariaDB [wordpress-one]> SELECT * FROM `wp_postmeta` WHERE `post_id` = 45 AND (`meta_key` LIKE '_billing_%' OR `meta_key` LIKE '_shipping_%') ORDER BY meta_key;
+---------+---------+-------------------------+---------------------------------------------------------------------------------------------------------------+
| meta_id | post_id | meta_key                | meta_value                                                                                                    |
+---------+---------+-------------------------+---------------------------------------------------------------------------------------------------------------+
|    1875 |      45 | _billing_address_1      | 55 Music Concourse Dr                                                                                         |
|    1898 |      45 | _billing_address_index  | Alfredo Sumaran  55 Music Concourse Dr  San Francisco CA 94118 US alfredo.sumaran@automattic.com +14153798000 |
|    1904 |      45 | _billing_checkbox       | 1                                                                                                             |
|    1876 |      45 | _billing_city           | San Francisco                                                                                                 |
|    1879 |      45 | _billing_country        | US                                                                                                            |
|    1880 |      45 | _billing_email          | alfredo.sumaran@automattic.com                                                                                |
|    1873 |      45 | _billing_first_name     | Alfredo                                                                                                       |
|    1906 |      45 | _billing_hidden         | billing_hidden default_value                                                                                  |
|    1874 |      45 | _billing_last_name      | Sumaran                                                                                                       |
|    1905 |      45 | _billing_no_type        | no_type default value                                                                                         |
|    1902 |      45 | _billing_password       | billing_password default_value                                                                                |
|    1881 |      45 | _billing_phone          | +14153798000                                                                                                  |
|    1878 |      45 | _billing_postcode       | 94118                                                                                                         |
|    1901 |      45 | _billing_radio          | billing_radio_default_value                                                                                   |
|    1900 |      45 | _billing_select         | billing_select_default_value                                                                                  |
|    1877 |      45 | _billing_state          | CA                                                                                                            |
|    1903 |      45 | _billing_textarea       | billing_textarea default_value                                                                                |
|    1884 |      45 | _shipping_address_1     | 55 Music Concourse Dr                                                                                         |
|    1899 |      45 | _shipping_address_index | Alfredo Sumaran  55 Music Concourse Dr  San Francisco CA 94118 US                                             |
|    1911 |      45 | _shipping_checkbox      | 1                                                                                                             |
|    1885 |      45 | _shipping_city          | San Francisco                                                                                                 |
|    1888 |      45 | _shipping_country       | US                                                                                                            |
|    1882 |      45 | _shipping_first_name    | Alfredo                                                                                                       |
|    1913 |      45 | _shipping_hidden        | shipping_hidden default_value                                                                                 |
|    1883 |      45 | _shipping_last_name     | Sumaran                                                                                                       |
|    1912 |      45 | _shipping_no_type       | no_type default value                                                                                         |
|    1909 |      45 | _shipping_password      | shipping_password default_value                                                                               |
|    1887 |      45 | _shipping_postcode      | 94118                                                                                                         |
|    1908 |      45 | _shipping_radio         | shipping_radio_default_value                                                                                  |
|    1910 |      45 | _shipping_select        | shipping_select_default_value                                                                                 |
|    1886 |      45 | _shipping_state         | CA                                                                                                            |
|    1907 |      45 | _shipping_textarea      | shipping_textarea default_value                                                                               |
+---------+---------+-------------------------+---------------------------------------------------------------------------------------------------------------+
32 rows in set (0.001 sec)
```

</details>

6. Add a product to the cart
7. Purchase using the Payment Request button in the "Cart" page. For this I'm using the `woocommerce-gateway-plugin` in test mode.
8. No error should be displayed and the payment should be done successfully.
9. Then we can confirm the fields are being saved with the default value.

<details>
<summary>post meta for newly created order using Payment Request button</summary>

```
MariaDB [wordpress-one]> SELECT * FROM `wp_postmeta` WHERE `post_id` = 46 AND (`meta_key` LIKE '_billing_%' OR `meta_key` LIKE '_shipping_%') ORDER BY meta_key;
+---------+---------+-------------------------+---------------------------------------------------------------------------------------------------------------+
| meta_id | post_id | meta_key                | meta_value                                                                                                    |
+---------+---------+-------------------------+---------------------------------------------------------------------------------------------------------------+
|    1940 |      46 | _billing_address_1      | 55 Music Concourse Dr                                                                                         |
|    1963 |      46 | _billing_address_index  | Alfredo Sumaran  55 Music Concourse Dr  San Francisco CA 94118 US alfredo.sumaran@automattic.com +14153798000 |
|    1969 |      46 | _billing_checkbox       | 1                                                                                                             |
|    1941 |      46 | _billing_city           | San Francisco                                                                                                 |
|    1944 |      46 | _billing_country        | US                                                                                                            |
|    1945 |      46 | _billing_email          | alfredo.sumaran@automattic.com                                                                                |
|    1938 |      46 | _billing_first_name     | Alfredo                                                                                                       |
|    1971 |      46 | _billing_hidden         | billing_hidden default_value                                                                                  |
|    1939 |      46 | _billing_last_name      | Sumaran                                                                                                       |
|    1970 |      46 | _billing_no_type        | no_type default value                                                                                         |
|    1967 |      46 | _billing_password       | billing_password default_value                                                                                |
|    1946 |      46 | _billing_phone          | +14153798000                                                                                                  |
|    1943 |      46 | _billing_postcode       | 94118                                                                                                         |
|    1966 |      46 | _billing_radio          | billing_radio_default_value                                                                                   |
|    1965 |      46 | _billing_select         | billing_select_default_value                                                                                  |
|    1942 |      46 | _billing_state          | CA                                                                                                            |
|    1968 |      46 | _billing_textarea       | billing_textarea default_value                                                                                |
|    1949 |      46 | _shipping_address_1     | 55 Music Concourse Dr                                                                                         |
|    1964 |      46 | _shipping_address_index | Alfredo Sumaran  55 Music Concourse Dr  San Francisco CA 94118 US                                             |
|    1976 |      46 | _shipping_checkbox      | 1                                                                                                             |
|    1950 |      46 | _shipping_city          | San Francisco                                                                                                 |
|    1953 |      46 | _shipping_country       | US                                                                                                            |
|    1947 |      46 | _shipping_first_name    | Alfredo                                                                                                       |
|    1978 |      46 | _shipping_hidden        | shipping_hidden default_value                                                                                 |
|    1948 |      46 | _shipping_last_name     | Sumaran                                                                                                       |
|    1977 |      46 | _shipping_no_type       | no_type default value                                                                                         |
|    1974 |      46 | _shipping_password      | shipping_password default_value                                                                               |
|    1952 |      46 | _shipping_postcode      | 94118                                                                                                         |
|    1973 |      46 | _shipping_radio         | shipping_radio_default_value                                                                                  |
|    1975 |      46 | _shipping_select        | shipping_select_default_value                                                                                 |
|    1951 |      46 | _shipping_state         | CA                                                                                                            |
|    1972 |      46 | _shipping_textarea      | shipping_textarea default_value                                                                               |
+---------+---------+-------------------------+---------------------------------------------------------------------------------------------------------------+
32 rows in set (0.001 sec)
```

</details>



### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

- Set checkout fields value with the default defined value where form is not presented to the user.
