### PR TITLE
Specify the `$object_type` property for the `WC_Customer` class

### DIFF
--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -79,6 +79,14 @@ class WC_Customer extends WC_Legacy_Customer {
 	protected $calculated_shipping = false;
 
 	/**
+	 * This is the name of this object type.
+	 *
+	 * @since 5.6.0
+	 * @var string
+	 */
+	protected $object_type = 'customer';
+
+	/**
 	 * Load customer data based on how WC_Customer is called.
 	 *
 	 * If $customer is 'new', you can build a new WC_Customer object. If it's empty, some

--- a/includes/class-wc-customer.php
+++ b/includes/class-wc-customer.php
@@ -127,16 +127,6 @@ class WC_Customer extends WC_Legacy_Customer {
 	}
 
 	/**
-	 * Prefix for action and filter hooks on data.
-	 *
-	 * @since  3.0.0
-	 * @return string
-	 */
-	protected function get_hook_prefix() {
-		return 'woocommerce_customer_get_';
-	}
-
-	/**
 	 * Delete a customer and reassign posts..
 	 *
 	 * @param int $reassign Reassign posts and links to new User ID.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

### Changes proposed in this Pull Request:

This PR sets the `$object_type` property for the `WC_Customer` class to `customer`. This property is essentially a required property for classes that inherit the `WC_Data` class.

The `WC_Data` class uses this property in 3 locations:
- Action: `woocommerce_before_{$this->object_type}_object_save`
- Action: `woocommerce_after_{$this->object_type}_object_save`
- Method: `WC_Data::get_hook_prefix()`

My motivation for this change is to be able to hook into the `woocommerce_before_customer_object_save` action.

Closes #30272.

### Todo:
- [ ] Update `@since` tag if required

### How to test the changes in this Pull Request:

Changes do not affect UI in any way.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Set 'WC_Customer::$object_type' to 'customer'
