### PR TITLE
Bump node version to align with v12 used in .nvmrc

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "wp-textdomain": "1.0.1"
   },
   "engines": {
-    "node": "^10.22.0",
+    "node": "^12.20.1",
     "npm": "^6.14.6"
   },
   "husky": {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Bump node engine version in package.json to `^12.20.1`. The `.nvmrc` specifies `v12`, so this change should merely formalize things / remove a conflict. 

Personally I've had issues pulling and pushing as I usually run `nvm use` to be on the right node version, the `package.json` has specified a different version, though. Example: 

```
~/Development/woocommerce-review (trunk)woocommerce-review % git pull --rebase
Updating fd624f77c8..d2da61ac53
Fast-forward
...
10 files changed, 338 insertions(+), 314 deletions(-)
error woocommerce@5.4.0: The engine "node" is incompatible with this module. Expected version "^10.22.0". Got "12.20.1"
error Commands cannot run with an incompatible environment.
```

### How to test the changes in this Pull Request:

1. checkout PR and run `nvm use`
2. ensure tests and other npm scripts still run without issue locally
3. check CI

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (N/A)
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.
