### PR TITLE
Set header cache-control for cart/checkout pages closes #29484

### DIFF
--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -64,7 +64,6 @@ class WC_Cache_Helper {
 			$set_cache = true;
 		}
 
-		// Note that is_cart() will return true even for checkout page.
 		if ( false !== strpos( $agent, 'Chrome' ) && is_cart() ) {
 			$set_cache = true;
 		}

--- a/includes/class-wc-cache-helper.php
+++ b/includes/class-wc-cache-helper.php
@@ -42,14 +42,34 @@ class WC_Cache_Helper {
 	 */
 	public static function additional_nocache_headers( $headers ) {
 		$agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) : ''; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+
+		$set_cache = false;
+
 		/**
 		 * Allow plugins to enable nocache headers. Enabled for Google weblight.
 		 *
-		 * @see   https://support.google.com/webmasters/answer/1061943?hl=en
 		 * @param bool $enable_nocache_headers Flag indicating whether to add nocache headers. Default: false.
 		 */
-		if ( false !== strpos( $agent, 'googleweblight' ) || apply_filters( 'woocommerce_enable_nocache_headers', false ) ) {
+		if ( apply_filters( 'woocommerce_enable_nocache_headers', false ) ) {
+			$set_cache = true;
+		}
+
+		/**
+		 * Enabled for Google weblight.
+		 *
+		 * @see https://support.google.com/webmasters/answer/1061943?hl=en
+		 */
+		if ( false !== strpos( $agent, 'googleweblight' ) ) {
 			// no-transform: Opt-out of Google weblight. https://support.google.com/webmasters/answer/6211428?hl=en.
+			$set_cache = true;
+		}
+
+		// Note that is_cart() will return true even for checkout page.
+		if ( false !== strpos( $agent, 'Chrome' ) && is_cart() ) {
+			$set_cache = true;
+		}
+
+		if ( $set_cache ) {
 			$headers['Cache-Control'] = 'no-transform, no-cache, no-store, must-revalidate';
 		}
 		return $headers;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

So apparently different browsers handles bfcache (back/forward cache) differently. Safari and Firefox seems to not cache the header directive by default while Chrome does.

This PR assumes that it is best to not cache the cart and will reflect that in the code. Note that `is_cart()` returns true for checkout page as well so this implementation will inadvertently affect the checkout page.

If we could decide for certain we don't need to cache cart/checkout pages at all, then we could essentially remove the "Chrome" check from the agent. We could also alternatively introduce a filter to disable the cache if they so choose.

Closes #29484 

### How to test the changes in this Pull Request:

1. Using Chrome, add several items to the cart.
2. Go to the cart page and remove/delete one of the items and go to checkout page.
3. Click the back button on your Chrome browser.
4. Ensure the item you removed/deleted is still gone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Prevent caching of cart/checkout page when using Chrome browser.
