### PR TITLE
Use prop function to set attributes closes #29709

### DIFF
--- a/assets/js/admin/settings.js
+++ b/assets/js/admin/settings.js
@@ -110,7 +110,7 @@
 
 		// Select all/none
 		$( '.woocommerce' ).on( 'click', '.select_all', function() {
-			$( this ).closest( 'td' ).find( 'select option' ).attr( 'selected', 'selected' );
+			$( this ).closest( 'td' ).find( 'select option' ).prop( 'selected', true );
 			$( this ).closest( 'td' ).find( 'select' ).trigger( 'change' );
 			return false;
 		});


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29709

Correctly set the attributes using `prop` function instead of `attr` function.

### How to test the changes in this Pull Request:

1. Go to `wp-admin/admin.php?page=wc-settings`
2. Set `Selling locations` to `Sell to specific countries`
3. In the Select2 multiple select box, click on `Select all`.
4. Then click on `Select none`.
5. Finally click on `Select all` again and make sure you're able to see all countries selected.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Issue in the country selection of the settings page where select all no longer works after selecting none.
