### PR TITLE
Fix: product attribute permalinks not working for non-ASCII characters

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -266,7 +266,7 @@ class WC_Post_Types {
 
 					if ( 1 === $tax->attribute_public && sanitize_title( $tax->attribute_name ) ) {
 						$taxonomy_data['rewrite'] = array(
-							'slug'         => trailingslashit( $permalinks['attribute_rewrite_slug'] ) . sanitize_title( $tax->attribute_name ),
+							'slug'         => trailingslashit( $permalinks['attribute_rewrite_slug'] ) . urldecode( sanitize_title( $tax->attribute_name ) ),
 							'with_front'   => false,
 							'hierarchical' => true,
 						);


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Product attribute lists permalinks ("/attribute/term") were not working for attribute names containing non-ASCII characters (e.g. Greek or Japanese). That's because when the attribute taxonomy was registered the url rewrite rules were created using the sanitized version of the attribute name, which implies converting these characters into the urlencoded version.

The fix consists of applying `urldecode` to the sanitized attribute name before using it to create the rewrite rule. The sanitization
needs to be kept for compatibility purposes, since it also replaces latin characters with accents into the non-accent versions (this conversion won't be affected by `urldecode`).

Closes #26975.

### How to test the changes in this Pull Request:

See [this comment in the issue](https://github.com/woocommerce/woocommerce/issues/26975#issuecomment-816453989); basically, create an attribute with a Japanese name, assign it to a product, and test the corresponding permalink. **Very important**: When creating the attribute, check the "Enable archives" option, otherwise permalinks won't work for that attribute.

Test also that when creating an attribute with accented latin characters the generated slug is the non-accented version (e.g. "ñá" becomes "na") and that the permalink still works in this case (with the non-accented slug).

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Fix - product attribute permalinks not working for non-ASCII characters.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
