### PR TITLE
Fix JS console error when add new shipping zone button clicked

### DIFF
--- a/assets/js/admin/wc-shipping-zones.js
+++ b/assets/js/admin/wc-shipping-zones.js
@@ -79,6 +79,11 @@
 					$tbody.on( 'change', { view: this }, this.updateModelOnChange );
 					$tbody.on( 'sortupdate', { view: this }, this.updateModelOnSort );
 					$( window ).on( 'beforeunload', { view: this }, this.unloadConfirmation );
+					$( document.body ).on( 'click', '.wc-shipping-zone-add', { view: this }, this.onAddNewRow );
+				},
+				onAddNewRow: function() {
+					var $link = $( this );
+					window.location.href = $link.attr( 'href' );
 				},
 				block: function() {
 					$( this.el ).block({

--- a/assets/js/admin/wc-shipping-zones.js
+++ b/assets/js/admin/wc-shipping-zones.js
@@ -79,7 +79,6 @@
 					$tbody.on( 'change', { view: this }, this.updateModelOnChange );
 					$tbody.on( 'sortupdate', { view: this }, this.updateModelOnSort );
 					$( window ).on( 'beforeunload', { view: this }, this.unloadConfirmation );
-					$( document.body ).on( 'click', '.wc-shipping-zone-add', { view: this }, this.onAddNewRow );
 				},
 				block: function() {
 					$( this.el ).block({


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
According to this issue #29984 , When we clicked the `Add Shipping Zone` button in WooCommerce->Settings->Shipping(tab) we are getting a js console error. Because we are binding an event but not working on this event. This button redirect to another page so I think we don't need to bind any js event for this button

That's why I removed this event handle for this button. 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Resolved a console error that could occur when clicking Add Shipping Zone. #29984
