### PR TITLE
Revert the use of prop here as we want to remove the attribute comple…

### DIFF
--- a/assets/js/admin/quick-edit.js
+++ b/assets/js/admin/quick-edit.js
@@ -57,7 +57,7 @@ jQuery(
 					'select[name="_visibility"] option, ' +
 					'select[name="_stock_status"] option, ' +
 					'select[name="_backorders"] option'
-				).removeAttr( 'selected' );
+				).prop( 'selected', false ).removeAttr( 'selected' );
 
 				var is_variable_product = 'variable' === product_type;
 				$( 'select[name="_stock_status"] ~ .wc-quick-edit-warning', '.inline-edit-row' ).toggle( is_variable_product );

--- a/assets/js/admin/quick-edit.js
+++ b/assets/js/admin/quick-edit.js
@@ -57,7 +57,7 @@ jQuery(
 					'select[name="_visibility"] option, ' +
 					'select[name="_stock_status"] option, ' +
 					'select[name="_backorders"] option'
-				).prop( 'selected', false );
+				).removeAttr( 'selected' );
 
 				var is_variable_product = 'variable' === product_type;
 				$( 'select[name="_stock_status"] ~ .wc-quick-edit-warning', '.inline-edit-row' ).toggle( is_variable_product );


### PR DESCRIPTION
…tely closes #30282

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30282

In the jQuery migration efforts, we used `prop` to set `selected` to be false which caused an issue with the UI. So just reverting it back to `removeAttr`. Nothing needs to be done here as far as jQuery 3 migration.

### How to test the changes in this Pull Request:

1. With this PR, go to products page.
2. Click on quick edit on one of the products and choose visibility hidden and update.
3. Click on quick edit on any different product and make sure visibility is not stuck on hidden. They should show as was saved.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Products quick edit was not showing the correct value for visibility setting.
