### PR TITLE
Use single quotes to delineate mysql values instead of double quotes …

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1118,7 +1118,7 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 			$product->get_id()
 		);
 
-		$query .= ' AND postmeta.meta_key IN ( "' . implode( '","', array_map( 'esc_sql', $meta_attribute_names ) ) . '" )';
+		$query .= " AND postmeta.meta_key IN ( '" . implode( "','", array_map( 'esc_sql', $meta_attribute_names ) ) . "' )";
 
 		$query .= ' ORDER BY posts.menu_order ASC, postmeta.post_id ASC;';
 


### PR DESCRIPTION
…closes #29969

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29969

### How to test the changes in this Pull Request:

This test is a bit unorthodox but it was easier for me to test.

1. Create a variable product with custom attributes (at least two of them). Take note of the attribute names.
2. Run the following code somewhere. I created a MU plugin.

```
global $wpdb;
$wpdb->set_sql_mode( array( 'ANSI_QUOTES' ) );
$meta_attribute_names = array( 'attribute_<ATTRIBUTE_NAME_FROM_STEP_1>', 'attribute_<ATTRIBUTE_NAME_FROM_STEP_1>' ); // PASS IN AT LEAST 2 ATTRIBUTES.

		$query = $wpdb->prepare(
			"
			SELECT postmeta.post_id, postmeta.meta_key, postmeta.meta_value, posts.menu_order FROM {$wpdb->postmeta} as postmeta
			LEFT JOIN {$wpdb->posts} as posts ON postmeta.post_id=posts.ID
			WHERE postmeta.post_id IN (
				SELECT ID FROM {$wpdb->posts}
				WHERE {$wpdb->posts}.post_parent = %d
				AND {$wpdb->posts}.post_status = 'publish'
				AND {$wpdb->posts}.post_type = 'product_variation'
			)
			",
			'2258'
		);

		$query .= " AND postmeta.meta_key IN ( '" . implode( "','", array_map( 'esc_sql', $meta_attribute_names ) ) . "' )";
		$query .= " ORDER BY posts.menu_order ASC, postmeta.post_id ASC;";

		$attributes = $wpdb->get_results( $query );
error_log( print_r( $attributes,true));
```
3. Check your error logs and ensure you don't get any errors and also you're seeing the query results.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Error when running `find_matching_product_variation` query when mysql configuration is set to `ANSI_QUOTES`.
