### PR TITLE
apply filter to errant hardcoded redirect on logout for custom endpoint

### DIFF
--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -36,7 +36,7 @@ function wc_template_redirect() {
 
 	// Logout.
 	if ( isset( $wp->query_vars['customer-logout'] ) && ! empty( $_REQUEST['_wpnonce'] ) && wp_verify_nonce( sanitize_key( $_REQUEST['_wpnonce'] ), 'customer-logout' ) ) {
-		wp_safe_redirect( str_replace( '&amp;', '&', wp_logout_url( wc_get_page_permalink( 'myaccount' ) ) ) );
+		wp_safe_redirect( str_replace( '&amp;', '&', wp_logout_url( apply_filters( 'woocommerce_logout_default_redirect_url', wc_get_page_permalink( 'myaccount' ) ) ) ) );
 		exit;
 	}
 


### PR DESCRIPTION
fix for one of the specific errant hardcoded redirects in https://github.com/woocommerce/woocommerce/issues/25288

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline]
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Full details and analysis in issue https://github.com/woocommerce/woocommerce/issues/25288
This PR is a specific fix for one specific case listed in the issue. This PR does ***not*** fix the entire issue and therefore does not close it.

### How to test the changes in this Pull Request:

1. run unit and e2e tests

I have run unit tests locally and it passes all tests except one. This failure is not related to this PR's code and is elsewhere.
This was verified by running the unit tests on the commit exactly before this PR 02000dc8a370b22e24b7ce376e4c7f56cb7a06a1 and this PR. The same test failed in the same way -- it is not related.

```
Installing...
Running as single site... To run multisite, use -c tests/phpunit/multisite.xml
Installing WooCommerce...
Not running ajax tests. To execute these, use --group ajax.
Not running ms-files tests. To execute these, use --group ms-files.
Not running external-http tests. To execute these, use --group external-http.
PHPUnit 6.5.14 by Sebastian Bergmann and contributors.

Runtime:       PHP 7.4.19
Configuration: /var/www/html/wp-content/plugins/woocommerce/phpunit.xml

.............................................................   61 / 1799 (  3%)
.............................................................  122 / 1799 (  6%)
...F.........................................................  183 / 1799 ( 10%)
.............................................................  244 / 1799 ( 13%)
.............................................................  305 / 1799 ( 16%)
.............................................................  366 / 1799 ( 20%)
.............................................................  427 / 1799 ( 23%)
.............................................................  488 / 1799 ( 27%)
.............................................................  549 / 1799 ( 30%)
.............................................................  610 / 1799 ( 33%)
.............................................................  671 / 1799 ( 37%)
.............................................................  732 / 1799 ( 40%)
.............................................................  793 / 1799 ( 44%)
.............................................................  854 / 1799 ( 47%)
.............................................................  915 / 1799 ( 50%)
.............................................................  976 / 1799 ( 54%)
............................................................. 1037 / 1799 ( 57%)
............................................................. 1098 / 1799 ( 61%)
............................................................. 1159 / 1799 ( 64%)
............................................................. 1220 / 1799 ( 67%)
............................................................. 1281 / 1799 ( 71%)
............................................................. 1342 / 1799 ( 74%)
............................................................. 1403 / 1799 ( 77%)
............................................................. 1464 / 1799 ( 81%)
............................................................. 1525 / 1799 ( 84%)
............................................................. 1586 / 1799 ( 88%)
............................................................. 1647 / 1799 ( 91%)
............................................................. 1708 / 1799 ( 94%)
............................................................. 1769 / 1799 ( 98%)
..............................                                1799 / 1799 (100%)

You should really fix these slow tests (>500ms)...
 1. 3342ms to run WC_Tests_REST_System_Status_V2:test_get_system_status_info_active_plugins
 2. 3238ms to run WC_Tests_REST_System_Status_V2:test_get_system_status_info_theme
 3. 3226ms to run WC_Tests_Paypal_Gateway_Request:test_request_url
 4. 3061ms to run WC_Tests_REST_System_Status_V2:test_get_system_status_info_returns_root_properties
 5. 3037ms to run WC_Tests_REST_System_Status_V2:test_get_system_status_info_security
 6. 2699ms to run WC_Tests_REST_System_Status_V2:test_get_system_status_info_database
 7. 2698ms to run WC_Tests_REST_System_Status_V2:test_get_system_status_info_settings
 8. 2693ms to run WC_Tests_REST_System_Status_V2:test_get_system_status_info_environment
 9. 2497ms to run WC_Tests_REST_System_Status_V2:test_get_system_status_info_pages
 10. 2013ms to run WC_Tests_Rate_Limiter:test_rate_limit_limits
...and there are 37 more above your threshold hidden from view

Time: 3.78 minutes, Memory: 129.00MB

There was 1 failure:

1) WC_Template_Cache::test_wc_get_template_part
Failed asserting that two strings are equal.
--- Expected
+++ Actual
@@ @@
-'/var/www/html/wp-content/plugins/woocommerce/templates/content-product-cat.php'
+'{{WP_PLUGIN_DIR}}/woocommerce/templates/content-product-cat.php'

/var/www/html/wp-content/plugins/woocommerce/tests/legacy/unit-tests/core/template-cache.php:46

FAILURES!
Tests: 1799, Assertions: 6930, Failures: 1.
```

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [X] Have you written new tests for your changes, as applicable?
* [X] Have you successfully run tests with your changes locally?

### Changelog entry

> Dev - Apply `woocommerce_logout_default_redirect_url` filter to logout for custom endpoint.
