### PR TITLE
Add a CLI command for dumping tracker data to terminal

### DIFF
--- a/includes/class-wc-cli.php
+++ b/includes/class-wc-cli.php
@@ -28,6 +28,7 @@ class WC_CLI {
 		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-rest-command.php';
 		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-tool-command.php';
 		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-update-command.php';
+		require_once dirname( __FILE__ ) . '/cli/class-wc-cli-tracker-command.php';
 	}
 
 	/**
@@ -37,6 +38,7 @@ class WC_CLI {
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Runner::after_wp_load' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Tool_Command::register_commands' );
 		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Update_Command::register_commands' );
+		WP_CLI::add_hook( 'after_wp_load', 'WC_CLI_Tracker_Command::register_commands' );
 	}
 }
 

--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -113,7 +113,7 @@ class WC_Tracker {
 	 *
 	 * @return array
 	 */
-	private static function get_tracking_data() {
+	public static function get_tracking_data() {
 		$data = array();
 
 		// General site info.

--- a/includes/cli/class-wc-cli-tracker-command.php
+++ b/includes/cli/class-wc-cli-tracker-command.php
@@ -12,7 +12,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 /**
  * Allows access to tracker snapshot for transparency and debugging.
  *
- * @since x.x.x
+ * @since 5.5.0
  * @package WooCommerce
  */
 class WC_CLI_Tracker_Command {

--- a/includes/cli/class-wc-cli-tracker-command.php
+++ b/includes/cli/class-wc-cli-tracker-command.php
@@ -26,14 +26,30 @@ class WC_CLI_Tracker_Command {
 
 	/**
 	 * Dump tracker snapshot data to screen.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * wp wc tracker snapshot --format=yaml
+	 * wp wc tracker snapshot --format=json
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--format=<format>]
+	 * : Render output in a particular format, see WP_CLI\Formatter for details.
+	 *
+	 * @see \WP_CLI\Formatter
+	 * @see WC_Tracker::get_tracking_data()
+	 * @param array $args WP-CLI positional arguments.
+	 * @param array $assoc_args WP-CLI associative arguments.
 	 */
-	public static function show_tracker_snapshot() {
+	public static function show_tracker_snapshot( $args, $assoc_args ) {
 		$snapshot_data = WC_Tracker::get_tracking_data();
 
-		// Using print_r as a convenient way to dump the snapshot data to screen in a readable form.
-		WP_CLI::log( print_r( $snapshot_data, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
-		// Could improve this, e.g. flatten keys (join nested fields with `-`) and render as CSV or json.
+		$formatter = new \WP_CLI\Formatter(
+			$assoc_args,
+			array_keys( $snapshot_data )
+		);
 
-		WP_CLI::success( 'Printed tracker data.' );
+		$formatter->display_items( array( $snapshot_data ) );
 	}
 }

--- a/includes/cli/class-wc-cli-tracker-command.php
+++ b/includes/cli/class-wc-cli-tracker-command.php
@@ -21,7 +21,7 @@ class WC_CLI_Tracker_Command {
 	 * Registers a command for showing WooCommerce Tracker snapshot data.
 	 */
 	public static function register_commands() {
-		WP_CLI::add_command( 'wc tracker-snapshot', array( 'WC_CLI_Tracker_Command', 'show_tracker_snapshot' ) );
+		WP_CLI::add_command( 'wc tracker snapshot', array( 'WC_CLI_Tracker_Command', 'show_tracker_snapshot' ) );
 	}
 
 	/**

--- a/includes/cli/class-wc-cli-tracker-command.php
+++ b/includes/cli/class-wc-cli-tracker-command.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * WC_CLI_Tracker_Command class file.
+ *
+ * @package WooCommerce\CLI
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Allows access to tracker snapshot for transparency and debugging.
+ *
+ * @since x.x.x
+ * @package WooCommerce
+ */
+class WC_CLI_Tracker_Command {
+
+	/**
+	 * Registers a command for showing WooCommerce Tracker snapshot data.
+	 */
+	public static function register_commands() {
+		WP_CLI::add_command( 'wc tracker-snapshot', array( 'WC_CLI_Tracker_Command', 'show_tracker_snapshot' ) );
+	}
+
+	/**
+	 * Dump tracker snapshot data to screen.
+	 */
+	public static function show_tracker_snapshot() {
+		$snapshot_data = WC_Tracker::get_tracking_data();
+
+		// Using print_r as a convenient way to dump the snapshot data to screen in a readable form.
+		WP_CLI::log( print_r( $snapshot_data, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r
+		// Could improve this, e.g. flatten keys (join nested fields with `-`) and render as CSV or json.
+
+		WP_CLI::success( 'Printed tracker data.' );
+	}
+}


### PR DESCRIPTION
Fixes #29982

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR adds a [wp-cli](https://wp-cli.org) command to show the [WooCommerce Tracker](https://woocommerce.com/usage-tracking/) snapshot for the store. 

This is helpful for debugging and development, e.g. adding new tracker fields, or debugging issues with fields showing incorrect info. 

Also this gives privacy-conscious merchants a way to easily inspect exactly what information is being tracked, from WooCommerce Core and plugins. 


### New CLI command docs

```txt
NAME

  wp wc tracker snapshot

DESCRIPTION

  Dump tracker snapshot data to screen.

SYNOPSIS

  wp wc tracker snapshot [--format=<format>]

EXAMPLES

  wp wc tracker snapshot --format=yaml
  wp wc tracker snapshot --format=json

OPTIONS

  [--format=<format>]
    Render output in a particular format, see WP_CLI\Formatter for details.
```

### How to test the changes in this Pull Request:
1. Check out this branch. Bonus points - install a plugin that adds some tracker fields ([see docs for other plugins](https://woocommerce.com/usage-tracking/)).
2. Ensure your store has WP-CLI installed/configured.
3. Run this command: `wc tracker snapshot --format=yaml`, or experiment with specifying different fields and formats.

Confirm the tracker data is readable and correct. 

### Other information:

* [x] _Have you added an explanation of what your changes do and why you'd like us to include them?_
* [ ] _Have you written new tests for your changes, as applicable?_ n/a, but happy to add a test if requested
* [ ] _Have you successfully run tests with your changes locally?_ I have manually tested locally and [on Jurassic Ninja](https://developing-ocelot.jurassic.ninja/wp-admin/)

### Changelog entry

> New: CLI command for viewing [tracking data](https://woocommerce.com/usage-tracking/) for your store.
