### PR TITLE
Added waits for the UI to be unblocked for shipping zone tests

### DIFF
--- a/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-settings-shipping-zones.test.js
@@ -9,6 +9,7 @@ const {
 	clearAndFillInput,
 	selectOptionInSelect2,
 	withRestApi,
+	uiUnblocked,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -76,6 +77,8 @@ const runAddNewShippingZoneTest = () => {
 			await selectOptionInSelect2('New York');
 			await expect(page).toClick('button[name="calc_shipping"]');
 
+			await uiUnblocked();
+
 			// Verify shipping costs
 			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.shipping .amount', {text: '$10.00'});
@@ -94,6 +97,8 @@ const runAddNewShippingZoneTest = () => {
 			await clearAndFillInput('#calc_shipping_postcode', '94000');
 			await expect(page).toClick('button[name="calc_shipping"]');
 
+			await uiUnblocked();
+
 			// Verify shipping method and cost
 			await page.waitForSelector('.order-total');
 			await expect(page).toMatchElement('.shipping ul#shipping_method > li', {text: 'Free shipping'});
@@ -107,6 +112,8 @@ const runAddNewShippingZoneTest = () => {
 			await expect(page).toClick('a.shipping-calculator-button');
 			await clearAndFillInput('#calc_shipping_postcode', '94107');
 			await expect(page).toClick('button[name="calc_shipping"]');
+
+			await uiUnblocked();
 
 			// Verify shipping method and cost
 			await page.waitForSelector('.order-total');

--- a/tests/e2e/utils/src/components.js
+++ b/tests/e2e/utils/src/components.js
@@ -453,12 +453,16 @@ const addShippingZoneAndMethod = async ( zoneName, zoneLocation = 'country:US', 
 	// Select shipping zone location
 	await expect(page).toSelect('select[name="zone_locations"]', zoneLocation);
 
+	await uiUnblocked();
+
 	// Fill shipping zone postcode if needed otherwise just put empty space
 	await page.waitForSelector('a.wc-shipping-zone-postcodes-toggle');
 	await expect(page).toClick('a.wc-shipping-zone-postcodes-toggle');
 	await expect(page).toFill('#zone_postcodes', zipCode);
 	await expect(page).toMatchElement('#zone_postcodes', zipCode);
 	await expect(page).toClick('button#submit');
+
+	await uiUnblocked();
 
 	// Add shipping zone method
 	await page.waitFor(1000);
@@ -467,6 +471,8 @@ const addShippingZoneAndMethod = async ( zoneName, zoneLocation = 'country:US', 
 	await expect(page).toSelect('select[name="add_method_id"]', zoneMethod);
 	await expect(page).toClick('button#btn-ok');
 	await page.waitForSelector('#zone_locations');
+
+	await uiUnblocked();
 };
 
 /**


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR adds in `await uiUnblocked()` when working with adding shipping zones and checking the UI for calculating cost for shipping.

### How to test the changes in this Pull Request:

1. Verify CI passes
2. Run the shipping zones test and verify it passes:
```
npx wc-e2e test:e2e specs/wp-admin/create-shipping-zones.test.js 
```