### PR TITLE
Update html-order-items.php to see all Tax Rates

### DIFF
--- a/includes/admin/meta-boxes/views/html-order-items.php
+++ b/includes/admin/meta-boxes/views/html-order-items.php
@@ -444,7 +444,7 @@ if ( wc_tax_enabled() ) {
 								</tr>
 							</thead>
 						<?php
-						$rates = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates ORDER BY tax_rate_name LIMIT 100" );
+						$rates = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates ORDER BY tax_rate_name LIMIT 2500" );
 						foreach ( $rates as $rate ) {
 							echo '
 									<tr>


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30172

### Solution:
![image](https://user-images.githubusercontent.com/11654917/126909719-3d30d435-08ac-449e-ba9b-d94d40805048.png)
[Download my tax_rates spreadsheet with 237 values (Source: Google Sheets)](https://docs.google.com/spreadsheets/d/e/2PACX-1vQscHZY94JyihvrMfH7kvP0neDIEA6CNNU5uyjX5XfwgnPVBEUdM-obducZxLR0iW7UPtL37az9EWt8/pub?gid=974681230&single=true&output=csv)

- **Edit** `woocommerce/includes/admin/meta-boxes/views/html-order-items.php` line 447. LIMIT is set to 100, increase the rate. 
- **Issue**: When trying to fix this, I originally tried setting NO LIMIT, but it doesn't work; once you set it, and try to add tax to an order it doesn't display any values.

_447_
- **Edit** `LIMIT` set at `100` to `2500`
```
<?php
$rates = $wpdb->get_results( "SELECT * FROM {$wpdb->prefix}woocommerce_tax_rates ORDER BY tax_rate_name LIMIT 2500" );
foreach ( $rates as $rate ) {
```
After change opened the orders again, made a new order and saw all the tax rates I've imported. Below image is a comparison of the rows originally before the fix, and after.
![image](https://user-images.githubusercontent.com/11654917/126909472-93dd4f51-53d6-41e4-8e49-a1cde5f31daf.png)

-------------

**Feedback Needed**: Is it a better solution to set the limit to something really high, add pagination to sort next and previous rows, or can we pull the number of rows we've imported/currently we have a tax for, then replace the hard coded values here with that variable?

-------------

### How to test the changes in this Pull Request:

1. Import a tax data file in CSV with more than 100 tax rates [Download my tax_rates spreadsheet with 237 values (Source: Google Sheets)](https://docs.google.com/spreadsheets/d/e/2PACX-1vQscHZY94JyihvrMfH7kvP0neDIEA6CNNU5uyjX5XfwgnPVBEUdM-obducZxLR0iW7UPtL37az9EWt8/pub?gid=974681230&single=true&output=csv)
2. Create a manual order on the backend
3. Add items and then add a tax, a popup will appear

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Update html-order-items.php to see all Tax Rates
