### PR TITLE
bump the fallback WP version to 5.8.0

### DIFF
--- a/tests/e2e/env/CHANGELOG.md
+++ b/tests/e2e/env/CHANGELOG.md
@@ -8,6 +8,7 @@
   - `downloadZip( fileUrl, downloadPath )` downloads a plugin zip file from a remote location to the provided path.
 - Added `getLatestReleaseZipUrl( owner, repository, getPrerelease, perPage )` util function to get the latest release zip from a GitHub repository.
 - Added `DEFAULT_TIMEOUT_OVERRIDE` that allows passing in a time in milliseconds to override the default Jest and Puppeteer timeouts.
+- Update fallback WordPress version to 5.8.0.
 
 # 0.2.2
 

--- a/tests/e2e/env/bin/docker-compose.sh
+++ b/tests/e2e/env/bin/docker-compose.sh
@@ -10,7 +10,7 @@ if [[ $1 ]]; then
 	if [[ $WP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then
 		export WORDPRESS_VERSION=$WP_VERSION
 	else
-		export WORDPRESS_VERSION="5.5.1"
+		export WORDPRESS_VERSION="5.8.0"
 	fi
 
 	if ! [[ $TRAVIS_PHP_VERSION =~ ^[0-9]+\.[0-9]+ ]]; then


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The fallback WordPress version in the E2E environment package is 5.5.1. WooCommerce now requires WP 5.6. The Github tag api appears to be down which is causing some PRs to fail (eg. https://github.com/woocommerce/woocommerce/pull/30524).

This PR bumps the fallback WordPress version to 5.8.0.

### How to test the changes in this Pull Request:

1. Verify CI.
2. Locally without this PR you will see the following if the api is still down:
```
npx wc-e2e docker:up
WordPress 5.5.1
PHP 7.4.9
MariaDB 10.6.4
```

### Changelog entry

> N/A
