### PR TITLE
Update My Subscriptions page title

### DIFF
--- a/includes/admin/class-wc-admin-menus.php
+++ b/includes/admin/class-wc-admin-menus.php
@@ -37,6 +37,7 @@ class WC_Admin_Menus {
 		add_filter( 'custom_menu_order', array( $this, 'custom_menu_order' ) );
 		add_filter( 'set-screen-option', array( $this, 'set_screen_option' ), 10, 3 );
 		add_filter( 'parent_file', array( $this, 'update_menu_highlight' ) );
+		add_filter( 'admin_title', array( $this, 'update_my_subscriptions_title' ) );
 
 		// Add endpoints custom URLs in Appearance > Menus > Pages.
 		add_action( 'admin_head-nav-menus.php', array( $this, 'add_nav_menu_meta_boxes' ) );


### PR DESCRIPTION
A tiny fix for #30380 - added a filter for admin page title to change it to 'My WooCommerce.com Subscriptions' on the My Subscriptions page:

![](https://d.pr/i/MKdpCQ+)