### PR TITLE
skip WCCOM connection until browser support resolved

### DIFF
--- a/tests/e2e/core-tests/specs/merchant/wp-admin-extensions-connect-wccom.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-extensions-connect-wccom.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests */
 /**
  * Internal dependencies
  */
@@ -21,7 +20,7 @@ const runInitiateWccomConnectionTest = () => {
 			await merchant.login();
 		});
 
-		it('can initiate WCCOM connection', async () => {
+		it.skip('can initiate WCCOM connection', async () => {
 			await merchant.openExtensions();
 
 			// Click on a tab to choose WooCommerce Subscriptions extension


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the E2E tests suite to skip the WCCOM connection test while we resolve the issue of the unsupported browser.

![screenshot_of_failed_test](https://user-images.githubusercontent.com/343847/128876079-737e2985-6edf-4ff0-ba69-dad16e756e35.png)


### How to test the changes in this Pull Request:

1. Verify CI run

### Changelog entry

> N/A

