### PR TITLE
Add base location's state and postcode for tracking

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -619,6 +619,8 @@ class WC_Tracker {
 			'version'                               => WC()->version,
 			'currency'                              => get_woocommerce_currency(),
 			'base_location'                         => WC()->countries->get_base_country(),
+			'base_state'                            => WC()->countries->get_base_state(),
+			'base_postcode'                         => WC()->countries->get_base_postcode(),
 			'selling_locations'                     => WC()->countries->get_allowed_countries(),
 			'api_enabled'                           => get_option( 'woocommerce_api_enabled' ),
 			'weight_unit'                           => get_option( 'woocommerce_weight_unit' ),


### PR DESCRIPTION
To be able to answer data requests for info with respect to regions within the US, it would he helpful to track the state and postcode of the base_location.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->


### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Track the state and postcode of the store location.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
