### PR TITLE
Revert "New hook for product external options"

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -31,8 +31,6 @@ defined( 'ABSPATH' ) || exit;
 				'description' => __( 'This text will be shown on the button linking to the external product.', 'woocommerce' ),
 			)
 		);
-		
-		do_action( 'woocommerce_product_options_external' );
 		?>
 	</div>
 


### PR DESCRIPTION
Reverts woocommerce/woocommerce#30229

Targeted the wrong branch. Should have been `trunk`