### PR TITLE
remove local container from smoke test

### DIFF
--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -39,5 +39,4 @@ jobs:
           E2E_SLACK_TOKEN: ${{ secrets.SMOKE_TEST_SLACK_TOKEN }}
           E2E_SLACK_CHANNEL: ${{ secrets.SMOKE_TEST_SLACK_CHANNEL }}
         run: |
-          npx wc-e2e docker:up
           npx wc-e2e test:e2e

--- a/package-lock.json
+++ b/package-lock.json
@@ -8919,7 +8919,8 @@
       "dev": true,
       "requires": {
         "@jest/globals": "^26.4.2",
-        "config": "3.3.3"
+        "config": "3.3.3",
+        "faker": "^5.1.0"
       },
       "dependencies": {
         "@jest/environment": {
@@ -9307,7 +9308,7 @@
               }
             },
             "prettier": {
-              "version": "npm:prettier@1.19.1",
+              "version": "npm:wp-prettier@1.19.1",
               "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
               "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
               "dev": true
@@ -25832,6 +25833,12 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
       "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+      "dev": true
+    },
+    "faker": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/faker/-/faker-5.5.3.tgz",
+      "integrity": "sha512-wLTv2a28wjUyWkbnX7u/ABZBkUkIF2fCd73V6P2oFqEGEktDfzWx4UxrSqtPRw0xPRAcjeAOIiJWqZm3pP4u3g==",
       "dev": true
     },
     "fast-deep-equal": {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the local test container startup from the smoke test daily CI script. The local container isn't used by the smoke test. It also has package lock maintenance for `faker`.

### How to test the changes in this Pull Request:

1. Review the changes
2. We can check the CI log the day after merging

### Changelog entry

> N/A
