### PR TITLE
turn off tracking in e2e onboarding tests

### DIFF
--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -94,11 +94,11 @@ const completeOnboardingWizard = async () => {
 			'.components-modal__header-heading', {text: 'Build a better WooCommerce'}
 		);
 
-		// Query for "Continue" buttons
-		const continueButtons = await page.$$( 'button.is-primary' );
-		expect( continueButtons ).toHaveLength( 2 );
+		// Query for "No Thanks" buttons
+		const continueButtons = await page.$$( '.woocommerce-usage-modal__actions button.is-secondary' );
+		expect( continueButtons ).toHaveLength( 1 );
 
-		await continueButtons[1].click();
+		await continueButtons[0].click();
 	}
 	await page.waitForNavigation( { waitUntil: 'networkidle0' } );
 
@@ -295,7 +295,7 @@ const createVariableProduct = async (varProduct = defaultVariableProduct) => {
 
 /**
  * Create grouped product.
- * 
+ *
  * @param groupedProduct Defaults to the grouped product object in `default.json`
  * @returns ID of the grouped product
  */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR changes the selector in the e2e onboarding data tracking popup to ensure that the `No Thanks` button is clicked regardless of it's position in the DOM.

Closes #30327 .

### How to test the changes in this Pull Request:

1. Run E2E tests on an new install
2. Go to WooCommerce -> Settings -> Advanced -> WooCommerce.com
3. Data tracking should be unchecked.

### Changelog entry

> N/A

