### PR TITLE
Update checkout tests to use API and wait on UI

### DIFF
--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests */
-
 /**
  * Internal dependencies
  */
@@ -10,7 +8,7 @@ const {
 	addShippingZoneAndMethod,
 	clearAndFillInput,
 	selectOptionInSelect2,
-	deleteAllShippingZones,
+	withRestApi,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -35,8 +33,8 @@ const runAddNewShippingZoneTest = () => {
 	describe('WooCommerce Shipping Settings - Add new shipping zone', () => {
 		beforeAll(async () => {
 			await createSimpleProduct();
+			await withRestApi.deleteAllShippingZones();
 			await merchant.login();
-			await deleteAllShippingZones();
 		});
 
 		it('add shipping zone for San Francisco with free Local pickup', async () => {
@@ -86,7 +84,7 @@ const runAddNewShippingZoneTest = () => {
 
 		it('allows customer to benefit from a Free shipping if in CA', async () => {
 			await page.reload();
-			
+
 			// Set shipping state to California
 			await expect(page).toClick('a.shipping-calculator-button');
 			await expect(page).toClick('#select2-calc_shipping_state-container');

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
@@ -39,6 +39,8 @@ const runCartCalculateShippingTest = () => {
 			await createSimpleProduct(firstProductName);
 			await createSimpleProduct(secondProductName, secondProductPrice);
 
+			await withRestApi.resetSettingsGroupToDefault( 'general' );
+
 			// Add a new shipping zone Germany with Free shipping
 			await withRestApi.addShippingZoneAndMethod(shippingZoneNameDE, shippingCountryDE, ' ', 'free_shipping');
 
@@ -71,7 +73,7 @@ const runCartCalculateShippingTest = () => {
 		});
 
 		it('allows customer to calculate Flat rate and Local pickup if in France', async () => {
-			await page.reload( { waitUntil: ['networkidle0', 'domcontentloaded'] });
+			await page.reload( { waitUntil: ['networkidle0', 'domcontentloaded'] } );
 
 			// Set shipping country to France
 			await expect(page).toClick('a.shipping-calculator-button');

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
@@ -1,16 +1,13 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/expect-expect */
-
 /**
  * Internal dependencies
  */
 const {
 	shopper,
-	merchant,
 	createSimpleProduct,
 	addShippingZoneAndMethod,
-	clearAndFillInput,
 	uiUnblocked,
 	selectOptionInSelect2,
+	merchant,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -43,25 +40,12 @@ const runCartCalculateShippingTest = () => {
 			await createSimpleProduct(firstProductName);
 			await createSimpleProduct(secondProductName, secondProductPrice);
 
-			await merchant.login();
-			await merchant.openNewShipping();
-
 			// Add a new shipping zone Germany with Free shipping
 			await addShippingZoneAndMethod(shippingZoneNameDE, shippingCountryDE, ' ', 'free_shipping');
 
 			// Add a new shipping zone for France with Flat rate & Local pickup
-			await addShippingZoneAndMethod(shippingZoneNameFR, shippingCountryFR, ' ', 'flat_rate');
-			await page.waitFor(1000); // to avoid flakiness in headless
-			await page.click('a.wc-shipping-zone-method-settings', {text: 'Flat rate'});
-			await clearAndFillInput('#woocommerce_flat_rate_cost', '5');
-			await page.click('.wc-backbone-modal-main button#btn-ok');
-			// Add additional method Local pickup for the same location
-			await page.waitFor(1000); // to avoid flakiness in headless
-			await page.click('button.wc-shipping-zone-add-method', {text:'Add shipping method'});
-			await page.waitForSelector('.wc-shipping-zone-method-selector');
-			await page.select('select[name="add_method_id"]', 'local_pickup');
-			await page.click('button#btn-ok');
-			await page.waitForSelector('#zone_locations');
+			await addShippingZoneAndMethod(shippingZoneNameFR, shippingCountryFR, ' ', 'flat_rate', '5', ['local_pickup']);
+
 			await merchant.logout();
 			await shopper.emptyCart();
 		});
@@ -76,6 +60,7 @@ const runCartCalculateShippingTest = () => {
 			await expect(page).toClick('#select2-calc_shipping_country-container');
 			await selectOptionInSelect2('Germany');
 			await expect(page).toClick('button[name="calc_shipping"]');
+			await uiUnblocked();
 
 			// Verify shipping costs
 			await page.waitForSelector('.order-total');
@@ -84,13 +69,14 @@ const runCartCalculateShippingTest = () => {
 		});
 
 		it('allows customer to calculate Flat rate and Local pickup if in France', async () => {
-			await page.reload();
+			await page.reload( { waitUntil: ['networkidle0', 'domcontentloaded'] });
 
 			// Set shipping country to France
 			await expect(page).toClick('a.shipping-calculator-button');
 			await expect(page).toClick('#select2-calc_shipping_country-container');
 			await selectOptionInSelect2('France');
 			await expect(page).toClick('button[name="calc_shipping"]');
+			await uiUnblocked();
 
 			// Verify shipping costs
 			await page.waitForSelector('.order-total');
@@ -119,13 +105,14 @@ const runCartCalculateShippingTest = () => {
 		});
 
 		it('should show correct total cart price with 2 products without flat rate', async () => {
-			await page.reload();
+			await page.reload( { waitUntil: ['networkidle0', 'domcontentloaded'] } );
 
 			// Set shipping country to Spain
 			await expect(page).toClick('a.shipping-calculator-button');
 			await expect(page).toClick('#select2-calc_shipping_country-container');
 			await selectOptionInSelect2('Spain');
 			await expect(page).toClick('button[name="calc_shipping"]');
+			await uiUnblocked();
 
 			// Verify shipping costs
 			await page.waitForSelector('.order-total');

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
@@ -4,10 +4,9 @@
 const {
 	shopper,
 	createSimpleProduct,
-	addShippingZoneAndMethod,
 	uiUnblocked,
 	selectOptionInSelect2,
-	merchant,
+	withRestApi,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -41,12 +40,16 @@ const runCartCalculateShippingTest = () => {
 			await createSimpleProduct(secondProductName, secondProductPrice);
 
 			// Add a new shipping zone Germany with Free shipping
-			await addShippingZoneAndMethod(shippingZoneNameDE, shippingCountryDE, ' ', 'free_shipping');
+			await withRestApi.addShippingZoneAndMethod(shippingZoneNameDE, shippingCountryDE, ' ', 'free_shipping');
 
 			// Add a new shipping zone for France with Flat rate & Local pickup
-			await addShippingZoneAndMethod(shippingZoneNameFR, shippingCountryFR, ' ', 'flat_rate', '5', ['local_pickup']);
+			await withRestApi.addShippingZoneAndMethod(shippingZoneNameFR, shippingCountryFR, ' ', 'flat_rate', '5', ['local_pickup']);
 
 			await shopper.emptyCart();
+		});
+
+		afterAll(async () => {
+			await withRestApi.deleteAllShippingZones();
 		});
 
 		it('allows customer to calculate Free Shipping if in Germany', async () => {

--- a/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart-calculate-shipping.test.js
@@ -46,7 +46,6 @@ const runCartCalculateShippingTest = () => {
 			// Add a new shipping zone for France with Flat rate & Local pickup
 			await addShippingZoneAndMethod(shippingZoneNameFR, shippingCountryFR, ' ', 'flat_rate', '5', ['local_pickup']);
 
-			await merchant.logout();
 			await shopper.emptyCart();
 		});
 

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -15,6 +15,7 @@
 - Added `deleteAllOrders()` that goes through and deletes all orders
 - Added `deleteAllShippingClasses()` which permanently deletes all shipping classes using the API
 - Added `statuses` optional parameter to `deleteAllRepositoryObjects()` to delete on specific statuses
+- Updated `addShippingZoneAndMethod` to use the API instead of UI to create shipping zones
 
 # 0.1.5
 

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -412,37 +412,78 @@ const createCoupon = async ( couponAmount = '5', discountType = 'Fixed cart disc
 };
 
 /**
- * Adds a shipping zone along with a shipping method.
+ * Adds a shipping zone along with a shipping method using the API.
  *
  * @param zoneName Shipping zone name.
- * @param zoneLocation Shiping zone location. Defaults to country:US. For states use: state:US:CA
- * @param zipCode Shipping zone zip code. Defaults to empty one space.
- * @param zoneMethod Shipping method type. Defaults to flat_rate (use also: free_shipping or local_pickup)
+ * @param zoneLocation Shiping zone location. Defaults to country:US. For states use: state:US:CA.
+ * @param zipCode Shipping zone zip code. Default is no zip code.
+ * @param zoneMethod Shipping method type. Defaults to flat_rate (use also: free_shipping or local_pickup).
+ * @param cost Shipping method cost. Default is no cost.
+ * @param additionalZoneMethods Array of additional zone methods to add to the shipping zone.
  */
-const addShippingZoneAndMethod = async ( zoneName, zoneLocation = 'country:US', zipCode = ' ', zoneMethod = 'flat_rate' ) => {
-	await merchant.openNewShipping();
+ const addShippingZoneAndMethod = async (
+	 zoneName,
+	 zoneLocation = 'country:US',
+	 zipCode = '',
+	 zoneMethod = 'flat_rate',
+	 cost = '',
+	 additionalZoneMethods = [] ) => {
 
-	// Fill shipping zone name
-	await page.waitForSelector('input#zone_name');
-	await expect(page).toFill('input#zone_name', zoneName);
+	const path = 'wc/v3/shipping/zones';
+
+	const response = await client.post( path, { name: zoneName } );
+	expect(response.statusCode).toEqual(201);
+	let zoneId = response.data.id;
 
 	// Select shipping zone location
-	await expect(page).toSelect('select[name="zone_locations"]', zoneLocation);
+	let zoneType = zoneLocation.split(/:(.)/)[0];
+	let zoneCode = zoneLocation.split(/:(.+)/)[1];
+	let zoneLocationPayload = [
+		{
+			code: zoneCode,
+			type: zoneType
+		}
+	];
 
-	// Fill shipping zone postcode if needed otherwise just put empty space
-	await page.waitForSelector('a.wc-shipping-zone-postcodes-toggle');
-	await expect(page).toClick('a.wc-shipping-zone-postcodes-toggle');
-	await expect(page).toFill('#zone_postcodes', zipCode);
-	await expect(page).toMatchElement('#zone_postcodes', zipCode);
-	await expect(page).toClick('button#submit');
+	// Fill shipping zone postcode if provided
+	if ( zipCode ) {
+		zoneLocationPayload.push( {
+			code: zipCode,
+			type: "postcode",
+		} );
+	};
+
+	const locationResponse = await client.put( path + `/${zoneId}/locations`, zoneLocationPayload );
+	expect(locationResponse.statusCode).toEqual(200);
 
 	// Add shipping zone method
-	await page.waitFor(1000);
-	await expect(page).toClick('button.wc-shipping-zone-add-method', {text:'Add shipping method'});
-	await page.waitForSelector('.wc-shipping-zone-method-selector');
-	await expect(page).toSelect('select[name="add_method_id"]', zoneMethod);
-	await expect(page).toClick('button#btn-ok');
-	await page.waitForSelector('#zone_locations');
+	let methodPayload = {
+		method_id: zoneMethod
+	}
+
+	const methodsResponse = await client.post( path + `/${zoneId}/methods`, methodPayload );
+	expect(methodsResponse.statusCode).toEqual(200);
+	let methodId = methodsResponse.data.id;
+
+	// Add in cost, if provided
+	if ( cost ) {
+		let costPayload = {
+			settings: {
+				cost: cost
+			}
+		}
+
+		const costResponse = await client.put( path + `/${zoneId}/methods/${methodId}`, costPayload );
+		expect(costResponse.statusCode).toEqual(200);
+	}
+
+	// Add any additional zones, if provided
+	if (additionalZoneMethods.length > 0) {
+		for ( let z = 0; z < additionalZoneMethods.length; z++ ) {
+			let response = await client.post( path + `/${zoneId}/methods`, { method_id: additionalZoneMethods[z] } );
+			expect(response.statusCode).toEqual(200);
+		}
+	}
 };
 
 /**

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -419,7 +419,7 @@ const createCoupon = async ( couponAmount = '5', discountType = 'Fixed cart disc
  * @param zipCode Shipping zone zip code. Defaults to empty one space.
  * @param zoneMethod Shipping method type. Defaults to flat_rate (use also: free_shipping or local_pickup)
  */
- const addShippingZoneAndMethod = async ( zoneName, zoneLocation = 'country:US', zipCode = ' ', zoneMethod = 'flat_rate' ) => {
+const addShippingZoneAndMethod = async ( zoneName, zoneLocation = 'country:US', zipCode = ' ', zoneMethod = 'flat_rate' ) => {
 	await merchant.openNewShipping();
 
 	// Fill shipping zone name

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -412,78 +412,37 @@ const createCoupon = async ( couponAmount = '5', discountType = 'Fixed cart disc
 };
 
 /**
- * Adds a shipping zone along with a shipping method using the API.
+ * Adds a shipping zone along with a shipping method.
  *
  * @param zoneName Shipping zone name.
- * @param zoneLocation Shiping zone location. Defaults to country:US. For states use: state:US:CA.
- * @param zipCode Shipping zone zip code. Default is no zip code.
- * @param zoneMethod Shipping method type. Defaults to flat_rate (use also: free_shipping or local_pickup).
- * @param cost Shipping method cost. Default is no cost.
- * @param additionalZoneMethods Array of additional zone methods to add to the shipping zone.
+ * @param zoneLocation Shiping zone location. Defaults to country:US. For states use: state:US:CA
+ * @param zipCode Shipping zone zip code. Defaults to empty one space.
+ * @param zoneMethod Shipping method type. Defaults to flat_rate (use also: free_shipping or local_pickup)
  */
- const addShippingZoneAndMethod = async (
-	 zoneName,
-	 zoneLocation = 'country:US',
-	 zipCode = '',
-	 zoneMethod = 'flat_rate',
-	 cost = '',
-	 additionalZoneMethods = [] ) => {
+ const addShippingZoneAndMethod = async ( zoneName, zoneLocation = 'country:US', zipCode = ' ', zoneMethod = 'flat_rate' ) => {
+	await merchant.openNewShipping();
 
-	const path = 'wc/v3/shipping/zones';
-
-	const response = await client.post( path, { name: zoneName } );
-	expect(response.statusCode).toEqual(201);
-	let zoneId = response.data.id;
+	// Fill shipping zone name
+	await page.waitForSelector('input#zone_name');
+	await expect(page).toFill('input#zone_name', zoneName);
 
 	// Select shipping zone location
-	let zoneType = zoneLocation.split(/:(.)/)[0];
-	let zoneCode = zoneLocation.split(/:(.+)/)[1];
-	let zoneLocationPayload = [
-		{
-			code: zoneCode,
-			type: zoneType
-		}
-	];
+	await expect(page).toSelect('select[name="zone_locations"]', zoneLocation);
 
-	// Fill shipping zone postcode if provided
-	if ( zipCode ) {
-		zoneLocationPayload.push( {
-			code: zipCode,
-			type: "postcode",
-		} );
-	};
-
-	const locationResponse = await client.put( path + `/${zoneId}/locations`, zoneLocationPayload );
-	expect(locationResponse.statusCode).toEqual(200);
+	// Fill shipping zone postcode if needed otherwise just put empty space
+	await page.waitForSelector('a.wc-shipping-zone-postcodes-toggle');
+	await expect(page).toClick('a.wc-shipping-zone-postcodes-toggle');
+	await expect(page).toFill('#zone_postcodes', zipCode);
+	await expect(page).toMatchElement('#zone_postcodes', zipCode);
+	await expect(page).toClick('button#submit');
 
 	// Add shipping zone method
-	let methodPayload = {
-		method_id: zoneMethod
-	}
-
-	const methodsResponse = await client.post( path + `/${zoneId}/methods`, methodPayload );
-	expect(methodsResponse.statusCode).toEqual(200);
-	let methodId = methodsResponse.data.id;
-
-	// Add in cost, if provided
-	if ( cost ) {
-		let costPayload = {
-			settings: {
-				cost: cost
-			}
-		}
-
-		const costResponse = await client.put( path + `/${zoneId}/methods/${methodId}`, costPayload );
-		expect(costResponse.statusCode).toEqual(200);
-	}
-
-	// Add any additional zones, if provided
-	if (additionalZoneMethods.length > 0) {
-		for ( let z = 0; z < additionalZoneMethods.length; z++ ) {
-			let response = await client.post( path + `/${zoneId}/methods`, { method_id: additionalZoneMethods[z] } );
-			expect(response.statusCode).toEqual(200);
-		}
-	}
+	await page.waitFor(1000);
+	await expect(page).toClick('button.wc-shipping-zone-add-method', {text:'Add shipping method'});
+	await page.waitForSelector('.wc-shipping-zone-method-selector');
+	await expect(page).toSelect('select[name="add_method_id"]', zoneMethod);
+	await expect(page).toClick('button#btn-ok');
+	await page.waitForSelector('#zone_locations');
 };
 
 /**

--- a/tests/e2e/utils/src/flows/with-rest-api.js
+++ b/tests/e2e/utils/src/flows/with-rest-api.js
@@ -118,8 +118,7 @@ export const withRestApi = {
 	   let zoneId = response.data.id;
 
 	   // Select shipping zone location
-	   let zoneType = zoneLocation.split(/:(.)/)[0];
-	   let zoneCode = zoneLocation.split(/:(.+)/)[1];
+	   let [ zoneType, zoneCode ] = zoneLocation.split(/:(.+)/);
 	   let zoneLocationPayload = [
 		   {
 			   code: zoneCode,
@@ -131,7 +130,7 @@ export const withRestApi = {
 	   if ( zipCode ) {
 		   zoneLocationPayload.push( {
 			   code: zipCode,
-			   type: "postcode",
+			   type: "postcode"
 		   } );
 	   };
 

--- a/tests/e2e/utils/src/flows/with-rest-api.js
+++ b/tests/e2e/utils/src/flows/with-rest-api.js
@@ -122,7 +122,7 @@ export const withRestApi = {
 	   let zoneLocationPayload = [
 		   {
 			   code: zoneCode,
-			   type: zoneType
+			   type: zoneType,
 		   }
 	   ];
 
@@ -130,9 +130,9 @@ export const withRestApi = {
 	   if ( zipCode ) {
 		   zoneLocationPayload.push( {
 			   code: zipCode,
-			   type: "postcode"
+			   type: "postcode",
 		   } );
-	   };
+	   }
 
 	   const locationResponse = await client.put( path + `/${zoneId}/locations`, zoneLocationPayload );
 	   expect(locationResponse.statusCode).toEqual(200);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the component function for e2e tests to use the API to create shipping zones. As this is used across multiple tests, the changes are very surgical in nature. Additionally, this PR updates the calculate shipping tests to wait more on the UI, including when reloading the page.

### How to test the changes in this Pull Request:

1. Verify the CI passes
2. Run the calculate shipping test locally and verify it passes:

```
npx wc-e2e test:e2e specs/front-end/cart-calculate-shipping.test.js
```