### PR TITLE
Add Tracks event for new My Subscriptions page

### DIFF
--- a/includes/tracks/events/class-wc-extensions-tracking.php
+++ b/includes/tracks/events/class-wc-extensions-tracking.php
@@ -29,10 +29,14 @@ class WC_Extensions_Tracking {
 	 */
 	public function track_extensions_page() {
 		// phpcs:disable WordPress.Security.NonceVerification.Recommended
-		$event      = 'extensions_view';
 		$properties = array(
 			'section' => empty( $_REQUEST['section'] ) ? '_featured' : wc_clean( wp_unslash( $_REQUEST['section'] ) ),
 		);
+
+		$event      = 'extensions_view';
+		if ( 'helper' === $properties['section'] ) {
+			$event = 'subscriptions_view';
+		}
 
 		if ( ! empty( $_REQUEST['search'] ) ) {
 			$event                     = 'extensions_view_search';


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

We are rendering the "Browse Extensions" and "WooCommerce.com Subscriptions" tabs on `admin.php?page=wc-addons` as two separate pages, "Marketplace" and "My Subscriptions". This change alters the function that records a Tracks event when the addons page loads, so we log a new event `wccadmin_subscriptions_view`, when the user visits the My Subscriptions page.

Closes 10998-gh-Automattic/woocommerce.com.

### How to test the changes in this Pull Request:

1. Check out the branch.
2. Open the Network tab of dev tools in your browser and filter requests for `https://pixel.wp.com/t.gif`.
3. Go to `wp-admin/admin.php?page=wc-addons` and check the pixel request. Note that the `_en` parameter is `wc_admin_extensions_view`.
4. Go to `wp-admin/admin.php?page=wc-addons&section=helper`. Note that the `_en` parameter is `wc_admin_subscriptions_view`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

Added a new Tracks event when the user views the My Subscriptions page.

### Screenshots

#### Marketplace

<img width="848" alt="image" src="https://user-images.githubusercontent.com/1647564/129230365-0f18c96a-66b3-4879-9df6-3ca7150565ed.png">

#### My Subscriptions

<img width="861" alt="image" src="https://user-images.githubusercontent.com/1647564/129230341-a0b8ae33-a15e-45b8-861a-e92fbc3a172d.png">


### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.