### PR TITLE
Rollback changes to download method fallback policy

### DIFF
--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -340,6 +340,13 @@ class WC_Download_Handler {
 		}
 
 		// Fallback.
+		wc_get_logger()->warning(
+			sprintf(
+				/* translators: %1$s contains the filepath of the digital asset. */
+				__( '%1$s could not be served using the X-Accel-Redirect/X-Sendfile method. A Force Download will be used instead.', 'woocommerce' ),
+				$file_path
+			)
+		);
 		self::download_file_force( $file_path, $filename );
 	}
 
@@ -435,7 +442,18 @@ class WC_Download_Handler {
 		$start  = isset( $download_range['start'] ) ? $download_range['start'] : 0;
 		$length = isset( $download_range['length'] ) ? $download_range['length'] : 0;
 		if ( ! self::readfile_chunked( $parsed_file_path['file_path'], $start, $length ) ) {
-			self::download_error( __( 'File not found', 'woocommerce' ) );
+			if ( $parsed_file_path['remote_file'] ) {
+				wc_get_logger()->warning(
+					sprintf(
+						/* translators: %1$s contains the filepath of the digital asset. */
+						__( '%1$s could not be served using the Force Download method. A redirect will be used instead.', 'woocommerce' ),
+						$file_path
+					)
+				);
+				self::download_file_redirect( $file_path );
+			} else {
+				self::download_error( __( 'File not found', 'woocommerce' ) );
+			}
 		}
 
 		exit;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

The product download handler uses a system of fallbacks. If X-Accel/Sendfile is the preferred method but cannot be used, it falls back on Force Download. In turn, if Force Download cannot be used _and if the digital product file is remote,_ then a final fallback is made to the Redirect method ... at least, that was the pre-5.5.0 behavior. 

In https://github.com/woocommerce/woocommerce/commit/f88586eb1f040b81a73a62f183aa7084dccfdbc5 we removed that final fallback, so as to avoid inadvertently exposing the digital asset's public path, however a case has been made for the restoration of that previous behavior.

This change reverts to the previous logic, but also adds logging (so that merchants have a means of seeing that the problem is happening—otherwise they have no way of knowing if their preferred download method is failing).

Closes #30288.

### How to test the changes in this Pull Request:

Setup

1. Configure your PHP so that `allow_url_fopen` is disabled.
2. Visit **WooCommerce ▸ Settings ▸ Products ▸ Downloadable Products**.
3. Set the **File Download Method** to **Force Downloads**.
4. Add a remote file to one of your downloadable products (remote := hosted on another site).

Testing

1. Try purchasing and downloading.
2. With this change: you should be able to access the digital asset (a redirect should take place).
3. Without this change: you will see a `File not found` error (you _may_ need to dig around with your browser's network tools to surface this).


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Restores the same fallback logic used by the product downloads handler before the 5.5.0 release. #30288
