### PR TITLE
Fix for getting a bad archive for releases

### DIFF
--- a/tests/e2e/env/utils/get-plugin-zip.js
+++ b/tests/e2e/env/utils/get-plugin-zip.js
@@ -64,11 +64,11 @@ const getLatestReleaseZipUrl = async ( owner, repository, getPrerelease = false,
 					// Loop until we find the first pre-release, then return it.
 					body.forEach(release => {
 						if ( release.prerelease ) {
-							resolve( release.zipball_url );
+							resolve( release.assets[0].browser_download_url );
 						}
 					});
 				} else {
-					resolve( body.zipball_url );
+					resolve( body.assets[0].browser_download_url );
 				}
 			}
 		})

--- a/tests/e2e/specs/smoke-tests/update-woocommerce.js
+++ b/tests/e2e/specs/smoke-tests/update-woocommerce.js
@@ -24,7 +24,7 @@ utils.describeIf( UPDATE_WC )( 'WooCommerce plugin can be uploaded and activated
 	beforeAll( async () => {
 
 		if ( TEST_RELEASE ) {
-			zipUrl = await getLatestReleaseZipUrl('woocommerce', 'woocommerce');
+			zipUrl = await getLatestReleaseZipUrl( 'woocommerce', 'woocommerce' );
 		} else {
 			zipUrl = 'https://github.com/woocommerce/woocommerce/releases/download/nightly/woocommerce-trunk-nightly.zip';
 		}


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates where we pull the release zip from. The previous link was downloading an invalid file; instead we need to use the browser download link.

Closes https://github.com/woocommerce/woocommerce/issues/30569.

### How to test the changes in this Pull Request:

1. Verify CI passes
2. Run the following (optionally commenting out the `it()` just to verify the download works):
```
TEST_RELEASE=1 UPDATE_WC=1 npx wc-e2e test:e2e ./tests/e2e/specs/smoke-tests/update-woocommerce.js
```
3. Verify `tests/e2e/plugins` has a valid zip file for the latest release (5.6.0 in this case).
4. Verify there is no log for `Bad archive`.
