### PR TITLE
Added order cleanup to e2e setup

### DIFF
--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -44,6 +44,7 @@ beforeAll(async () => {
 	await trashExistingPosts();
 	await withRestApi.deleteAllProducts();
 	await withRestApi.deleteAllCoupons();
+	await withRestApi.deleteAllOrders();
 	await page.goto(WP_ADMIN_LOGIN);
 	await clearLocalStorage();
 	await setBrowserViewport('large');

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -12,6 +12,7 @@
 - Added `describeIf()` to conditionally run a test suite
 - Added `itIf()` to conditionally run a test case.
 - Added merchant workflows around plugins: `uploadAndActivatePlugin()`, `activatePlugin()`, `deactivatePlugin()`, `deletePlugin()`
+- Added `deleteAllOrders` that goes through and deletes all orders
 
 # 0.1.5
 

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -14,6 +14,7 @@
 - Added merchant workflows around plugins: `uploadAndActivatePlugin()`, `activatePlugin()`, `deactivatePlugin()`, `deletePlugin()`
 - Added `deleteAllOrders()` that goes through and deletes all orders
 - Added `deleteAllShippingClasses()` which permanently deletes all shipping classes using the API
+- Added `statuses` optional parameter to `deleteAllRepositoryObjects()` to delete on specific statuses
 
 # 0.1.5
 

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -145,6 +145,7 @@ This package provides support for enabling retries in tests:
 | `deleteAllShippingZones` | | Permanently delete all shipping zones except the default |
 | `deleteCustomerByEmail` | `emailAddress` | Delete customer user account. Posts are reassigned to user ID 1 |
 | `resetSettingsGroupToDefault` | `settingsGroup` | Reset settings in settings group to default except `select` fields |
+| `deleteAllOrders` | | Permanently delete all orders |
 
 ### Page Utilities
 

--- a/tests/e2e/utils/src/flows/with-rest-api.js
+++ b/tests/e2e/utils/src/flows/with-rest-api.js
@@ -15,7 +15,7 @@ const userEndpoint = '/wp/v2/users';
  * @param statuses Status of the object to check
  * @returns {Promise<void>}
  */
- const deleteAllRepositoryObjects = async ( repository, defaultObjectId = null, statuses = [ 'draft', 'publish', 'trash' ] ) => {
+const deleteAllRepositoryObjects = async ( repository, defaultObjectId = null, statuses = [ 'draft', 'publish', 'trash' ] ) => {
 	let objects;
 	const minimum = defaultObjectId == null ? 0 : 1;
 

--- a/tests/e2e/utils/src/flows/with-rest-api.js
+++ b/tests/e2e/utils/src/flows/with-rest-api.js
@@ -5,6 +5,7 @@ const client = factories.api.withDefaultPermalinks;
 const onboardingProfileEndpoint = '/wc-admin/onboarding/profile';
 const shippingZoneEndpoint = '/wc/v3/shipping/zones';
 const userEndpoint = '/wp/v2/users';
+const ordersEndpoint = '/wc/v3/orders';
 
 /**
  * Utility function to delete all merchant created data store objects.
@@ -80,6 +81,24 @@ export const withRestApi = {
 	deleteAllProducts: async () => {
 		const repository = SimpleProduct.restRepository( client );
 		await deleteAllRepositoryObjects( repository );
+	},
+	/**
+	 * Use api package to delete all orders.
+	 *
+	 * @return {Promise} Promise resolving once orders have been deleted.
+	 */
+	deleteAllOrders: async () => {
+		// We need to specfically filter on order status here to make sure we catch all orders to delete.
+		const orderStatuses = ['pending', 'processing', 'on-hold', 'completed', 'cancelled', 'refunded', 'failed', 'trash'];
+		for (let s = 0; s < orderStatuses.length; s++) {
+			const orders = await client.get( ordersEndpoint + `?status=${orderStatuses[s]}` );
+			if ( orders.data && orders.data.length ) {
+				for ( let o = 0; o < orders.data.length; o++ ) {
+					const response = await client.delete( ordersEndpoint + `/${orders.data[o].id}?force=true` );
+					expect( response.statusCode ).toBe( 200 );
+				}
+			}
+		}
 	},
 	/**
 	 * Use api package to delete shipping zones.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces a cleanup orders function that permanently deletes all orders, regardless of status.

### How to test the changes in this Pull Request:

1. Verify the CI passes
2. Create a few simple orders in a variety of statuses (such as `pending`, `trash`, or `completed`). All possible order statuses are: `pending`, `processing`, `on-hold`, `completed`, `cancelled`, `refunded`, `failed`, `trash`.
3. Run the e2e tests with `npx wc-e2e test:e2e`
4. Open the `WooCommerce > Orders` page after the tests start running
5. Verify the orders you created get deleted