### PR TITLE
Hide PayPal Standard on new installs

### DIFF
--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -310,6 +310,7 @@ class WC_Install {
 		self::create_files();
 		self::maybe_create_pages();
 		self::maybe_set_activation_transients();
+		self::set_paypal_standard_load_eligibility();
 		self::update_wc_version();
 		self::maybe_update_db_version();
 
@@ -1621,6 +1622,16 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 			// Discard feedback.
 			ob_end_clean();
 		}
+	}
+
+	/**
+	 * Sets whether PayPal Standard will be loaded on install.
+	 *
+	 * @since 5.5.0
+	 */
+	private static function set_paypal_standard_load_eligibility() {
+		// Initiating the payment gateways sets the flag.
+		WC()->payment_gateways();
 	}
 }
 

--- a/includes/class-wc-install.php
+++ b/includes/class-wc-install.php
@@ -1631,7 +1631,9 @@ CREATE TABLE {$wpdb->prefix}wc_reserved_stock (
 	 */
 	private static function set_paypal_standard_load_eligibility() {
 		// Initiating the payment gateways sets the flag.
-		WC()->payment_gateways();
+		if ( class_exists( 'WC_Gateway_Paypal' ) ) {
+			( new WC_Gateway_Paypal() )->should_load();
+		}
 	}
 }
 

--- a/includes/class-wc-payment-gateways.php
+++ b/includes/class-wc-payment-gateways.php
@@ -78,8 +78,11 @@ class WC_Payment_Gateways {
 			'WC_Gateway_BACS',
 			'WC_Gateway_Cheque',
 			'WC_Gateway_COD',
-			'WC_Gateway_Paypal',
 		);
+
+		if ( $this->should_load_paypal_standard() ) {
+			$load_gateways[] = 'WC_Gateway_Paypal';
+		}
 
 		// Filter.
 		$load_gateways = apply_filters( 'woocommerce_payment_gateways', $load_gateways );
@@ -218,5 +221,16 @@ class WC_Payment_Gateways {
 		}
 
 		update_option( 'woocommerce_gateway_order', $order );
+	}
+
+	/**
+	 * Determines if PayPal Standard should be loaded.
+	 *
+	 * @since 5.5.0
+	 * @return bool Whether PayPal Standard should be loaded or not.
+	 */
+	protected function should_load_paypal_standard() {
+		$paypal = new WC_Gateway_Paypal();
+		return $paypal->should_load();
 	}
 }

--- a/includes/gateways/paypal/class-wc-gateway-paypal.php
+++ b/includes/gateways/paypal/class-wc-gateway-paypal.php
@@ -473,4 +473,42 @@ class WC_Gateway_Paypal extends WC_Payment_Gateway {
 
 		return $text;
 	}
+
+	/**
+	 * Determines whether PayPal Standard should be loaded or not.
+	 *
+	 * By default PayPal Standard isn't loaded on new installs or on existing sites which haven't set up the gateway.
+	 *
+	 * @since 5.5.0
+	 *
+	 * @return bool Whether PayPal Standard should be loaded.
+	 */
+	public function should_load() {
+		$option_key  = '_should_load';
+		$should_load = $this->get_option( $option_key );
+
+		if ( '' === $should_load ) {
+
+			// New installs without PayPal Standard enabled don't load it.
+			if ( 'no' === $this->enabled && WC_Install::is_new_install() ) {
+				$should_load = false;
+			} else {
+				$should_load = true;
+			}
+
+			$this->update_option( $option_key, wc_bool_to_string( $should_load ) );
+		} else {
+			$should_load = wc_string_to_bool( $should_load );
+		}
+
+		/**
+		 * Allow third-parties to filter whether PayPal Standard should be loaded or not.
+		 *
+		 * @since 5.5.0
+		 *
+		 * @param bool              $should_load Whether PayPal Standard should be loaded.
+		 * @param WC_Gateway_Paypal $this        The WC_Gateway_Paypal instance.
+		 */
+		return apply_filters( 'woocommerce_should_load_paypal_standard', $should_load, $this );
+	}
 }

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
@@ -82,7 +82,6 @@ const runCheckoutPageTest = () => {
 			await shopper.goToCheckout();
 			await shopper.productIsInCheckout(simpleProductName, `2`, twoProductPrice, twoProductPrice);
 
-			await expect(page).toClick('.wc_payment_method label', {text: 'PayPal'});
 			await expect(page).toClick('.wc_payment_method label', {text: 'Direct bank transfer'});
 			await expect(page).toClick('.wc_payment_method label', {text: 'Cash on delivery'});
 		});

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
@@ -66,14 +66,6 @@ const runCheckoutPageTest = () => {
 			// Verify that settings have been saved
 			await verifyCheckboxIsSet('#woocommerce_cod_enabled');
 
-			// Enable PayPal payment method
-			await merchant.openSettings('checkout', 'paypal');
-			await setCheckbox('#woocommerce_paypal_enabled');
-			await settingsPageSaveChanges();
-
-			// Verify that settings have been saved
-			await verifyCheckboxIsSet('#woocommerce_paypal_enabled');
-
 			await merchant.logout();
 		});
 

--- a/tests/legacy/bootstrap.php
+++ b/tests/legacy/bootstrap.php
@@ -58,6 +58,9 @@ class WC_Unit_Tests_Bootstrap {
 		// load test function so tests_add_filter() is available.
 		require_once $this->wp_tests_dir . '/includes/functions.php';
 
+		// Always load PayPal Standard for unit tests.
+		tests_add_filter( 'woocommerce_should_load_paypal_standard', '__return_true' );
+
 		// load WC.
 		tests_add_filter( 'muplugins_loaded', array( $this, 'load_wc' ) );
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR no longer loads PayPal Standard by default on new sites. This is part of our effort to encourage the adoption of PayPal Payments instead of PayPal Standard. See more @ pb0GrA-1ci-p2

I've used `WC_Install::is_new_install()` so PayPal Standard will be hidden by default for sites that have: 

- No `woocommerce_version`. 
- OR 
   - No products.
   - and have not set up the shop page.

From my tests, that's almost certainly sites that haven't been through the set-up wizard. All other sites will still load PayPal Standard by default.

If a new site wants to bring PayPal Standard back, there is a filter they can use to bypass this condition - `woocommerce_should_load_paypal_standard`.

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

### How to test the changes in this Pull Request:

1. On a fresh WP site, install WC using this branch.
2. Either complete the set-up wizard or skip it. 
3. Go to WooCommerce > Settings > Payments. 
4. PayPal Standard won't appear as an option.
5. On an existing store, with this branch. 
3. Go to WooCommerce > Settings > Payments. 
4. PayPal Standard will be listed. 

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

```
* Tweak - No longer load PayPal Standard by default on new installs.
```