### PR TITLE
Fix variations menu order not applying correctly when manually set cl…

### DIFF
--- a/assets/js/admin/meta-boxes-product-variation.js
+++ b/assets/js/admin/meta-boxes-product-variation.js
@@ -177,12 +177,22 @@ jQuery( function( $ ) {
 		 */
 		set_menu_order: function( event ) {
 			event.preventDefault();
-			var $menu_order  = $( this ).closest( '.woocommerce_variation' ).find('.variation_menu_order');
+			var $menu_order  = $( this ).closest( '.woocommerce_variation' ).find( '.variation_menu_order' );
+			var variation_id = $( this ).closest( '.woocommerce_variation' ).find( '.variable_post_id' ).val();
 			var value        = window.prompt( woocommerce_admin_meta_boxes_variations.i18n_enter_menu_order, $menu_order.val() );
 
 			if ( value != null ) {
 				// Set value, save changes and reload view
 				$menu_order.val( parseInt( value, 10 ) ).trigger( 'change' );
+
+				$( this ).closest( '.woocommerce_variation' )
+					.append( '<input type="hidden" name="new_variation_menu_order_id" value="'
+						+ encodeURIComponent( variation_id ) + '" />' );
+
+				$( this ).closest( '.woocommerce_variation' )
+					.append( '<input type="hidden" name="new_variation_menu_order_value" value="'
+						+ encodeURIComponent( parseInt( value, 10 ) ) + '" />' );
+
 				wc_meta_boxes_product_variations_ajax.save_variations();
 			}
 		},

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -437,6 +437,8 @@ class WC_Meta_Box_Product_Data {
 	 * @param WP_Post $post Post object.
 	 */
 	public static function save_variations( $post_id, $post ) {
+		global $wpdb;
+
 		// phpcs:disable WordPress.Security.NonceVerification.Missing
 		if ( isset( $_POST['variable_post_id'] ) ) {
 			$parent = wc_get_product( $post_id );
@@ -446,6 +448,35 @@ class WC_Meta_Box_Product_Data {
 			$max_loop   = max( array_keys( wp_unslash( $_POST['variable_post_id'] ) ) ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			$data_store = $parent->get_data_store();
 			$data_store->sort_all_product_variations( $parent->get_id() );
+			$new_variation_menu_order_id = ! empty( $_POST['new_variation_menu_order_id'] ) ? wc_clean( wp_unslash( $_POST['new_variation_menu_order_id'] ) ) : false;
+			$new_variation_menu_order_value = ! empty( $_POST['new_variation_menu_order_value'] ) ? wc_clean( wp_unslash( $_POST['new_variation_menu_order_value'] ) ) : false;
+
+			// Only perform this operation if setting menu order via the prompt.
+			if ( $new_variation_menu_order_id && $new_variation_menu_order_value ) {
+				/*
+				 * We need to gather all the variations with menu order that is
+				 * equal or greater than the menu order that is newly set and
+				 * increment them by one so that we can correctly insert the updated
+				 * variation menu order.
+				 */
+				$ids = $wpdb->get_col(
+					$wpdb->prepare(
+						"SELECT ID FROM {$wpdb->posts} WHERE post_type = 'product_variation' AND post_parent = %d AND post_status = 'publish' AND menu_order >= %d AND ID != %d ORDER BY menu_order ASC",
+						$post_id,
+						$new_variation_menu_order_value,
+						$new_variation_menu_order_id
+					)
+				);
+
+				foreach ( $ids as $id ) {
+					$wpdb->query(
+						$wpdb->prepare(
+							"UPDATE {$wpdb->posts} SET menu_order = menu_order + 1 WHERE ID = %d",
+							$id
+						)
+					);
+				}
+			}
 
 			for ( $i = 0; $i <= $max_loop; $i++ ) {
 
@@ -538,7 +569,6 @@ class WC_Meta_Box_Product_Data {
 				do_action( 'woocommerce_admin_process_variation_object', $variation, $i );
 
 				$variation->save();
-
 				do_action( 'woocommerce_save_product_variation', $variation_id, $i );
 			}
 		}

--- a/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-product-data.php
@@ -459,23 +459,14 @@ class WC_Meta_Box_Product_Data {
 				 * increment them by one so that we can correctly insert the updated
 				 * variation menu order.
 				 */
-				$ids = $wpdb->get_col(
+				$wpdb->query(
 					$wpdb->prepare(
-						"SELECT ID FROM {$wpdb->posts} WHERE post_type = 'product_variation' AND post_parent = %d AND post_status = 'publish' AND menu_order >= %d AND ID != %d ORDER BY menu_order ASC",
+						"UPDATE {$wpdb->posts} SET menu_order = menu_order + 1 WHERE post_type = 'product_variation' AND post_parent = %d AND post_status = 'publish' AND menu_order >= %d AND ID != %d",
 						$post_id,
 						$new_variation_menu_order_value,
 						$new_variation_menu_order_id
 					)
 				);
-
-				foreach ( $ids as $id ) {
-					$wpdb->query(
-						$wpdb->prepare(
-							"UPDATE {$wpdb->posts} SET menu_order = menu_order + 1 WHERE ID = %d",
-							$id
-						)
-					);
-				}
 			}
 
 			for ( $i = 0; $i <= $max_loop; $i++ ) {

--- a/includes/admin/meta-boxes/views/html-variation-admin.php
+++ b/includes/admin/meta-boxes/views/html-variation-admin.php
@@ -47,7 +47,7 @@ defined( 'ABSPATH' ) || exit;
 			<?php
 		}
 		?>
-		<input type="hidden" name="variable_post_id[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $variation_id ); ?>" />
+		<input type="hidden" class="variable_post_id" name="variable_post_id[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $variation_id ); ?>" />
 		<input type="hidden" class="variation_menu_order" name="variation_menu_order[<?php echo esc_attr( $loop ); ?>]" value="<?php echo esc_attr( $variation_object->get_menu_order( 'edit' ) ); ?>" />
 
 		<?php


### PR DESCRIPTION
…oses #29630

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #29630

So this was a bit tricky to tackle. We basically have two ways of setting the variations menu order. One is by using drag and drop which works fine. The other way is to manually set a menu order value by clicking on the drag and drop icon as noted by the tooltip if you hover over it. This is where the issue lies.  Current logic when `save_variations` action is triggered is to refresh the menu order values so they enumerate in sequential order (1..2...3...etc). After that is done, then it tries to update the current variation that you made change to, to the new menu order value in the DB. Doing could potentially create duplicated menu order values. Now when retrieving these variations menu order, it is no guarantee the order is correct anymore because you have a duplicate value where the value for that row could come before or after the variation row you are editing. Though this fix works, I feel there might be a better way. Open to suggestions.

### How to test the changes in this Pull Request:

1. Create a variable product.
2. Add a custom attribute with 20 terms.
3. Make sure to choose `Used as variations` and then save attributes.
4. Go to the variations tab and run `Create variations from all attributes`.
5. You should have at least 2 pages of variations.
6. On page 1, click on the drag and drop handle icon for the last variation.
7. You should see a window prompt asking you for the menu order value.
8. Enter 2 for example and ok/enter.
9. After an AJAX refresh, you should see the last variation is now in the second position from the top.
10. Click on each of the drag and drop handle icon to make sure the menu order values are indeed correct.
11. Perform the same test from step 6 - 10 except this time do it from page 2 and see if the results are correct.
12. Now test the drag and drop and make sure we don't have any regressions due to this fix.

**NOTE:**
It is normal for menu order values to be out of sequence in an incremental fashion. That is ok and will not deter from the function it is designed to do. For example if you only had 8 variations and you purposely set the 8th variation to menu order value of 10. As long as they're in an incremental menu order value sequentially without duplicates and from top down, it will work correctly.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Variations menu order not applying correctly when manually set in some cases.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
