### PR TITLE
reset E2E onboarding on retest

### DIFF
--- a/tests/e2e/config/jest.setup.js
+++ b/tests/e2e/config/jest.setup.js
@@ -5,13 +5,13 @@ import {
 	WP_ADMIN_LOGIN
 } from '@woocommerce/e2e-utils';
 
-const config = require('config');
-const { HTTPClientFactory } = require('@woocommerce/api');
+const config = require( 'config' );
+const { HTTPClientFactory } = require( '@woocommerce/api' );
 const { addConsoleSuppression, updateReadyPageStatus } = require( '@woocommerce/e2e-environment' );
 const { DEFAULT_TIMEOUT_OVERRIDE } = process.env;
 
 // @todo: remove this once https://github.com/woocommerce/woocommerce-admin/issues/6992 has been addressed
-addConsoleSuppression( 'woocommerce_shared_settings' );
+addConsoleSuppression( 'woocommerce_shared_settings', false );
 
 /**
  * Uses the WordPress API to delete all existing posts

--- a/tests/e2e/core-tests/specs/shopper/front-end-product-browse-search-sort.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-product-browse-search-sort.test.js
@@ -1,10 +1,10 @@
-/* eslint-disable jest/no-export, jest/no-disabled-tests */
 /**
  * Internal dependencies
  */
 const {
 	shopper,
 	createSimpleProductWithCategory,
+	utils,
 } = require( '@woocommerce/e2e-utils' );
 
 /**
@@ -15,6 +15,7 @@ const {
 	describe,
 	beforeAll,
 } = require( '@jest/globals' );
+const { WORDPRESS_VERSION } = process.env;
 
 const config = require( 'config' );
 const simpleProductName = config.get( 'products.simple.name' );
@@ -27,7 +28,7 @@ const hardware = 'Hardware';
 const productTitle = 'li.first > a > h2.woocommerce-loop-product__title';
 
 const runProductBrowseSearchSortTest = () => {
-	describe('Search, browse by categories and sort items in the shop', () => {
+	utils.describeIf( WORDPRESS_VERSION >= '5.8' )( 'Search, browse by categories and sort items in the shop', () => {
 		beforeAll(async () => {
 			// Create 1st product with Clothing category
 			await createSimpleProductWithCategory(simpleProductName + ' 1', singleProductPrice, clothing);

--- a/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.js
+++ b/tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.js
@@ -2,6 +2,15 @@ const {
 	testAdminOnboardingWizard,
 	testSelectiveBundleWCPay,
 } = require( '@woocommerce/admin-e2e-tests' );
+const {
+	withRestApi,
+	IS_RETEST_MODE,
+} = require( '@woocommerce/e2e-utils' );
+
+// Reset onboarding profile when re-running tests on a site
+if ( IS_RETEST_MODE ) {
+	withRestApi.resetOnboarding();
+}
 
 testAdminOnboardingWizard();
 testSelectiveBundleWCPay();

--- a/tests/e2e/utils/src/flows/shopper.js
+++ b/tests/e2e/utils/src/flows/shopper.js
@@ -171,9 +171,11 @@ const shopper = {
 		await page.waitForSelector(searchFieldSelector, { timeout: 100000 });
 		await expect(page).toFill(searchFieldSelector, prouductName);
 		await expect(page).toClick('.wp-block-search__button');
-		await page.waitForSelector('h2.entry-title');
-		await expect(page).toMatchElement('h2.entry-title', {text: prouductName});
-		await expect(page).toClick('h2.entry-title', {text: prouductName});
+		// Single search results may go directly to product page
+		if ( await page.waitForSelector('h2.entry-title') ) {
+			await expect(page).toMatchElement('h2.entry-title', {text: prouductName});
+			await expect(page).toClick('h2.entry-title', {text: prouductName});
+		}
 		await page.waitForSelector('h1.entry-title');
 		await expect(page.title()).resolves.toMatch(prouductName);
 		await expect(page).toMatchElement('h1.entry-title', prouductName);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR restores the onboarding reset on `E2E_RETEST=1` that was removed when we switched to using the `admin-e2e-tests` onboarding tests.

It also has some minor code cleanup including completely hiding the `woocommerce_shared_settings` deprecated message.
 
### How to test the changes in this Pull Request:

1. Use the release smoke test site
2. Run the following with `...` replaced with valid values
```
E2E_RETEST=1 \
SMOKE_TEST_URL=... \
SMOKE_TEST_ADMIN_USER=... \
SMOKE_TEST_ADMIN_PASSWORD=... \
SMOKE_TEST_ADMIN_USER_EMAIL=... 
npx wc-e2e test:e2e-dev tests/e2e/specs/activate-and-setup/complete-onboarding-wizard.test.js
```
3. Monitor the test browser to verify that the `CBD ...` industry is visible on the business section

