### PR TITLE
Add try catch around updating ready page status

### DIFF
--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -46,7 +46,11 @@ beforeAll(async () => {
 	}
 
 	// Update the ready page to prevent concurrent test runs
-	await updateReadyPageStatus('draft');
+	try {
+		await updateReadyPageStatus('draft');
+	} catch ( error ) {
+		// Prevent an error here causing tests to fail.
+	}
 
 	await trashExistingPosts();
 	await withRestApi.deleteAllProducts();


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds a try/catch around updating the ready page status, which would occasionally causes the tests to fail unnecessarily. Example failure:

<img width="995" alt="Screen Shot 2021-08-23 at 15 30 15" src="https://user-images.githubusercontent.com/71906536/130522081-1b88fb10-fe17-442c-8472-b7a6b23f3dfe.png">

Closes # https://github.com/woocommerce/woocommerce/issues/30542.

### How to test the changes in this Pull Request:

1. Make sure the CI passes
2. Run the e2e tests locally and make sure they pass.