### PR TITLE
Add page reload and split simple product page test

### DIFF
--- a/tests/e2e/core-tests/specs/merchant/wp-admin-product-new.test.js
+++ b/tests/e2e/core-tests/specs/merchant/wp-admin-product-new.test.js
@@ -55,7 +55,9 @@ const runAddSimpleProductTest = () => {
 			await verifyAndPublish();
 
 			await merchant.logout();
+		});
 
+		it('can have a shopper add the simple virtual product to the cart', async () => {
 			// See product in the shop and add it to the cart
 			await shopper.goToShop();
 			await shopper.addToCartFromShopPage(VirtualProductName);
@@ -80,9 +82,14 @@ const runAddSimpleProductTest = () => {
 			await verifyAndPublish();
 
 			await merchant.logout();
+		});
 
+		it('can have a shopper add the simple non-virtual product to the cart', async () => {
 			// See product in the shop and add it to the cart
 			await shopper.goToShop();
+
+			await page.reload({ waitUntil: ['networkidle0', 'domcontentloaded'] });
+
 			await shopper.addToCartFromShopPage(NonVirtualProductName);
 			await shopper.goToCart();
 			await shopper.productIsInCart(NonVirtualProductName);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR proposes splitting out the tests for `Add New Simple Product Page` as well as add a page reload when viewing the products in the store. Previously, the page would be cached and the newly added product wouldn't be shown. Now, the page is reloaded to make sure the new product (`Non-virtual product name`) is shown on the page.

### How to test the changes in this Pull Request:

1. Verify CI passes
2. Run the tests locally and verify they pass:
```
npx wc-e2e test:e2e specs/wp-admin/create-simple-product.test.js
```