### PR TITLE
remove the stale label when feedback is provided

### DIFF
--- a/.github/workflows/update-feedback-labels.yml
+++ b/.github/workflows/update-feedback-labels.yml
@@ -15,8 +15,10 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         labels: 'has feedback'
-    - name: remove needs feedback
+    - name: remove needs feedback, stale
       uses: actions-ecosystem/action-remove-labels@v1
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        labels: 'needs feedback'
+        labels: |
+          'needs feedback'
+          'stale'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds `stale` to the list of labels to be removed in the GH action `Update contributor feedback labels on comment`. See https://github.com/actions-ecosystem/action-remove-labels#inputs

### How to test the changes in this Pull Request:

1. Review CI script changes

### Changelog entry

> N/A
