### PR TITLE
fix get customer tokens limit

### DIFF
--- a/plugins/woocommerce/changelog/fix-29827
+++ b/plugins/woocommerce/changelog/fix-29827
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Adds new filter `woocommerce_get_customer_payment_tokens_limit` to set limit on number of payment methods fetched within the My Account page.

--- a/plugins/woocommerce/includes/class-wc-payment-tokens.php
+++ b/plugins/woocommerce/includes/class-wc-payment-tokens.php
@@ -74,6 +74,7 @@ class WC_Payment_Tokens {
 			array(
 				'user_id'    => $customer_id,
 				'gateway_id' => $gateway_id,
+				'limit'      => apply_filters( 'woocommerce_get_customer_payment_tokens_limit', 10 ),
 			)
 		);
 

--- a/plugins/woocommerce/includes/class-wc-payment-tokens.php
+++ b/plugins/woocommerce/includes/class-wc-payment-tokens.php
@@ -74,7 +74,7 @@ class WC_Payment_Tokens {
 			array(
 				'user_id'    => $customer_id,
 				'gateway_id' => $gateway_id,
-				'limit'      => apply_filters( 'woocommerce_get_customer_payment_tokens_limit', 10 ),
+				'limit'      => apply_filters( 'woocommerce_get_customer_payment_tokens_limit', get_option( 'posts_per_page' ) ),
 			)
 		);
 

--- a/plugins/woocommerce/includes/class-wc-payment-tokens.php
+++ b/plugins/woocommerce/includes/class-wc-payment-tokens.php
@@ -74,6 +74,13 @@ class WC_Payment_Tokens {
 			array(
 				'user_id'    => $customer_id,
 				'gateway_id' => $gateway_id,
+				/**
+				 * Controls the maximum number of Payment Methods that will be listed via the My Account page.
+				 *
+				 * @since 7.2.0
+				 *
+				 * @param int $limit Defaults to the value of the `posts_per_page` option.
+				 */
 				'limit'      => apply_filters( 'woocommerce_get_customer_payment_tokens_limit', get_option( 'posts_per_page' ) ),
 			)
 		);


### PR DESCRIPTION
get_customer_tokens is dependent on posts_per_page, if you have more payment methods than the value defined on posts_per_page you will not see all of the payment methods.

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
add a new filter `woocommerce_get_customer_payment_tokens_limit` with default value of 10.
I think that limit of five can work too but I decided to add ten, and give the user control of this.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29827.

### How to test the changes in this Pull Request:

1. To test this, you will first need to add a payment gateway that supports storage of payment tokens:
    - [WooCommerce Stripe Payment Gateway](https://wordpress.org/plugins/woocommerce-gateway-stripe/) is one such example. I recommend you test using this one.
    - Default gateways such as Direct Bank Transfer or Check Payments are **not** suitable.
2. As a logged-in customer, navigate to **My Account ▸ Payment Methods**.
3. Add two or more payment methods, unless you have some set-up already.
4. Test the following snippet (this could be added to a location such as `wp-content/mu-plugins/test-29850.php`):

```php
<?php
add_filter( 'woocommerce_get_customer_payment_tokens_limit', function() {
    return 1;
} );
```

5. Revisit or reload **My Account ▸ Payment Methods** ... you should only see one payment method.
6. Modify the above snippet to `return 20;` and you should see up to but no more than 20 payment methods (of course, if you only have 3 payment methods, then that is all that can be listed).
7. Remove the snippet altogether. Now, you should see up to *x* payment methods, where *x* is the value you see for the **Settings ▸ Reading ▸ Blog pages show at most** setting.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
