### PR TITLE
Remove Curaçao postcode

### DIFF
--- a/includes/class-wc-countries.php
+++ b/includes/class-wc-countries.php
@@ -937,6 +937,15 @@ class WC_Countries {
 							'required' => false,
 						),
 					),
+					'CW' => array(
+						'postcode' => array(
+							'required' => false,
+							'hidden'   => true,
+						),
+						'state'    => array(
+							'required' => false,
+						),
+					),
 					'CZ' => array(
 						'state' => array(
 							'required' => false,


### PR DESCRIPTION
### All Submissions:

* [X ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
Remove Curaçao postcode and State required fields in the checkout

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29840 

### How to test the changes in this Pull Request:

1. Change your country to Curaçao
2. Postcode and state are not required
3.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - By default the postcode field will no longer be used, and the state field will become optional, for Curaçao. Props @yehudah.