### PR TITLE
Fix pages were being re-created even though not set during a db migra…

### DIFF
--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2273,7 +2273,17 @@ function wc_update_500_db_version() {
  * See @link https://github.com/woocommerce/woocommerce/issues/29235.
  */
 function wc_update_560_create_refund_returns_page() {
+	function filter_created_pages( $pages ) {
+		$page_to_create = array( 'refund_returns' );
+
+		return array_intersect_key( $pages, array_flip( $page_to_create ) );
+	}
+
+	add_filter( 'woocommerce_create_pages', 'filter_created_pages' );
+
 	WC_Install::create_pages();
+
+	remove_filter( 'woocommerce_create_pages', 'filter_created_pages' );
 }
 
 /**

--- a/includes/wc-update-functions.php
+++ b/includes/wc-update-functions.php
@@ -2273,6 +2273,11 @@ function wc_update_500_db_version() {
  * See @link https://github.com/woocommerce/woocommerce/issues/29235.
  */
 function wc_update_560_create_refund_returns_page() {
+	/**
+	 * Filter on the pages created to return what we expect.
+	 *
+	 * @param array $pages The default WC pages.
+	 */
 	function filter_created_pages( $pages ) {
 		$page_to_create = array( 'refund_returns' );
 


### PR DESCRIPTION
…tion closes #30532

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30532

What's happening here is that some sites deliberately "unset" WC created pages such as the My-Account or Shop page. When updating to WC 5.6, there is a migration process that creates the Refund and Return Policy page. However we did not account for sites to have some pages not set for these and so these pages can reappear. This PR filters into the page creation list and removes the rest and only leaving the Refund and Return Policy page.

### How to test the changes in this Pull Request:

1. Go to `/wp-admin/admin.php?page=wc-settings&tab=advanced` and unset the My Account page or any of those pages and save.
2 To trigger an db update you can change the `woocommerce_db_version` in the `wp_options` table to `5.5.0`.
3. Reload the admin woocommerce area and now you should see the update database notice. Click to update.
4. After it is done and you see the "Thanks" notice, go back to `/wp-admin/admin.php?page=wc-settings&tab=advanced` and ensure the page you unsetted did not return.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - WC default pages are being re-created during db migration in some cases.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
