### PR TITLE
Fix the payment method title for the option "Other"

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -600,6 +600,10 @@ class WC_Meta_Box_Order_Data {
 				$payment_method_title = $methods[ $payment_method ]->get_title();
 			}
 
+			if ( $payment_method == 'other') {
+				$payment_method_title = esc_html__( 'Other', 'woocommerce' );
+			}
+			
 			$props['payment_method']       = $payment_method;
 			$props['payment_method_title'] = $payment_method_title;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This pull request fixes the payment method title for the option **Other**, to use its localized name instead of its raw value.

Closes: #30255

### How to test the changes in this Pull Request:

1. Go to WooCommerce > Orders > Edit an existent order > Edit the billing address and change the payment method to **Other**.

![image](https://user-images.githubusercontent.com/38109855/125228286-85a9a900-e2a2-11eb-8bb4-0563f8a523c9.png)

2. Query the `_payment_method_title` of the order, and you'll see that the payment method title is now the localized string for "Other". In this example, the translation to French:

![image](https://user-images.githubusercontent.com/38109855/125228409-af62d000-e2a2-11eb-966a-14d689bb53ff.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix the payment method title for the option "Other".
