### PR TITLE
Revert "Fix: the same set of related products is always displayed"

### DIFF
--- a/includes/data-stores/class-wc-product-data-store-cpt.php
+++ b/includes/data-stores/class-wc-product-data-store-cpt.php
@@ -1315,8 +1315,6 @@ class WC_Product_Data_Store_CPT extends WC_Data_Store_WP implements WC_Object_Da
 				AND p.post_type = 'product'
 
 			",
-			'orderby' => '
-				ORDER BY RAND()',
 			'limits' => '
 				LIMIT ' . absint( $limit ) . '
 			',


### PR DESCRIPTION
This reverts commit 8095482f691f97ca85c155d109bac132bbb1280c.

We're reverting this commit from this PR https://github.com/woocommerce/woocommerce/pull/30418

It was pointed out that this fix may not be performant if the data size is large. We will research a better way to handle this.
