### PR TITLE
Changes to class-wc-auth that allows it to work with sso auth

### DIFF
--- a/includes/class-wc-auth.php
+++ b/includes/class-wc-auth.php
@@ -315,7 +315,6 @@ class WC_Auth {
 	 */
 	protected function auth_endpoint( $route ) {
 		ob_start();
-
 		$consumer_data = array();
 
 		try {
@@ -326,6 +325,18 @@ class WC_Auth {
 
 			// Login endpoint.
 			if ( 'login' === $route && ! is_user_logged_in() ) {
+
+				if ( defined( 'JETPACK__PLUGIN_DIR' ) ) {
+					require_once JETPACK__PLUGIN_DIR . 'modules/sso.php';
+					$want_to_bypass = Jetpack_SSO_Helpers::bypass_login_forward_wpcom();
+					global $action;
+					$action = 'login'; // TODO, work out safer way to do this bit
+					$url = $this->build_url( $data, 'authorize' );
+					// Set this so that jetpack saves the redirect cookie correctly
+					$_GET['redirect_to'] = $url;
+					do_action( 'login_init' );
+				}
+
 				wc_get_template(
 					'auth/form-login.php', array(
 						'app_name'     => wc_clean( $data['app_name'] ),

--- a/includes/class-wc-auth.php
+++ b/includes/class-wc-auth.php
@@ -328,7 +328,6 @@ class WC_Auth {
 
 				if ( defined( 'JETPACK__PLUGIN_DIR' ) ) {
 					require_once JETPACK__PLUGIN_DIR . 'modules/sso.php';
-					$want_to_bypass = Jetpack_SSO_Helpers::bypass_login_forward_wpcom();
 					global $action;
 					$action = 'login'; // TODO, work out safer way to do this bit
 					$url = $this->build_url( $data, 'authorize' );


### PR DESCRIPTION
### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)? _Except for the use of the `global` for which I couldn't see a way around_
* [ x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This is an initial attempt to fix an issue with the wc-auth endpoint which doesn't work alongside WordPress' SSO implementation. The issue came to light when someone was testing the connection flow for the Facebook for Woocommerce plugin on their site which makes use of the wc-auth endpoint:

https://user-images.githubusercontent.com/1573005/119368147-98443080-bcaa-11eb-9ced-1257233970a7.mov

The password they entered is in fact correct and if they logged in via the normal route then restarted the flow they'd be able to continue. After a bit of digging I realised that the issue was that the user doesn't actually login to their site, when they go to /wp-admin it redirects them to a wordpress.com domain to login. Once they complete their login there they're redirected back to their actual site with some kind of authenticated token.

Wordpress SSO is handled via the Jetpack plugin so this PR aims to ensure that the login hook that Jetpack uses is correctly triggered by the wc-auth endpoint. The below video shows it working:

https://user-images.githubusercontent.com/1573005/119368862-70a19800-bcab-11eb-97df-faee091a4b00.mov

As can be seen it correctly redirects to the wordpress log in then redirects back to the OAuth flow that had originally been started with the logged in user.

> **NB**
> I do not know all the ways in which this endpoint is expected to be used so haven't been able to comprehensively test.

### How to test the changes in this Pull Request:

#### Manual Test
1. You'll need a site using the SSO method supplied by Jetpack
2. Visit https:/[YOUR SITE]/wc-auth/v1/authorize/?app_name=WooCommerce%20Integration&user_id=[USER ID]&return_url=[somewhere.com]&callback_url=[somewhereelse.com]&scope=read_write
3. Check that the redirect works

### Other information:

* [ x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ 0] Have you written new tests for your changes, as applicable? - **NB:** I'd like to but there are no existing tests for wc-auth (or at least none that I found with grep for wc-auth or WC_Auth. Is there any specific way you'd like these to be added?
* [ x] Have you successfully run tests with your changes locally?

### Changelog entry

Fixed OAuth flows that use the wc-auth endpoint on sites that use SSO with a redirect for authentication.