### PR TITLE
[#30185] Fix warning: Use of deprecated function wp.passwordStrength.userInputBlacklist

### DIFF
--- a/assets/js/frontend/password-strength-meter.js
+++ b/assets/js/frontend/password-strength-meter.js
@@ -84,7 +84,7 @@
 			var meter     = wrapper.find( '.woocommerce-password-strength' ),
 				hint      = wrapper.find( '.woocommerce-password-hint' ),
 				hint_html = '<small class="woocommerce-password-hint">' + wc_password_strength_meter_params.i18n_password_hint + '</small>',
-				strength  = wp.passwordStrength.meter( field.val(), wp.passwordStrength.userInputBlacklist() ),
+				strength  = wp.passwordStrength.meter( field.val(), wp.passwordStrength.userInputDisallowedList() ),
 				error     = '';
 
 			// Reset.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #30185.

### How to test the changes in this Pull Request:

1. Open the checkout page with a recent WordPress version
2. Make sure the password-strength meter is working
3. Check the browser console to ensure that the warning mentioned in the issue isn't raised anymore

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog

> Fix - Replaced `wp.passwordStrength` deprecated method.
