### PR TITLE
Added shipping classes cleanup to retest flow

### DIFF
--- a/tests/e2e/core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
+++ b/tests/e2e/core-tests/specs/activate-and-setup/onboarding-tasklist.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests */
-
 /**
  * Internal dependencies
  */
@@ -37,6 +35,10 @@ const runOnboardingFlowTest = () => {
 				await withRestApi.deleteAllShippingZones();
 			});
 
+			it('can reset shipping classes', async () => {
+				await withRestApi.deleteAllShippingClasses();
+			})
+
 			it('can reset to default settings', async () => {
 				await withRestApi.resetSettingsGroupToDefault('general');
 				await withRestApi.resetSettingsGroupToDefault('products');
@@ -55,7 +57,7 @@ const runTaskListTest = () => {
 		beforeAll(async () => {
 			await merchant.login();
 		});
-		
+
 		it('can setup shipping', async () => {
 			await page.evaluate(() => {
 				document.querySelector('.woocommerce-list__item-title').scrollIntoView();

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `describeIf()` to conditionally run a test suite
 - Added `itIf()` to conditionally run a test case.
 - Added merchant workflows around plugins: `uploadAndActivatePlugin()`, `activatePlugin()`, `deactivatePlugin()`, `deletePlugin()`
+- Added `deleteAllShippingClasses()` which permanently deletes all shipping classes using the API
 
 # 0.1.5
 

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -143,6 +143,7 @@ This package provides support for enabling retries in tests:
 | `deleteAllCoupons` | | Permanently delete all coupons |
 | `deleteAllProducts` | | Permanently delete all products |
 | `deleteAllShippingZones` | | Permanently delete all shipping zones except the default |
+| `deleteAllShippingClasses` | Permanently delete all shipping classes |
 | `deleteCustomerByEmail` | `emailAddress` | Delete customer user account. Posts are reassigned to user ID 1 |
 | `resetSettingsGroupToDefault` | `settingsGroup` | Reset settings in settings group to default except `select` fields |
 

--- a/tests/e2e/utils/src/flows/with-rest-api.js
+++ b/tests/e2e/utils/src/flows/with-rest-api.js
@@ -4,6 +4,7 @@ import {Coupon, Setting, SimpleProduct} from '@woocommerce/api';
 const client = factories.api.withDefaultPermalinks;
 const onboardingProfileEndpoint = '/wc-admin/onboarding/profile';
 const shippingZoneEndpoint = '/wc/v3/shipping/zones';
+const shippingClassesEndpoint = '/wc/v3/products/shipping_classes';
 const userEndpoint = '/wp/v2/users';
 
 /**
@@ -95,6 +96,20 @@ export const withRestApi = {
 					continue;
 				}
 				const response = await client.delete( shippingZoneEndpoint + `/${shippingZones.data[z].id}?force=true` );
+				expect( response.statusCode ).toBe( 200 );
+			}
+		}
+	},
+	/**
+	 * Use api package to delete shipping classes.
+	 *
+	 * @return {Promise} Promise resolving once shipping classes have been deleted.
+	 */
+	deleteAllShippingClasses: async () => {
+		const shippingClasses = await client.get( shippingClassesEndpoint );
+		if ( shippingClasses.data && shippingClasses.data.length ) {
+			for ( let c = 0; c < shippingClasses.data.length; c++ ) {
+				const response = await client.delete( shippingClassesEndpoint + `/${shippingClasses.data[c].id}?force=true` );
 				expect( response.statusCode ).toBe( 200 );
 			}
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces a cleanup step for shipping classes created in the tests when in retest mode. To do the cleanup, the function makes use of the REST API.

Please note this also removes the lints in the test file, specifically these, as the linter is currently unable able to find those definitions:

```javascript
/* eslint-disable jest/no-export, jest/no-disabled-tests */
```

Closes https://github.com/woocommerce/woocommerce/issues/29813

### How to test the changes in this Pull Request:

1. Make sure the CI passes.
2. Run the e2e tests and make sure they pass.
3. Run the e2e tests in retest mode using `E2E_RETEST=1 npx wc-e2e test:e2e` and verify the shipping classes from the previous test run under WooCommerce > Settings > Shipping > Shipping classes have been removed.