### PR TITLE
Improve type safety (avoid trying to multiply a string by an int).

### DIFF
--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -226,7 +226,7 @@ final class WC_Cart_Totals {
 			$item->taxable                 = 'taxable' === $cart_item['data']->get_tax_status();
 			$item->price_includes_tax      = wc_prices_include_tax();
 			$item->quantity                = $cart_item['quantity'];
-			$item->price                   = wc_add_number_precision_deep( (float) $cart_item['data']->get_price() * (int) $cart_item['quantity'] );
+			$item->price                   = wc_add_number_precision_deep( (float) $cart_item['data']->get_price() * (float) $cart_item['quantity'] );
 			$item->product                 = $cart_item['data'];
 			$item->tax_rates               = $this->get_item_tax_rates( $item );
 			$this->items[ $cart_item_key ] = $item;

--- a/includes/class-wc-cart-totals.php
+++ b/includes/class-wc-cart-totals.php
@@ -226,7 +226,7 @@ final class WC_Cart_Totals {
 			$item->taxable                 = 'taxable' === $cart_item['data']->get_tax_status();
 			$item->price_includes_tax      = wc_prices_include_tax();
 			$item->quantity                = $cart_item['quantity'];
-			$item->price                   = wc_add_number_precision_deep( $cart_item['data']->get_price() * $cart_item['quantity'] );
+			$item->price                   = wc_add_number_precision_deep( (float) $cart_item['data']->get_price() * (int) $cart_item['quantity'] );
 			$item->product                 = $cart_item['data'];
 			$item->tax_rates               = $this->get_item_tax_rates( $item );
 			$this->items[ $cart_item_key ] = $item;

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -84,7 +84,7 @@ class WC_Discounts {
 			$item->object        = $cart_item;
 			$item->product       = $cart_item['data'];
 			$item->quantity      = $cart_item['quantity'];
-			$item->price         = wc_add_number_precision_deep( (float) $item->product->get_price() * (int) $item->quantity );
+			$item->price         = wc_add_number_precision_deep( (float) $item->product->get_price() * (float) $item->quantity );
 			$this->items[ $key ] = $item;
 		}
 

--- a/includes/class-wc-discounts.php
+++ b/includes/class-wc-discounts.php
@@ -84,7 +84,7 @@ class WC_Discounts {
 			$item->object        = $cart_item;
 			$item->product       = $cart_item['data'];
 			$item->quantity      = $cart_item['quantity'];
-			$item->price         = wc_add_number_precision_deep( $item->product->get_price() * $item->quantity );
+			$item->price         = wc_add_number_precision_deep( (float) $item->product->get_price() * (int) $item->quantity );
 			$this->items[ $key ] = $item;
 		}
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

In two separate locations, we do some arithmetic looking like this:

```
$item->product->get_price() * $item->quantity
```

However, `get_price()` returns a string. Normally that's fine, because it will be a numeric string looking something like `'123.45'` and PHP (including PHP 8.x) handles this smoothly. However, this is also a filterable property of the product object and so it could be transformed into just about anything. This leads to the *potential* for the following type error to arise:

```
Uncaught TypeError: Unsupported operand types: string * int
```

Closes #30168.

### How to test the changes in this Pull Request:

I can't replicate directly (nor could we replicate when the bug was [first triaged](https://github.com/woocommerce/woocommerce/issues/30168#issuecomment-872868561)) so these steps are consequently a slightly contrived way of triggering the error.

Setting up:

1. Make sure you are running PHP 8.x.
2. Setup a coupon.
3. Add the following snippet to a location such as `wp-content/mu-plugins/temp.php` or some other suitable location.

```php
add_filter( 'woocommerce_product_get_price', function( $price_string ) {
	return is_checkout() ? "${$price_string}" : $price_string;
} );
```

Testing:

1. Add an item to the cart.
2. Proceed to checkout.
3. Observe breakage (you don't even need to add a coupon to see this).
4. Now checkout this branch.
5. Repeat the steps or simply refresh the checkout page, it should now work.
    * Caveat! Prices will display as `$0.00` ... that's a side-effect of the snippet, not the change itself, and so we don't need to worry about it here.
    * If you like, repeat the test later using this branch but with the snippet removed—you should find prices within the checkout page render correctly.
6. Try applying the coupon code you created (applying a coupon during checkout is a part of the original report).
7. Again, there should not be any breakages.

### Changelog entry

> Fix - Use type casts to reduce the risk of type errors in some unusual conditions.
