### PR TITLE
Add support for WooCommerce Payments ad banner on extensions screen's "Featured" section

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1,3 +1,4 @@
+
 /**
  * admin.scss
  * General WooCommerce admin styles. Settings, product data tabs, reports, etc.
@@ -101,43 +102,6 @@
 		height: 62px;
 	}
 
-	.addons-ad-block {
-		display: flex;
-		padding: 20px;
-
-		.addons-img {
-			height: auto;
-			width: 200px;
-		}
-	}
-
-	.addons-ad-block-content {
-		display: flex;
-		flex-direction: column;
-		margin-left: 24px;
-	}
-
-	.addons-ad-block-description {
-		margin-bottom: 20px;
-	}
-
-	.addons-ad-block-title {
-		margin: 0 0 16px;
-		padding: 0;
-	}
-
-	.addons-ad-block-buttons {
-		margin-top: auto;
-
-		.addons-button {
-			margin-right: 8px;
-
-			&:last-child {
-				margin-right: 0;
-			}
-		}
-	}
-
 	.addons-banner-block p {
 		margin: 0 0 20px;
 	}
@@ -194,6 +158,43 @@
 		.addons-img {
 			max-height: 86px;
 			max-width: 97px;
+		}
+	}
+
+	.addons-ad-block {
+		display: flex;
+		padding: 20px;
+
+		.addons-img {
+			height: auto;
+			width: 200px;
+		}
+	}
+
+	.addons-ad-block-content {
+		display: flex;
+		flex-direction: column;
+		margin-left: 24px;
+	}
+
+	.addons-ad-block-description {
+		margin-bottom: 20px;
+	}
+
+	.addons-ad-block-title {
+		margin: 0 0 16px;
+		padding: 0;
+	}
+
+	.addons-ad-block-buttons {
+		margin-top: auto;
+
+		.addons-button {
+			margin-right: 8px;
+
+			&:last-child {
+				margin-right: 0;
+			}
 		}
 	}
 
@@ -493,8 +494,9 @@
 			flex: 1;
 			overflow: hidden;
 			background: #f5f5f5;
-			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2),
-			inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+			box-shadow:
+				inset 0 1px 0 rgba(255, 255, 255, 0.2),
+				inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 
 			a {
 				text-decoration: none;
@@ -686,7 +688,7 @@ mark.amount {
 
 	&::after {
 
-		@include icon_dashicons("\f223");
+		@include icon_dashicons( "\f223" );
 		cursor: help;
 	}
 }
@@ -871,7 +873,7 @@ table.wc_status_table--tools {
 	}
 
 	// Adjust log table columns only when table is not collapsed
-	@media screen and (min-width: 783px) {
+	@media screen and ( min-width: 783px ) {
 
 		.column-timestamp {
 			width: 18%;
@@ -1062,7 +1064,7 @@ ul.wc_coupon_list {
 
 				&::before {
 
-					@include icon_dashicons("\f158");
+					@include icon_dashicons( "\f158" );
 				}
 
 				&:hover::before {
@@ -1106,7 +1108,7 @@ ul.wc_coupon_list_block {
 
 	&::after {
 
-		@include icon_dashicons("\f345");
+		@include icon_dashicons( "\f345" );
 		line-height: 28px;
 	}
 }
@@ -1630,7 +1632,7 @@ ul.wc_coupon_list_block {
 
 					&::before {
 
-						@include icon_dashicons("\f128");
+						@include icon_dashicons( "\f128" );
 						width: 38px;
 						line-height: 38px;
 						display: block;
@@ -1878,7 +1880,7 @@ ul.wc_coupon_list_block {
 
 				&::before {
 
-					@include icon("\e007");
+					@include icon( "\e007" );
 					color: #ccc;
 				}
 			}
@@ -1893,7 +1895,7 @@ ul.wc_coupon_list_block {
 
 				&::before {
 
-					@include icon("\e014");
+					@include icon( "\e014" );
 					color: #ccc;
 				}
 			}
@@ -1910,7 +1912,7 @@ ul.wc_coupon_list_block {
 
 					&::before {
 
-						@include icon("\e01a");
+						@include icon( "\e01a" );
 						color: #ccc;
 					}
 				}
@@ -1939,7 +1941,7 @@ ul.wc_coupon_list_block {
 
 					&::before {
 
-						@include icon_dashicons("\f153");
+						@include icon_dashicons( "\f153" );
 						color: #999;
 					}
 
@@ -1961,7 +1963,7 @@ ul.wc_coupon_list_block {
 
 				&::before {
 
-					@include icon_dashicons("\f171");
+					@include icon_dashicons( "\f171" );
 					position: relative;
 					top: auto;
 					left: auto;
@@ -2017,7 +2019,7 @@ ul.wc_coupon_list_block {
 
 		.edit-order-item::before {
 
-			@include icon_dashicons("\f464");
+			@include icon_dashicons( "\f464" );
 			position: relative;
 		}
 
@@ -2026,7 +2028,7 @@ ul.wc_coupon_list_block {
 
 			&::before {
 
-				@include icon_dashicons("\f158");
+				@include icon_dashicons( "\f158" );
 				position: relative;
 			}
 
@@ -2394,7 +2396,7 @@ ul.wc_coupon_list_block {
 
 			&::before {
 
-				@include icon("\e010");
+				@include icon( "\e010" );
 				line-height: 16px;
 				font-size: 14px;
 				vertical-align: middle;
@@ -2685,6 +2687,7 @@ ul.wc_coupon_list_block {
 	}
 
 	.wc_addons_wrap {
+
 		.addons-ad-block {
 			flex-direction: column;
 			padding: 24px;
@@ -2716,7 +2719,7 @@ ul.wc_coupon_list_block {
 
 	&::after {
 
-		@include icon("\e026");
+		@include icon( "\e026" );
 		line-height: 16px;
 	}
 }
@@ -2729,7 +2732,7 @@ ul.wc_coupon_list_block {
 
 	&::after {
 
-		@include icon("\e027");
+		@include icon( "\e027" );
 		line-height: 16px;
 	}
 }
@@ -2966,7 +2969,7 @@ table.wp-list-table {
 
 		&::before {
 
-			@include icon_dashicons("\f128");
+			@include icon_dashicons( "\f128" );
 		}
 	}
 
@@ -3931,19 +3934,19 @@ img.help_tip {
 
 .status-manual::before {
 
-	@include icon("\e008");
+	@include icon( "\e008" );
 	color: #999;
 }
 
 .status-enabled::before {
 
-	@include icon("\e015");
+	@include icon( "\e015" );
 	color: $woocommerce;
 }
 
 .status-disabled::before {
 
-	@include icon("\e013");
+	@include icon( "\e013" );
 	color: #ccc;
 }
 
@@ -4362,7 +4365,7 @@ img.help_tip {
 
 				&::after {
 
-					@include icon_dashicons("\f161");
+					@include icon_dashicons( "\f161" );
 					font-size: 2.618em;
 					line-height: 72px;
 					color: #ddd;
@@ -4404,7 +4407,7 @@ img.help_tip {
 
 						&::before {
 
-							@include icon_dashicons("\f153");
+							@include icon_dashicons( "\f153" );
 							color: #999;
 							background: #fff;
 							border-radius: 50%;
@@ -4591,7 +4594,7 @@ img.help_tip {
 
 				&::before {
 
-					@include iconbeforedashicons("\f107");
+					@include iconbeforedashicons( "\f107" );
 				}
 			}
 
@@ -4675,7 +4678,7 @@ img.help_tip {
 
 		.add.button::before {
 
-			@include iconbefore("\e007");
+			@include iconbefore( "\e007" );
 		}
 	}
 
@@ -4791,7 +4794,7 @@ img.help_tip {
 
 				&::before {
 
-					@include icon_dashicons("\f153");
+					@include icon_dashicons( "\f153" );
 					color: #999;
 				}
 
@@ -5706,7 +5709,7 @@ img.ui-datepicker-trigger {
 
 				&::before {
 
-					@include iconbeforedashicons("\f346");
+					@include iconbeforedashicons( "\f346" );
 					margin-right: 4px;
 				}
 			}
@@ -5833,7 +5836,7 @@ img.ui-datepicker-trigger {
 
 						&::after {
 
-							@include iconafter("\e035");
+							@include iconafter( "\e035" );
 							float: right;
 							font-size: 0.9em;
 							line-height: 1.618;
@@ -5966,8 +5969,9 @@ img.ui-datepicker-trigger {
 				}
 
 				&:hover {
-					box-shadow: inset 0 -1px 0 0 #dfdfdf,
-					inset 300px 0 0 rgba(156, 93, 144, 0.1);
+					box-shadow:
+						inset 0 -1px 0 0 #dfdfdf,
+						inset 300px 0 0 rgba(156, 93, 144, 0.1);
 					border-right: 5px solid #9c5d90 !important;
 					padding-left: 1.5em;
 					color: #9c5d90;
@@ -6167,27 +6171,27 @@ table.bar_chart {
 
 .post-type-shop_order .woocommerce-BlankState-message::before {
 
-	@include icon("\e01d");
+	@include icon( "\e01d" );
 }
 
 .post-type-shop_coupon .woocommerce-BlankState-message::before {
 
-	@include icon("\e600");
+	@include icon( "\e600" );
 }
 
 .post-type-product .woocommerce-BlankState-message::before {
 
-	@include icon("\e006");
+	@include icon( "\e006" );
 }
 
 .woocommerce-BlankState--api .woocommerce-BlankState-message::before {
 
-	@include icon("\e01c");
+	@include icon( "\e01c" );
 }
 
 .woocommerce-BlankState--webhooks .woocommerce-BlankState-message::before {
 
-	@include icon("\e01b");
+	@include icon( "\e01b" );
 }
 
 .woocommerce-BlankState {
@@ -7361,7 +7365,7 @@ table.bar_chart {
 
 			&::before {
 
-				@include icon("\e015");
+				@include icon( "\e015" );
 				color: #a16696;
 				position: static;
 				font-size: 100px;

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -1,4 +1,3 @@
-
 /**
  * admin.scss
  * General WooCommerce admin styles. Settings, product data tabs, reports, etc.
@@ -100,6 +99,43 @@
 
 	.addons-banner-block img {
 		height: 62px;
+	}
+
+	.addons-ad-block {
+		display: flex;
+		padding: 20px;
+
+		.addons-img {
+			height: auto;
+			width: 200px;
+		}
+	}
+
+	.addons-ad-block-content {
+		display: flex;
+		flex-direction: column;
+		margin-left: 24px;
+	}
+
+	.addons-ad-block-description {
+		margin-bottom: 20px;
+	}
+
+	.addons-ad-block-title {
+		margin: 0 0 16px;
+		padding: 0;
+	}
+
+	.addons-ad-block-buttons {
+		margin-top: auto;
+
+		.addons-button {
+			margin-right: 8px;
+
+			&:last-child {
+				margin-right: 0;
+			}
+		}
 	}
 
 	.addons-banner-block p {
@@ -364,6 +400,12 @@
 		color: #fff;
 	}
 
+	.addons-button-expandable {
+		display: inline-block;
+		padding: 0 16px;
+		width: auto !important;
+	}
+
 	.addons-button-solid:hover {
 		color: #fff;
 		opacity: 0.8;
@@ -451,9 +493,8 @@
 			flex: 1;
 			overflow: hidden;
 			background: #f5f5f5;
-			box-shadow:
-				inset 0 1px 0 rgba(255, 255, 255, 0.2),
-				inset 0 -1px 0 rgba(0, 0, 0, 0.1);
+			box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.2),
+			inset 0 -1px 0 rgba(0, 0, 0, 0.1);
 
 			a {
 				text-decoration: none;
@@ -645,7 +686,7 @@ mark.amount {
 
 	&::after {
 
-		@include icon_dashicons( "\f223" );
+		@include icon_dashicons("\f223");
 		cursor: help;
 	}
 }
@@ -830,7 +871,7 @@ table.wc_status_table--tools {
 	}
 
 	// Adjust log table columns only when table is not collapsed
-	@media screen and ( min-width: 783px ) {
+	@media screen and (min-width: 783px) {
 
 		.column-timestamp {
 			width: 18%;
@@ -1021,7 +1062,7 @@ ul.wc_coupon_list {
 
 				&::before {
 
-					@include icon_dashicons( "\f158" );
+					@include icon_dashicons("\f158");
 				}
 
 				&:hover::before {
@@ -1065,7 +1106,7 @@ ul.wc_coupon_list_block {
 
 	&::after {
 
-		@include icon_dashicons( "\f345" );
+		@include icon_dashicons("\f345");
 		line-height: 28px;
 	}
 }
@@ -1589,7 +1630,7 @@ ul.wc_coupon_list_block {
 
 					&::before {
 
-						@include icon_dashicons( "\f128" );
+						@include icon_dashicons("\f128");
 						width: 38px;
 						line-height: 38px;
 						display: block;
@@ -1837,7 +1878,7 @@ ul.wc_coupon_list_block {
 
 				&::before {
 
-					@include icon( "\e007" );
+					@include icon("\e007");
 					color: #ccc;
 				}
 			}
@@ -1852,7 +1893,7 @@ ul.wc_coupon_list_block {
 
 				&::before {
 
-					@include icon( "\e014" );
+					@include icon("\e014");
 					color: #ccc;
 				}
 			}
@@ -1869,7 +1910,7 @@ ul.wc_coupon_list_block {
 
 					&::before {
 
-						@include icon( "\e01a" );
+						@include icon("\e01a");
 						color: #ccc;
 					}
 				}
@@ -1898,7 +1939,7 @@ ul.wc_coupon_list_block {
 
 					&::before {
 
-						@include icon_dashicons( "\f153" );
+						@include icon_dashicons("\f153");
 						color: #999;
 					}
 
@@ -1920,7 +1961,7 @@ ul.wc_coupon_list_block {
 
 				&::before {
 
-					@include icon_dashicons( "\f171" );
+					@include icon_dashicons("\f171");
 					position: relative;
 					top: auto;
 					left: auto;
@@ -1976,7 +2017,7 @@ ul.wc_coupon_list_block {
 
 		.edit-order-item::before {
 
-			@include icon_dashicons( "\f464" );
+			@include icon_dashicons("\f464");
 			position: relative;
 		}
 
@@ -1985,7 +2026,7 @@ ul.wc_coupon_list_block {
 
 			&::before {
 
-				@include icon_dashicons( "\f158" );
+				@include icon_dashicons("\f158");
 				position: relative;
 			}
 
@@ -2353,7 +2394,7 @@ ul.wc_coupon_list_block {
 
 			&::before {
 
-				@include icon( "\e010" );
+				@include icon("\e010");
 				line-height: 16px;
 				font-size: 14px;
 				vertical-align: middle;
@@ -2642,6 +2683,29 @@ ul.wc_coupon_list_block {
 			float: right;
 		}
 	}
+
+	.wc_addons_wrap {
+		.addons-ad-block {
+			flex-direction: column;
+			padding: 24px;
+
+			.addons-img {
+				height: auto;
+				width: 100%;
+				max-width: 240px;
+				margin: 0 auto 20px;
+			}
+		}
+
+		.addons-ad-block-content {
+			display: block;
+			margin-left: 0;
+		}
+
+		.addons-ad-block-title {
+			margin-top: 4px;
+		}
+	}
 }
 
 .column-customer_message .note-on {
@@ -2652,7 +2716,7 @@ ul.wc_coupon_list_block {
 
 	&::after {
 
-		@include icon( "\e026" );
+		@include icon("\e026");
 		line-height: 16px;
 	}
 }
@@ -2665,7 +2729,7 @@ ul.wc_coupon_list_block {
 
 	&::after {
 
-		@include icon( "\e027" );
+		@include icon("\e027");
 		line-height: 16px;
 	}
 }
@@ -2902,7 +2966,7 @@ table.wp-list-table {
 
 		&::before {
 
-			@include icon_dashicons( "\f128" );
+			@include icon_dashicons("\f128");
 		}
 	}
 
@@ -3867,19 +3931,19 @@ img.help_tip {
 
 .status-manual::before {
 
-	@include icon( "\e008" );
+	@include icon("\e008");
 	color: #999;
 }
 
 .status-enabled::before {
 
-	@include icon( "\e015" );
+	@include icon("\e015");
 	color: $woocommerce;
 }
 
 .status-disabled::before {
 
-	@include icon( "\e013" );
+	@include icon("\e013");
 	color: #ccc;
 }
 
@@ -4298,7 +4362,7 @@ img.help_tip {
 
 				&::after {
 
-					@include icon_dashicons( "\f161" );
+					@include icon_dashicons("\f161");
 					font-size: 2.618em;
 					line-height: 72px;
 					color: #ddd;
@@ -4340,7 +4404,7 @@ img.help_tip {
 
 						&::before {
 
-							@include icon_dashicons( "\f153" );
+							@include icon_dashicons("\f153");
 							color: #999;
 							background: #fff;
 							border-radius: 50%;
@@ -4527,7 +4591,7 @@ img.help_tip {
 
 				&::before {
 
-					@include iconbeforedashicons( "\f107" );
+					@include iconbeforedashicons("\f107");
 				}
 			}
 
@@ -4611,7 +4675,7 @@ img.help_tip {
 
 		.add.button::before {
 
-			@include iconbefore( "\e007" );
+			@include iconbefore("\e007");
 		}
 	}
 
@@ -4727,7 +4791,7 @@ img.help_tip {
 
 				&::before {
 
-					@include icon_dashicons( "\f153" );
+					@include icon_dashicons("\f153");
 					color: #999;
 				}
 
@@ -5642,7 +5706,7 @@ img.ui-datepicker-trigger {
 
 				&::before {
 
-					@include iconbeforedashicons( "\f346" );
+					@include iconbeforedashicons("\f346");
 					margin-right: 4px;
 				}
 			}
@@ -5769,7 +5833,7 @@ img.ui-datepicker-trigger {
 
 						&::after {
 
-							@include iconafter( "\e035" );
+							@include iconafter("\e035");
 							float: right;
 							font-size: 0.9em;
 							line-height: 1.618;
@@ -5902,9 +5966,8 @@ img.ui-datepicker-trigger {
 				}
 
 				&:hover {
-					box-shadow:
-						inset 0 -1px 0 0 #dfdfdf,
-						inset 300px 0 0 rgba(156, 93, 144, 0.1);
+					box-shadow: inset 0 -1px 0 0 #dfdfdf,
+					inset 300px 0 0 rgba(156, 93, 144, 0.1);
 					border-right: 5px solid #9c5d90 !important;
 					padding-left: 1.5em;
 					color: #9c5d90;
@@ -6104,27 +6167,27 @@ table.bar_chart {
 
 .post-type-shop_order .woocommerce-BlankState-message::before {
 
-	@include icon( "\e01d" );
+	@include icon("\e01d");
 }
 
 .post-type-shop_coupon .woocommerce-BlankState-message::before {
 
-	@include icon( "\e600" );
+	@include icon("\e600");
 }
 
 .post-type-product .woocommerce-BlankState-message::before {
 
-	@include icon( "\e006" );
+	@include icon("\e006");
 }
 
 .woocommerce-BlankState--api .woocommerce-BlankState-message::before {
 
-	@include icon( "\e01c" );
+	@include icon("\e01c");
 }
 
 .woocommerce-BlankState--webhooks .woocommerce-BlankState-message::before {
 
-	@include icon( "\e01b" );
+	@include icon("\e01b");
 }
 
 .woocommerce-BlankState {
@@ -7298,7 +7361,7 @@ table.bar_chart {
 
 			&::before {
 
-				@include icon( "\e015" );
+				@include icon("\e015");
 				color: #a16696;
 				position: static;
 				font-size: 100px;

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -404,7 +404,7 @@
 	.addons-button-expandable {
 		display: inline-block;
 		padding: 0 16px;
-		width: auto !important;
+		width: auto;
 	}
 
 	.addons-button-solid:hover {

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -161,7 +161,7 @@
 		}
 	}
 
-	.addons-ad-block {
+	.addons-promotion-block {
 		display: flex;
 		padding: 20px;
 
@@ -171,22 +171,22 @@
 		}
 	}
 
-	.addons-ad-block-content {
+	.addons-promotion-block-content {
 		display: flex;
 		flex-direction: column;
 		margin-left: 24px;
 	}
 
-	.addons-ad-block-description {
+	.addons-promotion-block-description {
 		margin-bottom: 20px;
 	}
 
-	.addons-ad-block-title {
+	.addons-promotion-block-title {
 		margin: 0 0 16px;
 		padding: 0;
 	}
 
-	.addons-ad-block-buttons {
+	.addons-promotion-block-buttons {
 		margin-top: auto;
 
 		.addons-button {
@@ -2688,7 +2688,7 @@ ul.wc_coupon_list_block {
 
 	.wc_addons_wrap {
 
-		.addons-ad-block {
+		.addons-promotion-block {
 			flex-direction: column;
 			padding: 24px;
 
@@ -2700,12 +2700,12 @@ ul.wc_coupon_list_block {
 			}
 		}
 
-		.addons-ad-block-content {
+		.addons-promotion-block-content {
 			display: block;
 			margin-left: 0;
 		}
 
-		.addons-ad-block-title {
+		.addons-promotion-block-title {
 			margin-top: 4px;
 		}
 	}

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -50,6 +50,7 @@ class WC_Admin_Addons {
 
 		if ( is_object( $featured ) ) {
 			self::output_featured_sections( $featured->sections );
+
 			return $featured;
 		}
 	}
@@ -57,9 +58,9 @@ class WC_Admin_Addons {
 	/**
 	 * Build url parameter string
 	 *
-	 * @param  string $category Addon (sub) category.
-	 * @param  string $term     Search terms.
-	 * @param  string $country  Store country.
+	 * @param string $category Addon (sub) category.
+	 * @param string $term     Search terms.
+	 * @param string $country  Store country.
 	 *
 	 * @return string url parameter string
 	 */
@@ -77,14 +78,14 @@ class WC_Admin_Addons {
 	/**
 	 * Call API to get extensions
 	 *
-	 * @param  string $category Addon (sub) category.
-	 * @param  string $term     Search terms.
-	 * @param  string $country  Store country.
+	 * @param string $category Addon (sub) category.
+	 * @param string $term     Search terms.
+	 * @param string $country  Store country.
 	 *
 	 * @return array of extensions
 	 */
 	public static function get_extension_data( $category, $term, $country ) {
-		$parameters     = self::build_parameter_string( $category, $term, $country );
+		$parameters = self::build_parameter_string( $category, $term, $country );
 
 		$headers = array();
 		$auth    = WC_Helper_Options::get( 'auth' );
@@ -101,6 +102,7 @@ class WC_Admin_Addons {
 		if ( ! is_wp_error( $raw_extensions ) ) {
 			$addons = json_decode( wp_remote_retrieve_body( $raw_extensions ) )->products;
 		}
+
 		return $addons;
 	}
 
@@ -122,13 +124,14 @@ class WC_Admin_Addons {
 				}
 			}
 		}
+
 		return apply_filters( 'woocommerce_addons_sections', $addon_sections );
 	}
 
 	/**
 	 * Get section for the addons screen.
 	 *
-	 * @param  string $section_id Required section ID.
+	 * @param string $section_id Required section ID.
 	 *
 	 * @return object|bool
 	 */
@@ -137,13 +140,14 @@ class WC_Admin_Addons {
 		if ( isset( $sections[ $section_id ] ) ) {
 			return $sections[ $section_id ];
 		}
+
 		return false;
 	}
 
 	/**
 	 * Get section content for the addons screen.
 	 *
-	 * @param  string $section_id Required section ID.
+	 * @param string $section_id Required section ID.
 	 *
 	 * @return array
 	 */
@@ -226,12 +230,12 @@ class WC_Admin_Addons {
 								<h3><?php echo esc_html( $item->title ); ?></h3>
 								<p><?php echo esc_html( $item->description ); ?></p>
 								<?php
-									self::output_button(
-										$item->href,
-										$item->button,
-										'addons-button-solid',
-										$item->plugin
-									);
+								self::output_button(
+									$item->href,
+									$item->button,
+									'addons-button-solid',
+									$item->plugin
+								);
 								?>
 							</div>
 						</div>
@@ -288,12 +292,12 @@ class WC_Admin_Addons {
 						<div class="addons-column-block-item-content">
 							<h2><?php echo esc_html( $item->title ); ?></h2>
 							<?php
-								self::output_button(
-									$item->href,
-									$item->button,
-									'addons-button-solid',
-									$item->plugin
-								);
+							self::output_button(
+								$item->href,
+								$item->button,
+								'addons-button-solid',
+								$item->plugin
+							);
 							?>
 							<p><?php echo esc_html( $item->description ); ?></p>
 						</div>
@@ -320,11 +324,11 @@ class WC_Admin_Addons {
 				<div class="addons-small-light-block-buttons">
 					<?php foreach ( $block->buttons as $button ) : ?>
 						<?php
-							self::output_button(
-								$button->href,
-								$button->text,
-								'addons-button-solid'
-							);
+						self::output_button(
+							$button->href,
+							$button->text,
+							'addons-button-solid'
+						);
 						?>
 					<?php endforeach; ?>
 				</div>
@@ -352,11 +356,11 @@ class WC_Admin_Addons {
 							</div>
 						<?php endif; ?>
 						<?php
-							self::output_button(
-								$item->href,
-								$item->button,
-								'addons-button-outline-white'
-							);
+						self::output_button(
+							$item->href,
+							$item->button,
+							'addons-button-outline-white'
+						);
 						?>
 					</div>
 				<?php endforeach; ?>
@@ -461,11 +465,11 @@ class WC_Admin_Addons {
 					<?php endforeach; ?>
 				</ul>
 				<?php
-					self::output_button(
-						$block_data['href'],
-						$block_data['button'],
-						'addons-button-outline-purple'
-					);
+				self::output_button(
+					$block_data['href'],
+					$block_data['button'],
+					'addons-button-outline-purple'
+				);
 				?>
 			</div>
 		</div>
@@ -523,12 +527,70 @@ class WC_Admin_Addons {
 				<h1><?php echo esc_html( $block_data['title'] ); ?></h1>
 				<p><?php echo esc_html( $block_data['description'] ); ?></p>
 				<?php
-					self::output_button(
-						$block_data['href'],
-						$block_data['button'],
-						'addons-button-outline-purple'
-					);
+				self::output_button(
+					$block_data['href'],
+					$block_data['button'],
+					'addons-button-outline-purple'
+				);
 				?>
+			</div>
+		</div>
+		<?php
+	}
+
+	public static function output_ad_block( $section ) {
+		if (
+			! current_user_can( 'install_plugins' ) ||
+			! current_user_can( 'activate_plugins' )
+		) {
+			return;
+		}
+
+		$section_object = (object) $section;
+
+		if ( ! empty( $section_object->geowhitelist ) ) {
+			$section_object->geowhitelist = explode( ',', $section_object->geowhitelist );
+		}
+
+		if ( ! self::show_extension( $section_object ) ) {
+			return;
+		}
+
+		?>
+		<div class="addons-banner-block addons-ad-block">
+			<img
+				class="addons-img"
+				src="<?php echo esc_url( $section['image'] ); ?>"
+				alt="<?php echo esc_attr( $section['image_alt'] ); ?>"
+			/>
+			<div class="addons-ad-block-content">
+				<h1 class="addons-ad-block-title"><?php echo esc_html( $section['title'] ); ?></h1>
+				<div class="addons-ad-block-description">
+					<?php echo wp_kses_post( $section['description'] ); ?>
+				</div>
+				<div class="addons-ad-block-buttons">
+					<?php
+
+					if ( $section['button_1'] ) {
+						self::output_button(
+							$section['button_1_href'],
+							$section['button_1'],
+							'addons-button-expandable addons-button-solid',
+							$section['plugin']
+						);
+					}
+
+					if ( $section['button_2'] ) {
+						self::output_button(
+							$section['button_2_href'],
+							$section['button_2'],
+							'addons-button-expandable addons-button-outline-purple',
+							$section['plugin']
+						);
+					}
+
+					?>
+				</div>
 			</div>
 		</div>
 		<?php
@@ -566,6 +628,9 @@ class WC_Admin_Addons {
 				case 'wcpay_banner_block':
 					self::output_wcpay_banner_block( (array) $section );
 					break;
+				case 'wcpay_global_banner_block':
+					self::output_ad_block( (array) $section );
+					break;
 			}
 		}
 	}
@@ -577,6 +642,7 @@ class WC_Admin_Addons {
 		// Get url (from path onward) for the current page,
 		// so WCCOM "back" link returns user to where they were.
 		$back_admin_path = add_query_arg( array() );
+
 		return array(
 			'wccom-site'          => site_url(),
 			'wccom-back'          => rawurlencode( $back_admin_path ),
@@ -591,7 +657,7 @@ class WC_Admin_Addons {
 	 * Adds various url parameters to a url to support a streamlined
 	 * flow for obtaining and setting up WooCommerce extensons.
 	 *
-	 * @param string $url    Destination URL.
+	 * @param string $url Destination URL.
 	 */
 	public static function add_in_app_purchase_url_params( $url ) {
 		return add_query_arg(
@@ -632,6 +698,7 @@ class WC_Admin_Addons {
 
 		if ( isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
 			do_action( 'woocommerce_helper_output' );
+
 			return;
 		}
 
@@ -718,6 +785,7 @@ class WC_Admin_Addons {
 	 * Should an extension be shown on the featured page.
 	 *
 	 * @param object $item Item data.
+	 *
 	 * @return boolean
 	 */
 	public static function show_extension( $item ) {

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -539,7 +539,7 @@ class WC_Admin_Addons {
 	 *
 	 * @param array $section Section data.
 	 */
-	public static function output_ad_block( $section ) {
+	public static function output_promotion_block( $section ) {
 		if (
 			! current_user_can( 'install_plugins' ) ||
 			! current_user_can( 'activate_plugins' )
@@ -558,18 +558,18 @@ class WC_Admin_Addons {
 		}
 
 		?>
-		<div class="addons-banner-block addons-ad-block">
+		<div class="addons-banner-block addons-promotion-block">
 			<img
 				class="addons-img"
 				src="<?php echo esc_url( $section['image'] ); ?>"
 				alt="<?php echo esc_attr( $section['image_alt'] ); ?>"
 			/>
-			<div class="addons-ad-block-content">
-				<h1 class="addons-ad-block-title"><?php echo esc_html( $section['title'] ); ?></h1>
-				<div class="addons-ad-block-description">
+			<div class="addons-promotion-block-content">
+				<h1 class="addons-promotion-block-title"><?php echo esc_html( $section['title'] ); ?></h1>
+				<div class="addons-promotion-block-description">
 					<?php echo wp_kses_post( $section['description'] ); ?>
 				</div>
-				<div class="addons-ad-block-buttons">
+				<div class="addons-promotion-block-buttons">
 					<?php
 
 					if ( $section['button_1'] ) {
@@ -629,8 +629,8 @@ class WC_Admin_Addons {
 				case 'wcpay_banner_block':
 					self::output_wcpay_banner_block( (array) $section );
 					break;
-				case 'wcpay_global_banner_block':
-					self::output_ad_block( (array) $section );
+				case 'promotion_block':
+					self::output_promotion_block( (array) $section );
 					break;
 			}
 		}

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -537,7 +537,7 @@ class WC_Admin_Addons {
 	/**
 	 * Handles the output of a full-width block.
 	 *
-	 * @param $section
+	 * array $section Section data for this block, which is a section itself.
 	 */
 	public static function output_ad_block( $section ) {
 		if (

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -50,7 +50,6 @@ class WC_Admin_Addons {
 
 		if ( is_object( $featured ) ) {
 			self::output_featured_sections( $featured->sections );
-
 			return $featured;
 		}
 	}
@@ -58,9 +57,9 @@ class WC_Admin_Addons {
 	/**
 	 * Build url parameter string
 	 *
-	 * @param string $category Addon (sub) category.
-	 * @param string $term     Search terms.
-	 * @param string $country  Store country.
+	 * @param  string $category Addon (sub) category.
+	 * @param  string $term     Search terms.
+	 * @param  string $country  Store country.
 	 *
 	 * @return string url parameter string
 	 */
@@ -78,14 +77,14 @@ class WC_Admin_Addons {
 	/**
 	 * Call API to get extensions
 	 *
-	 * @param string $category Addon (sub) category.
-	 * @param string $term     Search terms.
-	 * @param string $country  Store country.
+	 * @param  string $category Addon (sub) category.
+	 * @param  string $term     Search terms.
+	 * @param  string $country  Store country.
 	 *
 	 * @return array of extensions
 	 */
 	public static function get_extension_data( $category, $term, $country ) {
-		$parameters = self::build_parameter_string( $category, $term, $country );
+		$parameters     = self::build_parameter_string( $category, $term, $country );
 
 		$headers = array();
 		$auth    = WC_Helper_Options::get( 'auth' );
@@ -102,7 +101,6 @@ class WC_Admin_Addons {
 		if ( ! is_wp_error( $raw_extensions ) ) {
 			$addons = json_decode( wp_remote_retrieve_body( $raw_extensions ) )->products;
 		}
-
 		return $addons;
 	}
 
@@ -124,14 +122,13 @@ class WC_Admin_Addons {
 				}
 			}
 		}
-
 		return apply_filters( 'woocommerce_addons_sections', $addon_sections );
 	}
 
 	/**
 	 * Get section for the addons screen.
 	 *
-	 * @param string $section_id Required section ID.
+	 * @param  string $section_id Required section ID.
 	 *
 	 * @return object|bool
 	 */
@@ -140,14 +137,13 @@ class WC_Admin_Addons {
 		if ( isset( $sections[ $section_id ] ) ) {
 			return $sections[ $section_id ];
 		}
-
 		return false;
 	}
 
 	/**
 	 * Get section content for the addons screen.
 	 *
-	 * @param string $section_id Required section ID.
+	 * @param  string $section_id Required section ID.
 	 *
 	 * @return array
 	 */
@@ -230,12 +226,12 @@ class WC_Admin_Addons {
 								<h3><?php echo esc_html( $item->title ); ?></h3>
 								<p><?php echo esc_html( $item->description ); ?></p>
 								<?php
-								self::output_button(
-									$item->href,
-									$item->button,
-									'addons-button-solid',
-									$item->plugin
-								);
+									self::output_button(
+										$item->href,
+										$item->button,
+										'addons-button-solid',
+										$item->plugin
+									);
 								?>
 							</div>
 						</div>
@@ -292,12 +288,12 @@ class WC_Admin_Addons {
 						<div class="addons-column-block-item-content">
 							<h2><?php echo esc_html( $item->title ); ?></h2>
 							<?php
-							self::output_button(
-								$item->href,
-								$item->button,
-								'addons-button-solid',
-								$item->plugin
-							);
+								self::output_button(
+									$item->href,
+									$item->button,
+									'addons-button-solid',
+									$item->plugin
+								);
 							?>
 							<p><?php echo esc_html( $item->description ); ?></p>
 						</div>
@@ -324,11 +320,11 @@ class WC_Admin_Addons {
 				<div class="addons-small-light-block-buttons">
 					<?php foreach ( $block->buttons as $button ) : ?>
 						<?php
-						self::output_button(
-							$button->href,
-							$button->text,
-							'addons-button-solid'
-						);
+							self::output_button(
+								$button->href,
+								$button->text,
+								'addons-button-solid'
+							);
 						?>
 					<?php endforeach; ?>
 				</div>
@@ -356,11 +352,11 @@ class WC_Admin_Addons {
 							</div>
 						<?php endif; ?>
 						<?php
-						self::output_button(
-							$item->href,
-							$item->button,
-							'addons-button-outline-white'
-						);
+							self::output_button(
+								$item->href,
+								$item->button,
+								'addons-button-outline-white'
+							);
 						?>
 					</div>
 				<?php endforeach; ?>
@@ -465,11 +461,11 @@ class WC_Admin_Addons {
 					<?php endforeach; ?>
 				</ul>
 				<?php
-				self::output_button(
-					$block_data['href'],
-					$block_data['button'],
-					'addons-button-outline-purple'
-				);
+					self::output_button(
+						$block_data['href'],
+						$block_data['button'],
+						'addons-button-outline-purple'
+					);
 				?>
 			</div>
 		</div>
@@ -527,17 +523,22 @@ class WC_Admin_Addons {
 				<h1><?php echo esc_html( $block_data['title'] ); ?></h1>
 				<p><?php echo esc_html( $block_data['description'] ); ?></p>
 				<?php
-				self::output_button(
-					$block_data['href'],
-					$block_data['button'],
-					'addons-button-outline-purple'
-				);
+					self::output_button(
+						$block_data['href'],
+						$block_data['button'],
+						'addons-button-outline-purple'
+					);
 				?>
 			</div>
 		</div>
 		<?php
 	}
 
+	/**
+	 * Handles the output of a full-width block.
+	 *
+	 * @param $section
+	 */
 	public static function output_ad_block( $section ) {
 		if (
 			! current_user_can( 'install_plugins' ) ||
@@ -642,7 +643,6 @@ class WC_Admin_Addons {
 		// Get url (from path onward) for the current page,
 		// so WCCOM "back" link returns user to where they were.
 		$back_admin_path = add_query_arg( array() );
-
 		return array(
 			'wccom-site'          => site_url(),
 			'wccom-back'          => rawurlencode( $back_admin_path ),
@@ -657,7 +657,7 @@ class WC_Admin_Addons {
 	 * Adds various url parameters to a url to support a streamlined
 	 * flow for obtaining and setting up WooCommerce extensons.
 	 *
-	 * @param string $url Destination URL.
+	 * @param string $url    Destination URL.
 	 */
 	public static function add_in_app_purchase_url_params( $url ) {
 		return add_query_arg(
@@ -698,7 +698,6 @@ class WC_Admin_Addons {
 
 		if ( isset( $_GET['section'] ) && 'helper' === $_GET['section'] ) {
 			do_action( 'woocommerce_helper_output' );
-
 			return;
 		}
 
@@ -785,7 +784,6 @@ class WC_Admin_Addons {
 	 * Should an extension be shown on the featured page.
 	 *
 	 * @param object $item Item data.
-	 *
 	 * @return boolean
 	 */
 	public static function show_extension( $item ) {

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -549,8 +549,8 @@ class WC_Admin_Addons {
 
 		$section_object = (object) $section;
 
-		if ( ! empty( $section_object->geowhitelist ) ) {
-			$section_object->geowhitelist = explode( ',', $section_object->geowhitelist );
+		if ( ! empty( $section_object->geo_allow_list ) ) {
+			$section_object->geo_allow_list = explode( ',', $section_object->geo_allow_list );
 		}
 
 		if ( ! self::show_extension( $section_object ) ) {
@@ -788,11 +788,11 @@ class WC_Admin_Addons {
 	 */
 	public static function show_extension( $item ) {
 		$location = WC()->countries->get_base_country();
-		if ( isset( $item->geowhitelist ) && ! in_array( $location, $item->geowhitelist, true ) ) {
+		if ( isset( $item->geo_allow_list ) && ! in_array( $location, $item->geo_allow_list, true ) ) {
 			return false;
 		}
 
-		if ( isset( $item->geoblacklist ) && in_array( $location, $item->geoblacklist, true ) ) {
+		if ( isset( $item->geo_block_list ) && in_array( $location, $item->geo_block_list, true ) ) {
 			return false;
 		}
 

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -537,7 +537,7 @@ class WC_Admin_Addons {
 	/**
 	 * Handles the output of a full-width block.
 	 *
-	 * array $section Section data for this block, which is a section itself.
+	 * @param array $section Section data.
 	 */
 	public static function output_ad_block( $section ) {
 		if (

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -553,6 +553,10 @@ class WC_Admin_Addons {
 			$section_object->geowhitelist = explode( ',', $section_object->geowhitelist );
 		}
 
+		if ( ! empty( $section_object->geoblacklist ) ) {
+			$section_object->geoblacklist = explode( ',', $section_object->geoblacklist );
+		}
+
 		if ( ! self::show_extension( $section_object ) ) {
 			return;
 		}

--- a/includes/admin/class-wc-admin-addons.php
+++ b/includes/admin/class-wc-admin-addons.php
@@ -549,8 +549,8 @@ class WC_Admin_Addons {
 
 		$section_object = (object) $section;
 
-		if ( ! empty( $section_object->geo_allow_list ) ) {
-			$section_object->geo_allow_list = explode( ',', $section_object->geo_allow_list );
+		if ( ! empty( $section_object->geowhitelist ) ) {
+			$section_object->geowhitelist = explode( ',', $section_object->geowhitelist );
 		}
 
 		if ( ! self::show_extension( $section_object ) ) {
@@ -788,11 +788,11 @@ class WC_Admin_Addons {
 	 */
 	public static function show_extension( $item ) {
 		$location = WC()->countries->get_base_country();
-		if ( isset( $item->geo_allow_list ) && ! in_array( $location, $item->geo_allow_list, true ) ) {
+		if ( isset( $item->geowhitelist ) && ! in_array( $location, $item->geowhitelist, true ) ) {
 			return false;
 		}
 
-		if ( isset( $item->geo_block_list ) && in_array( $location, $item->geo_block_list, true ) ) {
+		if ( isset( $item->geoblacklist ) && in_array( $location, $item->geoblacklist, true ) ) {
 			return false;
 		}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
We want to be able to show a banner on the wc-admin featured extensions page, to highlight the benefits WooCommerce Pay offers to store owners and customers.

- Add support for a banner on the featured extensions section.
- Add CSS rules for the banner to `admin.scss`.

### WooCommerce.com issue

This change is related to 9860-gh-Automattic/woocommerce.com.

### How to test the changes in this Pull Request:

1. Check the branch out locally and build assets.
2. If the update to the WooCommerce.com featured endpoint  in 10179-gh-Automattic/woocommerce.com hasn't been merged yet, you'll need to modify the featured endpoint locally to see the ad. Copy the JSON from [here](293e7-pb/) and make it available at some publicly-accessible URL, like a GitHub gist. Go to `includes/admin/class-wc-admin-addons.php` and replace

```php
$raw_featured = wp_safe_remote_get(
	'https://woocommerce.com/wp-json/wccom-extensions/1.0/featured',
	array(
		'headers'    => $headers,
		'user-agent' => 'WooCommerce Addons Page',
	)
);
```

with

```php
$raw_featured = wp_safe_remote_get(
	[ URL for the file ],
);
```

You may need to flush the object cache and featured transient to see the changes:

```
wp cache flush
wp transient delete wc_addons_featured
```
3. To see the ad, WCPay should not be active on your test site, and your location should be in the US, Canada, UK, Ireland, Australia or New Zealand. If you're not in one of these countries, you can cheat by commenting out lines 793-795 of `includes/admin/class-wc-admin-addons.php`:

```php
if ( isset( $item->geowhitelist ) && ! in_array( $location, $item->geowhitelist, true ) ) {
    return false;
}
```

4. Go to the WooCommerce > Extensions page in your test site. You should see the "featured" section (`/wp-admin/admin.php?page=wc-addons&section=_featured`). Check that the ad appears as expected, and the links work.
5. Install and activate WCPay. The ad should not appear.
6. For bonus points, view the screen from an unsupported location, or hack the `show_extension` method so it doesn't like your country. The ad should not appear.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

New - Feature WooCommerce Payments in the extensions store for stores in the US, Canada, UK, Ireland, Australia and New Zealand.

### Screenshots

<img width="300" src="https://user-images.githubusercontent.com/1647564/117308582-993b2c80-ae79-11eb-9dd9-02046a67494d.png"/>

<img width="500" src="https://user-images.githubusercontent.com/1647564/117308696-b3750a80-ae79-11eb-98fe-a4981495f0df.png"/>