### PR TITLE
Update WooCommerce Blocks package to 5.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.1",
     "woocommerce/woocommerce-admin": "2.4.1",
-    "woocommerce/woocommerce-blocks": "5.5.0"
+    "woocommerce/woocommerce-blocks": "5.5.1"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.1",
     "woocommerce/woocommerce-admin": "2.4.1",
-    "woocommerce/woocommerce-blocks": "5.3.1"
+    "woocommerce/woocommerce-blocks": "5.5.0"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6b6ffc4afddcbe536297cd42e497d82a",
+    "content-hash": "acab5cd3f2509342ed733e770638ab4c",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -584,16 +584,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v5.5.0",
+            "version": "v5.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "4ec2a9bfbae319342ee0303b1dece41d341b71f8"
+                "reference": "f3d8dbadb745cbb2544e86dfb3864e870146d197"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/4ec2a9bfbae319342ee0303b1dece41d341b71f8",
-                "reference": "4ec2a9bfbae319342ee0303b1dece41d341b71f8",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/f3d8dbadb745cbb2544e86dfb3864e870146d197",
+                "reference": "f3d8dbadb745cbb2544e86dfb3864e870146d197",
                 "shasum": ""
             },
             "require": {
@@ -629,9 +629,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.5.0"
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.5.1"
             },
-            "time": "2021-07-06T07:22:58+00:00"
+            "time": "2021-07-14T20:59:04+00:00"
         }
     ],
     "packages-dev": [
@@ -698,5 +698,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.0.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "78971f2035da15d44d3941df88d5afbc",
+    "content-hash": "6b6ffc4afddcbe536297cd42e497d82a",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -584,16 +584,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v5.3.1",
+            "version": "v5.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "28c7c4f9b5cace9098fb2246ff93abe110a26bca"
+                "reference": "4ec2a9bfbae319342ee0303b1dece41d341b71f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/28c7c4f9b5cace9098fb2246ff93abe110a26bca",
-                "reference": "28c7c4f9b5cace9098fb2246ff93abe110a26bca",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/4ec2a9bfbae319342ee0303b1dece41d341b71f8",
+                "reference": "4ec2a9bfbae319342ee0303b1dece41d341b71f8",
                 "shasum": ""
             },
             "require": {
@@ -629,9 +629,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.3.1"
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.5.0"
             },
-            "time": "2021-06-15T09:12:48+00:00"
+            "time": "2021-07-06T07:22:58+00:00"
         }
     ],
     "packages-dev": [
@@ -698,5 +698,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "2.1.0"
 }


### PR DESCRIPTION
This PR updates the WooCommerce Blocks plugin to version 5.5.0. 

It includes changes from WooCommerce Blocks 5.4.0 and 5.5.0. It is intended to target WooCommerce 5.6.0 for release.

Details from the releases included in this PR:

## Blocks 5.4.0

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4381)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/540.md)
* [Release post](https://developer.woocommerce.com/2021/06/23/woocommerce-blocks-5-4-0-release-notes/)

## Blocks 5.5.0

* [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4425)
* [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/550.md)
* [Release post](https://developer.woocommerce.com/2021/07/06/woocommerce-blocks-5-5-0-release-notes/)

### Changelog entry

### The following changelog entries are only those that impact existing blocks and functionality surfaced to users:

#### Enhancements
- Add screen reader text to price ranges. ([4367](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4367))
- Allow HTML in All Products Block Product Titles. ([4363](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4363))
- Made script and style handles consistent. ([4324](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4324))

#### Bug Fixes
- Ensure product grids display as intended in the editor. ([4424](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4424))
- Fix filtering by product type on Store API. ([4422](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4422))

#### Various
- Allow products to be added by SKU in the Hand-Picked Products block. ([4366](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4366))

#### Documentation

- Add documentation for the IntegrationInterface which extension developers can use to register scripts, styles, and data with WooCommerce Blocks. ([4394](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4394))


### The following changelog entries are for items that only apply when the feature plugin is active:

#### Enhancements
- Show loading state in the express payments area whilst payment is processing or the page is redirecting. ([4228](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4228))

#### Bug Fixes
- Wrap components in the Cart and Checkout sidebar in a TotalsWrapper. This will ensure consistent spacing and borders are applied to items in the sidebar. ([4415](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4415))
- Remove `couponName` filter and replace it with `coupons` filter. ([4312](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4312))
- Fix a warning shown when fees are included in the order. ([4360](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4360))
- Prevent PHP notice for variable products without enabled variations. ([4317](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4317))

#### Various
- Add Slot in the Discounts section of the Checkout sidebar to allow third party extensions to render their own components there. ([4310](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4310))


