### PR TITLE
chore: add shipping dimensions to sample products

### DIFF
--- a/sample-data/sample_products.xml
+++ b/sample-data/sample_products.xml
@@ -107,22 +107,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0.5]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[24]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[2]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -278,22 +278,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1.5]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[10]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[8]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[3]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -455,22 +455,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[2]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[10]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[6]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[3]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -620,22 +620,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0.8]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[8]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[6]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -785,22 +785,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0.2]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[4]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[5]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0.5]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -949,22 +949,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1.2]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[12]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[2]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1.5]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1115,22 +1115,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0.6]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[8]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[6.5]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[4]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1280,22 +1280,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0.2]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[4]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1.4]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1448,22 +1448,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[3]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[10]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[8]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[2]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1613,22 +1613,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[2]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[8]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[6]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[2]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1778,22 +1778,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[7]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[5]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1943,22 +1943,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0.8]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[6]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[5]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -3488,22 +3488,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0.5]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[10]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[12]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0.5]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -3653,22 +3653,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_weight</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_length</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_width</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
-  <wp:postmeta>
-    <wp:meta_key>_height</wp:meta_key>
-    <wp:meta_value><![CDATA[]]></wp:meta_value>
-  </wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+		<wp:meta_value><![CDATA[0.2]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
+		<wp:meta_value><![CDATA[6]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
+		<wp:meta_value><![CDATA[4]]></wp:meta_value>
+	</wp:postmeta>
+	<wp:postmeta>
+		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
+		<wp:meta_value><![CDATA[1]]></wp:meta_value>
+	</wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>

--- a/sample-data/sample_products.xml
+++ b/sample-data/sample_products.xml
@@ -107,22 +107,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[0.5]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[24]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[1]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[2]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[0.5]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[24]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[1]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[2]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -278,22 +278,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[1.5]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[10]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[8]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[3]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[1.5]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[10]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[8]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[3]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -455,22 +455,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[2]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[10]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[6]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[3]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[2]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[10]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[6]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[3]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -620,22 +620,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[0.8]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[8]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[6]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[1]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[0.8]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[8]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[6]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[1]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -785,22 +785,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[0.2]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[4]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[5]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[0.5]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[0.2]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[4]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[5]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[0.5]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -949,22 +949,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[1.2]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[12]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[2]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[1.5]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[1.2]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[12]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[2]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[1.5]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1115,22 +1115,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[0.6]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[8]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[6.5]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[4]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[0.6]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[8]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[6.5]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[4]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1280,22 +1280,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[0.2]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[4]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[1.4]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[1]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[0.2]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[4]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[1.4]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[1]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1448,22 +1448,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[3]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[10]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[8]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[2]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[3]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[10]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[8]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[2]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1613,22 +1613,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[2]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[8]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[6]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[2]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[2]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[8]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[6]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[2]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1778,22 +1778,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[1]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[7]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[5]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[1]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[1]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[7]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[5]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[1]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -1943,22 +1943,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[0.8]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[6]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[5]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[1]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[0.8]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[6]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[5]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[1]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -3488,22 +3488,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[0.5]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[10]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[12]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[0.5]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[0.5]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[10]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[12]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[0.5]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>
@@ -3653,22 +3653,22 @@
     <wp:meta_key>_sold_individually</wp:meta_key>
     <wp:meta_value><![CDATA[no]]></wp:meta_value>
   </wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_weight]]></wp:meta_key>
-		<wp:meta_value><![CDATA[0.2]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_length]]></wp:meta_key>
-		<wp:meta_value><![CDATA[6]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_width]]></wp:meta_key>
-		<wp:meta_value><![CDATA[4]]></wp:meta_value>
-	</wp:postmeta>
-	<wp:postmeta>
-		<wp:meta_key><![CDATA[_height]]></wp:meta_key>
-		<wp:meta_value><![CDATA[1]]></wp:meta_value>
-	</wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_weight]]></wp:meta_key>
+    <wp:meta_value><![CDATA[0.2]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_length]]></wp:meta_key>
+    <wp:meta_value><![CDATA[6]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_width]]></wp:meta_key>
+    <wp:meta_value><![CDATA[4]]></wp:meta_value>
+  </wp:postmeta>
+  <wp:postmeta>
+    <wp:meta_key><![CDATA[_height]]></wp:meta_key>
+    <wp:meta_value><![CDATA[1]]></wp:meta_value>
+  </wp:postmeta>
   <wp:postmeta>
     <wp:meta_key>_upsell_ids</wp:meta_key>
     <wp:meta_value><![CDATA[a:0:{}]]></wp:meta_value>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

I'd like to add the shipping dimensions to sample data.
The CSV includes the shipping dimensions, but the XML doesn't.
With these changes, the sample data in the XML matches the sample data in the CSV.

This is useful in WCShip when setting up a new site and importing sample data.

### How to test the changes in this Pull Request:

- Clean up your products
- Go to your site's import tool in Tools > Import > WordPress - `/wp-admin/admin.php?import=wordpress`
- Import the products from the CSV
- You should now get sample product data with XML included
- The imported products should now include shipping dimensions

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Add shipping dimensions to sample data.
