### PR TITLE
Update WooCommerce blocks package to 5.3.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.0",
     "woocommerce/woocommerce-admin": "2.3.1",
-    "woocommerce/woocommerce-blocks": "5.1.0"
+    "woocommerce/woocommerce-blocks": "5.3.0"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.0",
     "woocommerce/woocommerce-admin": "2.3.1",
-    "woocommerce/woocommerce-blocks": "5.3.0"
+    "woocommerce/woocommerce-blocks": "5.3.1"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4"

--- a/composer.lock
+++ b/composer.lock
@@ -584,7 +584,7 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v5.1.0",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",

--- a/composer.lock
+++ b/composer.lock
@@ -584,16 +584,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v5.3.0",
+            "version": "v5.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "a4f168596f3832e161b26dec636b69293039ee51"
+                "reference": "28c7c4f9b5cace9098fb2246ff93abe110a26bca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/a4f168596f3832e161b26dec636b69293039ee51",
-                "reference": "a4f168596f3832e161b26dec636b69293039ee51",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/28c7c4f9b5cace9098fb2246ff93abe110a26bca",
+                "reference": "28c7c4f9b5cace9098fb2246ff93abe110a26bca",
                 "shasum": ""
             },
             "require": {
@@ -629,9 +629,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.1.0"
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.3.1"
             },
-            "time": "2021-05-10T15:01:42+00:00"
+            "time": "2021-06-15T09:12:48+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This pull updates the WooCommerce Blocks plugin to 5.3.0. It includes changes from WooCommerce Blocks 5.2.0-5.3.0 and is intended to target WooCommerce 5.5.0 for release.
Details from all the different releases included in this pull:

## Blocks 5.2.0

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4266)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/520.md)
* [Release post](https://developer.woocommerce.com/2021/05/26/woocommerce-blocks-5-2-0-release-notes/)

## Blocks 5.3.0

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4318)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/530.md)
* [Release post](https://developer.woocommerce.com/2021/06/08/woocommerce-blocks-5-3-0-release-notes/)

## Blocks 5.3.1

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4348)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/531.md)
* [Release post](https://developer.woocommerce.com/2021/06/15/woocommerce-blocks-5-3-1-release-notes/)

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Enhancements
- Hide legacy widgets with a feature-complete block equivalent from the widget area block inserter. ([4237](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4237))
- Provide block transforms for legacy widgets with a feature-complete block equivalent. ([4292](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4292))
- Hide the All Products Block from the Customizer Widget Areas until full support is achieved. ([4225](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4225))
- Improved accessibility and styling of the controls of several of ours blocks. ([4100](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4100))
- Fix duplicate react keys in ProductDetails component. ([4187](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4187))

#### Bug Fixes
- Fix a bug in which Cart Widget didn’t update when adding items from the All Products block. ([4291](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4291))
- Fix an issue where an attempt to add an out-of-stock product to the cart was made when clicking the “Read more” button. ([4265](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4265))
- Fix Product Categories List block display in Site Editor ([#4335](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4335)).
- Make links in the Product Categories List block unclickable in the editor ([#4339](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4339)).
- Fix rating stars not being shown in the Site Editor ([#4345](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4345)).




### The following changelog entries are for items that only apply when the feature plugin is active:

#### Enhancements
- Added a key prop to each CartTotalItem within usePaymentMethodInterface. ([4240](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4240))
- Sync customer data during checkout with draft orders.  ([4197](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4197))
- Update the display of the sidebar/order summary in the Cart and Checkout blocks. ([4180](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4180))
- Hide the Cart and Checkout blocks from the new block-based widget editor.  ([4303](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4303))

#### Bug Fixes
- Hide tax breakdown if the total amount of tax to be paid is 0. ([4262](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4262))
- Prevent Coupon code panel from appearing in stores were coupons are disabled. ([4202](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4202))
- For payment methods, only use canMakePayment in the frontend (not the editor) context.  ([4188](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4188))
- Fix sending of confirmation emails for orders when no payment is needed. ([4186](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4186))
- Stopped a warning being shown when using WooCommerce Force Sells and adding a product with a Synced Force Sell to the cart.  ([4182](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4182))
- Fix some missing translations from the Cart and Checkout blocks.  ([4295](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4295))
- Fix the flickering of the Proceed to Checkout button on quantity update in the Cart Block.  ([4293](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4293))
- Fix a display issue when itemized taxes are enabled, but no products in the cart are taxable. ([4284](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4284))

### Compatibility

- Add the ability for extensions to register callbacks to be executed by Blocks when the cart/extensions endpoint is hit. Extensions can now tell Blocks they need to do some server-side processing which will update the cart. ([4298](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4298))

#### Various

- Add couponName filter to allow extensions to modify how coupons are displayed in the Cart and Checkout summary. ([4166](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4166))
- Move Button and Label components to `@woocommerce/blocks-checkout` package. ([4222](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4222))
- Add Slot in the Discounts section of the cart sidebar to allow third party extensions to render their own components there. ([4248](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4248))
