### PR TITLE
Fix code standards in orders code, and check payment method name instead of title on get order totals

### DIFF
--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -206,7 +206,7 @@ class WC_Meta_Box_Order_Data {
 								}
 							}
 
-							$to_add = $to_add ?? ' (' . esc_html( $transaction_id ) . ')';
+							$to_add                 = $to_add ?? ' (' . esc_html( $transaction_id ) . ')';
 							$payment_method_string .= $to_add;
 						}
 

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -309,7 +309,12 @@ class WC_Meta_Box_Order_Data {
 							}
 							?>
 							<select class="wc-customer-search" id="customer_user" name="customer_user" data-placeholder="<?php esc_attr_e( 'Guest', 'woocommerce' ); ?>" data-allow_clear="true">
-								<option value="<?php echo esc_attr( $user_id ); ?>" selected="selected"><?php /* htmlspecialchars to prevent XSS when rendered by selectWoo. */ echo esc_html( htmlspecialchars( wp_kses_post( $user_string ) ) ); ?></option>
+								<option value="<?php echo esc_attr( $user_id ); ?>" selected="selected">
+									<?php
+									// htmlspecialchars to prevent XSS when rendered by selectWoo.
+									echo esc_html( htmlspecialchars( wp_kses_post( $user_string ) ) );
+									?>
+								</option>
 							</select>
 							<!--/email_off-->
 						</p>
@@ -538,6 +543,8 @@ class WC_Meta_Box_Order_Data {
 	 * @throws Exception Required request data is missing.
 	 */
 	public static function save( $order_id ) {
+		// phpcs:disable WordPress.Security.NonceVerification.Missing
+
 		if ( ! isset( $_POST['order_status'] ) ) {
 			throw new Exception( __( 'Order status is missing.', 'woocommerce' ), 400 );
 		}
@@ -549,8 +556,6 @@ class WC_Meta_Box_Order_Data {
 		if ( ! isset( $_POST['_wpnonce'] ) ) {
 			throw new Exception( __( 'Nonce is missing.', 'woocommerce' ), 400 );
 		}
-
-		wp_verify_nonce( wc_clean( wp_unslash( $_POST['_wpnonce'], 'woocommerce_save_data' ) ) );
 
 		self::init_address_fields();
 
@@ -655,5 +660,7 @@ class WC_Meta_Box_Order_Data {
 		$order->set_props( $props );
 		$order->set_status( wc_clean( wp_unslash( $_POST['order_status'] ) ), '', true );
 		$order->save();
+
+		// phpcs:enable WordPress.Security.NonceVerification.Missing
 	}
 }

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -553,10 +553,6 @@ class WC_Meta_Box_Order_Data {
 			throw new Exception( __( 'Payment method is missing.', 'woocommerce' ), 400 );
 		}
 
-		if ( ! isset( $_POST['_wpnonce'] ) ) {
-			throw new Exception( __( 'Nonce is missing.', 'woocommerce' ), 400 );
-		}
-
 		self::init_address_fields();
 
 		// Ensure gateways are loaded in case they need to insert data into the emails.

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -198,14 +198,16 @@ class WC_Meta_Box_Order_Data {
 
 						$transaction_id = $order->get_transaction_id();
 						if ( $transaction_id ) {
+							$to_add = null;
 							if ( isset( $payment_gateways[ $payment_method ] ) ) {
 								$url = $payment_gateways[ $payment_method ]->get_transaction_url( $order );
 								if ( $url ) {
-									$payment_method_string .= ' (<a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $transaction_id ) . '</a>)';
+									$to_add .= ' (<a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $transaction_id ) . '</a>)';
 								}
-							} else {
-								$payment_method_string .= ' (' . esc_html( $transaction_id ) . ')';
 							}
+
+							$to_add = $to_add ?? ' (' . esc_html( $transaction_id ) . ')';
+							$payment_method_string .= $to_add;
 						}
 
 						$meta_list[] = $payment_method_string;

--- a/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
+++ b/plugins/woocommerce/includes/admin/meta-boxes/class-wc-meta-box-order-data.php
@@ -4,14 +4,12 @@
  *
  * Functions for displaying the order data meta box.
  *
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce\Admin\Meta Boxes
  * @version     2.2.0
  */
 
 if ( ! defined( 'ABSPATH' ) ) {
-	exit; // Exit if accessed directly
+	exit; // Exit if accessed directly.
 }
 
 /**
@@ -143,7 +141,7 @@ class WC_Meta_Box_Order_Data {
 	/**
 	 * Output the metabox.
 	 *
-	 * @param WP_Post $post
+	 * @param WP_Post $post The post to output the metabox for.
 	 */
 	public static function output( $post ) {
 		global $theorder;
@@ -171,14 +169,14 @@ class WC_Meta_Box_Order_Data {
 			#post-body-content, #titlediv { display:none }
 		</style>
 		<div class="panel-wrap woocommerce">
-			<input name="post_title" type="hidden" value="<?php echo empty( $post->post_title ) ? __( 'Order', 'woocommerce' ) : esc_attr( $post->post_title ); ?>" />
+			<input name="post_title" type="hidden" value="<?php echo empty( $post->post_title ) ? esc_attr__( 'Order', 'woocommerce' ) : esc_attr( $post->post_title ); ?>" />
 			<input name="post_status" type="hidden" value="<?php echo esc_attr( $post->post_status ); ?>" />
 			<div id="order_data" class="panel woocommerce-order-data">
 				<h2 class="woocommerce-order-data__heading">
 					<?php
 
-					/* translators: 1: order type 2: order number */
 					printf(
+						/* translators: 1: order type 2: order number */
 						esc_html__( '%1$s #%2$s details', 'woocommerce' ),
 						esc_html( $order_type_object->labels->singular_name ),
 						esc_html( $order->get_order_number() )
@@ -192,15 +190,19 @@ class WC_Meta_Box_Order_Data {
 					$meta_list = array();
 
 					if ( $payment_method && 'other' !== $payment_method ) {
-						/* translators: %s: payment method */
 						$payment_method_string = sprintf(
+							/* translators: %s: payment method */
 							__( 'Payment via %s', 'woocommerce' ),
 							esc_html( isset( $payment_gateways[ $payment_method ] ) ? $payment_gateways[ $payment_method ]->get_title() : $payment_method )
 						);
 
-						if ( $transaction_id = $order->get_transaction_id() ) {
-							if ( isset( $payment_gateways[ $payment_method ] ) && ( $url = $payment_gateways[ $payment_method ]->get_transaction_url( $order ) ) ) {
-								$payment_method_string .= ' (<a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $transaction_id ) . '</a>)';
+						$transaction_id = $order->get_transaction_id();
+						if ( $transaction_id ) {
+							if ( isset( $payment_gateways[ $payment_method ] ) ) {
+								$url = $payment_gateways[ $payment_method ]->get_transaction_url( $order );
+								if ( $url ) {
+									$payment_method_string .= ' (<a href="' . esc_url( $url ) . '" target="_blank">' . esc_html( $transaction_id ) . '</a>)';
+								}
 							} else {
 								$payment_method_string .= ' (' . esc_html( $transaction_id ) . ')';
 							}
@@ -210,17 +212,18 @@ class WC_Meta_Box_Order_Data {
 					}
 
 					if ( $order->get_date_paid() ) {
-						/* translators: 1: date 2: time */
 						$meta_list[] = sprintf(
+							/* translators: 1: date 2: time */
 							__( 'Paid on %1$s @ %2$s', 'woocommerce' ),
 							wc_format_datetime( $order->get_date_paid() ),
 							wc_format_datetime( $order->get_date_paid(), get_option( 'time_format' ) )
 						);
 					}
 
-					if ( $ip_address = $order->get_customer_ip_address() ) {
-						/* translators: %s: IP address */
+					$ip_address = $order->get_customer_ip_address();
+					if ( $ip_address ) {
 						$meta_list[] = sprintf(
+							/* translators: %s: IP address */
 							__( 'Customer IP: %s', 'woocommerce' ),
 							'<span class="woocommerce-Order-customerIP">' . esc_html( $ip_address ) . '</span>'
 						);
@@ -235,7 +238,7 @@ class WC_Meta_Box_Order_Data {
 						<h3><?php esc_html_e( 'General', 'woocommerce' ); ?></h3>
 
 						<p class="form-field form-field-wide">
-							<label for="order_date"><?php _e( 'Date created:', 'woocommerce' ); ?></label>
+							<label for="order_date"><?php esc_html_e( 'Date created:', 'woocommerce' ); ?></label>
 							<input type="text" class="date-picker" name="order_date" maxlength="10" value="<?php echo esc_attr( date_i18n( 'Y-m-d', strtotime( $post->post_date ) ) ); ?>" pattern="<?php echo esc_attr( apply_filters( 'woocommerce_date_input_html_pattern', '[0-9]{4}-(0[1-9]|1[012])-(0[1-9]|1[0-9]|2[0-9]|3[01])' ) ); ?>" />@
 							&lrm;
 							<input type="number" class="hour" placeholder="<?php esc_attr_e( 'h', 'woocommerce' ); ?>" name="order_date_hour" min="0" max="23" step="1" value="<?php echo esc_attr( date_i18n( 'H', strtotime( $post->post_date ) ) ); ?>" pattern="([01]?[0-9]{1}|2[0-3]{1})" />:
@@ -246,12 +249,12 @@ class WC_Meta_Box_Order_Data {
 						<p class="form-field form-field-wide wc-order-status">
 							<label for="order_status">
 								<?php
-								_e( 'Status:', 'woocommerce' );
+								esc_html_e( 'Status:', 'woocommerce' );
 								if ( $order->needs_payment() ) {
 									printf(
 										'<a href="%s">%s</a>',
 										esc_url( $order->get_checkout_payment_url() ),
-										__( 'Customer payment page &rarr;', 'woocommerce' )
+										esc_html__( 'Customer payment page &rarr;', 'woocommerce' )
 									);
 								}
 								?>
@@ -270,7 +273,7 @@ class WC_Meta_Box_Order_Data {
 							<!--email_off--> <!-- Disable CloudFlare email obfuscation -->
 							<label for="customer_user">
 								<?php
-								_e( 'Customer:', 'woocommerce' );
+								esc_html_e( 'Customer:', 'woocommerce' );
 								if ( $order->get_user_id( 'edit' ) ) {
 									$args = array(
 										'post_status'    => 'all',
@@ -280,12 +283,12 @@ class WC_Meta_Box_Order_Data {
 									printf(
 										'<a href="%s">%s</a>',
 										esc_url( add_query_arg( $args, admin_url( 'edit.php' ) ) ),
-										' ' . __( 'View other orders &rarr;', 'woocommerce' )
+										' ' . esc_html__( 'View other orders &rarr;', 'woocommerce' )
 									);
 									printf(
 										'<a href="%s">%s</a>',
 										esc_url( add_query_arg( 'user_id', $order->get_user_id( 'edit' ), admin_url( 'user-edit.php' ) ) ),
-										' ' . __( 'Profile &rarr;', 'woocommerce' )
+										' ' . esc_html__( 'Profile &rarr;', 'woocommerce' )
 									);
 								}
 								?>
@@ -294,10 +297,10 @@ class WC_Meta_Box_Order_Data {
 							$user_string = '';
 							$user_id     = '';
 							if ( $order->get_user_id() ) {
-								$user_id = absint( $order->get_user_id() );
-								$user    = get_user_by( 'id', $user_id );
-								/* translators: 1: user display name 2: user ID 3: user email */
+								$user_id     = absint( $order->get_user_id() );
+								$user        = get_user_by( 'id', $user_id );
 								$user_string = sprintf(
+									/* translators: 1: user display name 2: user ID 3: user email */
 									esc_html__( '%1$s (#%2$s &ndash; %3$s)', 'woocommerce' ),
 									$user->display_name,
 									absint( $user->ID ),
@@ -306,7 +309,7 @@ class WC_Meta_Box_Order_Data {
 							}
 							?>
 							<select class="wc-customer-search" id="customer_user" name="customer_user" data-placeholder="<?php esc_attr_e( 'Guest', 'woocommerce' ); ?>" data-allow_clear="true">
-								<option value="<?php echo esc_attr( $user_id ); ?>" selected="selected"><?php echo htmlspecialchars( wp_kses_post( $user_string ) ); // htmlspecialchars to prevent XSS when rendered by selectWoo. ?></option>
+								<option value="<?php echo esc_attr( $user_id ); ?>" selected="selected"><?php /* htmlspecialchars to prevent XSS when rendered by selectWoo. */ echo esc_html( htmlspecialchars( wp_kses_post( $user_string ) ) ); ?></option>
 							</select>
 							<!--/email_off-->
 						</p>
@@ -327,7 +330,7 @@ class WC_Meta_Box_Order_Data {
 							if ( $order->get_formatted_billing_address() ) {
 								echo '<p>' . wp_kses( $order->get_formatted_billing_address(), array( 'br' => array() ) ) . '</p>';
 							} else {
-								echo '<p class="none_set"><strong>' . __( 'Address:', 'woocommerce' ) . '</strong> ' . __( 'No billing address set.', 'woocommerce' ) . '</p>';
+								echo '<p class="none_set"><strong>' . esc_html__( 'Address:', 'woocommerce' ) . '</strong> ' . esc_html__( 'No billing address set.', 'woocommerce' ) . '</p>';
 							}
 
 							foreach ( self::$billing_fields as $key => $field ) {
@@ -402,7 +405,7 @@ class WC_Meta_Box_Order_Data {
 									foreach ( $payment_gateways as $gateway ) {
 										if ( 'yes' === $gateway->enabled ) {
 											echo '<option value="' . esc_attr( $gateway->id ) . '" ' . selected( $payment_method, $gateway->id, false ) . '>' . esc_html( $gateway->get_title() ) . '</option>';
-											if ( $payment_method == $gateway->id ) {
+											if ( $payment_method === $gateway->id ) {
 												$found_method = true;
 											}
 										}
@@ -446,7 +449,7 @@ class WC_Meta_Box_Order_Data {
 							if ( $order->get_formatted_shipping_address() ) {
 								echo '<p>' . wp_kses( $order->get_formatted_shipping_address(), array( 'br' => array() ) ) . '</p>';
 							} else {
-								echo '<p class="none_set"><strong>' . __( 'Address:', 'woocommerce' ) . '</strong> ' . __( 'No shipping address set.', 'woocommerce' ) . '</p>';
+								echo '<p class="none_set"><strong>' . esc_html__( 'Address:', 'woocommerce' ) . '</strong> ' . esc_html__( 'No shipping address set.', 'woocommerce' ) . '</p>';
 							}
 
 							if ( ! empty( self::$shipping_fields ) ) {
@@ -473,8 +476,8 @@ class WC_Meta_Box_Order_Data {
 								}
 							}
 
-							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' == get_option( 'woocommerce_enable_order_comments', 'yes' ) ) && $post->post_excerpt ) {
-								echo '<p class="order_note"><strong>' . __( 'Customer provided note:', 'woocommerce' ) . '</strong> ' . nl2br( esc_html( $post->post_excerpt ) ) . '</p>';
+							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' === get_option( 'woocommerce_enable_order_comments', 'yes' ) ) && $post->post_excerpt ) {
+								echo '<p class="order_note"><strong>' . esc_html__( 'Customer provided note:', 'woocommerce' ) . '</strong> ' . nl2br( esc_html( $post->post_excerpt ) ) . '</p>';
 							}
 							?>
 						</div>
@@ -510,10 +513,10 @@ class WC_Meta_Box_Order_Data {
 								}
 							}
 
-							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' == get_option( 'woocommerce_enable_order_comments', 'yes' ) ) ) :
+							if ( apply_filters( 'woocommerce_enable_order_notes_field', 'yes' === get_option( 'woocommerce_enable_order_comments', 'yes' ) ) ) :
 								?>
 								<p class="form-field form-field-wide">
-									<label for="excerpt"><?php _e( 'Customer provided note', 'woocommerce' ); ?>:</label>
+									<label for="excerpt"><?php esc_html_e( 'Customer provided note', 'woocommerce' ); ?>:</label>
 									<textarea rows="1" cols="40" name="excerpt" tabindex="6" id="excerpt" placeholder="<?php esc_attr_e( 'Customer notes about the order', 'woocommerce' ); ?>"><?php echo wp_kses_post( $post->post_excerpt ); ?></textarea>
 								</p>
 							<?php endif; ?>
@@ -532,8 +535,23 @@ class WC_Meta_Box_Order_Data {
 	 * Save meta box data.
 	 *
 	 * @param int $order_id Order ID.
+	 * @throws Exception Required request data is missing.
 	 */
 	public static function save( $order_id ) {
+		if ( ! isset( $_POST['order_status'] ) ) {
+			throw new Exception( __( 'Order status is missing.', 'woocommerce' ), 400 );
+		}
+
+		if ( ! isset( $_POST['_payment_method'] ) ) {
+			throw new Exception( __( 'Payment method is missing.', 'woocommerce' ), 400 );
+		}
+
+		if ( ! isset( $_POST['_wpnonce'] ) ) {
+			throw new Exception( __( 'Nonce is missing.', 'woocommerce' ), 400 );
+		}
+
+		wp_verify_nonce( wc_clean( wp_unslash( $_POST['_wpnonce'], 'woocommerce_save_data' ) ) );
+
 		self::init_address_fields();
 
 		// Ensure gateways are loaded in case they need to insert data into the emails.
@@ -598,7 +616,7 @@ class WC_Meta_Box_Order_Data {
 		}
 
 		// Payment method handling.
-		if ( $order->get_payment_method() !== wp_unslash( $_POST['_payment_method'] ) ) {
+		if ( $order->get_payment_method() !== wc_clean( wp_unslash( $_POST['_payment_method'] ) ) ) {
 			$methods              = WC()->payment_gateways->payment_gateways();
 			$payment_method       = wc_clean( wp_unslash( $_POST['_payment_method'] ) );
 			$payment_method_title = $payment_method;
@@ -607,10 +625,10 @@ class WC_Meta_Box_Order_Data {
 				$payment_method_title = $methods[ $payment_method ]->get_title();
 			}
 
-			if ( $payment_method == 'other') {
+			if ( 'other' === $payment_method ) {
 				$payment_method_title = esc_html__( 'Other', 'woocommerce' );
 			}
-			
+
 			$props['payment_method']       = $payment_method;
 			$props['payment_method_title'] = $payment_method_title;
 		}
@@ -619,13 +637,17 @@ class WC_Meta_Box_Order_Data {
 		if ( empty( $_POST['order_date'] ) ) {
 			$date = time();
 		} else {
+			if ( ! isset( $_POST['order_date_hour'] ) || ! isset( $_POST['order_date_minute'] ) || ! isset( $_POST['order_date_second'] ) ) {
+				throw new Exception( __( 'Order date, hour, minute and/or second are missing.', 'woocommerce' ), 400 );
+			}
+			// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
 			$date = gmdate( 'Y-m-d H:i:s', strtotime( $_POST['order_date'] . ' ' . (int) $_POST['order_date_hour'] . ':' . (int) $_POST['order_date_minute'] . ':' . (int) $_POST['order_date_second'] ) );
 		}
 
 		$props['date_created'] = $date;
 
 		// Set created via prop if new post.
-		if ( isset( $_POST['original_post_status'] ) && $_POST['original_post_status'] === 'auto-draft' ) {
+		if ( isset( $_POST['original_post_status'] ) && 'auto-draft' === $_POST['original_post_status'] ) {
 			$props['created_via'] = 'admin';
 		}
 

--- a/plugins/woocommerce/includes/class-wc-order.php
+++ b/plugins/woocommerce/includes/class-wc-order.php
@@ -2053,7 +2053,7 @@ class WC_Order extends WC_Abstract_Order {
 	 * @param string $tax_display Tax to display.
 	 */
 	protected function add_order_item_totals_payment_method_row( &$total_rows, $tax_display ) {
-		if ( $this->get_total() > 0 && $this->get_payment_method_title() && 'other' !== $this->get_payment_method_title() ) {
+		if ( $this->get_total() > 0 && $this->get_payment_method_title() && 'other' !== $this->get_payment_method() ) {
 			$total_rows['payment_method'] = array(
 				'label' => __( 'Payment method:', 'woocommerce' ),
 				'value' => $this->get_payment_method_title(),


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

#### Fix code standards errors in order details metabox (class-wc-meta-box-order-data.php)

- Sanitize all input.
- Escape all output.
- Verify nonce on `save`.
- Verify that all required POST parameters are present on `save`, throw an exception if not.
- Minor coding standards fixes (periods at end of comments, function docs, Yoda conditions...)

#### Check payment method name instead of display title in WC_Order::add_order_item_totals_payment_method_row

This method, used by `get_order_item_totals`, now adds a "payment method" row to the returned data only if the payment method name is different from `other` (the payment method title was being checked instead, but both are different since https://github.com/woocommerce/woocommerce/pull/30256 was merged).

### How to test the changes in this Pull Request:

For the code standards fixes: open an order in the admin area and verify that all the data in the order dettails box is rendered correctly. Do some changes in the order, click "Update" and verify that the changes are saved correctly.

For the change in `get_order_item_totals`:

1. Open an order in the admin area.
2. Edit the billing details, change the payment method to "Other", save.
3. In the "Order actions" box, run the "Email invoice/order details to customer" action.
4. Verify that the email sent **does not** contain a "payment method" row in the order details table (without the fix it will contain "Payment method: other"). 

You may want to use [the email logger plugin](https://es.wordpress.org/plugins/email-log/) to see the email sent.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

N/A - It's basically a fix for https://github.com/woocommerce/woocommerce/pull/30256, which is to be included in the same release.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
