### PR TITLE
fix e2e-utils readme url in package.json

### DIFF
--- a/tests/e2e/utils/package.json
+++ b/tests/e2e/utils/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/e2e-utils",
   "version": "0.1.5",
   "description": "End-To-End (E2E) test utils for WooCommerce",
-  "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e-utils/README.md",
+  "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/utils/README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/woocommerce/woocommerce.git"


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the URL that will show as the `@woocommerce/e2e-utils` package [home page](https://www.npmjs.com/package/@woocommerce/e2e-utils)

Closes #30484 .

### How to test the changes in this Pull Request:

1. Review the change. This won't have any effect until the next version of the package is published.

### Changelog entry

> N/A
