### PR TITLE
Add/e2e create order component and update tests

### DIFF
--- a/tests/e2e/core-tests/specs/activate-and-setup/activate.test.js
+++ b/tests/e2e/core-tests/specs/activate-and-setup/activate.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests */
 /**
  * Internal dependencies
  */
@@ -18,6 +17,10 @@ const runActivationTest = () => {
 		beforeAll(async () => {
 			await merchant.login();
 		});
+
+		it('can install all updates', async () => {
+			merchant.installAllUpdates();
+		})
 
 		it('can make sure WooCommerce is activated. If not, activate it', async () => {
 			const slug = 'woocommerce';

--- a/tests/e2e/core-tests/specs/activate-and-setup/activate.test.js
+++ b/tests/e2e/core-tests/specs/activate-and-setup/activate.test.js
@@ -18,10 +18,6 @@ const runActivationTest = () => {
 			await merchant.login();
 		});
 
-		it('can install all updates', async () => {
-			merchant.installAllUpdates();
-		})
-
 		it('can make sure WooCommerce is activated. If not, activate it', async () => {
 			const slug = 'woocommerce';
 			await merchant.openPlugins();

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
@@ -1,20 +1,16 @@
-/* eslint-disable jest/no-export, jest/no-standalone-expect */
-
 /**
  * Internal dependencies
  */
 const {
 	createSimpleProduct,
-	createSimpleOrder,
 	createCoupon,
 	uiUnblocked,
-	addProductToOrder,
 	evalAndClick,
-	merchant
+	merchant,
+	createOrder,
 } = require( '@woocommerce/e2e-utils' );
 
 const config = require( 'config' );
-const simpleProductName = config.get( 'products.simple.name' );
 const simpleProductPrice = config.has('products.simple.price') ? config.get('products.simple.price') : '9.99';
 const discountedPrice = simpleProductPrice - 5.00;
 
@@ -22,22 +18,18 @@ const couponDialogMessage = 'Enter a coupon code to apply. Discounts are applied
 
 let couponCode;
 let orderId;
+let productId;
 
 const runOrderApplyCouponTest = () => {
 	describe('WooCommerce Orders > Apply coupon', () => {
 		beforeAll(async () => {
-			await createSimpleProduct();
+			productId = await createSimpleProduct();
 			couponCode = await createCoupon();
-			
-			await merchant.login();
-			orderId = await createSimpleOrder('Pending payment', simpleProductName);
-			
-			await Promise.all([
-				addProductToOrder(orderId, simpleProductName),
+			orderId = await createOrder( { productId: productId, status: 'pending' } );
 
-				// We need to remove any listeners on the `dialog` event otherwise we can't catch the dialog below
-				page.removeAllListeners('dialog'),
-			]);
+			await merchant.login();
+			await merchant.goToOrder( orderId );
+			await page.removeAllListeners('dialog');
 
 			// Make sure the simple product price is greater than the coupon amount
 			await expect(Number(simpleProductPrice)).toBeGreaterThan(5.00);
@@ -71,6 +63,8 @@ const runOrderApplyCouponTest = () => {
 			await evalAndClick( 'a.remove-coupon' );
 
 			await uiUnblocked();
+
+			await page.waitFor(2000); // to avoid flakyness
 
 			// Verify the coupon pricing has been removed
 			await expect(page).not.toMatchElement('.wc_coupon_list li.code.editable', { text: couponCode.toLowerCase() });

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-apply-coupon.test.js
@@ -25,7 +25,7 @@ const runOrderApplyCouponTest = () => {
 		beforeAll(async () => {
 			productId = await createSimpleProduct();
 			couponCode = await createCoupon();
-			orderId = await createOrder( { productId: productId, status: 'pending' } );
+			orderId = await createOrder( { productId, status: 'pending' } );
 
 			await merchant.login();
 			await merchant.goToOrder( orderId );

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
@@ -1,4 +1,3 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/no-standalone-expect */
 const { createSimpleProduct } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -6,8 +5,7 @@ const { createSimpleProduct } = require( '@woocommerce/e2e-utils' );
  */
 const {
 	merchant,
-	createSimpleOrder,
-	addProductToOrder,
+	createOrder,
 } = require( '@woocommerce/e2e-utils' );
 
 // TODO create a function for the logic below getConfigSimpleProduct(), see: https://github.com/woocommerce/woocommerce/issues/29072
@@ -15,23 +13,15 @@ const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );
 const simpleProductPrice = config.has( 'products.simple.price' ) ? config.get( 'products.simple.price' ) : '9.99';
 
-let orderId;
-
 const runMerchantOrdersCustomerPaymentPage = () => {
+	let orderId;
+	let productId;
+
 	describe('WooCommerce Merchant Flow: Orders > Customer Payment Page', () => {
 		beforeAll(async () => {
-			await createSimpleProduct();
-			
+			productId = await createSimpleProduct();
+			orderId = await createOrder( { productId: productId } );
 			await merchant.login();
-			orderId = await createSimpleOrder();
-			await addProductToOrder( orderId, simpleProductName );
-
-			// We first need to click "Update" otherwise the link doesn't show
-			await Promise.all([
-				expect(page).toClick( 'button.save_order' ),
-				page.waitForNavigation( { waitUntil: 'networkidle0' } ),
-			]);
-
 		});
 
 		it('should show the customer payment page link on a pending payment order', async () => {

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-customer-payment-page.test.js
@@ -20,7 +20,7 @@ const runMerchantOrdersCustomerPaymentPage = () => {
 	describe('WooCommerce Merchant Flow: Orders > Customer Payment Page', () => {
 		beforeAll(async () => {
 			productId = await createSimpleProduct();
-			orderId = await createOrder( { productId: productId } );
+			orderId = await createOrder( { productId } );
 			await merchant.login();
 		});
 

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
@@ -1,27 +1,20 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, */
-
 /**
  * Internal dependencies
  */
 const {
 	merchant,
 	createSimpleProduct,
-	createSimpleOrder,
 	verifyCheckboxIsSet,
 	verifyValueOfInputField,
 	uiUnblocked,
-	addProductToOrder,
 	evalAndClick,
+	createOrder,
 } = require( '@woocommerce/e2e-utils' );
 
 const { waitForSelector } = require( '@woocommerce/e2e-environment' );
 
 const config = require( 'config' );
-const simpleProductName = config.get( 'products.simple.name' );
 const simpleProductPrice = config.has('products.simple.price') ? config.get('products.simple.price') : '9.99';
-
-let orderId;
-let currencySymbol;
 
 /**
  * Evaluate and click a button selector then wait for a result selector.
@@ -44,20 +37,24 @@ const clickAndWaitForSelector = async ( buttonSelector, resultSelector ) => {
 
 const runRefundOrderTest = () => {
 	describe('WooCommerce Orders > Refund an order', () => {
+		let productId;
+		let orderId;
+		let currencySymbol;
+
 		beforeAll(async () => {
-			await createSimpleProduct();
+			productId = await createSimpleProduct();
+			orderId = await createOrder( {
+				productId: productId,
+				status: 'completed'
+			} );
 
 			await merchant.login();
-			orderId = await createSimpleOrder();
-			await addProductToOrder(orderId, simpleProductName);
+			await merchant.goToOrder( orderId );
 
 			// Get the currency symbol for the store's selected currency
 			await page.waitForSelector('.woocommerce-Price-currencySymbol');
 			let currencyElement = await page.$('.woocommerce-Price-currencySymbol');
 			currencySymbol = await page.evaluate(el => el.textContent, currencyElement);
-
-			// Update order status to `Completed` so we can issue a refund
-			await merchant.updateOrderStatus(orderId, 'Completed');
 		});
 
 		it('can issue a refund by quantity', async () => {
@@ -93,7 +90,6 @@ const runRefundOrderTest = () => {
 				// Verify system note was added
 				expect(page).toMatchElement('.system-note', { text: 'Order status changed from Completed to Refunded.' }),
 			]);
-			page.waitForNavigation( { waitUntil: 'networkidle0' } );
 		});
 
 		it('can delete an issued refund', async () => {

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-refund.test.js
@@ -44,7 +44,7 @@ const runRefundOrderTest = () => {
 		beforeAll(async () => {
 			productId = await createSimpleProduct();
 			orderId = await createOrder( {
-				productId: productId,
+				productId,
 				status: 'completed'
 			} );
 

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-searching.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-searching.test.js
@@ -1,17 +1,12 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests, jest/expect-expect */
-
 /**
  * Internal dependencies
  */
 const {
 	merchant,
-	clearAndFillInput,
 	searchForOrder,
 	createSimpleProduct,
-	addProductToOrder,
-	clickUpdateOrder,
 	factories,
-	selectOptionInSelect2,
+	createOrder,
 } = require( '@woocommerce/e2e-utils' );
 
 const searchString = 'John Doe';
@@ -45,7 +40,7 @@ const customerShipping = {
 /**
  * Set the billing fields for the customer account for this test suite.
  *
- * @returns {Promise<void>}
+ * @returns {Promise<number>}
  */
 const updateCustomerBilling = async () => {
 	const client = factories.api.withDefaultPermalinks;
@@ -65,39 +60,33 @@ const updateCustomerBilling = async () => {
 		shipping: customerShipping,
 	};
 	await client.put( customerEndpoint + customerId, customerData );
+	return customerId;
 };
 
 const runOrderSearchingTest = () => {
 	describe('WooCommerce Orders > Search orders', () => {
+		let productId;
 		let orderId;
+		let customerId;
+
 		beforeAll( async () => {
-			await createSimpleProduct('Wanted Product');
-			await updateCustomerBilling();
+			productId = await createSimpleProduct('Wanted Product');
+			customerId = await updateCustomerBilling();
+			orderId = await createOrder({
+				customerId: customerId,
+				productId: productId,
+				customerBilling: customerBilling,
+				customerShipping: customerShipping,
+			});
 
-			// Create new order for testing
+			// Login and open All Orders view
 			await merchant.login();
-			await merchant.openNewOrder();
-			await page.waitForSelector('#order_status');
-			await page.click('#customer_user');
-			await page.click('span.select2-search > input.select2-search__field');
-			await page.type('span.select2-search > input.select2-search__field', 'Jane Smith');
-			await page.waitFor(2000); // to avoid flakyness
-			await page.keyboard.press('Enter');
-
-			// Get the post id
-			const variablePostId = await page.$('#post_ID');
-			orderId = (await(await variablePostId.getProperty('value')).jsonValue());
-
-			// Save new order and add desired product to order
-			await clickUpdateOrder('Order updated.', true);
-			await addProductToOrder(orderId, 'Wanted Product');
-
-			// Open All Orders view
 			await merchant.openAllOrdersView();
 		});
 
 		it('can search for order by order id', async () => {
-			await searchForOrder(orderId, orderId, searchString);
+			// Convert the order ID to string so we can search on it
+			await searchForOrder(orderId.toString(), orderId, searchString);
 		});
 
 		it('can search for order by billing first name', async () => {

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-order-searching.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-order-searching.test.js
@@ -73,10 +73,10 @@ const runOrderSearchingTest = () => {
 			productId = await createSimpleProduct('Wanted Product');
 			customerId = await updateCustomerBilling();
 			orderId = await createOrder({
-				customerId: customerId,
-				productId: productId,
-				customerBilling: customerBilling,
-				customerShipping: customerShipping,
+				customerId,
+				productId,
+				customerBilling,
+				customerShipping,
 			});
 
 			// Login and open All Orders view

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -16,6 +16,7 @@
 - Added `deleteAllOrders()` that goes through and deletes all orders
 - Added `deleteAllShippingClasses()` which permanently deletes all shipping classes using the API
 - Added `statuses` optional parameter to `deleteAllRepositoryObjects()` to delete on specific statuses
+- Added `createOrder()` component util that creates an order using the API with the passed in details
 
 # 0.1.5
 

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -194,6 +194,7 @@ This package provides support for enabling retries in tests:
 | `clickUpdateOrder` | `noticeText`, `waitForSave` | Helper method to click the Update button on the order details page |
 | `deleteAllShippingZones` | | Delete all the existing shipping zones |
 | `waitForSelectorWithoutThrow` | `selector`, `timeoutInSeconds` | conditionally wait for a selector without throwing an error. Default timeout is 5 seconds |
+| `createOrder` | `orderOptions` | Creates an order using the API with the passed in details |
 
 ### Test Utilities
 

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -323,6 +323,49 @@ const createGroupedProduct = async (groupedProduct = defaultGroupedProduct) => {
 };
 
 /**
+ * Use the API to create an order with the provided details.
+ *
+ * @param {object} orderOptions
+ * @returns {Promise<number>} ID of the created order.
+ */
+const createOrder = async ( orderOptions = {} ) => {
+	const client = factories.api.withDefaultPermalinks;
+	const ordersEndpoint = 'wc/v3/orders';
+	const newOrder = {};
+
+	if ( orderOptions.status ) {
+		newOrder.status = orderOptions.status;
+	}
+
+	if ( orderOptions.customerId ) {
+		newOrder.customer_id = orderOptions.customerId;
+	}
+
+	if ( orderOptions.customerBilling ) {
+		newOrder.billing = orderOptions.customerBilling;
+	}
+
+	if ( orderOptions.customerShipping ) {
+		newOrder.shipping = orderOptions.customerShipping;
+	}
+
+	if ( orderOptions.productId ) {
+		newOrder.line_items = [
+			{
+				product_id: orderOptions.productId
+			}
+		]
+	}
+
+	const order = await client.post( ordersEndpoint, newOrder );
+	if ( !order.data ) {
+		return;
+	}
+
+	return order.data.id;
+}
+
+/**
  * Create a basic order with the provided order status.
  *
  * @param orderStatus Status of the new order. Defaults to `Pending payment`.
@@ -522,4 +565,5 @@ export {
 	clickUpdateOrder,
 	deleteAllEmailLogs,
 	deleteAllShippingZones,
+	createOrder
 };


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces a new `createOrder()` component that calls the API to create an order, using the passed in parameters. The ID of the created order is returned. Currently, support has been added for:

* Adding a product
* Setting a status for the order
* Adding a customer billing contact
* Adding a customer shipping contact
* Adding a customer ID

This PR also updates the following tests with this component:

* Order searching
* Order refunds
* Customer payment page
* Order coupons

### How to test the changes in this Pull Request:

1. Verify CI passes
2. Run the tests locally and verify they pass
3. Optionally run each changed test individually and verify they pass:

_Order searching_
```
 npx wc-e2e test:e2e specs/wp-admin/order-searching.test.js
```

_Order refunds_
```
npx wc-e2e test:e2e specs/wp-admin/order-refund.test.js 
```

_Customer payment page_
```
npx wc-e2e test:e2e specs/wp-admin/order-customer-payment-page.test.js
```

_Order coupons_
```
npx wc-e2e test:e2e specs/wp-admin/order-coupon.test.js
```

Note the changes in `tests/e2e/core-tests/specs/activate-and-setup/activate.test.js` are from triaging pipeline failures but, due to the linting before committing, I can't add the line back in, unfortunately.