### PR TITLE
Bump woocommerce-admin version to 2.5.0-beta.2

### DIFF
--- a/bin/composer/wp/composer.lock
+++ b/bin/composer/wp/composer.lock
@@ -9,16 +9,16 @@
     "packages-dev": [
         {
             "name": "gettext/gettext",
-            "version": "v4.8.4",
+            "version": "v4.8.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Gettext.git",
-                "reference": "58bc0f7f37e78efb0f9758f93d4a0f669f0f84a1"
+                "reference": "ef2e312dff383fc0e4cd62dd39042e1157f137d4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/58bc0f7f37e78efb0f9758f93d4a0f669f0f84a1",
-                "reference": "58bc0f7f37e78efb0f9758f93d4a0f669f0f84a1",
+                "url": "https://api.github.com/repos/php-gettext/Gettext/zipball/ef2e312dff383fc0e4cd62dd39042e1157f137d4",
+                "reference": "ef2e312dff383fc0e4cd62dd39042e1157f137d4",
                 "shasum": ""
             },
             "require": {
@@ -26,7 +26,7 @@
                 "php": ">=5.4.0"
             },
             "require-dev": {
-                "illuminate/view": "*",
+                "illuminate/view": "^5.0.x-dev",
                 "phpunit/phpunit": "^4.8|^5.7|^6.5",
                 "squizlabs/php_codesniffer": "^3.0",
                 "symfony/yaml": "~2",
@@ -70,7 +70,7 @@
             "support": {
                 "email": "oom@oscarotero.com",
                 "issues": "https://github.com/oscarotero/Gettext/issues",
-                "source": "https://github.com/php-gettext/Gettext/tree/v4.8.4"
+                "source": "https://github.com/php-gettext/Gettext/tree/v4.8.5"
             },
             "funding": [
                 {
@@ -86,27 +86,26 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2021-03-10T19:35:49+00:00"
+            "time": "2021-07-13T16:45:53+00:00"
         },
         {
             "name": "gettext/languages",
-            "version": "2.6.0",
+            "version": "2.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-gettext/Languages.git",
-                "reference": "38ea0482f649e0802e475f0ed19fa993bcb7a618"
+                "reference": "4ad818b6341e177b7c508ec4c37e18932a7b788a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/38ea0482f649e0802e475f0ed19fa993bcb7a618",
-                "reference": "38ea0482f649e0802e475f0ed19fa993bcb7a618",
+                "url": "https://api.github.com/repos/php-gettext/Languages/zipball/4ad818b6341e177b7c508ec4c37e18932a7b788a",
+                "reference": "4ad818b6341e177b7c508ec4c37e18932a7b788a",
                 "shasum": ""
             },
             "require": {
                 "php": ">=5.3"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^2.16.0",
                 "phpunit/phpunit": "^4.8 || ^5.7 || ^6.5 || ^7.5 || ^8.4"
             },
             "bin": [
@@ -149,22 +148,32 @@
             ],
             "support": {
                 "issues": "https://github.com/php-gettext/Languages/issues",
-                "source": "https://github.com/php-gettext/Languages/tree/2.6.0"
+                "source": "https://github.com/php-gettext/Languages/tree/2.8.1"
             },
-            "time": "2019-11-13T10:30:21+00:00"
+            "funding": [
+                {
+                    "url": "https://paypal.me/mlocati",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/mlocati",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-07-14T15:03:58+00:00"
         },
         {
             "name": "mck89/peast",
-            "version": "v1.13.0",
+            "version": "v1.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mck89/peast.git",
-                "reference": "db38b1524f5bda921cbda2385e440c2bb71d18b4"
+                "reference": "ad912d4cf6ac682974058b6d49df4c2bf93d424d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mck89/peast/zipball/db38b1524f5bda921cbda2385e440c2bb71d18b4",
-                "reference": "db38b1524f5bda921cbda2385e440c2bb71d18b4",
+                "url": "https://api.github.com/repos/mck89/peast/zipball/ad912d4cf6ac682974058b6d49df4c2bf93d424d",
+                "reference": "ad912d4cf6ac682974058b6d49df4c2bf93d424d",
                 "shasum": ""
             },
             "require": {
@@ -176,7 +185,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.13.0-dev"
+                    "dev-master": "1.13.2-dev"
                 }
             },
             "autoload": {
@@ -198,9 +207,9 @@
             "description": "Peast is PHP library that generates AST for JavaScript code",
             "support": {
                 "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.13.0"
+                "source": "https://github.com/mck89/peast/tree/v1.13.2"
             },
-            "time": "2021-05-22T16:06:09+00:00"
+            "time": "2021-07-14T09:31:25+00:00"
         },
         {
             "name": "mustache/mustache",
@@ -366,26 +375,29 @@
         },
         {
             "name": "wp-cli/i18n-command",
-            "version": "v2.2.8",
+            "version": "v2.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/i18n-command.git",
-                "reference": "8bc234617edc533590ac0f41080164a8d85ec9ce"
+                "reference": "26e171c5708060b6d7cede9af934b946f5ec3a59"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/8bc234617edc533590ac0f41080164a8d85ec9ce",
-                "reference": "8bc234617edc533590ac0f41080164a8d85ec9ce",
+                "url": "https://api.github.com/repos/wp-cli/i18n-command/zipball/26e171c5708060b6d7cede9af934b946f5ec3a59",
+                "reference": "26e171c5708060b6d7cede9af934b946f5ec3a59",
                 "shasum": ""
             },
             "require": {
                 "gettext/gettext": "^4.8",
-                "mck89/peast": "^1.8",
+                "mck89/peast": "^1.13",
                 "wp-cli/wp-cli": "^2.5"
             },
             "require-dev": {
                 "wp-cli/scaffold-command": "^1.2 || ^2",
                 "wp-cli/wp-cli-tests": "^3.0.11"
+            },
+            "suggest": {
+                "ext-mbstring": "Used for calculating include/exclude matches in code extraction"
             },
             "type": "wp-cli-package",
             "extra": {
@@ -421,9 +433,9 @@
             "homepage": "https://github.com/wp-cli/i18n-command",
             "support": {
                 "issues": "https://github.com/wp-cli/i18n-command/issues",
-                "source": "https://github.com/wp-cli/i18n-command/tree/v2.2.8"
+                "source": "https://github.com/wp-cli/i18n-command/tree/v2.2.9"
             },
-            "time": "2021-05-10T10:24:16+00:00"
+            "time": "2021-07-20T21:25:54+00:00"
         },
         {
             "name": "wp-cli/mustangostang-spyc",
@@ -478,16 +490,16 @@
         },
         {
             "name": "wp-cli/php-cli-tools",
-            "version": "v0.11.12",
+            "version": "v0.11.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/wp-cli/php-cli-tools.git",
-                "reference": "e472e08489f7504d9e8c5c5a057e1419cd1b2b3e"
+                "reference": "a2866855ac1abc53005c102e901553ad5772dc04"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/e472e08489f7504d9e8c5c5a057e1419cd1b2b3e",
-                "reference": "e472e08489f7504d9e8c5c5a057e1419cd1b2b3e",
+                "url": "https://api.github.com/repos/wp-cli/php-cli-tools/zipball/a2866855ac1abc53005c102e901553ad5772dc04",
+                "reference": "a2866855ac1abc53005c102e901553ad5772dc04",
                 "shasum": ""
             },
             "require": {
@@ -526,9 +538,9 @@
             ],
             "support": {
                 "issues": "https://github.com/wp-cli/php-cli-tools/issues",
-                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.12"
+                "source": "https://github.com/wp-cli/php-cli-tools/tree/v0.11.13"
             },
-            "time": "2021-03-03T12:43:49+00:00"
+            "time": "2021-07-01T15:08:16+00:00"
         },
         {
             "name": "wp-cli/wp-cli",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.1",
-    "woocommerce/woocommerce-admin": "2.4.1",
+    "woocommerce/woocommerce-admin": "2.5.0-beta.2",
     "woocommerce/woocommerce-blocks": "5.5.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "acab5cd3f2509342ed733e770638ab4c",
+    "content-hash": "4c8530b8fbe190ef3cd009b7be769677",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -532,16 +532,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.4.1",
+            "version": "2.5.0-beta.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "dd446c2549c763a946bcd3a4deeeca1eb0f2b78f"
+                "reference": "12d7339e0d298e0a1fd21be5731a84fbf0141fca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/dd446c2549c763a946bcd3a4deeeca1eb0f2b78f",
-                "reference": "dd446c2549c763a946bcd3a4deeeca1eb0f2b78f",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/12d7339e0d298e0a1fd21be5731a84fbf0141fca",
+                "reference": "12d7339e0d298e0a1fd21be5731a84fbf0141fca",
                 "shasum": ""
             },
             "require": {
@@ -550,6 +550,7 @@
                 "php": ">=7.0"
             },
             "require-dev": {
+                "automattic/jetpack-changelogger": "^1.1",
                 "bamarni/composer-bin-plugin": "^1.4",
                 "suin/phpcs-psr4-sniff": "^2.2",
                 "woocommerce/woocommerce-sniffs": "0.1.0"
@@ -563,6 +564,23 @@
                 },
                 "bamarni-bin": {
                     "target-directory": "bin/composer"
+                },
+                "changelogger": {
+                    "changelog": "./changelog.txt",
+                    "formatter": {
+                        "filename": "bin/changelogger/WCAdminFormatter.php"
+                    },
+                    "versioning": "semver",
+                    "changes-dir": "./changelogs",
+                    "types": [
+                        "Fix",
+                        "Add",
+                        "Update",
+                        "Dev",
+                        "Tweak",
+                        "Performance",
+                        "Enhancement"
+                    ]
                 }
             },
             "autoload": {
@@ -578,9 +596,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.4.1"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.5.0-beta.2"
             },
-            "time": "2021-07-01T06:10:01+00:00"
+            "time": "2021-07-19T18:07:02+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",

--- a/tests/legacy/unit-tests/rest-api/Tests/Version2/payment-gateways.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version2/payment-gateways.php
@@ -49,21 +49,27 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertContains(
 			array(
-				'id'                 => 'cheque',
-				'title'              => 'Check payments',
-				'description'        => 'Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.',
-				'order'              => '',
-				'enabled'            => false,
-				'method_title'       => 'Check payments',
-				'method_description' => 'Take payments in person via checks. This offline gateway can also be useful to test purchases.',
-				'settings'           => array_diff_key(
+				'id'                     => 'cheque',
+				'title'                  => 'Check payments',
+				'description'            => 'Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.',
+				'order'                  => '',
+				'enabled'                => false,
+				'method_title'           => 'Check payments',
+				'method_description'     => 'Take payments in person via checks. This offline gateway can also be useful to test purchases.',
+				'settings'               => array_diff_key(
 					$this->get_settings( 'WC_Gateway_Cheque' ),
 					array(
 						'enabled'     => false,
 						'description' => false,
 					)
 				),
-				'_links'             => array(
+				'needs_setup'            => false,
+				'post_install_scripts'   => array(),
+				'settings_url'           => 'http://example.org/wp-admin/admin.php?page=wc-settings&tab=checkout&section=cheque',
+				'connection_url'         => '',
+				'setup_help_text'        => '',
+				'required_settings_keys' => array(),
+				'_links'                 => array(
 					'self'       => array(
 						array(
 							'href' => rest_url( '/wc/v2/payment_gateways/cheque' ),
@@ -105,20 +111,26 @@ class Payment_Gateways_V2 extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals(
 			array(
-				'id'                 => 'paypal',
-				'title'              => 'PayPal',
-				'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
-				'order'              => '',
-				'enabled'            => false,
-				'method_title'       => 'PayPal Standard',
-				'method_description' => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
-				'settings'           => array_diff_key(
+				'id'                     => 'paypal',
+				'title'                  => 'PayPal',
+				'description'            => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
+				'order'                  => '',
+				'enabled'                => false,
+				'method_title'           => 'PayPal Standard',
+				'method_description'     => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
+				'settings'               => array_diff_key(
 					$this->get_settings( 'WC_Gateway_Paypal' ),
 					array(
 						'enabled'     => false,
 						'description' => false,
 					)
 				),
+				'needs_setup'            => false,
+				'post_install_scripts'   => array(),
+				'settings_url'           => 'http://example.org/wp-admin/admin.php?page=wc-settings&tab=checkout&section=paypal',
+				'connection_url'         => null,
+				'setup_help_text'        => null,
+				'required_settings_keys' => array(),
 			),
 			$paypal
 		);

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/payment-gateways.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/payment-gateways.php
@@ -49,24 +49,30 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertContains(
 			array(
-				'id'                 => 'cheque',
-				'title'              => 'Check payments',
-				'description'        => 'Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.',
-				'order'              => '',
-				'enabled'            => false,
-				'method_title'       => 'Check payments',
-				'method_description' => 'Take payments in person via checks. This offline gateway can also be useful to test purchases.',
-				'method_supports'    => array(
+				'id'                     => 'cheque',
+				'title'                  => 'Check payments',
+				'description'            => 'Please send a check to Store Name, Store Street, Store Town, Store State / County, Store Postcode.',
+				'order'                  => '',
+				'enabled'                => false,
+				'method_title'           => 'Check payments',
+				'method_description'     => 'Take payments in person via checks. This offline gateway can also be useful to test purchases.',
+				'method_supports'        => array(
 					'products',
 				),
-				'settings'           => array_diff_key(
+				'settings'               => array_diff_key(
 					$this->get_settings( 'WC_Gateway_Cheque' ),
 					array(
 						'enabled'     => false,
 						'description' => false,
 					)
 				),
-				'_links'             => array(
+				'needs_setup'            => false,
+				'post_install_scripts'   => array(),
+				'settings_url'           => 'http://example.org/wp-admin/admin.php?page=wc-settings&tab=checkout&section=cheque',
+				'connection_url'         => '',
+				'setup_help_text'        => '',
+				'required_settings_keys' => array(),
+				'_links'                 => array(
 					'self'       => array(
 						array(
 							'href' => rest_url( '/wc/v3/payment_gateways/cheque' ),
@@ -108,24 +114,30 @@ class Payment_Gateways extends WC_REST_Unit_Test_Case {
 		$this->assertEquals( 200, $response->get_status() );
 		$this->assertEquals(
 			array(
-				'id'                 => 'paypal',
-				'title'              => 'PayPal',
-				'description'        => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
-				'order'              => '',
-				'enabled'            => false,
-				'method_title'       => 'PayPal Standard',
-				'method_description' => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
-				'method_supports'    => array(
+				'id'                     => 'paypal',
+				'title'                  => 'PayPal',
+				'description'            => "Pay via PayPal; you can pay with your credit card if you don't have a PayPal account.",
+				'order'                  => '',
+				'enabled'                => false,
+				'method_title'           => 'PayPal Standard',
+				'method_description'     => 'PayPal Standard redirects customers to PayPal to enter their payment information.',
+				'method_supports'        => array(
 					'products',
 					'refunds',
 				),
-				'settings'           => array_diff_key(
+				'settings'               => array_diff_key(
 					$this->get_settings( 'WC_Gateway_Paypal' ),
 					array(
 						'enabled'     => false,
 						'description' => false,
 					)
 				),
+				'needs_setup'            => false,
+				'post_install_scripts'   => array(),
+				'settings_url'           => 'http://example.org/wp-admin/admin.php?page=wc-settings&tab=checkout&section=paypal',
+				'connection_url'         => null,
+				'setup_help_text'        => null,
+				'required_settings_keys' => array(),
 			),
 			$paypal
 		);

--- a/tests/php/includes/settings/class-wc-settings-advanced-test.php
+++ b/tests/php/includes/settings/class-wc-settings-advanced-test.php
@@ -29,6 +29,7 @@ class WC_Settings_Advanced_Test extends WC_Settings_Unit_Test_Case {
 			'webhooks',
 			'legacy_api',
 			'woocommerce_com',
+			'features',
 		);
 
 		$this->assertEquals( $expected, $section_names );


### PR DESCRIPTION
This bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 2.5.0-beta.2

## Testing instructions

### Fix WC Home crash when the Analytics is disabled.

1. Navigate to WooCommerce -> Settings -> Advanced -> Features. Uncheck Analytics and save the changes.
2. Navigate to WooCommerce -> Home and confirm the page loads without an error.

### Fix links on the dismiss dropdown are not clickable #7342

Please make sure to test it on Safari as well.

1. Navigate to WooCommerce -> Home
2. Click [ Dismiss ] button
3. Confirm that the links are clickable

### Fix undefined method error when setting up WC Tax #7344

1. Set up your store with US address to make sure automated tax is supported.
2. Install "WooCommerce Shipping & Tax" plugin.
3. Go to WooCommerce > Home > Set up tax.
4. Click on "Yes please"
5. Confirm that no error has occurred and you're redirected to the home screen.

### Fix missing translation strings for CES #7270

1. Navigate to Settings -> General and change the site language to a non-English (I've used Espanol for testing purposes).
2. You might need to update the language file if it's your first time using the selected language. Update the language file from Dashboard -> Updates
3. Go to WooCommerce -> Settings
4. Click the [ Save Changes ] button to trigger the CES modal.
5. Confirm the modal has correct translations (Refer to the screenshots)

### Add missing translation strings in the business features section #7268

1. Checkout this branch and run `npm start`
2. Navigate to Settings -> General and change the site language to non-English (I've used Espanol for testing purposes)
3. You might need to download the new language in Dashboard -> Updates
4. Navigate to wp-admin/admin.php?page=wc-admin&path=%2Fsetup-wizard&step=business-features and confirm the translation is working as expected.

### Fix inbox note dismiss dropdown not closing on Safari #7278

1. Checkout this branch and run npm start
2. Navigate to WooCommerce -> Home
3. Click "Dismiss" on a note. Confirm the position of the popover is correct.
4. Click anywhere outside of the popover content and confirm the popover is closed.

### Add TableSummaryPlaceholder to support skeleton loading #7294

1. Visit any page using element Table to see this update.
2. For example, Products, Orders, Revenue under Analytics; or Transactions, Deposits under Payments.
3. While loading, scrolling down to the bottom of the table to see the placeholder of TableSummary.

### Sync the category lookup table when a new category gets created #7290

1. Navigate to Products -> Add New
2. Add a new category on the Add New page and assign the product to it.
3. Place an order with the product
4. Navigate to Analytics -> Categories
5. You should see the category.

### Remove facebook extension from onboarding extensions fallback list #7287

1. Go to the OBW and look at the Free features tab
1. Observe no Facebook extension in the list

### "Terms of service" link disappears from "Set up Tax" screen #7269

1. Go to OBW setup wizard.
2. Uncheck the "WooCommerce shipping" and "WooCommerce Tax" options at Free features step.
3. Complete the OBW setup.
4. Go to WooCommerce->Home.
5. Click on "Set up Tax" option on Task list.
6. TOS should not blink.

### Use saved values if available when switching tabs #7226

1. Start onboarding wizard and continue to step 4.
2. Enter selections for business details and choose "Continue"
3. Select the tab "Business details" to go back
4. Confirm that the previously selected values are shown.

### Change the emailed report file name #7178

**Confirm the default behaviour remains the same**

1. Create a new store and install the [WP Mail Logging by MailPoet plugin](https://wordpress.org/plugins/wp-mail-logging/)
2. Go to Analytics -> Revenue and change the date range to last month
3. Click the download button and make sure you see the "Your revenue report will be emailed to you" notification
4. Go to Tools -> Scheduled Action and run the newly created `woocommerce_admin_report_export` action. After that is complete, run the `woocommerce_admin_email_report_download_link` action.
5. Go to Tools -> WP Mail Log and check the latest email. The URL linked to the "Download your Revenue report" should work as usual. The URL will be something like `filename=wc-revenue-report-export-16236128226138`

**Confirm the new filter is working**

1. Add this code to the `woocommerce-admin.php` file

```php
add_filter( 'woocommerce_admin_export_id', function ($export_id) {
	return 'different_export_id';
} );
```

2. Repeat the same steps from above. The filename in the link now should be `different_export_id`.

### Payment gateway suggestions feature

1. Navigate to the homescreen via WooCommerce -> Home
2. Click on "Set up payments"

#### How to test

Individual payment gateway plugins dictate the settings and connection flow. For testing purposes, we'll test both the default behavior of the gateway and the enhanced configuration behavior.

1. On the payments task, click "Set up" or "Enable" next to a gateway
2. Note that the gateway is installed if it requires a plugin
3. On the connection step, a button should be presented that links to the gateway's (legacy) settings screen
4. Delete the plugin
5. Install some of the payment gateways from the links below. They don't need to be activated, but the folder names should match those on WordPress.org to avoid conflicts.
6. If setting fields are shown, make sure that validation works, input is saved, and is persisted on page refresh. Make sure the gateway is marked as enabled and not labeled "Requires setup" if all fields are completed.
7. If the "Connect" button is shown, follow the connection flow. Make sure that you are returned to the payments task and that the gateway is enabled and marked as configured.
8. Remove some settings manually under the payment gateway's legacy settings screen. Make sure the gateway is no longer marked as configured.

-   Klarna - https://github.com/woocommerce/woocommerce-admin/files/6880208/klarna-checkout-for-woocommerce.zip
-   PayFast - https://github.com/woocommerce/woocommerce-admin/files/6880205/woocommerce-payfast-gateway.zip
-   PayPal - https://github.com/woocommerce/woocommerce-admin/files/6880109/woocommerce-paypal-payments.zip
-   RazorPay - https://github.com/woocommerce/woocommerce-admin/files/6880201/woo-razorpay.zip
-   Stripe - https://github.com/woocommerce/woocommerce-admin/files/6880197/woocommerce-gateway-stripe.zip
-   MercaoPago - https://github.com/woocommerce/woocommerce-admin/files/6880192/woocommerce-mercadopago.zip
-   Square - https://github.com/woocommerce/woocommerce-admin/files/6880117/woocommerce-square.zip
-   eWAY - https://github.com/woocommerce/woocommerce-admin/files/6880111/woocommerce-gateway-eway.zip

##### PayFast

1. Set your country to South Africa in WooCommerce->Settings
2. Don't select CBD as an industry during onboarding

##### Paystack

1. Set your country to South Africa in WooCommerce->Settings
2. Don't select CBD as an industry during onboarding
3. Complete the payment tasks
4. Make sure that `ZAR` is the site currency after configuration of Paystack and that "test mode" is turned off in settings

##### Stripe

1. Set your store country to a Stripe supported country (e.g., US - https://stripe.com/global )
2. Don't select CBD as an industry during onboarding
3. Make sure you're using a site with https
4. Attempt to use the oauth connection flow to enable the gateway, making sure you are returned to the site and connection is successful
5. Remove the connection and use a non-https site
6. Check that the manual settings configuration flow is shown

##### PayPal

1. Set your store country to any country except India
2. Don't select CBD as an industry during onboarding
3. Make sure the PayPal connection flow is shown and works as expected
4. In Chrome, open the console "Network" tab and right-click on the `get-params` request and select "Block request URL"
5. Refresh the page and note that the manual settings flow is shown

##### Klarna

1. Set your store country to one of the following: `SE, FI, NO`
2. Don't select CBD as an industry during onboarding

##### Mollie

1. Set your store country to one of the following: `FR, DE, GB, AT, CH, ES, IT, PL, FI, NL, BE`
2. Don't select CBD as an industry during onboarding

##### Mercado Pago

1. Set your store country to one of the following: `AR, BR, CL, CO, MX, PE, UY`
2. Make sure the help text is shown when setting up the gateway with links to registration and the settings screen.

### WooCommerce Payments

1. Set your store country to one of the following: `US, PR`
2. Don't select CBD as an industry during onboarding
3. Make sure the WC Pay card is shown above the other payment gateways
4. Attempt to install and configured the gateway

##### Cash on Delivery

1. Make sure "Enable" is shown and clicking this enables the gateway
2. Make sure the "Manage" button is shown after enabling the gateway

##### Direct bank transfer

1. Make sure "Set up" is shown next to the gateway
2. Enter some bank details
3. Make sure the gateway is marked as enabled and configured with the entered settings when visiting the legacy settings screen

##### RazorPay

1. Set your store country to India
2. Don't select CBD as an industry during onboarding

##### PayU

1. Set your store country to India
2. Don't select CBD as an industry during onboarding

##### eWAY

1. Set your store country to one of the following: `AU, NZ`
2. Don't select CBD as an industry during onboarding
3. Make sure the API key and password fields are shown

##### Square

1. Set your store country to the `US` and select CBD as an industy during onboarding OR set your store country to one of `US, CA, JP, GB, AU, IE`, don't select CBD as an industry and select that you have a physical store in the business details step.
2. Make sure the connection flow is shown.


## Changelog
 
```
- Add: Add a delete option to completed tasks #7300
- Add: Add unit tests around extended payment gateway controller #7133
- Add: Add payment gateway suggestion unit tests #7142
- Add: Add TableSummaryPlaceholder to support skeleton loading #7294
- Add: Feature toggle to disable Analytics UI #7168
- Add: Hook reference slotFill support #6833
- Add: Adding tests for PaymentGatewaySuggestions > List component #7201
- Add: Remote Inbox feature setting toggle #7298
- Dev: Add `woocommerce_admin_export_id` filter for customizing the export file name #7178
- Dev: Allow packages to be build independently, fix commonjs module builds. #7286
- Dev: Point the changelog linter to updated changelog entry location #7318
- Dev: Remove old payment gateway task components #7224
- Fix: Attribute filter bug with "any X" variations. #7046
- Fix: Currency display on Orders activity card on homescreen #7181
- Fix: Fix obsolete key property in gateway defaults #7229
- Fix: Fixing button state logic for remote payment gateways #7200
- Fix: Recommended gateway suggestions not displayed properly #7231
- Fix: Include onboarding settings on the analytic pages #7109
- Fix: Load Analytics API only when feature is turned on #7193
- Fix: Localize string for description #7219
- Fix: Filters: On update respect all other queries, not just persistedQueries #7155
- Fix: Use saved form values if available when switching tabs #7226
- Fix: Skip schedule customer data deletion on site deletion #7214
- Fix: WCPay not working in local payments task #7151
- Fix: Report export filtering bug. #7165
- Fix: Add padding on table header button #7213
- Fix: Use tab char for the CSV injection prevention. #7154
- Fix: Add height auto on autocomplete popover button #7225
- Fix: Make WooCommerce-admin full-screen minimum height 100vh important #7230
- Fix: Cache product/variation revenue query results. #7067
- Fix: Transient overlapping adjacent content. #7302
- Fix: Unused feature preloaded options #7299
- Fix: Fix missing translation strings for CES #7270
- Fix: Add missing translation strings in the business features section #7268
- Fix: Fix inbox note dismiss dropdown not closing on Safari #7278
- Fix: Fixed OBW - Business details style #7353
- Fix: Fix links on the dismiss dropdown are not clickable #7342
- Fix: Fix undefined method error when setting up WC Tax #7344
- Fix: Invalidate task status when enabling a payment gateway #7330
- Fix: Redirect to homescreen after payment gateway setup #7332
- Fix: Create workable defaults for Reports that don’t have AdvancedFilters #7186
- Fix: Set default value for performanceIndicators variable #7343
- Sync the category lookup table when a new category gets created #7290
- Tweak: Remove performance indicators when Analytics Flag disabled #7234
- Tweak: Change event name when installing Google Listings and Ads. #7276
- Tweak: Removed unused feature flags #7233 and #7273
- Tweak: Render a spinner while woocommerce_setup_jetpack_opted_in is being loaded #7269
- Tweak: Repurpose disable wc-admin filter to remove optional features #7232
- Update: Notes to use a date range. #7222
- Update: Remove facebook extension from onboarding extensions fallback list #7287
- Performance: Add cache-control header to low stock REST API response #7364
- Performance: Add lazy loading by checking panel open status #7379
```

_Note:_ This PR also includes a few fixes to the PHP unit tests that were failing due to changes in the payment gateway APIs. These tests are still very brittle and should be revisited. 