### PR TITLE
Add error logging to the GitHub action for assigning a milestone to merged pull requests

### DIFF
--- a/.github/workflows/scripts/assign-milestone-to-merged-pr.php
+++ b/.github/workflows/scripts/assign-milestone-to-merged-pr.php
@@ -99,7 +99,7 @@ if ( getenv( 'DRY_RUN' ) ) {
  * Assign the milestone to the pull request.
  */
 
-echo "Assigning the milestone to the pull request...\n";
+echo 'Assigning the milestone to the pull request... ';
 
 $milestone_id = $chosen_milestone['id'];
 $mutation     = "
@@ -108,14 +108,25 @@ $mutation     = "
   }
 ";
 
-do_graphql_api_request( $mutation, true );
+$result = do_graphql_api_request( $mutation, true );
+if ( is_array( $result ) ) {
+	if ( empty( $result['errors'] ) ) {
+		echo "Ok!\n";
+	} else {
+		echo "\n*** Errors found while assigning the milestone:\n";
+		echo var_dump( $result['errors'] );
+	}
+} else {
+	echo "\n*** Error found while assigning the milestone: file_get_contents returned the following:\n";
+	echo var_dump( $result );
+}
 
 /**
  * Function to query the GitHub GraphQL API.
  *
  * @param string $body The GraphQL-formatted request body, without "query" or "mutation" wrapper.
  * @param bool   $is_mutation True if the request is a mutation, false if it's a query.
- * @return array The json-decoded response.
+ * @return mixed The json-decoded response if a response is received, 'false' (or whatever file_get_contents returns) otherwise.
  */
 function do_graphql_api_request( $body, $is_mutation = false ) {
 	global $github_token, $graphql_api_url;
@@ -138,7 +149,7 @@ function do_graphql_api_request( $body, $is_mutation = false ) {
 	);
 
 	$result = file_get_contents( $graphql_api_url, false, $context );
-	return json_decode( $result, true );
+	return is_string( $result ) ? json_decode( $result, true ) : $result;
 }
 
 // phpcs:enable WordPress.Security.EscapeOutput.OutputNotEscaped, WordPress.WP.AlternativeFunctions


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

[The GitHub action for automatic assignment of a milestone to a merged pull request](https://github.com/woocommerce/woocommerce/pull/29699) isn't working for pull requests coming from a fork of the WooCommerce repository. Looking at the checks for one of these pull requests ([example](https://github.com/woocommerce/woocommerce/runs/3076907999?check_suite_focus=true)) we see that the action runs and the API call for assigning the milestone is executed, but for some reason it doesn't work. Unfortunately the result of that API call isn't currently logged.

This pull request adds a console trace of the result of the milestone assignment API call when it returns an error, so that we can diagnose the problem.

### How to test the changes in this Pull Request:

1. Fork the WooCommerce repository, let's say the fork is _woo-a_.
2. Incorporate the changes from this pull request into _woo-a_.
3. Fork _woo-a_, let's say that second fork is _woo-b_.
4. Create a pull request from _woo-b_ targetting _woo-a_.
5. Merge the pull request and look at the trace of the "Assign milestone to merged pull request" job in the "Pull request post-merge processing" action.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Add - Error trace to the API call for automatic milestone assignment of merged pull requests.
