### PR TITLE
fix Slack OAuth scopes typo in README

### DIFF
--- a/tests/e2e/env/README.md
+++ b/tests/e2e/env/README.md
@@ -166,7 +166,7 @@ To implement the Slackbot in your CI:
 
 - Create a [Slackbot App](https://slack.com/help/articles/115005265703-Create-a-bot-for-your-workspace)
 - Give the app the following permissions:
-  - `channel:join`
+  - `channels:join`
   - `chat:write`
   - `files:write`
   - `incoming-webhook`


### PR DESCRIPTION
To test the changes in this Pull Request:

- review the change
- ensure change is according to [Slack's docs](https://api.slack.com/scopes/channels:join)
