### PR TITLE
Packages/e2e releases

### DIFF
--- a/tests/e2e/core-tests/CHANGELOG.md
+++ b/tests/e2e/core-tests/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Support for re-running setup and shopper tests
 - Shopper Order Email Receiving
+- New tests - See [README.md](https://github.com/woocommerce/woocommerce/blob/trunk/tests/e2e/core-tests/README.md) for list of available tests
 
 ## Fixed
 

--- a/tests/e2e/core-tests/README.md
+++ b/tests/e2e/core-tests/README.md
@@ -50,6 +50,7 @@ The functions to access the core tests are:
 ### Merchant
 
 - `runMerchantTests` - Run all merchant tests
+  - `runAddShippingClassesTest` - Merchant can create shipping classes and let shopper test them
   - `runAddNewShippingZoneTest` - Merchant can create shipping zones and let shopper test them
   - `runAddSimpleProductTest` - Merchant can create a simple product
   - `runAddVariableProductTest` - Merchant can create a variable product
@@ -57,6 +58,7 @@ The functions to access the core tests are:
   - `runCreateOrderTest` - Merchant can create order
   - `runMerchantOrdersCustomerPaymentPage` - Merchant can visit the customer payment page
   - `runMerchantOrderEmailsTest` - Merchant can receive order emails and resend emails by Order Actions
+  - `runEditOrderTest` - Merchant can edit an order in the dashboard
   - `runOrderStatusFilterTest` - Merchant can filter orders by order status
   - `runOrderRefundTest` - Merchant can refund an order
   - `runOrderApplyCouponTest` - Merchant can apply a coupon to an order
@@ -69,6 +71,7 @@ The functions to access the core tests are:
   - `runMerchantOrderEmailsTest` - Merchant can receive order emails and resend emails by Order Actions
   - `runAnalyticsPageLoadsTest` - Merchant can load and see all pages in Analytics
   - `runImportProductsTest` - Merchant can import products via CSV file
+  - `runInitiateWccomConnectionTest` - Merchant can initiate connection to WooCommerce.com
 
 ### Shopper
 
@@ -96,7 +99,7 @@ The functions to access the core tests are:
   - `runGroupedProductAPITest` - Can create, read, and delete a grouped product
   - `runVariableProductAPITest` - Can create, read, and delete a variable product and its variations
   - `runCouponApiTest` - Can create, read, and delete a coupon
-
+  - `runOrderApiTest` - Can create, read, and delete an order
 
 ## Contributing a new test
 

--- a/tests/e2e/core-tests/package.json
+++ b/tests/e2e/core-tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/e2e-core-tests",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": "End-To-End (E2E) tests for WooCommerce",
   "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/core-tests/README.md",
   "repository": {
@@ -15,8 +15,8 @@
     "faker": "^5.1.0"
   },
   "peerDependencies": {
-    "@woocommerce/api": "^0.1.2",
-    "@woocommerce/e2e-utils": "^0.1.4"
+    "@woocommerce/api": "^0.2.0",
+    "@woocommerce/e2e-utils": "^0.1.5"
   },
   "publishConfig": {
     "access": "public"

--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.2.2
+
 ## Added
 
 - `takeScreenshotFor` utility function to take screenshots within tests

--- a/tests/e2e/env/builtin.md
+++ b/tests/e2e/env/builtin.md
@@ -33,7 +33,20 @@ echo "Initializing WooCommerce E2E"
 
 wp plugin activate woocommerce
 wp theme install twentynineteen --activate
+wp user create customer customer@woocommercecoree2etestsuite.com \
+	--user_pass=password \
+	--role=subscriber \
+	--first_name='Jane' \
+	--last_name='Smith' \
+	--path=/var/www/html
+
+# we cannot create API keys for the API, so we using basic auth, this plugin allows that.
+wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate
+
+# install the WP Mail Logging plugin to test emails
+wp plugin install wp-mail-logging --activate
 ```
+
 ### Adhoc Initialization
 
 The container build script supports an initialization script parameter

--- a/tests/e2e/env/external.md
+++ b/tests/e2e/env/external.md
@@ -23,7 +23,11 @@ Each project will have its own begin test state and initialization script. For e
 wp core install --url=http://localhost:8084 --admin_user=admin --admin_password=password --admin_email=wooadmin@example.org
 wp plugin activate woocommerce
 wp theme install twentynineteen --activate
-wp user create customer customer@woocommercecoree2etestsuite.com --user_pass=password --role=customer
+wp user create customer customer@woocommercecoree2etestsuite.com \
+	--user_pass=password \
+	--role=subscriber \
+	--first_name='Jane' \
+	--last_name='Smith'
 ```
 
 ### Test Sequencer Setup

--- a/tests/e2e/env/package.json
+++ b/tests/e2e/env/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/e2e-environment",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "WooCommerce End to End Testing Environment Configuration.",
   "author": "Automattic",
   "license": "GPL-3.0-or-later",

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# 0.1.5
+
 ## Added
 
 - `emptyCart()` Shopper flow helper that empties the cart

--- a/tests/e2e/utils/package-lock.json
+++ b/tests/e2e/utils/package-lock.json
@@ -1,6 +1,6 @@
 {
 	"name": "@woocommerce/e2e-utils",
-	"version": "0.1.4",
+	"version": "0.1.5",
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {

--- a/tests/e2e/utils/package.json
+++ b/tests/e2e/utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@woocommerce/e2e-utils",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "End-To-End (E2E) test utils for WooCommerce",
   "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e-utils/README.md",
   "repository": {
@@ -18,7 +18,7 @@
     "fishery": "^1.2.0"
   },
   "peerDependencies": {
-    "@woocommerce/api": "^0.1.2"
+    "@woocommerce/api": "^0.2.0"
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the E2E packages including some documentation updates for packages released this week

- `@woocommerce/e2e-environment@0.2.2`
- `@woocommerce/e2e-utils@0.1.5`
- `@woocommerce/e2e-core-tests@0.1.4`

### How to test the changes in this Pull Request:

1. Set up the E2E boilerplate per [instructions](https://github.com/woocommerce/woocommerce-e2e-boilerplate)
2. Install the optional `e2e-environment` and `api` packages
2. Create `tests/e2e/docker/initialize.sh`
```
#!/bin/bash

echo "Initializing WooCommerce E2E"

wp plugin install woocommerce --activate 
wp theme install twentynineteen --activate
wp user create customer customer@woocommercecoree2etestsuite.com \
	--user_pass=password \
	--role=subscriber \
	--first_name='Jane' \
	--last_name='Smith' \
	--path=/var/www/html

# we cannot create API keys for the API, so we using basic auth, this plugin allows that.
wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --activate

# install the WP Mail Logging plugin to test emails
wp plugin install wp-mail-logging --activate
```
3. Copy these folders from this repo to the boiler plate
-  `tests/e2e/config`
-  `tests/e2e/specs`
-  `sample-data`
4. Run `npx wc-e2e docker:up`
5. Run `npx wc-e2e test:e2e`
6. All tests should run

### Changelog entry

> N/A
