### PR TITLE
Fix for CSS selectors on search e2e test

### DIFF
--- a/tests/e2e/utils/src/flows/shopper.js
+++ b/tests/e2e/utils/src/flows/shopper.js
@@ -167,10 +167,10 @@ const shopper = {
 	},
 
 	searchForProduct: async ( prouductName ) => {
-		const searchFieldSelector = 'input.wp-block-search__input';
+		const searchFieldSelector = 'input.search-field';
 		await page.waitForSelector(searchFieldSelector, { timeout: 100000 });
 		await expect(page).toFill(searchFieldSelector, prouductName);
-		await expect(page).toClick('.wp-block-search__button');
+		await expect(page).toClick('input.search-submit');
 		await page.waitForSelector('h2.entry-title');
 		await expect(page).toMatchElement('h2.entry-title', {text: prouductName});
 		await expect(page).toClick('h2.entry-title', {text: prouductName});


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR updates the CSS selectors used for the `Search, browse by categories and sort items in the shop` test.

### How to test the changes in this Pull Request:

1. Verify CI passes
2. Verify the tests pass locally:
```
npx wc-e2e test:e2e specs/front-end/product-browse-search-sort.test.js
```