### PR TITLE
Remove merchant login/logout calls

### DIFF
--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -19,19 +19,21 @@ async function trashExistingPosts() {
 
 	// If this selector doesn't exist there are no posts for us to delete.
 	const bulkSelector = await page.$( '#bulk-action-selector-top' );
-	if ( bulkSelector ) {
-		// Select all posts.
-		await page.waitForSelector( '#cb-select-all-1' );
-		await page.click( '#cb-select-all-1' );
-		// Select the "bulk actions" > "trash" option.
-		await page.select( '#bulk-action-selector-top', 'trash' );
-		// Submit the form to send all draft/scheduled/published posts to the trash.
-		await page.click( '#doaction' );
-		await page.waitForXPath(
-			'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
-		);
+	if ( ! bulkSelector ) {
+		await merchant.logout();
+		return;
 	}
-	
+
+	// Select all posts.
+	await page.waitForSelector( '#cb-select-all-1' );
+	await page.click( '#cb-select-all-1' );
+	// Select the "bulk actions" > "trash" option.
+	await page.select( '#bulk-action-selector-top', 'trash' );
+	// Submit the form to send all draft/scheduled/published posts to the trash.
+	await page.click( '#doaction' );
+	await page.waitForXPath(
+		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
+	);
 	await merchant.logout();
 }
 

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -25,7 +25,7 @@ async function trashExistingPosts() {
 	const posts = response.data;
 
 	// Delete each post
-	for(const post of posts){
+	for (const post of posts) {
 		await client.delete(`${wpPostsEndpoint}/${post.id}`);
 	}
 
@@ -34,11 +34,19 @@ async function trashExistingPosts() {
 // Before every test suite run, delete all content created by the test. This ensures
 // other posts/comments/etc. aren't dirtying tests and tests don't depend on
 // each other's side-effects.
-beforeAll( async () => {
+beforeAll(async () => {
 	await trashExistingPosts();
 	await withRestApi.deleteAllProducts();
 	await withRestApi.deleteAllCoupons();
 	await page.goto(WP_ADMIN_LOGIN);
 	await clearLocalStorage();
-	await setBrowserViewport( 'large' );
-} );
+	await setBrowserViewport('large');
+});
+
+// Clear browser cookies and cache using DevTools.
+// This is to ensure that each test ends with no user logged in.
+afterAll(async () => {
+	const client = await page.target().createCDPSession();
+	await client.send('Network.clearBrowserCookies');
+	await client.send('Network.clearBrowserCache');
+});

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -1,40 +1,34 @@
 import {
-	visitAdminPage,
 	clearLocalStorage,
 	setBrowserViewport,
-	withRestApi
+	withRestApi,
+	WP_ADMIN_LOGIN
 } from '@woocommerce/e2e-utils';
 
-const { merchant } = require( '@woocommerce/e2e-utils' );
+const config = require('config');
+const { HTTPClientFactory } = require('@woocommerce/api');
 
 /**
- * Navigates to the post listing screen and bulk-trashes any posts which exist.
- *
- * @return {Promise} Promise resolving once posts have been trashed.
+ * Uses the WordPress API to delete all existing posts
  */
 async function trashExistingPosts() {
-	await merchant.login();
-	// Visit `/wp-admin/edit.php` so we can see a list of posts and delete them.
-	await visitAdminPage( 'edit.php' );
+	const apiUrl = config.get('url');
+	const wpPostsEndpoint = '/wp/v2/posts';
+	const adminUsername = config.get('users.admin.username');
+	const adminPassword = config.get('users.admin.password');
+	const client = HTTPClientFactory.build(apiUrl)
+		.withBasicAuth(adminUsername, adminPassword)
+		.create();
 
-	// If this selector doesn't exist there are no posts for us to delete.
-	const bulkSelector = await page.$( '#bulk-action-selector-top' );
-	if ( ! bulkSelector ) {
-		await merchant.logout();
-		return;
+	// List all existing posts
+	const response = await client.get(wpPostsEndpoint);
+	const posts = response.data;
+
+	// Delete each post
+	for(const post of posts){
+		await client.delete(`${wpPostsEndpoint}/${post.id}`);
 	}
 
-	// Select all posts.
-	await page.waitForSelector( '#cb-select-all-1' );
-	await page.click( '#cb-select-all-1' );
-	// Select the "bulk actions" > "trash" option.
-	await page.select( '#bulk-action-selector-top', 'trash' );
-	// Submit the form to send all draft/scheduled/published posts to the trash.
-	await page.click( '#doaction' );
-	await page.waitForXPath(
-		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
-	);
-	await merchant.logout();
 }
 
 // Before every test suite run, delete all content created by the test. This ensures
@@ -44,6 +38,7 @@ beforeAll( async () => {
 	await trashExistingPosts();
 	await withRestApi.deleteAllProducts();
 	await withRestApi.deleteAllCoupons();
+	await page.goto(WP_ADMIN_LOGIN);
 	await clearLocalStorage();
 	await setBrowserViewport( 'large' );
 } );

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -19,20 +19,19 @@ async function trashExistingPosts() {
 
 	// If this selector doesn't exist there are no posts for us to delete.
 	const bulkSelector = await page.$( '#bulk-action-selector-top' );
-	if ( ! bulkSelector ) {
-		return;
+	if ( bulkSelector ) {
+		// Select all posts.
+		await page.waitForSelector( '#cb-select-all-1' );
+		await page.click( '#cb-select-all-1' );
+		// Select the "bulk actions" > "trash" option.
+		await page.select( '#bulk-action-selector-top', 'trash' );
+		// Submit the form to send all draft/scheduled/published posts to the trash.
+		await page.click( '#doaction' );
+		await page.waitForXPath(
+			'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
+		);
 	}
-
-	// Select all posts.
-	await page.waitForSelector( '#cb-select-all-1' );
-	await page.click( '#cb-select-all-1' );
-	// Select the "bulk actions" > "trash" option.
-	await page.select( '#bulk-action-selector-top', 'trash' );
-	// Submit the form to send all draft/scheduled/published posts to the trash.
-	await page.click( '#doaction' );
-	await page.waitForXPath(
-		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
-	);
+	
 	await merchant.logout();
 }
 

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -1,10 +1,8 @@
-import { SimpleProduct, Coupon } from '@woocommerce/api';
 import {
 	visitAdminPage,
-	switchUserToTest,
 	clearLocalStorage,
 	setBrowserViewport,
-	withRestApi,
+	withRestApi
 } from '@woocommerce/e2e-utils';
 
 const { merchant } = require( '@woocommerce/e2e-utils' );
@@ -35,7 +33,7 @@ async function trashExistingPosts() {
 	await page.waitForXPath(
 		'//*[contains(@class, "updated notice")]/p[contains(text(), "moved to the Trash.")]'
 	);
-	await switchUserToTest();
+	await merchant.logout();
 }
 
 // Before every test suite run, delete all content created by the test. This ensures

--- a/tests/e2e/core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
+++ b/tests/e2e/core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
@@ -24,6 +24,10 @@ const shippingZoneNameUS = config.get( 'addresses.customer.shipping.country' );
 
 const runOnboardingFlowTest = () => {
 	describe('Store owner can go through store Onboarding', () => {
+		beforeAll(async () => {
+			await merchant.login();
+		});
+
 		if ( IS_RETEST_MODE ) {
 			it('can reset onboarding to default settings', async () => {
 				await withRestApi.resetOnboarding();
@@ -48,6 +52,10 @@ const runOnboardingFlowTest = () => {
 
 const runTaskListTest = () => {
 	describe('Store owner can go through setup Task List', () => {
+		beforeAll(async () => {
+			await merchant.login();
+		});
+		
 		it('can setup shipping', async () => {
 			await page.evaluate(() => {
 				document.querySelector('.woocommerce-list__item-title').scrollIntoView();

--- a/tests/e2e/core-tests/specs/activate-and-setup/setup.test.js
+++ b/tests/e2e/core-tests/specs/activate-and-setup/setup.test.js
@@ -27,6 +27,9 @@ const {
 
 const runInitialStoreSettingsTest = () => {
 	describe('Store owner can finish initial store setup', () => {
+		beforeAll(async () => {
+			await merchant.login();
+		});
 
 		it('can enable tax rates and calculations', async () => {
 			// Go to general settings page

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
@@ -4,7 +4,6 @@
  * Internal dependencies
  */
 const {
-	merchant,
 	createSimpleProduct,
 	createSimpleOrder,
 	createCoupon,
@@ -26,7 +25,6 @@ let orderId;
 const runOrderApplyCouponTest = () => {
 	describe('WooCommerce Orders > Apply coupon', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			await createSimpleProduct();
 			couponCode = await createCoupon();
 			orderId = await createSimpleOrder('Pending payment', simpleProductName);

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
@@ -10,6 +10,7 @@ const {
 	uiUnblocked,
 	addProductToOrder,
 	evalAndClick,
+	merchant
 } = require( '@woocommerce/e2e-utils' );
 
 const config = require( 'config' );
@@ -27,7 +28,10 @@ const runOrderApplyCouponTest = () => {
 		beforeAll(async () => {
 			await createSimpleProduct();
 			couponCode = await createCoupon();
+			
+			await merchant.login();
 			orderId = await createSimpleOrder('Pending payment', simpleProductName);
+			
 			await Promise.all([
 				addProductToOrder(orderId, simpleProductName),
 

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
@@ -21,6 +21,8 @@ const runMerchantOrdersCustomerPaymentPage = () => {
 	describe('WooCommerce Merchant Flow: Orders > Customer Payment Page', () => {
 		beforeAll(async () => {
 			await createSimpleProduct();
+			
+			await merchant.login();
 			orderId = await createSimpleOrder();
 			await addProductToOrder( orderId, simpleProductName );
 

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
@@ -20,7 +20,6 @@ let orderId;
 const runMerchantOrdersCustomerPaymentPage = () => {
 	describe('WooCommerce Merchant Flow: Orders > Customer Payment Page', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			await createSimpleProduct();
 			orderId = await createSimpleOrder();
 			await addProductToOrder( orderId, simpleProductName );

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
@@ -46,6 +46,8 @@ const runRefundOrderTest = () => {
 	describe('WooCommerce Orders > Refund an order', () => {
 		beforeAll(async () => {
 			await createSimpleProduct();
+
+			await merchant.login();
 			orderId = await createSimpleOrder();
 			await addProductToOrder(orderId, simpleProductName);
 

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
@@ -45,7 +45,6 @@ const clickAndWaitForSelector = async ( buttonSelector, resultSelector ) => {
 const runRefundOrderTest = () => {
 	describe('WooCommerce Orders > Refund an order', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			await createSimpleProduct();
 			orderId = await createSimpleOrder();
 			await addProductToOrder(orderId, simpleProductName);

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-product-edit-details.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-product-edit-details.test.js
@@ -16,6 +16,7 @@ const runProductEditDetailsTest = () => {
 	describe('Products > Edit Product', () => {
 		beforeAll(async () => {
 			productId = await createSimpleProduct();
+			await merchant.login();
 		});
 
 		it('can edit a product and save the changes', async () => {

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-product-edit-details.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-product-edit-details.test.js
@@ -15,7 +15,6 @@ let productId;
 const runProductEditDetailsTest = () => {
 	describe('Products > Edit Product', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			productId = await createSimpleProduct();
 		});
 

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-product-search.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-product-search.test.js
@@ -19,6 +19,8 @@ const runProductSearchTest = () => {
 
 			// Make sure the simple product name is greater than 1 to do a search
 			await expect(simpleProductName.length).toBeGreaterThan(1);
+
+			await merchant.login();
 		});
 
 		beforeEach(async () => {

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-product-search.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-product-search.test.js
@@ -15,7 +15,6 @@ const simpleProductPrice = config.has('products.simple.price') ? config.get('pro
 const runProductSearchTest = () => {
 	describe('Products > Search and View a product', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			await createSimpleProduct();
 
 			// Make sure the simple product name is greater than 1 to do a search

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
@@ -35,6 +35,7 @@ const runAddNewShippingZoneTest = () => {
 	describe('WooCommerce Shipping Settings - Add new shipping zone', () => {
 		beforeAll(async () => {
 			await createSimpleProduct();
+			await merchant.login();
 			await deleteAllShippingZones();
 		});
 

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
@@ -34,7 +34,6 @@ const shippingZoneNameSF = 'SF with Local pickup';
 const runAddNewShippingZoneTest = () => {
 	describe('WooCommerce Shipping Settings - Add new shipping zone', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			await createSimpleProduct();
 			await deleteAllShippingZones();
 		});

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
@@ -42,6 +42,8 @@ const runCartCalculateShippingTest = () => {
 		beforeAll(async () => {
 			await createSimpleProduct(firstProductName);
 			await createSimpleProduct(secondProductName, secondProductPrice);
+
+			await merchant.login();
 			await merchant.openNewShipping();
 
 			// Add a new shipping zone Germany with Free shipping

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
@@ -40,7 +40,6 @@ const shippingCountryFR = 'country:FR';
 const runCartCalculateShippingTest = () => {
 	describe('Cart Calculate Shipping', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			await createSimpleProduct(firstProductName);
 			await createSimpleProduct(secondProductName, secondProductPrice);
 			await merchant.openNewShipping();

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-coupons.test.js
@@ -4,7 +4,6 @@
  */
 const {
 	shopper,
-	merchant,
 	createCoupon,
 	createSimpleProduct,
 	uiUnblocked,

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-redirection.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-redirection.test.js
@@ -28,7 +28,6 @@ const runCartRedirectionTest = () => {
 	describe('Cart > Redirect to cart from shop', () => {
 		let simplePostIdValue;
 		beforeAll(async () => {
-			await merchant.login();
 			simplePostIdValue = await createSimpleProduct();
 
 			// Set checkbox in settings to enable cart redirection

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-redirection.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-redirection.test.js
@@ -31,6 +31,7 @@ const runCartRedirectionTest = () => {
 			simplePostIdValue = await createSimpleProduct();
 
 			// Set checkbox in settings to enable cart redirection
+			await merchant.login();
 			await merchant.openSettings('products');
 			await setCheckbox('#woocommerce_cart_redirect_after_add');
 			await settingsPageSaveChanges();

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart.test.js
@@ -4,7 +4,6 @@
  */
 const {
 	shopper,
-	merchant,
 	createSimpleProduct,
 	uiUnblocked
 } = require( '@woocommerce/e2e-utils' );
@@ -26,9 +25,7 @@ const twoProductPrice = singleProductPrice * 2;
 const runCartPageTest = () => {
 	describe('Cart page', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			await createSimpleProduct();
-			await merchant.logout();
 		});
 
 		it('should display no item in the cart', async () => {

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -4,7 +4,6 @@
  */
 const {
 	shopper,
-	merchant,
 	createCoupon,
 	createSimpleProduct,
 	uiUnblocked,

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-login-account.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-login-account.test.js
@@ -29,6 +29,7 @@ const runCheckoutLoginAccountTest = () => {
 			await createSimpleProduct();
 
 			// Set checkbox for logging to account during checkout
+			await merchant.login();
 			await merchant.openSettings('account');
 			await setCheckbox('#woocommerce_enable_checkout_login_reminder');
 			await settingsPageSaveChanges();

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-login-account.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-login-account.test.js
@@ -26,7 +26,6 @@ const simpleProductName = config.get('products.simple.name');
 const runCheckoutLoginAccountTest = () => {
 	describe('Shopper Checkout Login Account', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			await createSimpleProduct();
 
 			// Set checkbox for logging to account during checkout

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
@@ -27,7 +27,6 @@ let customerOrderId;
 const runCheckoutPageTest = () => {
 	describe('Checkout page', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			await createSimpleProduct();
 
 			// Set free shipping within California

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
@@ -30,6 +30,7 @@ const runCheckoutPageTest = () => {
 			await createSimpleProduct();
 
 			// Set free shipping within California
+			await merchant.login();
 			await addShippingZoneAndMethod('Free Shipping CA', 'state:US:CA', ' ', 'free_shipping');
 			// Go to general settings page
 			await merchant.openSettings('general');

--- a/tests/e2e/core-tests/specs/shopper/front-end-my-account-pay-order.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-my-account-pay-order.test.js
@@ -18,7 +18,6 @@ const runMyAccountPayOrderTest = () => {
 	describe('Customer can pay for their order through My Account', () => {
 		beforeAll(async () => {
 			simplePostIdValue = await createSimpleProduct();
-			await merchant.logout();
 			await shopper.login();
 			await shopper.goToProduct(simplePostIdValue);
 			await shopper.addToCart(simpleProductName);

--- a/tests/e2e/core-tests/specs/shopper/front-end-my-account-pay-order.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-my-account-pay-order.test.js
@@ -17,7 +17,6 @@ const simpleProductName = config.get( 'products.simple.name' );
 const runMyAccountPayOrderTest = () => {
 	describe('Customer can pay for their order through My Account', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			simplePostIdValue = await createSimpleProduct();
 			await merchant.logout();
 			await shopper.login();

--- a/tests/e2e/core-tests/specs/shopper/front-end-my-account.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-my-account.test.js
@@ -10,7 +10,6 @@ const {
 const runMyAccountPageTest = () => {
 	describe('My account page', () => {
 		it('allows customer to login', async () => {
-			await merchant.logout();
 			await shopper.login();
 			await expect(page).toMatch('Hello');
 			await expect(page).toMatchElement('.woocommerce-MyAccount-navigation-link', {text: 'Dashboard'});

--- a/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
@@ -29,9 +29,10 @@ const {
 const runOrderEmailReceivingTest = () => {
 	describe('Shopper Order Email Receiving', () => {
 		beforeAll(async () => {
+			simplePostIdValue = await createSimpleProduct();
+			
 			await merchant.login();
 			await deleteAllEmailLogs();
-			simplePostIdValue = await createSimpleProduct();
 			await merchant.logout();
 		});
 

--- a/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
@@ -29,6 +29,7 @@ const {
 const runOrderEmailReceivingTest = () => {
 	describe('Shopper Order Email Receiving', () => {
 		beforeAll(async () => {
+			await merchant.login();
 			await deleteAllEmailLogs();
 			simplePostIdValue = await createSimpleProduct();
 			await merchant.logout();

--- a/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-order-email-receiving.test.js
@@ -29,7 +29,6 @@ const {
 const runOrderEmailReceivingTest = () => {
 	describe('Shopper Order Email Receiving', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			await deleteAllEmailLogs();
 			simplePostIdValue = await createSimpleProduct();
 			await merchant.logout();

--- a/tests/e2e/core-tests/specs/shopper/front-end-single-product.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-single-product.test.js
@@ -20,7 +20,6 @@ const simpleProductName = config.get( 'products.simple.name' );
 const runSingleProductPageTest = () => {
 	describe('Single Product Page', () => {
 		beforeAll(async () => {
-			await merchant.login();
 			simplePostIdValue = await createSimpleProduct();
 			await merchant.logout();
 		});

--- a/tests/e2e/core-tests/specs/shopper/front-end-single-product.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-single-product.test.js
@@ -21,7 +21,6 @@ const runSingleProductPageTest = () => {
 	describe('Single Product Page', () => {
 		beforeAll(async () => {
 			simplePostIdValue = await createSimpleProduct();
-			await merchant.logout();
 		});
 
 		it('should be able to add simple products to the cart', async () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #29191 .

This PR removes redundant `merchant.login()` and `merchant.logout()` around the `createSimpleProduct()` function calls throughout the test suite.

Also, this replaces `switchUserToTest()` with `merchant.logout()` in the `jest.setup.js` file. This is because  `switchUserToTest()` no longer seems to log the merchant out.

### How to test the changes in this Pull Request:

1. `cd` into the `woocommerce` repo and bring the e2e environment up.
2. Run the setup-onboarding test:

    ```
    npx wc-e2e test:e2e tests/e2e/specs/activate-and-setup/setup-onboarding.js
    ```
2. Run all the tests affected by this PR. You can use these commands to run them individually:

    ```
    # This test always fails in my headless runs
    # But always passes in non-headless mode
    npx wc-e2e test:e2e-dev tests/e2e/specs/wp-admin/order-coupon.test.js

    npx wc-e2e test:e2e tests/e2e/specs/wp-admin/order-refund.test.js 
    npx wc-e2e test:e2e tests/e2e/specs/wp-admin/product-edit.test.js
    npx wc-e2e test:e2e tests/e2e/specs/wp-admin/product-search.test.js 
    npx wc-e2e test:e2e tests/e2e/specs/wp-admin/create-shipping-zones.test.js 
    npx wc-e2e test:e2e tests/e2e/specs/front-end/cart-coupons.test.js 
    npx wc-e2e test:e2e tests/e2e/specs/front-end/cart-redirection.cart.js
    npx wc-e2e test:e2e tests/e2e/specs/front-end/cart-begin.test.js 
    npx wc-e2e test:e2e tests/e2e/specs/front-end/checkout-coupons.test.js 
    npx wc-e2e test:e2e tests/e2e/specs/front-end/checkout-begin.test.js 
    npx wc-e2e test:e2e tests/e2e/specs/front-end/my-account-pay-order.test.js 
    npx wc-e2e test:e2e tests/e2e/specs/front-end/order-email-receiving.test.js 
    npx wc-e2e test:e2e tests/e2e/specs/front-end/single-product-page.test.js

    # These tests rely on payment settings being setup first
    npx wc-e2e test:e2e tests/e2e/specs/front-end/checkout-login-account.test.js
    npx wc-e2e test:e2e tests/e2e/specs/wp-admin/order-customer-payment-page.test.js 
    npx wc-e2e test:e2e tests/e2e/specs/front-end/checkout-create-account.test.js
    ```
1. All these tests should pass

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Remove unnecessary `merchant.login()` and `merchant.logout()` calls around `createSimpleProduct()`
> Replace  `switchUserToTest()` with `merchant.logout()` in the `jest.setup.js` file
