### PR TITLE
Update woocommerce-admin to latest version 2.2.6

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
-    "woocommerce/woocommerce-admin": "2.2.2",
+    "woocommerce/woocommerce-admin": "2.2.6",
     "woocommerce/woocommerce-blocks": "4.9.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -503,7 +503,7 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.2.2",
+            "version": "2.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
@@ -511,8 +511,8 @@
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/161e6afa01a3fb69533cfa2b245a71df7512ec3f",
-                "reference": "161e6afa01a3fb69533cfa2b245a71df7512ec3f",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/65c5a4d0b0c3a7c7457e250c9ba1f7c15cac6cb8",
+                "reference": "65c5a4d0b0c3a7c7457e250c9ba1f7c15cac6cb8",
                 "shasum": ""
             },
             "require": {


### PR DESCRIPTION
_Note: This PR merges & overrides the 2.2.5 PR: https://github.com/woocommerce/woocommerce/pull/29859_

This bumps `woocommerce/woocommerce-admin` in Composer to the latest published package, version `2.2.6`.

## Testing Instructions
 
- Complete the OBW until you get to the business details step.
- Deselect "Add recommended business features to my site", and select only Jetpack and WooCommerce Payments for installation.
- The plugins should be installed and activated correctly, and you should be able to continue in the flow.
 
## Changelog
 
```
- Fix: Address an issue with OBW when installing only WooCommerce payments and Jetpack. #6957
```
