### PR TITLE
Changing of anonymous function to classic in filter calling

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -505,14 +505,7 @@ class WC_Query {
 		self::$product_query = $q;
 
 		// Additonal hooks to change WP Query.
-		add_filter(
-			'posts_clauses',
-			function( $args, $wp_query ) {
-				return $this->product_query_post_clauses( $args, $wp_query );
-			},
-			10,
-			2
-		);
+		add_filter( 'posts_clauses', array( $this, 'product_query_post_clauses' ), 10, 2 );
 		add_filter( 'the_posts', array( $this, 'handle_get_posts' ), 10, 2 );
 
 		do_action( 'woocommerce_product_query', $q, $this );
@@ -525,7 +518,7 @@ class WC_Query {
 	 * @param WP_Query $wp_query The current product query.
 	 * @return array The updated product query clauses array.
 	 */
-	private function product_query_post_clauses( $args, $wp_query ) {
+	public function product_query_post_clauses( $args, $wp_query ) {
 		$args = $this->price_filter_post_clauses( $args, $wp_query );
 		$args = $this->filterer->filter_by_attribute_post_clauses( $args, $wp_query, $this->get_layered_nav_chosen_attributes() );
 


### PR DESCRIPTION
Better filter removing using standard function call instead of anonymous

### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

I need to modify or completely remove filter calling product_query_post_clauses and it was not so easy with anonymous function. Using standard function is better way.

Closes # .

### How to test the changes in this Pull Request:

1. remove_filter( 'posts_clauses', array( $this, 'product_query_post_clauses' ), 10, 2 );
2. Check query with e. g. Query monitor

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Enter a summary of all changes on this Pull Request. This will appear in the changelog if accepted.

Allowing modify and remove filter for product_query_post_clauses.