### PR TITLE
Test for the presence of 3 or more args (not 2 or more). | #29124

### DIFF
--- a/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
+++ b/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php
@@ -640,7 +640,7 @@ class WC_REST_Products_V2_Controller extends WC_REST_CRUD_Controller {
 		 *
 		 *  TODO: Refactor to fix this behavior when DI gets included to make it obvious and clean.
 		*/
-		$request = func_num_args() >= 2 ? func_get_arg( 2 ) : new WP_REST_Request( '', '', array( 'context' => $context ) );
+		$request = func_num_args() >= 3 ? func_get_arg( 2 ) : new WP_REST_Request( '', '', array( 'context' => $context ) );
 		$fields  = $this->get_fields_for_response( $request );
 
 		$base_data = array();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

[`WC_REST_Products_V2_Controller::get_product_data()`](https://github.com/woocommerce/woocommerce/blob/5.2.2/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php#L629-L851) is slightly unusual because it:

* Requires one arg: `$product` → _exists in the method signature_
* Optionally accepts a second arg: `$context` → _exists in the method signature_
* Optionally accepts a third arg: `$request`→ _**magical!** We grab it via a func_get_arg() call_

However, when we test for the presence of that third arg our current test asks if we have 2 or more arguments, so even if only two args are passed we still go ahead and call `func_get_arg( 2 )`, which flops. This change adjusts the conditional so we test to see if we have **3** or more args before grabbing that third arg.

Closes #29124.

### How to test the changes in this Pull Request:

1. Activate the current version of WC Bookings alongside WC (trunk/stable version) and enable a suitable level of PHP error logging or, alternatively, set a breakpoint [around here](https://github.com/woocommerce/woocommerce/blob/5.2.2/includes/rest-api/Controllers/Version2/class-wc-rest-products-v2-controller.php#L644) so you can monitor the value of `$request`.
2. Use this Bookings REST API endpoint: `example.com/wp-json/wc-bookings/v1/products/1234` (where 1234 is the ID of a bookable product you have already created).
3. Monitor the logs/observe what you see via the breakpoint: note that a warning is generated and `$request` is not a `WP_REST_Request` object as expected, but instead is `(bool) false`.
4. Now check out this changeset and repeat. This time, `$request` will be an instance of `WP_REST_Request` as expected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Reduce the potential for errors when plugins implement REST API endpoints based on WooCommerce's own products controller. Props @fabregas4 for flagging this issue.
