### PR TITLE
Bump woocommerce-admin version to 2.6.0-rc.2

### DIFF
--- a/bin/composer/mozart/composer.lock
+++ b/bin/composer/mozart/composer.lock
@@ -33,7 +33,6 @@
                 "squizlabs/php_codesniffer": "^3.5",
                 "vimeo/psalm": "^4.4"
             },
-            "default-branch": true,
             "bin": [
                 "bin/mozart"
             ],
@@ -54,10 +53,6 @@
                 }
             ],
             "description": "Composes all dependencies as a package inside a WordPress plugin",
-            "support": {
-                "issues": "https://github.com/coenjacobs/mozart/issues",
-                "source": "https://github.com/coenjacobs/mozart/tree/master"
-            },
             "funding": [
                 {
                     "url": "https://github.com/coenjacobs",
@@ -148,10 +143,6 @@
                 "sftp",
                 "storage"
             ],
-            "support": {
-                "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/1.1.5"
-            },
             "funding": [
                 {
                     "url": "https://offset.earth/frankdejonge",
@@ -344,9 +335,6 @@
                 "console",
                 "terminal"
             ],
-            "support": {
-                "source": "https://github.com/symfony/console/tree/v5.3.6"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -633,9 +621,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.23.1"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -797,9 +782,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.23.1"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -959,9 +941,6 @@
                 "portable",
                 "shim"
             ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.23.1"
-            },
             "funding": [
                 {
                     "url": "https://symfony.com/sponsor",
@@ -1153,5 +1132,5 @@
     "platform-overrides": {
         "php": "7.3"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/bin/composer/phpcs/composer.lock
+++ b/bin/composer/phpcs/composer.lock
@@ -71,10 +71,6 @@
                 "stylecheck",
                 "tests"
             ],
-            "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
-            },
             "time": "2020-12-07T18:04:37+00:00"
         },
         {
@@ -243,10 +239,6 @@
                 "standards",
                 "wordpress"
             ],
-            "support": {
-                "issues": "https://github.com/PHPCompatibility/PHPCompatibilityWP/issues",
-                "source": "https://github.com/PHPCompatibility/PHPCompatibilityWP"
-            },
             "time": "2021-07-21T11:09:57+00:00"
         },
         {
@@ -343,10 +335,6 @@
                 "woocommerce",
                 "wordpress"
             ],
-            "support": {
-                "issues": "https://github.com/woocommerce/woocommerce-sniffs/issues",
-                "source": "https://github.com/woocommerce/woocommerce-sniffs/tree/0.1.1"
-            },
             "time": "2021-07-29T17:25:16+00:00"
         },
         {
@@ -411,5 +399,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/bin/composer/phpunit/composer.lock
+++ b/bin/composer/phpunit/composer.lock
@@ -1697,5 +1697,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/bin/composer/wp/composer.lock
+++ b/bin/composer/wp/composer.lock
@@ -205,10 +205,6 @@
                 }
             ],
             "description": "Peast is PHP library that generates AST for JavaScript code",
-            "support": {
-                "issues": "https://github.com/mck89/peast/issues",
-                "source": "https://github.com/mck89/peast/tree/v1.13.5"
-            },
             "time": "2021-07-28T17:14:56+00:00"
         },
         {
@@ -624,5 +620,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "pelago/emogrifier": "3.1.0",
     "psr/container": "1.0.0",
     "woocommerce/action-scheduler": "3.2.1",
-    "woocommerce/woocommerce-admin": "2.5.1",
+    "woocommerce/woocommerce-admin": "2.6.0-rc.2",
     "woocommerce/woocommerce-blocks": "5.7.0"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ddc585162239e09c69981f3a83d3d04",
+    "content-hash": "664a0a088829d2b3331c208cbf80b597",
     "packages": [
         {
             "name": "automattic/jetpack-autoloader",
@@ -532,16 +532,16 @@
         },
         {
             "name": "woocommerce/woocommerce-admin",
-            "version": "2.5.1",
+            "version": "2.6.0-rc.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/woocommerce/woocommerce-admin.git",
-                "reference": "093d698d770f49d41df8abe89a716dc897bb9e96"
+                "reference": "a6dd63d2b90111637f7879a95e26acb16dff2ac4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/093d698d770f49d41df8abe89a716dc897bb9e96",
-                "reference": "093d698d770f49d41df8abe89a716dc897bb9e96",
+                "url": "https://api.github.com/repos/woocommerce/woocommerce-admin/zipball/a6dd63d2b90111637f7879a95e26acb16dff2ac4",
+                "reference": "a6dd63d2b90111637f7879a95e26acb16dff2ac4",
                 "shasum": ""
             },
             "require": {
@@ -594,11 +594,7 @@
             ],
             "description": "A modern, javascript-driven WooCommerce Admin experience.",
             "homepage": "https://github.com/woocommerce/woocommerce-admin",
-            "support": {
-                "issues": "https://github.com/woocommerce/woocommerce-admin/issues",
-                "source": "https://github.com/woocommerce/woocommerce-admin/tree/v2.5.1"
-            },
-            "time": "2021-08-16T14:31:33+00:00"
+            "time": "2021-08-19T16:23:09+00:00"
         },
         {
             "name": "woocommerce/woocommerce-blocks",
@@ -645,10 +641,6 @@
                 "gutenberg",
                 "woocommerce"
             ],
-            "support": {
-                "issues": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/issues",
-                "source": "https://github.com/woocommerce/woocommerce-gutenberg-products-block/tree/v5.7.0"
-            },
             "time": "2021-08-17T12:58:49+00:00"
         }
     ],
@@ -716,5 +708,5 @@
     "platform-overrides": {
         "php": "7.0"
     },
-    "plugin-api-version": "2.0.0"
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
This PR bumps woocommerce/woocommerce-admin in Composer to the latest published package, version 2.6.0-rc.2

Version RC 2 includes the following PRs

- [Add Marketplace and My Subscriptions to the new WooCommerce Navigation. #7529](https://github.com/woocommerce/woocommerce-admin/pull/7529)

- [Split the Extensions page into Marketplace and My Subscriptions. #7471](https://github.com/woocommerce/woocommerce-admin/pull/7471)



## Testing Instructions

### Match stock status value in CSV download to table #7284
1. Add some products and set stock value.
2. Place an order and make it completed.
3. Navigate to Analytics -> Stocks
4. Click the Download button.
5. Open the downloaded file and confirm the status values match the table.


## Changelog

```
- Fix: Fixes action button mis-alignment within card footer. #7412
- Fix: Fixing issues with ReportTable component data not populating correctly #7355
- Fix: Fix tracks events for payment gateway suggestions #7304
- Fix: Update status values in CSV download to match the table #7284
- Fix: Allow super admins all capabilities within WooCommerce Admin #7489
- Fix: Fix blank screen by setting a default value #7506
- Fix: Fix analytics overview re-arrangement on initial load. #7475
- Fix: Fix up onboarding profiler not working when opted out of tracking #7490
- Fix: Fix blank screen on analytics screens when searching #7482
- Fix: Fix all links with hash to behind query parameters #7483
- Fix: Fix Stats module CSS issue introduced by Gutenberg #7488
- Add: Add boolean isReverseTrend prop to SummaryNumber to show "positive" delta for negative numbers. #7357
- Add: Adding links to help panel for marketing task #7384
- Add: Add installed marketing extensions card to extensions task #7419
- Add: Add marketing extensions task to task list #7383
- Add: Add tracks to marketing manage button click #7467
- Add: Add default marketing extensions as fallbacks #7466
- Add: Add marketing task completion check and tests #7451
- Add navigation items for the Marketplace menu. #7529
- Update: Add locale param as part of free extensions request #7391
- Update: Increase per_page value for search results on the Analytics pages. #7385
- Update: Removing grow section from local free extensions in OBW #7386
- Update: Don't show the marketing task if no marketing tasks exist #7460
- Update: Delete free extensions transient on WCA update #7454
- Update: Update business details to use extensions data store #7452
- Update: Split Extensions page into Marketplace and My Subscriptions. #7471
- Dev: Added utm_medium=product to woocommerce.com links. #7408
- Dev: Update Jest to version 27. #7430
- Tweak: Refactor on payment settings recommendations eligibility component for reuse. #7447
- Tweak: Register wc-admin page for all users and handle authorization in client #7285
 ```
