### PR TITLE
New hook for product external options

### DIFF
--- a/includes/admin/meta-boxes/views/html-product-data-general.php
+++ b/includes/admin/meta-boxes/views/html-product-data-general.php
@@ -31,6 +31,8 @@ defined( 'ABSPATH' ) || exit;
 				'description' => __( 'This text will be shown on the button linking to the external product.', 'woocommerce' ),
 			)
 		);
+		
+		do_action( 'woocommerce_product_options_external' );
 		?>
 	</div>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Proposes a new hook `woocommerce_product_options_external` for product external options, this way we could hook into that place to add new inputs required for one of our plugins, for the external products type. Currently we have no other way to add new inputs right below the 2 default ones from WooCommerce.

### How to test the changes in this Pull Request:

Just hook into the new action to add a new input:

```php
add_action( 'woocommerce_product_options_external', function() {
	woocommerce_wp_text_input(
		array(
			'id'          => '_some_id',
			'value'       => '',
			'label'       => __( 'Some input', 'woocommerce' ),
			'placeholder' => '',
			'description' => '',
		)
	);
} );
```
You should be able to see the new input on an external product "General" tab:

![Group 1](https://user-images.githubusercontent.com/533273/128325567-2df7c5e6-4bcf-4791-a730-d4fa9775d01e.png)

### Changelog entry:
> Dev - Added new `woocommerce_product_options_external` hook. #30448
