### PR TITLE
Bump woocommerce-admin version to 2.4.0-rc.2

### DIFF
--- a/bin/composer/wp/composer.lock
+++ b/bin/composer/wp/composer.lock
@@ -306,10 +306,6 @@
                 "iri",
                 "sockets"
             ],
-            "support": {
-                "issues": "https://github.com/WordPress/Requests/issues",
-                "source": "https://github.com/WordPress/Requests/tree/v1.8.1"
-            },
             "time": "2021-06-04T09:56:25+00:00"
         },
         {
@@ -612,5 +608,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/bin/composer/wp/composer.lock
+++ b/bin/composer/wp/composer.lock
@@ -254,16 +254,16 @@
         },
         {
             "name": "rmccue/requests",
-            "version": "v1.8.0",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/Requests.git",
-                "reference": "afbe4790e4def03581c4a0963a1e8aa01f6030f1"
+                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/Requests/zipball/afbe4790e4def03581c4a0963a1e8aa01f6030f1",
-                "reference": "afbe4790e4def03581c4a0963a1e8aa01f6030f1",
+                "url": "https://api.github.com/repos/WordPress/Requests/zipball/82e6936366eac3af4d836c18b9d8c31028fe4cd5",
+                "reference": "82e6936366eac3af4d836c18b9d8c31028fe4cd5",
                 "shasum": ""
             },
             "require": {
@@ -308,9 +308,9 @@
             ],
             "support": {
                 "issues": "https://github.com/WordPress/Requests/issues",
-                "source": "https://github.com/WordPress/Requests/tree/v1.8.0"
+                "source": "https://github.com/WordPress/Requests/tree/v1.8.1"
             },
-            "time": "2021-04-27T11:05:25+00:00"
+            "time": "2021-06-04T09:56:25+00:00"
         },
         {
             "name": "symfony/finder",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.0",
-    "woocommerce/woocommerce-admin": "2.4.0-rc.1",
+    "woocommerce/woocommerce-admin": "2.4.0-rc.2",
     "woocommerce/woocommerce-blocks": "5.3.1"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.0",
-    "woocommerce/woocommerce-admin": "2.3.1",
+    "woocommerce/woocommerce-admin": "2.4.0-rc.1",
     "woocommerce/woocommerce-blocks": "5.3.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f8559beec5d404538c243359bad85998",
+    "content-hash": "6427ca1d82e637782404faeb3b988ec3",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -51,9 +51,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "Creates a custom autoloader for a plugin or theme.",
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-autoloader/tree/2.10.1"
-            },
             "time": "2021-03-30T15:15:59+00:00"
         },
         {
@@ -85,9 +82,6 @@
                 "GPL-2.0-or-later"
             ],
             "description": "A wrapper for defining constants in a more testable way.",
-            "support": {
-                "source": "https://github.com/Automattic/jetpack-constants/tree/v1.5.1"
-            },
             "time": "2020-10-28T19:00:31+00:00"
         },
         {
@@ -220,10 +214,6 @@
                 "zend",
                 "zikula"
             ],
-            "support": {
-                "issues": "https://github.com/composer/installers/issues",
-                "source": "https://github.com/composer/installers/tree/v1.11.0"
-            },
             "funding": [
                 {
                     "url": "https://packagist.com",
@@ -298,10 +288,6 @@
                 "geolocation",
                 "maxmind"
             ],
-            "support": {
-                "issues": "https://github.com/maxmind/MaxMind-DB-Reader-php/issues",
-                "source": "https://github.com/maxmind/MaxMind-DB-Reader-php/tree/v1.6.0"
-            },
             "time": "2019-12-19T22:59:03+00:00"
         },
         {
@@ -376,10 +362,6 @@
                 "email",
                 "pre-processing"
             ],
-            "support": {
-                "issues": "https://github.com/MyIntervals/emogrifier/issues",
-                "source": "https://github.com/MyIntervals/emogrifier"
-            },
             "time": "2019-12-26T19:37:31+00:00"
         },
         {
@@ -429,10 +411,6 @@
                 "container-interop",
                 "psr"
             ],
-            "support": {
-                "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/master"
-            },
             "time": "2017-02-14T16:28:37+00:00"
         },
         {
@@ -486,9 +464,6 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/css-selector/tree/master"
-            },
             "time": "2017-05-01T15:01:29+00:00"
         },
         {
@@ -532,16 +507,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.4.0-rc.1",
+            "version": "2.4.0-rc.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "8535174d5326c74ddccb1d8f5ff3596cdc916a67"
+                "reference": "ed72985cd459831c555dff2ff5f75111b6e210c1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/8535174d5326c74ddccb1d8f5ff3596cdc916a67",
-                "reference": "8535174d5326c74ddccb1d8f5ff3596cdc916a67",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/ed72985cd459831c555dff2ff5f75111b6e210c1",
+                "reference": "ed72985cd459831c555dff2ff5f75111b6e210c1",
                 "shasum": ""
             },
             "require": {
@@ -576,11 +551,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "support": {
-                "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.4.0-rc.1"
-            },
-            "time": "2021-06-17T06:24:54+00:00"
+            "time": "2021-06-18T05:58:25+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -627,10 +598,6 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "support": {
-                "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.3.1"
-            },
             "time": "2021-06-15T09:12:48+00:00"
         }
     ],
@@ -679,10 +646,6 @@
                 "isolation",
                 "tool"
             ],
-            "support": {
-                "issues": "https://github.com/bamarni/composer-bin-plugin/issues",
-                "source": "https://github.com/bamarni/composer-bin-plugin/tree/master"
-            },
             "time": "2020-05-03T08:27:20+00:00"
         }
     ],
@@ -698,5 +661,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "21b06e63b5f65deec4b635463a10402b",
+    "content-hash": "f8559beec5d404538c243359bad85998",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -532,16 +532,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.3.1",
+            "version": "2.4.0-rc.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "f28cf3f027e27a6679e4fa8173d8b6859ec84838"
+                "reference": "8535174d5326c74ddccb1d8f5ff3596cdc916a67"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/f28cf3f027e27a6679e4fa8173d8b6859ec84838",
-                "reference": "f28cf3f027e27a6679e4fa8173d8b6859ec84838",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/8535174d5326c74ddccb1d8f5ff3596cdc916a67",
+                "reference": "8535174d5326c74ddccb1d8f5ff3596cdc916a67",
                 "shasum": ""
             },
             "require": {
@@ -578,9 +578,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.3.1"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.4.0-rc.1"
             },
-            "time": "2021-05-24T09:48:40+00:00"
+            "time": "2021-06-17T06:24:54+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -135,6 +135,9 @@ const completeOnboardingWizard = async () => {
 
 	// Business Details section
 
+	// Temporarily add delay to reduce test flakiness
+	await page.waitFor( 2000 );
+
 	// Query for the <SelectControl>s
 	const selectControls = await page.$$( '.woocommerce-select-control' );
 	expect( selectControls ).toHaveLength( 2 );


### PR DESCRIPTION
This bumps `woocommerce/woocommerce-admin` in Composer to the latest published package, version `2.4.0-rc.2` for consideration for inclusion to WooCommerce 5.5.
 
## Testing Instructions
Testing instructions are available in the wiki here: https://github.com/woocommerce/woocommerce-admin/wiki/Release-Testing-Instructions-WooCommerce-Admin-2.4.0
 
## Changelog
 
```
- Add: SlotFill to Abbreviated Notification panel #7091
- Add: Consume remote payment methods on frontend #6867
- Add: Extend payment gateways REST endpoint #6919
- Add: Add remote payment gateway recommendations initial docs #6962
- Add: Add loading placeholders for payment gateways task #7123
- Add: Note date range logic for GivingFeedback, and InsightFirstSale note. #6969
- Add: Add transient notices feature #6809
- Add: Add transformers in remote inbox notifications #6948
- Add: Add Mercado Pago as default fallback payment gateway #7043
- Add: Add in Razorpay as default fallback payment gateway #7096
- Add: Get post install scripts from gateway and enqueue in client #6967
- Add: Add eWAY as default fallback gateway #7108
- Add: Free extension list powered by remote config #6952
- Add: Add PayPal to fallback payment gateways #7001
- Add: Add a data store for WC Payments REST APIs #6918
- Add: Progressive setup checklist copy and call to action buttons. #6956
- Add: Add Paystack as fallback gateway #7025
- Add: Add Square as default fallback gateway #7107
- Add: Add COD method to default payment gateway recommendations #7057
- Add: Add BACS as default fallback payment gateway #7073
- Add: A/B test of progressive checklist features. #7089
- Add: Add payment gateway return URL and action #7095
- Add: Add Mollie to the default payment gateways. #7092
- Add: Show task and activity notifications in the Inbox panel #7017
- Add: Adding WCPay payment configuration defaults. #7097
- Add: Create onboarding package to house refactored WCPay card and relevant components #7058
- Dev: Add Jetpack Backup admin note #6738
- Dev: Reduce the specificity and complexity of the ReportError component #6846
- Dev: Converting <SettingsForm /> component to TypeScript. #6981
- Dev: Update package-lock to fix versioning of local packages. #6843
- Dev: Use rule processing for remote payment methods #6830
- Dev: Update E2E jest config, so it correctly creates screenshots on failure. #6858
- Dev: Fixed storybook build script #6875
- Dev: Removed allowed keys list for adding woocommerce_meta data. #6889 🎉 @xristos3490
- Dev: Delete all products when running product import tests, unskip previously skipped test. #6905
- Dev: Add payment method selector to onboarding store #6921
- Dev: Add disabled prop to SelectControl #6902
- Dev: Add filter variation to tracks data in products analytics. #6913
- Dev: Offload remote inbox notifications engine run using action-scheduler. #6995
- Dev: Add source param support for notes query. #6979
- Dev: Remove the use of Dashicons and replace with @wordpress/icons or gridicons. #7020
- Dev: Refactor inbox panel components and moved to experimental package. #7006
- Dev: Business features uncheck creative mail by default #7139
- Dev: Remove support for IE11. #7112
- Dev: Drop styling support for IE11. #7137
- Dev: Remove react-docgen docs in favor of Storybook #7055
- Enhancement: Add expand/collapse to extendable task list. #6910
- Enhancement: Add task hierarchy support to extended task list. #6916
- Enhancement: Add remind me later option to task list. #6923
- Enhancement: Enable Remote Free Extensions List #7144
- Enhancement: Adding Slotfills for remote payments and SettingsForm component. #6932
- Fix: Update the wordpress/babel-preset to avoid crashes in WP5.8 beta2 #7202
- Fix: Add fallback for the select/dispatch data-controls for older WP versions #7204
- Fix: RemoteFreeExtension hide bundle when all of its plugins are not visible #7182
- Fix: Issue where summary stats were not showing in Analytics > Stock. #7161
- Fix: Rule Processing Transformer to handle dotNotation default value #7009
- Fix: Remove Navigation's uneeded SlotFill context #6832
- Fix: Report filters expecting specific ordering. #6847
- Fix: Render bug with report comparison mode selections. #6862
- Fix: Throw exception if the data store cannot be loaded when trying to use notes. #6771
- Fix: Autocompleter for custom Search in FilterPicker #6880
- Fix: Get currency from CurrencyContext #6723
- Fix: Correct the left position of transient notices when the new nav is used. #6914
- Fix: Exclude WC Shipping for store that are only offering downloadable products #6917
- Fix: SelectControl focus and de-focus bug #6906
- Fix: Multiple preload tag output bug. #6998
- Fix: Call existing filters for leaderboards in analytics. #6626
- Fix: Set target to blank for the external links #6999
- Fix style regression with the Chart header. #7002
- Fix styling of the advanced filter operator selection. #7005
- Fix: Deprecated warnings from select control @wordpress/data-controls. #7007
- Fix: Bug with Orders Report coupon exclusion filter. #7021
- Fix: Show Google Listing and Ads in installed marketing extensions section. #7029
- Fix: Notices not dissapearing. #7077
- Fix: Keyboard accessibility on the free features tab. #7149
- Fix: Fix error handling when remote free extension API returns empty array. #7147
- Fix: Transformer casing is incorrect and creates an error on case-sensitive systems #7104
- Fix: Preventing redundant notices when installing plugins via payments task list. #7026
- Fix: Autocompleter for custom Search in CompareFilter #6911
- Fix: Add target to the button to open it in a new tab  #7110
- Fix: Make `Search` accept synchronous `autocompleter.options`. #6884
- Fix: Set autoload to false for all remote inbox notifications options. #7060
- Tweak: Setup checklist copy revert. #7015
- Tweak: Revert Card component removal #7167
- Update: Task list component with new Experimental Task list. #6849
- Update: Optimize payment gateway resolution #7124
- Update: Experimental task list import to the experimental package. #6950
- Update: Redirect to WC Home after setting up a payment method #6891
- Update: Hook up payments gateway data store #7038
- Update: Update remote payment docs gateway methods #7079
- Update: Remove original business step flow #7103
- Update: WooCommerce Shipping copy on onboarding steps #7148
```
 
### Changelog entry
 
> Update - WooCommerce Admin package 2.4.0-rc.1