### PR TITLE
Fix search input not getting focus when select2 dropdown element gets…

### DIFF
--- a/assets/js/selectWoo/selectWoo.full.js
+++ b/assets/js/selectWoo/selectWoo.full.js
@@ -1088,6 +1088,12 @@ S2.define('select2/results',[
 
       self.setClasses();
       self.ensureHighlightVisible();
+
+      // NOTE: DOM's version of the object and not jQuery.
+      var searchField = self.$results.parents( '.select2-container' ).find( 'input.select2-search__field' )[0];
+      if ( 'undefined' !== typeof searchField ) {
+           searchField.focus();
+      }
     });
 
     container.on('close', function () {


### PR DESCRIPTION
… focused closes #30607

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30607

Some alternatives I've tried is to use jQuery however browsers are not liking it so I opted to use the native DOM element combine with vanilla JS instead.

### How to test the changes in this Pull Request:

1. Go to an existing order click on "Add item" button. Make sure the order is in "Pending" status.
2. Then click on "Add product(s)" button.
3. You will see a popup menu. Click on TAB on the keyboard until it focuses on the Select2 Dropdown.
4. Start typing for a product to search.
5. Ensure it opens the dropdown and it starts searching for your key terms. Search for one that actually exists, highlight it and press enter.
6. Press your Tab key twice to highlight the next Select2 dropdown and repeat steps 4-5.
7. Ensure it gets focused is working.
8. Check other Select2 dropdowns and ensure there are no regression. Such as the Country dropdown field on checkout.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - Select2 dropdown search input not getting focus when select2 dropdown element gets focused.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
