### PR TITLE
Update WooCommerce Blocks package to 5.1.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.1.6",
     "woocommerce/woocommerce-admin": "2.2.6",
-    "woocommerce/woocommerce-blocks": "4.9.1"
+    "woocommerce/woocommerce-blocks": "5.1.0"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a604678b268820c78736d599e1eb6726",
+    "content-hash": "3f82e5bd9e485ba6bcd94111391f6f11",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -51,6 +51,9 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-autoloader/tree/2.10.1"
+            },
             "time": "2021-03-30T15:15:59+00:00"
         },
         {
@@ -82,6 +85,9 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for defining constants in a more testable way.",
+            "support": {
+                "source": "https://github.com/Automattic/jetpack-constants/tree/v1.5.1"
+            },
             "time": "2020-10-28T19:00:31+00:00"
         },
         {
@@ -214,6 +220,10 @@
                 "zend",
                 "zikula"
             ],
+            "support": {
+                "issues": "https://github.com/composer/installers/issues",
+                "source": "https://github.com/composer/installers/tree/v1.11.0"
+            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -288,6 +298,10 @@
                 "geolocation",
                 "maxmind"
             ],
+            "support": {
+                "issues": "https://github.com/maxmind/MaxMind-DB-Reader-php/issues",
+                "source": "https://github.com/maxmind/MaxMind-DB-Reader-php/tree/v1.6.0"
+            },
             "time": "2019-12-19T22:59:03+00:00"
         },
         {
@@ -362,6 +376,10 @@
                 "email",
                 "pre-processing"
             ],
+            "support": {
+                "issues": "https://github.com/MyIntervals/emogrifier/issues",
+                "source": "https://github.com/MyIntervals/emogrifier"
+            },
             "time": "2019-12-26T19:37:31+00:00"
         },
         {
@@ -411,6 +429,10 @@
                 "container-interop",
                 "psr"
             ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/master"
+            },
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
@@ -464,6 +486,9 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/css-selector/tree/master"
+            },
             "time": "2017-05-01T15:01:29+00:00"
         },
         {
@@ -499,6 +524,10 @@
             ],
             "description": "Action Scheduler for WordPress and WooCommerce",
             "homepage": "https://actionscheduler.org/",
+            "support": {
+                "issues": "https://github.com/woocommerce/action-scheduler/issues",
+                "source": "https://github.com/woocommerce/action-scheduler/tree/master"
+            },
             "time": "2020-05-12T16:22:33+00:00"
         },
         {
@@ -507,7 +536,7 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "161e6afa01a3fb69533cfa2b245a71df7512ec3f"
+                "reference": "65c5a4d0b0c3a7c7457e250c9ba1f7c15cac6cb8"
             },
             "dist": {
                 "type": "zip",
@@ -544,20 +573,24 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "time": "2021-04-29T14:11:48+00:00"
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.2.6"
+            },
+            "time": "2021-05-07T21:29:02+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v4.9.1",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "62f32bfb45dfcb2ba3ca349a6ed0a8cf48ddefce"
+                "reference": "a4f168596f3832e161b26dec636b69293039ee51"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/62f32bfb45dfcb2ba3ca349a6ed0a8cf48ddefce",
-                "reference": "62f32bfb45dfcb2ba3ca349a6ed0a8cf48ddefce",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/a4f168596f3832e161b26dec636b69293039ee51",
+                "reference": "a4f168596f3832e161b26dec636b69293039ee51",
                 "shasum": ""
             },
             "require": {
@@ -565,7 +598,7 @@
                 "composer/installers": "^1.7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "6.5.14",
+                "phpunit/phpunit": "7.5.20",
                 "woocommerce/woocommerce-sniffs": "0.1.0"
             },
             "type": "wordpress-plugin",
@@ -591,7 +624,11 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "time": "2021-04-13T16:11:16+00:00"
+            "support": {
+                "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.1.0"
+            },
+            "time": "2021-05-10T15:01:42+00:00"
         }
     ],
     "packages-dev": [
@@ -639,6 +676,10 @@
                 "isolation",
                 "tool"
             ],
+            "support": {
+                "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
+                "source": "https://github.com/bamarni/composer-bin-plugin/tree/master"
+            },
             "time": "2020-05-03T08:27:20+00:00"
         }
     ],
@@ -654,5 +695,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.0.0"
 }


### PR DESCRIPTION
This pull request updates the WooCommerce Blocks package to 5.1.0. It includes changes from WooCommerce Blocks 5.0.0 and 5.1.0 and is intended to target **WooCommerce 5.4.0 for release**.

Details from all the different releases included in this pull request:

## Blocks 5.0.0

- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4144)
- [Testing Instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/500.md)
    -  Testing should just involve [smoke testing](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/smoke-testing.md) existing blocks (other than Cart and Checkout blocks) since the only changes in this release affect C&C blocks.
- [Release Post](https://developer.woocommerce.com/2021/04/28/woocommerce-blocks-5-0-0-release-notes/)

## Blocks 5.1.0

- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4185)
- [Testing Instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/510.md)
    - Same thing here as with 5.0.0, the changes in this release were all around Cart and Checkout Blocks.
- [Release post](https://developer.woocommerce.com/2021/05/10/woocommerce-blocks-5-1-0-release-notes/)

## Changelog Entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Refactor
- Introduced AssetsController and BlockTypesController classes (which replace Assets.php and Library.php). ([4094](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4094))
- Replaced usage of the `woocommerce_shared_settings` hook. This will be deprecated. ([4092](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4092))

### The following changelog entries are for items that only apply when the feature plugin is active:

#### Enhancements

- Added support to the Store API for batching requests. This allows multiple POST requests to be made at once to reduce the number of separate requests being made to the API. ([4075](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4075))
- Improve error message displayed when a payment method didn't have all its dependencies registered. ([4176](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4176))
- Improvements to `emitEventWithAbort`. ([4158](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4158))

#### Bug Fixes

- Prevent parts of old addresses being displayed in the shipping calculator when changing countries. ([4038](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4038))
- Fix issue in which email and phone fields are cleared when using a separate billing address. ([4162](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4162))

#### Refactor

- Rename onCheckoutBeforeProcessing to onCheckoutValidationBeforeProcessing.
- Switched to `rest_preload_api_request` for API hydration in cart and checkout blocks. ([4090](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4090))