### PR TITLE
FSE: add link to Customizer WooCommerce panel in block-based themes

### DIFF
--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -270,7 +270,6 @@ class WC_Shop_Customizer {
 	 *
 	 * FSE themes hide the "Customize" link in the Appearance menu. In WooCommerce we have several options that can currently
 	 * only be edited via the Customizer. For now, we are thus adding a new link for WooCommerce specific Customizer options.
-	 * For further details see pca54o-1zX-p2.
 	 */
 	public function add_fse_customize_link() {
 

--- a/includes/customizer/class-wc-shop-customizer.php
+++ b/includes/customizer/class-wc-shop-customizer.php
@@ -21,6 +21,7 @@ class WC_Shop_Customizer {
 		add_action( 'customize_controls_print_styles', array( $this, 'add_styles' ) );
 		add_action( 'customize_controls_print_scripts', array( $this, 'add_scripts' ), 30 );
 		add_action( 'wp_enqueue_scripts', array( $this, 'add_frontend_scripts' ) );
+		add_action( 'admin_menu', array( $this, 'add_fse_customize_link' ) );
 	}
 
 	/**
@@ -83,6 +84,19 @@ class WC_Shop_Customizer {
 				width: auto;
 				display: inline-block;
 			}
+			<?php
+			// For FSE themes hide the back button so we only surface WooCommerce options.
+			if ( function_exists( 'gutenberg_is_fse_theme' ) && gutenberg_is_fse_theme() ) {
+				?>
+					#sub-accordion-panel-woocommerce .customize-panel-back{
+						display: none;
+					}
+					#customize-controls #sub-accordion-panel-woocommerce .panel-meta.customize-info .accordion-section-title {
+						margin-left: 0;
+					}
+				<?php
+			}
+			?>
 		</style>
 		<?php
 	}
@@ -249,6 +263,30 @@ class WC_Shop_Customizer {
 			} );
 		</script>
 		<?php
+	}
+
+	/**
+	 * For FSE themes add a "Customize WooCommerce" link to the Appearance menu.
+	 *
+	 * FSE themes hide the "Customize" link in the Appearance menu. In WooCommerce we have several options that can currently
+	 * only be edited via the Customizer. For now, we are thus adding a new link for WooCommerce specific Customizer options.
+	 * For further details see pca54o-1zX-p2.
+	 */
+	public function add_fse_customize_link() {
+
+		// Exit early if the FSE theme feature isn't present or the current theme is not a FSE theme.
+		if ( ! function_exists( 'gutenberg_is_fse_theme' ) || function_exists( 'gutenberg_is_fse_theme' ) && ! gutenberg_is_fse_theme() ) {
+			return;
+		}
+
+		// Add a link to the WooCommerce panel in the Customizer.
+		add_submenu_page(
+			'themes.php',
+			__( 'Customize WooCommerce', 'woocommerce' ),
+			__( 'Customize WooCommerce', 'woocommerce' ),
+			'edit_theme_options',
+			admin_url( 'customize.php?autofocus[panel]=woocommerce' )
+		);
 	}
 
 	/**


### PR DESCRIPTION
Fixes https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4297

This PR:
- adds a `Customize WooCommerce` link to the Appearance menu for block-based themes.
- hides the back button in the Customizer to only surface WooCommerce specific options.
 
FSE themes hide the "Customize" link in the Appearance menu. In WooCommerce we have several options though that can currently only be edited via the Customizer. For now, we are thus adding a link to the WooCommerce specific Customizer options. For the product decision and further details see pca54o-1zX-p2.


https://user-images.githubusercontent.com/1562646/120821308-a40adf00-c555-11eb-9f07-83754d75c17c.mp4

### How to test

1. Install the latest nightly version of WordPress 5.8 (for example using [WordPress beta tester](https://wordpress.org/plugins/wordpress-beta-tester/)).
2. Install the latest version of [Gutenberg](https://wordpress.org/plugins/gutenberg/).
3. With `Storefront` or another classic theme active, the `Customize` link should be present in the `Appearance` menu. Test that the link works as expected. Go to the WooCommerce panel and confirm that you can navigate back to the general panel from there.
4. Install & activate a block-based FSE theme (ie: [TT1 Blocks](https://wordpress.org/themes/tt1-blocks/)).
5. Confirm that the `Appearance` menu contains a `Customize WooCommerce` link. Follow the link and confirm it brings you to the WooCommerce panel in the Customizer. Confirm that this time you can't navigate back to the general Customizer panel from here.

### Changelog entry

> Add Customize WooCommerce link for block-based themes.

