### PR TITLE
Introduces a new hook after an email is sent

### DIFF
--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -661,7 +661,7 @@ class WC_Email extends WC_Settings_API {
 		/**
 		 * Action hook fired when an email is sent.
 		 *
-		 * @since 5.5.0
+		 * @since 5.6.0
 		 * @param bool     $return Whether the email was sent successfully.
 		 * @param int      $id     Email ID.
 		 * @param WC_Email $this   WC_Email instance.

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -658,15 +658,15 @@ class WC_Email extends WC_Settings_API {
 		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 		remove_filter( 'wp_mail_content_type', array( $this, 'get_content_type' ) );
 
-		$id = $this->id ? $this->id : 'default';
 		/**
 		 * Action hook fired when an email is sent.
 		 *
 		 * @since 5.5.0
-		 * @param bool $return Whether the email was sent successfully.
-		 * @param WC_Email $this WC_Email instance.
+		 * @param bool     $return Whether the email was sent successfully.
+		 * @param int      $id     Email ID.
+		 * @param WC_Email $this   WC_Email instance.
 		 */
-		do_action( 'woocommerce_email_' . $id . '_sent', $return, $this );
+		do_action( 'woocommerce_email_sent', $return, $this->id, $this );
 
 		return $return;
 	}

--- a/includes/emails/class-wc-email.php
+++ b/includes/emails/class-wc-email.php
@@ -658,6 +658,16 @@ class WC_Email extends WC_Settings_API {
 		remove_filter( 'wp_mail_from_name', array( $this, 'get_from_name' ) );
 		remove_filter( 'wp_mail_content_type', array( $this, 'get_content_type' ) );
 
+		$id = $this->id ? $this->id : 'default';
+		/**
+		 * Action hook fired when an email is sent.
+		 *
+		 * @since 5.5.0
+		 * @param bool $return Whether the email was sent successfully.
+		 * @param WC_Email $this WC_Email instance.
+		 */
+		do_action( 'woocommerce_email_' . $id . '_sent', $return, $this );
+
 		return $return;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This PR is an alternative for the changes proposed in https://github.com/woocommerce/woocommerce/pull/29711
While https://github.com/woocommerce/woocommerce/pull/29711 includes one hook in each email `trigger` method, this one includes directly into the `WC_Email->send()` method that is extended by all email classes.

Closes #24641

### How to test the changes in this Pull Request:

See https://github.com/woocommerce/woocommerce/pull/29711 for testing instructions.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Added new `woocommerce_email_sent` hook.
