### PR TITLE
Exclude block templates from showing up in product edit page

### DIFF
--- a/includes/admin/class-wc-admin-meta-boxes.php
+++ b/includes/admin/class-wc-admin-meta-boxes.php
@@ -233,7 +233,7 @@ class WC_Admin_Meta_Boxes {
 	 * @return string[] Templates array excluding block-based templates.
 	 */
 	public function remove_block_templates( $templates ) {
-		if ( count( $templates ) === 0 ) {
+		if ( count( $templates ) === 0 || ! function_exists( 'gutenberg_get_block_template' ) ) {
 			return $templates;
 		}
 

--- a/includes/admin/class-wc-admin-meta-boxes.php
+++ b/includes/admin/class-wc-admin-meta-boxes.php
@@ -67,6 +67,8 @@ class WC_Admin_Meta_Boxes {
 		// Error handling (for showing errors from meta boxes on next page load).
 		add_action( 'admin_notices', array( $this, 'output_errors' ) );
 		add_action( 'shutdown', array( $this, 'save_errors' ) );
+
+		add_filter( 'theme_product_templates', array( $this, 'remove_block_templates' ), 10, 1 );
 	}
 
 	/**
@@ -221,6 +223,32 @@ class WC_Admin_Meta_Boxes {
 		} elseif ( in_array( $post->post_type, array( 'product', 'shop_coupon' ), true ) ) {
 			do_action( 'woocommerce_process_' . $post->post_type . '_meta', $post_id, $post );
 		}
+	}
+
+	/**
+	 * Remove block-based templates from the list of available templates for products.
+	 *
+	 * @param string[] $templates Array of template header names keyed by the template file name.
+	 *
+	 * @return string[] Templates array excluding block-based templates.
+	 */
+	public function remove_block_templates( $templates ) {
+		if ( count( $templates ) === 0 ) {
+			return $templates;
+		}
+
+		$theme              = wp_get_theme()->get_stylesheet();
+		$filtered_templates = array();
+
+		foreach ( $templates as $template_key => $template_name ) {
+			$gutenberg_template = gutenberg_get_block_template( $theme . '//' . $template_key );
+
+			if ( ! $gutenberg_template ) {
+				$filtered_templates[ $template_key ] = $template_name;
+			}
+		}
+
+		return $filtered_templates;
 	}
 }
 


### PR DESCRIPTION
This PR hooks into the [`theme_product_templates` filter](https://github.com/WordPress/wordpress-develop/blob/df724f991b1af4d87c8897af2922e0ba826371d5/src/wp-includes/class-wp-theme.php#L1325) in order to filter out block-based templates from appearing as template options in the product edit page. This way, templates created with the template editor included in WP 5.8 do not appear in the product edit page.

The rationale is that currently WooCommerce relies on PHP templating to format the product page so templates chosen from that selector have no effect in the frontend of classic themes.

In the future, we might enable the selector again for block-based themes. But that would require some investigation on how we can ensure only templates relevant to products show up in the selector (related issue in Gutenberg: https://github.com/WordPress/gutenberg/issues/31704).

Closes #30136.

### How to test the changes in this Pull Request:

Requisites:
* WP 5.8 or Gutenberg plugin enabled.
* A classic theme.

Steps:

1. Go to create a new page, in the sidebar, create a new template:<br>
![](https://user-images.githubusercontent.com/3616980/122780878-8ce72380-d2af-11eb-8491-700c128cafe9.png)
2. Make some edits and click on Publish. Make sure the template you created is marked for publishing:<br>
![](https://user-images.githubusercontent.com/3616980/122781013-b0aa6980-d2af-11eb-90db-2e365137f857.png)
3. Now, go to edit a product.
4. Verify there is no metabox in the sidebar that lets you change the template.<br>
![](https://user-images.githubusercontent.com/3616980/122781187-dafc2700-d2af-11eb-8d8a-3b8f492acbe3.png)<br>
<i>(this is what you shouldn't see)</i> :point_up_2: 

### Changelog entry

> Exclude block templates from showing up in product edit page