### PR TITLE
Issues/30107 enhanced select sortable

### DIFF
--- a/assets/js/admin/wc-enhanced-select.js
+++ b/assets/js/admin/wc-enhanced-select.js
@@ -88,7 +88,7 @@ jQuery( function( $ ) {
 							tolerance   : 'pointer',
 							stop: function() {
 								$( $list.find( '.select2-selection__choice' ).get().reverse() ).each( function() {
-									var id     = $( self ).data( 'data' ).id;
+									var id     = $( this ).data( 'data' ).id;
 									var option = $select.find( 'option[value="' + id + '"]' )[0];
 									$select.prepend( option );
 								} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Use `$(this)` to refer to the enhanced select selected item instead of `$(self)` which refers to the `<select>` element and does not have a `data("data")` attribute.

Closes #30107 .

### How to test the changes in this Pull Request:

Follow same steps as described in #30107 . 
Attempt to re-order grouped products. Save. New order should be reflected on page load.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Script error in enhanced select re-ordering that prevented saving new order.
