### PR TITLE
Remove functionless ABSPATH check.

### DIFF
--- a/includes/interfaces/class-wc-logger-interface.php
+++ b/includes/interfaces/class-wc-logger-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
-
 /**
  * WC Logger Interface
  *


### PR DESCRIPTION
Checking for `ABSPATH` is recommended so WordPress functions are not called before WordPress has been loaded. This does not apply to interfaces.

I just tried to implement `WC_Logger_Interface` in my tests, seemingly before WordPress was loaded, and this check stops anything from running. Seems antithetical to open source to place restrictions like this and IIRC the philosophy of Gutenberg is to be useful beyond the WordPress ecosystem, so opening up the code feels coherent with WordPress.

PR #9534 (Nov 2015) and #15011 (May 2017) _added_  ABSPATH checks, but without much discussion (fair enough, it's convention). There's little discussion in [PRs or issues](https://github.com/woocommerce/woocommerce/pulls?q=ABSPATH+) about it.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Removes from [WC_Logger_Interface](https://github.com/woocommerce/woocommerce/blob/0507f06508a448995ae6ebec903115e670cc5ee4/includes/interfaces/class-wc-logger-interface.php#L9-L11):

```
if ( ! defined( 'ABSPATH' ) ) {
	exit; // Exit if accessed directly.
}
```

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?


### Changelog entry

* Remove ABSPATH check on WC_Logger_Interface
