### PR TITLE
Fix payment token default status can't be disabled

### DIFF
--- a/includes/data-stores/class-wc-payment-token-data-store.php
+++ b/includes/data-stores/class-wc-payment-token-data-store.php
@@ -362,7 +362,7 @@ class WC_Payment_Token_Data_Store extends WC_Data_Store_WP implements WC_Payment
 		global $wpdb;
 		$wpdb->update(
 			$wpdb->prefix . 'woocommerce_payment_tokens',
-			array( 'is_default' => $status ),
+			array( 'is_default' => (int) $status ),
 			array(
 				'token_id' => $token_id,
 			)


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Disabling `is_default` status for payment token doesn't work, it throws an error:
```
WordPress database error Incorrect integer value: '' for column `wccom`.`wp_woocommerce_payment_tokens`.`is_default` at row 1 for query UPDATE `wp_woocommerce_payment_tokens` SET `is_default` = '' WHERE `token_id` = '92' made by WC_Payment_Token_Data_Store::set_default_status
``` 
This happens due to providing an empty string for storing in a column of `TINYINT` type in `\WC_Payment_Token_Data_Store::set_default_status()`, when the new status is `false`:
https://github.com/woocommerce/woocommerce/blob/b19500728b4b292562afb65eb3a0c0f50d5859de/includes/data-stores/class-wc-payment-token-data-store.php#L365

A quick fix, provided in this PR, casts the boolean value to integer.

### How to test the changes in this Pull Request:
1. Ensure you have at least one payment token in the `wp_woocommerce_payment_tokens` table. Write down its ID from `token_id` column.
2. Run the following code (you may use `wp shell` for this):
  ```php 
  $token_id = 123;
  $data_store = WC_Data_Store::load( 'payment-token' );
  $data_store->set_default_status($token_id, true);
  ```
3. Confirm the `is_default` field value is equal to `1`, no error is thrown.
4. Run `  $data_store->set_default_status($token_id, false);`.
5. Confirm the `is_default` field value is equal to `0`, no error is thrown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Fixed inability to set payment token as non-default.