### PR TITLE
Validate Statecode of Odisha - India

### DIFF
--- a/i18n/states.php
+++ b/i18n/states.php
@@ -648,7 +648,7 @@ return array(
 		'ML' => __( 'Meghalaya', 'woocommerce' ),
 		'MZ' => __( 'Mizoram', 'woocommerce' ),
 		'NL' => __( 'Nagaland', 'woocommerce' ),
-		'OR' => __( 'Odisha', 'woocommerce' ),
+		'OD' => __( 'Odisha', 'woocommerce' ),
 		'PB' => __( 'Punjab', 'woocommerce' ),
 		'RJ' => __( 'Rajasthan', 'woocommerce' ),
 		'SK' => __( 'Sikkim', 'woocommerce' ),


### PR DESCRIPTION
Changed the valid state code of Odisha, India from OR to OD for Odisha