### PR TITLE
fix incorrect modification time in logs dropdown

### DIFF
--- a/includes/admin/views/html-admin-page-status-logs.php
+++ b/includes/admin/views/html-admin-page-status-logs.php
@@ -26,8 +26,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 					<?php foreach ( $logs as $log_key => $log_file ) : ?>
 						<?php
 							$timestamp = filemtime( WC_LOG_DIR . $log_file );
-							/* translators: 1: last access date 2: last access time */
-							$date = sprintf( __( '%1$s at %2$s', 'woocommerce' ), date_i18n( wc_date_format(), $timestamp ), date_i18n( wc_time_format(), $timestamp ) );
+							$date      = sprintf(
+								/* translators: 1: last access date 2: last access time 3: last access timezone abbreviation */
+								__( '%1$s at %2$s %3$s', 'woocommerce' ),
+								wp_date( wc_date_format(), $timestamp ),
+								wp_date( wc_time_format(), $timestamp ),
+								wp_date( 'T', $timestamp )
+							);
 						?>
 						<option value="<?php echo esc_attr( $log_key ); ?>" <?php selected( sanitize_title( $viewed_log ), $log_key ); ?>><?php echo esc_html( $log_file ); ?> (<?php echo esc_html( $date ); ?>)</option>
 					<?php endforeach; ?>


### PR DESCRIPTION
* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix for issue https://github.com/woocommerce/woocommerce/issues/30251

Reason: In the current state, the information about log modification time is misleading, this PR corrects the behavior and provides clarity.

Closes #30251 .

### Other information:

It seems safe to use wp_date (since WP 5.3) because minimal requirement for trunk WooCommerce is WP 5.5

If my assumption is wrong, I can provide fallback to previous code, if the function is not available.

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

* Fix - display of modification time of log files, convert to configure timezone and include time zone abbreviation