### PR TITLE
Bump woocommerce-admin version to 2.4.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.1",
-    "woocommerce/woocommerce-admin": "2.4.2",
+    "woocommerce/woocommerce-admin": "2.4.4",
     "woocommerce/woocommerce-blocks": "5.3.3"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.1",
-    "woocommerce/woocommerce-admin": "2.4.1",
+    "woocommerce/woocommerce-admin": "2.4.2",
     "woocommerce/woocommerce-blocks": "5.3.3"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8f2a03a347223bab52344daea771c464",
+    "content-hash": "c37c34d0d4c57307330b5d0d08bde1f7",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -532,16 +532,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.4.1",
+            "version": "2.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "dd446c2549c763a946bcd3a4deeeca1eb0f2b78f"
+                "reference": "dcf8dedaa0a5bfb9c08ffa0743eb8f4ee4bf1e5e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/dd446c2549c763a946bcd3a4deeeca1eb0f2b78f",
-                "reference": "dd446c2549c763a946bcd3a4deeeca1eb0f2b78f",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/dcf8dedaa0a5bfb9c08ffa0743eb8f4ee4bf1e5e",
+                "reference": "dcf8dedaa0a5bfb9c08ffa0743eb8f4ee4bf1e5e",
                 "shasum": ""
             },
             "require": {
@@ -578,9 +578,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.4.1"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.4.2"
             },
-            "time": "2021-07-01T06:10:01+00:00"
+            "time": "2021-07-19T08:22:14+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c37c34d0d4c57307330b5d0d08bde1f7",
+    "content-hash": "ed5e46446f7de86c068d881aa43b4c70",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -532,16 +532,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.4.2",
+            "version": "2.4.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "dcf8dedaa0a5bfb9c08ffa0743eb8f4ee4bf1e5e"
+                "reference": "fba09c51a08629b801a6667e6479794d8a919228"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/dcf8dedaa0a5bfb9c08ffa0743eb8f4ee4bf1e5e",
-                "reference": "dcf8dedaa0a5bfb9c08ffa0743eb8f4ee4bf1e5e",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/fba09c51a08629b801a6667e6479794d8a919228",
+                "reference": "fba09c51a08629b801a6667e6479794d8a919228",
                 "shasum": ""
             },
             "require": {
@@ -578,9 +578,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.4.2"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.4.4"
             },
-            "time": "2021-07-19T08:22:14+00:00"
+            "time": "2021-07-21T03:52:24+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
This PR Bumps WooCommerce Admin from 2.4.1 to 2.4.4, addressing performance issues in https://github.com/woocommerce/woocommerce-admin/issues/7358

### Changelog

```
2.4.4 7/21/2021

Fix: Fix homepage stock panel regression in 2.4.3. #7389

2.4.3 7/21/2021

Fix: Add a new low stock products endpoint to improve the performance. #7377

2.4.2 7/19/2021

Fix: Add lazy loading by checking panel open status #7376
Fix: Add cache-control header to low stock REST API response #7364
```

### Testing Instructions

To test the performance improvements, it is recommended using a site with at least 1000 products.

- Adjust the store to create many products with low stock levels.
- Open the browser console and filter network requests by `low`. 

<img width="1040" alt="Screen Shot 2021-07-21 at 2 16 42 pm" src="https://user-images.githubusercontent.com/9312929/126440517-2aaffada-34eb-4195-ad03-e6fbbd604690.png">

- See that these requests consistently return a 200 response when performing the following tasks:

1. Loading the home screen and using the "Stock" panel, including updating the stock level for some products.

<img width="534" alt="Screen Shot 2021-07-21 at 7 15 08 am" src="https://user-images.githubusercontent.com/9312929/126439967-0c50f55e-53c9-4042-90f9-7ca13c2134b5.png">

2. Opening the Inbox side panel from screens such as Orders.

![](https://user-images.githubusercontent.com/4723145/126049242-c6a212cb-48e4-4ebe-ad29-cccfcb134869.jpg)

Please also see the general [2.4 release instructions on the wiki.](https://github.com/woocommerce/woocommerce-admin/wiki/Release-Testing-Instructions-WooCommerce-Admin-2.4.0)