### PR TITLE
Fix symbol for SZL currency

### DIFF
--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -801,7 +801,7 @@ function get_woocommerce_currency_symbols() {
 			'SSP' => '&pound;',
 			'STN' => 'Db',
 			'SYP' => '&#x644;.&#x633;',
-			'SZL' => 'L',
+			'SZL' => 'E',
 			'THB' => '&#3647;',
 			'TJS' => '&#x405;&#x41c;',
 			'TMT' => 'm',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Change(s): Changed SZL symbol from "L" to "E"
Reason: "L" as the symbol for SZL is inaccurate. "E" is the correct and standard symbol.

### How to test the changes in this Pull Request:

1. Quoting from the official website of the Eswatini Central Bank: _"In Eswatini we have five (5) denominations of Emalangeni bank notes (E200, E100, E50, E20 and E10) and seven (7) denominations of coins (5c, 10c, 20c, 50c, E1, E2 and E5). The Lilangeni Currency (SZL) was introduced in 1974 at par with the South African Rand through the CMA (Common Monetary Area) to which it remains tied at a one-to-one exchange rate."_
https://www.centralbank.org.sz/currency/

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - SZL currency symbol. Updated from 'L' to 'E'.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
