### PR TITLE
Download handler: support falling back on the redirect method (as an option, not a default)

### DIFF
--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -387,11 +387,15 @@ class WC_Settings_Products extends WC_Settings_Page {
 				),
 
 				array(
-					'desc'          => __( 'Allow using redirect mode as a last resort', 'woocommerce' ),
+					'desc'          => __( 'Allow using redirect mode (insecure) as a last resort', 'woocommerce' ),
 					'id'            => 'woocommerce_downloads_redirect_fallback_allowed',
 					'type'          => 'checkbox',
 					'default'       => 'no',
-					'desc_tip'      => __( 'If the "Force Downloads" or "X-Accel-Redirect/X-Sendfile" download method is selected but does not work, the system will use the "Redirect" method as a last resort.', 'woocommerce' ),
+					'desc_tip'      => sprintf(
+						/* translators: %1$s is a link to the WooCommerce documentation. */
+						__( 'If the "Force Downloads" or "X-Accel-Redirect/X-Sendfile" download method is selected but does not work, the system will use the "Redirect" method as a last resort. <a href="%1$s">See this guide</a> for more details.', 'woocommerce' ),
+						'https://docs.woocommerce.com/document/digital-downloadable-product-handling/'
+					),
 					'checkboxgroup' => 'start',
 					'autoload'      => false,
 				),

--- a/includes/admin/settings/class-wc-settings-products.php
+++ b/includes/admin/settings/class-wc-settings-products.php
@@ -387,6 +387,16 @@ class WC_Settings_Products extends WC_Settings_Page {
 				),
 
 				array(
+					'desc'          => __( 'Allow using redirect mode as a last resort', 'woocommerce' ),
+					'id'            => 'woocommerce_downloads_redirect_fallback_allowed',
+					'type'          => 'checkbox',
+					'default'       => 'no',
+					'desc_tip'      => __( 'If the "Force Downloads" or "X-Accel-Redirect/X-Sendfile" download method is selected but does not work, the system will use the "Redirect" method as a last resort.', 'woocommerce' ),
+					'checkboxgroup' => 'start',
+					'autoload'      => false,
+				),
+
+				array(
 					'title'         => __( 'Access restriction', 'woocommerce' ),
 					'desc'          => __( 'Downloads require login', 'woocommerce' ),
 					'id'            => 'woocommerce_downloads_require_login',

--- a/includes/admin/views/html-notice-redirect-only-download.php
+++ b/includes/admin/views/html-notice-redirect-only-download.php
@@ -15,7 +15,7 @@ defined( 'ABSPATH' ) || exit;
 		echo wp_kses_post(
 			sprintf(
 				/* translators: %s: Link to settings page. */
-				__( 'Your store is configured to serve digital products using "Redirect only" method. This method is deprecated, <a href="%s">please switch to  a different method instead.</a><br><em>If you use a remote server for downloadable files (such as Google Drive, Dropbox, Amazon S3), the right method will automatically be used, so select any of the other options to make this notice go away.</em>', 'woocommerce' ),
+				__( 'Your store is configured to serve digital products using "Redirect only" method. This method is deprecated, <a href="%s">please switch to a different method instead.</a><br><em>If you use a remote server for downloadable files (such as Google Drive, Dropbox, Amazon S3), you may optionally wish to "allow using redirects as a last resort". Enabling that and/or selecting any of the other options will make this notice go away.</em>', 'woocommerce' ),
 				add_query_arg(
 					array(
 						'page'    => 'wc-settings',

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -340,6 +340,13 @@ class WC_Download_Handler {
 		}
 
 		// Fallback.
+		wc_get_logger()->warning(
+			sprintf(
+				/* translators: %1$s contains the filepath of the digital asset. */
+				__( '%1$s could not be served using the X-Accel-Redirect/X-Sendfile method. A Force Download will be used instead.', 'woocommerce' ),
+				$file_path
+			)
+		);
 		self::download_file_force( $file_path, $filename );
 	}
 
@@ -435,7 +442,18 @@ class WC_Download_Handler {
 		$start  = isset( $download_range['start'] ) ? $download_range['start'] : 0;
 		$length = isset( $download_range['length'] ) ? $download_range['length'] : 0;
 		if ( ! self::readfile_chunked( $parsed_file_path['file_path'], $start, $length ) ) {
-			self::download_error( __( 'File not found', 'woocommerce' ) );
+			if ( $parsed_file_path['remote_file'] ) {
+				wc_get_logger()->warning(
+					sprintf(
+						/* translators: %1$s contains the filepath of the digital asset. */
+						__( '%1$s could not be served using the Force Download method. A redirect will be used instead.', 'woocommerce' ),
+						$file_path
+					)
+				);
+				self::download_file_redirect( $file_path );
+			} else {
+				self::download_error( __( 'File not found', 'woocommerce' ) );
+			}
 		}
 
 		exit;

--- a/includes/class-wc-download-handler.php
+++ b/includes/class-wc-download-handler.php
@@ -442,7 +442,7 @@ class WC_Download_Handler {
 		$start  = isset( $download_range['start'] ) ? $download_range['start'] : 0;
 		$length = isset( $download_range['length'] ) ? $download_range['length'] : 0;
 		if ( ! self::readfile_chunked( $parsed_file_path['file_path'], $start, $length ) ) {
-			if ( $parsed_file_path['remote_file'] ) {
+			if ( $parsed_file_path['remote_file'] && 'yes' === get_option( 'woocommerce_downloads_redirect_fallback_allowed' ) ) {
 				wc_get_logger()->warning(
 					sprintf(
 						/* translators: %1$s contains the filepath of the digital asset. */

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-product.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-product.test.js
@@ -28,6 +28,7 @@ const runProductSettingsTest = () => {
 			await expect(page).toSelect('#woocommerce_file_download_method', 'Redirect only (Insecure)');
 			await setCheckbox('#woocommerce_downloads_require_login');
 			await setCheckbox('#woocommerce_downloads_grant_access_after_payment');
+			await setCheckbox('#woocommerce_downloads_redirect_fallback_allowed');
 			await settingsPageSaveChanges();
 
 			// Verify that settings have been saved
@@ -36,11 +37,14 @@ const runProductSettingsTest = () => {
 				expect(page).toMatchElement('#woocommerce_file_download_method', {text: 'Redirect only (Insecure)'}),
 				verifyCheckboxIsSet('#woocommerce_downloads_require_login'),
 				verifyCheckboxIsSet('#woocommerce_downloads_grant_access_after_payment'),
+				verifyCheckboxIsSet('#woocommerce_downloads_redirect_fallback_allowed'),
 			]);
 
+			await page.reload();
 			await expect(page).toSelect('#woocommerce_file_download_method', 'Force downloads');
 			await unsetCheckbox('#woocommerce_downloads_require_login');
 			await unsetCheckbox('#woocommerce_downloads_grant_access_after_payment');
+			await unsetCheckbox('#woocommerce_downloads_redirect_fallback_allowed');
 			await settingsPageSaveChanges();
 
 			// Verify that settings have been saved
@@ -49,6 +53,7 @@ const runProductSettingsTest = () => {
 				expect(page).toMatchElement('#woocommerce_file_download_method', {text: 'Force downloads'}),
 				verifyCheckboxIsUnset('#woocommerce_downloads_require_login'),
 				verifyCheckboxIsUnset('#woocommerce_downloads_grant_access_after_payment'),
+				verifyCheckboxIsUnset('#woocommerce_downloads_redirect_fallback_allowed'),
 			]);
 		});
 	});

--- a/tests/php/includes/settings/class-wc-settings-products-test.php
+++ b/tests/php/includes/settings/class-wc-settings-products-test.php
@@ -134,11 +134,12 @@ class WC_Settings_Products_Test extends WC_Settings_Unit_Test_Case {
 		$settings_ids_and_types = $this->get_ids_and_types( $settings );
 
 		$expected = array(
-			'digital_download_options'                   => array( 'title', 'sectionend' ),
-			'woocommerce_file_download_method'           => 'select',
-			'woocommerce_downloads_require_login'        => 'checkbox',
+			'digital_download_options'                         => array( 'title', 'sectionend' ),
+			'woocommerce_file_download_method'                 => 'select',
+			'woocommerce_downloads_redirect_fallback_allowed'  => 'checkbox',
+			'woocommerce_downloads_require_login'              => 'checkbox',
 			'woocommerce_downloads_grant_access_after_payment' => 'checkbox',
-			'woocommerce_downloads_add_hash_to_filename' => 'checkbox',
+			'woocommerce_downloads_add_hash_to_filename'       => 'checkbox',
 		);
 
 		$this->assertEquals( $expected, $settings_ids_and_types );


### PR DESCRIPTION
The product download handler supports 3 different methods of serving files:

| Method | Note |
| --- | --- |
| X-Accel/X-Sendfile | Secure _(customer cannot see the source URL)_ |
| Force Download | Secure _(customer cannot see the source URL)_ |
| Redirect Only | Insecure _(source URL is exposed to the customer)_ |

Previously (before 5.5.0) the system included a fallback mechanism as follows:

* If `X-Accel/X-Sendfile` is the preferred method but cannot be used, it falls back on Force Download. 
* If `Force Download` cannot be used and if the digital product file **is remote**, then a final fallback is made to the Redirect method 
* `Redirect` is the last method, there is no further fallback.

In f88586e we removed that final fallback, so as to avoid inadvertently exposing the digital asset's public path to the world (in other words, the idea was that redirects should be explicitly enabled or not happen at all), however there were some problems with this:

* In some cases, even though the merchant may have selected one of the secure delivery methods, their server was not configured appropriately and so downloads were relying on the redirect fallback. Therefore, removing that fallback had the effect of breaking their customers' access to purchased digital assets.
* In other cases, the merchant (knowingly or unkowingly) relied on the previous chain of fallbacks because they hosted their assets across a diverse range of storage platforms, some that were suitable for `Force Download` but others that were not. The previous system of fallbacks was therefore essential to supporting this arrangement.

In this change:

* We add a new option _"Allow using redirect mode as a last resort"._
* We add logging, so that a record is kept of any fallbacks that take place (letting the merchant or site operator find problems and take corrective steps if appropriate).

This hopefully gives the best of both worlds. Improved security (we don't allow redirects if the merchant hasn't specifically allowed for them) with the flexibility of the earlier, pre-5.5.0 approach (by allowing redirects as a final fallback, but only if explicitly enabled).

Closes #30288.

### Screenshots

![optional-redirect-fallback-option](https://user-images.githubusercontent.com/3594411/125869110-2760007f-f721-4a8a-b828-1dae61339073.png)
:point_up: New option, allowing fallbacks on redirects but making it something that needs to be explicitly enabled.

![Screenshot 2021-07-19 at 15-43-14 WooCommerce settings ‹ WC Lab — WordPress](https://user-images.githubusercontent.com/3594411/126238527-2ac980cf-9a41-4d83-ac12-9aa377f5b467.png)
:point_up: Revised message text for the deprecation warning that renders when _"Redirect Only"_ is selected.

### How to test the changes in this Pull Request:

Setup

1. Configure your PHP so that `allow_url_fopen` is disabled.
2. Visit **WooCommerce ▸ Settings ▸ Products ▸ Downloadable Products**.
3. Set the **File Download Method** to **Force Downloads**.
4. Enable the new _"Allow using redirect mode as a last resort"_ option.
5. Add a remote file to one of your downloadable products (remote := hosted on another site).

Testing

1. Try purchasing and downloading.
2. With _"Allow using redirect mode as a last resort"_ enabled, the download should work (but via a redirect).
3. Try again with _"Allow using redirect mode as a last resort"_ disabled, the download should not work.

Other aspects

1. See also this [alternative set of testing steps](https://github.com/woocommerce/woocommerce/pull/30294#issuecomment-884280912) (documented in a comment, below).
2. If fallbacks (to redirect mode) take place, an entry should be recorded in the logs to document it.
3. When "Redirect Only" is selected, the content of the resulting admin notice that renders (to warn that the method is deprecated) has been updated to reflect this change.

### Other information

* As an alternative, there is [another draft PR](https://github.com/woocommerce/woocommerce/pull/30292/) which, like this PR, adds logging—but otherwise essentially reverts things such that the previous fallback logic is always enabled.
* If we accept this change, we may need to adjust the following resources (not exhaustive):
    * [Digital Download Product Handling](https://docs.woocommerce.com/document/digital-downloadable-product-handling/)
    * [Amazon S3 Storage Docs](https://docs.woocommerce.com/document/amazon-s3-storage/)
    * Other extensions? The deprecation notice (see above screenshot) mentions Google Drive, for instance, but I'm unsure which extension that relates to.

### Changelog entry

> Fix - Add a new option allowing product downloads to be served using redirects as a last resort. #30288