### PR TITLE
Fix/e2e checkout page failures

### DIFF
--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
@@ -6,11 +6,7 @@ const {
 	merchant,
 	withRestApi,
 	createSimpleProduct,
-	setCheckbox,
-	settingsPageSaveChanges,
 	uiUnblocked,
-	verifyCheckboxIsSet,
-	addShippingZoneAndMethod,
 } = require( '@woocommerce/e2e-utils' );
 
 const config = require( 'config' );
@@ -33,46 +29,23 @@ const runCheckoutPageTest = () => {
 			await withRestApi.resetSettingsGroupToDefault('tax');
 
 			// Set free shipping within California
-			await merchant.login();
-			await addShippingZoneAndMethod('Free Shipping CA', 'state:US:CA', ' ', 'free_shipping');
-			// Go to general settings page
-			await merchant.openSettings('general');
+			await withRestApi.addShippingZoneAndMethod('Free Shipping CA', 'state:US:CA', ' ', 'free_shipping');
 
 			// Set base location with state CA.
-			await expect(page).toSelect('select[name="woocommerce_default_country"]', 'United States (US) — California');
-			// Sell to all countries
-			await expect(page).toSelect('#woocommerce_allowed_countries', 'Sell to all countries');
-			// Set currency to USD
-			await expect(page).toSelect('#woocommerce_currency', 'United States (US) dollar ($)');
-			// Tax calculation should have been enabled by another test - no-op
-			// Save
-			await settingsPageSaveChanges();
+			await withRestApi.updateSettingOption( 'general', 'woocommerce_default_country', { value: 'US:CA' } );
 
-			// Verify that settings have been saved
-			await Promise.all([
-				expect(page).toMatchElement('#message', {text: 'Your settings have been saved.'}),
-				expect(page).toMatchElement('select[name="woocommerce_default_country"]', {text: 'United States (US) — California'}),
-				expect(page).toMatchElement('#woocommerce_allowed_countries', {text: 'Sell to all countries'}),
-				expect(page).toMatchElement('#woocommerce_currency', {text: 'United States (US) dollar ($)'}),
-			]);
+			// Sell to all countries
+			await withRestApi.updateSettingOption( 'general', 'woocommerce_allowed_countries', { value: 'all' } );
+
+			// Set currency to USD
+			await withRestApi.updateSettingOption( 'general', 'woocommerce_currency', { value: 'USD' } );
+			// Tax calculation should have been enabled by another test - no-op
 
 			// Enable BACS payment method
-			await merchant.openSettings('checkout', 'bacs');
-			await setCheckbox('#woocommerce_bacs_enabled');
-			await settingsPageSaveChanges();
-
-			// Verify that settings have been saved
-			await verifyCheckboxIsSet('#woocommerce_bacs_enabled');
+			await withRestApi.updatePaymentGateway( 'bacs', { enabled: true } );
 
 			// Enable COD payment method
-			await merchant.openSettings('checkout', 'cod');
-			await setCheckbox('#woocommerce_cod_enabled');
-			await settingsPageSaveChanges();
-
-			// Verify that settings have been saved
-			await verifyCheckboxIsSet('#woocommerce_cod_enabled');
-
-			await merchant.logout();
+			await withRestApi.updatePaymentGateway( 'cod', { enabled: true } );
 		});
 
 		it('should display cart items in order review', async () => {
@@ -160,7 +133,7 @@ const runCheckoutPageTest = () => {
 			customerOrderId = orderReceivedText.split(/(\s+)/)[6].toString();
 		});
 
-		it('store owner can confirm the order was received', async () => {
+		it('merchant can confirm the order was received', async () => {
 			await merchant.login();
 			await merchant.verifyOrder(guestOrderId, simpleProductName, singleProductPrice, 5, fiveProductPrice);
 			await merchant.verifyOrder(customerOrderId, simpleProductName, singleProductPrice, 1, singleProductPrice, true);

--- a/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
+++ b/tests/e2e/core-tests/specs/shopper/front-end-checkout.test.js
@@ -29,7 +29,7 @@ const runCheckoutPageTest = () => {
 			await withRestApi.resetSettingsGroupToDefault('tax');
 
 			// Set free shipping within California
-			await withRestApi.addShippingZoneAndMethod('Free Shipping CA', 'state:US:CA', ' ', 'free_shipping');
+			await withRestApi.addShippingZoneAndMethod('Free Shipping CA', 'state:US:CA', '', 'free_shipping');
 
 			// Set base location with state CA.
 			await withRestApi.updateSettingOption( 'general', 'woocommerce_default_country', { value: 'US:CA' } );
@@ -46,6 +46,10 @@ const runCheckoutPageTest = () => {
 
 			// Enable COD payment method
 			await withRestApi.updatePaymentGateway( 'cod', { enabled: true } );
+		});
+
+		afterAll(async () => {
+			await withRestApi.deleteAllShippingZones();
 		});
 
 		it('should display cart items in order review', async () => {

--- a/tests/e2e/utils/CHANGELOG.md
+++ b/tests/e2e/utils/CHANGELOG.md
@@ -19,6 +19,8 @@
 - Added `statuses` optional parameter to `deleteAllRepositoryObjects()` to delete on specific statuses
 - Added `createOrder()` component util that creates an order using the API with the passed in details
 - Updated `addShippingZoneAndMethod` to use the API instead of UI to create shipping zones
+- Added `updateSettingOption` to use the API to update a setting option
+- Added `updatePaymentGateway` to use the API to update a payment gateway
 
 # 0.1.5
 

--- a/tests/e2e/utils/README.md
+++ b/tests/e2e/utils/README.md
@@ -149,6 +149,8 @@ This package provides support for enabling retries in tests:
 | `resetSettingsGroupToDefault` | `settingsGroup` | Reset settings in settings group to default except `select` fields |
 | `batchCreateOrders` | `orders` | Create a batch of orders using the "Batch Create Order" API endpoint |
 | `deleteAllOrders` | | Permanently delete all orders |
+| `updateSettingOption` | `settingsGroup`, `settingID`, `payload` | Update a settings group |
+| `updatePaymentGateway`| `paymentGatewayId`, `payload` | Update a payment gateway |
 
 ### Page Utilities
 

--- a/tests/e2e/utils/src/flows/with-rest-api.js
+++ b/tests/e2e/utils/src/flows/with-rest-api.js
@@ -252,16 +252,36 @@ export const withRestApi = {
 			}
 		}
 	},
-	
+	/**
+	 * Update a setting to the supplied value.
+	 *
+	 * @param {string} settingsGroup The settings group to update.
+	 * @param {string} settingId The setting ID to update
+	 * @param {object} payload An object with a key/value pair to update.
+	 */
+	updateSettingOption: async ( settingsGroup, settingId, payload = {} ) => {
+		const settingsClient = Setting.restRepository( client );
+		await settingsClient.update( settingsGroup, settingId, payload );
+	},
+	/**
+	 * Update a payment gateway.
+	 *
+	 * @param {string} paymentGatewayId The ID of the payment gateway to update.
+	 * @param {object} payload An object with the key/value pair to update.
+	 */
+	updatePaymentGateway: async ( paymentGatewayId, payload = {} ) => {
+		const response = await client.put( `/wc/v3/payment_gateways/${paymentGatewayId}`, payload );
+		expect( response.statusCode ).toBe( 200 );
+	},
 	/**
 	 * Create a batch of orders using the "Batch Create Order" API endpoint.
-	 * 
+	 *
 	 * @param orders Array of orders to be created
 	 */
 	batchCreateOrders : async (orders) => {
 		const path = '/wc/v3/orders/batch';
 		const payload = { create: orders };
-		
+
 		const { statusCode } = await client.post(path, payload);
 
 		expect(statusCode).toEqual(200);


### PR DESCRIPTION
### Changes proposed in this Pull Request:

This PR introduces two new functions using the API:
* `updateSettingOption()`: Update a particular setting option with the provided payload
* `updatePaymentGateway()`: Update a particular payment method with the provided payload

These new functions are used in the checkout page test as part of the setup.

### How to test the changes in this Pull Request:

1. Verify the CI passes
2. Run the checkout page test and verify it passes:
```
npx wc-e2e test:e2e specs/front-end/checkout-begin.test.js
```