### PR TITLE
Fix CSV import aborting too early due to progress overestimation

### DIFF
--- a/includes/admin/class-wc-admin-importers.php
+++ b/includes/admin/class-wc-admin-importers.php
@@ -151,7 +151,7 @@ class WC_Admin_Importers {
 			return;
 		}
 
-		$id          = absint( $_POST['import_id'] ); // PHPCS: input var ok.
+		$id          = absint( $_POST['import_id'] ); // PHPCS: input var ok, CSRF ok.
 		$file        = get_attached_file( $id );
 		$parser      = new WXR_Parser();
 		$import_data = $parser->parse( $file );
@@ -233,12 +233,14 @@ class WC_Admin_Importers {
 
 		$importer         = WC_Product_CSV_Importer_Controller::get_importer( $file, $params );
 		$results          = $importer->import();
+		$file_size        = $importer->get_file_size();
+		$file_position    = $importer->get_file_position();
 		$percent_complete = $importer->get_percent_complete();
 		$error_log        = array_merge( $error_log, $results['failed'], $results['skipped'] );
 
 		update_user_option( get_current_user_id(), 'product_import_error_log', $error_log );
 
-		if ( 100 === $percent_complete ) {
+		if ( $file_size === $file_position ) {
 			// @codingStandardsIgnoreStart.
 			$wpdb->delete( $wpdb->postmeta, array( 'meta_key' => '_original_id' ) );
 			$wpdb->delete( $wpdb->posts, array(

--- a/includes/import/abstract-wc-product-importer.php
+++ b/includes/import/abstract-wc-product-importer.php
@@ -150,12 +150,23 @@ abstract class WC_Product_Importer implements WC_Importer_Interface {
 	}
 
 	/**
+	 * Get the size of the file to be imported
+	 * The import is complete when get_file_position() equals get_file_size()
+	 *
+	 * @return int
+	 */
+	public function get_file_size() {
+		return filesize( $this->file );
+	}
+
+	/**
 	 * Get file pointer position as a percentage of file size.
+	 * This function returns rounded results and is only suitable for UI use.
 	 *
 	 * @return int
 	 */
 	public function get_percent_complete() {
-		$size = filesize( $this->file );
+		$size = $this->get_file_size();
 		if ( ! $size ) {
 			return 0;
 		}

--- a/includes/interfaces/class-wc-importer-interface.php
+++ b/includes/interfaces/class-wc-importer-interface.php
@@ -68,6 +68,14 @@ interface WC_Importer_Interface {
 	public function get_file_position();
 
 	/**
+	 * Get the size of the file to be imported
+	 * The import is complete when get_file_position() equals get_file_size()
+	 *
+	 * @return int
+	 */
+	public function get_file_size();
+
+	/**
 	 * Get file pointer position as a percentage of file size.
 	 *
 	 * @return int


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #29793 .
As suggested by @vedanshujain in the aforementioned issue I added an additional function `get_file_size` to the importer against which `get_file_position` is compared to determine whether the import has completed.

I also had to change
```php
               $id          = absint( $_POST['import_id'] ); // PHPCS: input var ok.
 ```

to
```php
               $id          = absint( $_POST['import_id'] ); // PHPCS: input var ok, CSRF ok.
```
to get the pre-commit hooks to pass.

I believe this change to be harmless from a security perspective due to the statement directly before it already disabling the linter issue.
```php
		if ( empty( $_POST['import_id'] ) || ! class_exists( 'WXR_Parser' ) ) { // PHPCS: input var ok, CSRF ok.
			return;
		}
```
However before merging this PR it would be useful for someone with a more in-depth knowledge of the architecture to double-check it.

### How to test the changes in this Pull Request:

See #29793 for a step-by-step test case.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
  - I tried adding a regression test in `tests/e2e/core-tests/specs/merchant/wp-admin-product-import-csv.test.js`, but ran into issue with the test running into timeouts. I have attached the patch file and the test data, if someone wants to give it a shot. 
[test.patch.txt](https://github.com/woocommerce/woocommerce/files/6615013/test.patch.txt)
[test_products_large.csv](https://github.com/woocommerce/woocommerce/files/6615018/test_products_large.csv)
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix CSV import aborting too early due to progress overestimation