### PR TITLE
Fix for not finding text in Merchant can add shipping classes test

### DIFF
--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-classes.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-classes.test.js
@@ -1,5 +1,3 @@
-/* eslint-disable jest/no-export*/
-
 /**
  * Internal dependencies
  */
@@ -55,7 +53,7 @@ const runAddShippingClassesTest = () => {
 			for (const { name, slug, description } of shippingClasses) {
 				const row = await expect(
 					page
-				).toMatchElement('.wc-shipping-class-rows tr', { text: slug });
+				).toMatchElement('.wc-shipping-class-rows tr', slug);
 
 				await expect(row).toMatchElement(
 					'.wc-shipping-class-name',

--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-classes.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-classes.test.js
@@ -53,7 +53,7 @@ const runAddShippingClassesTest = () => {
 			for (const { name, slug, description } of shippingClasses) {
 				const row = await expect(
 					page
-				).toMatchElement('.wc-shipping-class-rows tr', slug);
+				).toMatchElement('.wc-shipping-class-rows tr', { text: slug, timeout: 50000 });
 
 				await expect(row).toMatchElement(
 					'.wc-shipping-class-name',


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the shipping class search string `{ text: slug }` to include a timeout: `{ text: slug, timeout: 50000 }`.

### How to test the changes in this Pull Request:

1. Verify CI passes
2. Run the shipping test locally and verify it passes:
```
npx wc-e2e test:e2e specs/wp-admin/create-shipping-classes.test.js
```