### PR TITLE
Added wait for selector in search

### DIFF
--- a/tests/e2e/utils/src/flows/shopper.js
+++ b/tests/e2e/utils/src/flows/shopper.js
@@ -167,7 +167,7 @@ const shopper = {
 	},
 
 	searchForProduct: async ( prouductName ) => {
-		const searchFieldSelector = 'input.search-field';
+		const searchFieldSelector = 'input.wp-block-search__input';
 		await page.waitForSelector(searchFieldSelector, { timeout: 100000 });
 		await expect(page).toFill(searchFieldSelector, prouductName);
 		await expect(page).toClick('.search-submit');

--- a/tests/e2e/utils/src/flows/shopper.js
+++ b/tests/e2e/utils/src/flows/shopper.js
@@ -167,8 +167,9 @@ const shopper = {
 	},
 
 	searchForProduct: async ( prouductName ) => {
-		await page.waitForSelector('.search-field', { timeout: 100000 });
-		await expect(page).toFill('.search-field', prouductName);
+		const searchFieldSelector = 'input.search-field';
+		await page.waitForSelector(searchFieldSelector, { timeout: 100000 });
+		await expect(page).toFill(searchFieldSelector, prouductName);
 		await expect(page).toClick('.search-submit');
 		await page.waitForSelector('h2.entry-title');
 		await expect(page).toMatchElement('h2.entry-title', {text: prouductName});

--- a/tests/e2e/utils/src/flows/shopper.js
+++ b/tests/e2e/utils/src/flows/shopper.js
@@ -167,6 +167,7 @@ const shopper = {
 	},
 
 	searchForProduct: async ( prouductName ) => {
+		await page.waitForSelector('.search-field');
 		await expect(page).toFill('.search-field', prouductName);
 		await expect(page).toClick('.search-submit');
 		await page.waitForSelector('h2.entry-title');

--- a/tests/e2e/utils/src/flows/shopper.js
+++ b/tests/e2e/utils/src/flows/shopper.js
@@ -170,7 +170,7 @@ const shopper = {
 		const searchFieldSelector = 'input.wp-block-search__input';
 		await page.waitForSelector(searchFieldSelector, { timeout: 100000 });
 		await expect(page).toFill(searchFieldSelector, prouductName);
-		await expect(page).toClick('.search-submit');
+		await expect(page).toClick('.wp-block-search__button');
 		await page.waitForSelector('h2.entry-title');
 		await expect(page).toMatchElement('h2.entry-title', {text: prouductName});
 		await expect(page).toClick('h2.entry-title', {text: prouductName});

--- a/tests/e2e/utils/src/flows/shopper.js
+++ b/tests/e2e/utils/src/flows/shopper.js
@@ -167,7 +167,7 @@ const shopper = {
 	},
 
 	searchForProduct: async ( prouductName ) => {
-		await page.waitForSelector('.search-field');
+		await page.waitForSelector('.search-field', { timeout: 100000 });
 		await expect(page).toFill('.search-field', prouductName);
 		await expect(page).toClick('.search-submit');
 		await page.waitForSelector('h2.entry-title');


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR proposes adding in a wait for selector in the `shopper.searchForProduct()` flow as we've been seeing sporadic failures in recent PRs with this.

### How to test the changes in this Pull Request:

1. Verify the CI passes
2. Run the e2e tests locally and verify they pass