### PR TITLE
bump default e2e PHP version to 8.0

### DIFF
--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -8,6 +8,7 @@
   - `downloadZip( fileUrl, downloadPath )` downloads a plugin zip file from a remote location to the provided path.
 - Added `getLatestReleaseZipUrl( owner, repository, getPrerelease, perPage )` util function to get the latest release zip from a GitHub repository.
 - Added `DEFAULT_TIMEOUT_OVERRIDE` that allows passing in a time in milliseconds to override the default Jest and Puppeteer timeouts.
+- Update default PHP version to 8.0.9.
 
 # 0.2.2
 

--- a/tests/e2e/env/bin/docker-compose.sh
+++ b/tests/e2e/env/bin/docker-compose.sh
@@ -14,12 +14,12 @@ if [[ $1 ]]; then
 	fi
 
 	if ! [[ $TRAVIS_PHP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
-		TRAVIS_PHP_VERSION=$(./bin/get-latest-docker-tag.js php 7 2> /dev/null)
+		TRAVIS_PHP_VERSION=$(./bin/get-latest-docker-tag.js php 8 2> /dev/null)
 	fi
 	if [[ $TRAVIS_PHP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
 		export DC_PHP_VERSION=$TRAVIS_PHP_VERSION
 	else
-		export DC_PHP_VERSION="7.4.9"
+		export DC_PHP_VERSION="8.0.9"
 	fi
 
 	if ! [[ $TRAVIS_MARIADB_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR bumps the default E2E PHP version to 8.X and the fallback version to 8.0.9.

### How to test the changes in this Pull Request:

1. Verify CI
2. Run E2E test locally

### Changelog entry

> N/A

