### PR TITLE
Update the Azerbaijani manat symbol AZN

### DIFF
--- a/plugins/woocommerce/changelog/update-manat-currency-symbol
+++ b/plugins/woocommerce/changelog/update-manat-currency-symbol
@@ -1,0 +1,4 @@
+Significance: patch
+Type: tweak
+
+Updates the currency symbol used for the Azerbaijani manat.

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -673,7 +673,7 @@ function get_woocommerce_currency_symbols() {
 			'ARS' => '&#36;',
 			'AUD' => '&#36;',
 			'AWG' => 'Afl.',
-			'AZN' => 'AZN',
+			'AZN' => '&#8916',
 			'BAM' => 'KM',
 			'BBD' => '&#36;',
 			'BDT' => '&#2547;&nbsp;',

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -673,7 +673,7 @@ function get_woocommerce_currency_symbols() {
 			'ARS' => '&#36;',
 			'AUD' => '&#36;',
 			'AWG' => 'Afl.',
-			'AZN' => '&#8916',
+			'AZN' => '&#8380;',
 			'BAM' => 'KM',
 			'BBD' => '&#36;',
 			'BDT' => '&#2547;&nbsp;',
@@ -2580,4 +2580,3 @@ function wc_cache_get_multiple( $keys, $group = '', $force = false ) {
 	}
 	return $values;
 }
- 

--- a/plugins/woocommerce/includes/wc-core-functions.php
+++ b/plugins/woocommerce/includes/wc-core-functions.php
@@ -2580,3 +2580,4 @@ function wc_cache_get_multiple( $keys, $group = '', $force = false ) {
 	}
 	return $values;
 }
+ 

--- a/plugins/woocommerce/tests/api-core-tests/data/settings.js
+++ b/plugins/woocommerce/tests/api-core-tests/data/settings.js
@@ -17,7 +17,7 @@ const currencies = {
 	"ARS": "Argentine peso (&#36;)",
 	"AUD": "Australian dollar (&#36;)",
 	"AWG": "Aruban florin (Afl.)",
-	"AZN": "Azerbaijani manat (AZN)",
+	"AZN": "Azerbaijani manat (&#8380;)",
 	"BAM": "Bosnia and Herzegovina convertible mark (KM)",
 	"BBD": "Barbadian dollar (&#36;)",
 	"BDT": "Bangladeshi taka (&#2547;&nbsp;)",
@@ -2474,4 +2474,3 @@ module.exports = {
 	currencies,
 	stateOptions,
 };
-    

--- a/plugins/woocommerce/tests/api-core-tests/data/settings.js
+++ b/plugins/woocommerce/tests/api-core-tests/data/settings.js
@@ -2474,3 +2474,4 @@ module.exports = {
 	currencies,
 	stateOptions,
 };
+    

--- a/plugins/woocommerce/tests/api-core-tests/tests/data/data-crud.test.js
+++ b/plugins/woocommerce/tests/api-core-tests/tests/data/data-crud.test.js
@@ -24493,7 +24493,7 @@ test.describe('Data API tests', () => {
 			expect.objectContaining({
 				"code": "AZN",
 				"name": "Azerbaijani manat",
-				"symbol": "AZN",
+				"symbol": "&#8380;",
 				"_links": {
 					"self": [{
 						"href": expect.stringContaining("data/currencies/AZN")


### PR DESCRIPTION
Updates the symbol used for the Azerbaijani manat.

### How to test the changes in this Pull Request:

1. Navigate to **WooCommerce ▸ Settings ▸ General** and update the currency settings so you are using the Azerbaijani Manat. Save.
2. Visit the storefront and ensure prices are displayed using the Manat `₼` symbol. 

<table>
<tr><td>
<img width="659" alt="manat-settings" src="https://user-images.githubusercontent.com/3594411/201932885-55de8b3f-94d9-438b-8ce6-a0e3133873ae.png">
</td><td>
<img width="207" alt="manat-fe" src="https://user-images.githubusercontent.com/3594411/201932871-f14b9da5-efef-4ecf-9032-c7aa2eee6150.png">
</td></tr>
</table>

### Other information:

* [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
