### PR TITLE
Add support for Shipping Phone Number in Order and Customer classes

### DIFF
--- a/includes/admin/class-wc-admin-profile.php
+++ b/includes/admin/class-wc-admin-profile.php
@@ -142,6 +142,10 @@ if ( ! class_exists( 'WC_Admin_Profile', false ) ) :
 								'description' => __( 'State / County or state code', 'woocommerce' ),
 								'class'       => 'js_field-state',
 							),
+							'shipping_phone'      => array(
+								'label'       => __( 'Phone', 'woocommerce' ),
+								'description' => '',
+							),
 						),
 					),
 				)

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -133,6 +133,9 @@ class WC_Meta_Box_Order_Data {
 					'class' => 'js_field-state select short',
 					'show'  => false,
 				),
+				'phone'      => array(
+					'label' => __( 'Phone', 'woocommerce' ),
+				),
 			)
 		);
 	}
@@ -458,6 +461,10 @@ class WC_Meta_Box_Order_Data {
 										$field_value = $order->{"get_$field_name"}( 'edit' );
 									} else {
 										$field_value = $order->get_meta( '_' . $field_name );
+									}
+
+									if ( 'shipping_phone' === $field_name ) {
+										$field_value = wc_make_phone_clickable( $field_value );
 									}
 
 									if ( $field_value ) {

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -730,8 +730,9 @@ class WC_Customer extends WC_Legacy_Customer {
 	}
 
 	/**
-	 * Get shipping_phone.
+	 * Get shipping phone.
 	 *
+	 * @since 5.6.0
 	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
 	 * @return string
 	 */
@@ -1129,8 +1130,9 @@ class WC_Customer extends WC_Legacy_Customer {
 	}
 
 	/**
-	 * Set shipping_phone.
+	 * Set shipping phone.
 	 *
+	 * @since 5.6.0
 	 * @param string $value Shipping phone.
 	 */
 	public function set_shipping_phone( $value ) {

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -52,6 +52,7 @@ class WC_Customer extends WC_Legacy_Customer {
 			'postcode'   => '',
 			'country'    => '',
 			'state'      => '',
+			'phone'      => '',
 		),
 		'is_paying_customer' => false,
 	);
@@ -729,6 +730,16 @@ class WC_Customer extends WC_Legacy_Customer {
 	}
 
 	/**
+	 * Get shipping_phone.
+	 *
+	 * @param  string $context What the value is for. Valid values are 'view' and 'edit'.
+	 * @return string
+	 */
+	public function get_shipping_phone( $context = 'view' ) {
+		return $this->get_address_prop( 'phone', 'shipping', $context );
+	}
+
+	/**
 	 * Is the user a paying customer?
 	 *
 	 * @since  3.0.0
@@ -1115,6 +1126,15 @@ class WC_Customer extends WC_Legacy_Customer {
 	 */
 	public function set_shipping_country( $value ) {
 		$this->set_address_prop( 'country', 'shipping', $value );
+	}
+
+	/**
+	 * Set shipping_phone.
+	 *
+	 * @param string $value Shipping phone.
+	 */
+	public function set_shipping_phone( $value ) {
+		$this->set_address_prop( 'phone', 'shipping', $value );
 	}
 
 	/**

--- a/includes/class-wc-order-query.php
+++ b/includes/class-wc-order-query.php
@@ -63,6 +63,7 @@ class WC_Order_Query extends WC_Object_Query {
 				'shipping_state'       => '',
 				'shipping_postcode'    => '',
 				'shipping_country'     => '',
+				'shipping_phone'       => '',
 				'payment_method'       => '',
 				'payment_method_title' => '',
 				'transaction_id'       => '',

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -746,6 +746,7 @@ class WC_Order extends WC_Abstract_Order {
 	/**
 	 * Get shipping phone.
 	 *
+	 * @since  5.6.0
 	 * @param  string $context What the value is for. Valid values are view and edit.
 	 * @return string
 	 */
@@ -1246,6 +1247,7 @@ class WC_Order extends WC_Abstract_Order {
 	/**
 	 * Set shipping phone.
 	 *
+	 * @since 5.6.0
 	 * @param string $value Shipping phone.
 	 * @throws WC_Data_Exception Throws exception when invalid data is found.
 	 */

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -71,6 +71,7 @@ class WC_Order extends WC_Abstract_Order {
 			'state'      => '',
 			'postcode'   => '',
 			'country'    => '',
+			'phone'      => '',
 		),
 		'payment_method'       => '',
 		'payment_method_title' => '',
@@ -743,6 +744,16 @@ class WC_Order extends WC_Abstract_Order {
 	}
 
 	/**
+	 * Get shipping phone.
+	 *
+	 * @param  string $context What the value is for. Valid values are view and edit.
+	 * @return string
+	 */
+	public function get_shipping_phone( $context = 'view' ) {
+		return $this->get_address_prop( 'phone', 'shipping', $context );
+	}
+
+	/**
 	 * Get the payment method.
 	 *
 	 * @param  string $context What the value is for. Valid values are view and edit.
@@ -1230,6 +1241,16 @@ class WC_Order extends WC_Abstract_Order {
 	 */
 	public function set_shipping_country( $value ) {
 		$this->set_address_prop( 'country', 'shipping', $value );
+	}
+
+	/**
+	 * Set shipping phone.
+	 *
+	 * @param string $value Shipping phone.
+	 * @throws WC_Data_Exception Throws exception when invalid data is found.
+	 */
+	public function set_shipping_phone( $value ) {
+		$this->set_address_prop( 'phone', 'shipping', $value );
 	}
 
 	/**

--- a/includes/class-wc-order.php
+++ b/includes/class-wc-order.php
@@ -880,7 +880,7 @@ class WC_Order extends WC_Abstract_Order {
 		$address = $this->get_address( 'shipping' );
 
 		// Remove name and company before generate the Google Maps URL.
-		unset( $address['first_name'], $address['last_name'], $address['company'] );
+		unset( $address['first_name'], $address['last_name'], $address['company'], $address['phone'] );
 
 		$address = apply_filters( 'woocommerce_shipping_address_map_url_parts', $address, $this );
 

--- a/includes/class-wc-privacy-erasers.php
+++ b/includes/class-wc-privacy-erasers.php
@@ -52,7 +52,7 @@ class WC_Privacy_Erasers {
 				'billing_postcode'    => __( 'Billing Postal/Zip Code', 'woocommerce' ),
 				'billing_state'       => __( 'Billing State', 'woocommerce' ),
 				'billing_country'     => __( 'Billing Country / Region', 'woocommerce' ),
-				'billing_phone'       => __( 'Phone Number', 'woocommerce' ),
+				'billing_phone'       => __( 'Billing Phone Number', 'woocommerce' ),
 				'billing_email'       => __( 'Email Address', 'woocommerce' ),
 				'shipping_first_name' => __( 'Shipping First Name', 'woocommerce' ),
 				'shipping_last_name'  => __( 'Shipping Last Name', 'woocommerce' ),
@@ -63,6 +63,7 @@ class WC_Privacy_Erasers {
 				'shipping_postcode'   => __( 'Shipping Postal/Zip Code', 'woocommerce' ),
 				'shipping_state'      => __( 'Shipping State', 'woocommerce' ),
 				'shipping_country'    => __( 'Shipping Country / Region', 'woocommerce' ),
+				'shipping_phone'      => __( 'Shipping Phone Number', 'woocommerce' ),
 			),
 			$customer
 		);
@@ -257,6 +258,7 @@ class WC_Privacy_Erasers {
 				'shipping_postcode'   => 'text',
 				'shipping_state'      => 'address_state',
 				'shipping_country'    => 'address_country',
+				'shipping_phone'      => 'phone',
 				'customer_id'         => 'numeric_id',
 				'transaction_id'      => 'numeric_id',
 			),

--- a/includes/class-wc-privacy-exporters.php
+++ b/includes/class-wc-privacy-exporters.php
@@ -191,7 +191,7 @@ class WC_Privacy_Exporters {
 				'billing_postcode'    => __( 'Billing Postal/Zip Code', 'woocommerce' ),
 				'billing_state'       => __( 'Billing State', 'woocommerce' ),
 				'billing_country'     => __( 'Billing Country / Region', 'woocommerce' ),
-				'billing_phone'       => __( 'Phone Number', 'woocommerce' ),
+				'billing_phone'       => __( 'Billing Phone Number', 'woocommerce' ),
 				'billing_email'       => __( 'Email Address', 'woocommerce' ),
 				'shipping_first_name' => __( 'Shipping First Name', 'woocommerce' ),
 				'shipping_last_name'  => __( 'Shipping Last Name', 'woocommerce' ),
@@ -202,6 +202,7 @@ class WC_Privacy_Exporters {
 				'shipping_postcode'   => __( 'Shipping Postal/Zip Code', 'woocommerce' ),
 				'shipping_state'      => __( 'Shipping State', 'woocommerce' ),
 				'shipping_country'    => __( 'Shipping Country / Region', 'woocommerce' ),
+				'shipping_phone'      => __( 'Shipping Phone Number', 'woocommerce' ),
 			),
 			$customer
 		);
@@ -257,6 +258,7 @@ class WC_Privacy_Exporters {
 				'formatted_shipping_address' => __( 'Shipping Address', 'woocommerce' ),
 				'billing_phone'              => __( 'Phone Number', 'woocommerce' ),
 				'billing_email'              => __( 'Email Address', 'woocommerce' ),
+				'shipping_phone'             => __( 'Shipping Phone Number', 'woocommerce' ),
 			),
 			$order
 		);
@@ -367,11 +369,11 @@ class WC_Privacy_Exporters {
 			),
 			array(
 				'name'  => __( 'Access granted', 'woocommerce' ),
-				'value' => date( 'Y-m-d', $download->get_access_granted( 'edit' )->getTimestamp() ),
+				'value' => gmdate( 'Y-m-d', $download->get_access_granted( 'edit' )->getTimestamp() ),
 			),
 			array(
 				'name'  => __( 'Access expires', 'woocommerce' ),
-				'value' => ! is_null( $download->get_access_expires( 'edit' ) ) ? date( 'Y-m-d', $download->get_access_expires( 'edit' )->getTimestamp() ) : null,
+				'value' => ! is_null( $download->get_access_expires( 'edit' ) ) ? gmdate( 'Y-m-d', $download->get_access_expires( 'edit' )->getTimestamp() ) : null,
 			),
 		);
 

--- a/includes/data-stores/class-wc-customer-data-store-session.php
+++ b/includes/data-stores/class-wc-customer-data-store-session.php
@@ -48,6 +48,7 @@ class WC_Customer_Data_Store_Session extends WC_Data_Store_WP implements WC_Cust
 		'shipping_first_name',
 		'shipping_last_name',
 		'shipping_company',
+		'shipping_phone',
 	);
 
 	/**

--- a/includes/data-stores/class-wc-customer-data-store.php
+++ b/includes/data-stores/class-wc-customer-data-store.php
@@ -59,6 +59,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 		'shipping_first_name',
 		'shipping_last_name',
 		'shipping_company',
+		'shipping_phone',
 		'wptests_capabilities',
 		'wptests_user_level',
 		'syntax_highlighting',
@@ -301,6 +302,7 @@ class WC_Customer_Data_Store extends WC_Data_Store_WP implements WC_Customer_Dat
 			'shipping_state'      => 'shipping_state',
 			'shipping_postcode'   => 'shipping_postcode',
 			'shipping_country'    => 'shipping_country',
+			'shipping_phone'      => 'shipping_phone',
 		);
 
 		foreach ( $shipping_address_props as $meta_key => $prop ) {

--- a/includes/data-stores/class-wc-order-data-store-cpt.php
+++ b/includes/data-stores/class-wc-order-data-store-cpt.php
@@ -46,6 +46,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 		'_shipping_state',
 		'_shipping_postcode',
 		'_shipping_country',
+		'_shipping_phone',
 		'_completed_date',
 		'_paid_date',
 		'_edit_lock',
@@ -133,6 +134,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				'shipping_state'       => get_post_meta( $id, '_shipping_state', true ),
 				'shipping_postcode'    => get_post_meta( $id, '_shipping_postcode', true ),
 				'shipping_country'     => get_post_meta( $id, '_shipping_country', true ),
+				'shipping_phone'       => get_post_meta( $id, '_shipping_phone', true ),
 				'payment_method'       => get_post_meta( $id, '_payment_method', true ),
 				'payment_method_title' => get_post_meta( $id, '_payment_method_title', true ),
 				'transaction_id'       => get_post_meta( $id, '_transaction_id', true ),
@@ -240,6 +242,7 @@ class WC_Order_Data_Store_CPT extends Abstract_WC_Order_Data_Store_CPT implement
 				'_shipping_state'      => 'shipping_state',
 				'_shipping_postcode'   => 'shipping_postcode',
 				'_shipping_country'    => 'shipping_country',
+				'_shipping_phone'      => 'shipping_phone',
 			),
 		);
 

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-customers-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-customers-controller.php
@@ -259,6 +259,11 @@ class WC_REST_Customers_Controller extends WC_REST_Customers_V2_Controller {
 							'type'        => 'string',
 							'context'     => array( 'view', 'edit' ),
 						),
+						'phone'      => array(
+							'description' => __( 'Phone number.', 'woocommerce' ),
+							'type'        => 'string',
+							'context'     => array( 'view', 'edit' ),
+						),
 					),
 				),
 				'is_paying_customer' => array(

--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -12,7 +12,7 @@
  *
  * @see https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails
- * @version 3.9.0
+ * @version 5.6.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
@@ -45,7 +45,7 @@ $shipping   = $order->get_formatted_shipping_address();
 				<address class="address">
 					<?php echo wp_kses_post( $shipping ); ?>
 					<?php if ( $order->get_shipping_phone() ) : ?>
-						<br/><?php echo wc_make_phone_clickable( $order->get_shipping_phone() ); ?>
+						<br /><?php echo wc_make_phone_clickable( $order->get_shipping_phone() ); ?>
 					<?php endif; ?>
 				</address>
 			</td>

--- a/templates/emails/email-addresses.php
+++ b/templates/emails/email-addresses.php
@@ -42,7 +42,12 @@ $shipping   = $order->get_formatted_shipping_address();
 			<td style="text-align:<?php echo esc_attr( $text_align ); ?>; font-family: 'Helvetica Neue', Helvetica, Roboto, Arial, sans-serif; padding:0;" valign="top" width="50%">
 				<h2><?php esc_html_e( 'Shipping address', 'woocommerce' ); ?></h2>
 
-				<address class="address"><?php echo wp_kses_post( $shipping ); ?></address>
+				<address class="address">
+					<?php echo wp_kses_post( $shipping ); ?>
+					<?php if ( $order->get_shipping_phone() ) : ?>
+						<br/><?php echo wc_make_phone_clickable( $order->get_shipping_phone() ); ?>
+					<?php endif; ?>
+				</address>
 			</td>
 		<?php endif; ?>
 	</tr>

--- a/templates/emails/plain/email-addresses.php
+++ b/templates/emails/plain/email-addresses.php
@@ -12,20 +12,20 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates\Emails\Plain
- * @version 3.4.0
+ * @version 5.6.0
  */
 
 defined( 'ABSPATH' ) || exit;
 
 echo "\n" . esc_html( wc_strtoupper( esc_html__( 'Billing address', 'woocommerce' ) ) ) . "\n\n";
-echo preg_replace( '#<br\s*/?>#i', "\n", $order->get_formatted_billing_address() ) . "\n"; // WPCS: XSS ok.
+echo preg_replace( '#<br\s*/?>#i', "\n", $order->get_formatted_billing_address() ) . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 if ( $order->get_billing_phone() ) {
-	echo $order->get_billing_phone() . "\n"; // WPCS: XSS ok.
+	echo $order->get_billing_phone() . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
 if ( $order->get_billing_email() ) {
-	echo $order->get_billing_email() . "\n"; // WPCS: XSS ok.
+	echo $order->get_billing_email() . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
 if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() ) {
@@ -33,10 +33,10 @@ if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() ) {
 
 	if ( $shipping ) {
 		echo "\n" . esc_html( wc_strtoupper( esc_html__( 'Shipping address', 'woocommerce' ) ) ) . "\n\n";
-		echo preg_replace( '#<br\s*/?>#i', "\n", $shipping ) . "\n"; // WPCS: XSS ok.
+		echo preg_replace( '#<br\s*/?>#i', "\n", $shipping ) . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 
 		if ( $order->get_shipping_phone() ) {
-			echo $order->get_shipping_phone() . "\n"; // WPCS: XSS ok.
+			echo $order->get_shipping_phone() . "\n"; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 	}
 }

--- a/templates/emails/plain/email-addresses.php
+++ b/templates/emails/plain/email-addresses.php
@@ -34,5 +34,9 @@ if ( ! wc_ship_to_billing_address_only() && $order->needs_shipping_address() ) {
 	if ( $shipping ) {
 		echo "\n" . esc_html( wc_strtoupper( esc_html__( 'Shipping address', 'woocommerce' ) ) ) . "\n\n";
 		echo preg_replace( '#<br\s*/?>#i', "\n", $shipping ) . "\n"; // WPCS: XSS ok.
+
+		if ( $order->get_shipping_phone() ) {
+			echo $order->get_shipping_phone() . "\n"; // WPCS: XSS ok.
+		}
 	}
 }

--- a/templates/order/order-details-customer.php
+++ b/templates/order/order-details-customer.php
@@ -12,7 +12,7 @@
  *
  * @see     https://docs.woocommerce.com/document/template-structure/
  * @package WooCommerce\Templates
- * @version 3.4.4
+ * @version 5.6.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/templates/order/order-details-customer.php
+++ b/templates/order/order-details-customer.php
@@ -50,6 +50,10 @@ $show_shipping = ! wc_ship_to_billing_address_only() && $order->needs_shipping_a
 			<h2 class="woocommerce-column__title"><?php esc_html_e( 'Shipping address', 'woocommerce' ); ?></h2>
 			<address>
 				<?php echo wp_kses_post( $order->get_formatted_shipping_address( esc_html__( 'N/A', 'woocommerce' ) ) ); ?>
+
+				<?php if ( $order->get_shipping_phone() ) : ?>
+					<p class="woocommerce-customer-details--phone"><?php echo esc_html( $order->get_shipping_phone() ); ?></p>
+				<?php endif; ?>
 			</address>
 		</div><!-- /.col-2 -->
 

--- a/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -1232,6 +1232,16 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 	}
 
 	/**
+	 * Test: get_shipping_phone
+	 */
+	public function test_get_shipping_phone() {
+		$object = new WC_Order();
+		$set_to = '123456678';
+		$object->set_shipping_phone( $set_to );
+		$this->assertEquals( $set_to, $object->get_shipping_phone() );
+	}
+
+	/**
 	 * Test get_formatted_billing_address and has_billing_address.
 	 *
 	 * @since 3.3

--- a/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
+++ b/tests/legacy/unit-tests/order/class-wc-tests-crud-orders.php
@@ -1431,6 +1431,7 @@ class WC_Tests_CRUD_Orders extends WC_Unit_Test_Case {
 			'state'      => 'Boulder',
 			'postcode'   => '00001',
 			'country'    => 'US',
+			'phone'      => '',
 		);
 
 		$object->set_billing_first_name( 'Fred' );

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/customers.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/customers.php
@@ -93,6 +93,7 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 					'state'      => 'CA',
 					'postcode'   => '94110',
 					'country'    => 'US',
+					'phone'      => '',
 				),
 				'is_paying_customer' => false,
 				'orders_count'       => 0,

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/customers.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/customers.php
@@ -6,6 +6,12 @@
  * @since 3.0.0
  */
 
+/**
+ * Tests for the Customers REST API.
+ *
+ * @package WooCommerce\Tests\API
+ * @extends WC_REST_Unit_Test_Case
+ */
 class Customers_V2 extends WC_REST_Unit_Test_Case {
 
 	/**
@@ -177,6 +183,7 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 					'state'      => '',
 					'postcode'   => '',
 					'country'    => '',
+					'phone'      => '',
 				),
 				'is_paying_customer' => false,
 				'meta_data'          => array(),
@@ -187,7 +194,7 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 			$data
 		);
 
-		// Test extra data
+		// Test extra data.
 		$request = new WP_REST_Request( 'POST', '/wc/v2/customers' );
 		$request->set_body_params(
 			array(
@@ -245,6 +252,7 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 					'state'      => 'CA',
 					'postcode'   => '',
 					'country'    => 'US',
+					'phone'      => '',
 				),
 				'is_paying_customer' => false,
 				'meta_data'          => array(),
@@ -255,7 +263,7 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 			$data
 		);
 
-		// Test without required field
+		// Test without required field.
 		$request = new WP_REST_Request( 'POST', '/wc/v2/customers' );
 		$request->set_body_params(
 			array(
@@ -332,6 +340,7 @@ class Customers_V2 extends WC_REST_Unit_Test_Case {
 					'state'      => 'CA',
 					'postcode'   => '94110',
 					'country'    => 'US',
+					'phone'      => '',
 				),
 				'is_paying_customer' => false,
 				'meta_data'          => array(),

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/customers.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/customers.php
@@ -54,7 +54,7 @@ class Customers extends WC_REST_Unit_Test_Case {
 		);
 		$response     = $this->server->dispatch( $request );
 		$customers    = $response->get_data();
-		$date_created = get_date_from_gmt( date( 'Y-m-d H:i:s', strtotime( $customer_1->get_date_created() ) ) );
+		$date_created = get_date_from_gmt( gmdate( 'Y-m-d H:i:s', strtotime( $customer_1->get_date_created() ) ) );
 
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals( 2, count( $customers ) );
@@ -94,6 +94,7 @@ class Customers extends WC_REST_Unit_Test_Case {
 					'state'      => 'CA',
 					'postcode'   => '94110',
 					'country'    => 'US',
+					'phone'      => '',
 				),
 				'is_paying_customer' => false,
 				'avatar_url'         => $customer_1->get_avatar_url(),
@@ -125,7 +126,7 @@ class Customers extends WC_REST_Unit_Test_Case {
 		);
 		$response     = $this->server->dispatch( $request );
 		$customers    = $response->get_data();
-		$date_created = get_date_from_gmt( date( 'Y-m-d H:i:s', strtotime( $customer_3->get_date_created() ) ) );
+		$date_created = get_date_from_gmt( gmdate( 'Y-m-d H:i:s', strtotime( $customer_3->get_date_created() ) ) );
 
 		$this->assertEquals( 200, $response->get_status() );
 
@@ -164,6 +165,7 @@ class Customers extends WC_REST_Unit_Test_Case {
 					'state'      => 'CA',
 					'postcode'   => '94110',
 					'country'    => 'US',
+					'phone'      => '',
 				),
 				'is_paying_customer' => false,
 				'avatar_url'         => $customer_3->get_avatar_url(),
@@ -253,6 +255,7 @@ class Customers extends WC_REST_Unit_Test_Case {
 					'state'      => '',
 					'postcode'   => '',
 					'country'    => '',
+					'phone'      => '',
 				),
 				'is_paying_customer' => false,
 				'meta_data'          => array(),
@@ -319,6 +322,7 @@ class Customers extends WC_REST_Unit_Test_Case {
 					'state'      => 'CA',
 					'postcode'   => '',
 					'country'    => 'US',
+					'phone'      => '',
 				),
 				'is_paying_customer' => false,
 				'meta_data'          => array(),
@@ -630,5 +634,6 @@ class Customers extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'state', $properties['shipping']['properties'] );
 		$this->assertArrayHasKey( 'postcode', $properties['shipping']['properties'] );
 		$this->assertArrayHasKey( 'country', $properties['shipping']['properties'] );
+		$this->assertArrayHasKey( 'phone', $properties['shipping']['properties'] );
 	}
 }

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/customers.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/customers.php
@@ -408,6 +408,7 @@ class Customers extends WC_REST_Unit_Test_Case {
 					'state'      => 'CA',
 					'postcode'   => '94110',
 					'country'    => 'US',
+					'phone'      => '',
 				),
 				'is_paying_customer' => false,
 				'meta_data'          => array(),

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -295,6 +295,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 					'state'      => 'CA',
 					'postcode'   => '94103',
 					'country'    => 'US',
+					'phone'      => '(555) 555-5555',
 				),
 				'line_items'           => array(
 					array(
@@ -352,6 +353,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( $order->get_shipping_state(), $data['shipping']['state'] );
 		$this->assertEquals( $order->get_shipping_postcode(), $data['shipping']['postcode'] );
 		$this->assertEquals( $order->get_shipping_country(), $data['shipping']['country'] );
+		$this->assertEquals( $order->get_shipping_phone(), $data['shipping']['phone'] );
 		$this->assertEquals( 1, count( $data['line_items'] ) );
 		$this->assertEquals( 1, count( $data['shipping_lines'] ) );
 
@@ -417,6 +419,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 					'state'      => 'CA',
 					'postcode'   => '94103',
 					'country'    => 'US',
+					'phone'      => '(555) 555-5555',
 				),
 				'line_items'           => array(
 					array(
@@ -493,6 +496,7 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 					'state'      => 'CA',
 					'postcode'   => '94103',
 					'country'    => 'US',
+					'phone'      => '(555) 555-5555',
 				),
 				'line_items'           => array(
 					array(


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Creates support for shipping phone (matching billing phone) at CRUD and Rest API level. 

This does not add the field to the checkout, but it does add profile fields. Other user-facing places include:

- Order emails (plain and HTML), if set
- Order meta box (view), if set
- Order meta box (edit)
- User profile screen in WP admin

It is not visible on _Checkout_ or _My Account_. Whether we do this or not is up for discussion.

Added basic tests mimicking the current billing phone field.

### How to test the changes in this Pull Request:

#### Order meta:

1. Edit or add an order
2. Click edit besides the shipping address
3. Add phone number and save
4. View phone number. It will be clickable to match billing phone.

#### Order emails

1. After the previous test, edit the order
2. In the order actions metabox, send the invoice
3. Check the invoice email. Shipping phone will be displayed alongside the shipping address.

#### Rest API

Do a request to  `/wp-json/wc/v3/orders/<id>` and confirm shipping phone field exists with the shipping address.

#### Profile

1. Go to Admin > Users > Profile
2. Confirm the "phone" field exists under the shipping section
3. Confirm the value can be edited/saved

#### Conflicts

TODO

Test alongside WooCommerce Services.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Added support for Shipping Phone, in addition to Billing Phone.
