### PR TITLE
Register woocommerce.css so it can be enqueued in the editor

### DIFF
--- a/includes/admin/class-wc-admin-assets.php
+++ b/includes/admin/class-wc-admin-assets.php
@@ -54,6 +54,11 @@ if ( ! class_exists( 'WC_Admin_Assets', false ) ) :
 			wp_style_add_data( 'woocommerce_admin_marketplace_styles', 'rtl', 'replace' );
 			wp_style_add_data( 'woocommerce_admin_privacy_styles', 'rtl', 'replace' );
 
+			if ( $screen->is_block_editor() ) {
+				wp_register_style( 'woocommerce-general', WC()->plugin_url() . '/assets/css/woocommerce.css', array(), $version );
+				wp_style_add_data( 'woocommerce-general', 'rtl', 'replace' );
+			}
+
 			// Sitewide menu CSS.
 			wp_enqueue_style( 'woocommerce_admin_menu_styles' );
 


### PR DESCRIPTION
In order to fix https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4332, we need `woocommerce.css` to be registered in editor screens so it can be added as a dependency of our styles.

### Changes proposed in this Pull Request:

Register `woocommerce.css` in the block editor and site editor.

### How to test the changes in this Pull Request:

Smoke test the store frontend and verify  `woocommerce.css` is loaded as usual, so there are no visual regressions (they would be easily noticeable if `woocommerce.css` isn't loaded).

Optionally, you can test https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4345 which includes the fix for https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues/4332.

### Changelog entry

> Register woocommerce.css in editor screens.
