### PR TITLE
Updated old Woo to new Woo branding colour

### DIFF
--- a/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
+++ b/plugins/woocommerce/includes/admin/settings/class-wc-settings-emails.php
@@ -146,11 +146,11 @@ class WC_Settings_Emails extends WC_Settings_Page {
 				array(
 					'title'    => __( 'Base color', 'woocommerce' ),
 					/* translators: %s: default color */
-					'desc'     => sprintf( __( 'The base color for WooCommerce email templates. Default %s.', 'woocommerce' ), '<code>#96588a</code>' ),
+					'desc'     => sprintf( __( 'The base color for WooCommerce email templates. Default %s.', 'woocommerce' ), '<code>#7f54b3</code>' ),
 					'id'       => 'woocommerce_email_base_color',
 					'type'     => 'color',
 					'css'      => 'width:6em;',
-					'default'  => '#96588a',
+					'default'  => '#7f54b3',
 					'autoload' => false,
 					'desc_tip' => true,
 				),

--- a/plugins/woocommerce/legacy/css/wc-setup.scss
+++ b/plugins/woocommerce/legacy/css/wc-setup.scss
@@ -1489,7 +1489,7 @@ p.jetpack-terms {
 		margin-left: 4px;
 
 		&.recommended-item-icon-wc_admin {
-			background-color: #96588a;
+			background-color: #7f54b3;
 			padding: 0.5em;
 			height: 2em;
 		}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Woo has changed its brand colour from `#96588a` to `#7f54b3`. This PR fixes that for the email template and the old WC onboarding wizard's CSS.

### Changelog entry

> Updated default email color to new Woo purple

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
