### PR TITLE
Added text to be displayed when invalid data is entered into search input field and  no search results are found

### DIFF
--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -62,7 +62,7 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 
 	<div class="wrap">
 		<div class="marketplace-content-wrapper">
-			<?php if ( empty( $search ) ) : ?>
+			<?php if ( sizeof($addons)==0 ) : ?>
 				<h1 class="search-form-title">
 					<?php // translators: search keyword. ?>
 					<?php esc_html_e( 'Sorry, could not find anything. Try searching again using a different term.', 'woocommerce' ); ?></p>

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -68,7 +68,7 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 					<?php esc_html_e( 'Sorry, could not find anything. Try searching again using a different term.', 'woocommerce' ); ?></p>
 				</h1>
 			<?php endif; ?>
-			<?php if ( ! empty( $search ) ) : ?>
+			<?php if ( ! empty( $search ) && sizeof($addons)>0 ) : ?>
 				<h1 class="search-form-title">
 					<?php // translators: search keyword. ?>
 					<?php printf( esc_html__( 'Search results for "%s"', 'woocommerce' ), esc_html( sanitize_text_field( wp_unslash( $search ) ) ) ); ?>

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -62,6 +62,12 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 
 	<div class="wrap">
 		<div class="marketplace-content-wrapper">
+			<?php if ( empty( $search ) ) : ?>
+				<h1 class="search-form-title">
+					<?php // translators: search keyword. ?>
+					<?php esc_html_e( 'Sorry, could not find anything. Try searching again using a different term.', 'woocommerce' ); ?></p>
+				</h1>
+			<?php endif; ?>
 			<?php if ( ! empty( $search ) ) : ?>
 				<h1 class="search-form-title">
 					<?php // translators: search keyword. ?>

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -64,7 +64,6 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 		<div class="marketplace-content-wrapper">
 			<?php if ( count( $addons ) == 0 ) : ?>
 				<h1 class="search-form-title">
-					<?php // translators: search keyword. ?>
 					<?php esc_html_e( 'Sorry, could not find anything. Try searching again using a different term.', 'woocommerce' ); ?></p>
 				</h1>
 			<?php endif; ?>

--- a/includes/admin/views/html-admin-page-addons.php
+++ b/includes/admin/views/html-admin-page-addons.php
@@ -62,13 +62,13 @@ $current_section_name = __( 'Browse Categories', 'woocommerce' );
 
 	<div class="wrap">
 		<div class="marketplace-content-wrapper">
-			<?php if ( sizeof($addons)==0 ) : ?>
+			<?php if ( count( $addons ) == 0 ) : ?>
 				<h1 class="search-form-title">
 					<?php // translators: search keyword. ?>
 					<?php esc_html_e( 'Sorry, could not find anything. Try searching again using a different term.', 'woocommerce' ); ?></p>
 				</h1>
 			<?php endif; ?>
-			<?php if ( ! empty( $search ) && sizeof($addons)>0 ) : ?>
+			<?php if ( ! empty( $search ) && count( $addons ) > 0 ) : ?>
 				<h1 class="search-form-title">
 					<?php // translators: search keyword. ?>
 					<?php printf( esc_html__( 'Search results for "%s"', 'woocommerce' ), esc_html( sanitize_text_field( wp_unslash( $search ) ) ) ); ?>


### PR DESCRIPTION
Added text to be displayed when invalid data is entered into the search input field and no search results found
 in `WooCommerce-> Marketplace` , fixes issue #30588



### All Submissions:

* [x] Have you followed the [WooCommerce Contributing guideline](https://github.com/woocommerce/woocommerce/blob/trunk/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress' coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

<!-- Mark completed items with an [x] -->

<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request and the reason for such changes. -->

Closes # .

### How to test the changes in this Pull Request:

1. Create any test site using JN site.
2. Install and activate all the required plugins.
3. Install and activate WooCommerce 5.7.0 Beta-1.
4. Complete the setup wizard.
5. Go to WooCommerce->Marketplace.
6. Search invalid data (non-existing) in search field.
7. Screen displays `Sorry, could not find anything. Try searching again using a different term.`

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<!-- Mark completed items with an [x] -->

### Changelog entry

> Tweak - Show a search again message when marketplace results are empty.

### FOR PR REVIEWER ONLY:

* [x] I have reviewed that everything is sanitized/escaped appropriately for any SQL or XSS injection possibilities. I made sure Linting is not ignored or disabled.
