### PR TITLE
update DB in wp beta initialization script

### DIFF
--- a/tests/e2e/docker/init-wp-beta.sh
+++ b/tests/e2e/docker/init-wp-beta.sh
@@ -13,6 +13,7 @@ wp plugin install https://github.com/WP-API/Basic-Auth/archive/master.zip --acti
 wp plugin install wp-mail-logging --activate
 
 echo "Updating to WordPress Nightly Point Release"
+wp core update https://wordpress.org/nightly-builds/wordpress-latest.zip
 
-wp plugin install wordpress-beta-tester --activate
-wp core check-update
+echo "Updating the database"
+wp core update-db

--- a/tests/e2e/env/docker/wp-cli/Dockerfile
+++ b/tests/e2e/env/docker/wp-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM wordpress:cli-php7.4
+FROM wordpress:cli-2.5.0
 
 USER root
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the E2E WP beta initialization script to update the DB. This eliminates the update DB modal screen in the dashboard.

Closes #29547 .

### How to test the changes in this Pull Request:

1. Run `npx wc-e2e docker:up tests/e2e/docker/init-wp-beta.sh`
2. Run `npx wc-e2e test:e2e`
3. I had some tests fail locally. If the reviewer also has some fail we should create a new issue and investigate compatibility with WP 5.8 separately.

### Changelog entry

N/A
