### PR TITLE
Show variations in upsells when parent is not published

### DIFF
--- a/plugins/woocommerce/changelog/fix-show-private-variations-in-upsells
+++ b/plugins/woocommerce/changelog/fix-show-private-variations-in-upsells
@@ -1,0 +1,4 @@
+Significance: minor
+Type: add
+
+Display variation upsells from private variable products to users with required permissions.

--- a/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
+++ b/plugins/woocommerce/includes/abstracts/abstract-wc-product.php
@@ -1603,7 +1603,7 @@ class WC_Product extends WC_Abstract_Legacy_Product {
 		if ( $this->get_parent_id() ) {
 			$parent_product = wc_get_product( $this->get_parent_id() );
 
-			if ( $parent_product && 'publish' !== $parent_product->get_status() ) {
+			if ( $parent_product && 'publish' !== $parent_product->get_status() && ! current_user_can( 'edit_post', $parent_product->get_id() ) ) {
 				$visible = false;
 			}
 		}


### PR DESCRIPTION
I was struggling to get the upsell section to show for our eCommerce site. After some digging I found that line 1525 stopped variations from showing in the upsell section if the parent product was set to privately published. This makes testing products and upsells hard, and it's inconsistent behaviour when simple products that are privately published do show up. The proposed change will make variations show up as long as the current user can edit the parent product. This is consistent with the behaviour for simple products.

### Testing instructions:
Preconditions: WordPress with WooCommerce installed, at least 2 products where one is public and one is a privately published variable product, and a theme that displays the upsell section. A variation from the private product should be added as an upsell to the published product.
Action: Load the product page in two tabs. One logged in with capabilities to edit products, and one incognito as logged out.
Validation: Check that the upsell product shows in the logged in tab, and not in the logged out tab.

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?
