### PR TITLE
Fix e2e-utils homepage URL.

### DIFF
--- a/tests/e2e/utils/package.json
+++ b/tests/e2e/utils/package.json
@@ -2,7 +2,7 @@
   "name": "@woocommerce/e2e-utils",
   "version": "0.1.5",
   "description": "End-To-End (E2E) test utils for WooCommerce",
-  "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/utils/README.md",
+  "homepage": "https://github.com/woocommerce/woocommerce/tree/trunk/tests/e2e/utils/README.md",
   "repository": {
     "type": "git",
     "url": "https://github.com/woocommerce/woocommerce.git"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Fix e2e-utils homepage URL, as the previous one(s) leads to `404`.

Fixes https://github.com/woocommerce/woocommerce/issues/30484
and https://github.com/woocommerce/woocommerce/pull/30490


### How to test the changes in this Pull Request:

1. Open [`tests/e2e/utils/package.json`](https://github.com/woocommerce/woocommerce/pull/30506/files#diff-1183cb5d464cef0337ae5b9236ff5af18a3ad1de7e98219c1f3243a12fa40ad9R5)
2. Click on the `homepage` link.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [n/a] Have you written new tests for your changes, as applicable?
* [n/a] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> n/a

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
