### PR TITLE
Added functionality for release testing workflow in e2e tests

### DIFF
--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -37,8 +37,8 @@ jobs:
           SMOKE_TEST_CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
           WC_E2E_SCREENSHOTS: 1
           E2E_RETEST: 1
-          E2E_SLACK_TOKEN: ${{ secrets.RELEASE_TEST_SLACK_TOKEN }}
-          E2E_SLACK_CHANNEL: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
+          E2E_SLACK_TOKEN: ${{ secrets.SMOKE_TEST_SLACK_TOKEN }}
+          E2E_SLACK_CHANNEL: ${{ secrets.SMOKE_TEST_SLACK_CHANNEL }}
           TEST_RELEASE: 1
           UPDATE_WC: 1
         run: |

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -1,0 +1,46 @@
+name: Smoke test release
+on:
+  release:
+    types: [published]
+jobs:
+  login-run:
+    name: Daily smoke test on release.
+    runs-on: ubuntu-18.04
+    steps:
+
+      - name: Create dirs.
+        run: |
+              mkdir -p code/woocommerce
+              mkdir -p package/woocommerce
+              mkdir -p tmp/woocommerce
+              mkdir -p node_modules
+
+      - name: Checkout code.
+        uses: actions/checkout@v2
+        with:
+          ref: trunk
+
+      - name: Install prerequisites.
+        run: |
+          npm install
+          composer install --no-dev
+          npm run build:assets
+          npm install jest
+          
+      - name: Run smoke test.
+        env:
+          SMOKE_TEST_URL: ${{ secrets.RELEASE_TEST_URL }}
+          SMOKE_TEST_ADMIN_USER: ${{ secrets.RELEASE_TEST_ADMIN_USER }}
+          SMOKE_TEST_ADMIN_PASSWORD: ${{ secrets.RELEASE_TEST_ADMIN_PASSWORD }}
+          SMOKE_TEST_ADMIN_USER_EMAIL: ${{ secrets.RELEASE_TEST_ADMIN_USER_EMAIL }}
+          SMOKE_TEST_CUSTOMER_USER: ${{ secrets.RELEASE_TEST_CUSTOMER_USER }}
+          SMOKE_TEST_CUSTOMER_PASSWORD: ${{ secrets.RELEASE_TEST_CUSTOMER_PASSWORD }}
+          WC_E2E_SCREENSHOTS: 1
+          E2E_RETEST: 1
+          E2E_SLACK_TOKEN: ${{ secrets.RELEASE_TEST_SLACK_TOKEN }}
+          E2E_SLACK_CHANNEL: ${{ secrets.RELEASE_TEST_SLACK_CHANNEL }}
+          TEST_RELEASE: 1
+          UPDATE_WC: 1
+        run: |
+          npx wc-e2e test:e2e ./tests/e2e/specs/smoke-tests/update-woocommerce.js
+          npx wc-e2e test:e2e

--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -6,6 +6,7 @@
 - Added plugin zip utility functions:
   - `checkNestedZip( zipFilePath, savePath )` checks a plugin zip file for any nested zip files. If one is found, it is extracted. Returns the path where the zip file is located.
   - `downloadZip( fileUrl, downloadPath )` downloads a plugin zip file from a remote location to the provided path.
+- Added `getLatestReleaseZipUrl( owner, repository, getPrerelease, perPage )` util function to get the latest release zip from a GitHub repository
 
 # 0.2.2
 

--- a/tests/e2e/env/README.md
+++ b/tests/e2e/env/README.md
@@ -196,6 +196,14 @@ The above method also makes use of the following utility methods which can also 
 - `checkNestedZip( zipFilePath, savePath )` used to check a plugin zip file for any nested zip files. If one is found, it is extracted. Returns the path where the zip file is located.
 - `downloadZip( fileUrl, downloadPath )` can be used to directly download a plugin zip file from a remote location to the provided path.
 
+### Get the latest released zip URL
+
+If you would like to get the latest release zip URL, which can be used in the methods mentioned above, you can use the following helper function to do so:
+
+`getLatestReleaseZipUrl( owner, repository, getPrerelease, perPage )`
+
+This will return a string with the latest release URL. Optionally, you can use the `getPrerelease` boolean flag, which defaults to false, on whether or not to get a prerelease instead. The `perPage` flag can be used to return more results when getting the list of releases. The default value is 3.
+
 ## Additional information
 
 Refer to [`tests/e2e/core-tests`](https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/core-tests) for some test examples, and [`tests/e2e`](https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e) for general information on e2e tests.

--- a/tests/e2e/env/utils/get-plugin-zip.js
+++ b/tests/e2e/env/utils/get-plugin-zip.js
@@ -30,6 +30,52 @@ const getRemotePluginZip = async ( fileUrl ) => {
 };
 
 /**
+ * Get the latest release zip for a plugin from a GiHub repository.
+ *
+ * @param {string} owner The owner of the plugin repository.
+ * @param {string} repository The repository name.
+ * @param {boolean} getPrerelease Flag on whether to get a prelease or not.
+ * @param {number} perPage Limit of entries returned from the latest releases list, defaults to 3.
+ * @returns {Promise<string>}} Returns the URL for the release zip file.
+ */
+const getLatestReleaseZipUrl = async ( owner, repository, getPrerelease = false, perPage = 3 ) => {
+	let requesturl;
+
+	if ( getPrerelease ) {
+		requesturl = `https://api.github.com/repos/${owner}/${repository}/releases?per_page=${perPage}`;
+	} else {
+		requesturl = `https://api.github.com/repos/${owner}/${repository}/releases/latest`;
+	}
+
+	const options = {
+		url: requesturl,
+		method: 'GET',
+		json: true,
+		headers: {'user-agent': 'node.js'}
+	};
+
+	// Wrap in a promise to make the request async
+	return new Promise( function( resolve, reject ) {
+		request.get(options, function( err, resp, body ) {
+			if ( err ) {
+				reject( err );
+			} else {
+				if ( getPrerelease ) {
+					// Loop until we find the first pre-release, then return it.
+					body.forEach(release => {
+						if ( release.prerelease ) {
+							resolve( release.zipball_url );
+						}
+					});
+				} else {
+					resolve( body.zipball_url );
+				}
+			}
+		})
+	});
+}
+
+/**
  * Check the zip file for any nested zips. If one is found, extract it.
  *
  * @param {string} zipFilePath The location of the zip file.
@@ -80,6 +126,7 @@ const downloadZip = async ( fileUrl, downloadPath ) => {
 
 module.exports = {
 	getRemotePluginZip,
+	getLatestReleaseZipUrl,
 	checkNestedZip,
 	downloadZip,
 };

--- a/tests/e2e/env/utils/index.js
+++ b/tests/e2e/env/utils/index.js
@@ -1,7 +1,7 @@
 const getAppRoot = require( './app-root' );
 const { getAppName, getAppBase } = require( './app-name' );
 const { getTestConfig, getAdminConfig } = require( './test-config' );
-const { getRemotePluginZip } = require('./get-plugin-zip');
+const { getRemotePluginZip, getLatestReleaseZipUrl } = require('./get-plugin-zip');
 const takeScreenshotFor = require( './take-screenshot' );
 const updateReadyPageStatus = require('./update-ready-page');
 const consoleUtils = require( './filter-console' );
@@ -13,6 +13,7 @@ module.exports = {
 	getTestConfig,
 	getAdminConfig,
 	getRemotePluginZip,
+	getLatestReleaseZipUrl,
 	takeScreenshotFor,
 	updateReadyPageStatus,
 	...consoleUtils,

--- a/tests/e2e/specs/smoke-tests/update-woocommerce.js
+++ b/tests/e2e/specs/smoke-tests/update-woocommerce.js
@@ -3,7 +3,7 @@
  */
 const { merchant, utils } = require( '@woocommerce/e2e-utils' );
 
-const { getRemotePluginZip } = require( '@woocommerce/e2e-environment' );
+const { getRemotePluginZip, getLatestReleaseZipUrl } = require( '@woocommerce/e2e-environment' );
 
 /**
  * External dependencies
@@ -13,16 +13,23 @@ const {
 	beforeAll,
 } = require( '@jest/globals' );
 
-const { UPDATE_WC } = process.env;
+const { UPDATE_WC, TEST_RELEASE } = process.env;
 
-const nightlyZip = 'https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip';
+let zipUrl;
 const pluginName = 'WooCommerce';
 
 let pluginPath;
 
 utils.describeIf( UPDATE_WC )( 'WooCommerce plugin can be uploaded and activated', () => {
 	beforeAll( async () => {
-		pluginPath = await getRemotePluginZip( nightlyZip );
+
+		if ( TEST_RELEASE ) {
+			zipUrl = await getLatestReleaseZipUrl('woocommerce', 'woocommerce');
+		} else {
+			zipUrl = 'https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip';
+		}
+
+		pluginPath = await getRemotePluginZip( zipUrl );
 		await merchant.login();
 	});
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces logic to get the latest released version of a plugin, with the option to pull in a pre-release version as well. Additionally, a new release workflow has been added that will be triggered when a new release is published. Note this currently flags on `release` based on the GitHub documentation:

> Note: The prereleased type will not trigger for pre-releases published from draft releases, but the published type will trigger. If you want a workflow to run when stable and pre-releases publish, subscribe to published instead of released and prereleased.

More on this workflow can be found on the GitHub docs [here](https://docs.github.com/en/actions/reference/events-that-trigger-workflows#release).

### How to test the changes in this Pull Request:

1. Verify CI passes
2. Set up a test environment that allows for uploading/replacing the current WooCommerce plugin
3. Optionally install the WooCommerce Beta Tester plugin to easily switch between versions if desired
4. Run the first workflow and verify the nightly version gets installed: `UPDATE_WC=1 npx wc-e2e test:e2e ./tests/e2e/specs/smoke-tests/update-woocommerce.js`
5. Navigate to the `Plugins > Installed Plugins` page and verify the nightly version has been installed
6. Next, run the tests to pull in the latest _released_ version: `UPDATE_WC=1 TEST_RELEASE=1 npx wc-e2e test:e2e ./tests/e2e/specs/smoke-tests/update-woocommerce.js`
7. Navigate to the `Plugins > Installed Plugins` page and verify the latest released version has been installed
