### PR TITLE
Fix for deleted Reduce or Zero rate tax classes

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -619,9 +619,8 @@ class WC_Install {
 		add_option( 'woocommerce_checkout_highlight_required_fields', 'yes', '', 'yes' );
 		add_option( 'woocommerce_demo_store', 'no', '', 'no' );
 
-		// Define initial tax classes.
 		if ( self::is_new_install() ) {
-			// Moved behind only for new install.
+			// Define initial tax classes.
 			WC_Tax::create_tax_class( __( 'Reduced rate', 'woocommerce' ) );
 			WC_Tax::create_tax_class( __( 'Zero rate', 'woocommerce' ) );
 		}

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -620,8 +620,11 @@ class WC_Install {
 		add_option( 'woocommerce_demo_store', 'no', '', 'no' );
 
 		// Define initial tax classes.
-		WC_Tax::create_tax_class( __( 'Reduced rate', 'woocommerce' ) );
-		WC_Tax::create_tax_class( __( 'Zero rate', 'woocommerce' ) );
+		if (is_new_install()) {
+			//Moved behind only for new install
+			WC_Tax::create_tax_class( __( 'Reduced rate', 'woocommerce' ) );
+			WC_Tax::create_tax_class( __( 'Zero rate', 'woocommerce' ) );
+		}
 	}
 
 	/**

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -620,8 +620,8 @@ class WC_Install {
 		add_option( 'woocommerce_demo_store', 'no', '', 'no' );
 
 		// Define initial tax classes.
-		if (is_new_install()) {
-			//Moved behind only for new install
+		if ( self::is_new_install() ) {
+			// Moved behind only for new install.
 			WC_Tax::create_tax_class( __( 'Reduced rate', 'woocommerce' ) );
 			WC_Tax::create_tax_class( __( 'Zero rate', 'woocommerce' ) );
 		}


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is to fix an existing issue with default tax classes being re-created after a version upgrade:
https://github.com/woocommerce/woocommerce/issues/29708

### How to test the changes in this Pull Request:

1.  Remove WooCommerce plugin completely (deactivate + delete)
2. Reinstall v4.5 by uploading the zip file downloaded from https://developer.woocommerce.com/releases/
3. Unzip 5.3.0 zip, modify the lines as per solution above and re-create zip file
4. Upload for testing
5. Screen capture video: https://drive.google.com/file/d/1L9G4aXmtDo4PM8ueUJbeDr-4nCHuOHIB/view?usp=sharing

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry


> Dev - Added an if condition block to check for new install before creating Zero and Reduced rate tax classes in class-wc-install.php
