### PR TITLE
Bump e2e WordPress version to 5.8

### DIFF
--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -8,6 +8,7 @@
   - `downloadZip( fileUrl, downloadPath )` downloads a plugin zip file from a remote location to the provided path.
 - Added `getLatestReleaseZipUrl( owner, repository, getPrerelease, perPage )` util function to get the latest release zip from a GitHub repository.
 - Added `DEFAULT_TIMEOUT_OVERRIDE` that allows passing in a time in milliseconds to override the default Jest and Puppeteer timeouts.
+- Update default WordPress version to 5.8.
 
 # 0.2.2
 

--- a/tests/e2e/env/bin/docker-compose.sh
+++ b/tests/e2e/env/bin/docker-compose.sh
@@ -10,7 +10,7 @@ if [[ $1 ]]; then
 	if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
 		export WORDPRESS_VERSION=$WP_VERSION
 	else
-		export WORDPRESS_VERSION="5.5.1"
+		export WORDPRESS_VERSION="5.8"
 	fi
 
 	if ! [[ $TRAVIS_PHP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR bumps the default E2E WordPress to 5.8

### How to test the changes in this Pull Request:

1. Verify CI
2. Run E2E test locally
