### PR TITLE
Prep versions for trunk

### DIFF
--- a/includes/class-woocommerce.php
+++ b/includes/class-woocommerce.php
@@ -27,7 +27,7 @@ final class WooCommerce {
 	 *
 	 * @var string
 	 */
-	public $version = '5.6.0';
+	public $version = '5.8.0';
 
 	/**
 	 * WooCommerce Schema version.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "woocommerce",
   "title": "WooCommerce",
-  "version": "5.7.0",
+  "version": "5.8.0",
   "homepage": "https://woocommerce.com/",
   "repository": {
     "type": "git",

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: e-commerce, store, sales, sell, woo, shop, cart, checkout, downloadable, d
 Requires at least: 5.6
 Tested up to: 5.8
 Requires PHP: 7.0
-Stable tag: 5.5.2
+Stable tag: 5.6.0
 License: GPLv3
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/woocommerce.php
+++ b/woocommerce.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce
  * Plugin URI: https://woocommerce.com/
  * Description: An eCommerce toolkit that helps you sell anything. Beautifully.
- * Version: 5.7.0-dev
+ * Version: 5.8.0-dev
  * Author: Automattic
  * Author URI: https://woocommerce.com
  * Text Domain: woocommerce


### PR DESCRIPTION
Since 5.7 release branch has been cut, trunk is now 5.8-dev. This PR preps the trunk branch for this.

Note: I am unsure if we should add/update the readme.txt changelog section. I see a placeholder there however I don't think we actually need to add 5.7 items in there. This section is usually only needed in the release branch to my understanding.