### PR TITLE
update stale to Stale in feedback label CI

### DIFF
--- a/.github/workflows/update-feedback-labels.yml
+++ b/.github/workflows/update-feedback-labels.yml
@@ -21,4 +21,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         labels: |
           'needs feedback'
-          'stale'
+          'Stale'


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The change to the update feedback label Github Action is logging an error that a label does not exists. The action has `stale`. The label is capitalized. This PR updates the action script to be case sensitive.

### How to test the changes in this Pull Request:

1. Review script change

### Changelog entry

> N/A
