### PR TITLE
Add 'modified_before' and 'modified_after' params to REST API

### DIFF
--- a/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -555,7 +555,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 		$params['context']            = $this->get_context_param();
 		$params['context']['default'] = 'view';
 
-		$params['page']          = array(
+		$params['page']            = array(
 			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 1,
@@ -563,7 +563,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			'validate_callback' => 'rest_validate_request_arg',
 			'minimum'           => 1,
 		);
-		$params['per_page']      = array(
+		$params['per_page']        = array(
 			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
 			'type'              => 'integer',
 			'default'           => 10,
@@ -572,31 +572,43 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['search']        = array(
+		$params['search']          = array(
 			'description'       => __( 'Limit results to those matching a string.', 'woocommerce' ),
 			'type'              => 'string',
 			'sanitize_callback' => 'sanitize_text_field',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after']         = array(
+		$params['after']           = array(
 			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['before']        = array(
+		$params['before']          = array(
 			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
 			'type'              => 'string',
 			'format'            => 'date-time',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['dates_are_gmt'] = array(
-			'description'       => __( 'Whether to use GMT post dates.', 'woocommerce' ),
+		$params['modified_after']  = array(
+			'description'       => __( 'Limit response to resources modified after a given ISO8601 compliant date.', 'woocommerce' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['modified_before'] = array(
+			'description'       => __( 'Limit response to resources modified before a given ISO8601 compliant date.', 'woocommerce' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
+		);
+		$params['dates_are_gmt']   = array(
+			'description'       => __( 'Whether to consider GMT post dates when limiting response by published or modified date.', 'woocommerce' ),
 			'type'              => 'boolean',
 			'default'           => false,
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['exclude']       = array(
+		$params['exclude']         = array(
 			'description'       => __( 'Ensure result set excludes specific IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -605,7 +617,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['include']       = array(
+		$params['include']         = array(
 			'description'       => __( 'Limit result set to specific ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
@@ -614,20 +626,20 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['offset']        = array(
+		$params['offset']          = array(
 			'description'       => __( 'Offset the result set by a specific number of items.', 'woocommerce' ),
 			'type'              => 'integer',
 			'sanitize_callback' => 'absint',
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order']         = array(
+		$params['order']           = array(
 			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'desc',
 			'enum'              => array( 'asc', 'desc' ),
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby']       = array(
+		$params['orderby']         = array(
 			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
 			'type'              => 'string',
 			'default'           => 'date',

--- a/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
+++ b/includes/rest-api/Controllers/Version3/class-wc-rest-crud-controller.php
@@ -289,22 +289,40 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			$args['orderby'] = 'date ID';
 		}
 
-		$args['date_query'] = array();
-		// Set before into date query. Date query must be specified as an array of an array.
+		$date_query = array();
+		$use_gmt    = $request['dates_are_gmt'];
+
 		if ( isset( $request['before'] ) ) {
-			$args['date_query'][0]['before'] = $request['before'];
+			$date_query[] = array(
+				'column' => $use_gmt ? 'post_date_gmt' : 'post_date',
+				'before' => $request['before'],
+			);
 		}
 
-		// Set after into date query. Date query must be specified as an array of an array.
 		if ( isset( $request['after'] ) ) {
-			$args['date_query'][0]['after'] = $request['after'];
+			$date_query[] = array(
+				'column' => $use_gmt ? 'post_date_gmt' : 'post_date',
+				'after'  => $request['after'],
+			);
 		}
 
-		// Check flag to use post_date vs post_date_gmt.
-		if ( true === $request['dates_are_gmt'] ) {
-			if ( isset( $request['before'] ) || isset( $request['after'] ) ) {
-				$args['date_query'][0]['column'] = 'post_date_gmt';
-			}
+		if ( isset( $request['modified_before'] ) ) {
+			$date_query[] = array(
+				'column' => $use_gmt ? 'post_modified_gmt' : 'post_modified',
+				'before' => $request['modified_before'],
+			);
+		}
+
+		if ( isset( $request['modified_after'] ) ) {
+			$date_query[] = array(
+				'column' => $use_gmt ? 'post_modified_gmt' : 'post_modified',
+				'after'  => $request['modified_after'],
+			);
+		}
+
+		if ( ! empty( $date_query ) ) {
+			$date_query['relation'] = 'AND';
+			$args['date_query']     = $date_query;
 		}
 
 		// Force the post_type argument, since it's not a user input variable.
@@ -358,7 +376,10 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 * @return WP_Error|WP_REST_Response
 	 */
 	public function get_items( $request ) {
-		$query_args    = $this->prepare_objects_query( $request );
+		$query_args = $this->prepare_objects_query( $request );
+		if ( is_wp_error( current( $query_args ) ) ) {
+			return current( $query_args );
+		}
 		$query_results = $this->get_objects( $query_args );
 
 		$objects = array();
@@ -367,7 +388,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 				continue;
 			}
 
-			$data = $this->prepare_object_for_response( $object, $request );
+			$data      = $this->prepare_object_for_response( $object, $request );
 			$objects[] = $this->prepare_response_for_collection( $data );
 		}
 
@@ -388,7 +409,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 				$attrib_name_end  = strpos( $attrib_name_match[0], '>', $attrib_name_match[1] );
 				$attrib_name      = substr( $attrib_name_match[0], $beginning_offset, $attrib_name_end - $beginning_offset );
 				if ( isset( $request[ $attrib_name ] ) ) {
-					$base  = str_replace( "(?P<$attrib_name>[\d]+)", $request[ $attrib_name ], $base );
+					$base = str_replace( "(?P<$attrib_name>[\d]+)", $request[ $attrib_name ], $base );
 				}
 			}
 		}
@@ -513,7 +534,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 	 */
 	protected function prepare_links( $object, $request ) {
 		$links = array(
-			'self' => array(
+			'self'       => array(
 				'href' => rest_url( sprintf( '/%s/%s/%d', $this->namespace, $this->rest_base, $object->get_id() ) ),
 			),
 			'collection' => array(
@@ -534,40 +555,40 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 		$params['context']            = $this->get_context_param();
 		$params['context']['default'] = 'view';
 
-		$params['page'] = array(
-			'description'        => __( 'Current page of the collection.', 'woocommerce' ),
-			'type'               => 'integer',
-			'default'            => 1,
-			'sanitize_callback'  => 'absint',
-			'validate_callback'  => 'rest_validate_request_arg',
-			'minimum'            => 1,
+		$params['page']          = array(
+			'description'       => __( 'Current page of the collection.', 'woocommerce' ),
+			'type'              => 'integer',
+			'default'           => 1,
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
+			'minimum'           => 1,
 		);
-		$params['per_page'] = array(
-			'description'        => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
-			'type'               => 'integer',
-			'default'            => 10,
-			'minimum'            => 1,
-			'maximum'            => 100,
-			'sanitize_callback'  => 'absint',
-			'validate_callback'  => 'rest_validate_request_arg',
+		$params['per_page']      = array(
+			'description'       => __( 'Maximum number of items to be returned in result set.', 'woocommerce' ),
+			'type'              => 'integer',
+			'default'           => 10,
+			'minimum'           => 1,
+			'maximum'           => 100,
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['search'] = array(
-			'description'        => __( 'Limit results to those matching a string.', 'woocommerce' ),
-			'type'               => 'string',
-			'sanitize_callback'  => 'sanitize_text_field',
-			'validate_callback'  => 'rest_validate_request_arg',
+		$params['search']        = array(
+			'description'       => __( 'Limit results to those matching a string.', 'woocommerce' ),
+			'type'              => 'string',
+			'sanitize_callback' => 'sanitize_text_field',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['after'] = array(
-			'description'        => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'               => 'string',
-			'format'             => 'date-time',
-			'validate_callback'  => 'rest_validate_request_arg',
+		$params['after']         = array(
+			'description'       => __( 'Limit response to resources published after a given ISO8601 compliant date.', 'woocommerce' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['before'] = array(
-			'description'        => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
-			'type'               => 'string',
-			'format'             => 'date-time',
-			'validate_callback'  => 'rest_validate_request_arg',
+		$params['before']        = array(
+			'description'       => __( 'Limit response to resources published before a given ISO8601 compliant date.', 'woocommerce' ),
+			'type'              => 'string',
+			'format'            => 'date-time',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 		$params['dates_are_gmt'] = array(
 			'description'       => __( 'Whether to use GMT post dates.', 'woocommerce' ),
@@ -575,42 +596,42 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 			'default'           => false,
 			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['exclude'] = array(
+		$params['exclude']       = array(
 			'description'       => __( 'Ensure result set excludes specific IDs.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
-				'type'          => 'integer',
+				'type' => 'integer',
 			),
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['include'] = array(
+		$params['include']       = array(
 			'description'       => __( 'Limit result set to specific ids.', 'woocommerce' ),
 			'type'              => 'array',
 			'items'             => array(
-				'type'          => 'integer',
+				'type' => 'integer',
 			),
 			'default'           => array(),
 			'sanitize_callback' => 'wp_parse_id_list',
 		);
-		$params['offset'] = array(
-			'description'        => __( 'Offset the result set by a specific number of items.', 'woocommerce' ),
-			'type'               => 'integer',
-			'sanitize_callback'  => 'absint',
-			'validate_callback'  => 'rest_validate_request_arg',
+		$params['offset']        = array(
+			'description'       => __( 'Offset the result set by a specific number of items.', 'woocommerce' ),
+			'type'              => 'integer',
+			'sanitize_callback' => 'absint',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['order'] = array(
-			'description'        => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
-			'type'               => 'string',
-			'default'            => 'desc',
-			'enum'               => array( 'asc', 'desc' ),
-			'validate_callback'  => 'rest_validate_request_arg',
+		$params['order']         = array(
+			'description'       => __( 'Order sort attribute ascending or descending.', 'woocommerce' ),
+			'type'              => 'string',
+			'default'           => 'desc',
+			'enum'              => array( 'asc', 'desc' ),
+			'validate_callback' => 'rest_validate_request_arg',
 		);
-		$params['orderby'] = array(
-			'description'        => __( 'Sort collection by object attribute.', 'woocommerce' ),
-			'type'               => 'string',
-			'default'            => 'date',
-			'enum'               => array(
+		$params['orderby']       = array(
+			'description'       => __( 'Sort collection by object attribute.', 'woocommerce' ),
+			'type'              => 'string',
+			'default'           => 'date',
+			'enum'              => array(
 				'date',
 				'id',
 				'include',
@@ -618,15 +639,15 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 				'slug',
 				'modified',
 			),
-			'validate_callback'  => 'rest_validate_request_arg',
+			'validate_callback' => 'rest_validate_request_arg',
 		);
 
 		if ( $this->hierarchical ) {
-			$params['parent'] = array(
+			$params['parent']         = array(
 				'description'       => __( 'Limit result set to those of particular parent IDs.', 'woocommerce' ),
 				'type'              => 'array',
 				'items'             => array(
-					'type'          => 'integer',
+					'type' => 'integer',
 				),
 				'sanitize_callback' => 'wp_parse_id_list',
 				'default'           => array(),
@@ -635,7 +656,7 @@ abstract class WC_REST_CRUD_Controller extends WC_REST_Posts_Controller {
 				'description'       => __( 'Limit result set to all items except those of a particular parent ID.', 'woocommerce' ),
 				'type'              => 'array',
 				'items'             => array(
-					'type'          => 'integer',
+					'type' => 'integer',
 				),
 				'sanitize_callback' => 'wp_parse_id_list',
 				'default'           => array(),

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/coupons.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/coupons.php
@@ -6,7 +6,7 @@
  */
 
 // phpcs:ignore Squiz.Commenting.FileComment.Missing
-require __DIR__ . '/date-filtering.php';
+require_once __DIR__ . '/date-filtering.php';
 
 /**
  * Coupon API Tests

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/coupons.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/coupons.php
@@ -1,11 +1,24 @@
 <?php
 /**
+ * Tests for Coupons API.
+ *
+ * @package WooCommerce\Tests\API
+ */
+
+// phpcs:ignore Squiz.Commenting.FileComment.Missing
+require __DIR__ . '/date-filtering.php';
+
+/**
  * Coupon API Tests
  * @package WooCommerce\Tests\API
  * @since 3.5.0
  */
 class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
+	use DateFilteringForCrudControllers;
 
+	/**
+	 * @var WC_REST_Coupons_Controller
+	 */
 	protected $endpoint;
 
 	/**
@@ -467,5 +480,23 @@ class WC_Tests_API_Coupons extends WC_REST_Unit_Test_Case {
 		$this->assertArrayHasKey( 'maximum_amount', $properties );
 		$this->assertArrayHasKey( 'email_restrictions', $properties );
 		$this->assertArrayHasKey( 'used_by', $properties );
+	}
+
+	/**
+	 * Create an object for the tests in DateFilteringForCrudControllers.
+	 *
+	 * @return object The created object.
+	 */
+	private function get_item_for_date_filtering_tests() {
+		return \Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper::create_coupon( 'dummycoupon-1' );
+	}
+
+	/**
+	 * Get the REST API endpoint for the tests in DateFilteringForCrudControllers.
+	 *
+	 * @return string REST API endpoint for querying items.
+	 */
+	private function get_endpoint_for_date_filtering_tests() {
+		return '/wc/v3/coupons';
 	}
 }

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/date-filtering.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/date-filtering.php
@@ -31,7 +31,7 @@ trait DateFilteringForCrudControllers {
 	 * @param bool   $filter_by_gmt Whether the dates to filter by are GMT or not.
 	 * @param bool   $expected_to_be_returned True if the created item is expected to be included in the response, false otherwise.
 	 */
-	public function test_foo_filter_by_creation_or_modification_date( $param_name, $filter_by_gmt, $expected_to_be_returned ) {
+	public function test_filter_by_creation_or_modification_date( $param_name, $filter_by_gmt, $expected_to_be_returned ) {
 		global $wpdb;
 
 		wp_set_current_user( $this->user );
@@ -77,7 +77,7 @@ trait DateFilteringForCrudControllers {
 	 * @param bool   $filter_by_gmt Whether the dates to filter by are GMT or not.
 	 * @param bool   $expected_to_be_returned True if the created item is expected to be included in the response, false otherwise.
 	 */
-	public function test_foo_can_filter_by_more_than_one_date( $first_param_name, $first_param_value, $second_param_name, $second_param_value, $filter_by_gmt, $expected_to_be_returned ) {
+	public function test_can_filter_by_more_than_one_date( $first_param_name, $first_param_value, $second_param_name, $second_param_value, $filter_by_gmt, $expected_to_be_returned ) {
 		global $wpdb;
 
 		wp_set_current_user( $this->user );

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/date-filtering.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/date-filtering.php
@@ -1,0 +1,111 @@
+<?php
+/**
+ * Trait for testing the date filtering on controllers that inherit from WC_REST_CRUD_Controller.
+ *
+ * The class using this trait needs to provide two methods:
+ *
+ * object get_item_for_date_filtering_tests() --> create (in db) and return an object for testing (with get_id method).
+ * string get_endpoint_for_date_filtering_tests() --> get the REST API endpoint for querying items.
+ *
+ * @package WooCommerce\Tests\API
+ */
+
+/**
+ * Trait for testing the date filtering on controllers that inherit from WC_REST_CRUD_Controller.
+ */
+trait DateFilteringForCrudControllers {
+
+	/**
+	 * @testdox Items can be filtered by creation or modification date, and the specified dates can be GMT or not.
+	 *
+	 * @testWith ["after", false, true]
+	 *           ["after", true, false]
+	 *           ["before", true, true]
+	 *           ["before", false, false]
+	 *           ["modified_after", false, true]
+	 *           ["modified_after", true, false]
+	 *           ["modified_before", true, true]
+	 *           ["modified_before", false, false]
+	 *
+	 * @param string $param_name The name of the date parameter to filter by.
+	 * @param bool   $filter_by_gmt Whether the dates to filter by are GMT or not.
+	 * @param bool   $expected_to_be_returned True if the created item is expected to be included in the response, false otherwise.
+	 */
+	public function test_foo_filter_by_creation_or_modification_date( $param_name, $filter_by_gmt, $expected_to_be_returned ) {
+		global $wpdb;
+
+		wp_set_current_user( $this->user );
+		$item_id = $this->get_item_for_date_filtering_tests()->get_id();
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query(
+			'UPDATE ' . $wpdb->prefix . "posts SET
+			post_date = '2000-01-01T12:00:00',
+			post_date_gmt = '2000-01-01T10:00:00',
+			post_modified = '2000-02-01T12:00:00',
+			post_modified_gmt = '2000-02-01T10:00:00'
+			WHERE ID = " . $item_id
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		$request = new WP_REST_Request( 'GET', $this->get_endpoint_for_date_filtering_tests() );
+		$request->set_query_params(
+			array(
+				$param_name     => false === strpos( $param_name, 'modified' ) ? '2000-01-01T11:00:00' : '2000-02-01T11:00:00',
+				'dates_are_gmt' => $filter_by_gmt ? 'true' : 'false',
+			)
+		);
+		$response       = $this->server->dispatch( $request );
+		$response_items = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $expected_to_be_returned ? 1 : 0, count( $response_items ) );
+	}
+
+	/**
+	 * @testdox Items can be filtered by any combination of more than one date (but all must either be GMT or not be it).
+	 *
+	 * @testWith ["after", "2000-01-01T11:59:59", "modified_before", "2000-02-01T12:00:01", false, true]
+	 *           ["after", "2000-01-01T11:59:59", "modified_before", "2000-02-01T11:59:59", false, false]
+	 *           ["before", "2000-01-01T10:00:01", "modified_after", "2000-02-01T09:59:59", true, true]
+	 *           ["before", "2000-01-01T09:59:59", "modified_after", "2000-02-01T09:59:59", true, false]
+	 *
+	 * @param string $first_param_name Name of the first parameter to filter by.
+	 * @param string $first_param_value Value of the first parameter to filter by.
+	 * @param string $second_param_name Name of the second parameter to filter by.
+	 * @param string $second_param_value Value of the second parameter to filter by.
+	 * @param bool   $filter_by_gmt Whether the dates to filter by are GMT or not.
+	 * @param bool   $expected_to_be_returned True if the created item is expected to be included in the response, false otherwise.
+	 */
+	public function test_foo_can_filter_by_more_than_one_date( $first_param_name, $first_param_value, $second_param_name, $second_param_value, $filter_by_gmt, $expected_to_be_returned ) {
+		global $wpdb;
+
+		wp_set_current_user( $this->user );
+		$item_id = $this->get_item_for_date_filtering_tests()->get_id();
+
+		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
+		$wpdb->query(
+			'UPDATE ' . $wpdb->prefix . "posts SET
+			post_date = '2000-01-01T12:00:00',
+			post_date_gmt = '2000-01-01T10:00:00',
+			post_modified = '2000-02-01T12:00:00',
+			post_modified_gmt = '2000-02-01T10:00:00'
+			WHERE ID = " . $item_id
+		);
+		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
+
+		$request = new WP_REST_Request( 'GET', $this->get_endpoint_for_date_filtering_tests() );
+		$request->set_query_params(
+			array(
+				$first_param_name  => $first_param_value,
+				$second_param_name => $second_param_value,
+				'dates_are_gmt'    => $filter_by_gmt ? 'true' : 'false',
+			)
+		);
+		$response       = $this->server->dispatch( $request );
+		$response_items = $response->get_data();
+
+		$this->assertEquals( 200, $response->get_status() );
+		$this->assertEquals( $expected_to_be_returned ? 1 : 0, count( $response_items ) );
+	}
+}

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -6,6 +6,9 @@
  * @since 3.5.0
  */
 
+// phpcs:ignore Squiz.Commenting.FileComment.Missing
+require __DIR__ . '/date-filtering.php';
+
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
 
@@ -14,6 +17,7 @@ use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;
  */
 class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 	use WC_REST_API_Complex_Meta;
+	use DateFilteringForCrudControllers;
 
 	/**
 	 * Array of order to track
@@ -1159,5 +1163,23 @@ class WC_Tests_API_Orders extends WC_REST_Unit_Test_Case {
 		$meta_data_item_properties = $line_item_properties['meta_data']['items']['properties'];
 		$this->assertEquals( 5, count( $meta_data_item_properties ) );
 		$this->assertEquals( array( 'id', 'key', 'value', 'display_key', 'display_value' ), array_keys( $meta_data_item_properties ) );
+	}
+
+	/**
+	 * Create an object for the tests in DateFilteringForCrudControllers.
+	 *
+	 * @return object The created object.
+	 */
+	private function get_item_for_date_filtering_tests() {
+		return OrderHelper::create_order();
+	}
+
+	/**
+	 * Get the REST API endpoint for the tests in DateFilteringForCrudControllers.
+	 *
+	 * @return string REST API endpoint for querying items.
+	 */
+	private function get_endpoint_for_date_filtering_tests() {
+		return '/wc/v3/orders';
 	}
 }

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/orders.php
@@ -7,7 +7,7 @@
  */
 
 // phpcs:ignore Squiz.Commenting.FileComment.Missing
-require __DIR__ . '/date-filtering.php';
+require_once __DIR__ . '/date-filtering.php';
 
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\CouponHelper;
 use Automattic\WooCommerce\RestApi\UnitTests\Helpers\OrderHelper;

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
@@ -7,7 +7,7 @@
  */
 
 // phpcs:ignore Squiz.Commenting.FileComment.Missing
-require __DIR__ . '/date-filtering.php';
+require_once __DIR__ . '/date-filtering.php';
 
 /**
  * WC_Tests_API_Product class.

--- a/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
+++ b/tests/legacy/unit-tests/rest-api/Tests/Version3/products.php
@@ -6,11 +6,15 @@
  * @since 3.5.0
  */
 
+// phpcs:ignore Squiz.Commenting.FileComment.Missing
+require __DIR__ . '/date-filtering.php';
+
 /**
  * WC_Tests_API_Product class.
  */
 class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 	use WC_REST_API_Complex_Meta;
+	use DateFilteringForCrudControllers;
 
 	/**
 	 * Setup our test server, endpoints, and user info.
@@ -910,96 +914,20 @@ class WC_Tests_API_Product extends WC_REST_Unit_Test_Case {
 	}
 
 	/**
-	 * @testdox Products can be filtered by creation or modification date, and the specified dates can be GMT or not.
+	 * Create an object for the tests in DateFilteringForCrudControllers.
 	 *
-	 * @testWith ["after", false, true]
-	 *           ["after", true, false]
-	 *           ["before", true, true]
-	 *           ["before", false, false]
-	 *           ["modified_after", false, true]
-	 *           ["modified_after", true, false]
-	 *           ["modified_before", true, true]
-	 *           ["modified_before", false, false]
-	 *
-	 * @param string $param_name The name of the date parameter to filter by.
-	 * @param bool   $filter_by_gmt Whether the dates to filter by are GMT or not.
-	 * @param bool   $expected_to_be_returned True if the created product is expected to be included in the response, false otherwise.
+	 * @return object The created object.
 	 */
-	public function test_filter_by_creation_or_modification_date( $param_name, $filter_by_gmt, $expected_to_be_returned ) {
-		global $wpdb;
-
-		wp_set_current_user( $this->user );
-		$product_id = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product()->get_id();
-
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query(
-			'UPDATE ' . $wpdb->prefix . "posts SET
-			post_date = '2000-01-01T12:00:00',
-			post_date_gmt = '2000-01-01T10:00:00',
-			post_modified = '2000-02-01T12:00:00',
-			post_modified_gmt = '2000-02-01T10:00:00'
-			WHERE ID = " . $product_id
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-
-		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
-		$request->set_query_params(
-			array(
-				$param_name     => false === strpos( $param_name, 'modified' ) ? '2000-01-01T11:00:00' : '2000-02-01T11:00:00',
-				'dates_are_gmt' => $filter_by_gmt ? 'true' : 'false',
-			)
-		);
-		$response          = $this->server->dispatch( $request );
-		$response_products = $response->get_data();
-
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( $expected_to_be_returned ? 1 : 0, count( $response_products ) );
+	private function get_item_for_date_filtering_tests() {
+		return \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product();
 	}
 
 	/**
-	 * @testdox Products can be filtered by any combination of more than one date (but all must either be GMT or not be it).
+	 * Get the REST API endpoint for the tests in DateFilteringForCrudControllers.
 	 *
-	 * @testWith ["after", "2000-01-01T11:59:59", "modified_before", "2000-02-01T12:00:01", false, true]
-	 *           ["after", "2000-01-01T11:59:59", "modified_before", "2000-02-01T11:59:59", false, false]
-	 *           ["before", "2000-01-01T10:00:01", "modified_after", "2000-02-01T09:59:59", true, true]
-	 *           ["before", "2000-01-01T09:59:59", "modified_after", "2000-02-01T09:59:59", true, false]
-	 *
-	 * @param string $first_param_name Name of the first parameter to filter by.
-	 * @param string $first_param_value Value of the first parameter to filter by.
-	 * @param string $second_param_name Name of the second parameter to filter by.
-	 * @param string $second_param_value Value of the second parameter to filter by.
-	 * @param bool   $filter_by_gmt Whether the dates to filter by are GMT or not.
-	 * @param bool   $expected_to_be_returned True if the created product is expected to be included in the response, false otherwise.
+	 * @return string REST API endpoint for querying items.
 	 */
-	public function test_can_filter_by_more_than_one_date( $first_param_name, $first_param_value, $second_param_name, $second_param_value, $filter_by_gmt, $expected_to_be_returned ) {
-		global $wpdb;
-
-		wp_set_current_user( $this->user );
-		$product_id = \Automattic\WooCommerce\RestApi\UnitTests\Helpers\ProductHelper::create_simple_product()->get_id();
-
-		// phpcs:disable WordPress.DB.PreparedSQL.NotPrepared
-		$wpdb->query(
-			'UPDATE ' . $wpdb->prefix . "posts SET
-			post_date = '2000-01-01T12:00:00',
-			post_date_gmt = '2000-01-01T10:00:00',
-			post_modified = '2000-02-01T12:00:00',
-			post_modified_gmt = '2000-02-01T10:00:00'
-			WHERE ID = " . $product_id
-		);
-		// phpcs:enable WordPress.DB.PreparedSQL.NotPrepared
-
-		$request = new WP_REST_Request( 'GET', '/wc/v3/products' );
-		$request->set_query_params(
-			array(
-				$first_param_name  => $first_param_value,
-				$second_param_name => $second_param_value,
-				'dates_are_gmt'    => $filter_by_gmt ? 'true' : 'false',
-			)
-		);
-		$response          = $this->server->dispatch( $request );
-		$response_products = $response->get_data();
-
-		$this->assertEquals( 200, $response->get_status() );
-		$this->assertEquals( $expected_to_be_returned ? 1 : 0, count( $response_products ) );
+	private function get_endpoint_for_date_filtering_tests() {
+		return '/wc/v3/products';
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [ ] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [ ] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [ ] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Add two new parameters, `modified_before` and `modified_after`, to the `WC_REST_CRUD_Controller` class in the v3 REST API. This allows filtering by modification date in the endpoints for entities whose controllers inherit from that one; currently those are products, orders and coupons. These new parameters are affected by [the `dates_are_gmt` parameter introduced recently](https://github.com/woocommerce/woocommerce/pull/28132).

There's a corresponding documentation update pull request that needs to be merged when this is released: https://github.com/woocommerce/woocommerce-rest-api-docs/pull/209

Closes #29461.

### How to test the changes in this Pull Request:

1. Temporarily add this at the ned of your woocommerce.php file, this way you won't have to bother about REST API authentication:

```php
add_filter('woocommerce_rest_check_permissions', function() {return true;}, 10, 0 );
```

(note that this will cause a bunch of unit tests to fail)

2. Modify some old products so that the modification date is different from the creation date. You can do that from the admin area, or directly in the database, altering the value of the `post_modified` and `post_modified_gmt` fields in the corresponding entry in the `posts` table.

3. Query the API  endpoint and verify that the results that you get are consistent. You should be able to combine `beforep, `after`, `modified_before` and `modified_after` parameters and they should all apply, also you can use `dates_are_gmt`. Example with curl:

```
curl "localhost/wp-json/wc/v3/products?modified_before=2021-08-01T12:00:00&after=2020-01-01T00:00:00&dates_are_gmt=true" | jq .
```

(The `jq` part is optional, it will just pretty-print the json; install with `apt-get install jq`)

4. Repeat for orders and coupons.

You can also look at [the unit tests](https://github.com/woocommerce/woocommerce/blob/add/29461/tests/legacy/unit-tests/rest-api/Tests/Version3/date-filtering.php) for guidance.

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### Changelog entry

> Add - 'modified_before' and 'modified_after' filtering parameters to REST API for products, orders and coupons.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
