### PR TITLE
add wait between loading shop and add to cart

### DIFF
--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout-coupons.test.js
@@ -9,6 +9,7 @@ const {
 	uiUnblocked,
 	applyCoupon,
 	removeCoupon,
+	waitForSelectorWithoutThrow,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -33,6 +34,7 @@ const runCheckoutApplyCouponsTest = () => {
 			couponFixedProduct = await createCoupon('5', 'Fixed product discount');
 			await shopper.emptyCart();
 			await shopper.goToShop();
+			await waitForSelectorWithoutThrow( '.add_to_cart_button' );
 			await shopper.addToCartFromShopPage('Simple product');
 			await uiUnblocked();
 			await shopper.goToCheckout();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This is an attempt to fix the checkout coupon test which often fails when run against the smoke test site. It adds a wait for the add to cart button to allow the browser additional time to render the page before clicking the add to cart button. The screenshot shows that the product is listed in the shop but the `Add to Cart` button has not been clicked:

![screenshot_of_failed_test (2)](https://user-images.githubusercontent.com/343847/120381675-2185e380-c2f9-11eb-9612-4230dbd397e2.png)

### How to test the changes in this Pull Request:

1. Verify CI run
2. Run tests locally

### Changelog entry

> N/A
