### PR TITLE
Revert "Fix filter woocommerce_shipping_rate_cost backwards compatibility"

### DIFF
--- a/includes/class-wc-tax.php
+++ b/includes/class-wc-tax.php
@@ -82,13 +82,7 @@ class WC_Tax {
 	 * @return array
 	 */
 	public static function calc_shipping_tax( $price, $rates ) {
-		// Backwards compatible from WC_Shipping_Rate::get_cost().
-		if ( has_filter( 'woocommerce_shipping_rate_cost' ) ) {
-			$rate  = new WC_Shipping_Rate();
-			$price = $rate->get_cost();
-		}
 		$taxes = self::calc_exclusive_tax( $price, $rates );
-
 		return apply_filters( 'woocommerce_calc_shipping_tax', $taxes, $price, $rates );
 	}
 


### PR DESCRIPTION
The `woocommerce_shipping_rate_cost` filter is only intended to handle the content returned from `WC_Shipping_Rate::get_cost()`. While it's true that it modifies the cost of shipping, it does so after the original cost has been used heavily in `WC_Shipping_Method::add_rate()` for other calculations. Given the intention of the original PR, it makes sense to instead use `woocommerce_shipping_method_add_rate_args` to filter the rate and leave the rate object itself alone.