### PR TITLE
package lock maintenance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9308,7 +9308,7 @@
               }
             },
             "prettier": {
-              "version": "npm:prettier@1.19.1",
+              "version": "npm:wp-prettier@1.19.1",
               "resolved": "https://registry.npmjs.org/wp-prettier/-/wp-prettier-1.19.1.tgz",
               "integrity": "sha512-mqAC2r1NDmRjG+z3KCJ/i61tycKlmADIjxnDhQab+KBxSAGbF/W7/zwB2guy/ypIeKrrftNsIYkNZZQKf3vJcg==",
               "dev": true


### PR DESCRIPTION
`npm run build` currently fails in `trunk`. This PR updates the package lock.

###

1- run  `npm run build` in this branch