### PR TITLE
Calculate order total before applying a percentage fee

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1002,6 +1002,8 @@ class WC_AJAX {
 			);
 
 			if ( strstr( $amount, '%' ) ) {
+				// We need to calculate totals first, so that $order->get_total() is correct.
+				$order->calculate_totals( false );
 				$formatted_amount = $amount;
 				$percent          = floatval( trim( $amount, '%' ) );
 				$amount           = $order->get_total() * ( $percent / 100 );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an error where the first time a percentage fee is added to an order from wp-admin, it is not calculated correctly.

Closes #29891.

### How to test the changes in this Pull Request:

1. Create an order in `wp-admin`, add some items to your order.
2. Add a percentage fee and notice that prior to this PR, it wouldn't be calculated correctly (and show `$0`).
3. Apply this PR and against create an order in `wp-admin`, add some items to your order.
4. Add a percentage fee and verify that it's calculated correctly based on the existing items in the order.
5. Verify that the percentage fee is correct based on the items in the order at the time you add it.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fees added to an order from wp-admin are now calculated correctly the first time.
