### PR TITLE
make test environment container messages more generic

### DIFF
--- a/tests/e2e/env/bin/wait-for-build.sh
+++ b/tests/e2e/env/bin/wait-for-build.sh
@@ -14,17 +14,17 @@ printf "Testing URL: $WP_BASE_URL\n\n"
 while [[ "$(curl -s -o /dev/null -w ''%{http_code}'' ${WP_BASE_URL}/?pagename=ready)" != "200" ]]
 
 do
-  echo "$(date) - Docker container is still being built"
+  echo "$(date) - Waiting for testing environment"
   sleep ${DELAY_SEC}
 
   ((count++))
 
   if [[ $count -gt ${MAX_ATTEMPTS} ]]; then
-  	echo "$(date) - Docker container couldn't be built"
-  	exit 1
+	echo "$(date) - Testing environment couldn't be found"
+	exit 1
   fi
 done
 
 if [[ $count -gt 0 ]]; then
-  echo "$(date) - Docker container had been built successfully"
+  echo "$(date) - Testing environment is ready"
 fi


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the container waiting messages in the test runner to be more generic since the test environment might not be a docker container.

### How to test the changes in this Pull Request:

1. Review verbage of message changes
2. Run E2E tests locally

### Changelog entry

> N/A
