### PR TITLE
Add mobile section menu to marketplace

### DIFF
--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -97,7 +97,7 @@
 
 			@media only screen and ( min-width: 600px ) {
 				margin-left: 70px;
-				width: 200px;
+				width: 288px;
 			}
 		}
 
@@ -163,6 +163,10 @@
 				padding: 14px 18px;
 				position: relative;
 				width: 100%;
+
+				@media only screen and ( min-width: 600px ) {
+					padding: 10px 18px;
+				}
 			}
 
 			a.current::after {

--- a/assets/css/admin.scss
+++ b/assets/css/admin.scss
@@ -93,14 +93,16 @@
 
 		.current-section-dropdown {
 			position: relative;
-			width: 200px;
+			width: 100%;
 
 			@media only screen and ( min-width: 600px ) {
 				margin-left: 70px;
+				width: 200px;
 			}
 		}
 
 		.current-section-name {
+			cursor: pointer;
 			font-weight: 600;
 			font-size: 14px;
 			line-height: 20px;
@@ -108,10 +110,10 @@
 			position: relative;
 		}
 
-		.current-section-name:after {
+		.current-section-name::after {
 			background-image: url(../images/icons/gridicons-chevron-down.svg);
 			background-size: contain;
-			content: '';
+			content: "";
 			display: block;
 			height: 20px;
 			position: absolute;
@@ -122,7 +124,6 @@
 
 		ul {
 			background: #fff;
-			border: 1px solid #1E1E1E;
 			border-radius: 2px;
 			display: none;
 			flex-direction: column;
@@ -133,6 +134,10 @@
 			position: absolute;
 			top: 50px;
 			width: 100%;
+
+			@media only screen and ( min-width: 600px ) {
+				border: 1px solid #1e1e1e;
+			}
 
 			@media only screen and ( min-width: 1100px ) {
 				justify-content: center;
@@ -155,14 +160,14 @@
 				display: inline-block;
 				text-decoration: none;
 				outline: none;
-				padding: 10px 18px;
+				padding: 14px 18px;
 				position: relative;
 				width: 100%;
 			}
 
-			a.current:after {
+			a.current::after {
 				background-image: url(../images/icons/gridicons-checkmark.svg);
-				content: '';
+				content: "";
 				display: block;
 				height: 20px;
 				position: absolute;
@@ -172,8 +177,16 @@
 			}
 		}
 
-		.current-section-dropdown:hover ul {
-			display: flex;
+		.current-section-dropdown:hover,
+		.current-section-dropdown.is-open {
+
+			ul {
+				display: flex;
+			}
+
+			.current-section-name::after {
+				transform: rotate(0.5turn);
+			}
 		}
 	}
 

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -406,6 +406,21 @@
 				return window.confirm( woocommerce_admin.i18n_remove_personal_data_notice );
 			}
 		});
+
+		var marketplaceSectionDropdown = $( '#marketplace-current-section-dropdown' );
+		var marketplaceSectionName = $( '#marketplace-current-section-name' );
+		if ( marketplaceSectionDropdown.length && isTouchDevice() ) {
+			marketplaceSectionName.on('click', function() {
+				marketplaceSectionDropdown.toggleClass( 'is-open' );
+			} );
+		}
+
+		function isTouchDevice() {
+			return ( ( 'ontouchstart' in window ) ||
+				( navigator.maxTouchPoints > 0 ) ||
+				( navigator.msMaxTouchPoints > 0 ) );
+		}
+
 	});
 
 })( jQuery, woocommerce_admin );

--- a/assets/js/admin/woocommerce_admin.js
+++ b/assets/js/admin/woocommerce_admin.js
@@ -409,10 +409,32 @@
 
 		var marketplaceSectionDropdown = $( '#marketplace-current-section-dropdown' );
 		var marketplaceSectionName = $( '#marketplace-current-section-name' );
+		var marketplaceMenuIsOpen = false;
+
+		// Add event listener to toggle Marketplace menu on touch devices
 		if ( marketplaceSectionDropdown.length && isTouchDevice() ) {
-			marketplaceSectionName.on('click', function() {
-				marketplaceSectionDropdown.toggleClass( 'is-open' );
+			marketplaceSectionName.on( 'click', function() {
+				marketplaceMenuIsOpen = ! marketplaceMenuIsOpen;
+				if ( marketplaceMenuIsOpen ) {
+					marketplaceSectionDropdown.addClass( 'is-open' );
+					$( document ).on( 'click', maybeToggleMarketplaceMenu );
+				} else {
+					marketplaceSectionDropdown.removeClass( 'is-open' );
+					$( document ).off( 'click', maybeToggleMarketplaceMenu );
+				}
 			} );
+		}
+
+		// Close menu if the user clicks outside it
+		function maybeToggleMarketplaceMenu( e ) {
+			if (
+				! marketplaceSectionDropdown.is( e.target )
+				&& marketplaceSectionDropdown.has( e.target ).length === 0
+			) {
+				marketplaceSectionDropdown.removeClass( 'is-open' );
+				marketplaceMenuIsOpen = false;
+				$( document ).off( 'click', maybeToggleMarketplaceMenu );
+			}
 		}
 
 		function isTouchDevice() {

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -37,7 +37,7 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 	</div>
 
 	<div class="top-bar">
-		<div class="current-section-dropdown">
+		<div id="marketplace-current-section-dropdown" class="current-section-dropdown">
 			<ul>
 				<?php foreach ( $sections as $section ) : ?>
 					<?php
@@ -54,7 +54,7 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 					</li>
 				<?php endforeach; ?>
 			</ul>
-			<div class="current-section-name"><?php echo esc_html( $current_section_name ); ?></div>
+			<div id="marketplace-current-section-name" class="current-section-name"><?php echo esc_html( $current_section_name ); ?></div>
 		</div>
 		</div>
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

* Adds a mobile version of the marketplace section popover menu added in https://github.com/woocommerce/woocommerce/pull/30498 on viewports below 600px. This will fix the menu for touch devices and make it more accessible on mobiles.

### How to test the changes in this Pull Request:

1. Check out this branch.
2. Open dev tools, enable responsive design mode and select a mobile device like iPhone, so the browser stops recognising hover events.
2. Go to `wp-admin/admin.php?page=wc-addons`.
3. Click "Browse Categories". The mobile menu should open.
4. Click on an item in the menu. You should be taken to the section.
5. Change your device to desktop. The menu should have the mobile style on viewports less than 600px wide, but it should open and close on hover events.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Add - Mobile section menu to marketplace.

### Screenshots

<img width="250" src="https://user-images.githubusercontent.com/1647564/129361073-bc87825f-5ede-470b-886a-a370230fc1bd.png">

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
