### PR TITLE
Fix: automatic milestoning GitHub action not working with PRs coming from forks

### DIFF
--- a/.github/workflows/pull-request-post-merge-processing.yml
+++ b/.github/workflows/pull-request-post-merge-processing.yml
@@ -1,6 +1,6 @@
 name: "Pull request post-merge processing"
-on: 
-  pull_request:
+on:
+  pull_request_target:
     types: [closed]
 
 jobs:

--- a/.github/workflows/scripts/assign-milestone-to-merged-pr.php
+++ b/.github/workflows/scripts/assign-milestone-to-merged-pr.php
@@ -85,6 +85,7 @@ foreach ( $milestones as $milestone ) {
 
 // If all the milestones have a release branch, just take the newest one.
 if ( is_null( $chosen_milestone ) ) {
+	echo "WARNING: No milestone without release branch found, the newest one will be assigned.\n";
 	$chosen_milestone = $milestones[0];
 }
 


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The original GitHub event used, `pull_request`, runs in the context of the pull request branch. In the case of pull requests created from forks this means that a read-only GitHub token is used for API calls, and thus the call used to assign the milestone fails.

The fix is using the `pull_request_target` event, which runs in the context of the base branch, and thus with a read-write token. See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows#pull_request_target

Also, added a warning message when no milestone without a release branch is found and thus the newest existing milestone is assigned (this is a fallback that should normally not happen).

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - automatic milestoning GitHub action not working with PRs coming from forks.
