### PR TITLE
Remove tracking of admin User-Agent

### DIFF
--- a/includes/class-wc-tracker.php
+++ b/includes/class-wc-tracker.php
@@ -160,9 +160,6 @@ class WC_Tracker {
 		// Template overrides.
 		$data['template_overrides'] = self::get_all_template_overrides();
 
-		// Template overrides.
-		$data['admin_user_agents'] = self::get_admin_user_agents();
-
 		// Cart & checkout tech (blocks or shortcodes).
 		$data['cart_checkout'] = self::get_cart_checkout_info();
 
@@ -673,15 +670,6 @@ class WC_Tracker {
 			}
 		}
 		return $override_data;
-	}
-
-	/**
-	 * When an admin user logs in, there user agent is tracked in user meta and collected here.
-	 *
-	 * @return array
-	 */
-	private static function get_admin_user_agents() {
-		return array_filter( (array) get_option( 'woocommerce_tracker_ua', array() ) );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [X] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [X] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [X] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

Admin User-Agent is not used, so we can safely remove it from WCTracker. Also, `wcadmin_` Tracks events already send user-agent information.

### Other information:

* [X] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Dev - Remove tracking of admin user agent.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
