### PR TITLE
reset settings before cart, checkout tests

### DIFF
--- a/tests/e2e/core-tests/specs/shopper/front-end-cart.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-cart.test.js
@@ -1,9 +1,9 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/expect-expect */
 /**
  * Internal dependencies
  */
 const {
 	shopper,
+	withRestApi,
 	createSimpleProduct,
 	uiUnblocked
 } = require( '@woocommerce/e2e-utils' );
@@ -26,6 +26,9 @@ const runCartPageTest = () => {
 	describe('Cart page', () => {
 		beforeAll(async () => {
 			await createSimpleProduct();
+			await withRestApi.resetSettingsGroupToDefault('general');
+			await withRestApi.resetSettingsGroupToDefault('products');
+			await withRestApi.resetSettingsGroupToDefault('tax');
 		});
 
 		it('should display no item in the cart', async () => {

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
@@ -1,10 +1,10 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/expect-expect, jest/no-standalone-expect */
 /**
  * Internal dependencies
  */
 const {
 	shopper,
 	merchant,
+	withRestApi,
 	createSimpleProduct,
 	setCheckbox,
 	settingsPageSaveChanges,
@@ -28,6 +28,9 @@ const runCheckoutPageTest = () => {
 	describe('Checkout page', () => {
 		beforeAll(async () => {
 			await createSimpleProduct();
+			await withRestApi.resetSettingsGroupToDefault('general');
+			await withRestApi.resetSettingsGroupToDefault('products');
+			await withRestApi.resetSettingsGroupToDefault('tax');
 
 			// Set free shipping within California
 			await merchant.login();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds settings resets to default for the general, product, and tax settings groups to the first cart and first checkout test. Both cart and checkout tests currently depend on running the setup tests first. This PR will make the tests more atomic.

Closes # .

### How to test the changes in this Pull Request:

1. Verify CI
2. Run E2E tests locally

### Changelog entry

> N/A

