### PR TITLE
add draft status to deleteAllObjects

### DIFF
--- a/tests/e2e/utils/src/flows/with-rest-api.js
+++ b/tests/e2e/utils/src/flows/with-rest-api.js
@@ -16,7 +16,7 @@ const userEndpoint = '/wp/v2/users';
 const deleteAllRepositoryObjects = async ( repository, defaultObjectId = null ) => {
 	let objects;
 	const minimum = defaultObjectId == null ? 0 : 1;
-	const statuses = ['publish','trash'];
+	const statuses = ['draft','publish','trash'];
 
 	for ( let s = 0; s < statuses.length; s++ ) {
 		const status = statuses[ s ];


### PR DESCRIPTION
### Changes proposed in this Pull Request:

If a test that creates a product fails and leaves a draft product that product isn't deleted before the next test. The product import test relies on all products being deleted before the test and fails if there are existing draft products. This PR adds drafts to the list of statuses removed by `deleteAllObjects()`.

### How to test the changes in this Pull Request:

1. Verify CI run
2. Run tests locally

### Changelog entry

> N/A
