### PR TITLE
Revert previous jQuery migration changes as it is not needed here clo…

### DIFF
--- a/assets/js/jquery-tiptip/jquery.tipTip.js
+++ b/assets/js/jquery-tiptip/jquery.tipTip.js
@@ -58,7 +58,7 @@
 			}
 			if(org_title != ""){
 				if(!opts.content){
-					org_elem.prop(opts.attribute, false); //remove original Attribute
+					org_elem.removeAttr(opts.attribute); //remove original Attribute
 				}
 				var timeout = false;
 


### PR DESCRIPTION
…ses #30089

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30089 

Reverts a previously applied change for the jQuery migration efforts as it is not needed in this context.

### How to test the changes in this Pull Request:

1. Activate Product Add-ons extension.
2. Create a simple product with add-ons that is of type `Multiple Choice` displayed as `Images`
3. Add some options with images and option name.
4. Go to the product in the frontend and hover your mouse over the images and ensure you're seeing the correct option name with it's price (if set).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Issue with Product Add-ons where multiple choice (images) setting would show false when hovering over image
