### PR TITLE
Uncaught Error: Undefined constant "WC_PLUGIN_FILE" on plugin uninstall

### DIFF
--- a/uninstall.php
+++ b/uninstall.php
@@ -30,6 +30,8 @@ if ( defined( 'WC_REMOVE_ALL_DATA' ) && true === WC_REMOVE_ALL_DATA ) {
 	include_once dirname( __FILE__ ) . '/packages/woocommerce-admin/src/Install.php';
 	\Automattic\WooCommerce\Admin\Install::drop_tables();
 
+	define( 'WC_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+	
 	include_once dirname( __FILE__ ) . '/includes/class-wc-install.php';
 
 	// Roles + caps.


### PR DESCRIPTION
When `WC_REMOVE_ALL_DATA` is defined and the user performs uninstall the delete operation will crash due to Fatal error: undefined constant "WC_PLUGIN_FILE".
The constant is defined in `class-wc-install.php` that included from `uninstall .php`

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
define the `WC_PLUGIN_FILE` constant before including `class-wc-install.php`

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1.Deactivate the plugin
2.Delete the plugin
3.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X ] Have you written new tests for your changes, as applicable?
* [X ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
define the `WC_PLUGIN_FILE` constant before including `class-wc-install.php`