### PR TITLE
Clean up and reduce confusion around the `woocommerce_order_actions` filter

### DIFF
--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -150,7 +150,7 @@ class WC_Meta_Box_Order_Actions {
 	/**
 	 * Get the available order actions for a given order.
 	 *
-	 * @since x.x.x
+	 * @since 5.8.0
 	 *
 	 * @param WC_Order|null $order The order object or null if no order is available.
 	 *
@@ -168,7 +168,7 @@ class WC_Meta_Box_Order_Actions {
 		 * Allows filtering of the available order actions for an order.
 		 *
 		 * @since 2.1.0 Filter was added.
-		 * @since x.x.x The $order param was added.
+		 * @since 5.8.0 The $order param was added.
 		 *
 		 * @param array         $actions The available order actions for the order.
 		 * @param WC_Order|null $order   The order object or null if no order is available.

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -156,7 +156,7 @@ class WC_Meta_Box_Order_Actions {
 	 *
 	 * @return array
 	 */
-	public static function get_available_order_actions_for_order( $order ) {
+	private static function get_available_order_actions_for_order( $order ) {
 		$actions = array(
 			'send_order_details'              => __( 'Email invoice / order details to customer', 'woocommerce' ),
 			'send_order_details_admin'        => __( 'Resend new order notification', 'woocommerce' ),

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -30,14 +30,8 @@ class WC_Meta_Box_Order_Actions {
 			$theorder = wc_get_order( $post->ID );
 		}
 
-		$order_actions = apply_filters(
-			'woocommerce_order_actions',
-			array(
-				'send_order_details'              => __( 'Email invoice / order details to customer', 'woocommerce' ),
-				'send_order_details_admin'        => __( 'Resend new order notification', 'woocommerce' ),
-				'regenerate_download_permissions' => __( 'Regenerate download permissions', 'woocommerce' ),
-			)
-		);
+		$theorder = $theorder instanceof WC_Order ? $theorder : null;
+		$order_actions = self::get_available_order_actions_for_order( $theorder );
 		?>
 		<ul class="order_actions submitbox">
 
@@ -150,5 +144,33 @@ class WC_Meta_Box_Order_Actions {
 	 */
 	public static function set_email_sent_message( $location ) {
 		return add_query_arg( 'message', 11, $location );
+	}
+
+	/**
+	 * Get the available order actions for a given order.
+	 *
+	 * @since x.x.x
+	 *
+	 * @param WC_Order|null $order The order object or null if no order is available.
+	 *
+	 * @return array
+	 */
+	public static function get_available_order_actions_for_order( $order ) {
+		$actions = array(
+			'send_order_details'              => __( 'Email invoice / order details to customer', 'woocommerce' ),
+			'send_order_details_admin'        => __( 'Resend new order notification', 'woocommerce' ),
+			'regenerate_download_permissions' => __( 'Regenerate download permissions', 'woocommerce' ),
+		);
+
+		/**
+		 * Filter: woocommerce_order_actions
+		 * Allows filtering of the available order actions for an order.
+		 *
+		 * @since x.x.x The $order param was added.
+		 *
+		 * @param array         $actions The available order actions for the order.
+		 * @param WC_Order|null $order   The order object or null if no order is available.
+		 */
+		return apply_filters( 'woocommerce_order_actions', $actions, $order );
 	}
 }

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -4,8 +4,6 @@
  *
  * Functions for displaying the order actions meta box.
  *
- * @author      WooThemes
- * @category    Admin
  * @package     WooCommerce\Admin\Meta Boxes
  * @version     2.1.0
  */

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -26,6 +26,7 @@ class WC_Meta_Box_Order_Actions {
 		global $theorder;
 
 		// This is used by some callbacks attached to hooks such as woocommerce_order_actions which rely on the global to determine if actions should be displayed for certain orders.
+		// Avoid using this global with the `woocommerce_order_actions` filter, instead use the $order filter arg.
 		if ( ! is_object( $theorder ) ) {
 			$theorder = wc_get_order( $post->ID );
 		}

--- a/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
+++ b/includes/admin/meta-boxes/class-wc-meta-box-order-actions.php
@@ -167,6 +167,7 @@ class WC_Meta_Box_Order_Actions {
 		 * Filter: woocommerce_order_actions
 		 * Allows filtering of the available order actions for an order.
 		 *
+		 * @since 2.1.0 Filter was added.
 		 * @since x.x.x The $order param was added.
 		 *
 		 * @param array         $actions The available order actions for the order.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `woocommerce_order_actions` is used by a a bunch of plugins like WC Payments, Subscriptions, AutomateWoo and could be improved. Currently a global order object (`$theorder`) is commonly used to conditionally add items to the array depending on what type of order is being edited. Rather than use a global this should be a filter argument. 

This PR adds an `$order` filter argument to the `woocommerce_order_actions` filter while maintaining backwards compatibility.

### How to test the changes in this Pull Request:

1. Test that order actions appear on the order edit admin screen

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Add order argument to "woocommerce_order_actions" filter

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
