### PR TITLE
Add additional context to have browse all products open in new tab cl…

### DIFF
--- a/assets/js/admin/marketplace-suggestions.js
+++ b/assets/js/admin/marketplace-suggestions.js
@@ -121,7 +121,8 @@
 			var newTabContexts = [
 				'product-edit-meta-tab-header',
 				'product-edit-meta-tab-footer',
-				'product-edit-meta-tab-body'
+				'product-edit-meta-tab-body',
+				'products-list-empty-footer'
 			];
 			if ( _.includes( newTabContexts, context ) ) {
 				linkoutButton.setAttribute( 'target', 'blank' );


### PR DESCRIPTION
…oses #30264

### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes #30264

Things I've thought to do: Refactor the link generator to accept attributes but it seemed overkill for right now unless we will have other links that we need to customize. I know it is quite a catchall at the moment but I think we can reassess once we will have other links in the future.

### How to test the changes in this Pull Request:

1. With no products in your store load the products page. `/wp-admin/edit.php?post_type=product`.
2. Scroll down towards the bottom to find the link `Browse all extensions`.
3. Click on the link and ensure the page is loaded in a new tab instead of the current tab.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Open `Browse all extensions` link in a new tab.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
