### PR TITLE
Deleting unneeded double spaces in text strings.

### DIFF
--- a/i18n/states.php
+++ b/i18n/states.php
@@ -667,8 +667,8 @@ return array(
 		'PY' => __( 'Pondicherry (Puducherry)', 'woocommerce' ),
 	),
 	'IR' => array( // Iran States.
-		'KHZ' => __( 'Khuzestan  (خوزستان)', 'woocommerce' ),
-		'THR' => __( 'Tehran  (تهران)', 'woocommerce' ),
+		'KHZ' => __( 'Khuzestan (خوزستان)', 'woocommerce' ),
+		'THR' => __( 'Tehran (تهران)', 'woocommerce' ),
 		'ILM' => __( 'Ilaam (ایلام)', 'woocommerce' ),
 		'BHR' => __( 'Bushehr (بوشهر)', 'woocommerce' ),
 		'ADL' => __( 'Ardabil (اردبیل)', 'woocommerce' ),

--- a/includes/class-wc-privacy.php
+++ b/includes/class-wc-privacy.php
@@ -86,7 +86,7 @@ class WC_Privacy extends WC_Abstract_Privacy {
 			'<h2>' . __( 'What we collect and store', 'woocommerce' ) . '</h2>' .
 			'<p>' . __( 'While you visit our site, we’ll track:', 'woocommerce' ) . '</p>' .
 			'<ul>' .
-				'<li>' . __( 'Products you’ve viewed:  we’ll use this to, for example, show you products you’ve recently viewed', 'woocommerce' ) . '</li>' .
+				'<li>' . __( 'Products you’ve viewed: we’ll use this to, for example, show you products you’ve recently viewed', 'woocommerce' ) . '</li>' .
 				'<li>' . __( 'Location, IP address and browser type: we’ll use this for purposes like estimating taxes and shipping', 'woocommerce' ) . '</li>' .
 				'<li>' . __( 'Shipping address: we’ll ask you to enter this so we can, for instance, estimate shipping before you place an order, and send you the order!', 'woocommerce' ) . '</li>' .
 			'</ul>' .


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes https://github.com/woocommerce/woocommerce/issues/30486

### How to test the changes in this Pull Request:

There should be none, since it's simply removing some double spaces in strings.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Deleted unneeded double spaces in text strings.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
