### PR TITLE
Update order search test to create order with the API

### DIFF
--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-searching.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-searching.test.js
@@ -65,8 +65,8 @@ const updateCustomerBilling = async () => {
 /**
  * Use API to setup the order to search on
  *
- * @param {number} customerId
- * @param {string} productName
+ * @param {number} customerId ID of the customer to add to the order.
+ * @param {number} productId ID of the product to add to the order.
  *
  * @returns {Promise<number>}
  */


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the order search e2e test to use the API to create an order, add the customer, and add the products to the order to be searched on.

### How to test the changes in this Pull Request:

1. Verify CI passes
2. Run the order search test and verify it passes:

```
 npx wc-e2e test:e2e specs/wp-admin/order-searching.test.js
```