### PR TITLE
Widgets: show instance in Rest API

### DIFF
--- a/includes/abstracts/abstract-wc-widget.php
+++ b/includes/abstracts/abstract-wc-widget.php
@@ -64,6 +64,7 @@ abstract class WC_Widget extends WP_Widget {
 			'classname'                   => $this->widget_cssclass,
 			'description'                 => $this->widget_description,
 			'customize_selective_refresh' => true,
+			'show_instance_in_rest'       => true,
 		);
 
 		parent::__construct( $this->widget_id, $this->widget_name, $widget_ops );
@@ -372,7 +373,7 @@ abstract class WC_Widget extends WP_Widget {
 		}
 
 		// All current filters.
-		if ( $_chosen_attributes = WC_Query::get_layered_nav_chosen_attributes() ) { // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.Found, WordPress.CodeAnalysis.AssignmentInCondition.Found
+		if ( $_chosen_attributes = WC_Query::get_layered_nav_chosen_attributes() ) { // phpcs:ignore Squiz.PHP.DisallowMultipleAssignments.FoundInControlStructure, WordPress.CodeAnalysis.AssignmentInCondition.Found
 			foreach ( $_chosen_attributes as $name => $data ) {
 				$filter_name = wc_attribute_taxonomy_slug( $name );
 				if ( ! empty( $data['terms'] ) ) {


### PR DESCRIPTION
_This issue surfaced as part of our audit of the current state of using WooCommerce Blocks as Block Widgets in the new Widgets Editor and Customizer (pca54o-1pT-p2)._

Part of solving https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4220
Related to https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4292

In order to prepare WooCommerce for WP 5.8, as per https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4220 we want to provide block transforms for legacy widgets that have a block equivalent. This is being addressed in https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4292.

In order to be able to provide block transforms for legacy widgets though, we need to show the raw instance in the REST API.

In this PR I've set `show_instance_in_rest` to true for all WooCommerce widgets as we'll want to provide block equivalents for all widgets eventually. That said, technically right now we'd only need it for Product Search, Product Categories, and Recent Product Reviews. If deemed necessary we could also do this on a per widget basis.

I'd appreciate a sanity check on potential security implications I might have overlooked. 
To quote from the [related documentation in core](https://developer.wordpress.org/block-editor/how-to-guides/widgets/legacy-widget-block/#allowing-migration-to-a-block):

> This can be safely done if:
>You know that all of the values stored by your widget in $instance can be represented as JSON; and
You know that your widget does not store any private data in $instance that should be kept hidden from users that have permission to customize the site.


|Before|After|
|-|-|
|<img width="381" alt="Screenshot 2021-05-31 at 12 11 27" src="https://user-images.githubusercontent.com/1562646/120178086-63cff780-c209-11eb-9df3-eb073fbcf37a.png">|<img width="384" alt="Screenshot 2021-05-31 at 12 10 37" src="https://user-images.githubusercontent.com/1562646/120178103-69c5d880-c209-11eb-99a8-e1cacd79f08b.png">|

### How to test the changes in this Pull Request:

This PR can be best tested together with the PR it enables: https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4292

Widgets to test: Product Search, Product Categories, Recent Product Reviews

**Prerequisites:** 

1. Follow the `Prerequisites` testing instructions on https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4292


**What to test:**

1. Go to the Widgets editor in Appearance > Widgets.
2. Add the Product Search, Product Categories, Recent Product Reviews widgets.
3. Without this PR applied you won't see the transform options to the related blocks.
4. With this PR applied, you'll see the related block transform options.

<!-- If you can, add the appropriate labels -->

### Changelog

> Show legacy widget instance in Rest API.