### PR TITLE
Convert card information to strings if numbers

### DIFF
--- a/assets/js/jquery-payment/jquery.payment.js
+++ b/assets/js/jquery-payment/jquery.payment.js
@@ -586,7 +586,7 @@ jQuery( function( $ ) {
 
   $.payment.validateCardCVC = function(cvc, type) {
     var card, _ref;
-  	cvc = 'number' === typeof cvc ? cvc.toString() : cvc;
+    cvc = 'number' === typeof cvc ? cvc.toString() : cvc;
     cvc = 'string' === typeof cvc ? cvc.trim() : '';
     if (!/^\d+$/.test(cvc)) {
       return false;

--- a/assets/js/jquery-payment/jquery.payment.js
+++ b/assets/js/jquery-payment/jquery.payment.js
@@ -554,7 +554,9 @@ jQuery( function( $ ) {
     if (!(month && year)) {
       return false;
     }
+    month = 'number' === typeof month ? month.toString() : month;
     month = 'string' === typeof month ? month.trim() : '';
+    year = 'number' === typeof year ? year.toString() : year;
     year = 'string' === typeof year ? year.trim() : '';
     if (!/^\d+$/.test(month)) {
       return false;
@@ -584,6 +586,7 @@ jQuery( function( $ ) {
 
   $.payment.validateCardCVC = function(cvc, type) {
     var card, _ref;
+  	cvc = 'number' === typeof cvc ? cvc.toString() : cvc;
     cvc = 'string' === typeof cvc ? cvc.trim() : '';
     if (!/^\d+$/.test(cvc)) {
       return false;


### PR DESCRIPTION
This PR is a fix to the issue presented [here](https://github.com/woocommerce/woocommerce/issues/30069) following the same suggestion in the discussion.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Convert card information to `string` if they're numbers to prevent errors while trimming.

### How to test the changes in this Pull Request:

* Follow the same steps as the [original issue](https://github.com/woocommerce/woocommerce/issues/30069).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->
