### PR TITLE
Use prop to set checked state fixes #30471

### DIFF
--- a/assets/js/admin/quick-edit.js
+++ b/assets/js/admin/quick-edit.js
@@ -70,7 +70,7 @@ jQuery(
 				$( 'select[name="_backorders"] option[value="' + backorders + '"]', '.inline-edit-row' ).attr( 'selected', 'selected' );
 
 				if ( 'yes' === featured ) {
-					$( 'input[name="_featured"]', '.inline-edit-row' ).attr( 'checked', 'checked' );
+					$( 'input[name="_featured"]', '.inline-edit-row' ).prop( 'checked', true );
 				} else {
 					$( 'input[name="_featured"]', '.inline-edit-row' ).prop( 'checked', false );
 				}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30471

### How to test the changes in this Pull Request:

1. Go to All products page. `/wp-admin/edit.php?post_type=product`
2. Mark one of the product as a featured product by clicking on the `Star` icon.
3. Then find another product (that is not featured) and click on the `Quick Edit` link.
4. Make sure the featured setting is not checked and click on `Update`.
5. Find the product you set as featured from step 2 and click on the `Quick Edit` link.
6. Ensure the featured checkbox is checked.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Fix - During product quick edit, the featured setting is sometimes not shown correctly as checked.

### FOR PR REVIEWER ONLY:

* [ ] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
