### PR TITLE
package lock maintenance

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "woocommerce",
-  "version": "5.6.0",
+  "version": "5.7.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This is the package lock maintenance for #30344.

### Testing

1- `npm i` should complete successfully in a clone where npm packages had been installed previously.