### PR TITLE
Increase timeout waiting for variable is virtual selector

### DIFF
--- a/tests/e2e/core-tests/specs/merchant/wp-admin-product-new.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-product-new.test.js
@@ -185,7 +185,7 @@ const runAddVariableProductTest = () => {
 			}
 
 			await waitAndClick( page, '.variations-pagenav .expand_all');
-			await waitForSelectorWithoutThrow( 'input[name="variable_is_virtual[0]"]', 2 );
+			await waitForSelectorWithoutThrow( 'input[name="variable_is_virtual[0]"]', 5 );
 			await setCheckbox('input[name="variable_is_virtual[0]"]');
 			await expect(page).toFill('input[name="variable_regular_price[0]"]', '9.99');
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces a longer timeout for the `input[name="variable_is_virtual[0]"]` selector, bumping the timeout from 2 to 5 seconds.

### How to test the changes in this Pull Request:

1. Verify CI passes
2. Run the tests locally and make sure they pass:
```
npx wc-e2e test:e2e specs/wp-admin/create-variable-product.test.js
```