### PR TITLE
Fix regression of using jQuery ON when bind should be used ref #28822

### DIFF
--- a/assets/js/frontend/cart-fragments.js
+++ b/assets/js/frontend/cart-fragments.js
@@ -180,7 +180,7 @@ jQuery( function( $ ) {
 		wp.customize.widgetsPreview.WidgetPartial
 	);
 	if ( hasSelectiveRefresh ) {
-		wp.customize.selectiveRefresh.on( 'partial-content-rendered', function() {
+		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function() {
 			refresh_cart_fragment();
 		} );
 	}

--- a/assets/js/frontend/price-slider.js
+++ b/assets/js/frontend/price-slider.js
@@ -76,7 +76,7 @@ jQuery( function( $ ) {
 		wp.customize.widgetsPreview.WidgetPartial
 	);
 	if ( hasSelectiveRefresh ) {
-		wp.customize.selectiveRefresh.on( 'partial-content-rendered', function() {
+		wp.customize.selectiveRefresh.bind( 'partial-content-rendered', function() {
 			init_price_filter();
 		} );
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This fixes a regression from the jQuery migrate effort we merged recently. ref #28822

Closes #28822

### How to test the changes in this Pull Request:

1. Go to the customizer view/page.
2. Add the price slider widget.
3. Ensure the price slider is working without any JS errors in the console.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
