### PR TITLE
[twenty-twenty-one.scss] Use theme default font

### DIFF
--- a/assets/css/twenty-twenty-one.scss
+++ b/assets/css/twenty-twenty-one.scss
@@ -4,8 +4,8 @@
  * Sass variables
  */
 
-$headings: -apple-system, blinkmacsystemfont, "Helvetica Neue", helvetica, sans-serif;
-$body: nonbreakingspaceoverride, "Hoefler Text", garamond, "Times New Roman", serif;
+$headings: var(--heading--font-family);
+$body: var(--global--font-secondary);
 
 $body-color: currentColor;
 $highlights-color: #88a171;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

The 2021 theme heading font and body font can be customized, but Woocomerce hard-coded the heading and body fonts, which is very hard to overrite because it's a SASS variable and compiled to numerous places.

For heading, see below (--font-headings can be customized)

- https://github.com/WordPress/WordPress/blob/master/wp-content/themes/twentytwentyone/style.css#L125
- https://github.com/WordPress/WordPress/blob/master/wp-content/themes/twentytwentyone/style.css#L104

For body, see below (--font-base can be customized)

- https://github.com/WordPress/WordPress/blob/master/wp-content/themes/twentytwentyone/style.css#L1069
- https://github.com/WordPress/WordPress/blob/master/wp-content/themes/twentytwentyone/style.css#L105

But Woocomerce hard-coded the heading and body font.

<!-- Closes # . -->

### How to test the changes in this Pull Request:

Add css to customizer (or add css in Chrome devtools).

For heading:

```css
:root { --font-headings: "Arial"; }
```

For body:

```css
:root { --font-base: "Arial"; }
```

Currently, wc page font won't change. With the fix it will change.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [NA] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - For 2021 theme, use theme font, and allow font-family customization.
