### PR TITLE
fixed by putting strip all tag

### DIFF
--- a/includes/class-wc-ajax.php
+++ b/includes/class-wc-ajax.php
@@ -1673,7 +1673,7 @@ class WC_AJAX {
 		$products        = array();
 
 		foreach ( $product_objects as $product_object ) {
-			$products[ $product_object->get_id() ] = rawurldecode( $product_object->get_formatted_name() );
+			$products[ $product_object->get_id() ] = rawurldecode( wp_strip_all_tags( $product_object->get_formatted_name() ) );
 		}
 
 		wp_send_json( $products );


### PR DESCRIPTION
### All Submissions:

* [ x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:
To fix the described bug which is "showing of html tags while searching variable products at the time of giving grant access for downloadable product", I've just added strip_all_tag() function similarly was used for another section.

Since this one of the good first issue, so please merge it with trunk in next release.
<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30198

### How to test the changes in this Pull Request:

1. Create an order of any downloadable product.
2. On admin panel, edit order page, you can see the grant access field at the bottom
3. Here search for any variable product and select it. You will not the "span" tag now

### Other information:

* [x ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - variable product showing HTML content while granting access for downloadable product in orders.
