### PR TITLE
Bump version to the next

### DIFF
--- a/i18n/currency-info.php
+++ b/i18n/currency-info.php
@@ -3,7 +3,7 @@
  * Currency formatting information
  *
  * @package WooCommerce\i18n
- * @version 5.6.0
+ * @version 5.7.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/i18n/locale-info.php
+++ b/i18n/locale-info.php
@@ -3,7 +3,7 @@
  * Locales information
  *
  * @package WooCommerce\i18n
- * @version 5.6.0
+ * @version 5.7.0
  */
 
 defined( 'ABSPATH' ) || exit;


### PR DESCRIPTION
So in this PR https://github.com/woocommerce/woocommerce/pull/30216 which I reviewed, I commented to bump the version to `5.6.0`. However I totally forgot we are passed code freeze already and this would be included in `5.7.0`. So this PR just updates the versions.