### PR TITLE
Fix enable update cart button on some more events

### DIFF
--- a/assets/js/frontend/cart.js
+++ b/assets/js/frontend/cart.js
@@ -326,7 +326,15 @@ jQuery( function( $ ) {
 				'change input',
 				'.woocommerce-cart-form .cart_item :input',
 				this.input_changed );
-
+			$( document ).on(
+				'change',
+				'.woocommerce-cart-form .cart_item input',
+				this.input_changed );
+			$( document ).on(
+				'click',
+				'.woocommerce-cart-form .quantity button',
+				this.input_changed );
+			
 			$( '.woocommerce-cart-form :input[name="update_cart"]' ).prop( 'disabled', true ).attr( 'aria-disabled', true );
 		},
 


### PR DESCRIPTION
On a cart we use, the quantity buttons do not enable the update cart button.
So this fix, erased by all woocommerce update, can resolve it.
It can be add to the master.