### PR TITLE
Update WooCommerce Blocks package to 5.7.0

### DIFF
--- a/bin/composer/mozart/composer.lock
+++ b/bin/composer/mozart/composer.lock
@@ -68,16 +68,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "1.1.4",
+            "version": "1.1.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "f3ad69181b8afed2c9edf7be5a2918144ff4ea32"
+                "reference": "18634df356bfd4119fe3d6156bdb990c414c14ea"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/f3ad69181b8afed2c9edf7be5a2918144ff4ea32",
-                "reference": "f3ad69181b8afed2c9edf7be5a2918144ff4ea32",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/18634df356bfd4119fe3d6156bdb990c414c14ea",
+                "reference": "18634df356bfd4119fe3d6156bdb990c414c14ea",
                 "shasum": ""
             },
             "require": {
@@ -150,7 +150,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/1.1.4"
+                "source": "https://github.com/thephpleague/flysystem/tree/1.1.5"
             },
             "funding": [
                 {
@@ -158,7 +158,7 @@
                     "type": "other"
                 }
             ],
-            "time": "2021-06-23T21:56:05+00:00"
+            "time": "2021-08-17T13:49:42+00:00"
         },
         {
             "name": "league/mime-type-detection",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.1",
     "woocommerce/woocommerce-admin": "2.5.1",
-    "woocommerce/woocommerce-blocks": "5.5.1"
+    "woocommerce/woocommerce-blocks": "5.7.0"
   },
   "require-dev": {
     "bamarni/composer-bin-plugin": "^1.4"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "590e758559a0186574872d553d58c329",
+    "content-hash": "0ddc585162239e09c69981f3a83d3d04",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -602,16 +602,16 @@
         },
         {
             "name": "woocommerce/woocommerce-blocks",
-            "version": "v5.5.1",
+            "version": "v5.7.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-gutenberg-products-block.git",
-                "reference": "f3d8dbadb745cbb2544e86dfb3864e870146d197"
+                "reference": "6056eb0fd5ec74972237faa6ed0f08f774466324"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/f3d8dbadb745cbb2544e86dfb3864e870146d197",
-                "reference": "f3d8dbadb745cbb2544e86dfb3864e870146d197",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-gutenberg-products-block/zipball/6056eb0fd5ec74972237faa6ed0f08f774466324",
+                "reference": "6056eb0fd5ec74972237faa6ed0f08f774466324",
                 "shasum": ""
             },
             "require": {
@@ -647,9 +647,9 @@
             ],
             "support": {
                 "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.5.1"
+                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.7.0"
             },
-            "time": "2021-07-14T20:59:04+00:00"
+            "time": "2021-08-17T12:58:49+00:00"
         }
     ],
     "packages-dev": [


### PR DESCRIPTION
This PR updates the WooCommerce Blocks plugin to version 5.7.0. It includes changes from WooCommerce Blocks 5.6.x and 5.7.x and is intended to be included with the WooCommerce 5.7 release.

Details from the releases included in this PR:

## Blocks 5.6.0

- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4529)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/560.md)
- [Release post](https://developer.woocommerce.com/2021/08/02/woocommerce-blocks-5-6-0-release-notes/)

## Blocks 5.7.0

- [Release PR](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4584)
- [Testing instructions](https://github.com/woocommerce/woocommerce-gutenberg-products-block/blob/trunk/docs/testing/releases/570.md)
- [Release post](https://developer.woocommerce.com/2021/08/17/woocommerce-blocks-5-7-0-release-notes/)

## Changelog entry

_The following changelog entries are only those that impact functionality surfaced to users in core:_

#### Enhancements

- Featured Category Block:  Allow user to re-select categories using the edit icon. ([4559](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4559))
- Update pagination arrows to match core. ([4364](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4364))

#### Bug Fixes

- Adjusted store notice class names so that error notices show the correct icons. ([4568](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4568))
- Reviews by Category: Show review count instead of product count. ([4552](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4552))
- Add server side rendering to search block so the block can be used by non-admins. ([4551](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4551))
- Twenty Twenty: Fix broken sale badge left alignment. ([4549](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4549))
- Twenty Twenty-One: Adjust removable chip background color. ([4547](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4547))
- Fix handpicked product selections when a store has over 100 products. ([4534](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4534))
- Replace .screen-reader-text with .hidden for elements that are not relevant to screen readers. ([4530](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4530))
- Fixed the SKU search on the /wc/store/products endpoint. ([4469](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4469))
- Fix memory leak when previewing transform options for the All reviews block. ([4428](https://github.com/woocommerce/woocommerce-gutenberg-products-block/pull/4428))