### PR TITLE
Add filter woocommerce_order_item_name_plain

### DIFF
--- a/includes/class-wc-structured-data.php
+++ b/includes/class-wc-structured-data.php
@@ -477,7 +477,7 @@ class WC_Structured_Data {
 				),
 				'itemOffered'        => array(
 					'@type' => 'Product',
-					'name'  => wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, $is_visible ) ),
+					'name'  => wp_kses_post( apply_filters( 'woocommerce_order_item_name', apply_filters( 'woocommerce_order_item_name_plain', $item->get_name(), $item ), $item, $is_visible ) ),
 					'sku'   => $product_exists ? $product->get_sku() : '',
 					'image' => $product_exists ? wp_get_attachment_image_url( $product->get_image_id() ) : '',
 					'url'   => $is_visible ? get_permalink( $product->get_id() ) : get_home_url(),

--- a/templates/checkout/form-pay.php
+++ b/templates/checkout/form-pay.php
@@ -40,7 +40,7 @@ $totals = $order->get_order_item_totals(); // phpcs:ignore WordPress.WP.GlobalVa
 					<tr class="<?php echo esc_attr( apply_filters( 'woocommerce_order_item_class', 'order_item', $item, $order ) ); ?>">
 						<td class="product-name">
 							<?php
-								echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) );
+								echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', apply_filters( 'woocommerce_order_item_name_plain', $item->get_name(), $item ), $item, false ) );
 
 								do_action( 'woocommerce_order_item_meta_start', $item_id, $item, $order, false );
 

--- a/templates/emails/email-order-items.php
+++ b/templates/emails/email-order-items.php
@@ -47,7 +47,7 @@ foreach ( $items as $item_id => $item ) :
 		}
 
 		// Product name.
-		echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) );
+		echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', apply_filters( 'woocommerce_order_item_name_plain', $item->get_name(), $item ), $item, false ) );
 
 		// SKU.
 		if ( $show_sku && $sku ) {

--- a/templates/emails/plain/email-order-items.php
+++ b/templates/emails/plain/email-order-items.php
@@ -31,7 +31,7 @@ foreach ( $items as $item_id => $item ) :
 		}
 
 		// phpcs:disable WordPress.Security.EscapeOutput.OutputNotEscaped
-		echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $item->get_name(), $item, false ) );
+		echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', apply_filters( 'woocommerce_order_item_name_plain', $item->get_name(), $item ), $item, false ) );
 		if ( $show_sku && $sku ) {
 			echo ' (#' . $sku . ')';
 		}

--- a/templates/order/order-details-item.php
+++ b/templates/order/order-details-item.php
@@ -30,7 +30,8 @@ if ( ! apply_filters( 'woocommerce_order_item_visible', true, $item ) ) {
 		$is_visible        = $product && $product->is_visible();
 		$product_permalink = apply_filters( 'woocommerce_order_item_permalink', $is_visible ? $product->get_permalink( $item ) : '', $item, $order );
 
-		echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $product_permalink ? sprintf( '<a href="%s">%s</a>', $product_permalink, $item->get_name() ) : $item->get_name(), $item, $is_visible ) );
+		$item_name = apply_filters( 'woocommerce_order_item_name_plain', $item->get_name(), $item );
+		echo wp_kses_post( apply_filters( 'woocommerce_order_item_name', $product_permalink ? sprintf( '<a href="%s">%s</a>', $product_permalink, $item_name ) : $item_name, $item, $is_visible ) );
 
 		$qty          = $item->get_quantity();
 		$refunded_qty = $order->get_qty_refunded_for_item( $item_id );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:
The filter `woocommerce_order_item_name` usually gets the plain item name but there is a case (`templates/order/order-details-item.php`) in which it gets HTML as the 1st parameter.

The new filter always works with the plain name before adding HTML, so its user does not have to maintain the HTML code which might be more error-prone than modifying the plain name.

This would help with solving:
- #29386 (section *Describe alternatives you've considered*),
- @tivnet’s issue (see #8159),
- my current need for adjusting product names.

Adding a new filter is also suggested in [@franticpsyx’s comment to #8159](https://github.com/woocommerce/woocommerce/pull/8159#issuecomment-101935376).

#### Considered alternatives

- #8159 suggested changing the existing filter `woocommerce_order_item_name` to always work with plain item names but was refused as a [potentially a breaking change](https://github.com/woocommerce/woocommerce/pull/8159#issuecomment-101935376).
- Reconstructing the HTML as [suggested by @claudiosanches](https://github.com/woocommerce/woocommerce/pull/8159#issuecomment-105963876) breaks the [DRY principle](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself). If the original HTML was altered, the filter must be manually updated to incorporate the changes, too.
- Using [`str_replace`](https://www.php.net/manual/en/function.str-replace.php) (mentioned in the same comment) alone would fail if the search string appeared elsewhere in the search subject:
  ```php
  // Let 'basket' be the product.
  // The following line will break permalink. (Variables and function calls substituted already.)
  str_replace( 'basket', '★ BASKET ★', '<a href="http://myshop.net/product/basket/">basket</a>' );
  ```
- Using `preg_replace(_callback)` [mentioned by @tivnet](https://github.com/woocommerce/woocommerce/pull/8159#issuecomment-102620678) might fail if not designed carefully as [`>` might appear in a HTML attribute](https://stackoverflow.com/questions/94528/is-u003e-greater-than-sign-allowed-inside-an-html-element-attribute-value), for example. (Generally, [HTML is a non-regular language](https://stackoverflow.com/q/1732348/711006), not exhaustively coverable by a regular expression.)

### How to test the changes in this Pull Request:

1. Add a callback to the new filter (`add_filter( 'woocommerce_order_item_name_plain', …`) to your `functions.php`.
2. Submit a WooCommerce order.
3. The product name affected by the filter should appear on the Order Completed page and in the emails.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
  > No, I’d adjust `woocommerce_order_item_name` tests but have not found any.
* [x] Have you successfully run tests with your changes locally?
  > Yes, unit tests.

### Changelog entry

> Dev - Add `woocommerce_order_item_name_plain` filter to customize item names in orders