### PR TITLE
Use $version variable for jquery.payment.min.js version

### DIFF
--- a/includes/class-wc-frontend-scripts.php
+++ b/includes/class-wc-frontend-scripts.php
@@ -194,7 +194,7 @@ class WC_Frontend_Scripts {
 			'jquery-payment'             => array(
 				'src'     => self::get_asset_url( 'assets/js/jquery-payment/jquery.payment' . $suffix . '.js' ),
 				'deps'    => array( 'jquery' ),
-				'version' => '3.0.0',
+				'version' => $version,
 			),
 			'photoswipe'                 => array(
 				'src'     => self::get_asset_url( 'assets/js/photoswipe/photoswipe' . $suffix . '.js' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Although it has been updated twice in the last two months in commits [ef57248](https://github.com/woocommerce/woocommerce/commit/ef572483d8c71732018d11d00a03b103c9167fa1#diff-e301e88ee9816efd5b4bf60db07a3ffe40c8e84d61a767fb28869698dd3ef816) and [2fad2d7](https://github.com/woocommerce/woocommerce/commit/2fad2d7116815f3d5b2f3addcebe2a872e74cf67#diff-e301e88ee9816efd5b4bf60db07a3ffe40c8e84d61a767fb28869698dd3ef816), the version number for `jquery.payment.min.js` hasn't been updated since May 2017 in commit [2a51aa2](https://github.com/woocommerce/woocommerce/commit/2a51aa2020f55eb2b24c2af3d8330d5dada7183b).

This can cause a user to run a cached version of the file containing issue [30069](https://github.com/woocommerce/woocommerce/issues/30069) even after WooCommerce is updated to version 5.4.1.

I don't know if the core team prefers only some frontend scripts to use the `$version` variable or if the preference is to hardcode a value for certain frontend files, but I think this illustrates why hardcoding could be a problem.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Set the version number of jquery.payment.min.js to always equal the current WooCommerce version.
