### PR TITLE
remove e2e linting from main project linting

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,8 +1,6 @@
 /** @format */
 
-const { useE2EEsLintConfig } = require( './tests/e2e/env/config/use-config' );
-
-module.exports = useE2EEsLintConfig( {
+module.exports = {
 	root: true,
 	env: {
 		browser: true,
@@ -30,4 +28,4 @@ module.exports = useE2EEsLintConfig( {
 			jsx: true
 		}
 	},
-} );
+};


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR removes the E2E eslint config from the main package eslint config. The E2E eslint config depends on `@automattic/puppeteer-utils` which is removed by `npm install:no-e2e`. In `trunk`, `npm run build` fails due to the missing dependency.

Closes #30011.

### How to test the changes in this Pull Request:

1. `npm run build` should complete successfully

### Changelog entry

> N/A
