### PR TITLE
support analytics page tests having charts

### DIFF
--- a/tests/e2e/core-tests/specs/merchant/wp-admin-analytics-page-loads.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-analytics-page-loads.test.js
@@ -4,6 +4,7 @@
  */
  const {
 	merchant,
+	waitForSelectorWithoutThrow,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -25,7 +26,14 @@ const {
 const checkHeadingAndElement = async (
 	pageTitle, element = '.d3-chart__empty-message', elementText = 'No data for the selected date range') => {
 	await expect(page).toMatchElement('h1', {text: pageTitle});
-	await expect(page).toMatchElement(element, elementText);
+
+	// Depending on order of tests the chart may not be empty.
+	const found = await waitForSelectorWithoutThrow( element );
+	if ( found ) {
+		await expect(page).toMatchElement(element, {text: elementText});
+	} else {
+		await expect(page).toMatchElement( '.woocommerce-chart' );
+	}
  };
 
 const runAnalyticsPageLoadsTest = () => {


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In the local Docker test environment the processing of scheduled actions is delayed enough that the analytics import of customers, products & orders doesn't occur until after the analytics screen tests. due to variation in timing on the smoke testing site, these actions may or may not have run.

We are seeing days where the analytics screen tests fail because the charts have data:

![screenshot_of_failed_test (1)](https://user-images.githubusercontent.com/343847/119172546-7cd3ee00-ba3c-11eb-9fc9-d28a91d2d9ba.png)

This PR updates the analytics screen test to add a fallback check for a displayed chart if the `no data` message isn't found. 

### How to test the changes in this Pull Request:

1. Verify CI run
2. Locally run E2E tests
3. Create a product
4. Create a `processing` order with at least `1` of the product on the order
5. Go to Tools -> Scheduled Actions -> Pending
6. Run all `wc-admin-data` pending actions
7. Check Analytics -> Orders to verify a graph is shown
8. Run `npm wc-e2e test:e2e tests/e2e/specs/wp-admin/analytics-page-loads.test.js`

### Changelog entry

> N/A
