### PR TITLE
Remove abspath check on wc logger interface

### DIFF
--- a/includes/interfaces/class-wc-abstract-order-data-store-interface.php
+++ b/includes/interfaces/class-wc-abstract-order-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interfaces
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Order Data Store Interface
  *

--- a/includes/interfaces/class-wc-coupon-data-store-interface.php
+++ b/includes/interfaces/class-wc-coupon-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interfaces
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Coupon Data Store Interface
  *

--- a/includes/interfaces/class-wc-customer-data-store-interface.php
+++ b/includes/interfaces/class-wc-customer-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Customer Data Store Interface
  *

--- a/includes/interfaces/class-wc-customer-download-data-store-interface.php
+++ b/includes/interfaces/class-wc-customer-download-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Customer Download Data Store Interface.
  *

--- a/includes/interfaces/class-wc-customer-download-log-data-store-interface.php
+++ b/includes/interfaces/class-wc-customer-download-log-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Customer Download Log Data Store Interface.
  *

--- a/includes/interfaces/class-wc-importer-interface.php
+++ b/includes/interfaces/class-wc-importer-interface.php
@@ -6,10 +6,6 @@
  * @version  3.1.0
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC_Importer_Interface class.
  */

--- a/includes/interfaces/class-wc-log-handler-interface.php
+++ b/includes/interfaces/class-wc-log-handler-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
-
 /**
  * WC Log Handler Interface
  *

--- a/includes/interfaces/class-wc-logger-interface.php
+++ b/includes/interfaces/class-wc-logger-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
-
 /**
  * WC Logger Interface
  *

--- a/includes/interfaces/class-wc-object-data-store-interface.php
+++ b/includes/interfaces/class-wc-object-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Data Store Interface
  *

--- a/includes/interfaces/class-wc-order-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Order Data Store Interface
  *

--- a/includes/interfaces/class-wc-order-item-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-item-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Order Item Data Store Interface
  *

--- a/includes/interfaces/class-wc-order-item-product-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-item-product-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Order Item Data Store Interface
  *

--- a/includes/interfaces/class-wc-order-item-type-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-item-type-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Order Item Data Store Interface
  *

--- a/includes/interfaces/class-wc-order-refund-data-store-interface.php
+++ b/includes/interfaces/class-wc-order-refund-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Order Refund Data Store Interface
  *

--- a/includes/interfaces/class-wc-payment-token-data-store-interface.php
+++ b/includes/interfaces/class-wc-payment-token-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Payment Token Data Store Interface
  *

--- a/includes/interfaces/class-wc-product-data-store-interface.php
+++ b/includes/interfaces/class-wc-product-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Product Data Store Interface
  *

--- a/includes/interfaces/class-wc-product-variable-data-store-interface.php
+++ b/includes/interfaces/class-wc-product-variable-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Product Variable Data Store Interface
  *

--- a/includes/interfaces/class-wc-queue-interface.php
+++ b/includes/interfaces/class-wc-queue-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly.
-}
-
 /**
  * WC Queue Interface
  *

--- a/includes/interfaces/class-wc-shipping-zone-data-store-interface.php
+++ b/includes/interfaces/class-wc-shipping-zone-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WC Shipping Zone Data Store Interface.
  *

--- a/includes/interfaces/class-wc-webhooks-data-store-interface.php
+++ b/includes/interfaces/class-wc-webhooks-data-store-interface.php
@@ -6,10 +6,6 @@
  * @package  WooCommerce\Interface
  */
 
-if ( ! defined( 'ABSPATH' ) ) {
-	exit;
-}
-
 /**
  * WooCommerce Webhook data store interface.
  */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

This change got proposed by @BrianHenryIE in #30029, I merged into a new branch and starting a new PR to include all interface files.
We don't need to protect interface classes since those doesn't require WP to be loaded, also if someone access a file like that directly nothing will render anyway.

Description from the previous PR:

> Checking for `ABSPATH` is recommended so WordPress functions are not called before WordPress has been loaded. This does not apply to interfaces.
> 
> I just tried to implement `WC_Logger_Interface` in my tests, seemingly before WordPress was loaded, and this check stops anything from running. Seems antithetical to open source to place restrictions like this and IIRC the philosophy of Gutenberg is to be useful beyond the WordPress ecosystem, so opening up the code feels coherent with WordPress.
> 
> PR #9534 (Nov 2015) and #15011 (May 2017) _added_  ABSPATH checks, but without much discussion (fair enough, it's convention). There's little discussion in [PRs or issues](https://github.com/woocommerce/woocommerce/pulls?q=ABSPATH+) about it.

Closes #30029 

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Remove `ABSPATH` check in interfaces.
