### PR TITLE
Added default timeout override for e2e tests

### DIFF
--- a/.github/workflows/smoke-test-daily.yml
+++ b/.github/workflows/smoke-test-daily.yml
@@ -40,6 +40,7 @@ jobs:
           E2E_SLACK_TOKEN: ${{ secrets.SMOKE_TEST_SLACK_TOKEN }}
           E2E_SLACK_CHANNEL: ${{ secrets.SMOKE_TEST_SLACK_CHANNEL }}
           UPDATE_WC: 1
+          DEFAULT_TIMEOUT_OVERRIDE: 120000
         run: |
           npx wc-e2e test:e2e ./tests/e2e/specs/smoke-tests/update-woocommerce.js
           npx wc-e2e test:e2e

--- a/.github/workflows/smoke-test-release.yml
+++ b/.github/workflows/smoke-test-release.yml
@@ -41,6 +41,7 @@ jobs:
           E2E_SLACK_CHANNEL: ${{ secrets.SMOKE_TEST_SLACK_CHANNEL }}
           TEST_RELEASE: 1
           UPDATE_WC: 1
+          DEFAULT_TIMEOUT_OVERRIDE: 120000
         run: |
           npx wc-e2e test:e2e ./tests/e2e/specs/smoke-tests/update-woocommerce.js
           npx wc-e2e test:e2e

--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -8,6 +8,7 @@ import {
 const config = require('config');
 const { HTTPClientFactory } = require('@woocommerce/api');
 const { addConsoleSuppression, updateReadyPageStatus } = require( '@woocommerce/e2e-environment' );
+const { DEFAULT_TIMEOUT_OVERRIDE } = process.env;
 
 // @todo: remove this once https://github.com/woocommerce/woocommerce-admin/issues/6992 has been addressed
 addConsoleSuppression( 'woocommerce_shared_settings' );
@@ -38,6 +39,12 @@ async function trashExistingPosts() {
 // other posts/comments/etc. aren't dirtying tests and tests don't depend on
 // each other's side-effects.
 beforeAll(async () => {
+
+	if ( DEFAULT_TIMEOUT_OVERRIDE ) {
+		page.setDefaultNavigationTimeout( DEFAULT_TIMEOUT_OVERRIDE );
+		page.setDefaultTimeout( DEFAULT_TIMEOUT_OVERRIDE );
+	}
+
 	// Update the ready page to prevent concurrent test runs
 	await updateReadyPageStatus('draft');
 

--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Unreleased
 
-- `updateReadyPageStatus` utility to update the status of the ready page
-- Added plugin upload functionality util that provides a method to pull a plugin zip from a remote location
+- `updateReadyPageStatus` utility to update the status of the ready page.
+- Added plugin upload functionality util that provides a method to pull a plugin zip from a remote location:
   - `getRemotePluginZip( fileUrl )` to get the remote zip. Returns the filepath of the zip location.
 - Added plugin zip utility functions:
   - `checkNestedZip( zipFilePath, savePath )` checks a plugin zip file for any nested zip files. If one is found, it is extracted. Returns the path where the zip file is located.
   - `downloadZip( fileUrl, downloadPath )` downloads a plugin zip file from a remote location to the provided path.
-- Added `getLatestReleaseZipUrl( owner, repository, getPrerelease, perPage )` util function to get the latest release zip from a GitHub repository
+- Added `getLatestReleaseZipUrl( owner, repository, getPrerelease, perPage )` util function to get the latest release zip from a GitHub repository.
+- Added `DEFAULT_TIMEOUT_OVERRIDE` that allows passing in a time in milliseconds to override the default Jest and Puppeteer timeouts.
 
 # 0.2.2
 

--- a/tests/e2e/env/README.md
+++ b/tests/e2e/env/README.md
@@ -87,6 +87,21 @@ await takeScreenshotFor( 'name of current step' );
 
 Screenshots will be saved to `tests/e2e/screenshots`. This folder is cleared at the beginning of each test run.
 
+### Override default test timeout
+
+To override the default timeout for the tests, you can use the `DEFAULT_TIMEOUT_OVERRIDE` flag and pass in a maximum timeout in milliseconds. For example, you can pass it in when running the tests from the command line:
+
+```bash
+DEFAULT_TIMEOUT_OVERRIDE=35000 npx wc-e2e test:e2e
+```
+
+This value will override the default Jest timeout as well as pass the timeout to the following Puppeteer methods:
+
+* page.setDefaultTimeout();
+* page.setDefaultNavigationTimeout();
+
+For a list of the methods that the above timeout affects, please see the Puppeteer documentation for [`page.setDefaultTimeout()`](https://pptr.dev/#?product=Puppeteer&version=v10.2.0&show=api-pagesetdefaulttimeouttimeout) and [`page.setDefaultNavigationTimeout`](https://pptr.dev/#?product=Puppeteer&version=v10.2.0&show=api-pagesetdefaultnavigationtimeouttimeout) for more information.
+
 ### Jest Puppeteer Config
 
 The test sequencer uses the following default Puppeteer configuration:

--- a/tests/e2e/env/bin/e2e-test-integration.js
+++ b/tests/e2e/env/bin/e2e-test-integration.js
@@ -5,7 +5,7 @@ const program = require( 'commander' );
 const path = require( 'path' );
 const fs = require( 'fs' );
 const { getAppRoot } = require( '../utils' );
-const { WC_E2E_SCREENSHOTS, JEST_PUPPETEER_CONFIG } = process.env;
+const { WC_E2E_SCREENSHOTS, JEST_PUPPETEER_CONFIG, DEFAULT_TIMEOUT_OVERRIDE } = process.env;
 
 program
 	.usage( '<file ...> [options]' )
@@ -42,6 +42,10 @@ let testEnvVars = {
 	node_config_dev: program.dev ? 'yes' : 'no',
 	jest_test_timeout: program.dev ? 120000 : 30000,
 };
+
+if ( DEFAULT_TIMEOUT_OVERRIDE ) {
+	testEnvVars.jest_test_timeout = DEFAULT_TIMEOUT_OVERRIDE;
+}
 
 if ( ! JEST_PUPPETEER_CONFIG ) {
 	// Use local Puppeteer config if there is one.


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces a new environment variable, `DEFAULT_TIMEOUT_OVERRIDE`, which can be used to override the default Jest timeout. This is beneficial for multiple e2e tests that may fail due to hitting the default 30000ms timeout, but without needing to run the tests in dev mode. 

### How to test the changes in this Pull Request:

1. Verify the CI passes
2. Make sure the changes look good, including the timeout selected.