### PR TITLE
Check for needs_payment() instead of has_status( 'pending' )

### DIFF
--- a/templates/emails/customer-invoice.php
+++ b/templates/emails/customer-invoice.php
@@ -29,7 +29,7 @@ do_action( 'woocommerce_email_header', $email_heading, $email ); ?>
 <?php /* translators: %s: Customer first name */ ?>
 <p><?php printf( esc_html__( 'Hi %s,', 'woocommerce' ), esc_html( $order->get_billing_first_name() ) ); ?></p>
 
-<?php if ( $order->has_status( 'pending' ) ) { ?>
+<?php if ( $order->needs_payment() ) { ?>
 	<p>
 	<?php
 	printf(


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Include the payment link in invoices sent to the customers whenever the order needs payment, not just when the order is in "pending" state.

Closes #29832.

### How to test the changes in this Pull Request:

1. Add the following temporary hook handler so that all orders are handled as needing payment:

```php
add_filter('woocommerce_order_needs_payment', '__return_true');
```

2. In the admin area open any order that is NOT in the "pending" or "failed" state.
3. Send the invoice (select "Email invoice/order details to customer" under "Order actions" and click ">").
4. Verify that the email sent contains a link for making the payment.

Alternatively, you can temporarily hook into `woocommerce_valid_order_statuses_for_payment` instead.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - Invoice emails now contain payment link if the order needs payment, not just when the order is "pending".
