### PR TITLE
Fix: "search product" block not displaying textbox in shop page

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -209,15 +209,6 @@ final class WooCommerce {
 		add_action( 'woocommerce_installed', array( $this, 'add_woocommerce_inbox_variant' ) );
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_inbox_variant' ) );
 
-		add_filter(
-			'wp_kses_allowed_html',
-			function( $context, $context_type ) {
-				return $this->wp_kses_allowed_html_filter( $context, $context_type );
-			},
-			10,
-			2
-		);
-
 		// These classes set up hooks on instantiation.
 		wc_get_container()->get( DownloadPermissionsAdjuster::class );
 		wc_get_container()->get( AssignDefaultCategory::class );
@@ -1013,51 +1004,5 @@ final class WooCommerce {
 	 */
 	public function get_instance_of( string $class_name, ...$args ) {
 		return wc_get_container()->get( LegacyProxy::class )->get_instance_of( $class_name, ...$args );
-	}
-
-	/**
-	 * Handler for the wp_kses_allowed_html filter.
-	 *
-	 * @param string|array[] $context Context to judge allowed tags by (expected: array of allowed tags).
-	 * @param string         $context_type Context name.
-	 * @return array[] The updated list of allowed tags.
-	 */
-	private function wp_kses_allowed_html_filter( $context, $context_type ) {
-		if ( 'post' !== $context_type || ! is_shop() || ! is_array( $context ) ) {
-			return $context;
-		}
-
-		// This is needed for the "Search product" block to work on the shop page.
-
-		$context['input'] = array(
-			'type'        => true,
-			'id'          => true,
-			'class'       => true,
-			'placeholder' => true,
-			'name'        => true,
-			'value'       => true,
-		);
-
-		$context['button'] = array(
-			'type'  => true,
-			'class' => true,
-			'label' => true,
-		);
-
-		$context['svg'] = array(
-			'hidden'    => true,
-			'role'      => true,
-			'focusable' => true,
-			'xmlns'     => true,
-			'width'     => true,
-			'height'    => true,
-			'viewbox'   => true,
-		);
-
-		$context['path'] = array(
-			'd' => true,
-		);
-
-		return $context;
 	}
 }

--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -209,6 +209,15 @@ final class WooCommerce {
 		add_action( 'woocommerce_installed', array( $this, 'add_woocommerce_inbox_variant' ) );
 		add_action( 'woocommerce_updated', array( $this, 'add_woocommerce_inbox_variant' ) );
 
+		add_filter(
+			'wp_kses_allowed_html',
+			function( $context, $context_type ) {
+				return $this->wp_kses_allowed_html_filter( $context, $context_type );
+			},
+			10,
+			2
+		);
+
 		// These classes set up hooks on instantiation.
 		wc_get_container()->get( DownloadPermissionsAdjuster::class );
 		wc_get_container()->get( AssignDefaultCategory::class );
@@ -1004,5 +1013,51 @@ final class WooCommerce {
 	 */
 	public function get_instance_of( string $class_name, ...$args ) {
 		return wc_get_container()->get( LegacyProxy::class )->get_instance_of( $class_name, ...$args );
+	}
+
+	/**
+	 * Handler for the wp_kses_allowed_html filter.
+	 *
+	 * @param string|array[] $context Context to judge allowed tags by (expected: array of allowed tags).
+	 * @param string         $context_type Context name.
+	 * @return array[] The updated list of allowed tags.
+	 */
+	private function wp_kses_allowed_html_filter( $context, $context_type ) {
+		if ( 'post' !== $context_type || ! is_shop() || ! is_array( $context ) ) {
+			return $context;
+		}
+
+		// This is needed for the "Search product" block to work on the shop page.
+
+		$context['input'] = array(
+			'type'        => true,
+			'id'          => true,
+			'class'       => true,
+			'placeholder' => true,
+			'name'        => true,
+			'value'       => true,
+		);
+
+		$context['button'] = array(
+			'type'  => true,
+			'class' => true,
+			'label' => true,
+		);
+
+		$context['svg'] = array(
+			'hidden'    => true,
+			'role'      => true,
+			'focusable' => true,
+			'xmlns'     => true,
+			'width'     => true,
+			'height'    => true,
+			'viewbox'   => true,
+		);
+
+		$context['path'] = array(
+			'd' => true,
+		);
+
+		return $context;
 	}
 }

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1259,7 +1259,44 @@ if ( ! function_exists( 'woocommerce_product_archive_description' ) ) {
 		if ( is_post_type_archive( 'product' ) && in_array( absint( get_query_var( 'paged' ) ), array( 0, 1 ), true ) ) {
 			$shop_page = get_post( wc_get_page_id( 'shop' ) );
 			if ( $shop_page ) {
-				$description = wc_format_content( wp_kses_post( $shop_page->post_content ) );
+
+				$allowed_html = wp_kses_allowed_html( 'post' );
+
+				// This is needed for the search product block to work.
+				$allowed_html = array_merge(
+					$allowed_html,
+					array(
+						'input'  => array(
+							'type'        => true,
+							'id'          => true,
+							'class'       => true,
+							'placeholder' => true,
+							'name'        => true,
+							'value'       => true,
+						),
+
+						'button' => array(
+							'type'  => true,
+							'class' => true,
+							'label' => true,
+						),
+
+						'svg'    => array(
+							'hidden'    => true,
+							'role'      => true,
+							'focusable' => true,
+							'xmlns'     => true,
+							'width'     => true,
+							'height'    => true,
+							'viewbox'   => true,
+						),
+						'path'   => array(
+							'd' => true,
+						),
+					)
+				);
+
+				$description = wc_format_content( wp_kses( $shop_page->post_content, $allowed_html ) );
 				if ( $description ) {
 					echo '<div class="page-description">' . $description . '</div>'; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 				}

--- a/includes/wc-template-functions.php
+++ b/includes/wc-template-functions.php
@@ -1266,6 +1266,16 @@ if ( ! function_exists( 'woocommerce_product_archive_description' ) ) {
 				$allowed_html = array_merge(
 					$allowed_html,
 					array(
+						'form'   => array(
+							'action'         => true,
+							'accept'         => true,
+							'accept-charset' => true,
+							'enctype'        => true,
+							'method'         => true,
+							'name'           => true,
+							'target'         => true,
+						),
+
 						'input'  => array(
 							'type'        => true,
 							'id'          => true,


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The "seach block" product doesn't display the textbox because its HTML is filtered out by `wp_kses_post`. This fix hooks on
`wp_kses_allowed_html` in order to explicitly allow the HTML elements of the block in the shop page.

This is rather a "fixing the symptoms rather than the problem" kind of solution, but should be good until we find a proper fix (which will not be trivial).

Closes #29723.

### How to test the changes in this Pull Request:

1. Go to the Shop page editor.
2. Add a Product Search block.
3. Publish the page.
4. Check the published Shop page to see, the search box should be showing and working.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - "search product" block not displaying textbox in shop page
