### PR TITLE
Issue Labeling: Automate a flow for initial triage

### DIFF
--- a/.github/ISSUE_TEMPLATE/4-Bug-report.md
+++ b/.github/ISSUE_TEMPLATE/4-Bug-report.md
@@ -1,14 +1,14 @@
 ---
 name: "\U0001F41E Bug report"
-about: Report a bug if something isn't working as expected in the core WooCommerce
+about:
+  Report a bug if something isn't working as expected in the core WooCommerce
   plugin.
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
-Please provide us with the information requested in this bug report. Without these details, we won't be able to fully evaluate this issue. 
+Please provide us with the information requested in this bug report. Without these details, we won't be able to fully evaluate this issue.
 Bug reports lacking detail, or for any other reason than to report a bug, may be closed without action.
 
 <!-- This template is for confirmed bugs only. If you have a support request or custom code related question please see our docs or use our forums, helpdesk, or Slack Community! https://github.com/woocommerce/woocommerce/issues/new?assignees=&labels=&template=3-Support.md&title= -->
@@ -18,20 +18,37 @@ Bug reports lacking detail, or for any other reason than to report a bug, may be
 <!-- Search tip: Make use of GitHub's search syntax to refine your search https://help.github.com/en/github/searching-for-information-on-github/searching-issues-and-pull-requests -->
 
 **Prerequisites (mark completed items with an [x]):**
+
 - [ ] I have carried out troubleshooting steps and I believe I have found a bug.
 - [ ] I have searched for similar bugs in both open and closed issues and cannot find a duplicate.
 
+**What part of WooCommerce does this bug pertain to?**
+
+- [] Analytics
+- [] Customer facing pages
+- [] Checkout
+- [] Onboarding
+- [] Homescreen
+- [] Customers
+- [] Settings or Status
+- [] Coupons
+- [] Products
+- [] Orders
+- [] Payments
+- [] Rest API
+
 **Describe the bug**
-A clear and concise description of what the bug is. 
+A clear and concise description of what the bug is.
 
 **Expected behavior**
 A clear and concise description of what you expected to happen.
 
 **Actual behavior**
-A clear and concise description of what actually happens. Please be as descriptive as possible; 
+A clear and concise description of what actually happens. Please be as descriptive as possible;
 
 **Steps to reproduce the bug (We need to be able to reproduce the bug in order to fix it.)**
 Steps to reproduce the bug:
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
@@ -43,13 +60,15 @@ If applicable, add screenshots to help explain your problem.
 <!-- Please try testing your site for theme and plugins conflict. To do that deactivate all plugins except for WooCommerce and switch to a default WordPress theme or [Storefront](https://en-gb.wordpress.org/themes/storefront/). Then test again. If the issue is resolved with the default theme and all plugins deactivated, it means that one of your plugins or a theme is causing the issue. You will then need to enable it one by one and test every time you do that in order to figure out which plugin is causing the issue. -->
 
 **Isolating the problem (mark completed items with an [x]):**
+
 - [ ] I have deactivated other plugins and confirmed this bug occurs when only WooCommerce plugin is active.
 - [ ] This bug happens with a default WordPress theme active, or [Storefront](https://woocommerce.com/storefront/).
 - [ ] I can reproduce this bug consistently using the steps above.
 
 **WordPress Environment**
-We use the [WooCommerce System Status Report](https://docs.woocommerce.com/document/understanding-the-woocommerce-system-status-report/) to help us evaluate the issue. 
+We use the [WooCommerce System Status Report](https://docs.woocommerce.com/document/understanding-the-woocommerce-system-status-report/) to help us evaluate the issue.
 Without this report we won't be able to fully evaluate this issue.
+
 <details>
 ```
 The System Status Report is found in your WordPress admin under **WooCommerce > Status**. 

--- a/.github/ISSUE_TEMPLATE/5-Enhancement.md
+++ b/.github/ISSUE_TEMPLATE/5-Enhancement.md
@@ -1,16 +1,31 @@
 ---
 name: "✨ New Enhancement"
-about: If you have an idea to improve an existing feature in core or need something
+about:
+  If you have an idea to improve an existing feature in core or need something
   for development (such as a new hook) please let us know or submit a Pull Request!
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 <!--  Make sure to look through existing issues to see whether your idea is already being discussed. Feel free to contribute to any existing issues. -->
 
 <!-- Search tip: You can filter issues using our enhancement label https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue+label%3Aenhancement -->
+
+**What part of WooCommerce does this enhancement pertain to?**
+
+- [] Analytics
+- [] Customer facing pages
+- [] Checkout
+- [] Onboarding
+- [] Homescreen
+- [] Customers
+- [] Settings or Status
+- [] Coupons
+- [] Products
+- [] Orders
+- [] Payments
+- [] Rest API
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/ISSUE_TEMPLATE/6-Feature-request.md
+++ b/.github/ISSUE_TEMPLATE/6-Feature-request.md
@@ -1,16 +1,31 @@
 ---
 name: "\U0001F680 Feature request"
-about: "Suggest a new feature \U0001F389 We'll consider building it if it receives
+about:
+  "Suggest a new feature \U0001F389 We'll consider building it if it receives
   sufficient interest! \U0001F44D"
-title: ''
-labels: ''
-assignees: ''
-
+title: ""
+labels: ""
+assignees: ""
 ---
 
 <!--  Make sure to look through existing issues to see whether your idea is already being discussed. Feel free to contribute to any existing issues. -->
 
 <!-- Search tip: You can filter issues using our enhancement label https://github.com/woocommerce/woocommerce/issues?q=is%3Aissue+label%3Aenhancement -->
+
+**What part of WooCommerce does this feature request pertain to?**
+
+- [] Analytics
+- [] Customer facing pages
+- [] Checkout
+- [] Onboarding
+- [] Homescreen
+- [] Customers
+- [] Settings or Status
+- [] Coupons
+- [] Products
+- [] Orders
+- [] Payments
+- [] Rest API
 
 **Is your feature request related to a problem? Please describe.**
 A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,4 @@
+"[team] Isotope":
+  - "([x] Analytics|[x] Onboarding|[x Homescreen|[x] Customers)"
+"[team] Proton":
+  - "([x] Customer facing pages|[x] Checkout|[x] Settings or Status|[x] Coupons|[x] Products|[x] Orders|[x] Payments|[x] Rest API)"

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,4 @@
-"[team] Isotope":
+"team: Isotope":
   - "([x] Analytics|[x] Onboarding|[x Homescreen|[x] Customers)"
-"[team] Proton":
+"team: Proton":
   - "([x] Customer facing pages|[x] Checkout|[x] Settings or Status|[x] Coupons|[x] Products|[x] Orders|[x] Payments|[x] Rest API)"

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,15 @@
+name: "Issue Labeler"
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  triage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: github/issue-labeler@v2.0
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          configuration-path: .github/labeler.yml
+          not-before: 2021-09-08T00:00:00Z
+          enable-versioned-regex: 0


### PR DESCRIPTION
### All Submissions:

This PR explores the concept of using issue reporter declared areas of concern to automatically apply a label to an issue which directs the issue to the appropriate team.

### Changes proposed in this Pull Request:

Adds Github's [Issue Labeler](https://github.com/github/issue-labeler) github action to detect if a user selected a checkbox for a certain area of WooCommerce. Each area maps to a team with labels `team: Isotope` or `team: Proton`.

### How to test the changes in this Pull Request:

I'm not entirely sure how to test this without it being merged.

### Other information:

* A `not-before` parameter will need to be updated before a merge to exclude issues that predate this PR's inclusion.
* The teams will need to be updated or refined depending on the org structure and level of desired granularity.
* The checkboxes and categories are welcome to feedback

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
