### PR TITLE
Remove unnecessary search related 'where' in handling of 'posts_clauses'

### DIFF
--- a/includes/class-wc-query.php
+++ b/includes/class-wc-query.php
@@ -529,11 +529,6 @@ class WC_Query {
 		$args = $this->price_filter_post_clauses( $args, $wp_query );
 		$args = $this->filterer->filter_by_attribute_post_clauses( $args, $wp_query, $this->get_layered_nav_chosen_attributes() );
 
-		$search = $this->get_main_search_query_sql();
-		if ( $search ) {
-			$args['where'] .= ' AND ' . $search;
-		}
-
 		return $args;
 	}
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

https://github.com/woocommerce/woocommerce/pull/29896 added extra handling in response to the `post_clauses` hook in order to use the new product attributes lookup table. However it also added a new 'where' clause based on the value returned by
`get_main_search_query_sql`, which turns out is not needed and causes problems with some themes. This PR removes that extra `where`.

Closes #30298.

### How to test the changes in this Pull Request:

Follow the testing instructions in https://github.com/woocommerce/woocommerce/pull/29896 but adding to the mix a search box and `&post_type=product` as described in https://github.com/woocommerce/woocommerce/issues/30298. Also test with the mentioned theme builders (Divi and Woodmart) if possible.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - remove unnecessary search related 'where' clause added in the 'post_clauses' hook handling
