### PR TITLE
Fix issue with jQuery migration and editing addresses in wp-admin

### DIFF
--- a/assets/js/admin/meta-boxes-order.js
+++ b/assets/js/admin/meta-boxes-order.js
@@ -140,7 +140,7 @@ jQuery( function ( $ ) {
 				is_billing     = Boolean( $edit_address.find( 'input[name^="_billing_"]' ).length );
 
 			$address.hide();
-			$this.parent().find( 'a' ).trigger( 'toggle' );
+			$this.parent().find( 'a' ).toggle();
 
 			if ( ! $country_input.val() ) {
 				$country_input.val( woocommerce_admin_meta_boxes_order.default_country ).trigger( 'change' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

This PR fixes an issue with the address loading/copying links not appearing above the shipping address in the metabox because of an incorrect jQuery migration to `.trigger( 'toggle' )`. This PR switches back to `.toggle()`.

Closes #30075.

### How to test the changes in this Pull Request:

1. Create an order via the checkout flow.
2. Edit that order in wp-admin.
2. Attempt to edit the billing address and verify that the "load billing address" option is displayed at the top of the address fields.
3. Attempt to edit the shipping address and verify that both the "load shipping address" and "copy billing address" options are visible.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Restores the option to load and copy addresses to orders edited in the dashboard.
