### PR TITLE
Fixed backward compatibility with jQuery.trim() in select2.full.js

### DIFF
--- a/assets/js/select2/select2.full.js
+++ b/assets/js/select2/select2.full.js
@@ -3707,7 +3707,7 @@ S2.define('select2/data/tags',[
   };
 
   Tags.prototype.createTag = function (decorated, params) {
-    var term = params.term.trim();
+    var term = 'string' === typeof params.term ? params.term.trim() : '';
 
     if (term === '') {
       return null;
@@ -4941,7 +4941,7 @@ S2.define('select2/defaults',[
 
     function matcher (params, data) {
       // Always return the object if there is nothing to compare
-      if ( params.term.trim() === '' ) {
+      if ( 'undefined' === typeof params.term || ( 'string' === typeof params.term && '' === params.term.trim() ) ) {
         return data;
       }
 
@@ -5801,7 +5801,7 @@ S2.define('select2/compat/utils',[
   function syncCssClasses ($dest, $src, adapter) {
     var classes, replacements = [], adapted;
 
-    classes = $dest.attr('class').trim();
+    classes = 'string' === typeof $dest.attr('class') ? $dest.attr('class').trim() : '';
 
     if (classes) {
       classes = '' + classes; // for IE which returns object
@@ -5814,7 +5814,7 @@ S2.define('select2/compat/utils',[
       });
     }
 
-    classes = $src.attr('class').trim();
+    classes = 'string' === typeof $src.attr('class') ? $src.attr('class').trim() : '';
 
     if (classes) {
       classes = '' + classes; // for IE which returns object
@@ -6131,7 +6131,7 @@ S2.define('select2/compat/matcher',[
     function wrappedMatcher (params, data) {
       var match = $.extend(true, {}, data);
 
-      if (params.term == null || params.term.trim() === '') {
+      if ( params.term == null || ( 'string' === typeof params.term && '' === params.term.trim() ) ) {
         return match;
       }
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR fixes the compatibility issues caused by the changes introduced in [this commit](https://github.com/woocommerce/woocommerce/commit/80261317674fcf7971ab985f100b1f626fe53925#diff-c5e548951856a8eaba99f8d3a82e6111a591f287606ff09d5c6e538d78e99284) to the library `select2.full.js`.

<img width="486" alt="select2-trim-error" src="https://user-images.githubusercontent.com/2026888/119652254-22fd6a80-be26-11eb-846d-f2c3501298bd.png">

After replacing `$.trim()` by `String.prototype.trim()`, if you call this function in a non-string value (E.g. `undefinded`), the function throws an error. More info [here](https://api.jquery.com/jquery.trim/).

<img width="808" alt="jquery-trim-warning" src="https://user-images.githubusercontent.com/2026888/119652416-5f30cb00-be26-11eb-8117-8219a9b123a0.png">

**Note:** The replacement of the deprecated function `jQuery.trim()` was applied properly in the library `selectWoo.full.js` thanks to [this commit](https://github.com/woocommerce/woocommerce/commit/84533ac38fc033c952f4f0c893f1c78efe0ce2c6#diff-d3fc5ddc35a917fbdcdda3704efc8e329645ba31456980044127d27a81c8a71c). So I just applied the same changes to the `select2.full.js` file.

Although it's recommended to use the library `selectWoo` instead of `select2`. I think it's important to backport these changes to `select2` due to is still used in many plugins and extensions.

### How to test the changes in this Pull Request:

WooCommerce normally uses the selectWoo library, so I created a little plugin that adds a select field to the WC General settings to force the usage of the select2 library.

[woocommerce-select2-fix.zip](https://github.com/woocommerce/woocommerce/files/6546939/woocommerce-select2-fix.zip)


1. Install and activate the previous plugin in your WooCommerce store.
2. Open the browser console.
3. Go to "WooCommerce > Settings > General" and take a look at the first setting called "**Select2 test**".
4. Click on the "**Select 2 tes**t" field and check your browser console. The error showed in the previous screenshot should be thrown.
5. Apply the changes from this pull request and refresh the page. No errors should be thrown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### One more thing
 I noticed you updated the library selectWoo to version 1.0.9, but in the file `includes/admin/class-wc-admin-assets.php` line **126** still has the old version.
