### PR TITLE
Block Widgets: rename Products, Products by Rating and Recent Viewed Products widgets

### DIFF
--- a/includes/widgets/class-wc-widget-products.php
+++ b/includes/widgets/class-wc-widget-products.php
@@ -20,7 +20,7 @@ class WC_Widget_Products extends WC_Widget {
 		$this->widget_cssclass    = 'woocommerce widget_products';
 		$this->widget_description = __( "A list of your store's products.", 'woocommerce' );
 		$this->widget_id          = 'woocommerce_products';
-		$this->widget_name        = __( 'Products', 'woocommerce' );
+		$this->widget_name        = __( 'Products list', 'woocommerce' );
 		$this->settings           = array(
 			'title'       => array(
 				'type'  => 'text',

--- a/includes/widgets/class-wc-widget-recently-viewed.php
+++ b/includes/widgets/class-wc-widget-recently-viewed.php
@@ -20,7 +20,7 @@ class WC_Widget_Recently_Viewed extends WC_Widget {
 		$this->widget_cssclass    = 'woocommerce widget_recently_viewed_products';
 		$this->widget_description = __( "Display a list of a customer's recently viewed products.", 'woocommerce' );
 		$this->widget_id          = 'woocommerce_recently_viewed_products';
-		$this->widget_name        = __( 'Recent Viewed Products', 'woocommerce' );
+		$this->widget_name        = __( 'Recently Viewed Products list', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',

--- a/includes/widgets/class-wc-widget-top-rated-products.php
+++ b/includes/widgets/class-wc-widget-top-rated-products.php
@@ -21,7 +21,7 @@ class WC_Widget_Top_Rated_Products extends WC_Widget {
 		$this->widget_cssclass    = 'woocommerce widget_top_rated_products';
 		$this->widget_description = __( "A list of your store's top-rated products.", 'woocommerce' );
 		$this->widget_id          = 'woocommerce_top_rated_products';
-		$this->widget_name        = __( 'Products by Rating', 'woocommerce' );
+		$this->widget_name        = __( 'Products by Rating list', 'woocommerce' );
 		$this->settings           = array(
 			'title'  => array(
 				'type'  => 'text',


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4239

_This issue surfaced as part of our audit of the current state of using WooCommerce Blocks as Block Widgets in the new Widgets Editor and Customizer (pca54o-1pT-p2)._

We're currently preparing WooCommerce for the arrival of Block Widgets in the new Widgets Editor and Customizer. In pca54o-KL-p2#comment-1845 the product decision was made that while the `Products` and `Products by Rating` widgets should remain an option as part of the Legacy Widget block, going forward for better distinction their display names should be `Products list` and `Products by Rating list`.

### Screenshots

|Before|After|
|-|-|
|<img width="646" alt="Screenshot 2021-05-19 at 15 45 46" src="https://user-images.githubusercontent.com/1562646/118826128-8124cd80-b8bb-11eb-9d67-dedd3096a4b0.png">|<img width="646" alt="Screenshot 2021-05-19 at 15 46 48" src="https://user-images.githubusercontent.com/1562646/118826153-85e98180-b8bb-11eb-9a18-97d12c1f51ac.png">|

### How to test the changes in this Pull Request:

1. Ensure the Gutenberg feature plugin is enabled. To enable block widgets in the Customizer, go to Gutenberg -> Experiments and check the checkbox next to Widgets. After you’ve saved the experimental settings, navigate to Appearance -> Customize -> Widgets.
2. Go to Sidebar widgets and search for the `Products` and `Products by Rating` widgets. They should now display as `Products list` and `Products by Rating list`.

<!-- If you can, add the appropriate labels -->

### Changelog

> Rename Products, Products by Rating, and Recent Viewed Products widgets to Products list, Products by Rating list, and Recently Viewed Products list.