### PR TITLE
Set geolocation transients to expire in one day

### DIFF
--- a/includes/class-wc-geolocation.php
+++ b/includes/class-wc-geolocation.php
@@ -121,7 +121,7 @@ class WC_Geolocation {
 				}
 			}
 
-			set_transient( $transient_name, $external_ip_address, WEEK_IN_SECONDS );
+			set_transient( $transient_name, $external_ip_address, DAY_IN_SECONDS );
 		}
 
 		return $external_ip_address;
@@ -161,7 +161,7 @@ class WC_Geolocation {
 		 * @param array  $geolocation Geolocation data, including country, state, city, and postcode.
 		 * @param string $ip_address  IP Address.
 		 */
-		$geolocation  = apply_filters(
+		$geolocation = apply_filters(
 			'woocommerce_get_geolocation',
 			array(
 				'country'  => $country_code,
@@ -302,7 +302,7 @@ class WC_Geolocation {
 				}
 			}
 
-			set_transient( 'geoip_' . $ip_address, $country_code, WEEK_IN_SECONDS );
+			set_transient( 'geoip_' . $ip_address, $country_code, DAY_IN_SECONDS );
 		}
 
 		return $country_code;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR set all transients used for fallbacks of the `WC_Geolocation` class to expire in one day.
Users shouldn't never access `WC_Geolocation::get_external_ip_address()` if `WC_Geolocation::get_ip_address()` is working properly (of course this method doesn't works in localhost). Also `WC_Geolocation::geolocate_via_api()` shouldn't never get initialized if MaxMind GeoLite 2 integration is working as expected.

So for most of our users never will get any transient for `WC_Geolocation::get_external_ip_address()` or `WC_Geolocation::geolocate_via_api()` if their website is working as expected, if not we'll now set it to expire in one day.

Closes #29738.

### How to test the changes in this Pull Request:

This PR just sets a new transient expire date, not sure if there's any good way to test it, but in any case you can test with:

1. Go to "WooCommerce" > "Settings" > "General".
2. Set `Default customer location` to `Geolocate` (with cache works as well).
3. In a private time start to browser a shop, place some items and to go checkout.
4. Check your database for `_transient_external_ip_address_*` entries like: `SELECT * FROM wp_options WHERE option_name LIKE '%_transient_external_ip_address_%'`
5.  Wait for a day and see that the transient got removed by WordPress.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Set Geolocation fallback transients to expire in one day instead of one week.
