### PR TITLE
Change the shop page summary

### DIFF
--- a/includes/class-wc-post-types.php
+++ b/includes/class-wc-post-types.php
@@ -344,7 +344,7 @@ class WC_Post_Types {
 						'item_link'             => __( 'Product Link', 'woocommerce' ),
 						'item_link_description' => __( 'A link to a product.', 'woocommerce' ),
 					),
-					'description'         => __( 'This is where you can add new products to your store.', 'woocommerce' ),
+					'description'         => __( 'This is where you can browse products in this store.', 'woocommerce' ),
 					'public'              => true,
 					'show_ui'             => true,
 					'menu_icon'           => 'dashicons-archive',


### PR DESCRIPTION
The original summary is not relevant to the customers or visitors
but it was shown to them if the theme displays page summaries.
Changed to a public-friendly text.

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Closes #30553.

### How to test the changes in this Pull Request:

1. Install and activate a theme that shows page summary, e.g. [OceanWP](https://wordpress.org/themes/oceanwp/) or [NanoSpace](https://wordpress.org/themes/nanospace/).
2. Go to the Shop Page in the front-end.
3. See the sentence visible on the page (below “Products” or the store name).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you successfully run tests with your changes locally?

### Changelog entry

> Tweak - Change the shop page summary which was not relevant to the public