### PR TITLE
Update woocommerce-admin to latest version 2.2.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "2.2.2",
+    "woocommerce/woocommerce-admin": "2.2.5",
     "woocommerce/woocommerce-blocks": "4.9.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a604678b268820c78736d599e1eb6726",
+    "content-hash": "a254618fdbaa84ab8d4a1fb9ddd632e8",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -503,16 +503,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.2.2",
+            "version": "2.2.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "161e6afa01a3fb69533cfa2b245a71df7512ec3f"
+                "reference": "10d48b516d38fb72a2e567de76eaa22c44ea7f86"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/161e6afa01a3fb69533cfa2b245a71df7512ec3f",
-                "reference": "161e6afa01a3fb69533cfa2b245a71df7512ec3f",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/10d48b516d38fb72a2e567de76eaa22c44ea7f86",
+                "reference": "10d48b516d38fb72a2e567de76eaa22c44ea7f86",
                 "shasum": ""
             },
             "require": {
@@ -544,7 +544,11 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2021-04-29T14:11:48+00:00"
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.2.5"
+            },
+            "time": "2021-05-07T18:04:30+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
_Note: This PR merges & overrides the 2.2.4 PR: https://github.com/woocommerce/woocommerce/pull/29851_

This bumps `woocommerce/woocommerce-admin` in Composer to the latest published package, version `2.2.5`.

## Testing Instructions
 
- Load this branch and do a `npm run build:dev`
- Navigate to the **Marketing > Coupons** page, the page should load fine
- Finish the onboarding flow, and click on `Add tax rates` task, and click `Set up manually` in step 2.
- Add a tax rate and click `Save changes`
- A popup should appear to `Continue setup`
 
## Changelog
 
```
- Fix: Calling of get_script_asset_filename with extra parameter #6955
```
 
### Changelog entry
 
> Update - WooCommerce Admin package 2.2.5