### PR TITLE
Fix attributes lookup table creation and usage option name

### DIFF
--- a/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -368,17 +368,17 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 	}
 
 	/**
-	 * Check if everything is good to go to perform a per product lookup table data regeneration
+	 * Check if everything is good to go to perform a complete or per product lookup table data regeneration
 	 * and throw an exception if not.
 	 *
-	 * @param mixed $product_id The product id to check the regeneration viability for, or null to skip product check.
+	 * @param mixed $product_id The product id to check the regeneration viability for, or null to check if a complete regeneration is possible.
 	 * @throws \Exception Something prevents the regeneration from starting.
 	 */
 	private function check_can_do_lookup_table_regeneration( $product_id = null ) {
 		if ( ! $this->data_store->is_feature_visible() ) {
 			throw new \Exception( "Can't do product attribute lookup data regeneration: feature is not visible" );
 		}
-		if ( ! $this->data_store->check_lookup_table_exists() ) {
+		if ( $product_id && ! $this->data_store->check_lookup_table_exists() ) {
 			throw new \Exception( "Can't do product attribute lookup data regeneration: lookup table doesn't exist" );
 		}
 		if ( $this->data_store->regeneration_is_in_progress() ) {

--- a/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -95,7 +95,7 @@ class LookupDataStore {
 						$settings[] = array(
 							'title'         => __( 'Enable table usage', 'woocommerce' ),
 							'desc'          => __( 'Use the product attributes lookup table for catalog filtering.', 'woocommerce' ),
-							'id'            => 'woocommerce_attribute_lookup__enable',
+							'id'            => 'woocommerce_attribute_lookup__enabled',
 							'default'       => 'no',
 							'type'          => 'checkbox',
 							'checkboxgroup' => 'start',


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Fix two bugs related to the product attributes lookup table:

1. The `DataRegenerator::check_can_do_lookup_table_regeneration` method  was incorrectly throwing a "lookup table doesn't exist" exception when invoked with no product id (this method will always be called without method id in order to create the table, and by then the table will not exist).

2. The _Products - Advanced_ settings page was using the wrong option name to enable the feature.

Context for the product attributes lookup table feature development: https://github.com/woocommerce/woocommerce/pull/29778, https://github.com/woocommerce/woocommerce/pull/29896, https://github.com/woocommerce/woocommerce/pull/30041

### How to test the changes in this Pull Request:

To test the table creation:

1. Add the following snippet somewhere (e.g. at the end of `woocommerce.php`) to enable the feature:

```php
wc_get_container()
->get(\Automattic\WooCommerce\Internal\ProductAttributesLookup\LookupDataStore::class)
->show_feature();
```

2. Go to the _WooCommerce - Status - Tools_ page. If you have been testing the pull requests that implement the feature the lookup table migh exist in your database, if so you'll see a _"Delete the product attributes lookup table"_ tool. Run it if that's the case.

3. Now run the _"Create and fill product attributes lookup table"_ tool. Without this fix you'll get an error message stating that the lookup table doesn't exist. With this fix the table regeneration process will have started as described in https://github.com/woocommerce/woocommerce/pull/29778.

To test the feature enable option (prerequisite: the lookup table exists and has finished filling)

1. Go to _WooCommerce - Settings - Products - Advanced_.

2. Check the "Enable table usage" option and save changes.

3. Go to the tools page and run the _"Regenerate the product attributes lookup table"_ tool (leave the product selector empty). Wait for the process to finish (you can remove the `&action=regenerate_product_attributes_lookup_table` part from the URL and reload the tools page until the tool button is enabled again).

4. Go back to _WooCommerce - Settings - Products - Advanced_. Without the fix, the "Enable table usage" is still checked. With the fix, it's unchecked (table regeneration disables the table usage by design).

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Can't create product attributes lookup table from the tools page.
> Fix - Wrong option name in the "Enable table usage" option in Settings - Products - Advanced.
