### PR TITLE
release api package 0.2.0

### DIFF
--- a/tests/e2e/api/CHANGELOG.md
+++ b/tests/e2e/api/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.2.0
+
 ## Added
 
 - Support for orders.

--- a/tests/e2e/api/README.md
+++ b/tests/e2e/api/README.md
@@ -92,7 +92,7 @@ The following methods are available on all repositories if the corresponding met
 
 - `create( {...properties} )` - Create a single object of the model type
 - `delete( objectId )` - Delete a single object of the model type
-- `list` - Retrieve a list of the existing objects of that model type
+- `list( {...parameters} )` - Retrieve a list of the existing objects of that model type
 - `read( objectId )` - Read a single object of the model type
 - `update( objectId, {...properties} )` - Update a single object of the model type
 

--- a/tests/e2e/api/package-lock.json
+++ b/tests/e2e/api/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/api",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/tests/e2e/api/package.json
+++ b/tests/e2e/api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/api",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "author": "Automattic",
   "description": "A simple interface for interacting with a WooCommerce installation.",
   "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/api/README.md",


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the `@woocommerce/api` package to 0.2.0. This includes package bumps plus one small documentation fix.

### How to test the changes in this Pull Request:

1. Review file changes
2. Run tests with published package in e2e boilerplate repo

### Changelog entry

> N/A
