### PR TITLE
[Rest] Refunds add api_restock param to restock items

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
@@ -56,7 +56,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 				'reason'         => $request['reason'],
 				'line_items'     => $request['line_items'],
 				'refund_payment' => $request['api_refund'],
-				'restock_items'  => true,
+				'restock_items'  => $request['api_restock'],
 			)
 		);
 
@@ -108,6 +108,13 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 			'type'        => 'number',
 			'context'     => array( 'edit' ),
 			'readonly'    => true,
+		);
+
+		$schema['properties']['api_restock'] = array(
+			'description' => __( 'When true, items are restocked.', 'woocommerce' ),
+			'type'        => 'boolean',
+			'context'     => array( 'edit' ),
+			'default'     => true,
 		);
 
 		return $schema;

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-order-refunds-controller.php
@@ -111,7 +111,7 @@ class WC_REST_Order_Refunds_Controller extends WC_REST_Order_Refunds_V2_Controll
 		);
 
 		$schema['properties']['api_restock'] = array(
-			'description' => __( 'When true, items are restocked.', 'woocommerce' ),
+			'description' => __( 'When true, refunded items are restocked.', 'woocommerce' ),
 			'type'        => 'boolean',
 			'context'     => array( 'edit' ),
 			'default'     => true,

--- a/src/Internal/RestApiUtil.php
+++ b/src/Internal/RestApiUtil.php
@@ -20,6 +20,7 @@ class RestApiUtil {
 	 * [
 	 *   "reason" => "",
 	 *   "api_refund" => "x",
+	 *   "api_restock" => "x",
 	 *   "line_items" => [
 	 *     "id" => "111",
 	 *     "quantity" => 222,
@@ -35,13 +36,14 @@ class RestApiUtil {
 	 * ...to the internally used format:
 	 *
 	 * [
-	 *   "reason" => null,     (if it's missing or any empty value, set as null)
-	 *   "api_refund" => true, (if it's missing or non-bool, set as "true")
-	 *   "line_items" => [     (convert sequential array to associative based on "id")
+	 *   "reason" => null,      (if it's missing or any empty value, set as null)
+	 *   "api_refund" => true,  (if it's missing or non-bool, set as "true")
+	 *   "api_restock" => true, (if it's missing or non-bool, set as "true")
+	 *   "line_items" => [      (convert sequential array to associative based on "id")
 	 *     "111" => [
-	 *       "qty" => 222,     (rename "quantity" to "qty")
+	 *       "qty" => 222,      (rename "quantity" to "qty")
 	 *       "refund_total" => 333,
-	 *       "refund_tax" => [ (convert sequential array to associative based on "id" and "refund_total)
+	 *       "refund_tax" => [  (convert sequential array to associative based on "id" and "refund_total)
 	 *         "444" => 555,...
 	 *       ],...
 	 *   ]
@@ -64,6 +66,10 @@ class RestApiUtil {
 
 		if ( ! is_bool( $request['api_refund'] ) ) {
 			$request['api_refund'] = true;
+		}
+
+		if ( ! is_bool( $request['api_restock'] ) ) {
+			$request['api_restock'] = true;
 		}
 
 		if ( empty( $request['line_items'] ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?


### Changes proposed in this Pull Request:

In rest endpoint for creating refunds `restock_items` was hardcoded with value `true`. With this changes, this parameter can
be changed by client directly. I opened this pull request because i have a use case when i need to refund order from rest api but not restock the items.

### How to test the changes in this Pull Request:

1. Create an order with a product whose stock is managed either via the API or otherwise.
2. Before applying this PR, refund the order using the API. Verify that the stock is restored.
3. Apply this PR.
4. Create a new order.
5. Refund the order using the API. Do not specify the `api_restock` parameter. Verify that the previous behavior (defaults to `true`) remains, and that the stock is restored.
6. Create a new order.
7. Refund the order using the API, this time specifying the `api_restock` parameter with a `false` value. Verify that the stock is **not** restored.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Tweak - Allow the `api_restock` parameter to be specified via the refunds API, so that it's possible to refund without restocking refunded items. 
