### PR TITLE
Fix 'woocommerce_email_settings' filter being triggered twice

### DIFF
--- a/includes/admin/settings/class-wc-settings-emails.php
+++ b/includes/admin/settings/class-wc-settings-emails.php
@@ -51,8 +51,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 			'https://wordpress.org/plugins/wp-mail-logging/',
 			'https://docs.woocommerce.com/document/email-faq'
 		);
-		$settings = apply_filters(
-			'woocommerce_email_settings',
+		$settings =
 			array(
 				array(
 					'title' => __( 'Email notifications', 'woocommerce' ),
@@ -217,8 +216,7 @@ class WC_Settings_Emails extends WC_Settings_Page {
 					'type' => 'sectionend',
 					'id'   => 'email_merchant_notes',
 				),
-			)
-		);
+			);
 
 		return apply_filters( 'woocommerce_email_settings', $settings );
 	}

--- a/tests/php/includes/settings/class-wc-settings-emails-test.php
+++ b/tests/php/includes/settings/class-wc-settings-emails-test.php
@@ -5,7 +5,6 @@
  * @package WooCommerce\Tests\Settings
  */
 
-use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\FunctionsMockerHack;
 use Automattic\WooCommerce\Testing\Tools\CodeHacking\Hacks\StaticMockerHack;
 
 require_once __DIR__ . '/class-wc-settings-unit-test-case.php';


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

[The settings pages refacttoring](https://github.com/woocommerce/woocommerce/pull/27684) introduced a small bug: the `woocommerce_email_settings` filter is triggered twice, causing any settings added to the Emails tab by exttensions to appear twice too. This pull request fixes that.

Closes #30390.

### How to test the changes in this Pull Request:

Add the following snippet somehwre:

```php
add_filter('woocommerce_email_settings', function($settings) {
	array_unshift(
		$settings,
		array(
			'title' => 'This is a test',
			'desc'  => 'Yes, this is just a test',
			'type'  => 'title',
			'id'    => 'foobar',
		)
	);
	return $settings;
}, 999, 1);
```

Then go to _WooCommerce - Settings - Emails_ and verify that you see the "This is a test" title at the beginning of the page only once (without the fix you'll see it twice).

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - 'woocommerce_email_settings' filter being triggered twice.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
