### PR TITLE
Fix reference to coupon code for `removed_coupon_in_checkout` event

### DIFF
--- a/assets/js/frontend/checkout.js
+++ b/assets/js/frontend/checkout.js
@@ -668,7 +668,7 @@ jQuery( function( $ ) {
 					if ( code ) {
 						$( 'form.woocommerce-checkout' ).before( code );
 
-						$( document.body ).trigger( 'removed_coupon_in_checkout', [ data.coupon_code ] );
+						$( document.body ).trigger( 'removed_coupon_in_checkout', [ data.coupon ] );
 						$( document.body ).trigger( 'update_checkout', { update_shipping_method: false } );
 
 						// Remove coupon code from coupon field


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The JavaScript `removed_coupon_in_checkout` event does not include the coupon code which was just removed because the code references the incorrect key from the `data` object.  This PR fixes the key reference so the event can receive the code as expected.

### How to test the changes in this Pull Request:

1. Add some frontend JavaScript hooking the `removed_coupon_in_checkout` event:

```javascript
jQuery( document.body ).on( 'removed_coupon_in_checkout', function ( e, coupon_code ) {
	console.log( arguments );
} );
```

2. Make sure you have a product in your cart with a coupon applied
3. Open your browser's developer console
4. Remove a coupon from the active cart on the checkout page
5. Inspect the logged arguments object and note that what should be the `coupon_code` argument is actually undefined
6. Apply the patch and remove a coupon again, see the code is properly passed through

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

Fix reference to coupon code for `removed_coupon_in_checkout` event