### PR TITLE
Bump woocommerce-admin version to 2.5.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.1",
-    "woocommerce/woocommerce-admin": "2.5.0",
+    "woocommerce/woocommerce-admin": "2.5.1",
     "woocommerce/woocommerce-blocks": "5.5.1"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "190546c0839729dcc8e8c9eb8268455e",
+    "content-hash": "590e758559a0186574872d553d58c329",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -532,16 +532,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "99a0bd3a48bf33a054efd3b0df29bf42766761f8"
+                "reference": "093d698d770f49d41df8abe89a716dc897bb9e96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/99a0bd3a48bf33a054efd3b0df29bf42766761f8",
-                "reference": "99a0bd3a48bf33a054efd3b0df29bf42766761f8",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/093d698d770f49d41df8abe89a716dc897bb9e96",
+                "reference": "093d698d770f49d41df8abe89a716dc897bb9e96",
                 "shasum": ""
             },
             "require": {
@@ -596,9 +596,9 @@
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.5.0"
+                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.5.1"
             },
-            "time": "2021-08-09T21:00:32+00:00"
+            "time": "2021-08-16T14:31:33+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 2.5.1

## Changelog
 
```
- Fix: Fix blank screen by setting a default value #7506
```