### PR TITLE
Allow block templates for WooCommerce pages

### DIFF
--- a/includes/class-wc-template-loader.php
+++ b/includes/class-wc-template-loader.php
@@ -96,23 +96,53 @@ class WC_Template_Loader {
 	}
 
 	/**
-	 * Get the default filename for a template.
+	 * Checks whether a block template with that name exists.
+	 *
+	 * @since  5.5.0
+	 * @param string $template_name Template to check.
+	 * @return boolean
+	 */
+	private static function has_block_template( $template_name ) {
+		if ( ! $template_name ) {
+			return false;
+		}
+
+		return is_readable(
+			get_stylesheet_directory() . '/block-templates/' . $template_name . '.html'
+		);
+	}
+
+	/**
+	 * Get the default filename for a template except if a block template with
+	 * the same name exists.
 	 *
 	 * @since  3.0.0
+	 * @since  5.5.0 If a block template with the same name exists, return an
+	 * empty string.
 	 * @return string
 	 */
 	private static function get_template_loader_default_file() {
-		if ( is_singular( 'product' ) ) {
+		if (
+			is_singular( 'product' ) &&
+			! self::has_block_template( 'single-product' )
+		) {
 			$default_file = 'single-product.php';
 		} elseif ( is_product_taxonomy() ) {
 			$object = get_queried_object();
 
 			if ( is_tax( 'product_cat' ) || is_tax( 'product_tag' ) ) {
-				$default_file = 'taxonomy-' . $object->taxonomy . '.php';
-			} else {
+				if ( self::has_block_template( 'taxonomy-' . $object->taxonomy ) ) {
+					$default_file = '';
+				} else {
+					$default_file = 'taxonomy-' . $object->taxonomy . '.php';
+				}
+			} elseif ( ! self::has_block_template( 'archive-product' ) ) {
 				$default_file = 'archive-product.php';
 			}
-		} elseif ( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) {
+		} elseif (
+			( is_post_type_archive( 'product' ) || is_page( wc_get_page_id( 'shop' ) ) ) &&
+			! self::has_block_template( 'archive-product' )
+		) {
 			$default_file = self::$theme_support ? 'archive-product.php' : '';
 		} else {
 			$default_file = '';


### PR DESCRIPTION
WordPress 5.8 will introduce support for block-based themes (also known as FSE themes). Those themes don't use the typical PHP system for templates but instead templates are defined with HTML.

Currently, WooCommerce assumes any theme that declares support with `add_theme_support( 'woocommerce' );` will use PHP templates (ie: sidebar.php, header.php...). However, that might no longer be the case for block-based themes.

This PR makes it so if a theme has a block template, WooCommerce will not enforce the PHP template override.

### How to test the changes in this Pull Request:

0. Make sure you have Gutenberg installed or you are using WordPress 5.8. Otherwise, block-based themes won't work.
1. Ensure nothing is broken with a classic theme (ie: Storefront or Twenty Twenty One). Do some basic smoke testing: does the header look correct? Does the product page have the correct template? Etc.
2. Do some basic smoke testing with a block-based theme that don't explicitly supports WooCommerce too (ie: [TT1 Blocks](https://wordpress.org/themes/tt1-blocks/)).
3. Test a block-based theme which supports WooCommerce. Currently, there is no block-based theme with support for WooCommerce that I'm aware of. So I needed to tweak TT1 Blocks for this:
   * In [`functions.php` L58](https://github.com/WordPress/theme-experiments/blob/master/tt1-blocks/functions.php#L59), add `add_theme_support( 'woocommerce' );`.
   * In [`block-templates`](https://github.com/WordPress/theme-experiments/tree/master/tt1-blocks/block-templates), create a file named `single-product.html` with these contents:

```HTML
<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header","layout":{"inherit":true}} /-->

<h1>This is a product</h1>
<!-- wp:post-title {"level":1,"align":"wide"} /-->
<!-- wp:post-content {"layout":{"inherit":true}} /-->

<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer","layout":{"inherit":true}} /-->
```
4. Go to a product page and verify there are no PHP errors and instead the HTML template you just created is shown:
![Screenshot of the product template](https://user-images.githubusercontent.com/3616980/120181792-d93dc700-c20d-11eb-8a05-5c2feeb080b4.png)
5. You can repeat the process with other templates:
<details>
<summary>archive-product.html</summary>

```HTML
<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header","layout":{"inherit":true}} /-->

<h1>This is the products archive</h1>

<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer","layout":{"inherit":true}} /-->
```

</details>
<details>
<summary>taxonomy-product_cat.html</summary>

```HTML
<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header","layout":{"inherit":true}} /-->

<h1>This is a product category</h1>

<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer","layout":{"inherit":true}} /-->
```

</details>

<details>
<summary>taxonomy-product_tag.html</summary>

```HTML
<!-- wp:template-part {"slug":"header","tagName":"header","className":"site-header","layout":{"inherit":true}} /-->

<h1>This is a product tag</h1>

<!-- wp:template-part {"slug":"footer","tagName":"footer","className":"site-footer","layout":{"inherit":true}} /-->
```

</details>

### Changelog entry

> Allow block templates for WooCommerce pages
