### PR TITLE
At cancelled status for bulk actions closes #29928

### DIFF
--- a/includes/admin/list-tables/class-wc-admin-list-table-orders.php
+++ b/includes/admin/list-tables/class-wc-admin-list-table-orders.php
@@ -145,6 +145,7 @@ class WC_Admin_List_Table_Orders extends WC_Admin_List_Table {
 		$actions['mark_processing'] = __( 'Change status to processing', 'woocommerce' );
 		$actions['mark_on-hold']    = __( 'Change status to on-hold', 'woocommerce' );
 		$actions['mark_completed']  = __( 'Change status to completed', 'woocommerce' );
+		$actions['mark_cancelled']  = __( 'Change status to cancelled', 'woocommerce' );
 
 		if ( wc_string_to_bool( get_option( 'woocommerce_allow_bulk_remove_personal_data', 'no' ) ) ) {
 			$actions['remove_personal_data'] = __( 'Remove personal data', 'woocommerce' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29928 

### How to test the changes in this Pull Request:

1. Go to your list of orders page `/wp-admin/edit.php?post_type=shop_order`.
2. Select a few orders by checking the bulk action checkbox on each one.
3. Click on the `Bulk actions` dropdown. Select `Change status to cancelled`.
4. Click on `Apply`.
5. Ensure all the selected orders now have a status of `Cancelled`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Add ability to bulk update order status to cancelled.
