### PR TITLE
Fix option names used by the product attributes lookup table feature

### DIFF
--- a/src/Internal/ProductAttributesLookup/DataRegenerator.php
+++ b/src/Internal/ProductAttributesLookup/DataRegenerator.php
@@ -20,7 +20,7 @@ defined( 'ABSPATH' ) || exit;
  * are supposed to be created/updated by the appropriate data store classes (or by the code that uses
  * the data store classes) whenever a product is created/updated.
  *
- * Additionally, after the regeneration is completed a 'woocommerce_attribute_lookup__enabled' option
+ * Additionally, after the regeneration is completed a 'woocommerce_attribute_lookup_enabled' option
  * with a value of 'no' will have been created.
  *
  * This class also adds two entries to the Status - Tools menu: one for manually regenerating the table contents,
@@ -115,9 +115,9 @@ class DataRegenerator {
 	public function delete_all_attributes_lookup_data() {
 		global $wpdb;
 
-		delete_option( 'woocommerce_attribute_lookup__enabled' );
-		delete_option( 'woocommerce_attribute_lookup__last_product_id_to_process' );
-		delete_option( 'woocommerce_attribute_lookup__last_products_page_processed' );
+		delete_option( 'woocommerce_attribute_lookup_enabled' );
+		delete_option( 'woocommerce_attribute_lookup_last_product_id_to_process' );
+		delete_option( 'woocommerce_attribute_lookup_last_products_page_processed' );
 		$this->data_store->unset_regeneration_in_progress_flag();
 
 		// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared
@@ -166,8 +166,8 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 		}
 
 		$this->data_store->set_regeneration_in_progress_flag();
-		update_option( 'woocommerce_attribute_lookup__last_product_id_to_process', current( $last_existing_product_id ) );
-		update_option( 'woocommerce_attribute_lookup__last_products_page_processed', 0 );
+		update_option( 'woocommerce_attribute_lookup_last_product_id_to_process', current( $last_existing_product_id ) );
+		update_option( 'woocommerce_attribute_lookup_last_products_page_processed', 0 );
 
 		return true;
 	}
@@ -209,7 +209,7 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 	 * @return bool True if more steps need to be run, false otherwise.
 	 */
 	private function do_regeneration_step() {
-		$last_products_page_processed = get_option( 'woocommerce_attribute_lookup__last_products_page_processed' );
+		$last_products_page_processed = get_option( 'woocommerce_attribute_lookup_last_products_page_processed' );
 		$current_products_page        = (int) $last_products_page_processed + 1;
 
 		$product_ids = WC()->call_function(
@@ -232,9 +232,9 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 			$this->data_store->create_data_for_product( $id );
 		}
 
-		update_option( 'woocommerce_attribute_lookup__last_products_page_processed', $current_products_page );
+		update_option( 'woocommerce_attribute_lookup_last_products_page_processed', $current_products_page );
 
-		$last_product_id_to_process = get_option( 'woocommerce_attribute_lookup__last_product_id_to_process' );
+		$last_product_id_to_process = get_option( 'woocommerce_attribute_lookup_last_product_id_to_process' );
 		return end( $product_ids ) < $last_product_id_to_process;
 	}
 
@@ -242,9 +242,9 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 	 * Cleanup/final option setup after the regeneration has been completed.
 	 */
 	private function finalize_regeneration() {
-		delete_option( 'woocommerce_attribute_lookup__last_product_id_to_process' );
-		delete_option( 'woocommerce_attribute_lookup__last_products_page_processed' );
-		update_option( 'woocommerce_attribute_lookup__enabled', 'no' );
+		delete_option( 'woocommerce_attribute_lookup_last_product_id_to_process' );
+		delete_option( 'woocommerce_attribute_lookup_last_products_page_processed' );
+		update_option( 'woocommerce_attribute_lookup_enabled', 'no' );
 		$this->data_store->unset_regeneration_in_progress_flag();
 	}
 
@@ -300,7 +300,7 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 			$entry['button'] = sprintf(
 				/* translators: %d: How many products have been processed so far. */
 				__( 'Filling in progress (%d)', 'woocommerce' ),
-				get_option( 'woocommerce_attribute_lookup__last_products_page_processed', 0 ) * self::PRODUCTS_PER_GENERATION_STEP
+				get_option( 'woocommerce_attribute_lookup_last_products_page_processed', 0 ) * self::PRODUCTS_PER_GENERATION_STEP
 			);
 			$entry['disabled'] = true;
 		} else {
@@ -364,7 +364,7 @@ CREATE TABLE ' . $this->lookup_table_name . '(
 			throw new \Exception( "Can't enable or disable the attributes lookup table usage while it's regenerating." );
 		}
 
-		update_option( 'woocommerce_attribute_lookup__enabled', $enable ? 'yes' : 'no' );
+		update_option( 'woocommerce_attribute_lookup_enabled', $enable ? 'yes' : 'no' );
 	}
 
 	/**

--- a/src/Internal/ProductAttributesLookup/Filterer.php
+++ b/src/Internal/ProductAttributesLookup/Filterer.php
@@ -44,7 +44,7 @@ class Filterer {
 	 * @return bool
 	 */
 	public function filtering_via_lookup_table_is_active() {
-		return 'yes' === get_option( 'woocommerce_attribute_lookup__enabled' );
+		return 'yes' === get_option( 'woocommerce_attribute_lookup_enabled' );
 	}
 
 	/**

--- a/src/Internal/ProductAttributesLookup/LookupDataStore.php
+++ b/src/Internal/ProductAttributesLookup/LookupDataStore.php
@@ -95,7 +95,7 @@ class LookupDataStore {
 						$settings[] = array(
 							'title'         => __( 'Enable table usage', 'woocommerce' ),
 							'desc'          => __( 'Use the product attributes lookup table for catalog filtering.', 'woocommerce' ),
-							'id'            => 'woocommerce_attribute_lookup__enabled',
+							'id'            => 'woocommerce_attribute_lookup_enabled',
 							'default'       => 'no',
 							'type'          => 'checkbox',
 							'checkboxgroup' => 'start',
@@ -104,7 +104,7 @@ class LookupDataStore {
 						$settings[] = array(
 							'title'         => __( 'Direct updates', 'woocommerce' ),
 							'desc'          => __( 'Update the table directly upon product changes, instead of scheduling a deferred update.', 'woocommerce' ),
-							'id'            => 'woocommerce_attribute_lookup__direct_updates',
+							'id'            => 'woocommerce_attribute_lookup_direct_updates',
 							'default'       => 'no',
 							'type'          => 'checkbox',
 							'checkboxgroup' => 'start',
@@ -201,14 +201,14 @@ AND table_name = %s;',
 	 * Schedule an update of the product attributes lookup table for a given product.
 	 * If an update for the same action is already scheduled, nothing is done.
 	 *
-	 * If the 'woocommerce_attribute_lookup__direct_update' option is set to 'yes',
+	 * If the 'woocommerce_attribute_lookup_direct_update' option is set to 'yes',
 	 * the update is done directly, without scheduling.
 	 *
 	 * @param int $product_id The product id to schedule the update for.
 	 * @param int $action The action to perform, one of the ACTION_ constants.
 	 */
 	private function maybe_schedule_update( int $product_id, int $action ) {
-		if ( 'yes' === get_option( 'woocommerce_attribute_lookup__direct_updates' ) ) {
+		if ( 'yes' === get_option( 'woocommerce_attribute_lookup_direct_updates' ) ) {
 			$this->run_update_callback( $product_id, $action );
 			return;
 		}
@@ -669,20 +669,20 @@ AND table_name = %s;',
 	 * @return bool True if a lookup table regeneration is already in progress.
 	 */
 	public function regeneration_is_in_progress() {
-		return 'yes' === get_option( 'woocommerce_attribute_lookup__regeneration_in_progress', null );
+		return 'yes' === get_option( 'woocommerce_attribute_lookup_regeneration_in_progress', null );
 	}
 
 	/**
 	 * Set a permanent flag (via option) indicating that the lookup table regeneration is in process.
 	 */
 	public function set_regeneration_in_progress_flag() {
-		update_option( 'woocommerce_attribute_lookup__regeneration_in_progress', 'yes' );
+		update_option( 'woocommerce_attribute_lookup_regeneration_in_progress', 'yes' );
 	}
 
 	/**
 	 * Remove the flag indicating that the lookup table regeneration is in process.
 	 */
 	public function unset_regeneration_in_progress_flag() {
-		delete_option( 'woocommerce_attribute_lookup__regeneration_in_progress' );
+		delete_option( 'woocommerce_attribute_lookup_regeneration_in_progress' );
 	}
 }

--- a/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
+++ b/tests/php/src/Internal/ProductAttributesLookup/DataRegeneratorTest.php
@@ -120,9 +120,9 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 
 		$this->sut->initiate_regeneration();
 
-		$this->assertEquals( 100, get_option( 'woocommerce_attribute_lookup__last_product_id_to_process' ) );
-		$this->assertEquals( 0, get_option( 'woocommerce_attribute_lookup__last_products_page_processed' ) );
-		$this->assertFalse( get_option( 'woocommerce_attribute_lookup__enabled' ) );
+		$this->assertEquals( 100, get_option( 'woocommerce_attribute_lookup_last_product_id_to_process' ) );
+		$this->assertEquals( 0, get_option( 'woocommerce_attribute_lookup_last_products_page_processed' ) );
+		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_enabled' ) );
 
 		$expected_enqueued = array(
 			'method'    => 'schedule_single',
@@ -155,9 +155,9 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 
 		$this->sut->initiate_regeneration();
 
-		$this->assertFalse( get_option( 'woocommerce_attribute_lookup__last_product_id_to_process' ) );
-		$this->assertFalse( get_option( 'woocommerce_attribute_lookup__last_products_page_processed' ) );
-		$this->assertEquals( 'no', get_option( 'woocommerce_attribute_lookup__enabled' ) );
+		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_product_id_to_process' ) );
+		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_products_page_processed' ) );
+		$this->assertEquals( 'no', get_option( 'woocommerce_attribute_lookup_enabled' ) );
 		$this->assertEmpty( $this->queue->get_methods_called() );
 	}
 
@@ -186,13 +186,13 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		$this->sut->initiate_regeneration();
 		$this->queue->clear_methods_called();
 
-		update_option( 'woocommerce_attribute_lookup__last_products_page_processed', 7 );
+		update_option( 'woocommerce_attribute_lookup_last_products_page_processed', 7 );
 
 		do_action( 'woocommerce_run_product_attribute_lookup_regeneration_callback' );
 
 		$this->assertEquals( array( 1, 2, 3 ), $this->lookup_data_store->passed_products );
 		$this->assertEquals( array( 8 ), $requested_products_pages );
-		$this->assertEquals( 8, get_option( 'woocommerce_attribute_lookup__last_products_page_processed' ) );
+		$this->assertEquals( 8, get_option( 'woocommerce_attribute_lookup_last_products_page_processed' ) );
 
 		$expected_enqueued = array(
 			'method'    => 'schedule_single',
@@ -236,9 +236,9 @@ class DataRegeneratorTest extends \WC_Unit_Test_Case {
 		do_action( 'woocommerce_run_product_attribute_lookup_regeneration_callback' );
 
 		$this->assertEquals( $product_ids, $this->lookup_data_store->passed_products );
-		$this->assertFalse( get_option( 'woocommerce_attribute_lookup__last_product_id_to_process' ) );
-		$this->assertFalse( get_option( 'woocommerce_attribute_lookup__last_products_page_processed' ) );
-		$this->assertEquals( 'no', get_option( 'woocommerce_attribute_lookup__enabled' ) );
+		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_product_id_to_process' ) );
+		$this->assertFalse( get_option( 'woocommerce_attribute_lookup_last_products_page_processed' ) );
+		$this->assertEquals( 'no', get_option( 'woocommerce_attribute_lookup_enabled' ) );
 		$this->assertEmpty( $this->queue->get_methods_called() );
 	}
 }

--- a/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
+++ b/tests/php/src/Internal/ProductAttributesLookup/FiltererTest.php
@@ -408,7 +408,7 @@ class FiltererTest extends \WC_Unit_Test_Case {
 	 * @param bool $use The value to set the option to.
 	 */
 	private function set_use_lookup_table( $use ) {
-		update_option( 'woocommerce_attribute_lookup__enabled', $use ? 'yes' : 'no' );
+		update_option( 'woocommerce_attribute_lookup_enabled', $use ? 'yes' : 'no' );
 	}
 
 	/**

--- a/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
+++ b/tests/php/src/Internal/ProductAttributesLookup/LookupDataStoreTest.php
@@ -1147,7 +1147,7 @@ class LookupDataStoreTest extends \WC_Unit_Test_Case {
 	 * @param bool $value True to set the option to 'yes', false for 'no'.
 	 */
 	private function set_direct_update_option( bool $value ) {
-		update_option( 'woocommerce_attribute_lookup__direct_updates', $value ? 'yes' : 'no' );
+		update_option( 'woocommerce_attribute_lookup_direct_updates', $value ? 'yes' : 'no' );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The feature was using option names prefixed with `woocommerce_attribute_lookup__`. That double underscore breaks WP
standards for option names  ([related comment](https://github.com/woocommerce/woocommerce/pull/30351#discussion_r676822904)). This pull request changes these option names so that they use a single underscore instead.

**Note:** If you were already using the feature, after incorporating these changes:

1. You'll have to set the related settings again (_WooCommerce - Settings - Products - Advanced_)

2. You'll need to manually delete the old options (although it won't hurt if you leave them in place), you can use this SQL command for that:

```SQL
DELETE FROM wp_options WHERE option_name LIKE 'woocommerce\_attribute\_lookup\_\_%'
```

### How to test the changes in this Pull Request:

Try the feature as described in the original pull requests that implement it (https://github.com/woocommerce/woocommerce/pull/29778, https://github.com/woocommerce/woocommerce/pull/29896, https://github.com/woocommerce/woocommerce/pull/30041)

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - non-standard option names used by the product attributes lookup table feature.
